### PR TITLE
preventing WPSInitializer from producing unecessary event traffic

### DIFF
--- a/src/extension/wps/wps-core/pom.xml
+++ b/src/extension/wps/wps-core/pom.xml
@@ -154,6 +154,11 @@
           <scope>test</scope>
         </dependency>
         <dependency>
+          <groupId>org.easymock</groupId>
+          <artifactId>easymockclassextension</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
           <groupId>com.mockrunner</groupId>
           <artifactId>mockrunner</artifactId>
           <scope>test</scope>

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/WPSInitializer.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/WPSInitializer.java
@@ -42,13 +42,6 @@ public class WPSInitializer implements GeoServerInitializer {
         initWPS(geoServer.getService(WPSInfo.class), geoServer);
 
         geoServer.addListener(new ConfigurationListenerAdapter() {
-
-            public void handleGlobalChange(GeoServerInfo global, List<String> propertyNames,
-                    List<Object> oldValues, List<Object> newValues) {
-
-                initWPS(geoServer.getService(WPSInfo.class), geoServer);
-            }
-
             @Override
             public void handlePostGlobalChange(GeoServerInfo global) {
                 initWPS(geoServer.getService(WPSInfo.class), geoServer);
@@ -98,6 +91,8 @@ public class WPSInitializer implements GeoServerInitializer {
     }
 
     static void lookupNewProcessGroups(WPSInfo info, GeoServer geoServer) {
+        List<ProcessGroupInfo> newGroups = new ArrayList();
+
         for (ProcessGroupInfo available : lookupProcessGroups()) {
             boolean found = false;
             for (ProcessGroupInfo configured : info.getProcessGroups()) {
@@ -108,10 +103,15 @@ public class WPSInitializer implements GeoServerInitializer {
             }
             if (!found) {
                 //add it
-                info.getProcessGroups().add(available);
+                newGroups.add(available);
             }
         }
-        geoServer.save(info);
+
+        //only save if we have anything new to add
+        if (!newGroups.isEmpty()) {
+            info.getProcessGroups().addAll(newGroups);
+            geoServer.save(info);
+        }
     }
 
     static List<ProcessGroupInfo> lookupProcessGroups() {

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/WPSInitializerTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/WPSInitializerTest.java
@@ -1,0 +1,121 @@
+package org.geoserver.wps;
+
+import static org.easymock.classextension.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.easymock.IArgumentMatcher;
+import org.easymock.internal.LastControl;
+import org.geoserver.config.ConfigurationListener;
+import org.geoserver.config.GeoServer;
+import org.geoserver.wps.executor.DefaultProcessManager;
+import org.geoserver.wps.executor.WPSExecutionManager;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WPSInitializerTest {
+
+    WPSInitializer initer;
+
+    @Before
+    public void mockUp() {
+        WPSExecutionManager execMgr = createNiceMock(WPSExecutionManager.class);
+        DefaultProcessManager procMgr = createNiceMock(DefaultProcessManager.class);
+        WPSStorageCleaner cleaner = createNiceMock(WPSStorageCleaner.class);
+
+        replay(execMgr, procMgr, cleaner);
+
+        initer = new WPSInitializer(execMgr, procMgr, cleaner);
+    }
+
+    @Test
+    public void testNoSave() throws Exception {
+        GeoServer gs = createMock(GeoServer.class);
+
+        List<ConfigurationListener> listeners = new ArrayList();
+        gs.addListener(capture(listeners));
+        expectLastCall().atLeastOnce();
+
+        //load all process groups so there is no call to save
+        List<ProcessGroupInfo> procGroups = WPSInitializer.lookupProcessGroups();
+
+        WPSInfo wps = createNiceMock(WPSInfo.class);
+        expect(wps.getProcessGroups()).andReturn(procGroups).anyTimes();
+        replay(wps);
+        
+        expect(gs.getService(WPSInfo.class)).andReturn(wps).anyTimes();
+        replay(gs);
+
+        initer.initialize(gs);
+
+        assertEquals(1, listeners.size());
+
+        ConfigurationListener l = listeners.get(0);
+        l.handleGlobalChange(null, null, null, null);
+        l.handlePostGlobalChange(null);
+
+        verify(gs);
+    }
+
+    @Test
+    public void testSingleSave() throws Exception {
+        
+        GeoServer gs = createMock(GeoServer.class);
+
+        List<ConfigurationListener> listeners = new ArrayList();
+        gs.addListener(capture(listeners));
+        expectLastCall().atLeastOnce();
+
+        //empty list should cause save
+        List<ProcessGroupInfo> procGroups = new ArrayList();
+
+        WPSInfo wps = createNiceMock(WPSInfo.class);
+        expect(wps.getProcessGroups()).andReturn(procGroups).anyTimes();
+        replay(wps);
+        
+        expect(gs.getService(WPSInfo.class)).andReturn(wps).anyTimes();
+        gs.save(wps);
+        expectLastCall().once();
+        replay(gs);
+
+        initer.initialize(gs);
+
+        assertEquals(1, listeners.size());
+
+        ConfigurationListener l = listeners.get(0);
+        l.handleGlobalChange(null, null, null, null);
+        l.handlePostGlobalChange(null);
+
+        verify(gs);
+    }
+
+    ConfigurationListener capture(List<ConfigurationListener> listeners) {
+        LastControl.reportMatcher(new ListenerCapture(listeners));
+        return null;
+    }
+
+    static class ListenerCapture implements IArgumentMatcher {
+
+        List<ConfigurationListener> listeners;
+
+        public ListenerCapture(List<ConfigurationListener> listeners) {
+            this.listeners = listeners;
+        }
+        @Override
+        public boolean matches(Object argument) {
+            if (argument instanceof ConfigurationListener) {
+                listeners.add((ConfigurationListener) argument);
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public void appendTo(StringBuffer buffer) {
+            buffer.append("ListenerCapture");
+        }
+    
+    }
+}


### PR DESCRIPTION
When working on a configuration/catalog listener I noticed that for a single event (say add a new catalog catalog object) many events are generated. Tracking it down I found that WPSInitializer produces events when it doesn't need to. The pull request makes it so that:
1. the initializer only does its think on post global change, rather than both pre and post
2. the initialzier only saves back the WPSinfo config if something actually changes
