### PR TITLE
support for escaping SQL special characters (UI & featurestore config to...

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -1872,6 +1872,9 @@ public class XStreamPersister {
             writer.startNode("sql");
             writer.setValue(vt.getSql());
             writer.endNode();
+            writer.startNode("escapeSql");
+            writer.setValue(Boolean.toString(vt.isEscapeSql()));
+            writer.endNode();
             if(vt.getPrimaryKeyColumns() != null) {
                 for(String pk : vt.getPrimaryKeyColumns()) {
                     writer.startNode("keyColumn");
@@ -1924,7 +1927,19 @@ public class XStreamPersister {
         public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
             String name = readValue("name", String.class, reader);
             String sql = readValue("sql", String.class, reader);
-            VirtualTable vt = new VirtualTable(name, sql);
+            
+            // escapeSql value may be missing from existing definitions.  In this 
+            // case set it to false to prevent changing behaviour
+            boolean escapeSql;
+            try {
+                escapeSql = Boolean.valueOf(readValue("escapeSql", String.class, reader));
+            } catch (IllegalArgumentException e) {
+                escapeSql = false;
+                // the reader is now in the wrong position, it must be moved back a line
+                reader.moveUp();
+            }
+                
+            VirtualTable vt = new VirtualTable(name, sql, escapeSql);
             List<String> primaryKeys = new ArrayList<String>();
             while(reader.hasMoreChildren()) {
                 reader.moveDown();

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.html
@@ -17,8 +17,9 @@
         <li><label for="parameters"><wicket:message key="parameters">parameters</wicket:message></label>
             <a href="#" wicket:id="guessParams"><wicket:message key="guessParams">guess from sql</wicket:message></a>&nbsp;&nbsp;&nbsp;&nbsp;
             <a href="#" wicket:id="addNewParam"><wicket:message key="addNewParam">add new</wicket:message></a>&nbsp;&nbsp;&nbsp;&nbsp;
-            <a href="#" wicket:id="removeParam"><wicket:message key="removeSelected">remove elected</wicket:message></a>
+            <a href="#" wicket:id="removeParam"><wicket:message key="removeSelected">remove selected</wicket:message></a>
             <div wicket:id="parameters"></div>
+            <input type="checkbox" wicket:id="escapeSql"><wicket:message key="escapeSql">Escape special characters</wicket:message></input>
         </li>
         <li><label for="attributes"><wicket:message key="attributes">attributes</wicket:message></label>
             <a href="#" wicket:id="refresh"><wicket:message key="refresh">refresh</wicket:message></a>&nbsp;&nbsp;&nbsp;

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
@@ -101,6 +101,8 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
     boolean guessGeometrySrid = false;
 
     private CheckBox guessCheckbox;
+    
+    private boolean escapeSql = true;
 
     private static final List GEOMETRY_TYPES = Arrays.asList(Geometry.class,
             GeometryCollection.class, Point.class, MultiPoint.class, LineString.class,
@@ -155,6 +157,7 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
 
             name = virtualTable.getName();
             sql = virtualTable.getSql();
+            escapeSql = virtualTable.isEscapeSql();
 
             paramProvider.init(virtualTable);
             try {
@@ -227,7 +230,8 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
         // the "refresh attributes" link
         form.add(refreshLink());
         form.add(guessCheckbox = new CheckBox("guessGeometrySrid", new PropertyModel(this, "guessGeometrySrid")));
-
+        form.add(new CheckBox("escapeSql"));
+ 
         // the editable attribute table
         attributes = new GeoServerTablePanel<SQLViewAttribute>("attributes", attProvider) {
 
@@ -378,6 +382,7 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
             VirtualTable vt = new VirtualTable(vtName, virtualTable);
             // hide the primary key definitions or we'll loose some columns
             vt.setPrimaryKeyColumns(Collections.EMPTY_LIST);
+            vt.setEscapeSql(escapeSql);
             ds.addVirtualTable(vt);
             return guessFeatureType(ds, vt.getName(), guessGeometrySrid);
         } finally {

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -447,6 +447,7 @@ SQLViewAbstractPage.invalidRegexp=Invalid regular expression ${regexp}: ${error}
 SQLViewAbstractPage.duplicateSqlViewName=A '${name}' sql view is already used in the '${typeName}' feature type, please choose a different name
 SQLViewAbstractPage.guessGeometrySridWarning=Warning, guessing requires running a query that will retrieve one row or the result. Depending on the query nature and the amount of data it might take a significant amount of time.
 SQLViewAbstractPage.guessGeometrySrid=Guess geometry type and srid
+SQLViewAbstractPage.escapeSql=Escape special SQL characters
 
 SQLViewNewPage.title=Create new SQL view
 SQLViewNewPage.description=Define a new SQL view and configure its identified and geometry columns


### PR DESCRIPTION
... activate support in GeoTools)

This is the companion request to https://github.com/geotools/geotools/pull/186 which activates the option in GeoServer.

I've added a checkbox to the "edit sql view" page to enable escaping special sql characters (quotes - and strip backslashes)

The XStreamPersister class has also been modified to serialize the new escapeSql attribute of the VirtualTable class to config files.  I've coded it not to swallow the exception and rewind the file if it parses a config file that doesn't already have the escapeSql option defined.
