### PR TITLE
Don't check . ($PWD) when searching for something in the GeoServer data dir

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
@@ -197,10 +197,6 @@ public class GeoServerResourceLoader extends DefaultResourceLoader implements Ap
         //first to an existance check
         File file = parent != null ? new File(parent,location) : new File(location);
         
-        if (file.exists()) {
-            return file;
-        }
-        
         if (file.isAbsolute()) {
             return file.exists() ? file : null;
         } else {


### PR DESCRIPTION
Our app server runs with a present working directory of /, and there is a directory named /security. GeoServerResourceLoader.find(File, File) calls File.exists() even on relative paths, effectively searching $PWD for data dir entries. If GeoServer needs to search $PWD, and I don't think it should do so implicitly, it should do so after GeoServerResourceLoader.searchLocations is searched, or the startup code could just add "." to the end of GeoServerResourceLoader.searchLocations after GEOSERVER_DATA_DIR and the other usual search paths. This pull request just removes the check for File.exists().
