### PR TITLE
Add local workspace remove prefix configuration

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerInfo.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerInfo.java
@@ -216,7 +216,7 @@ public interface GeoServerInfo extends Info {
      * @deprecated use {@link #getSettings()}
      */
     boolean isVerboseExceptions();
-    
+
     /**
      * Set the XML error handling mode for the server.
      * 

--- a/src/main/src/main/java/org/geoserver/config/SettingsInfo.java
+++ b/src/main/src/main/java/org/geoserver/config/SettingsInfo.java
@@ -141,4 +141,19 @@ public interface SettingsInfo extends Info {
      * </p>
      */
     Map<Object, Object> getClientProperties();
+
+    /**
+     * If true local workspace should keep the namespace prefixes in
+     * getCapabilities etc...
+     */
+    boolean isLocalWorkspaceIncludesPrefix();
+
+    /**
+     * Set whether or not a local workspace should keep namespace prefixes in
+     * the getCapabilities etc...
+     *
+     * @param includePrefix
+     *            if true then the prefixes will be kept, default behaviour is to remove it.
+     */
+    void setLocalWorkspaceIncludesPrefix(boolean includePrefix);
 }

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.catalog.impl.LocalWorkspaceCatalog;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.ConfigurationListener;
 import org.geoserver.config.GeoServer;
@@ -85,6 +86,13 @@ public class GeoServerImpl implements GeoServer, ApplicationContextAware {
     
     public void setCatalog(Catalog catalog) {
         this.catalog = catalog;
+        
+        // This instance of check is has to be here because this Geoserver cannot be injected
+        // into LocalWorkspaceCatalog because it causes a circular reference
+        if (catalog instanceof LocalWorkspaceCatalog) {
+            LocalWorkspaceCatalog lwCatalog = (LocalWorkspaceCatalog) catalog;
+            lwCatalog.setGeoServer(this);
+        }
     }
     
     public GeoServerInfo getGlobal() {

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
@@ -208,7 +208,7 @@ public class GeoServerInfoImpl implements GeoServerInfo {
     public void setAdminUsername(String adminUsername) {
         this.adminUsername = adminUsername;
     }
-    
+
     public int getFeatureTypeCacheSize() {
         return featureTypeCacheSize;
     }

--- a/src/main/src/main/java/org/geoserver/config/impl/SettingsInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/SettingsInfoImpl.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import org.geoserver.catalog.MetadataMap;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.ContactInfo;
-import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.SettingsInfo;
 
 public class SettingsInfoImpl implements SettingsInfo {
@@ -40,6 +39,8 @@ public class SettingsInfoImpl implements SettingsInfo {
     protected MetadataMap metadata = new MetadataMap();
 
     protected Map<Object, Object> clientProperties = new HashMap<Object, Object>();
+
+    private boolean localWorkspaceIncludesPrefix = false;
 
     @Override
     public String getId() {
@@ -251,6 +252,16 @@ public class SettingsInfoImpl implements SettingsInfo {
     public String toString() {
         return new StringBuilder(getClass().getSimpleName()).append('[').append(title).append(']')
                 .toString();
+    }
+
+    @Override
+    public boolean isLocalWorkspaceIncludesPrefix() {
+        return localWorkspaceIncludesPrefix;
+    }
+
+    @Override
+    public void setLocalWorkspaceIncludesPrefix(boolean removePrefix) {
+        localWorkspaceIncludesPrefix = removePrefix;
     }
 
 }

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -109,7 +109,6 @@ public class XStreamPersisterTest {
         g1.setUpdateSequence( 123 );
         g1.setVerbose( true );
         g1.setVerboseExceptions( true );
-        
         g1.getMetadata().put( "one", new Integer(1) );
         g1.getMetadata().put( "two", new Double(2.2) );
         

--- a/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
@@ -870,6 +870,7 @@ public class SystemTestData extends CiteTestData {
         settings.setOnlineResource("http://geoserver.org");
         settings.setVerbose(false);
         settings.setVerboseExceptions(false);
+        settings.setLocalWorkspaceIncludesPrefix(false);
 
         if (ws != null) {
             if (settings.getId() != null) {

--- a/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage$SettingsPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage$SettingsPanel.html
@@ -19,6 +19,10 @@
               <input id="verboseExceptions" class="field checkbox" type="checkbox" wicket:id="verboseExceptions" />
               <label for="verboseExceptions" class="choice"><wicket:message key="verboseExceptions">Enable Verbose Exceptions</wicket:message></label>
             </li>
+		    <li>
+		      <input id="localWorkspaceIncludesPrefix" class="field checkbox" type="checkbox" wicket:id="localWorkspaceIncludesPrefix" />
+		      <label for="localWorkspaceIncludesPrefix" class="choice"><wicket:message key="localWorkspaceIncludesPrefix">Remove Layer Prefix from Local Workspace Capabilities</wicket:message></label>
+		    </li>
             <li>
               <label for="numDecimals"><wicket:message key="numDecimals">Number of Decimals</wicket:message></label>
               <input id="numDecimals" class="field text" type="text" wicket:id="numDecimals" />

--- a/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage.java
@@ -322,6 +322,7 @@ public class WorkspaceEditPage extends GeoServerSecuredPage {
             otherSettingsPanel.setVisible(set.enabled);
             otherSettingsPanel.add(new CheckBox("verbose"));
             otherSettingsPanel.add(new CheckBox("verboseExceptions"));
+            otherSettingsPanel.add(new CheckBox("localWorkspaceIncludesPrefix"));
             otherSettingsPanel.add(new TextField<Integer>("numDecimals").add(new MinimumValidator<Integer>(0)));
             otherSettingsPanel.add(new DropDownChoice("charset", GlobalSettingsPage.AVAILABLE_CHARSETS));
             otherSettingsPanel.add(new TextField("proxyBaseUrl").add(new UrlValidator()));

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -606,6 +606,7 @@ WorkspaceEditPage.numDecimals       = Number of Decimals
 WorkspaceEditPage.proxyBaseUrl      = Proxy Base URL
 WorkspaceEditPage.verboseExceptions = Verbose Exception Reporting
 WorkspaceEditPage.verboseMessaging  = Verbose Messages
+WorkspaceEditPage.localWorkspaceIncludesPrefix  = Include Layer Prefix in Local Workspace Capabilities
 
 WorkspaceNewPage.description = Configure a new workspace
 WorkspaceNewPage.title       = New Workspace

--- a/src/web/core/src/test/java/org/geoserver/web/data/workspace/WorkspaceEditPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/workspace/WorkspaceEditPageTest.java
@@ -43,7 +43,6 @@ public class WorkspaceEditPageTest extends GeoServerWicketTestSupport {
         tester.startPage(new WorkspaceEditPage(citeWorkspace));
     }
 
-
     @Test
     public void testURIRequired() {
         FormTester form = tester.newFormTester("form");
@@ -139,6 +138,25 @@ public class WorkspaceEditPageTest extends GeoServerWicketTestSupport {
 
         tester.assertNoErrorMessage();
         assertNotNull(gs.getSettings(citeWorkspace));
+    }
+    
+    @Test
+    public void testLocalworkspaceRemovePrefix() throws Exception {
+        GeoServer gs = getGeoServer();
+        SettingsInfo settings = gs.getFactory().createSettings();
+        settings.setLocalWorkspaceIncludesPrefix(true);
+        settings.setWorkspace(citeWorkspace);
+        gs.add(settings);
+
+        assertNotNull(gs.getSettings(citeWorkspace));
+        tester.startPage(new WorkspaceEditPage(citeWorkspace));
+        tester.assertRenderedPage(WorkspaceEditPage.class);
+
+        FormTester form = tester.newFormTester("form");
+        form.setValue("settings:settingsContainer:otherSettings:localWorkspaceIncludesPrefix", false);
+        form.submit();
+
+        assertEquals(false, settings.isLocalWorkspaceIncludesPrefix());
     }
 
     @Test


### PR DESCRIPTION
Currently by default the capabilities document produced from virtual workspaces will remove the namespace prefix from the layer names.  This commit adds a configuraton option to disable this behaviour.

This is also a fix for http://jira.codehaus.org/browse/GEOS-5476

My main concern with this change is how I obtain the GeoServer instance in the LocalWorkspaceCatalog.  I couldn't set the instance in the applicationContext.xml because that creates a "unresolvable circular reference".  Because of this I modified the GeoServerImpl setCatalog method to call the setGeoServer() method on the catalog.  

My second concern is that I had to follow the pattern of setValidated for the UI.  This meant getters and setters in both SettingsInfo and GeoServerInfo.

If you have advice for how to better implement those concerns I will happily do so.

Jesse
