### PR TITLE
Don't add virtual table if the virtual table's already in the datastore

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -660,7 +660,9 @@ public class ResourcePool {
                             ft = jstore.getSchema(vtName);
                         } else {
                             vtName = vt.getName();
-                            jstore.addVirtualTable(vt);
+                            if(!jstore.getVirtualTables().containsValue(vt)) {
+                                jstore.addVirtualTable(vt);
+                            }
                             ft = jstore.getSchema(vt.getName());
                         }
                     } else {
@@ -864,7 +866,9 @@ public class ResourcePool {
                 info.getMetadata().containsKey(FeatureTypeInfo.JDBC_VIRTUAL_TABLE)) {
             VirtualTable vt = (VirtualTable) info.getMetadata().get(FeatureTypeInfo.JDBC_VIRTUAL_TABLE);
             JDBCDataStore jstore = (JDBCDataStore) dataStore;
-            jstore.addVirtualTable(vt);
+            if(!jstore.getVirtualTables().containsValue(vt)) {
+                 jstore.addVirtualTable(vt);
+            }
         }
                 
         //


### PR DESCRIPTION
ResourcePool called addVirtualTable even when the identical virtual table's already stored in the DataStore. The DataStore does a catalog query against the PostGIS database whenever adding a virtual table. So, this resulted in a postgis query for every tile loaded, even when the tile was cached.

This patch checks to make sure the virtual table isn't already in the DataStore before adding it.
