### PR TITLE
GEOS-6216: app-schema axis order is wrong if bbox property is specified in POST request.

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/BBoxFilterTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/BBoxFilterTest.java
@@ -128,6 +128,42 @@ public class BBoxFilterTest extends AbstractAppSchemaTestSupport {
         assertXpathEvaluatesTo("2", "/wfs:FeatureCollection/@numberOfFeatures", doc);
         assertXpathCount(2, "//ex:geomContainer", doc);
     }
+    
+    /**
+     * The following performs a WFS request specifying a BBOX parameter of axis ordering latitude
+     * longitude and srsName in URN format using POST request (GEOS-6216). 
+     * This test should return features if the axis ordering behaves similar to queries
+     * to Simple features.
+     */
+    @Test
+    public void testQueryBboxLatLongPost() {
+        
+        String xml = "<wfs:GetFeature service=\"WFS\" version=\"1.1.0\" " //
+                + "xmlns:ogc=\"http://www.opengis.net/ogc\" " //
+                + "xmlns:wfs=\"http://www.opengis.net/wfs\" " //
+                + "xmlns:gml=\"http://www.opengis.net/gml\" " //
+                + "xmlns:ex=\"http://example.com\" " //
+                + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " //
+                + "xsi:schemaLocation=\"" //
+                + "http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd \">" //
+                + "<wfs:Query typeName=\"ex:geomContainer\">" //
+                + "    <ogc:Filter>" //
+                + "        <ogc:BBOX>" //
+                + "            <ogc:PropertyName>ex:geom</ogc:PropertyName>" //
+                + "            <gml:Envelope srsName=\"urn:x-ogc:def:crs:EPSG:4326\">" //
+                + "                  <gml:lowerCorner>-29 130</gml:lowerCorner>" //
+                + "                  <gml:upperCorner>-24 134</gml:upperCorner>" //
+                + "            </gml:Envelope>" //
+                + "        </ogc:BBOX>" //
+                + "    </ogc:Filter>" //
+                + "</wfs:Query>" //
+                + "</wfs:GetFeature>"; //
+        validate(xml);
+        Document doc = postAsDOM("wfs", xml);
+        LOGGER.info(WFS_GET_FEATURE_LOG + " with POST filter " + prettyString(doc));
+        assertXpathEvaluatesTo("2", "/wfs:FeatureCollection/@numberOfFeatures", doc);
+        assertXpathCount(2, "//ex:geomContainer", doc);
+    }
 
     /**
      * The following performs a WFS request specifying a BBOX parameter of axis ordering longitude

--- a/src/wfs/src/main/java/org/geoserver/wfs/BBOXNamespaceSettingVisitor.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/BBOXNamespaceSettingVisitor.java
@@ -1,0 +1,38 @@
+package org.geoserver.wfs;
+
+import org.geotools.filter.visitor.DuplicatingFilterVisitor;
+import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.spatial.BBOX;
+import org.xml.sax.helpers.NamespaceSupport;
+
+/**
+ * This is to set namespace context to handle complex attributes in the bbox filter.
+ * 
+ * @author Rini Angreani (CSIRO Earth Science and Resource Engineering)
+ */
+
+public class BBOXNamespaceSettingVisitor extends DuplicatingFilterVisitor {
+
+    private NamespaceSupport nsContext;
+
+    public BBOXNamespaceSettingVisitor(NamespaceSupport ns) {
+        nsContext = ns;
+    }
+
+    @Override
+    public Object visit(BBOX filter, Object extraData) {
+        String propertyName = null;
+        if (filter.getExpression1() instanceof PropertyName) {
+            propertyName = ((PropertyName) filter.getExpression1()).getPropertyName();
+        } else if (filter.getExpression2() instanceof PropertyName) {
+            propertyName = ((PropertyName) filter.getExpression2()).getPropertyName();
+        }
+
+        if (propertyName != null) {
+            PropertyName propertyAtt = ff.property(propertyName, nsContext);
+            filter = ff.bbox(propertyAtt, filter.getBounds());
+        }
+        return filter;
+    }
+
+}


### PR DESCRIPTION
BBOX reprojections are done in GetFeature before getting passed on to the data store (app-schema).
As the geom property name is created from the filter property name, it doesn't have the namespace context. 
As a result, it fails to resolve the geom property name if it's a complex attribute, and then it fails to pass on the CRS, resulting in the wrong axis order.

I added a visitor to inject the namespace context before ReprojectingFilterVisitor processes it. 

Part 2 is in Geotools ReprojectingFilterVisitor: https://github.com/geotools/geotools/pull/347
