### PR TITLE
fix persisters writing temporary writing

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.xsd.XSDElementDeclaration;
 import org.eclipse.xsd.XSDParticle;
@@ -1675,20 +1676,42 @@ public class ResourcePool {
     public void writeStyle( StyleInfo style, InputStream in ) throws IOException {
         synchronized ( styleCache ) {
             File styleFile = dataDir().findOrCreateStyleSldFile(style);
-            BufferedOutputStream out = new BufferedOutputStream( new FileOutputStream( styleFile ) );
-            
-            try {
-                IOUtils.copy( in, out );
-                out.flush();
-                
-                clear(style);
-            }
-            finally {
-                out.close();
-            }
+            writeStyle(in, styleFile);
+            clear(style);
         }
     }
-    
+
+	/**
+	 * Safe write on styleFile the passed inputStream
+	 * 
+	 * @param in
+	 *            the new stream to write to styleFile
+	 * @param styleFile
+	 *            file to update
+	 * @throws IOException
+	 */
+	public static void writeStyle(final InputStream in, final File styleFile)
+			throws IOException {
+		final File temporaryFile = File.createTempFile(styleFile.getName(),
+				null, styleFile.getParentFile());
+		BufferedOutputStream out = null;
+		try {
+			out = new BufferedOutputStream(new FileOutputStream(temporaryFile));
+			IOUtils.copy(in, out);
+			out.flush();
+		} finally {
+			out.close();
+		}
+		// move the file
+		try {
+			org.geoserver.data.util.IOUtils.rename(temporaryFile, styleFile);
+		} finally {
+			if (temporaryFile.exists()) {
+				temporaryFile.delete();
+			}
+		}
+	}
+
     /**
      * Deletes a style from the configuration.
      * 

--- a/src/main/src/main/java/org/geoserver/data/util/IOUtils.java
+++ b/src/main/src/main/java/org/geoserver/data/util/IOUtils.java
@@ -388,37 +388,46 @@ public class IOUtils {
         }
     }
 
-    /**
-     * Performs serialization with an {@link XStreamPersister} in a safe manner in which a temp
-     * file is used for the serialization so that the true destination file is not partially 
-     * written in the case of an error. 
-     * 
-     * @param f The file to write to, only modified if the temp file serialization was error free.
-     * @param obj The object to serialize.
-     * @param xp The persister.
-     * 
-     * @throws Exception
-     */
-    public static void xStreamPersist(File f, Object obj, XStreamPersister xp) throws IOException {
-        //first save to a temp file
-        File temp = new File(f.getParentFile(),f.getName()+".tmp");
-        if ( temp.exists() ) {
-            temp.delete();
-        }
-        
-        BufferedOutputStream out = null;
-        try{
-            out=new BufferedOutputStream( new FileOutputStream( temp ) );
-            xp.save( obj, out );
-            out.flush();
-        } finally {
-            if (out != null)
-                org.apache.commons.io.IOUtils.closeQuietly(out);
-        }
-        
-        //no errors, overwrite the original file
-        rename(temp,f);
-    }
+	/**
+	 * Performs serialization with an {@link XStreamPersister} in a safe manner
+	 * in which a temp file is used for the serialization so that the true
+	 * destination file is not partially written in the case of an error.
+	 * 
+	 * @param f
+	 *            The file to write to, only modified if the temp file
+	 *            serialization was error free.
+	 * @param obj
+	 *            The object to serialize.
+	 * @param xp
+	 *            The persister.
+	 * 
+	 * @throws Exception
+	 */
+	public static void xStreamPersist(File f, Object obj, XStreamPersister xp)
+			throws IOException {
+		// first save to a temp file
+		final File temp = File.createTempFile(f.getName(), null,
+				f.getParentFile());
+
+		BufferedOutputStream out = null;
+		try {
+			out = new BufferedOutputStream(new FileOutputStream(temp));
+			xp.save(obj, out);
+			out.flush();
+		} finally {
+			if (out != null)
+				org.apache.commons.io.IOUtils.closeQuietly(out);
+		}
+
+		// no errors, overwrite the original file
+		try {
+			rename(temp, f);
+		} finally {
+			if (temp.exists()) {
+				temp.delete();
+			}
+		}
+	}
 
     /**
      * Backs up a directory <tt>dir</tt> by creating a .bak next to it.


### PR DESCRIPTION
This may fix most of the GEOS-6373 cases:
http://jira.codehaus.org/browse/GEOS-6373

Note that we can still have some trouble with windows rename since it is still not atomic function.

About tests:  these functions are really low level functions called by many higher level tests so they are implicitly tested.
