### PR TITLE
added FeatureCount for JSON-OutputFormat

### DIFF
--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
@@ -182,4 +182,18 @@ public class GeoJSONTest extends WFSTestSupport {
         JSONObject aFeature = featureCol.getJSONObject(0);
         assertEquals(aFeature.getString("geometry_name"), "surfaceProperty");
     }
+    
+    @Test
+    public void testGetFeatureCount() throws Exception {	
+    	//request without filter
+    	String out = getAsString("wfs?request=GetFeature&version=1.0.0&typename=sf:PrimitiveGeoFeature&maxfeatures=10&outputformat="+JSONType.json);
+    	JSONObject rootObject = JSONObject.fromObject( out );
+    	assertEquals(rootObject.get("totalFeatures"),5);
+
+    	//request with filter (featureid=PrimitiveGeoFeature.f001)
+    	String out2 = getAsString("wfs?request=GetFeature&version=1.0.0&typename=sf:PrimitiveGeoFeature&maxfeatures=10&outputformat="+JSONType.json+"&featureid=PrimitiveGeoFeature.f001");
+    	
+    	JSONObject rootObject2 = JSONObject.fromObject( out2 );
+    	assertEquals(rootObject2.get("totalFeatures"),1);
+    }
 }


### PR DESCRIPTION
Hi GeoServer-Developers,

I have just extended the GeoJSONOutput-format with an extra 'totalFeatures' attribute, that shows the featureCount for a request.

I made this patch in agreement with the geoserver developer list (see thread http://osgeo-org.1560.x6.nabble.com/JSON-output-total-number-of-features-for-paging-td5035093.html)

I have also created the test "testGetFeatureCount() in "GeoJSONTest.java" which shows the featureCount in a request without a filter and a request with a filter.

I would be glad if you could implement the patch into the main branch.

Best regards
Paul
