### PR TITLE
update getFeatureCount-function for JSON-OutputFormat

### DIFF
--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
@@ -199,6 +199,12 @@ public class GeoJSONTest extends WFSTestSupport {
         String out3 = getAsString("wfs?request=GetFeature&version=1.0.0&typename=sf:PrimitiveGeoFeature&maxfeatures=1&outputformat="+JSONType.json+"&featureid=PrimitiveGeoFeature.f001,PrimitiveGeoFeature.f002");
         JSONObject rootObject3 = JSONObject.fromObject( out3 );
         assertEquals(rootObject3.get("totalFeatures"),2);
+        
+        //request with multiple featureTypes and Filter
+        String out4 = getAsString("wfs?request=GetFeature&version=1.0.0&typename=sf:PrimitiveGeoFeature,sf:AggregateGeoFeature&outputformat="+JSONType.json + "&featureid=PrimitiveGeoFeature.f001,PrimitiveGeoFeature.f002,AggregateGeoFeature.f009");
+        JSONObject rootObject4 = JSONObject.fromObject( out4 );
+        assertEquals(rootObject4.get("totalFeatures"),3);
+        
     }
 
     @Test
@@ -217,6 +223,12 @@ public class GeoJSONTest extends WFSTestSupport {
         String out3 = getAsString("wfs?request=GetFeature&version=2.0.0&typename=sf:PrimitiveGeoFeature&maxfeatures=1&outputformat="+JSONType.json+"&featureid=PrimitiveGeoFeature.f001,PrimitiveGeoFeature.f002");
         JSONObject rootObject3 = JSONObject.fromObject( out3 );
         assertEquals(rootObject3.get("totalFeatures"),2);
+        
+        //request with multiple featureTypes and Filter
+        String out4 = getAsString("wfs?request=GetFeature&version=2.0.0&typename=sf:PrimitiveGeoFeature,sf:AggregateGeoFeature&outputformat="+JSONType.json + "&featureid=PrimitiveGeoFeature.f001,PrimitiveGeoFeature.f002,AggregateGeoFeature.f009");
+        JSONObject rootObject4 = JSONObject.fromObject( out4 );
+        assertEquals(rootObject4.get("totalFeatures"),3);
+        
     }
     
 }


### PR DESCRIPTION
I have updated the getFeatureCount-function for the JSON-OutputFormat respecting the comments on the pull request #213  (https://github.com/geoserver/geoserver/pull/213).

I was not able to update the existing pull request, so I created this one. Sorry for this. 

I have simplified the getFeatureCount-function so that it doesn't have to do a new request to get the featureCount. It simply sums up the features from the featureCollection, which is used for the output. So there shouldn't be any issues regarding the WFS versions.

Please take a look.
