### PR TITLE
add a reference to the Geoserver Data Directory from the Windows installation page

### DIFF
--- a/doc/en/user/source/installation/windows/binary.rst
+++ b/doc/en/user/source/installation/windows/binary.rst
@@ -32,7 +32,7 @@ You will need to set the ``JAVA_HOME`` environment variable if it is not already
 
 #. Click OK three times.
 
-.. note:: You may also want to set the ``GEOSERVER_HOME`` variable, which is the directory where GeoServer is installed, and the ``GEOSERVER_DATA_DIR`` variable, which is the location of the GeoServer data directory (usually :file:`%GEOSERVER_HOME\\data_dir`).  The latter is mandatory if you wish to use a data directory other than the one built in to GeoServer.  The procedure for setting these variables is identical to the above.
+.. note:: You may also want to set the ``GEOSERVER_HOME`` variable, which is the directory where GeoServer is installed, and the ``GEOSERVER_DATA_DIR`` variable, which is the location of the GeoServer data directory (usually :file:`%GEOSERVER_HOME\\data_dir`).  The latter is mandatory if you wish to use a data directory other than the one built in to GeoServer. The procedure for setting these variables is identical to the above. Note that the specified data directory should be a valid :ref:`data_directory`.
 
 Running
 -------


### PR DESCRIPTION
The Windows binary Installation page (http://docs.geoserver.org/2.2.2/user/installation/windows/binary.html) provides info on how to configure the GEOSERVER_DATA_DIR but it doesn't explicitly state that it needs to be a valid one. The structure of a valid Geoserver data dir is explained after a couple of chapters but an user could already have started geoserver by following the installation page instructions, resulting into an invalid data directory being used at startup.

This simple pull request add a reference to the Geoserver Data Directory section
