### PR TITLE
added i18n support for security PaletteFormComponent's (web-security)

### DIFF
--- a/src/web/security/src/main/java/org/geoserver/security/web/PaletteFormComponent.java
+++ b/src/web/security/src/main/java/org/geoserver/security/web/PaletteFormComponent.java
@@ -13,11 +13,12 @@ import org.apache.wicket.Component;
 import org.apache.wicket.behavior.IBehavior;
 import org.apache.wicket.extensions.markup.html.form.palette.Palette;
 import org.apache.wicket.extensions.markup.html.form.palette.component.Recorder;
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
-import org.geoserver.security.impl.GeoServerUserGroup;
+import org.apache.wicket.model.ResourceModel;
 
 public class PaletteFormComponent<T> extends FormComponentPanel {
 
@@ -45,10 +46,44 @@ public class PaletteFormComponent<T> extends FormComponentPanel {
                 toAdd.clear();
                 return rec;
             }
+            
+            /**
+             * Override otherwise the header is not i18n'ized
+             */
+            @Override
+            public Component newSelectedHeader(final String componentId) {
+                
+                return new Label(componentId, new ResourceModel(getSelectedHeaderPropertyKey()));
+            }
+
+            /**
+             * Override otherwise the header is not i18n'ized
+             */
+            @Override
+            public Component newAvailableHeader(final String componentId) {
+                return new Label(componentId, new ResourceModel(
+                        getAvaliableHeaderPropertyKey()));
+            }
         });
         palette.setOutputMarkupId(true);
     }
 
+    /**
+     * @return the default key, subclasses may override, if "Selected" is not
+     *         illustrative enough
+     */
+    protected String getSelectedHeaderPropertyKey() {
+        return "PaletteFormComponent.selectedHeader";
+    }
+
+    /**
+     * @return the default key, subclasses may override, if "Available" is not
+     *         illustrative enough
+     */
+    protected String getAvaliableHeaderPropertyKey() {
+        return "PaletteFormComponent.availableHeader";
+    }
+    
     @Override
     public Component add(IBehavior... behaviors) {
         if (palette.getRecorderComponent() == null) {

--- a/src/web/security/src/main/java/org/geoserver/security/web/role/RolePaletteFormComponent.java
+++ b/src/web/security/src/main/java/org/geoserver/security/web/role/RolePaletteFormComponent.java
@@ -90,4 +90,16 @@ public class RolePaletteFormComponent extends PaletteFormComponent<GeoServerRole
     public List<GeoServerRole> getSelectedRoles() {
         return new ArrayList(palette.getModelCollection());
     }
+    
+    @Override
+    protected String getSelectedHeaderPropertyKey() {
+        return "RolePaletteFormComponent.selectedHeader";
+    }
+    
+    @Override
+    protected String getAvaliableHeaderPropertyKey() {
+        // TODO Auto-generated method stub
+        return "RolePaletteFormComponent.availableHeader";
+    }
+
 }

--- a/src/web/security/src/main/java/org/geoserver/security/web/role/RuleRolesFormComponent.java
+++ b/src/web/security/src/main/java/org/geoserver/security/web/role/RuleRolesFormComponent.java
@@ -51,6 +51,16 @@ public class RuleRolesFormComponent extends RolePaletteFormComponent {
         return (Boolean) get("anyRole").getDefaultModelObject();
     }
 
+    @Override
+    protected String getSelectedHeaderPropertyKey() {
+        return "RuleRolesFormComponent.selectedHeader";
+    }
+    
+    @Override
+    protected String getAvaliableHeaderPropertyKey() {
+        return "RuleRolesFormComponent.availableHeader";
+    }
+
 //    
 //        add(hasAnyBox);
 //        if (hasStoredAnyRole(rootObject)) {

--- a/src/web/security/src/main/java/org/geoserver/security/web/user/UserGroupPaletteFormComponent.java
+++ b/src/web/security/src/main/java/org/geoserver/security/web/user/UserGroupPaletteFormComponent.java
@@ -90,4 +90,14 @@ public class UserGroupPaletteFormComponent extends PaletteFormComponent<GeoServe
         }
 
     }
+    
+    @Override
+    protected String getSelectedHeaderPropertyKey() {
+        return "UserGroupPaletteFormComponent.selectedHeader";
+    }
+    
+    @Override
+    protected String getAvaliableHeaderPropertyKey() {
+        return "UserGroupPaletteFormComponent.availableHeader";
+    }
 }

--- a/src/web/security/src/main/resources/GeoServerApplication.properties
+++ b/src/web/security/src/main/resources/GeoServerApplication.properties
@@ -687,3 +687,18 @@ AuthFilterChainPalette.availableHeader = Available
 
 AuthenticationChainPalette.selectedHeader = Selected
 AuthenticationChainPalette.availableHeader = Available
+
+# default values for palette headers (avaliable/selected)
+# if subclasses of PaletteFormComponent have no need to ovverride
+# getSelectedHeaderPropertyKey() / getAvaliableHeaderPropertyKey()
+PaletteFormComponent.selectedHeader = Selected
+PaletteFormComponent.availableHeader = Available
+
+RolePaletteFormComponent.selectedHeader = Selected Roles
+RolePaletteFormComponent.availableHeader = Available Roles
+
+RuleRolesFormComponent.selectedHeader = Selected Roles
+RuleRolesFormComponent.availableHeader = Available Roles
+
+UserGroupPaletteFormComponent.selectedHeader = Selected Groups
+UserGroupPaletteFormComponent.availableHeader = Available Groups


### PR DESCRIPTION
See [GEOS-5573](https://jira.codehaus.org/browse/GEOS-5573)

This patch adds support for internationalization of palette headers of the web-security module. Sublcasses of PaletteFormComponent can override default headers (see **PaletteFormComponent.selectedHeader** and **PaletteFormComponent.availableHeader** in _GeoServerApplication.properties_) by overriding the two methods 
- getSelectedHeaderPropertyKey()
- getAvaliableHeaderPropertyKey()
