### PR TITLE
Fix typo.

### DIFF
--- a/src/wms/src/main/resources/org/geoserver/wms/capabilities/getcaps_111_internalDTD.xsl
+++ b/src/wms/src/main/resources/org/geoserver/wms/capabilities/getcaps_111_internalDTD.xsl
@@ -5,7 +5,7 @@
   <xsl:param name="DTDDeclaration">
     <xsl:comment>
       The value for this parameter is passed by GetCapabilitiesResponse and contains
-      the full DTD delcaration including
+      the full DTD declaration including
       SYSTEM identifiers and internal DTD elements
     </xsl:comment>
   </xsl:param>


### PR DESCRIPTION
This fixes a small typo in `getcaps_111_internalDTD.xsl`.
