### PR TITLE
[GEOS-5395] Catalog reload breaks GWC integration

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -4,13 +4,9 @@
  */
 package org.geoserver.gwc;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import static org.geoserver.data.test.MockData.BASIC_POLYGONS;
-import static org.geoserver.gwc.GWC.tileLayerName;
+import static junit.framework.Assert.*;
+import static org.geoserver.data.test.MockData.*;
+import static org.geoserver.gwc.GWC.*;
 
 import java.io.IOException;
 import java.util.Date;
@@ -50,6 +46,7 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
     @Before
     public void resetLayers() throws IOException {
         revertLayer(BASIC_POLYGONS);
+        revertLayer(MPOINTS);
     }
 
     @Test 
@@ -338,4 +335,28 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
             assertTrue(true);
         }
     }
+    
+    @Test
+    public void testRemoveLayerAfterReload() throws Exception {
+        Catalog cat = getCatalog();
+        TileLayerDispatcher tld = GeoWebCacheExtensions.bean(TileLayerDispatcher.class);
+        
+        LayerInfo li = cat.getLayerByName(super.getLayerId(MockData.MPOINTS));
+        String layerName = tileLayerName(li);
+
+        assertNotNull(tld.getTileLayer(layerName));
+
+        // force reload
+        getGeoServer().reload();
+        
+        // now remove the layer and check it has been removed from GWC as well
+        cat.remove(li);
+        try {
+            tld.getTileLayer(layerName);
+            fail("Layer should not exist");
+        } catch (GeoWebCacheException gwce) {
+            // fine
+        }
+    }
+    
 }

--- a/src/main/src/main/java/org/geoserver/catalog/Catalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Catalog.java
@@ -1764,4 +1764,11 @@ public interface Catalog extends CatalogInfo {
             final Filter filter, @Nullable Integer offset, @Nullable Integer count,
             @Nullable SortBy sortBy);
 
+    /**
+     * Removes all the listeners which are instances of the specified class
+     * 
+     * @param listenerClass
+     */
+    public void removeListeners(Class listenerClass);
+
 }

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -1641,7 +1641,7 @@ public class ResourcePool {
     /**
      * Listens to catalog events clearing cache entires when resources are modified.
      */
-    class CacheClearingListener extends CatalogVisitorAdapter implements CatalogListener {
+    public class CacheClearingListener extends CatalogVisitorAdapter implements CatalogListener {
 
         public void handleAddEvent(CatalogAddEvent event) {
         }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogDecorator.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogDecorator.java
@@ -686,4 +686,8 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
             Integer offset, Integer count, SortBy sortOrder) {
         return delegate.list(of, filter, offset, count, sortOrder);
     }
+
+    public void removeListeners(Class listenerClass) {
+        delegate.removeListeners(listenerClass);
+    }
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1273,6 +1273,16 @@ public class CatalogImpl implements Catalog {
     public void removeListener(CatalogListener listener) {
         listeners.remove(listener);
     }
+    
+    @Override
+    public void removeListeners(Class listenerClass) {
+        for (Iterator it = listeners.iterator(); it.hasNext();) {
+            CatalogListener listener = (CatalogListener) it.next();
+            if(listenerClass.isInstance(listener)) {
+                it.remove();
+            }
+        }
+    }
 
     public Iterator search(String cql) {
         // TODO Auto-generated method stub
@@ -1294,7 +1304,6 @@ public class CatalogImpl implements Catalog {
         this.resourceLoader = resourceLoader;
     }
     public void dispose() {
-        if ( listeners != null ) listeners.clear();
         if ( resourcePool != null ) resourcePool.dispose();
         facade.dispose();
     }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
@@ -15,6 +15,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
 import org.geoserver.ows.LocalWorkspace;
@@ -330,5 +331,9 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
             }
         };
         return CloseableIteratorAdapter.transform(iterator, wrappingFunction);
+    }
+
+    public void removeListeners(Class listenerClass) {
+        delegate.removeListeners(listenerClass);
     }
 }

--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -31,16 +31,17 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ResourcePool;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.Wrapper;
+import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.util.LegacyCatalogImporter;
 import org.geoserver.catalog.util.LegacyCatalogReader;
 import org.geoserver.catalog.util.LegacyFeatureTypeInfoReader;
-import org.geoserver.config.impl.GeoServerInfoImpl;
 import org.geoserver.config.util.LegacyConfigurationImporter;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterFactory;
@@ -49,10 +50,7 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geotools.util.logging.Logging;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.web.context.WebApplicationContext;
 import org.vfny.geoserver.global.GeoserverDataDirectory;
 
@@ -214,18 +212,30 @@ public abstract class GeoServerLoader {
     }
 
     protected void readCatalog(Catalog catalog, XStreamPersister xp) throws Exception {
+        // we are going to synch up the catalogs and need to preserve listeners,
+        // but these two fellas are attached to the new catalog as well
+        catalog.removeListeners(ResourcePool.CacheClearingListener.class);
+        catalog.removeListeners(GeoServerPersister.class);
+        List<CatalogListener> listeners = new ArrayList<CatalogListener>(catalog.getListeners());
+
         //look for catalog.xml, if it exists assume we are dealing with 
         // an old data directory
         File f = resourceLoader.find( "catalog.xml" );
         if ( f == null ) {
             //assume 2.x style data directory
             CatalogImpl catalog2 = (CatalogImpl) readCatalog( xp );
+            // make to remove the old resource pool catalog listener
             ((CatalogImpl)catalog).sync( catalog2 );
         } else {
             // import old style catalog, register the persister now so that we start 
             // with a new version of the catalog
             CatalogImpl catalog2 = (CatalogImpl) readLegacyCatalog( f, xp );
             ((CatalogImpl)catalog).sync( catalog2 );
+        }
+        
+        // attach back the old listeners
+        for (CatalogListener listener : listeners) {
+            catalog.addListener(listener);
         }
     }
     

