### PR TITLE
GEOS-5826 allow request parameters access from HTMLFeatureInfoOutputFormat

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/GetFeatureInfo.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetFeatureInfo.java
@@ -28,7 +28,6 @@ import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.catalog.WMSLayerInfo;
-import org.geoserver.ows.Dispatcher;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.featureinfo.FeatureCollectionDecorator;
 import org.geotools.coverage.GridSampleDimension;
@@ -198,7 +197,7 @@ public class GetFeatureInfo {
                 getMapReq.getCrs());
         final double scaleDenominator = RendererUtilities.calculateOGCScale(bbox, width, null);
         final List<Object> elevations = request.getGetMapRequest().getElevation();
-        final List<Object> times = request.getGetMapRequest().getTime();
+		final List<Object> times = request.getGetMapRequest().getTime();
         final FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(GeoTools.getDefaultHints());
 
         List<FeatureCollection> results = new ArrayList<FeatureCollection>(requestedLayers.size());
@@ -238,7 +237,7 @@ public class GetFeatureInfo {
             FeatureCollection collection = null;
             if (layer.getType() == MapLayerInfo.TYPE_VECTOR) {
                 final Map<String, String> viewParam = viewParams != null ? viewParams.get(i) : null;
-                collection = identifyVectorLayer(filters, x, y, buffer, viewParam,
+				collection = identifyVectorLayer(filters, x, y, buffer, viewParam,
                         requestedCRS, width, height, bbox, ff, results, i, layer, rules, maxFeatures,
                         times, elevations, names);
             } else if (layer.getType() == MapLayerInfo.TYPE_RASTER) {
@@ -293,15 +292,11 @@ public class GetFeatureInfo {
             
 
             if (collection != null) {
-                Name name;
                 if (!(collection.getSchema() instanceof SimpleFeatureType)) {
                     //put wrapper around it with layer name
-                     name = new NameImpl (layer.getFeature().getNamespace().getName(), layer.getFeature().getName());                                    
-                } else {
-                    name = collection.getSchema().getName();                
+                    Name name = new NameImpl (layer.getFeature().getNamespace().getName(), layer.getFeature().getName());                
+                    collection = new FeatureCollectionDecorator(name, collection);
                 }
-                collection = new FeatureCollectionDecorator(name, collection,
-                        Dispatcher.REQUEST.get());
                 
                 int size = collection.size();
                 if(size != 0) {
@@ -314,12 +309,12 @@ public class GetFeatureInfo {
                     // feature accordingly.
                     // This is a Hack, this information should not be passed through feature type
                     // appschema will need to remove this information from the feature type again
-                    if (! (collection instanceof SimpleFeatureCollection)) {
+                	if (! (collection instanceof SimpleFeatureCollection)) {
                        collection.getSchema().getUserData().put("targetCrs", request.getGetMapRequest().getCrs());
                        collection.getSchema().getUserData().put("targetVersion", "wms:getfeatureinfo");
                        
                     }
-                
+                	
                     results.add(collection);
                     
                     // don't return more than FEATURE_COUNT
@@ -400,11 +395,11 @@ public class GetFeatureInfo {
             // it's fine, users might legitimately query point outside, we just don't
             // return anything
         } finally {
-            RenderedImage ri = coverage.getRenderedImage();
-            coverage.dispose(true);
-            if(ri instanceof PlanarImage) {
-                ImageUtilities.disposePlanarImageChain((PlanarImage) ri);
-            }
+        	RenderedImage ri = coverage.getRenderedImage();
+        	coverage.dispose(true);
+        	if(ri instanceof PlanarImage) {
+        		ImageUtilities.disposePlanarImageChain((PlanarImage) ri);
+        	}
         }
         return pixel;
     }
@@ -520,7 +515,7 @@ public class GetFeatureInfo {
         // if we could not include the rules filter into the query, post process in
         // memory
         if (!Filter.INCLUDE.equals(postFilter)) {
-            match = new FilteringFeatureCollection(match, postFilter);
+        	match = new FilteringFeatureCollection(match, postFilter);
         }
 
         // this was crashing Gml2FeatureResponseDelegate due to not setting

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureCollectionDecorator.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureCollectionDecorator.java
@@ -9,7 +9,6 @@ package org.geoserver.wms.featureinfo;
 import java.io.IOException;
 import java.util.Collection;
 
-import org.geoserver.ows.Request;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -38,8 +37,6 @@ import org.opengis.util.ProgressListener;
 @SuppressWarnings("unchecked")
 public class FeatureCollectionDecorator implements FeatureCollection<FeatureType, Feature> {
 
-    private Request request;
-    
     /**
      * Get Resource Name of a Feature Collection
      * 
@@ -58,21 +55,11 @@ public class FeatureCollectionDecorator implements FeatureCollection<FeatureType
     protected FeatureCollection fc;
     protected Name name;
     
-    public FeatureCollectionDecorator(Name name, FeatureCollection fc,
-            Request request) {
+    public FeatureCollectionDecorator(Name name, FeatureCollection fc){
         this.name = name;
         this.fc = fc;
-        this.request = request;
     }
     
-    
-    
-    public Request getRequest() {
-        return request;
-    }
-
-
-
     public Name getName() {
         return name;
     }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import net.opengis.wfs.FeatureCollectionType;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.template.DirectTemplateFeatureCollectionFactory;
@@ -62,12 +63,9 @@ public class HTMLFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
     
             @Override
             public TemplateModel wrap(Object object) throws TemplateModelException {
-                if (object instanceof FeatureCollectionDecorator) {
-                    SimpleHash map = (SimpleHash) super.wrap(object);
-                    Request request = ((FeatureCollectionDecorator) object)
-                            .getRequest();
-                    map.put("request", request.getKvp());
-    
+                if (object instanceof FeatureCollection) {
+                    SimpleHash map = (SimpleHash) super.wrap(object);                    
+                    map.put("request", Dispatcher.REQUEST.get().getKvp());    
                     return map;
                 }
                 return super.wrap(object);

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
@@ -28,6 +28,7 @@ import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.impl.NamespaceInfoImpl;
 import org.geoserver.data.test.MockData;
+import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.template.GeoServerTemplateLoader;
 import org.geoserver.wms.GetFeatureInfoRequest;
@@ -87,15 +88,12 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
         parameters.put("ENV", env);
         request.setKvp(parameters);
         
+        Dispatcher.REQUEST.set(request);
+        
         final FeatureTypeInfo featureType = getFeatureTypeInfo(MockData.PRIMITIVEGEOFEATURE);
         
-        // fake FeatureCollectionDecorator, wrapping the test request
-        FeatureCollectionDecorator fc = new FeatureCollectionDecorator(null,
-                featureType.getFeatureSource(null, null).getFeatures(), request);
-        
-        
         fcType = WfsFactory.eINSTANCE.createFeatureCollectionType();
-        fcType.getFeature().add(fc);
+        fcType.getFeature().add(featureType.getFeatureSource(null, null).getFeatures());
         
         // fake layer list
         List<MapLayerInfo> queryLayers = new ArrayList<MapLayerInfo>();               


### PR DESCRIPTION
Allows to write something like ${request.parameter} to access a request parameter inside the content template file
