### PR TITLE
Update REST docs to match changes in GEOS-5512. (2.4.x)

### DIFF
--- a/doc/en/user/source/rest/api/services.rst
+++ b/doc/en/user/source/rest/api/services.rst
@@ -40,7 +40,7 @@ Controls Web Coverage Service settings.
      - 
 
 
-``/services/wcs/<ws>/settings[.<format>]``
+``/services/wcs/workspaces/<ws>/settings[.<format>]``
 ------------------------------------------
 
 Controls Web Coverage Service settings for a given workspace.
@@ -110,7 +110,7 @@ Controls Web Feature Service settings.
      -
 
 
-``/services/wfs/<ws>/settings[.<format>]``
+``/services/wfs/workspaces/<ws>/settings[.<format>]``
 ------------------------------------------
 
 Controls Web Feature Service settings for a given workspace.
@@ -181,7 +181,7 @@ Controls Web Map Service settings.
      -
 
 
-``/services/wms/<ws>/settings[.<format>]``
+``/services/wms/workspaces/<ws>/settings[.<format>]``
 ------------------------------------------
 
 Controls Web Map Service settings for a given workspace.


### PR DESCRIPTION
86d8ed7 added a workspaces/ container around REST urls for service-specific settings.

Doesn't appear the doc changes around restconfig -> rest included it, so the current rest api docs don't refer to the container.

This PR is for 2.4.x, see https://github.com/geoserver/geoserver/pull/302 for master, and another one for 2.3.x
