### PR TITLE
Added Title and Abstract to LayerGroups (branch 2.2.x)

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/LayerGroupInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerGroupInfo.java
@@ -6,7 +6,6 @@ package org.geoserver.catalog;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Set;
 
 import org.geotools.geometry.jts.ReferencedEnvelope;
 
@@ -28,6 +27,26 @@ public interface LayerGroupInfo extends CatalogInfo {
      * Sets the name of the layer group.
      */
     void setName( String name );
+    
+    /**
+     * The title of the layer group.
+     */
+    String getTitle();
+    
+    /**
+     * Sets the title of the layer group.
+     */
+    void setTitle(String title);
+    
+    /**
+     * The abstract of the layer group.
+     */
+    String getAbstract();
+    
+    /**
+     * Sets the abstract of the layer group.
+     */
+    void setAbstract(String abstractTxt);    
     
     /**
      * The workspace the layer group is part of, or <code>null</code> if the layer group is global.

--- a/src/main/src/main/java/org/geoserver/catalog/impl/LayerGroupInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LayerGroupInfoImpl.java
@@ -62,6 +62,22 @@ public class LayerGroupInfoImpl implements LayerGroupInfo {
         this.name = name;
     }
 
+    public String getTitle() {
+        return metadata.get("title", String.class);
+    }
+    
+    public void setTitle(String title) {
+        metadata.put("title", title);
+    }
+    
+    public String getAbstract() {
+        return metadata.get("abstract", String.class);
+    }
+    
+    public void setAbstract(String abstractTxt) {
+        metadata.put("abstract", abstractTxt);
+    }    
+    
     public WorkspaceInfo getWorkspace() {
         return workspace;
     }

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingLayerGroupInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingLayerGroupInfo.java
@@ -73,6 +73,22 @@ public class DecoratingLayerGroupInfo extends AbstractDecorator<LayerGroupInfo> 
         return delegate.getMetadata();
     }
     
+    public String getTitle() {
+        return delegate.getTitle();
+    }
+    
+    public void setTitle(String title) {
+        delegate.setTitle(title);
+    }
+    
+    public String getAbstract() {
+        return delegate.getAbstract();
+    }
+    
+    public void setAbstract(String abstractTxt) {
+        delegate.setAbstract(abstractTxt);
+    }        
+    
     public void accept(CatalogVisitor visitor) {
         delegate.accept(visitor);
     }

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -1643,6 +1643,48 @@ public class CatalogImplTest extends TestCase {
         assertEquals(1, catalog.getLayerGroupsByWorkspace((WorkspaceInfo)null).size());
     }
 
+    public void testLayerGroupTitle() {
+        LayerGroupInfo lg2 = catalog.getFactory().createLayerGroup();
+        lg2.setWorkspace(catalog.getDefaultWorkspace());
+        lg2.setName("layerGroup2");
+        lg2.setTitle("layerGroup2 title");
+        lg2.getLayers().add(l);
+        lg2.getStyles().add(s);
+        catalog.add(lg2);
+
+        assertEquals(1, catalog.getLayerGroups().size());
+        
+        lg2 = catalog.getLayerGroupByName("layerGroup2");
+        assertEquals("layerGroup2 title", lg2.getTitle());
+
+        lg2.setTitle("another title");
+        catalog.save(lg2);
+        
+        lg2 = catalog.getLayerGroupByName("layerGroup2");
+        assertEquals("another title", lg2.getTitle());        
+    }    
+    
+    public void testLayerGroupAbstract() {
+        LayerGroupInfo lg2 = catalog.getFactory().createLayerGroup();
+        lg2.setWorkspace(catalog.getDefaultWorkspace());
+        lg2.setName("layerGroup2");
+        lg2.setAbstract("layerGroup2 abstract");
+        lg2.getLayers().add(l);
+        lg2.getStyles().add(s);
+        catalog.add(lg2);
+
+        assertEquals(1, catalog.getLayerGroups().size());
+        
+        lg2 = catalog.getLayerGroupByName("layerGroup2");
+        assertEquals("layerGroup2 abstract", lg2.getAbstract());
+
+        lg2.setAbstract("another abstract");
+        catalog.save(lg2);
+        
+        lg2 = catalog.getLayerGroupByName("layerGroup2");
+        assertEquals("another abstract", lg2.getAbstract());        
+    }    
+    
     static class TestListener implements CatalogListener {
 
         public List<CatalogAddEvent> added = new ArrayList();

--- a/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.html
@@ -8,6 +8,14 @@
          <input wicket:id="name" id="name" class="text"></input>
        </li>
        <li>
+         <label for="title"><wicket:message key="layerGroupTitle">Title</wicket:message></label>
+         <input wicket:id="title" id="title" class="text"></input>
+       </li>
+       <li>
+         <label for="abstract"><wicket:message key="abstract">Abstract</wicket:message></label>
+         <textarea rows="60" cols="20" wicket:id="abstract"></textarea>
+       </li>       
+       <li>
          <label for="workspace"><wicket:message key="workspace">Workspace</wicket:message></label>
          <select wicket:id="workspace"></select>
        </li>

--- a/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.logging.Level;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.Page;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
@@ -19,6 +18,7 @@ import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.SubmitLink;
+import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
@@ -80,6 +80,9 @@ public abstract class AbstractLayerGroupPage extends GeoServerSecuredPage {
         //JD: don't need this, this is validated at the catalog level
         //name.add(new GroupNameValidator());
         form.add(name);
+        
+        form.add(new TextField("title"));
+        form.add(new TextArea("abstract"));
         
         DropDownChoice<WorkspaceInfo> wsChoice = 
                 new DropDownChoice("workspace", new WorkspacesModel(), new WorkspaceChoiceRenderer());

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -274,6 +274,7 @@ JVMFontsPage.th.previewImage = Preview
 
 KeywordsEditor.currentKeywords = Current Keywords
 
+AbstractLayerGroupPage.layerGroupTitle = Title
 AbstractLayerGroupPage.bounds          = Bounds
 AbstractLayerGroupPage.chooseLayer     = Choose new layer
 AbstractLayerGroupPage.chooseStyle     = Choose alternate style

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -27,6 +27,7 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang.StringUtils;
 import org.geoserver.catalog.AttributionInfo;
 import org.geoserver.catalog.AuthorityURLInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -44,7 +45,6 @@ import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.ows.URLMangler.URLType;
-import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.ExtendedCapabilitiesProvider;
 import org.geoserver.wms.GetCapabilities;
@@ -63,9 +63,7 @@ import org.geotools.util.logging.Logging;
 import org.geotools.xml.transform.TransformerBase;
 import org.geotools.xml.transform.Translator;
 import org.opengis.feature.type.Name;
-import org.opengis.geometry.MismatchedDimensionException;
 import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.TransformException;
 import org.springframework.util.Assert;
@@ -929,8 +927,18 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                 qatts.addAttribute("", "queryable", "queryable", "", queryable ? "1" : "0");
                 start("Layer", qatts);
                 element("Name", layerName);
-                element("Title", layerName);
-                element("Abstract", "Layer-Group type layer: " + layerName);
+                
+                if (StringUtils.isEmpty(layerGroup.getTitle())) {
+                    element("Title", layerName);                    
+                } else {
+                    element("Title", layerGroup.getTitle());
+                }
+
+                if (StringUtils.isEmpty(layerGroup.getAbstract())) {
+                    element("Abstract", "Layer-Group type layer: " + layerName);
+                } else {
+                    element("Abstract", layerGroup.getAbstract());
+                }
 
                 final ReferencedEnvelope layerGroupBounds = layerGroup.getBounds();
                 final ReferencedEnvelope latLonBounds = layerGroupBounds.transform(

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -32,6 +32,7 @@ import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 
+import org.apache.commons.lang.StringUtils;
 import org.geoserver.catalog.AttributionInfo;
 import org.geoserver.catalog.AuthorityURLInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -956,9 +957,19 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                 // qatts.addAttribute("", "cascaded", "cascaded", "", "1");
                 start("Layer", qatts);
                 element("Name", layerName);
-                element("Title", layerName);
-                element("Abstract", "Layer-Group type layer: " + layerName);
+                
+                if (StringUtils.isEmpty(layerGroup.getTitle())) {
+                    element("Title", layerName);                    
+                } else {
+                    element("Title", layerGroup.getTitle());
+                }
 
+                if (StringUtils.isEmpty(layerGroup.getAbstract())) {
+                    element("Abstract", "Layer-Group type layer: " + layerName);
+                } else {
+                    element("Abstract", layerGroup.getAbstract());
+                } 
+                
                 final ReferencedEnvelope layerGroupBounds = layerGroup.getBounds();
                 final ReferencedEnvelope latLonBounds = layerGroupBounds.transform(
                         DefaultGeographicCRS.WGS84, true);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LayerGroupWorkspaceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LayerGroupWorkspaceTest.java
@@ -26,16 +26,16 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
 
         Catalog cat = getCatalog();
 
-        global = createLayerGroup(cat, "base", 
+        global = createLayerGroup(cat, "base", "base default",
             layer(cat, MockData.LAKES), layer(cat, MockData.FORESTS));
         cat.add(global);
 
-        sf = createLayerGroup(cat, "base", layer(cat, MockData.PRIMITIVEGEOFEATURE), 
+        sf = createLayerGroup(cat, "base", "sf base", layer(cat, MockData.PRIMITIVEGEOFEATURE),
             layer(cat, MockData.AGGREGATEGEOFEATURE));
         sf.setWorkspace(cat.getWorkspaceByName("sf"));
         cat.add(sf);
 
-        cite = createLayerGroup(cat, "base", layer(cat, MockData.BRIDGES), 
+        cite = createLayerGroup(cat, "base", "cite base", layer(cat, MockData.BRIDGES), 
             layer(cat, MockData.BUILDINGS));
         cite.setWorkspace(cat.getWorkspaceByName("cite"));
         cat.add(cite);
@@ -49,9 +49,11 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
         return cat.getLayerByName(getLayerId(name));
     }
 
-    LayerGroupInfo createLayerGroup(Catalog cat, String name, LayerInfo... layers) throws Exception {
+    LayerGroupInfo createLayerGroup(Catalog cat, String name, String title, LayerInfo... layers) throws Exception {
         LayerGroupInfo group = cat.getFactory().createLayerGroup();
         group.setName(name);
+        group.setTitle("title for layer group " + title);
+        group.setAbstract("abstract for layer group " + title); 
         group.getLayers().addAll(Arrays.asList(layers));
         new CatalogBuilder(cat).calculateLayerGroupBounds(group);
         return group;
@@ -59,7 +61,7 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
 
     public void testAddLayerGroup() throws Exception {
         Catalog cat = getCatalog();
-        LayerGroupInfo lg = createLayerGroup(cat, "base", layer(cat, MockData.LOCKS));
+        LayerGroupInfo lg = createLayerGroup(cat, "base", "base", layer(cat, MockData.LOCKS));
         try {
             cat.add(lg);
             fail();
@@ -80,6 +82,20 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
         assertBounds(cite, "cite:base", dom);
     }
 
+    public void testLayerGroupTitleInCapabilities() throws Exception {
+        Document dom = getAsDOM("wms?request=getcapabilities&version=1.3.0");
+        assertXpathExists("//wms:Layer/wms:Title[text() = 'title for layer group base default']", dom);
+        assertXpathExists("//wms:Layer/wms:Title[text() = 'title for layer group sf base']", dom);
+        assertXpathExists("//wms:Layer/wms:Title[text() = 'title for layer group cite base']", dom);
+    }
+    
+    public void testLayerGroupAbstractInCapabilities() throws Exception {
+        Document dom = getAsDOM("wms?request=getcapabilities&version=1.3.0", false);
+        assertXpathExists("//wms:Layer/wms:Abstract[text() = 'abstract for layer group base default']", dom);
+        assertXpathExists("//wms:Layer/wms:Abstract[text() = 'abstract for layer group sf base']", dom);
+        assertXpathExists("//wms:Layer/wms:Abstract[text() = 'abstract for layer group cite base']", dom);
+    }    
+    
     public void testWorkspaceCapabilities() throws Exception {
         Document dom = getAsDOM("sf/wms?request=getcapabilities&version=1.3.0");
 


### PR DESCRIPTION
Hi,
this patch should fix these issues for 2.2.x:
http://jira.codehaus.org/browse/GEOS-5325
http://jira.codehaus.org/browse/GEOS-4142

I've added Title and Abstract to LayerGroupInfo (using metadata). 
Updated the web admin UI.
Updated WMS 1.1 and 1.3 GetCapabilities response.
