### PR TITLE
Extended PointSymbolizer to manage all marks in HTML imagemap

### DIFF
--- a/src/extension/imagemap/ExtendedPointSymbolizer
+++ b/src/extension/imagemap/ExtendedPointSymbolizer
@@ -1,0 +1,1 @@
+Poitsymbolizer should manage all kind of marks, and not only circle marks.


### PR DESCRIPTION
PointSymbolizer can manage all marks, like star, cross, etc... and not only circles.
Anyway, the map uses the "circle"  tag to render the mark.
this looks a valid compromise, because the map actually shows a tooltip and doesn't need to match perfectly the rendered image.
