### PR TITLE
Added support for WCS 1.0.0 requests via WPS.

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/xml/WPSConfiguration.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/xml/WPSConfiguration.java
@@ -24,5 +24,6 @@ public class WPSConfiguration extends org.geotools.wps.WPSConfiguration {
         super.configureContext(container);
 
         container.registerComponentInstance(new WCSParserDelegate());
+        container.registerComponentInstance(new org.geoserver.wcs.xml.v1_0_0.WCSParserDelegate());
     }
 }

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/xml/v1_0_0/WCSParserDelegate.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/xml/v1_0_0/WCSParserDelegate.java
@@ -1,0 +1,19 @@
+/* Copyright (c) 2001 - 2012 TOPP - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, availible at the root
+ * application directory.
+ */
+package org.geoserver.wcs.xml.v1_0_0;
+
+import org.geotools.wcs.WCSConfiguration;
+import org.geotools.xml.XSDParserDelegate;
+
+/**
+ * Parser delegate for WCS 1.0.0.
+ * 
+ * @author Chad Phillips 
+ */
+public class WCSParserDelegate extends XSDParserDelegate {
+    public WCSParserDelegate() {
+        super(new WCSConfiguration());
+    }
+}


### PR DESCRIPTION
The code in the WPS module for fulfilling WCS 1.0.0 requests already existed but, since no parser delegate existed for WCS 1.0.0, the WCS 1.0.0 requests could not be properly unmarshalled.  This provides the missing parser delegate and adds it to the WPS config.
