### PR TITLE
[GEOS-5907] Add Legend panel to CSS demo

### DIFF
--- a/src/extension/css/src/main/java/org/geoserver/community/css/web/OpenLayersMapPanel.java
+++ b/src/extension/css/src/main/java/org/geoserver/community/css/web/OpenLayersMapPanel.java
@@ -4,26 +4,35 @@
  */
 package org.geoserver.community.css.web;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.markup.html.IHeaderContributor;
+import org.apache.wicket.markup.html.IHeaderResponse;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.web.GeoServerApplication;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.logging.Logging;
 
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import org.apache.wicket.WicketRuntimeException;
-import org.apache.wicket.markup.html.IHeaderContributor;
-import org.apache.wicket.markup.html.IHeaderResponse;
-import org.apache.wicket.markup.html.panel.Panel;
-
-import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.catalog.StyleInfo;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 
 class OpenLayersMapPanel extends Panel implements IHeaderContributor {
+    static final Logger LOGGER  = Logging.getLogger(OpenLayersMapPanel.class);
     final static Configuration templates;
     
     static {
@@ -43,7 +52,24 @@ class OpenLayersMapPanel extends Panel implements IHeaderContributor {
         this.resource = resource;
         this.style = style;
         setOutputMarkupId(true);
+        
+        try {
+            ensureLegendDecoration();
+        } catch(IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to put legend layout file in the data directory, the legend decoration will not appear", e);
+        }
     } 
+
+    private void ensureLegendDecoration() throws IOException {
+        GeoServerDataDirectory dd = GeoServerApplication.get().getBeanOfType(GeoServerDataDirectory.class);
+        File layouts = dd.findOrCreateDir("layouts");
+        File legend = new File(layouts, "css-legend.xml");
+        if(!legend.exists()) {
+            String legendLayout = IOUtils.toString(OpenLayersMapPanel.class.getResourceAsStream("css-legend.xml"));
+            FileUtils.writeStringToFile(legend, legendLayout);
+        }
+        
+    }
 
     public void renderHead(IHeaderResponse header) {
         try {

--- a/src/extension/css/src/main/resources/org/geoserver/community/css/web/css-legend.xml
+++ b/src/extension/css/src/main/resources/org/geoserver/community/css/web/css-legend.xml
@@ -1,0 +1,3 @@
+<layout>
+    <decoration type="legend" affinity="top,right" offset="0,0" size="auto"/>
+</layout>

--- a/src/extension/css/src/main/resources/org/geoserver/community/css/web/ol-load.ftl
+++ b/src/extension/css/src/main/resources/org/geoserver/community/css/web/ol-load.ftl
@@ -21,9 +21,11 @@ map.addLayer(new OpenLayers.Layer.WMS("GeoServer WMS", "../wms",
       layers: "${layer}",
       styles: "${style}",
       format: "image/png",
+      format_options: "layout:css-legend;fontAntiAliasing:true",
       random: ${cachebuster?c}
     }, {
-      singleTile: true
+      singleTile: true,
+      ratio: 1
     }
   )
 );

--- a/src/wms/src/main/java/org/geoserver/wms/decoration/LegendDecoration.java
+++ b/src/wms/src/main/java/org/geoserver/wms/decoration/LegendDecoration.java
@@ -111,6 +111,14 @@ public class LegendDecoration extends AbstractDispatcherCallback implements MapD
 
                 Font oldFont = g2d.getFont();
                 g2d.setFont(newFont);
+                if (LegendUtils.isFontAntiAliasing(legend.request)) {
+                    g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                            RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+                } else {
+                    g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                            RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+                }
+
                 BufferedImage titleImage = LegendUtils.renderLabel(title, g2d, request);
                 g2d.setFont(oldFont);
 
@@ -198,14 +206,6 @@ public class LegendDecoration extends AbstractDispatcherCallback implements MapD
                     finalLegend,
                     new HashMap<RenderingHints.Key, Object>()
                 );
-
-            if (LegendUtils.isFontAntiAliasing(legend.request)) {
-                finalGraphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                        RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            } else {
-                finalGraphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                        RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-            }
 
             // title
             int titleHeightOffset = 0;


### PR DESCRIPTION
This one uses legend decorations (which are added automatically to the data dir) to show the legend in a scale dependent manner:

![zoom1](https://f.cloud.github.com/assets/325433/933161/f459b594-0050-11e3-9549-18df6e4a3d68.png)

![zoom2](https://f.cloud.github.com/assets/325433/933160/f459d4fc-0050-11e3-8a1b-4ec8b15ecfdc.png)

Hmmm... the way titles are combined needs work, this way they get long, and they are combined in a english specific way (title1 with title2)
