### PR TITLE
[GEOS-5774] Fix concurrency issue in TimeKvpParser

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/kvp/TimeKvpParser.java
+++ b/src/ows/src/main/java/org/geoserver/ows/kvp/TimeKvpParser.java
@@ -49,18 +49,18 @@ public class TimeKvpParser extends KvpParser {
         MONTH("yyyy-MM", Calendar.MONTH),
         YEAR("yyyy", Calendar.YEAR);
 
-        public final ThreadLocal<SimpleDateFormat> format;
+        public final String format;
         public final int precision;
 
         FormatAndPrecision(final String format, int precision) {
-            this.format = new ThreadLocal<SimpleDateFormat>() {
-                @Override protected SimpleDateFormat initialValue() {
-                    SimpleDateFormat sdf = new SimpleDateFormat(format);
-                    sdf.setTimeZone(UTC_TZ);
-                    return sdf;
-                }
-            };
+            this.format = format;
             this.precision = precision;
+        }
+
+        public SimpleDateFormat getFormat() {
+            SimpleDateFormat sdf = new SimpleDateFormat(format);
+            sdf.setTimeZone(UTC_TZ);
+            return sdf;
         }
 
         public DateRange expand(Date d) {
@@ -295,7 +295,7 @@ public class TimeKvpParser extends KvpParser {
 
         for (FormatAndPrecision f : FormatAndPrecision.values()) {
             ParsePosition pos = new ParsePosition(0);
-            Date time = f.format.get().parse(value, pos);
+            Date time = f.getFormat().parse(value, pos);
             if (pos.getIndex() == value.length()) {
                 DateRange range  = f.expand(time);
                 if (range.getMinValue().equals(range.getMaxValue())) {


### PR DESCRIPTION
The enum FormatAndPrecision in TimeKvpParser contained a SimpleDateFormat object that was shared across threads. This caused concurrency issues under concurrent load. This commit changes the single SimpleDateFormat object per enum instance to a ThreadLocal<SimpleDateFormat> to make the parser thread safe.
