### PR TITLE
Use a distinct function for extracting zip archives vs. copying flat files

### DIFF
--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -93,7 +93,7 @@ public class GetCoverageTest extends WCSTestSupport {
         super.populateDataDirectory(dataDirectory);
         
         // this also adds the raster style
-        dataDirectory.addCoverage(MOSAIC, 
+        dataDirectory.addCoverageFromZip(MOSAIC, 
                 MockData.class.getResource("raster-filter-test.zip"), null, "raster");
     }
 

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/test/WCSTestSupport.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/test/WCSTestSupport.java
@@ -83,7 +83,7 @@ public abstract class WCSTestSupport extends CoverageTestSupport {
         super.populateDataDirectory(dataDirectory);
         
         // add a raster mosaic with time and elevation
-        dataDirectory.addCoverage(WATTEMP, TestData.class.getResource("watertemp.zip"),
+        dataDirectory.addCoverageFromZip(WATTEMP, TestData.class.getResource("watertemp.zip"),
                         null, "raster");
     }
 

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -55,7 +55,7 @@ public class GetCoverageTest extends AbstractGetCoverageTest {
         super.populateDataDirectory(dataDirectory);
         
         // this also adds the raster style
-        dataDirectory.addCoverage(MOSAIC, 
+        dataDirectory.addCoverageFromZip(MOSAIC, 
                 MockData.class.getResource("raster-filter-test.zip"), null, "raster");
     }
 

--- a/src/wms/src/test/java/org/geoserver/wms/ResourceAccessManagerWMSTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/ResourceAccessManagerWMSTest.java
@@ -102,7 +102,7 @@ public class ResourceAccessManagerWMSTest extends WMSTestSupport {
         // add a mosaic as well
         URL style = MockData.class.getResource("raster.sld");
         dataDirectory.addStyle("raster", style);
-        dataDirectory.addCoverage(new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX), 
+        dataDirectory.addCoverageFromZip(new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX), 
                 MockData.class.getResource("raster-filter-test.zip"), null, "raster");
 
         

--- a/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
@@ -42,7 +42,7 @@ public class WMSDimensionsTestSupport extends WMSTestSupport {
         URL style = getClass().getResource("../temperature.sld");
         String styleName = "temperature";
         dataDirectory.addStyle(styleName, style);
-        dataDirectory.addCoverage(WATTEMP, TestData.class.getResource("watertemp.zip"),
+        dataDirectory.addCoverageFromZip(WATTEMP, TestData.class.getResource("watertemp.zip"),
                         null, styleName);
     }
 

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
@@ -42,10 +42,10 @@ public class GetMapIntegrationTest extends WMSTestSupport {
         dataDirectory.addCoverage(new QName(MockData.SF_URI, "paletted", MockData.SF_PREFIX),
                 GetMapIntegrationTest.class.getResource("paletted.tif"), "tif", "raster");
         // a filterable mosaic
-        dataDirectory.addCoverage(new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX), 
+        dataDirectory.addCoverageFromZip(new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX), 
                 MockData.class.getResource("raster-filter-test.zip"), null, "raster");
         // a 4 bits world image
-        dataDirectory.addCoverage(new QName(MockData.SF_URI, "fourbits", MockData.SF_PREFIX),
+        dataDirectory.addCoverageFromZip(new QName(MockData.SF_URI, "fourbits", MockData.SF_PREFIX),
                 MockData.class.getResource("fourbits.zip"), null, "raster");
     }
     

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -87,11 +87,11 @@ public class GetFeatureInfoTest extends WMSTestSupport {
                 null);
         
         // this also adds the raster style
-        dataDirectory.addCoverage(new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX), 
+        dataDirectory.addCoverageFromZip(new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX), 
                MockData.class.getResource("raster-filter-test.zip"), null, "raster");
         
         // add a raster with a a custom projection
-        dataDirectory.addCoverage(CUSTOM, GetFeatureInfoTest.class.getResource("custom.zip"), null, "raster");
+        dataDirectory.addCoverageFromZip(CUSTOM, GetFeatureInfoTest.class.getResource("custom.zip"), null, "raster");
     }
     
     /**

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
@@ -136,7 +136,7 @@ public class GetMapIntegrationTest extends WMSTestSupport {
         URL style = MockData.class.getResource("raster.sld");
         String styleName = "raster";
         dataDirectory.addStyle(styleName, style);
-        dataDirectory.addCoverage(new QName(MockData.SF_URI, "mosaic_holes", MockData.SF_PREFIX), 
+        dataDirectory.addCoverageFromZip(new QName(MockData.SF_URI, "mosaic_holes", MockData.SF_PREFIX), 
                 GetMapIntegrationTest.class.getResource("mosaic_holes.zip"), null, "raster");
         
         // add a raster style with translucent color map


### PR DESCRIPTION
Here is a commit that differentiates between single flat files and zip archives for setting up coverages in test fixtures.  This allows us to use appropriate coverage store types (such as WorldImage) as opposed to loading everything as a single-tile ImageMosaic.  ImageMosaic is still supported though - just set the "format" for the file to null.
