### PR TITLE
Documentation license Creative Commons by Attribution (GEOS-5543)

### DIFF
--- a/doc/en/developer/source/conf.py
+++ b/doc/en/developer/source/conf.py
@@ -39,7 +39,7 @@ master_doc = 'index'
 # General substitutions.
 project = u'GeoServer'
 manual = u'Developer Manual'
-copyright = u'2012, TOPP'
+copyright = u'2013, OpenPlans'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/doc/en/docguide/source/conf.py
+++ b/doc/en/docguide/source/conf.py
@@ -39,7 +39,7 @@ master_doc = 'index'
 # General substitutions.
 project = u'GeoServer'
 manual = u'Documentation Guide'
-copyright = u'2012, TOPP'
+copyright = u'2013, OpenPlans'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/doc/en/themes/geoserver/layout.html
+++ b/doc/en/themes/geoserver/layout.html
@@ -208,7 +208,7 @@
   {%- if hasdoc('copyright') %}
     &copy; <a href="{{ pathto('copyright') }}">Copyright</a> {{ copyright }}.
   {%- else %}
-    &copy; Copyright {{ copyright }}.
+    &copy; Copyright {{ copyright }}. License <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution</a>.
   {%- endif %}
   {%- if last_updated %}
     Last updated on {{ last_updated }}.

--- a/doc/en/user/source/conf.py
+++ b/doc/en/user/source/conf.py
@@ -39,7 +39,7 @@ master_doc = 'index'
 # General substitutions.
 project = u'GeoServer'
 manual = u'User Manual'
-copyright = u'2012, TOPP'
+copyright = u'2013, OpenPlans'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.


### PR DESCRIPTION
Result of http://geoserver.org/display/GEOS/GSIP+89+Creative+Commons+with+Attribution

Link to Jira here: http://jira.codehaus.org/browse/GEOS-5543

Change:
- updates geoserver template with a link to creative commons license
- udpates the conf.py files to say "2013 OpenPlans"
