### PR TITLE
Support for opaque WMS layers

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/LayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerInfo.java
@@ -161,7 +161,7 @@ public interface LayerInfo extends PublishedInfo {
 
     /**
      * Sets the queryable status
-     * 
+     *
      * @param {@code true} to set this Layer as queryable and subject of GetFeatureInfo requests,
      *        {@code false} to make the layer not queryable.
      */
@@ -174,6 +174,22 @@ public interface LayerInfo extends PublishedInfo {
      * </p>
      */
     boolean isQueryable();
+
+    /**
+     * Sets the opaque status
+     * 
+     * @param {@code true} to set this Layer as opaque,
+     *        {@code false} to make the layer not opaque.
+     */
+    void setOpaque(boolean opaque);
+
+    /**
+     * Whether the layer is opaque
+     * <p>
+     * Defaults to {@code false}
+     * </p>
+     */
+    boolean isOpaque();
 
     /**
      * Gets the attribution information for this layer.  

--- a/src/main/src/main/java/org/geoserver/catalog/impl/LayerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LayerInfoImpl.java
@@ -64,6 +64,8 @@ public class LayerInfoImpl implements LayerInfo {
 
     protected Boolean queryable;
 
+    protected Boolean opaque;
+
     protected MetadataMap metadata = new MetadataMap();
 
     protected AttributionInfo attribution;
@@ -342,6 +344,16 @@ public class LayerInfoImpl implements LayerInfo {
     @Override
     public boolean isQueryable() {
         return this.queryable == null? true : this.queryable.booleanValue();
+    }
+
+    @Override
+    public void setOpaque(boolean opaque) {
+        this.opaque = opaque;
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return this.opaque == null? false : this.opaque.booleanValue();
     }
 
     @Override

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingLayerInfo.java
@@ -127,11 +127,18 @@ public class DecoratingLayerInfo extends AbstractDecorator<LayerInfo> implements
 
     public void setQueryable(boolean _queryableEnabled) {
         delegate.setQueryable(_queryableEnabled);
-
     }
 
     public boolean isQueryable() {
         return delegate.isQueryable();
+    }
+
+    public void setOpaque(boolean _opaqueEnabled) {
+        delegate.setOpaque(_opaqueEnabled);
+    }
+
+    public boolean isOpaque() {
+        return delegate.isOpaque();
     }
 
     @Override

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
@@ -13,6 +13,12 @@
             <label for="queryableEnabled" class="choice"><wicket:message key="queryable">Queryable</wicket:message></label>
           </li>
         </ul>
+        <ul>
+          <li>
+            <input id="opaqueEnabled" class="field checkbox" type="checkbox" wicket:id="opaqueEnabled"></input>
+            <label for="opaqueEnabled" class="choice"><wicket:message key="opaque">Opaque</wicket:message></label>
+          </li>
+        </ul>
         <ul wicket:id="styles">
           <li>
             <label for="defaultStyle"><wicket:message key="defaultStyle">Default Style</wicket:message></label>

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
@@ -37,6 +37,7 @@ public class WMSLayerConfig extends LayerConfigurationPanel {
         super(id, layerModel);
         
         add(new CheckBox("queryableEnabled", new PropertyModel(layerModel,"queryable")));
+        add(new CheckBox("opaqueEnabled", new PropertyModel(layerModel,"opaque")));
         
         // styles block container
         WebMarkupContainer styleContainer = new WebMarkupContainer("styles");

--- a/src/web/wms/src/main/resources/GeoServerApplication.properties
+++ b/src/web/wms/src/main/resources/GeoServerApplication.properties
@@ -102,6 +102,7 @@ WMSLayerConfig.defaultTitle     = WMS Settings
 WMSLayerConfig.defaultWmsPath   = Default WMS Path
 WMSLayerConfig.defaultRenderingBuffer = Default Rendering Buffer
 WMSLayerConfig.queryable              = Queryable
+WMSLayerConfig.opaque                 = Opaque
 WMSLayerConfig.layerIdentifier = Layer Identifier
 
 LayerAuthoritiesAndIdentifiersPanel.authorityURLs       = Authority URLs for this WMS Layer

--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -758,6 +758,13 @@ public class WMS implements ApplicationContextAware {
         }
     }
 
+    /**
+     * Returns true if the layer is opaque
+     */
+    public boolean isOpaque(LayerInfo layer) {
+        return layer.isOpaque();
+    }
+
     public Integer getCascadedHopCount(LayerInfo layer) {
         if (!(layer.getResource() instanceof WMSLayerInfo)) {
             return null;

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -879,6 +879,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
         protected void handleLayer(final LayerInfo layer) throws IOException {
             boolean queryable = wmsConfig.isQueryable(layer);
             AttributesImpl qatts = attributes("queryable", queryable ? "1" : "0");
+            boolean opaque = wmsConfig.isOpaque(layer);
+            qatts.addAttribute("", "opaque", "opaque", "", opaque ? "1" : "0");
             Integer cascadedHopCount = wmsConfig.getCascadedHopCount(layer);
             if (cascadedHopCount != null) {
                 qatts.addAttribute("", "cascaded", "cascaded", "", String.valueOf(cascadedHopCount));

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -818,6 +818,8 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             AttributesImpl qatts = new AttributesImpl();
             boolean queryable = wmsConfig.isQueryable(layer);
             qatts.addAttribute("", "queryable", "queryable", "", queryable ? "1" : "0");
+            boolean opaque = wmsConfig.isOpaque(layer);
+            qatts.addAttribute("", "opaque", "opaque", "", opaque ? "1" : "0");
             Integer cascaded = wmsConfig.getCascadedHopCount(layer);
             if (cascaded != null) {
                 qatts.addAttribute("", "cascaded", "cascaded", "", String.valueOf(cascaded));

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
@@ -313,7 +313,7 @@ public class CapabilitiesTest extends WMSTestSupport {
         assertXpathEvaluatesTo("__fax", cinfo + "ContactFacsimileTelephone", doc);
         assertXpathEvaluatesTo("e@mail", cinfo + "ContactElectronicMailAddress", doc);
     }
-    
+
     @Test
     public void testQueryable() throws Exception{
         LayerInfo lines = getCatalog().getLayerByName(MockData.LINES.getLocalPart());
@@ -325,7 +325,7 @@ public class CapabilitiesTest extends WMSTestSupport {
 
         String linesName = MockData.LINES.getPrefix() + ":" + MockData.LINES.getLocalPart();
         String pointsName = MockData.POINTS.getPrefix() + ":" + MockData.POINTS.getLocalPart();
-        
+
         Document doc = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.1.1", true);
         // print(doc);
 
@@ -333,4 +333,21 @@ public class CapabilitiesTest extends WMSTestSupport {
         assertXpathEvaluatesTo("0", "//Layer[Name='" + pointsName + "']/@queryable", doc);
     }
 
+    @Test
+    public void testOpaque() throws Exception{
+        LayerInfo lines = getCatalog().getLayerByName(MockData.LINES.getLocalPart());
+        lines.setOpaque(true);
+        getCatalog().save(lines);
+        LayerInfo points = getCatalog().getLayerByName(MockData.POINTS.getLocalPart());
+        points.setOpaque(false);
+        getCatalog().save(points);        
+
+        String linesName = MockData.LINES.getPrefix() + ":" + MockData.LINES.getLocalPart();
+        String pointsName = MockData.POINTS.getPrefix() + ":" + MockData.POINTS.getLocalPart();
+        
+        Document doc = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.1.1", true);
+
+        assertXpathEvaluatesTo("1", "//Layer[Name='" + linesName + "']/@opaque", doc);
+        assertXpathEvaluatesTo("0", "//Layer[Name='" + pointsName + "']/@opaque", doc);
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
@@ -344,6 +344,24 @@ public class CapabilitiesIntegrationTest extends WMSTestSupport {
         assertXpathEvaluatesTo("1", "//wms:Layer[wms:Name='" + linesName + "']/@queryable", doc);
         assertXpathEvaluatesTo("0", "//wms:Layer[wms:Name='" + pointsName + "']/@queryable", doc);
     }
+    
+    @org.junit.Test
+    public void testOpaque() throws Exception {
+        LayerInfo lines = getCatalog().getLayerByName(MockData.LINES.getLocalPart());
+        lines.setOpaque(true);
+        getCatalog().save(lines);
+        LayerInfo points = getCatalog().getLayerByName(MockData.POINTS.getLocalPart());
+        points.setOpaque(false);
+        getCatalog().save(points);
+
+        String linesName = MockData.LINES.getPrefix() + ":" + MockData.LINES.getLocalPart();
+        String pointsName = MockData.POINTS.getPrefix() + ":" + MockData.POINTS.getLocalPart();
+
+        Document doc = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+
+        assertXpathEvaluatesTo("1", "//wms:Layer[wms:Name='" + linesName + "']/@opaque", doc);
+        assertXpathEvaluatesTo("0", "//wms:Layer[wms:Name='" + pointsName + "']/@opaque", doc);
+    }
 
     @org.junit.Test
     public void testKeywordVocab() throws Exception {


### PR DESCRIPTION
The WMS spec says about the opaque layer property : "If the optional Boolean attribute opaque is absent or false, then maps made from that Layer will generally have significant no-data areas that a client may display as transparent. Vector features such as points and lines are considered not to be opaque in this context (even though at some scales and symbol sizes a collection of features might fill the map area). A true value for opaque indicates that the Layer represents an area-filling coverage. For example, a map that represents topography and bathymetry as regions of differing colours will have no transparent areas. The opaque declaration should be taken as a hint to the Client to place such a Layer at the bottom of a stack of maps."
