### PR TITLE
[GEOS-6328]: use direct read when creating the small sample image

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -945,14 +945,21 @@ public class CatalogBuilder {
         if (customParameters != null) {
         	parameters.putAll(customParameters);
         }
-        
+
         // make sure mosaics with many superimposed tiles won't blow up with 
         // a "too many open files" exception
         String maxAllowedTiles = ImageMosaicFormat.MAX_ALLOWED_TILES.getName().toString();
-        if(parameters.keySet().contains(maxAllowedTiles)) {
+        if (parameters.keySet().contains(maxAllowedTiles)) {
             parameters.put(maxAllowedTiles, 1);
         }
-        
+
+        // Since the read sample image won't be greater than 5x5 pixels and we are limiting the
+        // number of granules to 1, we may do direct read instead of using JAI
+        String useJaiImageRead = ImageMosaicFormat.USE_JAI_IMAGEREAD.getName().toString();
+        if (parameters.keySet().contains(useJaiImageRead)) {
+            parameters.put(useJaiImageRead, false);
+        }
+
         parameters.put(AbstractGridFormat.READ_GRIDGEOMETRY2D.getName().toString(), new GridGeometry2D(testRange, testEnvelope));
 
         // try to read this coverage


### PR DESCRIPTION
[GEOS-6328]: use direct read when creating the small sample image

I have tested it against a 60GB mosaic as well as with a 100 granules mosaic.
No issues when creating the coverage, since coverageBuilder read a 5x5 pixels from a single granule in any case.

The code change also includes some minimal reformatting due to bad tabs or spaces there.
