### PR TITLE
GEOS-6086 remove WfsDispatcher from describelayer

### DIFF
--- a/src/main/src/main/java/org/vfny/geoserver/servlets/Dispatcher.java
+++ b/src/main/src/main/java/org/vfny/geoserver/servlets/Dispatcher.java
@@ -37,7 +37,6 @@ import org.vfny.geoserver.util.requests.readers.KvpRequestReader;
  *
  * @task TODO: rework to work too for WMS servlets, and to get the servlets
  *       from ServletContext instead of having them hardcoded
- * @task TODO: move the post dispatcher work from WfsDispatcher up here.
  */
 
 //JD: kill this class
@@ -87,7 +86,7 @@ public class Dispatcher extends HttpServlet {
     public static final int ERROR = -2;
     protected ServletConfig servletConfig;
 
-    //HACK! This is just to fix instances where the first request is a 
+    //HACK! This is just to fix instances where the first request is a
     //dispatcher, and the strategy hasn't been inited yet.  This can be
     //fixed in two ways, one by having Dispatcher extend Abstract ServiceConfig,
     //which it should do, and two by having the configuration of the strategy

--- a/src/wms/src/main/java/org/geoserver/wms/describelayer/DescribeLayerModel.java
+++ b/src/wms/src/main/java/org/geoserver/wms/describelayer/DescribeLayerModel.java
@@ -46,8 +46,7 @@ public class DescribeLayerModel {
             String owsType = null;
             URL owsURL = null;
             if (MapLayerInfo.TYPE_VECTOR == layer.getType()) {
-                // REVISIT: not sure why we need WfsDispatcher, "wfs?" should suffice imho
-                owsUrl = buildURL(baseURL, "wfs/WfsDispatcher", null, URLType.SERVICE);
+                owsUrl = buildURL(baseURL, "wfs", null, URLType.SERVICE);
                 owsUrl = appendQueryString(owsUrl, "");
                 try {
                     owsURL = new URL(owsUrl);

--- a/src/wms/src/main/java/org/geoserver/wms/describelayer/DescribeLayerTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/describelayer/DescribeLayerTransformer.java
@@ -149,8 +149,7 @@ public class DescribeLayerTransformer extends TransformerBase {
                 String owsUrl;
                 String owsType;
                 if (MapLayerInfo.TYPE_VECTOR == layer.getType()) {
-                    // REVISIT: not sure why we need WfsDispatcher, "wfs?" should suffice imho
-                    owsUrl = buildURL(baseURL, "wfs/WfsDispatcher", null, URLType.SERVICE);
+                    owsUrl = buildURL(baseURL, "wfs", null, URLType.SERVICE);
                     owsUrl = appendQueryString(owsUrl, "");
                     owsType = "WFS";
                     layerAtts.addAttribute("", "wfs", "wfs", "", owsUrl);

--- a/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerJsonTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerJsonTest.java
@@ -128,13 +128,13 @@ public class DescribeLayerJsonTest extends WMSTestSupport {
         JSONObject layerDesc = layerDescs.getJSONObject(0);
         assertEquals(layerDesc.get("layerName"),
                 MockData.LAKES.getPrefix() + ":" + MockData.LAKES.getLocalPart());
-        assertTrue(layerDesc.get("owsURL").toString().endsWith("geoserver/wfs/WfsDispatcher?"));
+        assertTrue(layerDesc.get("owsURL").toString().endsWith("geoserver/wfs?"));
         assertEquals(layerDesc.get("owsType"), "WFS");
 
         layerDesc = layerDescs.getJSONObject(1);
         assertEquals(layerDesc.get("layerName"), MockData.FORESTS.getPrefix() + ":"
                 + MockData.FORESTS.getLocalPart());
-        assertTrue(layerDesc.get("owsURL").toString().endsWith("geoserver/wfs/WfsDispatcher?"));
+        assertTrue(layerDesc.get("owsURL").toString().endsWith("geoserver/wfs?"));
         assertEquals(layerDesc.get("owsType"), "WFS");
 
     }

--- a/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerTransformerTest.java
@@ -198,7 +198,7 @@ public class DescribeLayerTransformerTest {
         assertXpathExists(layerDescPath, dom);
         assertXpathEvaluatesTo("fakeWs:states", layerDescPath + "/@name", dom);
 
-        final String expectedWfsAtt = serverBaseUrl + "/wfs/WfsDispatcher?";
+        final String expectedWfsAtt = serverBaseUrl + "/wfs?";
         assertXpathExists(layerDescPath + "/@wfs", dom);
         assertXpathEvaluatesTo(expectedWfsAtt, layerDescPath + "/@wfs", dom);
 


### PR DESCRIPTION
(and all other places in the code base)

Looks like a little trailing whitespace fix found it's way in there, too.

Bug applies to 2.3.x and 2.4.x, too. Patch applies cleanly, too :)
