### PR TITLE
GEOS-5844 fix nulls in SecureCatalog.list

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -66,6 +66,7 @@ import org.springframework.util.Assert;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 
 /**
  * Wraps the catalog and applies the security directives provided by a {@link ResourceAccessManager}
@@ -1388,7 +1389,13 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         final CloseableIterator<T> filteredWrapped;
         filteredWrapped = CloseableIteratorAdapter.transform(filtered, securityWrapper);
 
-        return filteredWrapped;
+        // wrap the iterator in a notNull filter to ensure any filtered
+        // layers (result is null) don't get passed on from the securityWrapper
+        // Function. When the AccessLevel is HIDDEN and a layer gets filtered 
+        // out via a CatalogFilter - for example, this can happen with a
+        // LocalWorkspaceCatalogFilter and a virtual service request
+        return new CloseableIteratorAdapter(Iterators.filter(filteredWrapped,
+                com.google.common.base.Predicates.notNull()));
     }
 
     /**
@@ -1464,9 +1471,10 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     /**
-     * Checks if the current user is authenticated and is the administrator
+     * Checks if the current user is authenticated and is the administrator.
+     * Protected to allow overriding in tests.
      */
-    private boolean isAdmin(Authentication authentication) {
+    protected boolean isAdmin(Authentication authentication) {
         
         return GeoServerExtensions.bean(GeoServerSecurityManager.class).
                 checkAuthenticationForAdminRole(authentication);

--- a/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.security.impl;
 
+import java.util.Collections;
+import java.util.Iterator;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -15,11 +17,18 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.impl.AbstractCatalogDecorator;
+import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.catalog.util.CloseableIteratorAdapter;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
+import org.geoserver.security.AbstractCatalogFilter;
+import org.geoserver.security.CatalogFilterAccessManager;
 import org.geoserver.security.ResourceAccessManager;
 import org.geoserver.security.SecureCatalogImpl;
 import org.geoserver.security.decorators.ReadOnlyDataStoreTest;
@@ -29,6 +38,9 @@ import org.geoserver.security.decorators.SecuredLayerGroupInfo;
 import org.geoserver.security.decorators.SecuredLayerInfo;
 import org.junit.Before;
 import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.sort.SortBy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecureCatalogImplTest extends AbstractAuthorizationTest {
@@ -315,6 +327,54 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
         assertSame(statesStore, sc.getDataStoreByName("states"));
         assertSame(roadsStore, sc.getDataStoreByName("roads"));
         assertSame(arcGridStore, sc.getCoverageStoreByName("arcGrid"));
+    }
+
+    @Test
+    public void testCatalogFilteredGetLayers() throws Exception {
+        ResourceAccessManager manager = buildManager("publicRead.properties");
+
+        CatalogFilterAccessManager filter = new CatalogFilterAccessManager();
+        filter.setDelegate(manager);
+
+        // make a catalog that uses our layers
+        Catalog withLayers = new AbstractCatalogDecorator(catalog) {
+
+            @Override
+            public <T extends CatalogInfo> CloseableIterator<T> list(Class<T> of, Filter filter, Integer offset, Integer count, SortBy sortBy) {
+                return new CloseableIteratorAdapter<T>((Iterator<T>) layers.iterator());
+            }
+        };
+
+        // and the secure catalog with the filter
+        SecureCatalogImpl sc = new SecureCatalogImpl(withLayers, filter) {
+
+            @Override
+            // override so we don't need GeoServerSecurityManager
+            protected boolean isAdmin(Authentication authentication) {
+                return false;
+            }
+
+        };
+
+        // base behavior sanity
+        assertTrue(layers.size() > 1);
+        assertTrue(sc.getLayers().size() > 1);
+
+        // setup a catalog filter that will hide the layer
+        // an example of this happening is when the LocalWorkspaceCatalogFilter
+        // detects 'LocalLayer.get' contains the local layer
+        // the result is it gets filtered out
+        filter.setCatalogFilters(Collections.singletonList(new AbstractCatalogFilter() {
+
+            @Override
+            public boolean hideLayer(LayerInfo layer) {
+                return layer != statesLayer;
+            }
+
+        }));
+
+        assertEquals(1, sc.getLayers().size());
+        assertEquals(statesLayer.getName(), sc.getLayers().get(0).getName());
     }
 
     @Test


### PR DESCRIPTION
a catalog filter can potentially result in nulls being in the
returned iterator. an example is a LocalWorkspaceCatalogFilter
when a WMS virtual service getcaps request occurs.

forward port from 5edc2cc67de9aa922c798c1e8049939178a9d529

had to add means to override check on GeoServerSecurityManager
so test cases would not depend on full spring context
