### PR TITLE
Remove hacks for comments in WMS capabilities.

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -78,7 +78,6 @@ import org.springframework.util.Assert;
 import org.vfny.geoserver.util.ResponseUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
-import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
 import com.google.common.collect.Iterables;
@@ -1316,23 +1315,6 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             element("southBoundLatitude", miny);
             element("northBoundLatitude", maxy);
             end("EX_GeographicBoundingBox");
-        }
-
-        /**
-         * adds a comment to the output xml file. THIS IS A BIG HACK. TODO: do this in the correct
-         * manner!
-         * 
-         * @param comment
-         */
-        public void comment(String comment) {
-            if (contentHandler instanceof LexicalHandler) {
-                try {
-                    LexicalHandler ch = (LexicalHandler) contentHandler;
-                    ch.comment(comment.toCharArray(), 0, comment.length());
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
         }
 
         /**

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -72,7 +72,6 @@ import org.springframework.util.Assert;
 import org.vfny.geoserver.util.ResponseUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
-import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
 import com.google.common.collect.Iterables;
@@ -1274,23 +1273,6 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             bboxAtts.addAttribute("", "maxy", "maxy", "", maxy);
 
             element("LatLonBoundingBox", null, bboxAtts);
-        }
-
-        /**
-         * adds a comment to the output xml file. THIS IS A BIG HACK. TODO: do this in the correct
-         * manner!
-         * 
-         * @param comment
-         */
-        public void comment(String comment) {
-            if (contentHandler instanceof LexicalHandler) {
-                try {
-                    LexicalHandler ch = (LexicalHandler) contentHandler;
-                    ch.comment(comment.toCharArray(), 0, comment.length());
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
         }
 
         /**


### PR DESCRIPTION
This functionality should be in TranslatorSupport in GeoTools, see https://github.com/geotools/geotools/pull/192
