### PR TITLE
cache-control headers in integrated wms, GEOS-5686

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/wms/CachingWebMapService.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/wms/CachingWebMapService.java
@@ -23,8 +23,11 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.httpclient.util.DateParseException;
 import org.apache.commons.httpclient.util.DateUtil;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MetadataMap;
 import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.HttpErrorCodeException;
 import org.geoserver.wms.GetMapRequest;
@@ -119,10 +122,25 @@ public class CachingWebMapService implements MethodInterceptor {
 
         RawMap map = new RawMap(null, tileBytes, mimeType);
 
-        map.setResponseHeader("Cache-Control", "no-cache");
-        map.setResponseHeader("ETag", etag);
-
         map.setContentDispositionHeader(null, "." + cachedTile.getMimeType().getFileExtension(), false);
+
+        Object cacheAgeMax = getCacheAge(layer);
+        LOGGER.log(Level.FINE, "Using cacheAgeMax {0}", cacheAgeMax);
+        if (cacheAgeMax != null) {
+            map.setResponseHeader("Cache-Control", "max-age=" + cacheAgeMax);
+        } else {
+            map.setResponseHeader("Cache-Control", "no-cache");
+        }
+
+        setConditionalGetHeaders(map, cachedTile, request, etag);
+        setCacheMetadataHeaders(map, cachedTile, layer);
+
+        return map;
+
+    }
+
+    private void setConditionalGetHeaders(RawMap map, ConveyorTile cachedTile, GetMapRequest request, String etag) {
+        map.setResponseHeader("ETag", etag);
 
         final long tileTimeStamp = cachedTile.getTSCreated();
         final String ifModSinceHeader = request.getHttpRequestHeader("If-Modified-Since");
@@ -152,7 +170,9 @@ public class CachingWebMapService implements MethodInterceptor {
                 }
             }
         }
+    }
 
+    private void setCacheMetadataHeaders(RawMap map, ConveyorTile cachedTile, TileLayer layer) {
         long[] tileIndex = cachedTile.getTileIndex();
         CacheResult cacheResult = cachedTile.getCacheResult();
         GridSubset gridSubset = layer.getGridSubset(cachedTile.getGridSetId());
@@ -165,9 +185,25 @@ public class CachingWebMapService implements MethodInterceptor {
         map.setResponseHeader("geowebcache-tile-bounds", tileBounds.toString());
         map.setResponseHeader("geowebcache-gridset", gridSubset.getName());
         map.setResponseHeader("geowebcache-crs", gridSubset.getSRS().toString());
+    }
 
-        return map;
-
+    private Object getCacheAge(TileLayer layer) {
+        Object cacheAge = null;
+        if (layer instanceof GeoServerTileLayer) {
+            LayerInfo layerInfo = ((GeoServerTileLayer) layer).getLayerInfo();
+            // configuring caching does not appear possible for layergroup
+            if (layerInfo != null) {
+                MetadataMap metadata = layerInfo.getResource().getMetadata();
+                Object enabled = metadata.get("cachingEnabled");
+                // do a string comparison since if set via REST, it will be a
+                // string, if set via the web UI and fresh in the cache, it
+                // will be a boolean ...
+                if (enabled != null && enabled.toString().equalsIgnoreCase("true")) {
+                    cacheAge = layerInfo.getResource().getMetadata().get("cacheAgeMax");
+                }
+            }
+        }
+        return cacheAge;
     }
 
     private GetMapRequest getRequest(MethodInvocation invocation) {

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 
 import com.mockrunner.mock.web.MockHttpServletRequest;
 import com.mockrunner.mock.web.MockHttpServletResponse;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
 
 public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
@@ -159,6 +160,33 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
         httpReq.setHeader("If-Modified-Since", ifModifiedSince);
         response = dispatch(httpReq, "UTF-8");
         assertEquals(HttpServletResponse.SC_NOT_MODIFIED, response.getErrorCode());
+    }
+
+    @Test public void testDirectWMSIntegrationMaxAge() throws Exception {
+        final GWC gwc = GWC.get();
+        gwc.getConfig().setDirectWMSIntegrationEnabled(true);
+        final String layerName = BASIC_POLYGONS.getPrefix() + ":" + BASIC_POLYGONS.getLocalPart();
+        final String path = buildGetMap(true, layerName, "EPSG:4326", null) + "&tiled=true";
+        final String qualifiedName = super.getLayerId(BASIC_POLYGONS);
+        final GeoServerTileLayer tileLayer = (GeoServerTileLayer) gwc.getTileLayerByName(qualifiedName);
+        tileLayer.getLayerInfo().getResource().getMetadata().put("cachingEnabled", "true");
+        tileLayer.getLayerInfo().getResource().getMetadata().put("cacheAgeMax", 3456);
+
+        MockHttpServletResponse response = getAsServletResponse(path);
+        String cacheControl = response.getHeader("Cache-Control");
+        assertEquals("max-age=3456", cacheControl);
+        assertNotNull(response.getHeader("Last-Modified"));
+
+        tileLayer.getLayerInfo().getResource().getMetadata().put("cachingEnabled", "false");
+        response = getAsServletResponse(path);
+        cacheControl = response.getHeader("Cache-Control");
+        assertEquals("no-cache", cacheControl);
+
+        // make sure a boolean is handled, too - see comment in CachingWebMapService
+        tileLayer.getLayerInfo().getResource().getMetadata().put("cachingEnabled", Boolean.FALSE);
+        response = getAsServletResponse(path);
+        cacheControl = response.getHeader("Cache-Control");
+        assertEquals("no-cache", cacheControl);
     }
 
     @Test public void testDirectWMSIntegrationWithVirtualServices() throws Exception {


### PR DESCRIPTION
- cleanup interceptor, add max-age header from layer metadata if
  declared
- add test

Conflicts:

```
src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
```
