### PR TITLE
Remove filter from catalog query when not needed. Fixes GEOS-6398

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/AdvertisedCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AdvertisedCatalog.java
@@ -176,6 +176,12 @@ public class AdvertisedCatalog extends AbstractFilteredCatalog {
 
     @Override
     protected <T extends CatalogInfo> Filter securityFilter(Class<T> infoType, Filter filter) {
+        if(!isOgcCapabilitiesRequest()) {
+            // Not needed for other kinds of request
+            // TODO use a common implementation for GetCapabilities and Layer Preview
+            return filter;
+        }
+        
         if (!ResourceInfo.class.isAssignableFrom(infoType) && 
             !LayerInfo.class.isAssignableFrom(infoType) &&
             !LayerGroupInfo.class.isAssignableFrom(infoType)) 


### PR DESCRIPTION
Removes AdvertisedCatalog's filter from requests on which it is not needed.  This speeds up certain requests (the "Layers" page in particular) against large JDBCConfig catalogs.
