### PR TITLE
I've changed StringBuffer to StringBuilder

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
@@ -283,7 +283,7 @@ public class GeoServerResourceLoader extends DefaultResourceLoader implements Ap
      * Helper method to build up a file path from components.
      */
     String concat( String... location ) {
-        StringBuffer loc = new StringBuffer();
+        StringBuilder loc = new StringBuilder();
         for ( int i = 0; i < location.length; i++ ) {
             loc.append( location[i] ).append( File.separator );
         }


### PR DESCRIPTION
StringBuilder javadoc:
Where possible,
- it is recommended that this class be used in preference to StringBuffer as it will be faster under most implementations.
