### PR TITLE
GEOS-4970: fixed ScaleRatio value when using custom DPI

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/decoration/ScaleRatioDecoration.java
+++ b/src/wms/src/main/java/org/geoserver/wms/decoration/ScaleRatioDecoration.java
@@ -14,15 +14,13 @@ import java.awt.Stroke;
 import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import org.geoserver.wms.WMSMapContent;
 import org.geotools.renderer.lite.RendererUtilities;
+import org.geotools.renderer.lite.StreamingRenderer;
+
 
 public class ScaleRatioDecoration implements MapDecoration {
-    /** A logger for this class. */
-    private static final Logger LOGGER = 
-        org.geotools.util.logging.Logging.getLogger("org.geoserver.wms.responses");
 
     public void loadOptions(Map<String, String> options) {
     }
@@ -32,17 +30,20 @@ public class ScaleRatioDecoration implements MapDecoration {
         return new Dimension(metrics.stringWidth(getScaleText(mapContent)), metrics.getHeight());
     }
 
-    public String getScaleText(WMSMapContent mapContent) {
-        return String.format(
-            "1 : %0$1.0f", 
-            RendererUtilities.calculateOGCScale(
+    public double getScale(WMSMapContent mapContent) {
+        double dpi = RendererUtilities.getDpi(mapContent.getRequest().getFormatOptions());
+        Map hints = new HashMap();        
+        hints.put(StreamingRenderer.DPI_KEY, dpi);
+        return RendererUtilities.calculateOGCScale(
                 mapContent.getRenderingArea(),
                 mapContent.getRequest().getWidth(),
-                new HashMap()
-            )
-        );
+                hints);
     }
 
+    public String getScaleText(WMSMapContent mapContent) {
+        return String.format("1 : %0$1.0f", getScale(mapContent));
+    }
+    
     public void paint(Graphics2D g2d, Rectangle paintArea, WMSMapContent mapContent) 
     throws Exception {
         FontMetrics metrics = g2d.getFontMetrics(g2d.getFont());

--- a/src/wms/src/test/java/org/geoserver/wms/decoration/ScaleRatioDecorationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/decoration/ScaleRatioDecorationTest.java
@@ -1,0 +1,63 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geoserver.wms.decoration;
+
+import java.util.HashMap;
+
+import junit.framework.Assert;
+
+import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.WMSMapContent;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Envelope;
+
+
+public class ScaleRatioDecorationTest {
+
+    public WMSMapContent createMapContent(double dpi) {
+        GetMapRequest request = new GetMapRequest();
+        request.setWidth(1000);
+        request.setHeight(1000);
+        request.setRawKvp(new HashMap<String, String>());
+    
+        if (dpi > 0) {
+            request.getFormatOptions().put("dpi", dpi);
+        }
+    
+        WMSMapContent map = new WMSMapContent(request);
+        map.getViewport().setBounds(
+                new ReferencedEnvelope(new Envelope(0, 0.01, 0, 0.01),
+                        DefaultGeographicCRS.WGS84));
+        return map;
+    }
+    
+    @Test
+    public void testRatio() throws Exception {
+        ScaleRatioDecoration d = new ScaleRatioDecoration();
+    
+        // 90 is DPI default value
+        Assert.assertEquals(3975, d.getScale(createMapContent(-1)), 1);
+        Assert.assertEquals(3975, d.getScale(createMapContent(25.4 / 0.28)), 1);
+    
+        Assert.assertEquals(13147, d.getScale(createMapContent(300)), 1);
+        Assert.assertEquals(26295, d.getScale(createMapContent(600)), 1);
+        Assert.assertEquals(78887, d.getScale(createMapContent(1800)), 1);
+    }
+}


### PR DESCRIPTION
Hi,

I've fixed the Scale Ratio issue reported in GEOS-4970 (http://jira.codehaus.org/browse/GEOS-4970).
Now the Scale Ratio is calculated in accordance with the DPI value sent in the WMS request.

In the same Jira it's reported a Scale Line width issue, but I wasn't able to reproduce it, it works for me.
