### PR TITLE
Update to latest GeoScript JS to work with GeoTools 9

### DIFF
--- a/src/community/script/js/pom.xml
+++ b/src/community/script/js/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.geoscript</groupId>
             <artifactId>geoscript-js</artifactId>
-            <version>0.16-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.geoserver.script</groupId>

--- a/src/community/script/js/src/test/resources/org/geoserver/script/js/scripts/wps/bufferSplit.js
+++ b/src/community/script/js/src/test/resources/org/geoserver/script/js/scripts/wps/bufferSplit.js
@@ -13,8 +13,8 @@
 var Process = require("geoscript/process").Process;
 
 // get two existing processes for use later
-var buffer = Process.get("JTS:buffer");
-var split = Process.get("JTS:splitPolygon");
+var buffer = Process.get("geo:buffer");
+var split = Process.get("geo:splitPolygon");
 
 exports.process = new Process({
     title: "Buffer and Split",

--- a/src/community/script/js/src/test/resources/org/geoserver/script/js/scripts/wps/bufferedUnion.js
+++ b/src/community/script/js/src/test/resources/org/geoserver/script/js/scripts/wps/bufferedUnion.js
@@ -6,7 +6,7 @@
 var Process = require("geoscript/process").Process;
 
 // this is contrived to use the union process here, but this tests process composition
-var union = Process.get("JTS:union");
+var union = Process.get("geo:union");
 
 exports.process = new Process({
     title: "Union & Buffer Process",


### PR DESCRIPTION
This gets tests passing on the 2.3.x branch.  @jdeolive, could you give this a quick glance?  Not sure of the commit policy or if this should go to master first.

Also, I'm not able to build the scripting module due to failures in the py tests.  Didn't know if this had to do with my local setup or not.

```
Results :

Tests in error: 
  testLayerData(org.geoserver.script.py.PyCatalogDataTest): TypeError: __init__() got an unexpected keyword argument 'source' in <script> at line number 1
  testRun(org.geoserver.script.py.PyProcessTest): java.io.IOException: javax.script.ScriptException: AttributeError: 'module' object has no attribute 'unmap' in ./target/mock4977343582298132395data/scripts/wps/buffer.py at line number 4
  testTitle(org.geoserver.script.py.PyProcessTest): java.io.IOException: javax.script.ScriptException: AttributeError: 'module' object has no attribute 'unmap' in ./target/mock1344339653159149887data/scripts/wps/buffer.py at line number 4
  testDescription(org.geoserver.script.py.PyProcessTest): java.io.IOException: javax.script.ScriptException: AttributeError: 'module' object has no attribute 'unmap' in ./target/mock4798377665201690272data/scripts/wps/buffer.py at line number 4
  testInputs(org.geoserver.script.py.PyProcessTest): java.io.IOException: javax.script.ScriptException: AttributeError: 'module' object has no attribute 'unmap' in ./target/mock2249301681333395435data/scripts/wps/buffer.py at line number 4
  testOutputs(org.geoserver.script.py.PyProcessTest): java.io.IOException: javax.script.ScriptException: AttributeError: 'module' object has no attribute 'unmap' in ./target/mock1282197474349005582data/scripts/wps/buffer.py at line number 4
  testRunMultipleOutputs(org.geoserver.script.py.PyProcessTest): java.io.IOException: javax.script.ScriptException: AttributeError: 'module' object has no attribute 'unmap' in ./target/mock200663788306337389data/scripts/wps/buffer-multipleOutputs.py at line number 4

Tests run: 23, Failures: 0, Errors: 7, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] JavaScript Scripting Extension .................... SUCCESS [2:10.668s]
[INFO] Python Scripting Extension ........................ FAILURE [2:26.649s]
[INFO] Ruby Scripting Extension .......................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4:39.720s
[INFO] Finished at: Mon May 20 22:52:30 MDT 2013
[INFO] Final Memory: 17M/81M
[INFO] ------------------------------------------------------------------------
```
