### PR TITLE
Use github issues instead of Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ build the application run maven from the ```src``` directory.
 See the [developer guide](http://docs.geoserver.org/stable/en/developer/) 
 for more details.
 
-## Bugs
-
-GeoServer uses [JIRA](http://jira.codehaus.org/browse/GEOS), hosted by 
-[CodeHaus](http://www.codehaus.org/), for issue tracking.
-
 ## Mailing Lists
 
 The [mailing list page](http://geoserver.org/display/GEOS/Mailing+Lists) on the GeoServer web site provides


### PR DESCRIPTION
Or at least open the issues here so people can report them here, somebody has proboly written a bot that will open issues reported on github in jira.  If you want users to report bugs they find then using an issue tracker that requires making an account is going to be a hindrance. Using an issue tracker that doesn't allow registration 
![jira](https://f.cloud.github.com/assets/1128607/2190976/ac8b0774-9838-11e3-8ce0-242519f97983.png)
that says we don't care about our users.
