### PR TITLE
Fix GeoServerResourceLoader when $PWD is /

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
@@ -197,7 +197,7 @@ public class GeoServerResourceLoader extends DefaultResourceLoader implements Ap
         //first to an existance check
         File file = parent != null ? new File(parent,location) : new File(location);
         
-        if (file.exists()) {
+        if (parent != null && file.exists()) {
             return file;
         }
         


### PR DESCRIPTION
When $PWD is / for the process running GeoServer, GeoServerResourceLoader can "find" files and directories outside GEOSERVER_DATA_DIR. For instance, our VM images include a /security directory. GeoServer interprets this as its own "security" directory and tries to read from/write to it, which fails. This pull request just refuses to look outside the search path unless a parent directory is also specified, in which case looking in $PWD might be intentional, as it is during unit tests.
