### PR TITLE
Null pointer when CRS Envelope isn't available in w3ds community module

### DIFF
--- a/src/community/w3ds/src/main/java/org/geoserver/w3ds/kvp/KVPUtils.java
+++ b/src/community/w3ds/src/main/java/org/geoserver/w3ds/kvp/KVPUtils.java
@@ -68,22 +68,25 @@ public class KVPUtils {
 					"Invalid parameter BOUNDINGBOX (MIN_Y [" + miny + "] is "
 							+ "greater than MAX_Y [" + maxy + "]): " + bboxstr);
 		}
-		ReferencedEnvelope crs_e = new ReferencedEnvelope(CRS.getEnvelope(crs));
 		ReferencedEnvelope bbox_e = new ReferencedEnvelope(minx, maxx, miny,
 				maxy, crs);
-		if (!crs_e.covers(bbox_e)) {
-			// The specification says: If the Bounding Box values are
-			// not defined for the given CRS (e.g., latitudes greater than 90
-			// degrees in CRS:84), the
-			// server should return empty content for areas outside the valid
-			// range of the CRS.
-			LOGGER.warning("CRS [" + crs.getName().getCodeSpace() + ":"
-					+ crs.getName().getCode()
-					+ "] envelope don't covers the boundingbox [" + bboxstr
-					+ "] envelope");
-			// throw new
-			// IllegalArgumentException("Invalid mandatory parameter BOUNDINGBOX (crs envelope don't covers the boundingbox envelope): "
-			// + bboxstr);
+		Envelope crsEnvelope = CRS.getEnvelope(crs);
+		if (crsEnvelope != null) {
+			ReferencedEnvelope crs_e = new ReferencedEnvelope(CRS.getEnvelope(crs));
+			if (!crs_e.covers(bbox_e)) {
+				// The specification says: If the Bounding Box values are
+				// not defined for the given CRS (e.g., latitudes greater than 90
+				// degrees in CRS:84), the
+				// server should return empty content for areas outside the valid
+				// range of the CRS.
+				LOGGER.warning("CRS [" + crs.getName().getCodeSpace() + ":"
+						+ crs.getName().getCode()
+						+ "] envelope don't covers the boundingbox [" + bboxstr
+						+ "] envelope");
+				// throw new
+				// IllegalArgumentException("Invalid mandatory parameter BOUNDINGBOX (crs envelope don't covers the boundingbox envelope): "
+				// + bboxstr);
+			}
 		}
 		// Isto só tá assim porque tinha um erro tem que se corrigir
 		// return new ReferencedEnvelope(crs_e.intersection(bbox_e), crs);

--- a/src/community/w3ds/src/test/java/org/geoserver/w3ds/kvp/KVPUtilsTest.java
+++ b/src/community/w3ds/src/test/java/org/geoserver/w3ds/kvp/KVPUtilsTest.java
@@ -1,0 +1,39 @@
+/* Copyright (c) 2014 OpenPlans - www.openplans.org. All rights reserved.
+* This code is licensed under the GPL 2.0 license, available at the root
+* application directory.
+*/
+package org.geoserver.w3ds.kvp;
+
+import junit.framework.TestCase;
+import org.geotools.referencing.CRS;
+import org.opengis.geometry.Envelope;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.util.logging.Logger;
+
+
+/**
+ * Test case for KVPUtils.
+ * 
+ * @author Glen Blanchard
+ * @since 2.5.x
+ * 
+ */
+
+public class KVPUtilsTest extends TestCase {
+    
+    protected static Logger LOGGER = org.geotools.util.logging.Logging.getLogger("org.geoserver.w3ds");
+
+    public void testParseBBoxWithNullProducingEnvelope() throws Exception {
+
+        CoordinateReferenceSystem crs = KVPUtils.parseCRS("EPSG:900913");
+        String input = "0,0,100,100";
+
+        Envelope crsEnvelope = CRS.getEnvelope(crs);
+        assertNull("This envelope needs to be null so that we will trigger the fault or we will get a false positive", crsEnvelope);
+        Envelope env = KVPUtils.parseBbox(input, crs, LOGGER);
+        assertEquals("testStandardRequest",100.0,env.getMaximum(0));
+    }
+    
+
+}


### PR DESCRIPTION
This is the same patch for master as Pull request #541

Because CRS.getEnvelope can return a null envelope for some definitions.

When this case occurs then the original envelope will be returned.
