### PR TITLE
[GEOS-5556] count=0 - WFS GetFeature

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
@@ -179,7 +179,12 @@ public abstract class FeatureTypeSchemaBuilder {
         if (baseUrl == null)
             baseUrl = wfs.getSchemaBaseURL(); 
                 
-        if (ns2featureTypeInfos.entrySet().size() == 1) {
+        if (ns2featureTypeInfos.entrySet().size() == 0) {
+            // for WFS 2.0 encoding to work we need to have at least a dependency on GML and
+            // a target namespace. We are going to use the GML one.
+            importGMLSchema(schema, factory, baseUrl);
+            schema.setTargetNamespace(gmlSchema().getTargetNamespace());
+        } else if (ns2featureTypeInfos.entrySet().size() == 1) {
             // only 1 namespace, write target namespace out
             String targetPrefix = (String) ns2featureTypeInfos.keySet().iterator().next();
             String targetNamespace = catalog.getNamespaceByPrefix(targetPrefix).getURI();

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
@@ -552,5 +552,14 @@ public class GetFeaturePagingTest extends WFS20TestSupport {
         assertStartIndexCount(doc, "previous", 0, 15);
         assertFalse(doc.getDocumentElement().hasAttribute("next"));
     }
+    
+    @Test
+    public void testCountZero() throws Exception {
+        Document doc = getAsDOM("/wfs?request=GetFeature&version=2.0.0&service=wfs&" +
+                "typename=gs:Fifteen&count=0");
+        XMLAssert.assertXpathExists("/wfs:FeatureCollection", doc);
+        XMLAssert.assertXpathEvaluatesTo("0", "/wfs:FeatureCollection/@numberMatched", doc);
+        XMLAssert.assertXpathEvaluatesTo("0", "/wfs:FeatureCollection/@numberReturned", doc);
+    }
 
 }


### PR DESCRIPTION
I thought this one was going to be a piece of cake and found myself in XML hell soo... I could probably use a review for the patch itself.

When count=0 in WFS 2.0 GetFeature we get no collections to encode, no feature types, as a result  FeatureTypeSchemaBuilder fails to build the output schema since it assumes, wrongly, that there will always be at least one feature type.
The fix I've made is to take into account that case, but still build enough schema to be able to encode a GML 3.2 collection, which means, adding the dependency to GML and setting the target namespace accordingly. 
