### PR TITLE
I've removed inefficient new String(String) constructor

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
@@ -658,7 +658,7 @@ public class GeoServerResourceLoader extends DefaultResourceLoader implements Ap
             // Loop over variable access methods
             for (int j = 0; j < typeStrs.length && dataDirStr == null; j++) {
                 String value = null;
-                String varStr = new String(varStrs[i]);
+                String varStr = varStrs[i];
                 String typeStr = typeStrs[j];
 
                 // Lookup section


### PR DESCRIPTION
Using the java.lang.String(String) constructor wastes memory because the object so constructed will be functionally indistinguishable from the String passed as a parameter.  Just use the argument String directly.
