### PR TITLE
upgrade to geowebcache 1.4-SNAPSHOT

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -1057,4 +1057,9 @@ public class GeoServerTileLayer extends TileLayer {
         return new StringBuilder(getClass().getSimpleName()).append("[").append(info).append("]")
                 .toString();
     }
+
+	// @Override not an override until you update to 1.4-SNAPSHOT
+	public List<MimeType> getInfoMimeTypes() {
+		return Collections.emptyList();
+	}
 }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1457,7 +1457,7 @@
  <properties>
   <gs.version>2.4-SNAPSHOT</gs.version>
   <gt.version>10-SNAPSHOT</gt.version>
-  <gwc.version>1.4-M20130509a</gwc.version>
+  <gwc.version>1.4-SNAPSHOT</gwc.version>
   <spring.version>3.1.1.RELEASE</spring.version>
   <spring.security.version>3.1.0.RELEASE</spring.security.version> 
   <poi.version>3.8</poi.version>


### PR DESCRIPTION
Some small API burn keeping us from using 1.4-SNAPSHOT.
