### PR TITLE
Remove redundant calls to toString() on String objects

### DIFF
--- a/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkDescriptionDecoratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkDescriptionDecoratorFactory.java
@@ -48,7 +48,7 @@ public class PlacemarkDescriptionDecoratorFactory implements KmlDecoratorFactory
             SimpleFeature sf = context.getCurrentFeature();
             String description = null;
             try {
-                description = template.description(sf).toString();
+                description = template.description(sf);
             } catch (IOException e) {
                 String msg = "Error occured processing 'description' template.";
                 LOGGER.log(Level.WARNING, msg, e);

--- a/src/ows/src/main/java/org/geoserver/ows/AbstractURLPublisher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/AbstractURLPublisher.java
@@ -64,7 +64,7 @@ public abstract class AbstractURLPublisher extends AbstractController {
         
         File file = DataUtilities.urlToFile(url);
         if(file != null && file.exists() && file.isDirectory()) {
-            String uri = request.getRequestURI().toString();
+            String uri = request.getRequestURI();
             uri += uri.endsWith("/") ? "index.html" : "/index.html";
             
             response.addHeader("Location", uri);

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10DescribeCoverageTransformer.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10DescribeCoverageTransformer.java
@@ -285,8 +285,8 @@ public class Wcs10DescribeCoverageTransformer extends TransformerBase {
 
                 final String minCP = referencedEnvelope.getMinX() + " " + referencedEnvelope.getMinY();
                 final String maxCP = referencedEnvelope.getMaxX() + " " + referencedEnvelope.getMaxY();
-                element("gml:pos", minCP.toString());
-                element("gml:pos", maxCP.toString());
+                element("gml:pos", minCP);
+                element("gml:pos", maxCP);
                 
                 // are we going to report time?
                 DimensionInfo timeInfo = ci.getMetadata().get(ResourceInfo.TIME, DimensionInfo.class);

--- a/src/web/core/src/main/java/org/geoserver/web/AboutGeoServerPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/AboutGeoServerPage.java
@@ -19,7 +19,7 @@ public class AboutGeoServerPage extends GeoServerBasePage {
 
     public AboutGeoServerPage() {
         add(new Label("geotoolsVersion", GeoTools.getVersion().toString()));
-        add(new Label("geotoolsRevision", GeoTools.getBuildRevision().toString()));
+        add(new Label("geotoolsRevision", GeoTools.getBuildRevision()));
         add(new Label("geowebcacheVersion", getGwcVersion()));
         add(new Label("geowebcacheRevision", getGwcRevision()));
     }

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/DimensionHelper.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/DimensionHelper.java
@@ -285,7 +285,7 @@ abstract class DimensionHelper {
                 }
                 buff.append(",");
             }
-            elevationMetadata = buff.substring(0, buff.length() - 1).toString().replaceAll("\\[",
+            elevationMetadata = buff.substring(0, buff.length() - 1).replaceAll("\\[",
                     "").replaceAll("\\]", "").replaceAll(" ", "");
         } else if (DimensionPresentation.CONTINUOUS_INTERVAL == dimension.getPresentation()) {
             NumberRange<Double> range = getMinMaxZInterval(values);
@@ -345,7 +345,7 @@ abstract class DimensionHelper {
                 buff.append(df.format(date));
                 buff.append(",");
             }
-            timeMetadata = buff.substring(0, buff.length() - 1).toString().replaceAll("\\[", "")
+            timeMetadata = buff.substring(0, buff.length() - 1).replaceAll("\\[", "")
                     .replaceAll("\\]", "").replaceAll(" ", "");
         } else if (DimensionPresentation.CONTINUOUS_INTERVAL == dimension.getPresentation()) {
             DateRange interval = getMinMaxTimeInterval(values);

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesResponse.java
@@ -146,7 +146,7 @@ public class GetCapabilitiesResponse extends BaseCapabilitiesResponse {
 
             // Set the full DTD declaration, including internal elements provided by
             // ExtendedCapabilitiesProviders, as an stylesheet parameter
-            dtdIncludeTransformer.setParameter("DTDDeclaration", internalDTDDeclaration.toString());
+            dtdIncludeTransformer.setParameter("DTDDeclaration", internalDTDDeclaration);
 
             Source source;
             try {


### PR DESCRIPTION
I wanted to help contribute and thought I'd start with something small and trivial, but annoying (IntelliJ warns about this by default).

There were 8 instances where toString() was being called on a String object. This pull request removes that redundant call that does nothing.
