### PR TITLE
GEOS-6006: Animation doesn't work with REQUEST=GetMap

### DIFF
--- a/src/wms/src/main/java/applicationContext.xml
+++ b/src/wms/src/main/java/applicationContext.xml
@@ -605,6 +605,8 @@
       <value>wms</value>
     </constructor-arg>
   </bean>
+ 		
+	<bean id="animateFilter" class="org.geoserver.wms.animate.AnimatorFilter"/>
  	
 	<bean id="animateURLMapping" 
 		class="org.geoserver.ows.OWSHandlerMapping">

--- a/src/wms/src/main/java/org/geoserver/wms/animate/AnimatorFilter.java
+++ b/src/wms/src/main/java/org/geoserver/wms/animate/AnimatorFilter.java
@@ -1,0 +1,134 @@
+/* Copyright (c) 2001 - 2013 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.animate;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import org.geoserver.filters.GeoServerFilter;
+import org.geotools.util.logging.Logging;
+
+/**
+ * GIF Animated reflecting service request filter.
+ * <p>
+ * Modifies requests against the WMS animate reflector service endpoints
+ * in order to address <a href="http://jira.codehaus.org/browse/GEOS-6006">GEOS-6006</a>
+ * </p>
+ * 
+ * @author Tom Kunicki, Boundless
+ */
+public class AnimatorFilter implements GeoServerFilter {
+    
+    private static final Logger LOGGER = Logging.getLogger(AnimatorFilter.class);
+
+    private final static String ENDPOINT = "animate";
+    private final static String REQUEST = "Request";
+    private final static String GETMAP = "GetMap";
+
+    /**
+     *
+     * @param config
+     * @throws ServletException
+     */
+    @Override
+    public void init(FilterConfig config) throws ServletException {
+        // nothing to do
+    }
+
+    /**
+     * Removes KVP argument <code>Request=GetMap</code> <i>(case independent)</i> if present
+     * for calls against <code>.../animate</code> service endpoints.
+     * 
+     * @param request   current HTTP request
+     * @param response  current HTTP response
+     * @param chain     currently executing filter chain
+     * @throws java.io.IOException 
+     * @throws javax.servlet.ServletException 
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            HttpServletRequest requestHTTP = (HttpServletRequest)request;
+            if (requestNeedsWrapper(requestHTTP)) {
+                LOGGER.log(Level.FINER, "Modified request to {0}, removed \"Request\" KVP argument (GEOS-6006)", requestHTTP.getRequestURI());
+                request = new RequestWrapper(requestHTTP);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void destroy() {
+        // nothing to do...
+    }
+    
+    private boolean requestNeedsWrapper(HttpServletRequest request) {
+        if (request.getRequestURI().endsWith(ENDPOINT)) {
+            Enumeration<String> names = request.getParameterNames();
+            while (names.hasMoreElements()) {
+                String name = names.nextElement();
+                if (REQUEST.equalsIgnoreCase(name) &&
+                    GETMAP.equalsIgnoreCase(request.getParameter(name))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
+    private static class RequestWrapper extends HttpServletRequestWrapper {        
+        private RequestWrapper(HttpServletRequest wrapped) {
+            super(wrapped);
+        }
+
+        @Override
+        public Enumeration getParameterNames() {
+            return Collections.enumeration(getParameterMap().keySet());
+        }
+
+        @Override
+        public Map<String,String[]> getParameterMap() {
+            Map<String, String[]> original = super.getParameterMap();
+            Map filtered = new HashMap<String, String[]>();
+            for (Map.Entry<String, String[]> entry : original.entrySet()) {
+                String key = entry.getKey();
+                if (!REQUEST.equalsIgnoreCase(key)) {
+                    filtered.put(key, entry.getValue());
+                }
+            }
+            return filtered;
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            if (REQUEST.equalsIgnoreCase(name)) {
+                return null;
+            }
+            return super.getParameterValues(name);
+        }
+
+        @Override
+        public String getParameter(String name) {
+            if (REQUEST.equalsIgnoreCase(name)) {
+                return null;
+            }
+            return super.getParameter(name);
+        }
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/animate/AnimatorFilterTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/animate/AnimatorFilterTest.java
@@ -1,0 +1,83 @@
+/* Copyright (c) 2001 - 2013 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.animate;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import javax.servlet.Filter;
+import org.geoserver.wms.WMSTestSupport;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+
+/**
+ * Some unit and functional tests for animator filter
+ * 
+ * @author Tom Kunicki, Boundless
+ */
+public class AnimatorFilterTest extends WMSTestSupport {
+
+    @Override
+    public List<Filter> getFilters() {
+        return Arrays.asList((Filter)new AnimatorFilter());
+    }
+    
+    @Test
+    public void testDefaults() throws Exception {
+
+        String requestURL = "cite/wms/animate?aparam=layers&avalues=MapNeatline,Buildings,Lakes";
+        
+        MockHttpServletResponse resp = getAsServletResponse(requestURL);
+        
+        // check mime type
+        assertEquals("image/gif", resp.getContentType());
+        // check for multiple (3) frames
+        assertEquals(3, extractImageCountFromGIF(resp));
+    }
+    
+    @Test
+    public void testGEOS_6006() throws Exception {
+
+        String requestURL = "cite/wms/animate?request=getmap&aparam=layers&avalues=MapNeatline,Buildings,Lakes";
+        
+        MockHttpServletResponse resp = getAsServletResponse(requestURL);
+        
+        // check mime type
+        assertEquals("image/gif", resp.getContentType());
+        // check for multiple (3) frames
+        assertEquals(3, extractImageCountFromGIF(resp));
+    }
+    
+    private int extractImageCountFromGIF(MockHttpServletResponse response) throws IOException {
+        InputStream is = null;
+        ImageInputStream iis = null;
+        ImageReader r = null;
+        try {
+            is = getBinaryInputStream(response);
+            iis = ImageIO.createImageInputStream(is);
+            r = ImageIO.getImageReadersBySuffix("gif").next();
+            r.setInput(iis);
+            return r.getNumImages(true);
+        } finally {
+            if (r != null) { 
+                r.dispose();
+            }
+            if (iis != null) {
+                iis.close();
+            }
+            if (is != null) {
+                try { is.close(); } catch (IOException ignore) {}
+            }
+          
+        }
+    }
+    
+}


### PR DESCRIPTION
This issue is related to how the GeoServer OWS dispatcher parses requests coupled with how the animator is currently shimmed into the WMS service ("animate" is implemented as a request).  In the absence of HTTP GET KVP arguments for `Service` and `Request` the OWS dispatcher infers these arguments from the path used to generate the request. For example for a URI with the path `/wms/animate?...` the service is inferred as `wms` and the request inferred as `animate` _unless_ overridden by a KVP argument. In the presence of a KVP `Request=GetMap` the `animate` request is overridden.  Since `animate` is intended to override `GetMap` this leads to undesired behavior.

The quick fix is to intercept calls to the animator and remove `Request=GetMap` (if present) before the dispatcher is called.  A long term fix may be drop the need for an explicit animation request and trigger the behavior from the requested output format (i.e. "image/gif;subtype=animate" which is specific to animation")

This pull request implements a interceptor to remove `Request=GetMap`, if present, from any call to the animate end point so that animate is successfully called.
