### PR TITLE
GEOS-5710 GetLegendGraphic for a layergroup with a coverage invisble at current scale fails

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
@@ -280,10 +280,12 @@ public class BufferedImageLegendGraphicBuilder {
             if (buildRasterLegend) {
                 final RasterLayerLegendHelper rasterLegendHelper = new RasterLayerLegendHelper(request,gt2Style,ruleName);
                 final BufferedImage image = rasterLegendHelper.getLegend();
-                if(image != null && titleImage != null) {
+                if(image != null) {
+                    if(titleImage != null) {
                     layersImages.add(titleImage);
                 }
                 layersImages.add(image);
+                }                
             } else {
                 
                 final Feature sampleFeature;

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/RasterLayerLegendHelper.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/RasterLayerLegendHelper.java
@@ -114,9 +114,8 @@ public class RasterLayerLegendHelper {
         } else {
             applicableRules = LegendUtils.getApplicableRules(ftStyles, scaleDenominator);
         }
-        if (applicableRules.length != 1)
-            throw new IllegalArgumentException(
-                    "Unable to create a legend for this style, we need exactly 1 rule");
+        // no rules means no legend has to be produced
+        if (applicableRules.length != 0) {
 
 //        final NumberRange<Double> scaleRange = NumberRange.create(scaleDenominator,
 //                scaleDenominator);
@@ -192,6 +191,7 @@ public class RasterLayerLegendHelper {
 
         } else
             cMapLegendCreator = null;
+        }
 
     }
 
@@ -201,6 +201,9 @@ public class RasterLayerLegendHelper {
      * @return a {@link BufferedImage} that represents the legend for the provided request.
      */
     public BufferedImage getLegend() {
+        if(rasterSymbolizer == null) {
+            return null;
+        }
         return createResponse();
     }
 

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
@@ -6,6 +6,7 @@ package org.geoserver.wms.legendgraphic;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.awt.Color;
@@ -402,10 +403,127 @@ public class AbstractLegendGraphicOutputFormatTest extends WMSTestSupport {
     
     /**
      * Tests that the legend graphic is produced for multiple layers
-     * with different style for each layer.
+     * with vector and coverage layers.
      */
+    @org.junit.Test    
+	public void testMultipleLayersWithVectorAndCoverage() throws Exception {        
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest();
+        
+        int titleHeight = getTitleHeight(req);
+        
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName(
+                MockData.ROAD_SEGMENTS.getNamespaceURI(), MockData.ROAD_SEGMENTS.getLocalPart());
+        List<FeatureType> layers=new ArrayList<FeatureType>();
+        layers.add(ftInfo.getFeatureType());
+        
+        CoverageInfo cInfo = getCatalog().getCoverageByName("world");
+        assertNotNull(cInfo);
+
+        GridCoverage coverage = cInfo.getGridCoverage(null, null);
+        try {
+	        SimpleFeatureCollection feature;
+	        feature = FeatureUtilities.wrapGridCoverage((GridCoverage2D) coverage);
+	        layers.add(feature.getSchema());
+	        
+	        req.setLayers(layers);
+	        
+	        List<Style> styles=new ArrayList<Style>();
+	        Style style1= getCatalog().getStyleByName(
+	                MockData.ROAD_SEGMENTS.getLocalPart()).getStyle();
+	        styles.add(style1);
+	        
+	        Style style2= getCatalog().getStyleByName("rainfall").getStyle();
+	        styles.add(style2);
+	        req.setStyles(styles);
+	        
+	        this.legendProducer.buildLegendGraphic(req);
+	
+	        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+	
+	        
+	        // vector layer
+	        assertPixel(image, 10, 10+titleHeight, new Color(192,160,0));
+	        
+	        assertPixel(image, 10, 30+titleHeight, new Color(0,0,0));
+	        
+	        assertPixel(image, 10, 50+titleHeight, new Color(224,64,0));
+	        
+	        // coverage layer        
+	        assertPixel(image, 10, 70+titleHeight*2, new Color(115,38,0));
+		} finally {
+	        RenderedImage ri = coverage.getRenderedImage();
+	        if(coverage instanceof GridCoverage2D) {
+	            ((GridCoverage2D) coverage).dispose(true);
+	        }
+	        if(ri instanceof PlanarImage) {
+	            ImageUtilities.disposePlanarImageChain((PlanarImage) ri);
+	        }
+	    }
+
+    }
+    
+    /**
+     * Tests that the legend graphic is produced for multiple layers
+     * with vector and coverage layers, when coverage is not visible
+     * at current scale.
+     */    
     @org.junit.Test
-    public void testMixedGeometry() throws Exception {
+    public void testMultipleLayersWithVectorAndInvisibleCoverage() throws Exception {        
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest();
+        req.setScale(1000);
+        int titleHeight = getTitleHeight(req);
+        
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName(
+                MockData.ROAD_SEGMENTS.getNamespaceURI(), MockData.ROAD_SEGMENTS.getLocalPart());
+        List<FeatureType> layers=new ArrayList<FeatureType>();
+        layers.add(ftInfo.getFeatureType());
+        
+        CoverageInfo cInfo = getCatalog().getCoverageByName("world");
+        assertNotNull(cInfo);
+
+        GridCoverage coverage = cInfo.getGridCoverage(null, null);
+        try {
+	        SimpleFeatureCollection feature;
+	        feature = FeatureUtilities.wrapGridCoverage((GridCoverage2D) coverage);
+	        layers.add(feature.getSchema());
+	        
+	        req.setLayers(layers);
+	        
+	        List<Style> styles=new ArrayList<Style>();
+	        Style style1= getCatalog().getStyleByName(
+	                MockData.ROAD_SEGMENTS.getLocalPart()).getStyle();
+	        styles.add(style1);
+	        
+	        styles.add(readSLD("InvisibleRaster.sld"));
+	        
+	        
+	        req.setStyles(styles);
+	        
+	        this.legendProducer.buildLegendGraphic(req);
+	
+	        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+	        
+	        // vector layer
+	        assertPixel(image, 10, 10+titleHeight, new Color(192,160,0));
+	        
+	        assertPixel(image, 10, 30+titleHeight, new Color(0,0,0));
+	        
+	        assertPixel(image, 10, 50+titleHeight, new Color(224,64,0));
+	                
+	        // no coverage
+	        assertTrue(image.getHeight() < 70+titleHeight*2);
+	    } finally {
+	        RenderedImage ri = coverage.getRenderedImage();
+	        if(coverage instanceof GridCoverage2D) {
+	            ((GridCoverage2D) coverage).dispose(true);
+	        }
+	        if(ri instanceof PlanarImage) {
+	            ImageUtilities.disposePlanarImageChain((PlanarImage) ri);
+	        }
+	    }
+    }
+
+	public void testMixedGeometry() throws Exception {
         GetLegendGraphicRequest req = new GetLegendGraphicRequest();
     
         SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/InvisibleRaster.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/InvisibleRaster.sld
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+This document is used by AbstractLegendGraphicOutputFormatTest.testMixedGeometry.
+This document contains styles for Polygons, Lines and Points.
+-->
+    <UserStyle>
+        <Name>InvisibleRaster</Name>
+        <Title>Default Styler</Title>
+        <Abstract></Abstract>
+        <FeatureTypeStyle>            
+            <Rule>
+                <Name>raster</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title</Title>
+                <MaxScaleDenominator>500</MaxScaleDenominator>
+                <RasterSymbolizer>                    
+                </RasterSymbolizer>
+            </Rule>
+            
+        </FeatureTypeStyle>
+    </UserStyle>
+   </StyledLayerDescriptor>


### PR DESCRIPTION
If a layergroup contains a coverage, asking a legend for the group throws an IllegalArgumentException if the coverage is not visible at current scale, because there is no rule applicable for the coverage.
RasterLayerLegendHelper should simply return a null image in this case, letting BufferedImageLegendGraphicBuilder collect legends for the other group layers.
