### PR TITLE
[Backport] GEOS-5332 KMLTransformer does not include sld and vendor para...

### DIFF
--- a/doc/en/user/source/services/wms/vendor.rst
+++ b/doc/en/user/source/services/wms/vendor.rst
@@ -120,26 +120,10 @@ The supported format options are:
   For example, to print  a 100x100 image at 300 DPI request a 333x333 image with the DPI value set to 300: ``&width=333&height=333&format_options=dpi:300`` 
 * ``layout``: specifies a layout name to use.  Layouts are used to add decorators such as compasses and legends.  This capability is discussed further in the :ref:`wms_decorations` section.
 * ``quantizer`` ((values = ``octree``, ``mediancut``): controls the color quantizer used to produce PNG8 images. GeoServer 2.2.0 provides two quantizers, a fast RGB quantizer called ``octree`` that does not handle translucency and a slower but more accurate RGBA quantizer called ``mediancut``. By default the first is used on opaque images, whilst the second is enabled if the client asks for a transparent image (``transparent=true``). This vendor parameter can be used to manually force the usage of a particular quantizer.
-
-kmattr
-------
-
-The ``kmattr`` parameter determines whether the KML returned by GeoServer should include clickable attributes or not.  
-This parameter primarily affects Google Earth rendering.  
-The syntax is::
-
-   kmattr=[true|false]
-
-kmscore
--------
-
-The ``kmscore`` parameter sets whether GeoServer should render KML data as vector or raster.  
-This parameter primarily affects Google Earth rendering.  
-The syntax is::
-
-   kmscore=<value>
-
-The possible values for this parameter are between ``0`` (force raster output) and ``100`` (force vector output).
+* ``kmattr`` ((values = ``true``,``false``)): determines whether the KML returned by GeoServer should include clickable attributes or not. This parameter primarily affects Google Earth rendering.  
+* ``legend`` ((values = ``true``,``false``)): KML may add the legend.
+* ``kmscore`` ((values = between ``0`` to force raster output and ``100`` to force vector output)): parameter sets whether GeoServer should render KML data as vector or raster. This parameter primarily affects Google Earth rendering.  
+* ``kmltitle``: parameter sets the KML title.
 
 maxFeatures and startIndex
 --------------------------

--- a/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
@@ -6,6 +6,7 @@ package org.geoserver.ows.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -15,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,6 +32,7 @@ import org.geotools.util.Version;
  * @author Chris Holmes, TOPP
  * @author Gabriel Rold?n, Axios
  * @author Justin Deoliveira, TOPP
+ * @author Carlo Cancellieri - Geo-Solutions SAS
  *
  * @version $Id$
  */
@@ -370,101 +373,143 @@ public class KvpUtils {
      */
     public static List<Throwable> parse( Map kvp ) {
 
-        //look up parser objects
-        Collection parsers = GeoServerExtensions.extensions(KvpParser.class);
-       
-        //strip out parsers which do not match current service/request/version
-        String service = (String) kvp.get( "service" );
-        String version = (String) kvp.get( "version" );
-        String request = (String) kvp.get( "request" );
-        for (Iterator p = parsers.iterator(); p.hasNext(); ) {
-            KvpParser parser = (KvpParser) p.next();
-            
-            if ( parser.getService() != null && !parser.getService().equalsIgnoreCase(service) ) {
-                p.remove();
-                continue;
-            }
-            
-            if ( parser.getVersion() != null && !parser.getVersion().toString().equals(version) ) {
-                p.remove();
-                continue;
-            }
-            
-            if ( parser.getRequest() != null && !parser.getRequest().equalsIgnoreCase(request) ) {
-                p.remove();
-            }
-        }
-        
-        //parser the kvp's
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+
+        // strip out parsers which do not match current service/request/version
+        String service = (String) kvp.get("service");
+        String version = (String) kvp.get("version");
+        String request = (String) kvp.get("request");
+
+        purgeParsers(parsers, service, version, request);
+
+        // parser the kvp's
         ArrayList<Throwable> errors = new ArrayList<Throwable>();
-        for (Iterator itr = kvp.entrySet().iterator(); itr.hasNext();) {
-            Map.Entry entry = (Map.Entry) itr.next();
+        for (Iterator<Map.Entry<Object, Object>> itr = kvp.entrySet().iterator(); itr.hasNext();) {
+            Map.Entry<Object, Object> entry = itr.next();
             String key = (String) entry.getKey();
             String value = (String) entry.getValue();
             
-            //find the parser for this key value pair
+            // find the parser for this key value pair
             Object parsed = null;
-
-            KvpParser parser = null;
-            for (Iterator pitr = parsers.iterator(); pitr.hasNext() && parsed == null;) {
-                KvpParser candidate = (KvpParser) pitr.next();
-                if (key.equalsIgnoreCase(candidate.getKey())) {
-                    if (parser == null) {
-                        parser = candidate;
-                    }
-                    else {
-                        String curService = parser.getService();
-                        Version curVersion = parser.getVersion();
-
-                        String trgService = candidate.getService();
-                        Version trgVersion = candidate.getVersion();
-
-                        //determine if this parser more closely matches the request
-                        if (curService == null) {
-                            //if target service matches, it is a closer match
-                            if (trgService != null && trgService.equalsIgnoreCase(service)) {
-                                parser = candidate;
-                            }
-                        }
-                        else {
-                            if (trgService != null && trgService.equalsIgnoreCase(service)) {
-                                //both match, filter by version
-                                if (trgVersion != null) {
-                                    if (curVersion == null && trgVersion.toString().equals(version)) {
-                                        parser = candidate;
-                                    }
-                                }
-                                else {
-                                    if (curVersion == null) {
-                                        //ambiguous, unable to match
-                                        //TODO: use request
-                                        throw new IllegalStateException("Multiple kvp parsers: " + 
-                                            parser + "," +  candidate);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (parser != null) {
-                try {
-                    parsed = parser.parse(value);
-                } catch (Throwable t) {
-                    //dont throw any exceptions yet, befor the service is
-                    // known
-                    errors.add( t );
-                }
+            
+            try {
+                // find the parser for this key value pair
+                parsed = parseKey(key, value, service, request, version, parsers);
+            } catch (Throwable t) {
+                // dont throw any exceptions yet, befor the service is
+                // known
+                errors.add(t);
             }
             
-            //if noone could parse, just set to string value
+            // We only change the value of the parameter if the parser was found and no exception is thrown (parsed != null) If so (==null) it is
+            // untouched (remains a String)
             if (parsed != null) {
                 entry.setValue(parsed);
             }
         }
-        
+
         return errors;
+    }
+    
+    /**
+     * Strip out parsers which do not match current service/request/version
+     * 
+     * @param parsers list of {@link KvpParser} to purge (see {@link GeoServerExtensions#extensions(Class)})
+     * @param service the service parameter from the kvp (can be null)
+     * @param version the version parameter from the kvp (can be null)
+     * @param request the request parameter from the kvp (can be null)
+     */
+    public static void purgeParsers(List<KvpParser> parsers, final String service,
+            final String version, final String request) {
+        for (Iterator<KvpParser> p = parsers.iterator(); p.hasNext();) {
+            KvpParser parser = p.next();
+
+            if (parser.getService() != null && !parser.getService().equalsIgnoreCase(service)) {
+                p.remove();
+            } else if (parser.getVersion() != null
+                    && !parser.getVersion().toString().equals(version)) {
+                p.remove();
+            } else if (parser.getRequest() != null
+                    && !parser.getRequest().equalsIgnoreCase(request)) {
+                p.remove();
+            }
+        }
+    }
+    
+    /**
+     * Find a parser for the passed key into registered parsers ({@link KvpParser})
+     * 
+     * @param key the key matching the value to parse
+     * @param service the service parameter from the kvp (can be null)
+     * @param version the version parameter from the kvp (can be null)
+     * @param request the request parameter from the kvp (can be null)
+     * @param parsers the purged parsers list (see {@link #purgeParsers(List, String, String, String)}
+     * @return the found parser or null (if no parser is found)
+     * @throws IllegalStateException if more than one candidate parser is found
+     */
+    public static KvpParser findParser(final String key, final String service,
+            final String request, final String version, Collection<KvpParser> parsers) {
+        // find the parser for this key value pair
+        KvpParser parser = null;
+        final Iterator<KvpParser> pitr = parsers.iterator();
+        while (pitr.hasNext()) {
+            KvpParser candidate = pitr.next();
+            if (key.equalsIgnoreCase(candidate.getKey())) {
+                if (parser == null) {
+                    parser = candidate;
+                } else {
+                    // if target service matches, it is a closer match
+                    String trgService = candidate.getService();
+                    if (trgService != null && trgService.equalsIgnoreCase(service)) {
+                        // determine if this parser more closely matches the request
+                        String curService = parser.getService();
+                        if (curService == null) {
+                            parser = candidate;
+                        } else {
+                            // both match, filter by version
+                            Version curVersion = parser.getVersion();
+                            Version trgVersion = candidate.getVersion();
+                            if (trgVersion != null) {
+                                if (curVersion == null && trgVersion.toString().equals(version)) {
+                                    parser = candidate;
+                                }
+                            } else {
+                                if (curVersion == null) {
+                                    // ambiguous, unable to match
+                                    throw new IllegalStateException("Multiple kvp parsers: "
+                                            + parser + "," + candidate);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return parser;
+    }
+    
+    /**
+     * Parse this key value pair using registered parsers ({@link KvpParser})
+     * 
+     * @param key the key matching the value to parse
+     * @param value the value to parse
+     * @param service the service parameter from the kvp (can be null)
+     * @param version the version parameter from the kvp (can be null)
+     * @param request the request parameter from the kvp (can be null)
+     * @param parsers the purged parsers list (see {@link #purgeParsers(List, String, String, String)}
+     * @return the parsed value or null (if no parser is found)
+     * @throws Exception if the selected parser throws an exception
+     * @throws IllegalStateException if more than one candidate parser is found
+     */
+    public static Object parseKey(final String key, final String value, final String service,
+            final String request, final String version, List<KvpParser> parsers) throws Exception {
+        // find the parser for this key value pair
+        KvpParser parser = findParser(key, service, request, version, parsers);
+        if (parser == null) {
+            return null;
+        }
+        return parser.parse(value);
     }
     
     /**

--- a/src/wms/src/main/java/org/geoserver/kml/KMLReflector.java
+++ b/src/wms/src/main/java/org/geoserver/kml/KMLReflector.java
@@ -15,6 +15,8 @@ import org.geoserver.wms.DefaultWebMapService;
 import org.geoserver.wms.GetMapRequest;
 import org.geoserver.wms.MapLayerInfo;
 import org.geoserver.wms.WMS;
+import org.geoserver.wms.WMSRequest;
+import org.geoserver.wms.WMSRequests;
 import org.geoserver.wms.WebMapService;
 
 /**
@@ -155,7 +157,9 @@ public class KMLReflector {
         Map fo = request.getFormatOptions();
 
         KvpUtils.merge(fo, modeOptions);
-
+        
+        organizeFormatOptionsParams(request.getRawKvp(), fo);
+        
         if (fo.get("kmattr") == null) {
             fo.put("kmattr", wmsConfiguration.getKmlKmAttr());
         }
@@ -202,6 +206,26 @@ public class KMLReflector {
         wmsResponse.setResponseHeader("Content-Disposition", contentDisposition);
 
         return wmsResponse;
+    }
+    
+    
+    /**
+     * Copy all the format_options parameters from the kvp map and put them into the formatOptions map. If a parameter is already present in
+     * formatOption map it will be preserved.
+     * 
+     * @param kvp
+     * @param formatOptions
+     * @throws Exception 
+     */
+    public static void organizeFormatOptionsParams(Map<String, String> kvp,
+            Map<String, Object> formatOptions) throws Exception {
+
+        WMSRequests.mergeEntry(kvp, formatOptions, "legend");
+        WMSRequests.mergeEntry(kvp, formatOptions, "kmscore");
+        WMSRequests.mergeEntry(kvp, formatOptions, "kmattr");
+        WMSRequests.mergeEntry(kvp, formatOptions, "kmltitle");
+//        WMSRequests.mergeEntry(kvp, formatOptions, "superoverlay");
+
     }
 
 }

--- a/src/wms/src/main/java/org/geoserver/kml/KMLTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/kml/KMLTransformer.java
@@ -26,6 +26,7 @@ import org.xml.sax.ContentHandler;
  * Transformer to create a KML document from a {@link WMSMapContent}.
  * 
  * @author Justin Deoliveira
+ * @author Carlo Cancellieri - GeoSolutions SAS
  * 
  * @version $Id$
  * @see KMLVectorTransformer
@@ -99,8 +100,14 @@ public class KMLTransformer extends TransformerBase {
 
             // if we have more than one layer ( or a legend was requested ),
             // use the name "GeoServer" to group them
-            boolean group = (layers.size() > 1) || request.getLegend();
-
+            boolean group;
+            Boolean legend = (Boolean) request.getFormatOptions().get("legend");
+            if (legend != null) {
+                group = (layers.size() > 1) || legend.booleanValue();
+            } else {
+                group = (layers.size() > 1);
+            }
+            
             if (group) {
                 StringBuffer sb = new StringBuffer();
                 for (int i = 0; i < layers.size(); i++) {
@@ -139,7 +146,7 @@ public class KMLTransformer extends TransformerBase {
             }
 
             // legend suppoer
-            if (request.getLegend()) {
+            if (legend != null && legend.booleanValue()) {
                 // for every layer specified in the request
                 for (int i = 0; i < layers.size(); i++) {
                     // layer and info

--- a/src/wms/src/main/java/org/geoserver/wms/GetMapRequest.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMapRequest.java
@@ -235,62 +235,6 @@ public class GetMapRequest extends WMSRequest {
     }
 
     /**
-     * @return the KML/KMZ score value for image vs. vector response
-     * @deprecated use <code>getFormatOptions().get( "kmscore" )</code>
-     */
-    public int getKMScore() {
-        Integer kmscore = (Integer) getFormatOptions().get("kmscore");
-
-        if (kmscore != null) {
-            return kmscore.intValue();
-        }
-
-        return 40; // old default
-    }
-
-    /**
-     * @return true: return full attribution for placemark <description>
-     * @deprecated use <code>getFormatOptions().get( "kmattr" )</code>
-     */
-    public boolean getKMattr() {
-        Boolean kmattr = (Boolean) getFormatOptions().get("kmattr");
-
-        if (kmattr != null) {
-            return kmattr.booleanValue();
-        }
-
-        return true; // old default
-    }
-
-    // /**
-    // * @return super overlay flag, <code>true</code> if super overlay requested.
-    // * @deprecated use <code>getFormatOptions().get( "superoverlay" )</code>
-    // */
-    // public boolean getSuperOverlay() {
-    // Boolean superOverlay = (Boolean) getFormatOptions().get("superoverlay");
-    //
-    // if (superOverlay != null) {
-    // return superOverlay.booleanValue();
-    // }
-    //
-    // return false; //old default
-    // }
-
-    /**
-     * @return kml legend flag, <code>true</code> if legend is enabled.
-     * @deprecated use <code>getFormatOptions().get( "legend" )</code>
-     */
-    public boolean getLegend() {
-        Boolean legend = (Boolean) getFormatOptions().get("legend");
-
-        if (legend != null) {
-            return legend.booleanValue();
-        }
-
-        return false; // old default
-    }
-
-    /**
      * @return The time request parameter. The list may contain {@link Date} or {@link DateRange} objects
      */
     public List<Object> getTime() {
@@ -514,43 +458,6 @@ public class GetMapRequest extends WMSRequest {
 
     public void setWidth(Integer width) {
         this.mandatoryParams.width = width.intValue();
-    }
-
-    /**
-     * @param score
-     *            the KML/KMZ score value for image vs. vector response, from 0 to 100
-     * @deprecated use <code>getFormatOptions().put( "kmscore", new Integer( score ) );</code>
-     */
-    public void setKMScore(int score) {
-        getFormatOptions().put("kmscore", new Integer(score));
-    }
-
-    /**
-     * @param on
-     *            true: full attribution; false: no attribution
-     * @deprecated use <code>getFormatOptions().put( "kmattr", new Boolean( on ) );</code>
-     */
-    public void setKMattr(boolean on) {
-        getFormatOptions().put("kmattr", new Boolean(on));
-    }
-
-    /**
-     * Sets the super overlay parameter on the request.
-     * 
-     * @deprecated use
-     *             <code>getFormatOptions().put( "superoverlay", new Boolean( superOverlay ) );</code>
-     */
-    public void setSuperOverlay(boolean superOverlay) {
-        getFormatOptions().put("superoverlay", new Boolean(superOverlay));
-    }
-
-    /**
-     * Sets the kml legend parameter of the request.
-     * 
-     * @deprecated use <code>getFormatOptions().put( "legend", new Boolean( legend ) );</code>
-     */
-    public void setLegend(boolean legend) {
-        getFormatOptions().put("legend", new Boolean(legend));
     }
 
     /**

--- a/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
@@ -4,11 +4,9 @@
  */
 package org.geoserver.wms;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -16,11 +14,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.geoserver.config.GeoServer;
+import org.geoserver.ows.KvpParser;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.ows.util.ResponseUtils;
-import org.geoserver.platform.ServiceException;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geotools.map.Layer;
+import org.geotools.map.MapLayer;
 import org.geotools.styling.Style;
 import org.vfny.geoserver.util.Requests;
 
@@ -30,6 +30,7 @@ import com.vividsolutions.jts.geom.Envelope;
  * Utility class for creating wms requests.
  * 
  * @author Justin Deoliveira, The Open Planning Project, jdeolive@openplans.org
+ * @author Carlo Cancellieri Geo-Solutions SAS 
  * @see Requests
  */
 public class WMSRequests {
@@ -360,6 +361,46 @@ public class WMSRequests {
         if (req.getViewParams() != null && !req.getViewParams().isEmpty()) {
             params.put("viewParams", encodeFormatOptions(req.getViewParams()));
         }
+        
+        Map<String,String> kvpMap=req.getRawKvp();
+        String propertyName=kvpMap.get("propertyName");
+        if (propertyName != null && !propertyName.isEmpty()) {
+            params.put("propertyName", propertyName);
+        }
+        
+        if (req.getSld() != null) {
+            params.put("sld", req.getSld().toString());
+        }
+        
+        if (req.getSldBody() != null) {
+            params.put("sld_body", req.getSldBody());
+        }
+        
+        if (req.getEnv() != null && !req.getEnv().isEmpty()) {
+            params.put("env", encodeFormatOptions(req.getEnv()));
+        }
+        
+        String tilesOrigin=kvpMap.get("tilesorigin");
+        if (tilesOrigin != null && !tilesOrigin.isEmpty()) {
+            params.put("tilesorigin", tilesOrigin);
+        }
+        
+        if (req.isTiled()) {
+            params.put("tiled", req.isTiled()?"true":"false");
+        }
+        
+        String palette=kvpMap.get("palette");
+        if (palette!= null && !palette.isEmpty()) {
+            params.put("palette", palette);
+        }
+
+        if (req.getBuffer()>0){
+            params.put("buffer", Integer.toString(req.getBuffer()));
+        }
+        
+        if (Double.compare(req.getAngle(),0.0)!=0){
+            params.put("angle", Double.toString(req.getAngle()));
+        }
 
         // overrides / additions
         for (int i = 0; (kvp != null) && (i < kvp.length); i += 2) {
@@ -367,6 +408,43 @@ public class WMSRequests {
         }
 
         return params;
+    }
+
+
+    /**
+     * Copy the Entry matching the key from the kvp map and put it into the formatOptions map. If a parameter is already present in formatOption map
+     * its value will be preserved.
+     * 
+     * @param kvp
+     * @param formatOptions
+     * @param key the key to parse
+     * @throws Exception - In the event of an unsuccesful parse.
+     */
+    public static void mergeEntry(Map<String, String> kvp, Map<String, Object> formatOptions,
+            final String key) throws Exception {
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+
+        // strip out parsers which do not match current service/request/version
+        String service = (String) kvp.get("service");
+        String version = (String) kvp.get("version");
+        String request = (String) kvp.get("request");
+
+        KvpUtils.purgeParsers(parsers, service, version, request);
+
+        String val = null;
+        if ((val = kvp.get(key)) != null) {
+            Object foValue = formatOptions.get(key);
+            // if not found in format option
+            if (foValue == null) {
+                Object parsed = KvpUtils.parseKey(key, val, service, request, version, parsers);
+                if (parsed != null) {
+                    formatOptions.put(key, parsed);
+                } else {
+                    formatOptions.put(key, val);
+                }
+            }
+        }
     }
 
     /**

--- a/src/wms/src/test/java/org/geoserver/kml/KMLReflectorTest.java
+++ b/src/wms/src/test/java/org/geoserver/kml/KMLReflectorTest.java
@@ -22,6 +22,7 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.data.test.MockData;
 import org.geoserver.ows.kvp.FormatOptionsKvpParser;
+import org.geoserver.wms.WMSRequests;
 import org.geoserver.wms.WMSTestSupport;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -132,6 +133,28 @@ public class KMLReflectorTest extends WMSTestSupport {
         assertEquals("att1>1000", kvp2.get("CQL_FILTER"));
     }
 
+    /**
+     * @see {@link KMLReflector#organizeFormatOptionsParams(Map, Map)}
+     * @throws Exception
+     */
+    public void testKmlFormatOptionsAsKVP() throws Exception {
+        final String layerName = MockData.BASIC_POLYGONS.getPrefix() + ":"
+                + MockData.BASIC_POLYGONS.getLocalPart();
+
+        final String baseUrl = "wms/kml?layers=" + layerName + "&styles=&mode=superoverlay";
+        final String requestUrl = baseUrl
+                + "&kmltitle=myCustomLayerTitle&kmscore=10&legend=true&kmattr=true";
+        Document dom = getAsDOM(requestUrl);
+        XPath xpath = XPathFactory.newInstance().newXPath();
+
+        // print(dom);
+        // all the kvp parameters (which should be set as format_options now are correctly parsed) 
+        assertTrue(xpath
+                .evaluate("kml/Folder/NetworkLink[1]/Link/href", dom)
+                .contains(
+                        "&format_options=LEGEND:true;SUPEROVERLAY:true;KMPLACEMARK:false;OVERLAYMODE:auto;KMSCORE:10;KMATTR:true;KMLTITLE:myCustomLayerTitle;"));
+    }
+        
     public void testKmltitleFormatOption() throws Exception {
         final String layerName = MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart();
 

--- a/src/wms/src/test/java/org/geoserver/kml/KMLTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/kml/KMLTransformerTest.java
@@ -12,12 +12,16 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
 
 import junit.framework.Test;
 
@@ -310,6 +314,20 @@ public class KMLTransformerTest extends WMSTestSupport {
 
         Element href = (Element) document.getElementsByTagName("href").item(0);
         assertTrue(href.getFirstChild().getNodeValue().startsWith("http://localhost"));
+    }
+
+    public void testRasterTransformerSLD() throws Exception {
+        KMLRasterTransformer transformer = new KMLRasterTransformer(getWMS(), mapContent);
+
+        mapContent.getRequest().setSld(new URL("http://my.external/dynamic/sldService"));
+        Document document = WMSTestSupport.transform(layer, transformer);
+
+        assertEquals(mapContent.layers().size(), document.getElementsByTagName("href").getLength());
+
+        Element href = (Element) document.getElementsByTagName("href").item(0);
+
+        assertTrue(href.getFirstChild().getNodeValue()
+                .contains("&sld=http%3A%2F%2Fmy.external%2Fdynamic%2FsldService"));
     }
 
     public void testRasterPlacemarkTrue() throws Exception {


### PR DESCRIPTION
...meters into the request
Improve reflector arguments recognition
Add JUnit tests
Comment out deprecated methods form GetMapRequest
Fix problem introduced by previous commit
GEOS-5332 Fix the patch as requested
fixed as requested
remove formatting
remove comments

NOTE: this is the backport for:
https://github.com/geoserver/geoserver/pull/73

It is essentially the same with some minor changes to the KVPUtils due to recent changes into the master branch.
Cheers,
Carlo
