### PR TITLE
Backported WMS GetLegendGraphic support for LayerGroups

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
@@ -4,13 +4,16 @@
  */
 package org.geoserver.wms;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.geotools.styling.Rule;
 import org.geotools.styling.Style;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.Name;
 
 /**
  * Holds the parsed parameters for a GetLegendGraphic WMS request.
@@ -24,10 +27,10 @@ import org.opengis.feature.type.FeatureType;
  *  <tr><td><b>Parameter</b></td><td><b>Required</b></td><td><b>Description</b></td></tr>
  *  <tr><td>VERSION </td><td>Required </td><td>Version as required by OGC interfaces.</td></tr>
  *  <tr><td>REQUEST </td><td>Required </td><td>Value must be  GetLegendRequest . </td></tr>
- *  <tr><td>LAYER </td><td>Required </td><td>Layer for which to produce legend graphic. </td></tr>
- *  <tr><td>STYLE </td><td>Optional </td><td>Style of layer for which to produce legend graphic. If not present, the default style is selected. The style may be any valid style available for a layer, including non-SLD internally-defined styles.</td></tr>
+ *  <tr><td>LAYER </td><td>Required </td><td>Layer for which to produce legend graphic. A layergroup can be specified, too. In this case, STYLE and RULE parameters can have multiple values (separated by commas), one for each of the group layers.</td></tr>
+ *  <tr><td>STYLE </td><td>Optional </td><td>Style of layer for which to produce legend graphic. If not present, the default style is selected. The style may be any valid style available for a layer, including non-SLD internally-defined styles. A list of styles separated by commas can be used to specify styles for single layers of a layergroup. To override default style only for some layers leave empty the not overridden ones in the list (ex. style1,,style3,style4 to use default style for layer 2).</td></tr>
  *  <tr><td>FEATURETYPE </td><td>Optional </td><td>Feature type for which to produce the legend graphic. This is not needed if the layer has only a single feature type. </td></tr>
- *  <tr><td>RULE </td><td>Optional </td><td>Rule of style to produce legend graphic for, if applicable. In the case that a style has multiple rules but no specific rule is selected, then the map server is obligated to produce a graphic that is representative of all of the rules of the style.</td></tr>
+ *  <tr><td>RULE </td><td>Optional </td><td>Rule of style to produce legend graphic for, if applicable. In the case that a style has multiple rules but no specific rule is selected, then the map server is obligated to produce a graphic that is representative of all of the rules of the style. A list of rules separated by commas can be used to specify rules for single layers of a layergroup. To specify rule only for some layers leave empty the not overridden ones in the list (ex. rule1,,rule3,rule4 to not specify rule for layer 2).</td></tr>
  *  <tr><td>SCALE </td><td>Optional </td><td>In the case that a RULE is not specified for a style, this parameter may assist the server in selecting a more appropriate representative graphic by eliminating internal rules that are outof- scope. This value is a standardized scale denominator, defined in Section 10.2</td></tr>
  *  <tr><td>SLD </td><td>Optional </td><td>This parameter specifies a reference to an external SLD document. It works in the same way as the SLD= parameter of the WMS GetMap operation. </td></tr>
  *  <tr><td>SLD_BODY </td><td>Optional </td><td>This parameter allows an SLD document to be included directly in an HTTP-GET request. It works in the same way as the SLD_BODY= parameter of the WMS GetMap operation.</td></tr>
@@ -78,16 +81,19 @@ public class GetLegendGraphicRequest extends WMSRequest {
      */
     public static final String DEFAULT_FORMAT = "image/png";
 
-    /** The featuretype of the requested LAYER */
-    private FeatureType layer;
+    /** The featuretype(s) of the requested LAYER(s) */
+    private List<FeatureType> layers=new ArrayList<FeatureType>();
+    
+    /** The featuretype name -> title association map */
+    private Map<Name,String> titles=new HashMap<Name,String>();
 
     /**
-     * The Style object for styling the legend graphic, or layer's default if not provided. This
+     * The Style object(s) for styling the legend graphic, or layer's default if not provided. This
      * style can be aquired by evaluating the STYLE parameter, which provides one of the layer's
      * named styles, the SLD parameter, which provides a URL for an external SLD document, or the
      * SLD_BODY parameter, which provides the SLD body in the request body.
      */
-    private Style style;
+    private List<Style> styles=new ArrayList<Style>();
 
     /**
      * should hold FEATURETYPE parameter value, though not used by now, since GeoServer WMS still
@@ -96,8 +102,8 @@ public class GetLegendGraphicRequest extends WMSRequest {
      */
     private String featureType;
 
