### PR TITLE
enable useSreenMenuBar Property

### DIFF
--- a/src/release/installer/mac/GeoServer.app/Contents/Info.plist
+++ b/src/release/installer/mac/GeoServer.app/Contents/Info.plist
@@ -46,7 +46,7 @@
 		<key>Properties</key>
 		<dict>
 			<key>apple.laf.useScreenMenuBar</key>
-			<string>false</string>
+			<string>true</string>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
moves Start/Stop Action to native OS X Screen Menu bar - tested on  OS X 10.9 - Mavericks
