### PR TITLE
[GEOS-4982] A locked Layer must not hide its LayerGroup

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -614,11 +614,19 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         boolean needsWrapping = false;
         for (LayerInfo layer : layers) {
             LayerInfo checked = checkAccess(user, layer);
-            if(checked == null)
-                return null;
-            else if(checked != null && checked != layer) 
-                needsWrapping = true;
-            wrapped.add(checked);
+            if (checked != null) {
+                if (checked != layer) {
+                    needsWrapping = true;
+                }
+                wrapped.add(checked);
+            } else {
+                needsWrapping = true;                
+            }
+        }
+        
+        // if no layer can be accessed we hide the group
+        if (wrapped.size() == 0) {
+            return null;
         }
         
         if(needsWrapping)

--- a/src/main/src/test/java/org/geoserver/ows/LocalWorkspaceSecureCatalogTest.java
+++ b/src/main/src/test/java/org/geoserver/ows/LocalWorkspaceSecureCatalogTest.java
@@ -62,11 +62,11 @@ public class LocalWorkspaceSecureCatalogTest extends AbstractAuthorizationTest {
         CatalogFilterAccessManager mgr = setupAccessManager();
 
         SecureCatalogImpl sc = new SecureCatalogImpl(catalog, mgr) {};
-        assertEquals(2, sc.getLayerGroups().size());
+        assertEquals(3, sc.getLayerGroups().size());
 
         WorkspaceInfo ws = sc.getWorkspaceByName("topp");
         LocalWorkspace.set(ws);
-        assertEquals(1, sc.getLayerGroups().size());
+        assertEquals(2, sc.getLayerGroups().size());
         LocalWorkspace.remove();
 
         ws = sc.getWorkspaceByName("nurc");

--- a/src/main/src/test/java/org/geoserver/security/impl/AbstractAuthorizationTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/AbstractAuthorizationTest.java
@@ -81,6 +81,8 @@ public abstract class AbstractAuthorizationTest extends SecureObjectsTest {
     protected LayerGroupInfo layerGroupGlobal;
 
     protected LayerGroupInfo layerGroupTopp;
+
+    protected LayerGroupInfo layerGroupWithSomeLockedLayer;
     
     protected List<LayerInfo> layers;
 
@@ -139,8 +141,9 @@ public abstract class AbstractAuthorizationTest extends SecureObjectsTest {
         lineStyle = buildStyle("line", toppWs);
         
         // layer groups
-        layerGroupGlobal = buildLayerGroup("layerGroup", arcGridLayer, pointStyle, null);
-        layerGroupTopp = buildLayerGroup("layerGroupTopp", statesLayer, lineStyle, toppWs);
+        layerGroupGlobal = buildLayerGroup("layerGroup", pointStyle, null, arcGridLayer);
+        layerGroupTopp = buildLayerGroup("layerGroupTopp", lineStyle, toppWs, statesLayer);
+        layerGroupWithSomeLockedLayer = buildLayerGroup("layerGroupWithSomeLockedLayer", lineStyle, toppWs, statesLayer, roadsLayer);        
     }
 
     protected LayerInfo buildLayer(String name, WorkspaceInfo ws,
@@ -189,7 +192,7 @@ public abstract class AbstractAuthorizationTest extends SecureObjectsTest {
         return style;
     }
 
-    protected LayerGroupInfo buildLayerGroup(String name, LayerInfo layer, StyleInfo style, WorkspaceInfo ws) {
+    protected LayerGroupInfo buildLayerGroup(String name, StyleInfo style, WorkspaceInfo ws, LayerInfo... layer) {
         LayerGroupInfo layerGroup = createNiceMock(LayerGroupInfo.class);
         expect(layerGroup.getName()).andReturn(name).anyTimes();
         expect(layerGroup.getLayers()).andReturn(Arrays.asList(layer)).anyTimes();
@@ -197,7 +200,7 @@ public abstract class AbstractAuthorizationTest extends SecureObjectsTest {
         expect(layerGroup.getWorkspace()).andReturn(ws).anyTimes();
         replay(layerGroup);
         return layerGroup;
-    }
+    }    
     
     protected ResourceAccessManager buildManager(String propertyFile) throws Exception {
         return new DataAccessManagerAdapter(buildLegacyAccessManager(propertyFile));
@@ -257,9 +260,10 @@ public abstract class AbstractAuthorizationTest extends SecureObjectsTest {
         expect(catalog.getStyles()).andReturn(Arrays.asList(pointStyle, lineStyle)).anyTimes();
         expect(catalog.getStylesByWorkspace(toppWs)).andReturn(Arrays.asList(pointStyle, lineStyle)).anyTimes();
         expect(catalog.getStylesByWorkspace(nurcWs)).andReturn(Arrays.asList(pointStyle)).anyTimes();
-        expect(catalog.getLayerGroups()).andReturn(Arrays.asList(layerGroupGlobal, layerGroupTopp)).anyTimes();
-        expect(catalog.getLayerGroupsByWorkspace("topp")).andReturn(Arrays.asList(layerGroupTopp)).anyTimes();
+        expect(catalog.getLayerGroups()).andReturn(Arrays.asList(layerGroupGlobal, layerGroupTopp, layerGroupWithSomeLockedLayer)).anyTimes();
+        expect(catalog.getLayerGroupsByWorkspace("topp")).andReturn(Arrays.asList(new LayerGroupInfo[] { layerGroupTopp, layerGroupWithSomeLockedLayer })).anyTimes();
         expect(catalog.getLayerGroupsByWorkspace("nurc")).andReturn(Arrays.asList(layerGroupGlobal)).anyTimes();
+        expect(catalog.getLayerGroupByName("topp", layerGroupWithSomeLockedLayer.getName())).andReturn(layerGroupWithSomeLockedLayer).anyTimes();
         replay(catalog);
     }
 }

--- a/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -1,8 +1,8 @@
 package org.geoserver.security.impl;
 
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.security.ResourceAccessManager;
@@ -10,7 +10,9 @@ import org.geoserver.security.SecureCatalogImpl;
 import org.geoserver.security.decorators.ReadOnlyDataStoreTest;
 import org.geoserver.security.decorators.SecuredDataStoreInfo;
 import org.geoserver.security.decorators.SecuredFeatureTypeInfo;
+import org.geoserver.security.decorators.SecuredLayerGroupInfo;
 import org.geoserver.security.decorators.SecuredLayerInfo;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecureCatalogImplTest extends AbstractAuthorizationTest {
 
@@ -337,5 +339,44 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
         // ... bases requires one to be in the military
         assertSame(bases, sc.getFeatureTypeByName("topp:bases"));
     }
-     
+        
+    public void testLockedLayerMustNotHideItsLayerGroup() throws Exception {        
+        ResourceAccessManager manager = buildManager("lockedLayerInLayerGroup.properties");
+        SecureCatalogImpl sc = new SecureCatalogImpl(catalog, manager);
+
+        SecurityContextHolder.getContext().setAuthentication(rwUser);
+        assertSame(states, sc.getFeatureTypeByName("topp:states"));
+        assertSame(roads, sc.getFeatureTypeByName("topp:roads"));
+        LayerGroupInfo layerGroup = sc.getLayerGroupByName("topp", "layerGroupWithSomeLockedLayer");        
+        assertSame(layerGroupWithSomeLockedLayer, layerGroup);
+        assertEquals(2, layerGroup.getLayers().size());
+        
+        // try with read-only user
+        SecurityContextHolder.getContext().setAuthentication(roUser);
+        assertNull(sc.getFeatureTypeByName("topp:states"));
+        assertSame(roads, sc.getFeatureTypeByName("topp:roads"));
+        layerGroup = sc.getLayerGroupByName("topp", "layerGroupWithSomeLockedLayer");                
+        assertNotNull(layerGroup);
+        assertTrue(layerGroup instanceof SecuredLayerGroupInfo);
+        assertEquals(1, layerGroup.getLayers().size());
+    }
+    
+    public void testLayerGroupWithAllLayersBlockedMustBeHidden() throws Exception {
+        ResourceAccessManager manager = buildManager("lockedLayerInLayerGroup.properties");
+        SecureCatalogImpl sc = new SecureCatalogImpl(catalog, manager);
+
+        SecurityContextHolder.getContext().setAuthentication(rwUser);
+        assertSame(states, sc.getFeatureTypeByName("topp:states"));
+        assertSame(roads, sc.getFeatureTypeByName("topp:roads"));        
+        LayerGroupInfo layerGroup = sc.getLayerGroupByName("topp", "layerGroupWithSomeLockedLayer");        
+        assertSame(layerGroupWithSomeLockedLayer, layerGroup);
+        assertEquals(2, layerGroup.getLayers().size());
+        
+        // try with anonymous user
+        SecurityContextHolder.getContext().setAuthentication(anonymous);
+        assertNull(sc.getFeatureTypeByName("topp:states"));
+        assertNull(sc.getFeatureTypeByName("topp:roads"));
+        layerGroup = sc.getLayerGroupByName("topp", "layerGroupWithSomeLockedLayer");                
+        assertNull(layerGroup);
+    }
 }

--- a/src/main/src/test/java/org/geoserver/security/impl/lockedLayerInLayerGroup.properties
+++ b/src/main/src/test/java/org/geoserver/security/impl/lockedLayerInLayerGroup.properties
@@ -1,0 +1,7 @@
+mode=HIDE
+
+topp.roads.r=READER
+topp.roads.r=READER
+
+topp.states.r=WRITER
+topp.states.w=WRITER


### PR DESCRIPTION
Hi,
I think I've fixed this issue:
http://jira.codehaus.org/browse/GEOS-4982