-    /** holds RULE parameter value, or <code>null</code> if not provided */
-    private String rule;
+    /** holds RULE parameter value(s), or <code>null</code> if not provided */
+    private List<String> rules=new ArrayList<String>();
 
     /**
      * holds the standarized scale denominator passed as the SCALE parameter value, or
@@ -179,20 +185,38 @@ public class GetLegendGraphicRequest extends WMSRequest {
         this.height = height;
     }
 
-    public FeatureType getLayer() {
-        return layer;
+    public List<FeatureType> getLayers() {
+        return layers;
     }
 
+    public void setLayers(List<FeatureType> layers) {
+        this.layers = layers;
+    }
+    
+    public void setTitle(Name featureTypeName,String title) {
+        titles.put(featureTypeName, title);
+    }
+    
+    public String getTitle(Name featureTypeName) {
+        return titles.get(featureTypeName);
+    }
+    
     public void setLayer(FeatureType layer) {
-        this.layer = layer;
+    	this.layers.clear();
+    	this.layers.add(layer);
     }
 
-    public String getRule() {
-        return rule;
+    public List<String> getRules() {
+        return rules;
     }
 
+    public void setRules(List<String> rules) {
+        this.rules = rules;
+    }
+    
     public void setRule(String rule) {
-        this.rule = rule;
+        this.rules.clear();
+        this.rules.add(rule);
     }
 
     public double getScale() {
@@ -203,12 +227,17 @@ public class GetLegendGraphicRequest extends WMSRequest {
         this.scale = scale;
     }
 
-    public Style getStyle() {
-        return style;
+    public List<Style> getStyles() {
+        return styles;
     }
 
+    public void setStyles(List<Style> styles) {
+        this.styles = styles;
+    }
+    
     public void setStyle(Style style) {
-        this.style = style;
+    	this.styles.clear();
+        this.styles.add(style);
     }
 
     public int getWidth() {
@@ -241,6 +270,9 @@ public class GetLegendGraphicRequest extends WMSRequest {
      * rendering. Anything of the following works: "yes", "true", "1". Anything else means false.
      * <li><code>forceLabels</code>: "on" means labels will always be drawn, even if only one rule
      * is available. "off" means labels will never be drawn, even if multiple rules are available.
+     * <li><code>forceTitles</code>: "on" means layer titles for layergroups will always be drawn, 
+     * even if only one layer is available. "off" means titles will never be drawn, even if multiple
+     * layers are available.
      * </ul>
      * </p>
      * 

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
@@ -100,12 +100,6 @@ public class BufferedImageLegendGraphicBuilder {
     private static final GeometryFactory geomFac = new GeometryFactory();
 
     /**
-     * set to <code>true</code> when <code>abort()</code> gets called, indicates that the rendering
-     * of the legend graphic should stop gracefully as soon as possible
-     */
-    private boolean renderingStopRequested;
-
-    /**
      * Just a holder to avoid creating many polygon shapes from inside <code>getSampleShape()</code>
      */
     private LiteShape2 sampleRect;
