### PR TITLE
DataStoreFileResource: enclose cleanup code in a finally block

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
@@ -457,23 +457,23 @@ public class DataStoreFileResource extends StoreFileResource {
         catch (Exception e) {
             //TODO: report a proper error code
             throw new RuntimeException ( e );
-        }
-        
-        //dispose the datastore
-        source.dispose();
-        
-        //clean up the files if we can
-        if (isInlineUpload(method) && canRemoveFiles) {
-            if (uploadedFile.isFile()) uploadedFile = uploadedFile.getParentFile();
-            try {
-                FileUtils.deleteDirectory(uploadedFile);
-            } 
-            catch (IOException e) {
-                LOGGER.info("Unable to delete " + uploadedFile.getAbsolutePath());
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.log(Level.FINE, "", e);
-                }
-            }
+        } finally {
+            //dispose the datastore
+            source.dispose();
+            
+            //clean up the files if we can
+            if (isInlineUpload(method) && canRemoveFiles) {
+        		if (uploadedFile.isFile()) uploadedFile = uploadedFile.getParentFile();
+        		try {
+        			FileUtils.deleteDirectory(uploadedFile);
+        		} 
+        		catch (IOException ie) {
+        			LOGGER.info("Unable to delete " + uploadedFile.getAbsolutePath());
+        			if (LOGGER.isLoggable(Level.FINE)) {
+        				LOGGER.log(Level.FINE, "", ie);
+        			}
+        		}
+            }        	
         }
     }
 


### PR DESCRIPTION
If GeoServer is importing a shapefile to a PostGIS database, schema creation might fail (line 335) with an IOException ("Error occurred creating table") if the shapefile attributes include reserved column names, and in this case the source will not be disposed nor will the uploaded files directory be deleted.  Enclosing these steps in a finally block ensures that they will be run even if such an exception occurs.
