### PR TITLE
remove stax as a dependency, it comes with the JDK since Java 6

### DIFF
--- a/src/community/ftp/pom.xml
+++ b/src/community/ftp/pom.xml
@@ -22,18 +22,6 @@
          <artifactId>ftpserver-core</artifactId>
          <version>1.0.5</version>
       </dependency>
-      <dependency>
-        <!-- StAX API is the standard java XML processing API defined by JSR-173 -->
-        <groupId>stax</groupId>
-        <artifactId>stax-api</artifactId>
-        <version>1.0.1</version>
-      </dependency>
-      <dependency>
-        <!-- StAX is the reference implementation of the StAX API -->
-        <groupId>stax</groupId>
-        <artifactId>stax</artifactId>
-        <version>1.2.0</version>
-      </dependency>
 
       <!-- Testing -->
       <dependency>

--- a/src/extension/geosearch/pom.xml
+++ b/src/extension/geosearch/pom.xml
@@ -41,15 +41,6 @@
    <version>2.3-SNAPSHOT</version>
   </dependency>
   <dependency>
-    <groupId>stax</groupId>
-    <artifactId>stax-api</artifactId>
-  </dependency>
-  <dependency>
-    <!-- StAX is the reference implementation of the StAX API -->
-    <groupId>stax</groupId>
-    <artifactId>stax</artifactId>
-  </dependency>
-  <dependency>
    <groupId>org.geoserver</groupId>
    <artifactId>main</artifactId>
    <version>2.3-SNAPSHOT</version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -614,17 +614,6 @@
     <version>1.1.3.4.O</version>
    </dependency>
    <dependency>
-     <groupId>stax</groupId>
-     <artifactId>stax-api</artifactId>
-     <version>1.0.1</version>
-   </dependency>
-   <dependency>
-     <!-- StAX is the reference implementation of the StAX API -->
-     <groupId>stax</groupId>
-     <artifactId>stax</artifactId>
-     <version>1.2.0</version>
-   </dependency>
-   <dependency>
     <groupId>org.codehaus.jettison</groupId>
     <artifactId>jettison</artifactId>
     <version>1.0.1</version>


### PR DESCRIPTION
This patch removes the stax api and implementation libraries as dependencies from the poms, since StAX is now a standard API in Java 6
