### PR TITLE
GEOS-5548: fixed nested layer groups rest support

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/ResolvingProxy.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ResolvingProxy.java
@@ -13,6 +13,7 @@ import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourceInfo;
@@ -111,6 +112,13 @@ public class ResolvingProxy extends ProxyBase {
                     }
                     return (T) l; 
                 }
+                if ( object instanceof LayerGroupInfo ) {
+                    Object g = catalog.getLayerGroup( ref );
+                    if ( g == null ) {
+                        g = catalog.getLayerGroupByName( ref );
+                    }
+                    return (T) g; 
+                }                
                 if ( object instanceof StyleInfo ) {
                     Object s = catalog.getStyle( ref );
                     if ( s == null ) {

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
@@ -31,6 +31,7 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
         removeLayerGroup(null, "newLayerGroup");
         removeLayerGroup(null, "newLayerGroupWithTypeCONTAINER");
         removeLayerGroup(null, "newLayerGroupWithTypeEO");
+        removeLayerGroup(null, "nestedLayerGroupTest");
         
         LayerGroupInfo lg = catalog.getFactory().createLayerGroup();
         lg.setName( "sfLayerGroup" );
@@ -145,6 +146,44 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
         assertNotNull( lg.getBounds() );
     }
 
+    @Test
+    public void testPostWithNestedGroups() throws Exception {
+        String xml = 
+                "<layerGroup>" + 
+                    "<name>nestedLayerGroupTest</name>" +
+                    "<publishables>" +
+                      "<published type=\"layer\">Ponds</published>" +
+                      "<published type=\"layer\">Forests</published>" +
+                      "<published type=\"layerGroup\">sfLayerGroup</published>" +
+                    "</publishables>" +
+                    "<styles>" +
+                      "<style>polygon</style>" +
+                      "<style>point</style>" +
+                      "<style></style>" +                      
+                    "</styles>" +
+                  "</layerGroup>";
+            
+            MockHttpServletResponse response = postAsServletResponse("/rest/layergroups", xml );
+            assertEquals( 201, response.getStatusCode() );
+            
+            assertNotNull( response.getHeader( "Location") );
+            assertTrue( response.getHeader("Location").endsWith( "/layergroups/nestedLayerGroupTest" ) );
+
+            LayerGroupInfo lg = catalog.getLayerGroupByName( "nestedLayerGroupTest");
+            assertNotNull( lg );
+            
+            assertEquals( 3, lg.getLayers().size() );
+            assertEquals( "Ponds", lg.getLayers().get( 0 ).getName() );
+            assertEquals( "Forests", lg.getLayers().get( 1 ).getName() );
+            assertEquals( "sfLayerGroup", lg.getLayers().get( 2 ).getName() );
+            assertEquals( 3, lg.getStyles().size() );
+            assertEquals( "polygon", lg.getStyles().get( 0 ).getName() );
+            assertEquals( "point", lg.getStyles().get( 1 ).getName() );
+            assertNull( lg.getStyles().get( 2 ) );
+            
+            assertNotNull( lg.getBounds() );
+    }
+    
     @Test
     public void testPostWithTypeContainer() throws Exception {
         String xml = 


### PR DESCRIPTION
Hi,
I've fixed an issue about REST support for nested layer groups.
