### PR TITLE
GEOS-5849 added localized rule labels support to GetLegendGraphic output

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.geotools.styling.Style;
@@ -36,6 +37,7 @@ import org.opengis.feature.type.Name;
  *  <tr><td>FORMAT </td><td>Required </td><td>This gives the MIME type of the file format in which to return the legend graphic. Allowed values are the same as for the FORMAT= parameter of the WMS GetMap request. </td></tr>
  *  <tr><td>WIDTH </td><td>Optional </td><td>This gives a hint for the width of the returned graphic in pixels. Vector-graphics can use this value as a hint for the level of detail to include. </td></tr>
  *  <tr><td>HEIGHT </td><td>Optional </td><td>This gives a hint for the height of the returned graphic in pixels. </td></tr>
+ *  <tr><td>LANGUAGE </td><td>Optional </td><td>Permits to have internationalized text in legend output. </td></tr>
  *  <tr><td>EXCEPTIONS </td><td>Optional </td><td>This gives the MIME type of the format in which to return exceptions. Allowed values are the same as for the EXCEPTIONS= parameter of the WMS GetMap request.</td></tr>
  *  <tr><td>TRANSPARENT </td><td>Optional </td><td><code>true</code> if the legend image background should be transparent. Defaults to <code>false</code>.</td></tr>
  *  </table>
