### PR TITLE
[GEOS-5352] Use JDK Xalan to reduce PermGen consumption

### DIFF
--- a/src/community/app-schema/webservice-test/pom.xml
+++ b/src/community/app-schema/webservice-test/pom.xml
@@ -33,12 +33,6 @@
 			<artifactId>wfs</artifactId>
 		</dependency>
 		<dependency>
-			<!-- required for complex feature WFS output (see GML3OutputFormat) -->
-			<groupId>xalan</groupId>
-			<artifactId>xalan</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.geoserver.extension</groupId>
 			<artifactId>app-schema-test</artifactId>
 			<version>${project.version}</version>

--- a/src/extension/app-schema/app-schema-oracle-test/pom.xml
+++ b/src/extension/app-schema/app-schema-oracle-test/pom.xml
@@ -40,12 +40,6 @@
             <artifactId>wms</artifactId>
         </dependency>     		
         <dependency>
-            <!-- required for complex feature WFS output (see GML3OutputFormat) -->
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.geoserver</groupId>
             <artifactId>restconfig</artifactId>
             <version>${project.version}</version>

--- a/src/extension/app-schema/app-schema-postgis-test/pom.xml
+++ b/src/extension/app-schema/app-schema-postgis-test/pom.xml
@@ -40,12 +40,6 @@
             <artifactId>wms</artifactId>
         </dependency>
         <dependency>
-            <!-- required for complex feature WFS output (see GML3OutputFormat) -->
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.geoserver</groupId>
             <artifactId>restconfig</artifactId>
             <version>${project.version}</version>

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -40,12 +40,6 @@
             <artifactId>wms</artifactId>
         </dependency>
         <dependency>
-            <!-- required for complex feature WFS output (see GML3OutputFormat) -->
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.geoserver</groupId>
             <artifactId>restconfig</artifactId>
             <version>${project.version}</version>

--- a/src/extension/app-schema/sample-data-access-test/pom.xml
+++ b/src/extension/app-schema/sample-data-access-test/pom.xml
@@ -32,12 +32,6 @@
 			<groupId>org.geoserver</groupId>
 			<artifactId>wfs</artifactId>
 		</dependency>
-        <dependency>
-            <!-- required for complex feature WFS output (see GML3OutputFormat) -->
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <scope>test</scope>
-        </dependency>
 		<dependency>
 			<!-- text-feature-list runtime dependency -->
 			<groupId>com.mockrunner</groupId>

--- a/src/release/LICENSE.txt
+++ b/src/release/LICENSE.txt
@@ -272,11 +272,12 @@ SOFTWARE.
 -------
 
 GeoServer uses a number of libraries licensed under the Apache License, 
-Version 2.0.  These include Spring - http://www.springsource.org/, a number of Apache commons libraries - http://jakarta.apache.org/commons/
+Version 2.0.  These include Spring - http://www.springsource.org/,
+a number of Apache commons libraries - http://jakarta.apache.org/commons/
 whose jars we distribute and include in our source tree under lib/.  Also 
 included as libraries are log4 http://logging.apache.org/log4j/docs/index.htmlj, 
-batik http://xmlgraphics.apache.org/batik/, xerces http://xerces.apache.org/xerces-j/
-and xalan http://xml.apache.org/xalan-j/.  Note there is some disagreement as to 
+batik http://xmlgraphics.apache.org/batik/, and xerces http://xerces.apache.org/xerces-j/.
+Note there is some disagreement as to 
 whether GPL and Apache 2.0 are compatible see 
 http://www.apache.org/licenses/GPL-compatibility.html for more information.  We
 hope that something will work out, as GeoServer would not be possible without

--- a/src/release/ext-app-schema.xml
+++ b/src/release/ext-app-schema.xml
@@ -19,8 +19,6 @@
                 <!-- gt-app-schema and gt-app-schema-resolver jars-->
                 <include>gt-app-schema-*.jar</include>
                 <include>xml-commons-resolver-*.jar</include>
-                <!-- required for complex feature WFS output (see GML3OutputFormat) -->
-                <include>xalan-*.jar</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/src/release/extensions/app-schema/app-schema-README.txt
+++ b/src/release/extensions/app-schema/app-schema-README.txt
@@ -8,11 +8,10 @@ Installation
 1. Extract the contents of the zip archive.
 
 2. Copy the jar files into the WEB-INF/lib/ directory in your GeoServer installation.
-   There should be four of these:
+   There should be three of these:
    - gt-app-schema-{something}.jar
    - gt-app-schema-resolver-{something}.jar
    - xml-commons-resolver-{something}.jar
-   - xalan-{something}.jar
 
 3. Restart GeoServer by reloading the servlet or restarting your servlet container.
 

--- a/src/release/pom.xml
+++ b/src/release/pom.xml
@@ -46,10 +46,6 @@
    <artifactId>xmlParserAPIs</artifactId>
   </dependency>
   <dependency>
-   <groupId>xalan</groupId>
-   <artifactId>xalan</artifactId>
-  </dependency>
-  <dependency>
    <groupId>commons-el</groupId>
    <artifactId>commons-el</artifactId>
   </dependency>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -399,11 +399,6 @@
             <artifactId>gt-app-schema</artifactId>
             <version>${gt.version}</version>
         </dependency>
-        <dependency>
-            <!-- required for complex feature WFS output (see GML3OutputFormat) -->
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/src/wfs/src/main/resources/ChangeNumberOfFeature.xslt
+++ b/src/wfs/src/main/resources/ChangeNumberOfFeature.xslt
@@ -8,7 +8,7 @@
             <xsl:apply-templates select="@*|node()" />
         </xsl:copy>
     </xsl:template>
-    <xsl:template match="@*|text()|comment()|processing-instruction">
+    <xsl:template match="@*|text()|comment()|processing-instruction()">
         <xsl:copy-of select="." />
     </xsl:template>
     <xsl:template match="//wfs:FeatureCollection/@numberOfFeatures">

--- a/src/wfs/src/main/resources/ChangeNumberOfFeature32.xslt
+++ b/src/wfs/src/main/resources/ChangeNumberOfFeature32.xslt
@@ -7,7 +7,7 @@
             <xsl:apply-templates select="@*|node()" />
         </xsl:copy>
     </xsl:template>
-    <xsl:template match="@*|text()|comment()|processing-instruction">
+    <xsl:template match="@*|text()|comment()|processing-instruction()">
         <xsl:copy-of select="." />
     </xsl:template>
     <xsl:template match="/wfs:FeatureCollection">


### PR DESCRIPTION
Justin,

in addition to app-schema pom changes, this commit makes two tiny changes in wfs to the XSLTs used by GML3OutputFormat and GML32OutputFormat to workaround a problem in the the Xalan 2.6.0 shipped with the JDK:
https://jira.codehaus.org/browse/GEOS-5352

The fix, which was suggested by Pavel Golodoniuc, is to add brackets "()" after processing-instruction.

xalan is still used in geoxacml (community) and in the test phase of ows and wms, so there is a remaining dependency version set in the top-level pom. Until this change, xalan was included in the app-schema plugin, but now we no longer need to ship xalan with GeoServer .

Kind regards,
Ben.
