### PR TITLE
GEOS-5672: fixed nested group loop

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
@@ -245,7 +245,7 @@ public class LayerGroupHelper {
         
         for (PublishedInfo child : group.getLayers()) {
             if (child instanceof LayerGroupInfo) {
-                if (path.contains(child)) {
+                if (isGroupInStack((LayerGroupInfo) child, path)) {
                     path.push((LayerGroupInfo) child);
                     return true;
                 } else if (checkLoops((LayerGroupInfo) child, path)) {
@@ -255,6 +255,16 @@ public class LayerGroupHelper {
         }
         
         path.pop();
+        return false;
+    }
+    
+    private static boolean isGroupInStack(LayerGroupInfo group, Stack<LayerGroupInfo> path) {
+        for (LayerGroupInfo groupInPath : path) {
+            if (groupInPath.getId().equals(group.getId())) {
+                return true;
+            }
+        }
+        
         return false;
     }
 }

--- a/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
@@ -1,6 +1,8 @@
 package org.geoserver.catalog;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
@@ -10,6 +12,7 @@ import java.util.Stack;
 import javax.xml.namespace.QName;
 
 import org.geoserver.catalog.LayerGroupInfo.Mode;
+import org.geoserver.catalog.impl.LayerGroupInfoImpl;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.MockTestData;
 import org.geoserver.test.GeoServerMockTestSupport;
@@ -64,7 +67,8 @@ public class LayerGroupHelperTest extends GeoServerMockTestSupport {
     }
 
     private LayerGroupInfo buildGroup(String name, PublishedInfo... publisheds) {
-        LayerGroupInfo group = getCatalog().getFactory().createLayerGroup();
+        LayerGroupInfoImpl group = (LayerGroupInfoImpl) getCatalog().getFactory().createLayerGroup();
+        group.setId(name);
         group.setName(name);
         group.getLayers().addAll(Arrays.asList(publisheds));
 
@@ -145,6 +149,27 @@ public class LayerGroupHelperTest extends GeoServerMockTestSupport {
         path = helper.checkLoops();
         Assert.assertNotNull(path);
         Assert.assertEquals("/loop2/ponds/loop2", helper.getLoopAsString(path));        
+    }
+    
+    @Test
+    public void testSimpleLoopWithNotEqualGroups() {
+        LayerGroupInfo myLoop = buildGroup("myLoop", forestLayer);
+         LayerGroupInfo loopClone = buildGroup("myLoop", forestLayer);
+         assertTrue(myLoop.equals(loopClone));
+            
+         // change the LayerGroup
+         myLoop.setTitle("new title");
+         // now the two groups aren't equal anymore
+         assertFalse(myLoop.equals(loopClone));
+            
+         // create loop
+         myLoop.getLayers().add(loopClone);
+
+         // validate
+         LayerGroupHelper helper = new LayerGroupHelper(myLoop);
+         Stack<LayerGroupInfo> path = helper.checkLoops();
+         Assert.assertNotNull(path);
+         Assert.assertEquals("/myLoop/myLoop", helper.getLoopAsString(path));
     }
     
     @Test


### PR DESCRIPTION
Hi,
I've fixed http://jira.codehaus.org/browse/GEOS-5672
Now groups are compared by id.
