### PR TITLE
Migrate importer tests to the new tests infrastructure

### DIFF
--- a/src/extension/importer/bdb/src/test/java/org/geoserver/importer/bdb/BDBImportStoreTest.java
+++ b/src/extension/importer/bdb/src/test/java/org/geoserver/importer/bdb/BDBImportStoreTest.java
@@ -4,28 +4,38 @@
  */
 package org.geoserver.importer.bdb;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.Iterator;
+
+import org.apache.commons.io.FileUtils;
 import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImportContext;
 import org.geoserver.importer.ImportStore.ImportVisitor;
 import org.geoserver.importer.Importer;
 import org.geoserver.importer.ImporterTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 
 public class BDBImportStoreTest extends ImporterTestSupport {
 
     BDBImportStore store;
+    File dbRoot;
     
-    @Override
-    protected void setUpInternal() throws Exception {
-        super.setUpInternal();
-        
+    @Before
+    public void setupStoreField() throws Exception {
         store = new BDBImportStore(importer);
         store.init();
+        dbRoot = new File(importer.getImportRoot(), "bdb");
     }
     
     // in order to test this, run once, then change the serialVersionUID of ImportContext2
+    @Test
     public void testSerialVersionUIDChange() throws Exception {
         Importer imp =  new Importer(null) {
 
@@ -59,6 +69,7 @@ public class BDBImportStoreTest extends ImporterTestSupport {
         private static final long serialVersionUID = 12345;
     }
 
+    @Test
     public void testAdd() throws Exception {
         File dir = unpack("shape/archsites_epsg_prj.zip");
         ImportContext context = importer.createContext(new Directory(dir));
@@ -102,6 +113,7 @@ public class BDBImportStoreTest extends ImporterTestSupport {
         assertNotNull(context2.getTasks().get(0).getLayer());
     }
 
+    @Test
     public void testSave() throws Exception {
         testAdd();
 
@@ -121,10 +133,12 @@ public class BDBImportStoreTest extends ImporterTestSupport {
         assertEquals(ImportContext.State.COMPLETE, context2.getState());
     }
 
+    @Test
     public void testDatabaseRecovery() throws Exception {
         
     }
     
+    @Test
     public void testIDManagement() throws Exception {
         // verify base - first one is zero
         ImportContext zero = new ImportContext();
@@ -166,14 +180,11 @@ public class BDBImportStoreTest extends ImporterTestSupport {
         }
     }
 
-    @Override
-    protected void tearDownInternal() throws Exception {
-        super.tearDownInternal();
+    @After
+    public void destroyStore() throws Exception {
         store.destroy();
-
-//        Environment env = db.getEnvironment();
-//        db.close();
-//        classDb.close();
-//        env.close();
+        // clean up the databse       
+        FileUtils.deleteDirectory(dbRoot);
+        
     }
 }

--- a/src/extension/importer/bdb/src/test/java/org/geoserver/importer/bdb/SerialVersionSafeSerialBindingTest.java
+++ b/src/extension/importer/bdb/src/test/java/org/geoserver/importer/bdb/SerialVersionSafeSerialBindingTest.java
@@ -4,8 +4,11 @@
  */
 package org.geoserver.importer.bdb;
 
-import java.io.File;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import java.io.File;
 
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
@@ -14,11 +17,13 @@ import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImportContext;
 import org.geoserver.importer.ImportTask;
 import org.geoserver.importer.ImporterTestSupport;
+import org.junit.Test;
 
 import com.sleepycat.je.DatabaseEntry;
 
 public class SerialVersionSafeSerialBindingTest extends ImporterTestSupport {
 
+    @Test
     public void testSerialize() throws Exception {
         createH2DataStore("sf", "data");
 

--- a/src/extension/importer/bdb/src/test/java/org/geoserver/importer/bdb/XStreamInfoSerialBindingTest.java
+++ b/src/extension/importer/bdb/src/test/java/org/geoserver/importer/bdb/XStreamInfoSerialBindingTest.java
@@ -4,6 +4,10 @@
  */
 package org.geoserver.importer.bdb;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.HashMap;
@@ -18,12 +22,14 @@ import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImportContext;
 import org.geoserver.importer.ImportTask;
 import org.geoserver.importer.ImporterTestSupport;
+import org.junit.Test;
 import org.w3c.dom.Document;
 
 import com.sleepycat.je.DatabaseEntry;
 
 public class XStreamInfoSerialBindingTest extends ImporterTestSupport {
 
+    @Test
     public void testSerializeWithNewStore() throws Exception {
         File dir = unpack("shape/archsites_epsg_prj.zip");
         ImportContext context = importer.createContext(new Directory(dir));
@@ -69,6 +75,7 @@ public class XStreamInfoSerialBindingTest extends ImporterTestSupport {
         return dom(new ByteArrayInputStream(xml.getBytes()));
     }
 
+    @Test
     public void testSerialize2() throws Exception {
         Catalog cat = getCatalog();
 

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/MemoryImportStore.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/MemoryImportStore.java
@@ -127,9 +127,10 @@ public class MemoryImportStore implements ImportStore {
 
     @Override
     public void destroy() {
+        idseq.set(0);
         imports.clear();
     }
-
+    
     static abstract class ImportCollector implements ImportVisitor {
 
         List<ImportContext> collected = new ArrayList();

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/DataFormatTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/DataFormatTest.java
@@ -4,12 +4,17 @@
  */
 package org.geoserver.importer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.Test;
 
 public class DataFormatTest extends ImporterTestSupport {
 
+    @Test
     public void testLookupShapefile() {
         DataFormat format = DataFormat.lookup(new File("foo.shp"));
         assertNotNull("No format found for shape files", format);
@@ -17,6 +22,7 @@ public class DataFormatTest extends ImporterTestSupport {
         assertEquals("Shapefile format not found", "Shapefile", name);
     }
 
+    @Test
     public void testLookupTiff() throws Exception {
         File dir = unpack("geotiff/EmissiveCampania.tif.bz2");
         File tif = new File(dir, "EmissiveCampania.tif");
@@ -26,6 +32,7 @@ public class DataFormatTest extends ImporterTestSupport {
         assertEquals("Tif format not found", "GeoTIFF", name);
     }
 
+    @Test
     public void testLookupCSV() throws Exception {
         DataFormat format = DataFormat.lookup(new File("foo.csv"));
         assertNotNull("No format found for csv files", format);
@@ -33,6 +40,7 @@ public class DataFormatTest extends ImporterTestSupport {
         assertEquals("CSV format not found", "CSV", name);
     }
 
+    @Test
     public void testLookupKML() throws Exception {
         File kmlFile = new File(tmpDir(), "foo.kml");
         FileUtils.touch(kmlFile);

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImportTransformTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImportTransformTest.java
@@ -4,17 +4,33 @@
  */
 package org.geoserver.importer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
 
+import org.geoserver.catalog.CascadeDeleteVisitor;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.importer.transform.DateFormatTransform;
+import org.geoserver.importer.transform.IntegerFieldToDateTransform;
+import org.geoserver.importer.transform.NumberFormatTransform;
+import org.geoserver.importer.transform.ReprojectTransform;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.referencing.CRS;
-import org.geoserver.importer.transform.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -22,10 +38,8 @@ public class ImportTransformTest extends ImporterTestSupport {
 
     DataStoreInfo store;
 
-    @Override
-    protected void setUpInternal() throws Exception {
-        super.setUpInternal();
-        
+    @Before
+    public void setupStore() {
         Catalog cat = getCatalog();
 
         store = cat.getFactory().createDataStore();
@@ -39,6 +53,13 @@ public class ImportTransformTest extends ImporterTestSupport {
         store.getConnectionParameters().putAll(params);
         store.setEnabled(true);
         cat.add(store);
+    }
+    
+    @After
+    public void dropStore() {
+        Catalog cat = getCatalog();
+        CascadeDeleteVisitor visitor = new CascadeDeleteVisitor(cat);
+        store.accept(visitor);
     }
     
     public void testNumberFormatTransform() throws Exception {
@@ -79,6 +100,7 @@ public class ImportTransformTest extends ImporterTestSupport {
         }
     }
     
+    @Test
     public void testIntegerToDateTransform() throws Exception {
         Catalog cat = getCatalog();
 
@@ -127,6 +149,7 @@ public class ImportTransformTest extends ImporterTestSupport {
         }
     }
 
+    @Test
     public void testDateFormatTransform() throws Exception {
         Catalog cat = getCatalog();
 
@@ -166,6 +189,7 @@ public class ImportTransformTest extends ImporterTestSupport {
         }
     }
 
+    @Test
     public void testReprojectTransform() throws Exception {
         Catalog cat = getCatalog();
 

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDbTestBase.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDbTestBase.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.importer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 import java.sql.Connection;
 import java.sql.Statement;
@@ -11,6 +14,7 @@ import java.sql.Statement;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geotools.data.jdbc.JDBCUtils;
+import org.junit.Test;
 
 public abstract class ImporterDbTestBase extends ImporterDbTestSupport {
 
@@ -45,6 +49,7 @@ public abstract class ImporterDbTestBase extends ImporterDbTestSupport {
         runSafe("DROP TABLE " + tableName(tableName), st);
     }
 
+    @Test
     public void testDirectImport() throws Exception {
         Database db = new Database(getConnectionParams());
     
@@ -57,6 +62,7 @@ public abstract class ImporterDbTestBase extends ImporterDbTestSupport {
         runChecks("gs:" + tableName("widgets"));
     }
     
+    @Test
     public void testIndirectToShapefile() throws Exception {
         File dir = tmpDir();
         unpack("shape/archsites_epsg_prj.zip", dir);
@@ -85,6 +91,7 @@ public abstract class ImporterDbTestBase extends ImporterDbTestSupport {
         runChecks("gs:" + tableName("widgets"));
     }
     
+    @Test
     public void testIndirectToDb() throws Exception {
         Catalog cat = getCatalog();
         DataStoreInfo ds = cat.getFactory().createDataStore();

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDbTestSupport.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDbTestSupport.java
@@ -12,29 +12,22 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;
 
 import org.geoserver.data.test.LiveDbmsData;
-import org.geoserver.data.test.MockData;
-import org.geotools.data.DataStore;
+import org.geoserver.data.test.SystemTestData;
 
 public abstract class ImporterDbTestSupport extends ImporterTestSupport {
 
+    
+    
     @Override
-    public DbTestData buildTestData() throws Exception {
-        return new DbTestData();
+    public SystemTestData createTestData() throws Exception {
+        return new DbmsTestData(getDataDirectory().root(), getFixtureId(), null);
     }
 
-    @Override
-    protected final void setUpInternal() throws Exception {
-        if (getTestData().isTestDataAvailable()) {
-            super.setUpInternal();
-            doSetUpInternal();
-        }
-    }
 
     protected void doSetUpInternal() throws Exception {
     }
@@ -42,11 +35,11 @@ public abstract class ImporterDbTestSupport extends ImporterTestSupport {
     protected abstract String getFixtureId();
 
     protected Connection getConnection() throws Exception  {
-        return ((DbTestData)getTestData()).getConnection();
+        return ((DbmsTestData)getTestData()).getConnection();
     }
 
     protected Map getConnectionParams() throws IOException {
-        return ((DbTestData)getTestData()).getConnectionParams();
+        return ((DbmsTestData)getTestData()).getConnectionParams();
     }
 
     protected void run(String sql, Statement st) throws SQLException {
@@ -73,41 +66,7 @@ public abstract class ImporterDbTestSupport extends ImporterTestSupport {
         public File getFixture() {
             return fixture;
         }
-    }
-    
-    class DbTestData extends MockData {
-
-        DbmsTestData dbTestData;
         
-        public DbTestData() throws IOException {
-            dbTestData = new DbmsTestData(getDataDirectoryRoot(), getFixtureId(), null);
-        } 
-    
-        @Override
-        public void setUp() throws IOException {
-            try {
-                dbTestData.setUp();
-            } catch (Exception e) {
-                throw new IOException(e);
-            }
-            super.setUp();
-        }
-
-        @Override
-        public boolean isTestDataAvailable() {
-            if (dbTestData.isTestDataAvailable()) {
-                //actually try a connection
-                try {
-                    getConnection();
-                    return true;
-                }
-                catch(Exception e) {
-                    LOGGER.log(Level.SEVERE, "Could not obtain connection", e);
-                }
-            }
-            return false;
-        }
-
         public Connection getConnection() throws Exception {
             Map p = getConnectionParams();
             Class.forName((String)p.get("driver"));
@@ -121,7 +80,7 @@ public abstract class ImporterDbTestSupport extends ImporterTestSupport {
 
         public Map getConnectionParams() throws IOException {
             Properties props = new Properties();
-            FileInputStream fin = new FileInputStream(dbTestData.getFixture());
+            FileInputStream fin = new FileInputStream(getFixture());
             try {
                 props.load(fin);
             }
@@ -132,4 +91,6 @@ public abstract class ImporterDbTestSupport extends ImporterTestSupport {
             return new HashMap(props);
         }
     }
+    
+
 }

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTest.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.importer;
 
+import static org.junit.Assert.*;
+
 import java.io.File;
 import java.util.HashSet;
 

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTestSupport.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTestSupport.java
@@ -4,12 +4,20 @@
  */
 package org.geoserver.importer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -17,24 +25,40 @@ import net.sf.json.util.JSONBuilder;
 
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
+import org.geoserver.catalog.CascadeDeleteVisitor;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
-import org.geoserver.test.GeoServerTestSupport;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
+import org.junit.After;
+import org.junit.Before;
 import org.w3c.dom.Document;
 
 import com.mockrunner.mock.web.MockHttpServletResponse;
 
-public abstract class ImporterTestSupport extends GeoServerTestSupport {
+public abstract class ImporterTestSupport extends GeoServerSystemTestSupport {
+    
+    static final Set<String> DEFAULT_STYLEs = new HashSet<String>() {{
+        add(StyleInfo.DEFAULT_POINT);
+        add(StyleInfo.DEFAULT_LINE);
+        add(StyleInfo.DEFAULT_POLYGON);
+        add(StyleInfo.DEFAULT_RASTER);
+    }};
+    
 
     protected Importer importer;
-
+    
     @Override
-    protected void oneTimeSetUp() throws Exception {
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        
         ImporterTestUtils.setComparisonTolerance();
 
         // init xmlunit
@@ -44,16 +68,35 @@ public abstract class ImporterTestSupport extends GeoServerTestSupport {
         namespaces.put("wms", "http://www.opengis.net/wms");
         
         XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(namespaces));
-
-        super.oneTimeSetUp();
     }
-
+    
     @Override
-    protected void setUpInternal() throws Exception {
-        super.setUpInternal();
-        importer = (Importer) applicationContext.getBean("importer");
+    protected void setUpTestData(SystemTestData testData) throws Exception {
+        // no pre-existing test data needed for the importer
+        // super.setUpTestData(testData);
     }
-
+    
+    @After
+    public void cleanCatalog() throws IOException {
+        for (StoreInfo s : getCatalog().getStores(StoreInfo.class)) {
+            removeStore(null, s.getName());
+        }
+        for (StyleInfo s : getCatalog().getStyles()) {
+            String styleName = s.getName();
+            if(!DEFAULT_STYLEs.contains(styleName)) {
+                removeStyle(null, styleName);
+            }
+        }
+    }
+    
+    @Before
+    public void setupImporterField() {
+        importer = (Importer) applicationContext.getBean("importer");
+        // clean up the import history (to isolate tests from each other)
+        MemoryImportStore store = (MemoryImportStore) importer.getStore();
+        store.destroy();
+    }
+    
     protected File tmpDir() throws Exception {
         return ImporterTestUtils.tmpDir();
     }
@@ -115,6 +158,45 @@ public abstract class ImporterTestSupport extends GeoServerTestSupport {
         cat.add(ds);
         
         return ds;
+    }
+    
+    /**
+     * Adding special treatment for H2 databases, we want to also kill the db itself 
+     */
+    @Override
+    protected void removeStore(String workspaceName, String name) {
+        Catalog cat = getCatalog();
+        StoreInfo store = cat.getStoreByName(workspaceName, name, StoreInfo.class);
+        if (store == null) {
+            return;
+        }
+        
+        // store the database location in case it's a H2 store
+        Map<String, Serializable> params = store.getConnectionParameters();
+        String databaseLocation = null;
+        if("h2".equals(params.get("dbtype"))) {
+            databaseLocation = (String) params.get("database");
+        }
+
+        CascadeDeleteVisitor v = new CascadeDeleteVisitor(getCatalog());
+        store.accept(v);
+        
+        // clean up the database files if needed
+        if(databaseLocation != null) {
+            final File dbFile = new File(databaseLocation);
+            File container = dbFile.getParentFile();
+            File[] dbFiles = container.listFiles(new FilenameFilter() {
+                
+                @Override
+                public boolean accept(File dir, String name) {
+                    return name.startsWith(dbFile.getName());
+                }
+            });
+            for (File f : dbFiles) {
+                assertTrue(f.delete());
+            }
+        }
+    
     }
     
     private String createSRSJSON(String srs) {

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/mosaic/ImporterMosaicTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/mosaic/ImporterMosaicTest.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.importer.mosaic;
 
+import static org.junit.Assert.*;
+
 import java.io.File;
 import java.util.Calendar;
 import java.util.Date;
@@ -63,6 +65,7 @@ public class ImporterMosaicTest extends ImporterTestSupport {
         }
     }
 
+    @Test
     public void testTimeMosaic() throws Exception {
         Mosaic m = new Mosaic(unpack("mosaic/bm_time.zip"));
 
@@ -92,6 +95,7 @@ public class ImporterMosaicTest extends ImporterTestSupport {
         
     }
 
+    @Test
     public void testTimeMosaicAuto() throws Exception {
         Mosaic m = new Mosaic(unpack("mosaic/bm_time.zip"));
         m.setTimeMode(TimeMode.AUTO);

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/DataResourceTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/DataResourceTest.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.importer.rest;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 
 import net.sf.json.JSONArray;
@@ -11,37 +13,42 @@ import net.sf.json.JSONObject;
 
 import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImporterTestSupport;
+import org.junit.Before;
+import org.junit.Test;
 
 import com.mockrunner.mock.web.MockHttpServletResponse;
 
 public class DataResourceTest extends ImporterTestSupport {
 
-    @Override
-    protected void setUpInternal() throws Exception {
-        super.setUpInternal();
     
+    @Before
+    public void prepareData() throws Exception {
         File dir = unpack("shape/archsites_epsg_prj.zip");
         unpack("shape/bugsites_esri_prj.tar.gz", dir);
         importer.createContext(new Directory(dir));
     }
-
+    
+    @Test
     public void testGet() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports/0/data");
         assertEquals("directory", json.getString("type"));
         assertEquals(2, json.getJSONArray("files").size());
     }
 
+    @Test
     public void testGetFiles() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports/0/data/files");
         assertEquals(2, json.getJSONArray("files").size());
     }
 
+    @Test
     public void testGetFile() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports/0/data/files/archsites.shp");
         assertEquals("archsites.shp", json.getString("file"));
         assertEquals("archsites.prj", json.getString("prj"));
     }
 
+    @Test
     public void testDelete() throws Exception {
         MockHttpServletResponse response = 
             getAsServletResponse("/rest/imports/0/data/files/archsites.shp");

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportJSONIOTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportJSONIOTest.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.importer.rest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -14,12 +17,14 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import org.geoserver.catalog.StoreInfo;
-import org.geoserver.rest.PageInfo;
 import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImportTask;
 import org.geoserver.importer.ImporterTestSupport;
 import org.geoserver.importer.transform.DateFormatTransform;
 import org.geoserver.importer.transform.TransformChain;
+import org.geoserver.rest.PageInfo;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *
@@ -30,10 +35,8 @@ public class ImportJSONIOTest extends ImporterTestSupport {
 
     private ByteArrayOutputStream buf;
 
-    @Override
-    protected void setUpInternal() throws Exception {
-        super.setUpInternal();
-
+    @Before
+    public void prepareData() throws Exception {
         File dir = unpack("shape/archsites_epsg_prj.zip");
         importer.createContext(new Directory(dir));
         
@@ -67,6 +70,7 @@ public class ImportJSONIOTest extends ImporterTestSupport {
         return new ByteArrayInputStream(json.toString().getBytes());
     }
 
+    @Test
     public void testSettingTargetStore() throws IOException {
         ImportTask task = importer.getContext(0).getTasks().get(0);
         writer.task(task, true, 1);
@@ -89,6 +93,7 @@ public class ImportJSONIOTest extends ImporterTestSupport {
         assertEquals(getCatalog().getDefaultWorkspace().getName(), store.getWorkspace().getName());
     }
 
+    @Test
     public void testAddingDateTransform() throws IOException {
         ImportTask task = importer.getContext(0).getTasks().get(0);
         writer.task(task, true, 1);

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportResourceTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportResourceTest.java
@@ -4,33 +4,38 @@
  */
 package org.geoserver.importer.rest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
-
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
-import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.DataStoreInfo;
-import org.geotools.data.h2.H2DataStoreFactory;
 import org.geoserver.importer.Database;
 import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImportContext;
+import org.geoserver.importer.ImportStore;
 import org.geoserver.importer.ImporterTestSupport;
+import org.geoserver.importer.MemoryImportStore;
 import org.geoserver.importer.SpatialFile;
+import org.geotools.data.h2.H2DataStoreFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import com.mockrunner.mock.web.MockHttpServletRequest;
 import com.mockrunner.mock.web.MockHttpServletResponse;
-import java.util.Iterator;
 
 public class ImportResourceTest extends ImporterTestSupport {
 
-    @Override
-    protected void setUpInternal() throws Exception {
-        super.setUpInternal();
-    
+    @Before
+    public void prepareData() throws Exception {
+        // prepare the contexts used in thsi test
         File dir = unpack("shape/archsites_epsg_prj.zip");
         unpack("shape/bugsites_esri_prj.tar.gz", dir);
         importer.createContext(new Directory(dir));
@@ -41,7 +46,14 @@ public class ImportResourceTest extends ImporterTestSupport {
         dir = unpack("shape/archsites_no_crs.zip");
         importer.createContext(new SpatialFile(new File(dir, "archsites.shp")));
     }
+    
+    @After
+    public void cleanupData() throws Exception {
+        // remove the cookbook store if any
+        removeStore(null, "cookbook");
+    }
 
+    @Test
     public void testGetAllImports() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports?all");
         assertNotNull(json.get("imports"));
@@ -62,12 +74,14 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertTrue(imprt.getString("href").endsWith("/imports/2"));
     }
     
+    @Test
     public void testGetNonExistantImport() throws Exception {
         MockHttpServletResponse resp = getAsServletResponse(("/rest/imports/9999"));
         
         assertEquals(404, resp.getStatusCode());
     }
 
+    @Test
     public void testGetImport() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports/0");
         assertNotNull(json.get("import"));
@@ -82,6 +96,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertEquals("READY", tasks.getJSONObject(1).get("state"));
     }
     
+    @Test
     public void testGetImportExpandChildren() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports/0?expand=2");
 
@@ -106,6 +121,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertEquals("READY", t.getString("state"));
     }
     
+    @Test
     public void testGetImport2() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports/1?expand=3");
         assertNotNull(json.get("import"));
@@ -130,6 +146,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertEquals("EmissiveCampania.tif", source.getString("file"));
     }
 
+    @Test
     public void testGetImport3() throws Exception {
         JSONObject json = (JSONObject) getAsJSON("/rest/imports/2?expand=2");
         assertNotNull(json.get("import"));
@@ -149,6 +166,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertEquals("archsites.shp", source.getString("file"));
     }
 
+    @Test
     public void testGetImportDatabase() throws Exception {
         File dir = unpack("h2/cookbook.zip");
 
@@ -171,6 +189,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertTrue(tables.contains("polygon"));
     }
 
+    @Test
     public void testPost() throws Exception {
         
         MockHttpServletResponse resp = postAsServletResponse("/rest/imports", "");
@@ -187,6 +206,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertEquals(id, imprt.getInt("id"));
     }
     
+    @Test
     public void testPutWithId() throws Exception {
         // propose a new import id
         MockHttpServletResponse resp = putAsServletResponse("/rest/imports/8675309");
@@ -219,6 +239,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertTrue(resp.getHeader("Location").endsWith( "/imports/8675311"));
     }
 
+    @Test
     public void testPostWithTarget() throws Exception {
         createH2DataStore("sf", "skunkworks");
 
@@ -260,16 +281,19 @@ public class ImportResourceTest extends ImporterTestSupport {
         return dispatch(request);
     }
 
+    @Test
     public void testPostNoMediaType() throws Exception {
         MockHttpServletResponse resp = postAsServletResponseNoContentType("/rest/imports", "");
         assertEquals(201, resp.getStatusCode());
     }
 
+    @Test
     public void testImportSessionIdNotInt() throws Exception {
         MockHttpServletResponse resp = postAsServletResponse("/rest/imports/foo", "");
         assertEquals(404, resp.getStatusCode());
     }
 
+    @Test
     public void testContentNegotiation() throws Exception {
         MockHttpServletResponse res = getAsServletResponse("/rest/imports/0");
         assertEquals("application/json", res.getContentType());

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RESTDataTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RESTDataTest.java
@@ -4,10 +4,18 @@
  */
 package org.geoserver.importer.rest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
@@ -17,30 +25,25 @@ import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.multipart.FilePart;
 import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
 import org.apache.commons.httpclient.methods.multipart.Part;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImportContext;
 import org.geoserver.importer.ImporterTestSupport;
+import org.geotools.data.DataStore;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.junit.Test;
+import org.restlet.data.MediaType;
 
 import com.google.common.collect.Lists;
 import com.mockrunner.mock.web.MockHttpServletRequest;
 import com.mockrunner.mock.web.MockHttpServletResponse;
 
-import java.io.FileInputStream;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.DataStoreInfo;
-import org.geoserver.catalog.LayerInfo;
-import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.data.test.MockData;
-import org.geoserver.platform.GeoServerExtensions;
-import org.geotools.data.DataStore;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.restlet.data.MediaType;
-
 public class RESTDataTest extends ImporterTestSupport {
 
+    @Test
     public void testSingleFileUpload() throws Exception {
         int i = postNewImport();
         int t = postNewTaskAsMultiPartForm(i, "shape/archsites_epsg_prj.zip");
@@ -52,6 +55,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks("archsites");
     }
 
+    @Test
     public void testTitleAndDescriptionOnUpload() throws Exception {
         int i = postNewImport();
         int t = postNewTaskAsMultiPartForm(i, "shape/archsites_epsg_prj.zip");
@@ -70,6 +74,7 @@ public class RESTDataTest extends ImporterTestSupport {
         assertEquals("Archeological Sites", r.getAbstract());
     }
 
+    @Test
     public void testFilePut() throws Exception {
         int i = postNewImport();
         int t1 = putNewTask(i, "shape/archsites_epsg_prj.zip");
@@ -81,6 +86,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks("archsites");
     }
 
+    @Test
     public void testMultipleFileUpload() throws Exception {
         int i = postNewImport();
         int t1 = postNewTaskAsMultiPartForm(i, "shape/archsites_epsg_prj.zip");
@@ -97,6 +103,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks("bugsites");
     }
 
+    @Test
     public void testFileUploadWithConfigChange() throws Exception {
         int i = postNewImport();
         int t = postNewTaskAsMultiPartForm(i, "shape/archsites_no_crs.zip");
@@ -138,6 +145,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks("archsites");
     }
 
+    @Test
     public void testSingleFileUploadIntoDb() throws Exception {
         DataStoreInfo acme = createH2DataStore("sf", "acme");
 
@@ -172,6 +180,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks("sf:archsites");
     }
 
+    @Test
     public void testSingleFileUploadIntoDb2() throws Exception {
         DataStoreInfo acme = createH2DataStore("sf", "acme");
 
@@ -204,6 +213,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks("sf:archsites");
     }
 
+    @Test
     public void testIndirectUpdateSRS() throws Exception {
         Catalog cat = getCatalog();
         DataStoreInfo ds = createH2DataStore(cat.getDefaultWorkspace().getName(), "spearfish");
@@ -234,6 +244,7 @@ public class RESTDataTest extends ImporterTestSupport {
         assertEquals("archsites", store.getTypeNames()[0]);
     }
 
+    @Test
     public void testMosaicUpload() throws Exception {
         String json = 
                 "{" + 
@@ -254,6 +265,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks(layername);
     }
 
+    @Test
     public void testTimeMosaicUpload() throws Exception {
         String json = 
                 "{" + 
@@ -279,6 +291,7 @@ public class RESTDataTest extends ImporterTestSupport {
         runChecks(l.getName());
     }
 
+    @Test
     public void testTimeMosaicManual() throws Exception {
         String json = 
                 "{" + 
@@ -328,6 +341,7 @@ public class RESTDataTest extends ImporterTestSupport {
         }
     }
 
+    @Test
     public void testTimeMosaicAuto() throws Exception {
         String json = 
                 "{" + 

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/TransformTestSupport.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/TransformTestSupport.java
@@ -4,21 +4,19 @@
  */
 package org.geoserver.importer.rest;
 
-import static org.easymock.classextension.EasyMock.*;
+import static org.easymock.classextension.EasyMock.createNiceMock;
+import static org.easymock.classextension.EasyMock.replay;
 
 import java.beans.PropertyDescriptor;
 import java.io.StringWriter;
-import junit.framework.TestCase;
-import net.sf.json.JSONObject;
-import net.sf.json.util.JSONBuilder;
 
-import org.geoserver.rest.PageInfo;
+import junit.framework.TestCase;
+
 import org.geoserver.importer.ImportContext;
 import org.geoserver.importer.ImportTask;
 import org.geoserver.importer.Importer;
-import org.geoserver.importer.rest.ImportJSONWriter;
-import org.geoserver.importer.rest.ImportJSONReader;
 import org.geoserver.importer.transform.ImportTransform;
+import org.geoserver.rest.PageInfo;
 import org.springframework.beans.BeanUtils;
 
 /**


### PR DESCRIPTION
Migrated all tests to the new test infrastructure, shaving another minute and 15 seconds from the overall test time for importer (down to 1m46s on my machine)

Now.. not 100% sure how to run the Oracle and SQL tests, so it's rather likely I've not done that migration right. Justin/Ian, can you help?
Do you prefer to take over the pull request, or me to commit and follow up with fixes for those two tests?
