### PR TITLE
A fix for https://jira.codehaus.org/browse/GEOS-5822

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -18,6 +18,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,10 +41,12 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.LayerInfo.Type;
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.MetadataLinkInfo;
+import org.geoserver.catalog.Predicates;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
@@ -652,8 +655,17 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             
             // encode layer groups
             try {
-                List<LayerGroupInfo> layerGroups = wmsConfig.getLayerGroups();
-                layersAlreadyProcessed = handleLayerGroups(new ArrayList<LayerGroupInfo>(layerGroups));
+                LinkedList<LayerGroupInfo> layerGroups = new LinkedList<LayerGroupInfo>();
+                CloseableIterator<LayerGroupInfo> layerGroupsIter = wmsConfig.getCatalog().list(LayerGroupInfo.class, Predicates.acceptAll());
+
+                try {
+                    while(layerGroupsIter.hasNext()) {
+                        layerGroups.add(layerGroupsIter.next());
+                    }
+                } finally {
+                    layerGroupsIter.close();
+                }
+                layersAlreadyProcessed = handleLayerGroups(layerGroups);
             } catch (FactoryException e) {
                 throw new RuntimeException("Can't obtain Envelope of Layer-Groups: "
                         + e.getMessage(), e);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LayerGroupWorkspaceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LayerGroupWorkspaceTest.java
@@ -8,10 +8,14 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
 
 import javax.xml.namespace.QName;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
 
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
@@ -27,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 public class LayerGroupWorkspaceTest extends WMSTestSupport {
 
@@ -39,7 +44,6 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
         WMSInfo wms = gs.getService(WMSInfo.class);
         wms.getSRS().add("4326");
         gs.save(wms);
-        
         Catalog cat = getCatalog();
 
         global = createLayerGroup(cat, "base", "base default",
@@ -206,7 +210,28 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
         assertXpathExists("/WMT_MS_Capabilities/Capability/Layer/Layer[Name[text() = 'base']]/Layer/Name[text() = 'cite:Forests']", dom);                
     }    
     
-    @Test 
+    @Test
+    public void testWorkspace1_1_1vs1_3_0Capabilities() throws Exception {
+        Document dom1_1_1 = getAsDOM("sf/wms?request=getcapabilities&version=1.1.1");
+        Document dom1_3_0 = getAsDOM("sf/wms?request=getcapabilities&version=1.3.0");
+
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList nodes1_1_1 = (NodeList) xPath.evaluate("//*[name() = 'Layer']/*[name() = 'Name']", dom1_1_1, XPathConstants.NODESET);
+        NodeList nodes1_3_0 = (NodeList) xPath.evaluate("//*[name() = 'Layer']/*[name() = 'Name']", dom1_3_0, XPathConstants.NODESET);
+
+        String[] names1_1_1 = new String[nodes1_1_1.getLength()];
+        for (int i = 0; i < names1_1_1.length; i++) {
+            names1_1_1[i] = nodes1_1_1.item(i).getTextContent();
+        }
+
+        String[] names1_3_0 = new String[nodes1_3_0.getLength()];
+        for (int i = 0; i < names1_3_0.length; i++) {
+            names1_3_0[i] = nodes1_3_0.item(i).getTextContent();
+        }
+        assertArrayEquals(names1_1_1, names1_3_0);
+    }
+
+    @Test
     public void testWorkspaceCapabilities() throws Exception {
         Document dom = getAsDOM("sf/wms?request=getcapabilities&version=1.1.1");
 


### PR DESCRIPTION
use list in 1.1.1 capabilities so that both 1.3.0 and 1.1.1 list same layergroups

See https://jira.codehaus.org/browse/GEOS-5822 for details on this issue.
