### PR TITLE
[GEOS-5985] Tomcat with APR can result in full JVM crashes

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -234,7 +234,7 @@ public class Dispatcher extends AbstractController {
 
         //set request / response
         request.setHttpRequest(httpRequest);
-        request.setHttpResponse(httpResponse);
+        request.setHttpResponse(new FlushSafeResponse(httpResponse));
 
         Service service = null;
 

--- a/src/ows/src/main/java/org/geoserver/ows/FlushSafeResponse.java
+++ b/src/ows/src/main/java/org/geoserver/ows/FlushSafeResponse.java
@@ -1,0 +1,70 @@
+package org.geoserver.ows;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+/**
+ * A wrapper making sure the servlet container will never see a flush call once the output stream
+ * is closed
+ *  
+ * @author Andrea Aime - GeoSolutions
+ */
+class FlushSafeResponse extends HttpServletResponseWrapper implements HttpServletResponse {
+    
+    ServletOutputStream os = null;
+
+    public FlushSafeResponse(HttpServletResponse response) {
+        super(response);
+    }
+    
+    @Override
+    public synchronized ServletOutputStream getOutputStream() throws IOException {
+        if(os == null) {
+            os = new FlushSaveServletOutputStream(super.getOutputStream()); 
+        }
+        return os;
+    }
+    
+    static class FlushSaveServletOutputStream extends ServletOutputStream {
+
+        OutputStream delegate;
+        boolean closed = false;
+
+        public FlushSaveServletOutputStream(OutputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte b[]) throws IOException {
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte b[], int off, int len) throws IOException {
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            if(!closed) {
+                delegate.flush();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            delegate.close();
+        }
+    }
+
+}

--- a/src/ows/src/test/java/org/geoserver/ows/MessageResponse.java
+++ b/src/ows/src/test/java/org/geoserver/ows/MessageResponse.java
@@ -23,6 +23,8 @@ public class MessageResponse extends Response {
         throws IOException {
         Message message = (Message) value;
         output.write(message.message.getBytes());
+        output.close();
+        output.flush();
     }
 
     public void abort(Object value, OutputStream output, Operation operation)


### PR DESCRIPTION
It seems fine to me, but the change has the potential to affect every single OGC request.
I'd like to commit on trunk and then backport on 2.4.x, since apparently the APR runtime is installed by default on Windows.
