### PR TITLE
[GEOS-4011] Unquoded subtype=gml/<version> breaks HTTP/1.1 standard

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -898,6 +898,7 @@ public class Dispatcher extends AbstractController {
                 req.getHttpResponse().setContentType(SOAP_MIME);
             }
             else {
+                mimeType = mimeType.replaceAll("(subtype=)(gml/[0-9.]*)", "$1\"$2\"");          // fix for [GEOS-4011]
                 req.getHttpResponse().setContentType(mimeType);
             }
 


### PR DESCRIPTION
Patch for master

I originally proposed this patch for the 2.2.x branch as that is the one we are using here. In any case, it also applies to the master branch.

Best wishes.
