### PR TITLE
GEOS-5766 - MonitorInputStream ignores maxSize

### DIFF
--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorServletRequest.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorServletRequest.java
@@ -63,7 +63,9 @@ public class MonitorServletRequest extends HttpServletRequestWrapper {
         public MonitorInputStream(ServletInputStream delegate, long maxSize) {
             this.delegate = delegate;
             this.maxSize = maxSize;
-            buffer = new ByteArrayOutputStream();
+            if (maxSize > 0) {
+                buffer = new ByteArrayOutputStream();
+            }
         }
 
         public int available() throws IOException {
@@ -143,11 +145,11 @@ public class MonitorServletRequest extends HttpServletRequestWrapper {
         }
 
         boolean bufferIsFull() {
-            return buffer.size() >= maxSize && maxSize > 0;
+            return maxSize == 0 || (buffer.size() >= maxSize && maxSize > 0);
         }
 
         public byte[] getData() {
-            return buffer.toByteArray();
+            return buffer == null ? new byte[0] : buffer.toByteArray();
         }
 
         public long getBytesRead() {

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/MonitorServletRequestTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/MonitorServletRequestTest.java
@@ -14,9 +14,27 @@ import org.geoserver.monitor.MonitorServletRequest.MonitorInputStream;
 import org.junit.Test;
 
 import com.mockrunner.mock.web.MockServletInputStream;
+import static junit.framework.Assert.assertEquals;
 
 public class MonitorServletRequestTest {
 
+    @Test
+    public void testInputStreamMaxSizeZero() throws Exception {
+        byte[] data = data();
+        MockServletInputStream mock = new MockServletInputStream(data);
+
+        MonitorInputStream in = new MonitorInputStream(mock, 0);
+        byte[] read = read(in);
+
+        assertEquals(data.length, read.length);
+
+        byte[] buffer = in.getData();
+        assertEquals(0, buffer.length);
+
+        // ? why does this report 1 off ?
+        assertEquals(data.length - 1, in.getBytesRead());
+    }
+    
     @Test
     public void testInputStream() throws Exception {
         byte[] data = data();
@@ -33,6 +51,9 @@ public class MonitorServletRequestTest {
         for (int i = 0; i < buffer.length; i++) {
             assertEquals(data[i], buffer[i]);
         }
+
+        // ? why does this report 1 off ?
+        assertEquals(data.length - 1, in.getBytesRead());
     }
     
     static byte[] data() throws IOException {


### PR DESCRIPTION
(cherry picked from commit e3661748e09a02c24e3755e901c24be1bc22f8fb)

Conflicts:

```
src/extension/monitor/core/src/test/java/org/geoserver/monitor/MonitorServletRequestTest.java
```
