### PR TITLE
EnvelopePanel and ReferencedEnvelope fixes for GEOS-5474 and GEOS-5475

### DIFF
--- a/src/community/monitoring/src/main/java/org/geoserver/monitor/ows/wfs/WFSRequestObjectHandler.java
+++ b/src/community/monitoring/src/main/java/org/geoserver/monitor/ows/wfs/WFSRequestObjectHandler.java
@@ -40,7 +40,7 @@ public abstract class WFSRequestObjectHandler extends RequestObjectHandler {
             try {
                 bounds = filter.getBounds();
                 if(bounds.getCoordinateReferenceSystem()==null){
-                    bounds = ReferencedEnvelope.reference(bounds, bbox.getCoordinateReferenceSystem());
+                    bounds = ReferencedEnvelope.create(bounds, bbox.getCoordinateReferenceSystem());
                 }
                 bounds.toBounds(monitorConfig.getBboxLogCrs());
             } catch (TransformException ex) {

--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -39,6 +39,7 @@ import org.geotools.data.wms.WebMapServer;
 import org.geotools.factory.GeoTools;
 import org.geotools.gce.imagemosaic.ImageMosaicFormat;
 import org.geotools.geometry.GeneralEnvelope;
+import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.CRS.AxisOrder;
@@ -514,8 +515,7 @@ public class CatalogBuilder {
             if (!CRS.equalsIgnoreMetadata(DefaultGeographicCRS.WGS84, declaredCRS)) {
                 // transform
                 try {
-                    ReferencedEnvelope bounds = new ReferencedEnvelope(nativeBounds, declaredCRS);
-                    return bounds.transform(DefaultGeographicCRS.WGS84, true);
+                	return JTS.toGeographic( nativeBounds );
                 } catch (Exception e) {
                     throw (IOException) new IOException("transform error").initCause(e);
                 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/ResourceInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ResourceInfoImpl.java
@@ -25,6 +25,8 @@ import org.geotools.util.logging.Logging;
 import org.opengis.feature.type.Name;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
+import com.vividsolutions.jts.geom.Envelope;
+
 /**
  * Default implementation of {@link ResourceInfo}.
  * 
@@ -222,7 +224,7 @@ public abstract class ResourceInfoImpl implements ResourceInfo {
           php == ProjectionPolicy.REPROJECT_TO_DECLARED ) {
           return nativeBox.transform(declaredCRS,true); 
       } else if(php == ProjectionPolicy.FORCE_DECLARED) {
-          return new ReferencedEnvelope(nativeBox, declaredCRS);
+    	  return ReferencedEnvelope.create( (Envelope) nativeBox, declaredCRS);
       }
       
       return nativeBox;

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.html
@@ -15,12 +15,20 @@
       <input wicket:id="minY" id="minY" type="text" class="text" style="width: 100px;"/>
      </li>
      <li class="leftwise">
+      <label for="minZ" wicket:id="minZL">Min Z</label>
+      <input wicket:id="minZ" id="minZ" type="text" class="text" style="width: 100px;"/>
+     </li>
+     <li class="leftwise">
       <label for="maxX" wicket:id="maxXL">Max X</label>
       <input wicket:id="maxX" id="maxX" type="text" class="text" style="width: 100px;"/>
      </li>
      <li class="leftwise">
       <label for="maxY" wicket:id="maxYL">Max Y</label>
       <input wicket:id="maxY" id="maxY" type="text" class="text" style="width: 100px;"/>
+     </li>
+     <li class="leftwise">
+      <label for="maxZ" wicket:id="maxZL">Max Z</label>
+      <input wicket:id="maxZ" id="maxZ" type="text" class="text" style="width: 100px;"/>
      </li>
      <br/>
      <li class="clearBoth" wicket:id="crsContainer">

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.java
@@ -14,6 +14,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.geometry.jts.ReferencedEnvelope3D;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
@@ -26,11 +27,11 @@ import com.vividsolutions.jts.geom.Envelope;
  */
 public class EnvelopePanel extends FormComponentPanel {
 
-    protected Label minXLabel, minYLabel, maxXLabel, maxYLabel;
+    protected Label minXLabel, minYLabel, maxXLabel, maxYLabel, minZLabel, maxZLabel;
 
-    protected Double minX,minY,maxX,maxY;
+    protected Double minX,minY,maxX,maxY,minZ,maxZ;
 
-    protected DecimalTextField minXInput, minYInput, maxXInput, maxYInput;
+    protected DecimalTextField minXInput, minYInput, maxXInput, maxYInput, minZInput, maxZInput;
 
     protected CoordinateReferenceSystem crs;
     protected WebMarkupContainer crsContainer;
@@ -74,11 +75,17 @@ public class EnvelopePanel extends FormComponentPanel {
         this.crsRequired = crsRequired;
     }
     
+    public boolean is3D(){
+    	return crs != null && crs.getCoordinateSystem().getDimension() >= 3;
+    }
+    
     public void setLabelsVisibility(boolean visible) {
         minXLabel.setVisible(visible);
         minYLabel.setVisible(visible);
         maxXLabel.setVisible(visible);
         maxYLabel.setVisible(visible);
+        minZLabel.setVisible(visible && is3D());
+        maxZLabel.setVisible(visible && is3D());
     }
 
     void initComponents() {
@@ -86,13 +93,24 @@ public class EnvelopePanel extends FormComponentPanel {
         
         add(minXLabel = new Label("minXL", new ResourceModel("minX")));
         add(minYLabel = new Label("minYL", new ResourceModel("minY")));
+        add(minZLabel = new Label("minZL", new ResourceModel("minZ")));
         add(maxXLabel = new Label("maxXL", new ResourceModel("maxX")));
         add(maxYLabel = new Label("maxYL", new ResourceModel("maxY")));
+        add(maxZLabel = new Label("maxZL", new ResourceModel("maxZ")));
 
+        
         add( minXInput = new DecimalTextField( "minX", new PropertyModel(this, "minX")) );
         add( minYInput = new DecimalTextField( "minY", new PropertyModel(this, "minY")) );
+        add( minZInput = new DecimalTextField( "minZ", new PropertyModel(this, "minZ")) );
         add( maxXInput = new DecimalTextField( "maxX", new PropertyModel(this, "maxX") ));
         add( maxYInput = new DecimalTextField( "maxY", new PropertyModel(this, "maxY")) );
+        add( maxZInput = new DecimalTextField( "maxZ", new PropertyModel(this, "maxZ")) );
+        
+        minZInput.setVisible(is3D());
+        minZLabel.setVisible(is3D());
+        maxZInput.setVisible(is3D());
+        maxZLabel.setVisible(is3D());
+        
         crsContainer = new WebMarkupContainer("crsContainer");
         crsContainer.setVisible(false);
         crsPanel = new CRSPanel("crs", new PropertyModel(this, "crs"));
@@ -114,6 +132,20 @@ public class EnvelopePanel extends FormComponentPanel {
             this.maxX = e.getMaxX();
             this.maxY = e.getMaxY();
             this.crs = e.getCoordinateReferenceSystem();
+            if( is3D() ){
+            	if( e instanceof ReferencedEnvelope3D ){
+	            	this.minZ = ((ReferencedEnvelope3D)e).getMinZ();
+	            	this.maxZ = ((ReferencedEnvelope3D)e).getMaxZ();
+            	}
+            	else {
+            		this.minZ = Double.NaN;
+            		this.maxZ = Double.NaN;
+            	}
+            }
+            else {
+            	this.minZ = Double.NaN;
+        		this.maxZ = Double.NaN;
+            }
         }
     }
    
@@ -147,7 +179,14 @@ public class EnvelopePanel extends FormComponentPanel {
             if(crsRequired && crs == null) {
                 setConvertedInput(null);
             } else {
-                setConvertedInput(new ReferencedEnvelope(minX, maxX, minY, maxY, crs));
+            	if( is3D() ){
+        			double minZsafe = minZ == null ? Double.NaN : minZ;
+        			double maxZsafe = maxZ == null ? Double.NaN : maxZ;
+    				setConvertedInput(new ReferencedEnvelope3D(minX, maxX, minY, maxY, minZsafe, maxZsafe,crs));
+        		}
+            	else {
+            		setConvertedInput(new ReferencedEnvelope(minX, maxX, minY, maxY, crs));
+            	}
             }
         } else {
             setConvertedInput(null);

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -169,8 +169,10 @@ DemoPage.title       = GeoServer Demos
 
 EnvelopePanel.maxX  = Max X
 EnvelopePanel.maxY  = Max Y
+EnvelopePanel.maxZ  = Max Z
 EnvelopePanel.minX  = Min X
 EnvelopePanel.minY  = Min Y
+EnvelopePanel.minZ  = Min Z
 EnvelopePanel.title = Envelope Panel
 EnvelopePanel.crs = Coordinate Reference System
 

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/AbstractGridSetPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/AbstractGridSetPage.java
@@ -250,8 +250,11 @@ abstract class AbstractGridSetPage extends GeoServerSecuredPage {
 
                 minXInput.add(new UpdateTableBehavior());
                 minYInput.add(new UpdateTableBehavior());
+                minZInput.add(new UpdateTableBehavior());
                 maxXInput.add(new UpdateTableBehavior());
                 maxYInput.add(new UpdateTableBehavior());
+                maxZInput.add(new UpdateTableBehavior());
+                
             }
         }
 


### PR DESCRIPTION
https://jira.codehaus.org/browse/GEOS-5475
Adding Layer with 2.5D geometry trips up over number of ordinates when generating initial bounds

Update EnvelopePanel to dynamically display an MinZ / MaxZ label and field based on CoordinateReferenceSystem selected. With this fix you can now configure an Oracle layer that makes use of 3D data.

(Please accept  https://github.com/geotools/geotools/pull/71 before applying this fix.)

https://jira.codehaus.org/browse/GEOS-5475
GetCapabilities Generation fails when encountering 3D SRS

Upstream changes to ReferenceEnvelope handling has resolved GetCapabilities generation.
(Please accept  https://github.com/geotools/geotools/pull/71 before applying this fix.)
