### PR TITLE
Attach geoserver web-app war artifact for use with maven war overlays

### DIFF
--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -290,10 +290,32 @@
 		</configuration>
 		<executions>
 			<execution>
-				<phase>install</phase>
+				<phase>package</phase>
 				<goals>
 					<goal>war</goal>
 				</goals>
+			</execution>
+		</executions>
+	</plugin>
+	<plugin>
+		<groupId>org.codehaus.mojo</groupId>
+		<artifactId>build-helper-maven-plugin</artifactId>
+		<version>1.8</version>
+		<executions>
+			<execution>
+				<id>attach-war</id>
+				<phase>package</phase>
+				<goals>
+					<goal>attach-artifact</goal>
+				</goals>
+				<configuration>
+					<artifacts>
+						<artifact>
+							<file>${project.build.directory}/geoserver.war</file>
+							<type>war</type>
+						</artifact>
+					</artifacts>
+				</configuration>
 			</execution>
 		</executions>
 	</plugin>


### PR DESCRIPTION
A number of groups utilize maven war overlays to generate custom and version controlled geoserver war deployments using maven war overlays.  This requires the presence of a geoserver war artifact in a maven repository.  This commit will allow for the web-app war artifact to be attached in addition to the project jar when building from source and with use of the maven release plugin. 
