### PR TITLE
[GEOS-5378] Rest config and ogr2ogr failures under JDK7

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
@@ -24,13 +24,14 @@ import org.opengis.util.ProgressListener;
 public class FeatureTypeInfoImpl extends ResourceInfoImpl implements
         FeatureTypeInfo {
 
-    protected List<AttributeTypeInfo> attributes = new ArrayList<AttributeTypeInfo>();
-    
     protected Filter filter;
 
     protected int maxFeatures;
     protected int numDecimals;
 
+    protected List<AttributeTypeInfo> attributes = new ArrayList<AttributeTypeInfo>();
+
+    
     protected FeatureTypeInfoImpl() {
     }
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -948,7 +948,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.3.1</version>
+      <version>1.4.3</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/FeatureTypeResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/FeatureTypeResource.java
@@ -286,7 +286,6 @@ public class FeatureTypeResource extends AbstractCatalogResource {
 
     @Override
     protected void configurePersister(XStreamPersister persister, DataFormat format) {
-        persister.setHideFeatureTypeAttributes();
         persister.setCallback( new XStreamPersister.Callback() {
             @Override
             protected void postEncodeReference(Object obj, String ref, String prefix,
@@ -299,18 +298,6 @@ public class FeatureTypeResource extends AbstractCatalogResource {
                     DataStoreInfo ds = (DataStoreInfo) obj;
                     encodeLink( "/workspaces/" + encode(ds.getWorkspace().getName()) + 
                         "/datastores/" + encode(ds.getName()), writer );
-                }
-            }
-            
-            @Override
-            protected void postEncodeFeatureType(FeatureTypeInfo ft,
-                    HierarchicalStreamWriter writer, MarshallingContext context) {
-                try {
-                    writer.startNode("attributes");
-                    context.convertAnother(ft.attributes());
-                    writer.endNode();
-                } catch (IOException e) {
-                    throw new RuntimeException("Could not get native attributes", e);
                 }
             }
         });

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/JSONType.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/JSONType.java
@@ -244,7 +244,7 @@ public enum JSONType {
             jsonWriter.endNode();
             jsonWriter.endNode();
             jsonWriter.endNode();
-
+            jsonWriter.flush();
         } catch (JSONException jsonException) {
             ServiceException serviceException = new ServiceException("Error: "
                     + jsonException.getMessage());

--- a/src/wms/src/main/java/org/geoserver/wms/describelayer/GeoJSONDescribeLayerResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/describelayer/GeoJSONDescribeLayerResponse.java
@@ -125,7 +125,7 @@ public class GeoJSONDescribeLayerResponse extends DescribeLayerResponse {
                 jsonWriter.endNode();
             }
             jsonWriter.endNode();
-
+            jsonWriter.flush();
         } catch (JSONException jsonException) {
             ServiceException serviceException = new ServiceException("Error: "
                     + jsonException.getMessage());


### PR DESCRIPTION
This one upgrades XStream to version 1.4.x which does support JDK7. Without this fix both the RestConfig and the OGR2OGR modules are failing with XStream exceptions about not finding the no-arg constructor under JDK 7 (both when running tests, and at runtime)