--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -1459,4 +1459,8 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         }
         return false;
     }
+
+    public void removeListeners(Class listenerClass) {
+        delegate.removeListeners(listenerClass);
+    }
 }

--- a/src/main/src/test/java/org/geoserver/catalog/CatalogIntegrationTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/CatalogIntegrationTest.java
@@ -1,19 +1,23 @@
 package org.geoserver.catalog;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.*;
 
 import java.util.List;
 
-import org.geoserver.data.test.TestData;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.config.GeoServerPersister;
+import org.geoserver.data.test.MockData;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.test.SystemTest;
+import org.geoserver.test.TestSetup;
+import org.geoserver.test.TestSetupFrequency;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(SystemTest.class)
+@TestSetup(run=TestSetupFrequency.REPEAT)
 public class CatalogIntegrationTest extends GeoServerSystemTestSupport {
-
+    
     @Test
     public void testWorkspaceRemoveAndReadd() {
         // remove all workspaces
@@ -36,5 +40,46 @@ public class CatalogIntegrationTest extends GeoServerSystemTestSupport {
         
         // get back by name (this would NPE too)
         assertNotNull(catalog.getNamespaceByURI(defaultNamespace.getURI()));
+    }
+    
+    /**
+     * Checks that the namespace/workspace listener keeps on working after
+     * a catalog reload
+     */
+    @Test
+    public void testNamespaceWorkspaceListenerAttached() throws Exception {
+        Catalog catalog = getCatalog();
+        
+        NamespaceInfo ns = catalog.getNamespaceByPrefix(MockData.CITE_PREFIX);
+        String newName = "XYWZ1234";
+        ns.setPrefix(newName);
+        catalog.save(ns);
+        assertNotNull(catalog.getWorkspaceByName(newName));
+        assertNotNull(catalog.getNamespaceByPrefix(newName));
+        
+        // force a reload
+        int listenersBefore = catalog.getListeners().size();
+        getGeoServer().reload();
+        int listenersAfter = catalog.getListeners().size();
+        assertEquals(listenersBefore, listenersAfter);
+        
+        // check the NamespaceWorkspaceListener is still attached and working
+        ns = catalog.getNamespaceByPrefix(newName);
+        ns.setPrefix(MockData.CITE_PREFIX);
+        catalog.save(ns);
+        assertNotNull(catalog.getWorkspaceByName(MockData.CITE_PREFIX));
+        
+        // make sure we only have one resource pool listener and one catalog persister
+        int countCleaner = 0;
+        int countPersister = 0;
+        for (CatalogListener listener : catalog.getListeners()) {
+            if(listener instanceof ResourcePool.CacheClearingListener) {
+                countCleaner++;
+            } else if(listener instanceof GeoServerPersister) {
+                countPersister++;
+            }
+        }
+        assertEquals(1, countCleaner);
+        assertEquals(1, countPersister);
     }
 }

--- a/src/main/src/test/java/org/geoserver/catalog/impl/util/LegacyCatalogImporterTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/util/LegacyCatalogImporterTest.java
@@ -8,6 +8,7 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.util.LegacyCatalogImporter;
+import org.geoserver.config.GeoServerLoader;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.TestData;
 import org.geoserver.test.GeoServerAbstractTestSupport;
@@ -15,6 +16,13 @@ import org.geoserver.test.GeoServerAbstractTestSupport;
 public class LegacyCatalogImporterTest extends GeoServerAbstractTestSupport {
 
     private static final QName typeName = MockData.BASIC_POLYGONS;
+    
+    @Override
+    protected void tearDownInternal() throws Exception {
+        super.tearDownInternal();
+        // reset the legacy flag so that other tests are not getting affected by it
+        GeoServerLoader.setLegacy(false);
+    }
 
     @Override
     protected TestData buildTestData() throws Exception {

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -23,6 +23,7 @@ import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CatalogFactory;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.config.GeoServerLoader;
 import org.geoserver.data.test.MockData;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.platform.ServiceException;
@@ -64,6 +65,13 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         gi.getStyles().add(getCatalog().getStyleByName("polygon"));
         cb.calculateLayerGroupBounds(gi);
         getCatalog().add(gi);
+    }
+    
+    @Override
+    protected void oneTimeTearDown() throws Exception {
+        super.oneTimeTearDown();
+        // reset the legacy flag so that other tests are not getting affected by it
+        GeoServerLoader.setLegacy(false);
     }
 
     protected void setUpInternal() throws Exception {


### PR DESCRIPTION
Compared to the approach discussed in the mailing list I've found that also the geoserver persister was causing issues, also the order of the operations prevented a simple "clean and re-add" approach where the listeners were being re-attached, so moved the approach out of the catalog and into the code which is the origin of the problem.
The GeoServer loader now stores the "non persistence" related listeners and adds them back after the synch is performed.
Imho this looks better than having the catalog knowing which listers it has to deal with.