@@ -141,6 +143,12 @@ public class GetLegendGraphicRequest extends WMSRequest {
     private boolean transparent;
 
     private boolean strict = true;
+    
+    /**
+     * Optional locale to be used for text in output.
+     * 
+     */
+    private Locale locale;
 
     /**
      * Creates a new GetLegendGraphicRequest object.
@@ -273,6 +281,7 @@ public class GetLegendGraphicRequest extends WMSRequest {
      * are available.
      * <li><code>minSymbolSize</code>: a number defining the minimum size to be rendered for a 
      * symbol (defaults to 3).
+     * 
      * </ul>
      * </p>
      * 
@@ -336,6 +345,8 @@ public class GetLegendGraphicRequest extends WMSRequest {
 	/** SLD replacement */
     private Map /* <String,Object> */env = new HashMap();
 
+    
+
     /**
      * Map of strings that make up the SLD enviroment for variable substitution
      *
@@ -352,5 +363,23 @@ public class GetLegendGraphicRequest extends WMSRequest {
      */
     public void setEnv(Map enviroment) {
         this.env = enviroment;
+    }
+
+    /**
+     * Sets the optional Locale to be used for text in legend output.
+     * 
+     * @param locale
+     */
+    public void setLocale(Locale locale) {
+        this.locale = locale;
+    }
+    
+    /**
+     * Gets the locale to be used for text in output
+     * (null to use default locale).
+     * @return
+     */
+    public Locale getLocale() {
+        return this.locale;
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.geoserver.platform.ServiceException;
@@ -649,9 +650,15 @@ public class BufferedImageLegendGraphicBuilder {
                     // What's the label on this rule? We prefer to use
                     // the 'title' if it's available, but fall-back to 'name'
                     final Description description = rule.getDescription();
+                    Locale locale = req.getLocale();
+                    
                     if (description != null && description.getTitle() != null) {
                         final InternationalString title = description.getTitle();
+                        if(locale != null) {
+                        	labels[i] = title.toString(locale);
+                        } else {
                         labels[i] = title.toString();
+                        }
                     } else if (rule.getName() != null) {
                         labels[i] = rule.getName();
                     } else {

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
@@ -13,6 +13,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.logging.Level;
@@ -96,6 +97,11 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
                 version = wms.getVersion();
             }
             request.setVersion(version);
+        }
+        
+        final String language = (String) rawKvp.get("LANGUAGE");
+        if(language != null) {
+            request.setLocale(new Locale(language));
         }
 
         // Fix for http://jira.codehaus.org/browse/GEOS-710

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
@@ -16,14 +16,17 @@ import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.awt.image.IndexColorModel;
 import java.awt.image.RenderedImage;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import javax.imageio.ImageIO;
 import javax.media.jai.PlanarImage;
 import javax.xml.namespace.QName;
 
@@ -811,6 +814,50 @@ public class AbstractLegendGraphicOutputFormatTest extends WMSTestSupport {
         assertPixel(image, 1, 61, new Color(255, 255, 255));
         assertPixel(image, 7, 67, new Color(255, 0, 0));
         assertPixel(image, 10, 70, new Color(255, 0, 0));
+    }
+    
+    /**
+     * Tests that minSymbolSize legend option is respected.
+     */
+    @org.junit.Test
+    public void testInternationalizedLabels() throws Exception {
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest();
+        
+        Map<String,String> options = new HashMap<String,String>();
+        options.put("forceLabels", "on");
+        req.setLegendOptions(options);
+        
+        FeatureTypeInfo ftInfo = getCatalog()
+                .getFeatureTypeByName(MockData.MPOINTS.getNamespaceURI(),
+                        MockData.MPOINTS.getLocalPart());
+    
+        
+        List<FeatureType> layers = new ArrayList<FeatureType>();
+        layers.add(ftInfo.getFeatureType());
+        req.setLayers(layers);
+    
+        List<Style> styles = new ArrayList<Style>();
+        req.setStyles(styles);
+    
+        styles.add(readSLD("Internationalized.sld"));
+    
+        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+        int noLocalizedWidth = image.getWidth();        
+        
+        
+        req.setLocale(Locale.ITALIAN);
+        image = this.legendProducer.buildLegendGraphic(req);
+        // test that using localized labels we get a different label than when not using it
+        int itWidth = image.getWidth();
+        assertTrue(itWidth != noLocalizedWidth);
+        
+        req.setLocale(Locale.ENGLISH);
+        image = this.legendProducer.buildLegendGraphic(req);
+        // test that using localized labels we get a different label than when not using it
+        int enWidth = image.getWidth();
+        assertTrue(enWidth != noLocalizedWidth);
+        assertTrue(enWidth != itWidth);
+        
     }
     
     /**

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
@@ -7,11 +7,13 @@ package org.geoserver.wms.legendgraphic;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.geoserver.platform.ServiceException;
@@ -65,6 +67,7 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
      * <li>SLD_BODY/Optional
      * <li>WIDTH/Optional
      * <li>HEIGHT/Optional
+     * <li>LANGUAGE/Optional
      * <li>EXCEPTIONS/Optional
      * </ul>
      */
@@ -83,6 +86,7 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
         optionalParameters.put("SCALE", "1000");
         optionalParameters.put("WIDTH", "120");
         optionalParameters.put("HEIGHT", "90");
+        optionalParameters.put("LANGUAGE", "en");
         // ??optionalParameters.put("EXCEPTIONS", "");
         allParameters = new HashMap<String, String>(requiredParameters);
         allParameters.putAll(optionalParameters);
@@ -177,6 +181,17 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
         requiredParameters.put("LAYER", NATURE_GROUP);
         request = requestReader.read(new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
         assertTrue(request.getLayers().size() > 1);
+    }
+    
+    @org.junit.Test
+    public void testLanguage() throws Exception {
+        GetLegendGraphicRequest request;
+        
+        request = requestReader.read(new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
+        assertNull(request.getLocale());
+        
+        request = requestReader.read(new GetLegendGraphicRequest(), allParameters, allParameters);
+        assertEquals(Locale.ENGLISH, request.getLocale());
     }
     
     @org.junit.Test

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/Internationalized.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/Internationalized.sld
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+This document is used by AbstractLegendGraphicOutputFormatTest.testMixedGeometry.
+This document contains styles for Polygons, Lines and Points.
+-->
+    <UserStyle>
+        <Name>SymbolSize</Name>
+        <Title>Default Styler</Title>
+        <Abstract></Abstract>
+        <FeatureTypeStyle>                        
+            <Rule>
+                <Name>Size1</Name>
+                <Abstract>Abstract</Abstract>
+                <Title>title
+                <Localized lang="en">anothertitle</Localized>
+                <Localized lang="it">titolomoltolungo</Localized>
+                </Title>
+                <PointSymbolizer>
+                  <Graphic>
+                    <Mark>
+                      <WellKnownName>circle</WellKnownName>
+                      <Fill>
+                        <CssParameter name="fill">#FF0000</CssParameter>
+                      </Fill>
+                    </Mark>
+                  <Size>40</Size>
+                </Graphic>
+              </PointSymbolizer>
+            </Rule>            
+        </FeatureTypeStyle>
+    </UserStyle>
+   </StyledLayerDescriptor>


### PR DESCRIPTION
Adding a language parameter to request a locale for the labels in SLD rule can be chosen, if the SLD contains rule titles with Localized tags they will be used when matching the requested language
