### PR TITLE
Groovy Eclipse Compiler

### DIFF
--- a/src/community/script/groovy/pom.xml
+++ b/src/community/script/groovy/pom.xml
@@ -42,35 +42,34 @@
  <build>
    <plugins>
         <plugin>
-            <groupId>org.codehaus.gmaven</groupId>
-            <artifactId>gmaven-plugin</artifactId>
-            <version>1.4</version>
-            <configuration>
-                <providerSelection>1.8</providerSelection>
-            </configuration>
-            <dependencies>
-                <dependency>
-                    <groupId>org.codehaus.gmaven.runtime</groupId>
-                    <artifactId>gmaven-runtime-1.8</artifactId>
-                    <version>1.4</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
-                    <version>1.8.8</version>
-                </dependency>
-            </dependencies>
-            <executions>
-                <execution>
-                    <goals>
-                    	<goal>generateStubs</goal>
-                        <goal>compile</goal>
-                        <goal>generateTestStubs</goal>
-                        <goal>testCompile</goal>
-                    </goals>
-                </execution>
-            </executions>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-eclipse-compiler</artifactId>
+            <version>2.9.0-01-SNAPSHOT</version>
+            <extensions>true</extensions>
         </plugin>
+		<plugin>
+			<artifactId>maven-compiler-plugin</artifactId>
+            <version>3.1</version>
+			<configuration>
+				<compilerId>groovy-eclipse-compiler</compilerId>
+                <debug>true</debug>
+                <source>1.6</source>
+                <target>1.6</target>
+                <encoding>UTF-8</encoding>
+			</configuration>
+			<dependencies>
+				<dependency>
+					<groupId>org.codehaus.groovy</groupId>
+					<artifactId>groovy-eclipse-compiler</artifactId>
+					<version>2.9.0-01-SNAPSHOT</version>
+				</dependency>
+				<dependency>
+					<groupId>org.codehaus.groovy</groupId>
+					<artifactId>groovy-eclipse-batch</artifactId>
+					<version>2.1.5-03</version>
+				</dependency>
+			</dependencies>
+		</plugin>
         <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
@@ -94,4 +93,14 @@
         </plugin>
    </plugins>
  </build>
+ <pluginRepositories>
+      <!-- Required for groovy-eclipse-compiler snapshot --> 
+      <pluginRepository>
+          <id>nexus</id>
+          <url>http://nexus.codehaus.org/snapshots/</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+      </pluginRepository>
+ </pluginRepositories>
 </project>


### PR DESCRIPTION
GeoScript Groovy version 1.2 is going to upgrade from Groovy 1.8.9 to Groovy 2.1.6.  The groovy compiler used in the GeoServer community script module doesn't support Groovy 2.1.6.  This pull request replaces the GMaven compiler with the Groovy Eclipse compiler.  All code compiles and unit tests pass and all examples from my Scripting GeoServer CUGOS presentation (https://docs.google.com/file/d/0B8cwqNmbcThpNkRKT0VDc3V6Q0E/edit?usp=sharing) still work.

Thanks!
Jared
