### PR TITLE
[GEOS-5312] Fix embedded Windows newlines in WFS CSV output.

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
@@ -11,6 +11,7 @@ import java.io.OutputStreamWriter;
 import java.text.NumberFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import javax.xml.namespace.QName;
 
@@ -157,20 +158,22 @@ public class CSVOutputFormat extends WFSGetFeatureOutputFormat {
      * delimited by double quotes, and also that double quotes within fields
      * must be escaped.  This method takes a field and returns one that
      * obeys the CSV spec.
-     */    
+     */
+    Pattern CSV_ESCAPES = Pattern.compile("[\"\n,\r]");
+
     private String prepCSVField(String field){
-    	// "embedded double-quote characters must be represented by a pair of double-quote characters."
-    	String mod = field.replaceAll("\"", "\"\"");
-    	
-    	/*
-    	 * Enclose string in double quotes if it contains double quotes, commas, or newlines
-    	 */
-    	if(mod.matches(".*(\"|\n|,).*")){
-    		mod = "\"" + mod + "\"";
-    	}
-    	
-		return mod;
-    	
+        // "embedded double-quote characters must be represented by a pair of double-quote characters."
+        String mod = field.replaceAll("\"", "\"\"");
+
+        /*
+         * Enclose string in double quotes if it contains double quotes, commas, or newlines
+         */
+        if(CSV_ESCAPES.matcher(mod).find()){
+            mod = "\"" + mod + "\"";
+        }
+
+        return mod;
+
     }
     
     @Override

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
@@ -68,10 +68,12 @@ public class CSVOutputFormatTest extends WFSTestSupport {
         GeometryFactory gf = new GeometryFactory();
         SimpleFeature f1 = SimpleFeatureBuilder.build(type, new Object[]{gf.createPoint(new Coordinate(5, 8)), "A label with \"quotes\""}, null);
         SimpleFeature f2 = SimpleFeatureBuilder.build(type, new Object[]{gf.createPoint(new Coordinate(5, 4)), "A long label\nwith newlines"}, null);
+        SimpleFeature f3 = SimpleFeatureBuilder.build(type, new Object[]{gf.createPoint(new Coordinate(5, 4)), "A long label\r\nwith windows\r\nnewlines"}, null);
         
         MemoryDataStore data = new MemoryDataStore();
         data.addFeature(f1);
         data.addFeature(f2);
+        data.addFeature(f3);
         SimpleFeatureSource fs = data.getFeatureSource("funnyLabels");
         
         // build the request objects and feed the output format
@@ -99,6 +101,8 @@ public class CSVOutputFormatTest extends WFSTestSupport {
         // check we have the expected values in the string attributes
         assertEquals(f1.getAttribute("label"), lines.get(1)[2]);
         assertEquals(f2.getAttribute("label"), lines.get(2)[2]);
+        // the test CSVReader helpfully turns \r\n into \n for us.
+        assertEquals(((String)f3.getAttribute("label")).replace("\r\n", "\n"), lines.get(3)[2]);
     }
     
     /**


### PR DESCRIPTION
http://jira.codehaus.org/browse/GEOS-5312

Test-case included.

Also changes the escaping to using a pre-compiled, simpler regex and `.find()` rather than `String.matches()`
