### PR TITLE
GEOS-5548 - reverted change to SystemTestData.tearDown()

### DIFF
--- a/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
@@ -904,11 +904,7 @@ public class SystemTestData extends CiteTestData {
     
     @Override
     public void tearDown() throws Exception {
-        try {
-            FileUtils.deleteDirectory(data);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        FileUtils.deleteDirectory(data);        
     }
     
     @Override


### PR DESCRIPTION
Hi,
I've reverted a small change that shouldn't have been in the GEOS-5548 Nested Layer Groups patch.

On Windows I had a test failing to execute tearDown, so I added a catch for IOException.
