### PR TITLE
Typo on inimage exception WMS reference doc

### DIFF
--- a/doc/en/user/source/services/wms/reference.rst
+++ b/doc/en/user/source/services/wms/reference.rst
@@ -63,7 +63,7 @@ Formats in which WMS can report exceptions. The supported values for exceptions 
      - ``EXCEPTIONS=application/vnd.ogc.se_xml``
      - Xml output. (The default format)
    * - PNG
-     - ``EXCEPTIONS=application/vnd.ogc.inimage``
+     - ``EXCEPTIONS=application/vnd.ogc.se_inimage``
      - Generates an image
    * - Blank
      - ``EXCEPTIONS=application/vnd.ogc.se_blank``


### PR DESCRIPTION
fixed small typo on inimage exception

BTW I have to admit is also my first pull request on github so this is a test :)
