### PR TITLE
Fixed maven3 pom warnings.

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1146,6 +1146,7 @@
    <plugin>
      <groupId>org.apache.maven.plugins</groupId>
      <artifactId>maven-resources-plugin</artifactId>
+     <version>2.6</version>
      <configuration>
        <encoding>UTF-8</encoding>
      </configuration>
@@ -1245,6 +1246,7 @@
 
    <plugin>
 	<artifactId>maven-jar-plugin</artifactId>
+    <version>2.4</version>
 	<executions>
 		<execution>
 			<phase>package</phase>
@@ -1275,6 +1277,7 @@
     <inherited>true</inherited>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-source-plugin</artifactId>
+    <version>2.2.1</version>
     <configuration>
      <attach>true</attach>
     </configuration>
@@ -1327,11 +1330,13 @@
    <!-- website -->
    <plugin>
     <artifactId>maven-site-plugin</artifactId>
+    <version>3.0</version>
    </plugin>
 
    <!-- javadoc -->
    <plugin>
     <artifactId>maven-javadoc-plugin</artifactId>
+    <version>2.9</version>
     <configuration>
      <source>1.5</source>
      <version>false</version>
@@ -1388,11 +1393,13 @@
    <!-- basic project information -->
    <plugin>
     <artifactId>maven-project-info-reports-plugin</artifactId>
+    <version>2.4</version>
    </plugin>
 
    <!-- test reports -->
    <plugin>
     <artifactId>maven-surefire-report-plugin</artifactId>
+    <version>2.12</version>
     <configuration>
      <linkXRef>true</linkXRef>
     </configuration>
@@ -1401,6 +1408,7 @@
    <!-- HTML based, cross-reference version of Java source code -->
    <plugin>
     <artifactId>maven-jxr-plugin</artifactId>
+    <version>2.1</version>
     <configuration>
      <aggregate>true</aggregate>
     </configuration>
@@ -1410,6 +1418,7 @@
    <plugin>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>taglist-maven-plugin</artifactId>
+    <version>2.4</version>
     <configuration>
      <tags>
       <tag>@revisit</tag>
@@ -1424,6 +1433,7 @@
    <plugin>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>cobertura-maven-plugin</artifactId>
+    <version>2.5.2</version>
     <configuration>
        <formats>
           <format>html</format>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -180,6 +180,7 @@
       <!-- Builds a valid data directory into the web app -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
         <executions>
           <execution>
             <id>configPackage</id>
@@ -267,6 +268,7 @@
 		<inherited>true</inherited>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-war-plugin</artifactId>
+        <version>2.3</version>
 		<configuration>
 			<warName>geoserver</warName>
 			<webappDirectory>${project.build.directory}/geoserver</webappDirectory>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -148,7 +148,7 @@
             <phase>process-resources</phase>
             <configuration>
               <tasks>
-                <replace dir="${build.outputDirectory}" encoding="ISO-8859-1">
+                <replace dir="${project.build.outputDirectory}" encoding="ISO-8859-1">
                   <include name="*.properties"/> 
                   <replacefilter token="@project.version@" value="${project.version}"/>
                   <replacefilter token="@build.revision@" value="${build.commit.id}"/>


### PR DESCRIPTION
- Declaring version for all plugins
- using project.build.outputDirectory rather than just build.outputDirectory
