### PR TITLE
Added symbols size handling in WMS GetLegendGraphic

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
@@ -269,9 +269,10 @@ public class GetLegendGraphicRequest extends WMSRequest {
      * rendering. Anything of the following works: "yes", "true", "1". Anything else means false.
      * <li><code>forceLabels</code>: "on" means labels will always be drawn, even if only one rule
      * is available. "off" means labels will never be drawn, even if multiple rules are available.
-     * <li><code>forceTitles</code>: "on" means layer titles for layergroups will always be drawn, 
-     * even if only one layer is available. "off" means titles will never be drawn, even if multiple
-     * layers are available.
+     * <li><code>forceTitles</code>: "off" means titles will never be drawn, even if multiple layers
+     * are available.
+     * <li><code>minSymbolSize</code>: a number defining the minimum size to be rendered for a 
+     * symbol (defaults to 3).
      * </ul>
      * </p>
      * 

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/BigSymbol.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/BigSymbol.sld
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+This document is used by AbstractLegendGraphicOutputFormatTest.testMixedGeometry.
+This document contains styles for Polygons, Lines and Points.
+-->
+    <UserStyle>
+        <Name>SymbolSize</Name>
+        <Title>Default Styler</Title>
+        <Abstract></Abstract>
+        <FeatureTypeStyle>                        
+            <Rule>
+                <Name>Size1</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>40</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+        </FeatureTypeStyle>
+    </UserStyle>
+   </StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ProportionalSymbols.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ProportionalSymbols.sld
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+This document is used by AbstractLegendGraphicOutputFormatTest.testMixedGeometry.
+This document contains styles for Polygons, Lines and Points.
+-->
+    <UserStyle>
+        <Name>SymbolSize</Name>
+        <Title>Default Styler</Title>
+        <Abstract></Abstract>
+        <FeatureTypeStyle>                        
+            <Rule>
+                <Name>Size1</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>40</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size2</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>20</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size3</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>10</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size4</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>1</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+        </FeatureTypeStyle>
+    </UserStyle>
+   </StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ProportionalSymbolsPartialUOM.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ProportionalSymbolsPartialUOM.sld
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+This document is used by AbstractLegendGraphicOutputFormatTest.testMixedGeometry.
+This document contains styles for Polygons, Lines and Points.
+-->
+    <UserStyle>
+        <Name>SymbolSize</Name>
+        <Title>Default Styler</Title>
+        <Abstract></Abstract>
+        <FeatureTypeStyle>
+            <Rule>
+                <Name>Size1</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>4</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size2</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>40</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            
+        </FeatureTypeStyle>
+    </UserStyle>
+   </StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ProportionalSymbolsUOM.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ProportionalSymbolsUOM.sld
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+This document is used by AbstractLegendGraphicOutputFormatTest.testMixedGeometry.
+This document contains styles for Polygons, Lines and Points.
+-->
+    <UserStyle>
+        <Name>SymbolSize</Name>
+        <Title>Default Styler</Title>
+        <Abstract></Abstract>
+        <FeatureTypeStyle>
+            <Rule>
+                <Name>Size1</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>40</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size2</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>20</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size3</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>10</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size4</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>1</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+        </FeatureTypeStyle>
+    </UserStyle>
+   </StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/SymbolExpression.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/SymbolExpression.sld
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+This document is used by AbstractLegendGraphicOutputFormatTest.testMixedGeometry.
+This document contains styles for Polygons, Lines and Points.
+-->
+    <UserStyle>
+        <Name>SymbolSize</Name>
+        <Title>Default Styler</Title>
+        <Abstract></Abstract>
+        <FeatureTypeStyle>                        
+            <Rule>
+                <Name>Size1</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size><ogc:PropertyName>id</ogc:PropertyName></Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+            <Rule>
+                <Name>Size2</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>40</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>
+        </FeatureTypeStyle>
+    </UserStyle>
+   </StyledLayerDescriptor>


### PR DESCRIPTION
GEOS-5592

This patch handles size for symbols used in PointSymbolizer for the GetLegendGraphic WMS operation allowing:
- symbols bigger than icon size to always being drawn inside the icon box
- have proportional size rendering for symbols used in different rules of the same SLD
- specify a minimum rendered symbol size using the new minSymbolSize LEGEND_OPTIONS key
