### PR TITLE
GEOS-4173: Proper handling of POST/PUT bodies

### DIFF
--- a/src/community/proxy/src/main/java/org/geoserver/rest/proxy/ProxyRestlet.java
+++ b/src/community/proxy/src/main/java/org/geoserver/rest/proxy/ProxyRestlet.java
@@ -92,30 +92,40 @@ public class ProxyRestlet extends Restlet {
         /* The first argument should be the request for a URL to grab by proxy */
         String url = f.getFirstValue("url");
         try {
+            Boolean isPutOrPost = request.getMethod().equals(Method.PUT)
+                    || request.getMethod().equals(Method.POST);
+
             /*Construct the connection to the server*/
             URL resolved = new URL(url);
-            final HttpURLConnection connection = (HttpURLConnection) resolved.openConnection();;
-            
-            /*Set appropriately whether the connection does output.*/
-            if (request.getMethod().equals(Method.PUT)
-                    || request.getMethod().equals(Method.POST)) {
+            final HttpURLConnection connection = (HttpURLConnection) resolved.openConnection();
+
+            if (isPutOrPost) {
+                /*Set appropriately whether the connection does output.*/
                 connection.setDoOutput(true);
+                connection.setChunkedStreamingMode(4096);
             }
             
             //connection 
             connection.setRequestMethod(request.getMethod().toString());
 
-            /*Check if this request is permitted to be forwarded*/
+            if (isPutOrPost) {
+                String contentType = request.getEntity().getMediaType().toString();
+
+                /*Check if this request is permitted to be forwarded*/
+                if (checkPermission(resolved, contentType) != true) {
+                    throw new RestletException("Nonpermitted hostname or request body with nonpermitted content type",
+                            Status.CLIENT_ERROR_BAD_REQUEST);
+                }
+
+                /*Appropriately forward the message*/
+                connection.addRequestProperty("Content-Type", contentType);
+                copyStream(request.getEntity().getStream(), connection.getOutputStream());
+            }
+
+            /*Check if this response is permitted to be forwarded*/
             if (checkPermission(resolved, connection.getContentType()) != true) {
                 throw new RestletException("Request for nonpermitted content type or hostname",
                         Status.CLIENT_ERROR_BAD_REQUEST);
-            }
-                
-            /*Appropriately forward the message*/
-            if (request.getMethod().equals(Method.PUT)
-                    || request.getMethod().equals(Method.POST)) {
-                //connection.setDoOutput(true);
-                copyStream(request.getEntity().getStream(), connection.getOutputStream());
             }
                 
             response.setEntity(new StreamRepresentation(new MediaType(connection


### PR DESCRIPTION
With this change, request bodies and Content-Type headers are properly
forwarded to the upstream server. Permissions are now checked twice:
before sending the request, and before receiving the response. For the
request, the same Content-Type restrictions apply as for the response.