@@ -144,160 +138,279 @@ public class BufferedImageLegendGraphicBuilder {
      */
     public BufferedImage buildLegendGraphic(GetLegendGraphicRequest request)
             throws ServiceException {
-        // the style we have to build a legend for
-        Style gt2Style = request.getStyle();
-        if (gt2Style == null) {
-            throw new NullPointerException("request.getStyle()");
-        }
+        // list of images to be rendered for the layers (more than one if
+        // a layer group is given)
+        List<RenderedImage> layersImages=new ArrayList<RenderedImage>();
         
-        // width and height, we might have to rescale those in case of DPI usage
-        int w = request.getWidth();
-        int h = request.getHeight();
-
-        // apply dpi rescale
-        double dpi = RendererUtilities.getDpi(request.getLegendOptions());
-        double standardDpi = RendererUtilities.getDpi(Collections.emptyMap());
-        if(dpi != standardDpi) {
-            double scaleFactor = dpi / standardDpi;
-            w = (int) Math.round(w * scaleFactor);
-            h = (int) Math.round(h * scaleFactor);
-            DpiRescaleStyleVisitor dpiVisitor = new DpiRescaleStyleVisitor(scaleFactor);
-            dpiVisitor.visit(gt2Style);
-            gt2Style = (Style) dpiVisitor.getCopy();
-        }
-        // apply UOM rescaling if we have a scale
-        if (request.getScale() > 0) {
-            double pixelsPerMeters = RendererUtilities.calculatePixelsPerMeterRatio(request.getScale(), request.getLegendOptions());
-            UomRescaleStyleVisitor rescaleVisitor = new UomRescaleStyleVisitor(pixelsPerMeters);
-            rescaleVisitor.visit(gt2Style);
-            gt2Style = (Style) rescaleVisitor.getCopy();
-        }
-
-        final FeatureType layer = request.getLayer();
-        boolean strict = request.isStrict();
-        final boolean buildRasterLegend = (!strict && layer == null && LegendUtils
-                .checkRasterSymbolizer(gt2Style)) || LegendUtils.checkGridLayer(layer);
-        if (buildRasterLegend) {
-            final RasterLayerLegendHelper rasterLegendHelper = new RasterLayerLegendHelper(request);
-            final BufferedImage image = rasterLegendHelper.getLegend();
-            return image;
-        }
-
-       // final SimpleFeature sampleFeature;
-        final Feature sampleFeature;
-        if (layer == null) {
-            sampleFeature = createSampleFeature();
-        } else {
-        	sampleFeature = createSampleFeature(layer);
-        }
-        final FeatureTypeStyle[] ftStyles = gt2Style.featureTypeStyles().toArray(
-                new FeatureTypeStyle[0]);
-        final double scaleDenominator = request.getScale();
-
-        final Rule[] applicableRules;
-        String ruleName = request.getRule();
-        if (ruleName != null) {
-            Rule rule = LegendUtils.getRule(ftStyles, ruleName);
-            if (rule == null) {
-                throw new ServiceException("Specified style does not contains a rule named " + ruleName);
-            }
-            applicableRules = new Rule[] {rule};
-        } else {
-            applicableRules = LegendUtils.getApplicableRules(ftStyles, scaleDenominator);
-        }
-
-        final NumberRange<Double> scaleRange = NumberRange.create(scaleDenominator,
-                scaleDenominator);
-        final int ruleCount = applicableRules.length;
-
-        /**
-         * A legend graphic is produced for each applicable rule. They're being held here until the
-         * process is done and then painted on a "stack" like legend.
-         */
-        final List<RenderedImage> legendsStack = new ArrayList<RenderedImage>(ruleCount);
-
-        final SLDStyleFactory styleFactory = new SLDStyleFactory();
-        final Color bgColor = LegendUtils.getBackgroundColor(request);
-        for (int i = 0; i < ruleCount; i++) {
-            final Symbolizer[] symbolizers = applicableRules[i].getSymbolizers();
-
-            // BufferedImage image = prepareImage(w, h, request.isTransparent());
-            final boolean transparent = request.isTransparent();
-            final RenderedImage image = ImageUtils.createImage(w, h, (IndexColorModel) null,
-                    transparent);
-            final Map<RenderingHints.Key, Object> hintsMap = new HashMap<RenderingHints.Key, Object>();
-            final Graphics2D graphics = ImageUtils.prepareTransparency(transparent, bgColor, image,
-                    hintsMap);
-            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-                    RenderingHints.VALUE_ANTIALIAS_ON);
-
-            for (int sIdx = 0; sIdx < symbolizers.length; sIdx++) {
-                final Symbolizer symbolizer = symbolizers[sIdx];
-
-                if (symbolizer instanceof RasterSymbolizer) {
-                    throw new IllegalStateException(
-                            "It is not legal to have a RasterSymbolizer here");
-                } else {
-                    Style2D style2d = styleFactory.createStyle(sampleFeature, symbolizer,
-                            scaleRange);
-                    LiteShape2 shape = getSampleShape(symbolizer, w, h);
-                    
-                    if (style2d != null) {
-                        shapePainter.paint(graphics, shape, style2d, scaleDenominator);
-                    }
-                }
-            }
-
-            legendsStack.add(image);
-            graphics.dispose();
-        }
-
-        // JD: changed legend behavior, see GEOS-812
-        // this.legendGraphic = scaleImage(mergeLegends(legendsStack), request);
-        BufferedImage image = mergeLegends(legendsStack, applicableRules, request);
-        return image;
-    }
-    
-    /**
-     * Recieves a list of <code>BufferedImages</code> and produces a new one which holds all the
-     * images in <code>imageStack</code> one above the other.
-     * 
-     * @param imageStack
-     *            the list of BufferedImages, one for each applicable Rule
-     * @param rules
-     *            The applicable rules, one for each image in the stack
-     * @param request
-     *            The request.
-     * 
-     * @return the stack image with all the images on the argument list.
-     * 
-     * @throws IllegalArgumentException
-     *             if the list is empty
-     */
-    private static BufferedImage mergeLegends(List<RenderedImage> imageStack, Rule[] rules,
-            GetLegendGraphicRequest req) {
-
-        Font labelFont = LegendUtils.getLabelFont(req);
-        boolean useAA = LegendUtils.isFontAntiAliasing(req);
-
+        
+        List<FeatureType> layers=request.getLayers();
+        List<Style> styles=request.getStyles();
+        List<String> rules=request.getRules();
+        
+        
         boolean forceLabelsOn = false;
         boolean forceLabelsOff = false;
-        if (req.getLegendOptions().get("forceLabels") instanceof String) {
-            String forceLabelsOpt = (String) req.getLegendOptions().get("forceLabels");
+        if (request.getLegendOptions().get("forceLabels") instanceof String) {
+            String forceLabelsOpt = (String) request.getLegendOptions().get("forceLabels");
             if (forceLabelsOpt.equalsIgnoreCase("on")) {
                 forceLabelsOn = true;
             } else if (forceLabelsOpt.equalsIgnoreCase("off")) {
                 forceLabelsOff = true;
             }
         }
+        
+        boolean forceTitlesOn = false;
+        boolean forceTitlesOff = false;
+        if (request.getLegendOptions().get("forceTitles") instanceof String) {
+            String forceTitlesOpt = (String) request.getLegendOptions().get("forceTitles");
+            if (forceTitlesOpt.equalsIgnoreCase("on")) {
+                forceTitlesOn = true;
+            } else if (forceTitlesOpt.equalsIgnoreCase("off")) {
+                forceTitlesOff = true;
+            }
+        }
+        
+        for (int pos = 0; pos < layers.size(); pos++) {
+            // current layer
+            FeatureType layer=layers.get(pos);
+            
+            // style and rule to use for the current layer
+            Style gt2Style = styles.get(pos);
+            String ruleName = null;
+            
+            if (gt2Style == null) {
+                throw new NullPointerException("request.getStyle()");
+            }
+                        
+            // get rule corresponding to the layer index
+            if(rules.size() > 0) {
+                ruleName = rules.get(pos);
+            }
+            // normalize to null for NO RULE
+            if(ruleName != null && ruleName.equals("")) {
+                ruleName = null;
+            }
+            
+            // width and height, we might have to rescale those in case of DPI usage
+            int w = request.getWidth();
+            int h = request.getHeight();
+
+            // apply dpi rescale
+            double dpi = RendererUtilities.getDpi(request.getLegendOptions());
+            double standardDpi = RendererUtilities.getDpi(Collections.emptyMap());
+            if(dpi != standardDpi) {
+                double scaleFactor = dpi / standardDpi;
+                w = (int) Math.round(w * scaleFactor);
+                h = (int) Math.round(h * scaleFactor);
+                DpiRescaleStyleVisitor dpiVisitor = new DpiRescaleStyleVisitor(scaleFactor);
+                dpiVisitor.visit(gt2Style);
+                gt2Style = (Style) dpiVisitor.getCopy();
+            }
+            // apply UOM rescaling if we have a scale
+            if (request.getScale() > 0) {
+                double pixelsPerMeters = RendererUtilities.calculatePixelsPerMeterRatio(request.getScale(), request.getLegendOptions());
+                UomRescaleStyleVisitor rescaleVisitor = new UomRescaleStyleVisitor(pixelsPerMeters);
+                rescaleVisitor.visit(gt2Style);
+                gt2Style = (Style) rescaleVisitor.getCopy();
+            }
+            
+            boolean strict = request.isStrict();
+            
+            final boolean transparent = request.isTransparent();
+            RenderedImage titleImage=null;
+            // if we have more than one layer, we put a title on top of each layer legend
+            if(layers.size() > 1 && !forceTitlesOff) {
+                titleImage=getLayerTitle(layer,  w, h, transparent, request);
+            }
+            
+            final boolean buildRasterLegend = (!strict && layer == null && LegendUtils
+                    .checkRasterSymbolizer(gt2Style)) || LegendUtils.checkGridLayer(layer);
+            if (buildRasterLegend) {
+                final RasterLayerLegendHelper rasterLegendHelper = new RasterLayerLegendHelper(request,gt2Style,ruleName);
+                final BufferedImage image = rasterLegendHelper.getLegend();
+                if(image != null && titleImage != null) {
+                    layersImages.add(titleImage);
+                }
+                layersImages.add(image);
+            } else {
+                
+                // final SimpleFeature sampleFeature;
+                final Feature sampleFeature;
+                if (layer == null) {
+                    sampleFeature = createSampleFeature();
+                } else {
+                    sampleFeature = createSampleFeature(layer);
+                }
+                final FeatureTypeStyle[] ftStyles = gt2Style.featureTypeStyles().toArray(
+                        new FeatureTypeStyle[0]);
+                final double scaleDenominator = request.getScale();
+                
+                final Rule[] applicableRules;
+                
+                if (ruleName != null) {
+                    Rule rule = LegendUtils.getRule(ftStyles, ruleName);
+                    if (rule == null) {
+                        throw new ServiceException("Specified style does not contains a rule named " + ruleName);
+                    }
+                    applicableRules = new Rule[] {rule};
+                } else {
+                    applicableRules = LegendUtils.getApplicableRules(ftStyles, scaleDenominator);
+                }
+                
+                final NumberRange<Double> scaleRange = NumberRange.create(scaleDenominator,
+                        scaleDenominator);
+                final int ruleCount = applicableRules.length;
+                
+                /**
+                 * A legend graphic is produced for each applicable rule. They're being held 
+                 * here until the process is done and then painted on a "stack" like legend.
+                 */
+                final List<RenderedImage> legendsStack = new ArrayList<RenderedImage>(ruleCount);
+                
+                final SLDStyleFactory styleFactory = new SLDStyleFactory();
+                
+                for (int i = 0; i < ruleCount; i++) {
+                    final Symbolizer[] symbolizers = applicableRules[i].getSymbolizers();
+                    
+                    // BufferedImage image = prepareImage(w, h, request.isTransparent());
+                    
+                    final RenderedImage image = ImageUtils.createImage(w, h, (IndexColorModel) null,
+                            transparent);
+                    final Map<RenderingHints.Key, Object> hintsMap = new HashMap<RenderingHints.Key, Object>();
+                    final Graphics2D graphics = ImageUtils.prepareTransparency(transparent, LegendUtils.getBackgroundColor(request), image,
+                            hintsMap);
+                    graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                            RenderingHints.VALUE_ANTIALIAS_ON);
+                    
+                    for (int sIdx = 0; sIdx < symbolizers.length; sIdx++) {
+                        final Symbolizer symbolizer = symbolizers[sIdx];
+                        
+                        if (symbolizer instanceof RasterSymbolizer) {
+                            throw new IllegalStateException(
+                                    "It is not legal to have a RasterSymbolizer here");
+                        } else {
+                            Style2D style2d = styleFactory.createStyle(sampleFeature, symbolizer,
+                                    scaleRange);
+                            LiteShape2 shape = getSampleShape(symbolizer, w, h);
+                            
+                            if (style2d != null) {
+                                shapePainter.paint(graphics, shape, style2d, scaleDenominator);
+                            }
+                        }
+                    }
+                    if(image != null && titleImage != null) {
+                        layersImages.add(titleImage);
+                        titleImage = null;
+                    }
+                    legendsStack.add(image);
+                    graphics.dispose();
+                }
+                
+                // JD: changed legend behavior, see GEOS-812
+                // this.legendGraphic = scaleImage(mergeLegends(legendsStack), request);
+                BufferedImage image = mergeLegends(legendsStack, applicableRules, request, 
+                        forceLabelsOn, forceLabelsOff);
+                if(image != null) {
+                    layersImages.add(image);
+                }
+            }
+            
+        }
+        // all legend graphics are merged if we have a layer group
+        BufferedImage finalLegend = mergeLegends(layersImages,null,request, forceLabelsOn, forceLabelsOff);
+        if(finalLegend == null) {
+            throw new IllegalArgumentException("no legend passed");
+        }
+        return finalLegend;
+    }
+    
+    /**
+     * Renders a title for a layer (to be put on top of the layer legend).
+     * 
+     * @param layer FeatureType representing the layer
+     * @param w width for the image (hint)
+     * @param h height for the image (hint)
+     * @param transparent (should the image be transparent)
+     * @param request GetLegendGraphicRequest being built
+     * @return image with the title
+     */
+    private RenderedImage getLayerTitle(FeatureType layer, int w, int h, boolean transparent, 
+            GetLegendGraphicRequest request) {
+        // we choose a title with the following priority:
+        //  - layer title
+        //  - layer name
+        String title=request.getTitle(layer.getName());
+        if (title == null) {
+            title=layer.getName().getLocalPart();
+        }
+        final BufferedImage image = ImageUtils.createImage(w, h, (IndexColorModel) null,
+                transparent);
+        return getRenderedLabel(image,title,request);
+    }
+   
+
+    /**
+     * Renders a label on the given image, using parameters from the request
+     * for the rendering style.
+     * 
+     * @param image
+     * @param label
+     * @param request
+     * @return
+     */
+    private BufferedImage getRenderedLabel(BufferedImage image, String label,
+            GetLegendGraphicRequest request) {
+        Font labelFont = LegendUtils.getLabelFont(request);
+        boolean useAA = LegendUtils.isFontAntiAliasing(request);
+                        
+        final Graphics2D graphics = image.createGraphics();
+        graphics.setFont(labelFont);
+        if(useAA) {
+            graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                    RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        } else {
+            graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                    RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+        }
+        return LegendUtils.renderLabel(label, graphics, request);
+    }
+
+    /**
+     * Receives a list of <code>BufferedImages</code> and produces a new one which holds all the
+     * images in <code>imageStack</code> one above the other, handling labels.
+     * 
+     * @param imageStack
+     *            the list of BufferedImages, one for each applicable Rule
+     * @param rules
+     *            The applicable rules, one for each image in the stack (if not null it's used to
+     *            compute labels)
+     * @param request
+     *            The request.
+     * @param forceLabelsOn
+     *            true for force labels on also with a single image.
+     * @param forceLabelsOff
+     *            true for force labels off also with more than one rule.
+     * 
+     * @return the stack image with all the images on the argument list.
+     * 
+     * @throws IllegalArgumentException
+     *             if the list is empty
+     */
+    private BufferedImage mergeLegends(List<RenderedImage> imageStack, Rule[] rules,
+            GetLegendGraphicRequest req, boolean forceLabelsOn, boolean forceLabelsOff) {
+
+        Font labelFont = LegendUtils.getLabelFont(req);
+        boolean useAA = LegendUtils.isFontAntiAliasing(req);
+
+        
 
         if (imageStack.size() == 0) {
-            throw new IllegalArgumentException("No legend graphics passed");
+            return null;
         }
 
         final BufferedImage finalLegend;
 
-        if (imageStack.size() == 1 && !forceLabelsOn) {
+        if (imageStack.size() == 1 && (!forceLabelsOn || rules == null)) {
             finalLegend = (BufferedImage) imageStack.get(0);
         } else {
             final int imgCount = imageStack.size();
@@ -312,7 +425,7 @@ public class BufferedImageLegendGraphicBuilder {
             for (int i = 0; i < imgCount; i++) {
                 img = (BufferedImage) imageStack.get(i);
 
-                if (forceLabelsOff) {
+                if (forceLabelsOff || rules == null) {
                     totalWidth = (int) Math.ceil(Math.max(img.getWidth(), totalWidth));
                     rowHeights[i] = img.getHeight();
                     totalHeight += img.getHeight();
@@ -331,21 +444,9 @@ public class BufferedImageLegendGraphicBuilder {
                     } else {
                         labels[i] = "";
                     }
-
-                    Graphics2D g = img.createGraphics();
-                    g.setFont(labelFont);
-
-                    if (useAA) {
-                        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                                RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-                    } else {
-                        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                                RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-                    }
-
+                    
                     if (labels[i] != null && labels[i].length() > 0) {
-                        final BufferedImage renderedLabel = LegendUtils.renderLabel(labels[i], g,
-                                req);
+                        final BufferedImage renderedLabel = getRenderedLabel(img,labels[i],req);
                         labelsGraphics[i] = renderedLabel;
                         final Rectangle2D bounds = new Rectangle2D.Double(0, 0,
                                 renderedLabel.getWidth(), renderedLabel.getHeight());
@@ -391,7 +492,7 @@ public class BufferedImageLegendGraphicBuilder {
                 }
 
                 finalGraphics.drawImage(img, 0, y, null);
-                if (forceLabelsOff) {
+                if (forceLabelsOff || rules == null) {
                     topOfRow += rowHeights[i];
                     continue;
                 }
@@ -430,6 +531,8 @@ public class BufferedImageLegendGraphicBuilder {
         }
         return finalLegend;
     }
+    
+    
 
     /**
      * Returns a <code>java.awt.Shape</code> appropiate to render a legend graphic given the
@@ -531,9 +634,9 @@ public class BufferedImageLegendGraphicBuilder {
         Feature sampleFeature;
         try {
             if (schema instanceof SimpleFeatureType) {
-                sampleFeature = SimpleFeatureBuilder.template((SimpleFeatureType) schema, null);            
-            } else {            	
-            	sampleFeature = DataUtilities.templateFeature(schema);
+                sampleFeature = SimpleFeatureBuilder.template((SimpleFeatureType) schema, null);
+            } else {
+                sampleFeature = DataUtilities.templateFeature(schema);
             }
         } catch (IllegalAttributeException e) {
             throw new ServiceException(e);

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/RasterLayerLegendHelper.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/RasterLayerLegendHelper.java
@@ -70,7 +70,8 @@ public class RasterLayerLegendHelper {
     private Color bgColor;
 
     private ColorMapLegendCreator cMapLegendCreator;
-
+    
+    
     /**
      * Constructor for a RasterLayerLegendHelper.
      * 
@@ -78,15 +79,18 @@ public class RasterLayerLegendHelper {
      * It takes a {@link GetLegendGraphicRequest} object in order to do its magic.
      * 
      * @param request
-     *            the {@link GetLegendGraphicRequest} for which we want to builda legend
+     *            the {@link GetLegendGraphicRequest} for which we want to build a legend
+     * @param style the {@link Style} for which we want to build a legend
+     * @param rule the {@link Rule} to use for rendering
      */
-    public RasterLayerLegendHelper(final GetLegendGraphicRequest request) {
+    public RasterLayerLegendHelper(final GetLegendGraphicRequest request,Style style,String ruleName) {
         PackagedUtils.ensureNotNull(request, "The provided GetLegendGraphicRequest is null");
-        parseRequest(request);
+        
+        parseRequest(request,style,ruleName);
     }
 
     @SuppressWarnings("unchecked")
-    private void parseRequest(final GetLegendGraphicRequest request) {
+    private void parseRequest(final GetLegendGraphicRequest request,Style gt2Style,String ruleName) {
         // get the requested layer
         // and check that it is actually a grid
         // final FeatureType layer = request.getLayer();
@@ -95,13 +99,12 @@ public class RasterLayerLegendHelper {
         // if(!found)
         // throw new IllegalArgumentException("Unable to create legend for non raster style");
 
-        // get the style and its rules
-        final Style gt2Style = request.getStyle();
+        
         final FeatureTypeStyle[] ftStyles = gt2Style.getFeatureTypeStyles();
         final double scaleDenominator = request.getScale();
 
         final Rule[] applicableRules;
-        String ruleName = request.getRule();
+        
         if (ruleName != null) {
             Rule rule = LegendUtils.getRule(ftStyles, ruleName);
             if (rule == null) {

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
@@ -4,8 +4,16 @@
  */
 package org.geoserver.wms.legendgraphic;
 
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import javax.xml.namespace.QName;
@@ -18,6 +26,7 @@ import org.geoserver.data.test.MockData;
 import org.geoserver.wms.GetLegendGraphic;
 import org.geoserver.wms.GetLegendGraphicRequest;
 import org.geoserver.wms.WMSTestSupport;
+import org.geoserver.wms.map.ImageUtils;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.resources.coverage.FeatureUtilities;
@@ -25,6 +34,7 @@ import org.geotools.styling.Rule;
 import org.geotools.styling.Style;
 import org.geotools.util.logging.Logging;
 import org.opengis.coverage.grid.GridCoverage;
+import org.opengis.feature.type.FeatureType;
 
 /**
  * Tets the functioning of the abstract legend producer for raster formats, which relies on
@@ -186,5 +196,192 @@ public class AbstractLegendGraphicOutputFormatTest extends WMSTestSupport {
         // was the legend painted?
         assertNotBlank("testRainfall", image, LegendUtils.DEFAULT_BG_COLOR);
 
+    }
+    
+    /**
+     * Tests that the legend graphic is produced for multiple layers
+     */    
+    public void testMultipleLayers() throws Exception {              
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest();
+        
+        int titleHeight = getTitleHeight(req);
+        
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName(
+                MockData.ROAD_SEGMENTS.getNamespaceURI(), MockData.ROAD_SEGMENTS.getLocalPart());
+        List<FeatureType> layers=new ArrayList<FeatureType>();
+        layers.add(ftInfo.getFeatureType());
+        
+        req.setLayers(layers);
+        
+        List<Style> styles=new ArrayList<Style>();
+        styles.add(getCatalog().getStyleByName(
+                MockData.ROAD_SEGMENTS.getLocalPart()).getStyle());
+        req.setStyles(styles);
+        
+        this.legendProducer.buildLegendGraphic(req);
+
+        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+
+        // was the legend painted?
+        assertNotBlank("testMultipleLayers", image, LegendUtils.DEFAULT_BG_COLOR);
+        int height=image.getHeight();
+        
+        layers.add(ftInfo.getFeatureType());
+        styles.add(getCatalog().getStyleByName(
+                MockData.ROAD_SEGMENTS.getLocalPart()).getStyle());
+        this.legendProducer.buildLegendGraphic(req);
+
+        image = this.legendProducer.buildLegendGraphic(req);        
+        
+        // was the legend painted?
+        assertNotBlank("testMultipleLayers", image, LegendUtils.DEFAULT_BG_COLOR);
+        // with 2 layers we should have a legend at least 2 times taller (title + 2 layers)
+        
+        assertEquals(2*(height+titleHeight),image.getHeight());
+        
+        // first title
+        assertPixel(image, 1, titleHeight/2, new Color(0,0,0));
+        
+        // first layer
+        assertPixel(image, 10, 10+titleHeight, new Color(192,160,0));
+        
+        assertPixel(image, 10, 30+titleHeight, new Color(0,0,0));
+        
+        assertPixel(image, 10, 50+titleHeight, new Color(224,64,0));
+        
+        // second title
+        assertPixel(image, 1, 60+titleHeight+titleHeight/2, new Color(0,0,0));
+        
+        // same colors for the second layer
+        assertPixel(image, 10, 70+titleHeight*2, new Color(192,160,0));
+        
+        assertPixel(image, 10, 90+titleHeight*2, new Color(0,0,0));
+        
+        assertPixel(image, 10, 110+titleHeight*2, new Color(224,64,0));
+        
+    }
+    
+    /**
+     * Tests that with forceTitles option off no title is rendered
+     */
+    public void testForceTitlesOff() throws Exception {        
+        
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest();
+        Map<String,String> options = new HashMap<String,String>();
+        options.put("forceTitles", "off");
+        req.setLegendOptions(options);
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName(
+                MockData.ROAD_SEGMENTS.getNamespaceURI(), MockData.ROAD_SEGMENTS.getLocalPart());
+        List<FeatureType> layers=new ArrayList<FeatureType>();
+        layers.add(ftInfo.getFeatureType());
+        
+        req.setLayers(layers);
+        
+        List<Style> styles = new ArrayList<Style>();
+        styles.add(getCatalog().getStyleByName(
+                MockData.ROAD_SEGMENTS.getLocalPart()).getStyle());
+        req.setStyles(styles);
+        
+        this.legendProducer.buildLegendGraphic(req);
+
+        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+
+        // was the legend painted?
+        assertNotBlank("testMultipleLayers", image, LegendUtils.DEFAULT_BG_COLOR);
+        int height=image.getHeight();
+        
+        layers.add(ftInfo.getFeatureType());
+        styles.add(getCatalog().getStyleByName(
+                MockData.ROAD_SEGMENTS.getLocalPart()).getStyle());
+        this.legendProducer.buildLegendGraphic(req);
+
+        image = this.legendProducer.buildLegendGraphic(req);        
+        
+        // was the legend painted?
+        assertNotBlank("testForceTitlesOff", image, LegendUtils.DEFAULT_BG_COLOR);
+        
+        
+        assertEquals(2*height,image.getHeight());
+                
+        // first layer
+        assertPixel(image, 10, 10, new Color(192,160,0));
+        
+        assertPixel(image, 10, 30, new Color(0,0,0));
+        
+        assertPixel(image, 10, 50, new Color(224,64,0));
+                
+        // same colors for the second layer
+        assertPixel(image, 10, 70, new Color(192,160,0));
+        
+        assertPixel(image, 10, 90, new Color(0,0,0));
+        
+        assertPixel(image, 10, 110, new Color(224,64,0));
+        
+    }
+    
+    /**
+     * Tests that the legend graphic is produced for multiple layers
+     * with different style for each layer.
+     */    
+    public void testMultipleLayersWithDifferentStyles() throws Exception {        
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest();
+        
+        int titleHeight = getTitleHeight(req);
+        
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName(
+                MockData.ROAD_SEGMENTS.getNamespaceURI(), MockData.ROAD_SEGMENTS.getLocalPart());
+        List<FeatureType> layers=new ArrayList<FeatureType>();
+        layers.add(ftInfo.getFeatureType());
+        layers.add(ftInfo.getFeatureType());
+        req.setLayers(layers);
+        
+        List<Style> styles=new ArrayList<Style>();
+        Style style1= getCatalog().getStyleByName(
+                MockData.ROAD_SEGMENTS.getLocalPart()).getStyle();
+        styles.add(style1);
+        
+        Style style2= getCatalog().getStyleByName(
+                MockData.LAKES.getLocalPart()).getStyle();
+        styles.add(style2);
+        req.setStyles(styles);
+        
+        this.legendProducer.buildLegendGraphic(req);
+
+        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+
+        
+        // first layer
+        assertPixel(image, 10, 10+titleHeight, new Color(192,160,0));
+        
+        assertPixel(image, 10, 30+titleHeight, new Color(0,0,0));
+        
+        assertPixel(image, 10, 50+titleHeight, new Color(224,64,0));
+        
+        // different color (style) for the second layer
+        assertPixel(image, 10, 70+titleHeight*2, new Color(64,64,192));
+
+    }
+    
+    private int getTitleHeight(GetLegendGraphicRequest req) {    
+        final BufferedImage image = ImageUtils.createImage(req.getWidth(),
+                req.getHeight(), (IndexColorModel) null, req.isTransparent());
+        return getRenderedLabel(image, "TESTTITLE", req).getHeight();
+    }
+    
+    private BufferedImage getRenderedLabel(BufferedImage image, String label,
+            GetLegendGraphicRequest request) {
+        Font labelFont = LegendUtils.getLabelFont(request);
+        boolean useAA = LegendUtils.isFontAntiAliasing(request);
+    
+        final Graphics2D graphics = image.createGraphics();
+        graphics.setFont(labelFont);
+        if (useAA) {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_ON);
+        } else {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_OFF);
+        }
+        return LegendUtils.renderLabel(label, graphics, request);
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
@@ -14,6 +14,7 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.GetLegendGraphicRequest;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSTestSupport;
+import org.geotools.feature.NameImpl;
 import org.geotools.styling.Style;
 
 import com.mockrunner.mock.web.MockHttpServletRequest;
@@ -110,7 +111,7 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
                 allParameters, allParameters);
 
         // the style names Ponds is declared in third position on the sld doc
-        Style selectedStyle = request.getStyle();
+        Style selectedStyle = request.getStyles().get(0);
         assertNotNull(selectedStyle);
         assertEquals("Ponds", selectedStyle.getName());
 
@@ -120,7 +121,7 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
         request = requestReader.read(new GetLegendGraphicRequest(), allParameters, allParameters);
 
         // the style names Ponds is declared in third position on the sld doc
-        selectedStyle = request.getStyle();
+        selectedStyle = request.getStyles().get(0);
         assertNotNull(selectedStyle);
         assertEquals("Lakes", selectedStyle.getName());
     }
@@ -158,5 +159,42 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
         allParameters.remove("LAYER");
         request = requestReader.read(new GetLegendGraphicRequest(), allParameters, allParameters);
         assertFalse(request.isStrict());
+    }
+    
+    public void testLayerGroup() throws Exception {
+        GetLegendGraphicRequest request;
+        
+        request = requestReader.read(new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
+        assertTrue(request.getLayers().size() == 1);
+        
+        requiredParameters.put("LAYER", "nature");
+        request = requestReader.read(new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
+        assertTrue(request.getLayers().size() > 1);
+    }
+    
+    public void testStylesForLayerGroup() throws Exception {
+        GetLegendGraphicRequest request;
+               
+        requiredParameters.put("LAYER", "nature");
+        requiredParameters.put("STYLE", "style1,style2");
+        request = requestReader.read(new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
+        assertTrue(request.getStyles().size() == 2);
+    }
+    
+    public void testRulesForLayerGroup() throws Exception {
+        GetLegendGraphicRequest request;
+               
+        requiredParameters.put("LAYER", "nature");
+        requiredParameters.put("RULE", "rule1,rule2");
+        request = requestReader.read(new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
+        assertTrue(request.getRules().size() == 2);
+    }
+    
+    public void testLabelsForLayerGroup() throws Exception {
+        GetLegendGraphicRequest request;
+               
+        requiredParameters.put("LAYER", "nature");
+        request = requestReader.read(new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
+        assertNotNull(request.getTitle(new NameImpl("http://www.opengis.net/cite","Lakes")));
     }
 }


### PR DESCRIPTION
Backport of GEOS-5524 on 2.2.x (GEOS-5560)

LayerGroups are supported in the following manner:
- just use a layergroup name, instead of a layer name, in the LAYER parameter to get a legend for the group
- if STYLE is not specified, the default style is used for all the layers of the group
- if STYLE is specified it should be a comma separated list to specify styles for any single layer of the group (empty values can be given to use default style for one or more layers)
- the RULE parameter is used similarly to STYLE to specify rules for some or all the styles
- the layer Title (or Name if title is missing) is drawn as a label on top of each layer
- forceTitles legend option can be used to force layer titles off or on
