### PR TITLE
[GEOS-4011] Unquoded subtype=gml/<version> breaks HTTP/1.1 standard

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -898,6 +898,7 @@ public class Dispatcher extends AbstractController {
                 req.getHttpResponse().setContentType(SOAP_MIME);
             }
             else {
+                mimeType = mimeType.replaceAll("(subtype=)(gml/[0-9.]*)", "$1\"$2\"");          // fix for [GEOS-4011]
                 req.getHttpResponse().setContentType(mimeType);
             }
 


### PR DESCRIPTION
Backport to 2.3.x

Please see discussion here: https://github.com/geoserver/geoserver/pull/168
