### PR TITLE
Fixed an error in community/release pom.xml file

### DIFF
--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -83,11 +83,6 @@
      <artifactId>gs-wms-eo</artifactId>
      <version>${project.version}</version>
    </dependency>
-   <dependency>
-     <groupId>org.geoserver.community</groupId>
-     <artifactId>gs-libjpeg-turbo</artifactId>
-     <version>${project.version}</version>
-   </dependency> 
    
  </dependencies>
  <build>


### PR DESCRIPTION
Fixed an error in community/release pom.xml file caused by an old libjpeg-turbo reference.
