### PR TITLE
[GEOS-6381] fixed missing roles using Authkey Authentication Filter

### DIFF
--- a/src/community/authkey/src/main/java/org/geoserver/security/GeoServerAuthenticationKeyFilter.java
+++ b/src/community/authkey/src/main/java/org/geoserver/security/GeoServerAuthenticationKeyFilter.java
@@ -161,9 +161,8 @@ public class GeoServerAuthenticationKeyFilter extends  GeoServerSecurityFilter
                        
             
         Collection<GeoServerRole> roles= new ArrayList<GeoServerRole>();
-        for (GrantedAuthority auth: user.getAuthorities()) {
-            roles.add((GeoServerRole)auth);
-        }        
+        roles.addAll(getSecurityManager().getActiveRoleService().getRolesForUser(user.getUsername()));
+        
         if (roles.contains(GeoServerRole.AUTHENTICATED_ROLE)==false)
             roles.add(GeoServerRole.AUTHENTICATED_ROLE);            
         KeyAuthenticationToken result = new KeyAuthenticationToken(authKey,  authKeyParamName,user, roles);


### PR DESCRIPTION
The only role of the user was ROLE_AUTHENTICATED. The fix takes roles directly from the active RoleService of the SecurityManager.
