### PR TITLE
Exclude old json-lib version from GWC

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -146,6 +146,12 @@
     <groupId>org.geoserver</groupId>
     <artifactId>gwc</artifactId>
     <version>${gs.version}</version>
+    <exclusions>
+    	<exclusion>
+    		<groupId>net.sf.json-lib</groupId>
+      		<artifactId>json-lib</artifactId>
+    	</exclusion>
+    </exclusions>
    </dependency>
    <dependency>
     <groupId>org.geoserver</groupId>


### PR DESCRIPTION
GeoServer depends on two different version of the json-lib library (2.1 and 2.2.3).

The 2.1 version comes from GeoWebCache (https://github.com/GeoWebCache/geowebcache/blob/master/geowebcache/pom.xml) while the 2.2.3 version comes from GeoServer itself (https://github.com/geoserver/geoserver/blob/master/src/pom.xml).

This pull requests adds an exclusion to the GWC json-lib dependency.   This is necessary to get GeoScript Groovy working with the community script module.
