### PR TITLE
Geo server http session listener proxy

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerHttpSessionListenerProxy.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerHttpSessionListenerProxy.java
@@ -68,7 +68,7 @@ public class GeoServerHttpSessionListenerProxy implements HttpSessionListener {
      *
      * @return
      */
-    private Set<HttpSessionListener> listeners() {
+    protected Set<HttpSessionListener> listeners() {
         if (listeners == null) {
            synchronized(this) {
                if (listeners == null) {


### PR DESCRIPTION
"This method may contain an instance of double-checked locking.  This idiom is not correct according to the semantics of the Java memory model.  For more information, see the web page http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html." - findbugs

It seems to me 
protected Set<HttpSessionListener> listeners() 
is used in  public class GeoServerHttpSessionListenerProxy 
only.
And Where do you use the class GeoServerHttpSessionListenerProxy?
