### PR TITLE
Reinitialize logging from JDBCConfg during start up, GEOS-6416

### DIFF
--- a/src/community/jdbcconfig/src/main/resources/applicationContext.xml
+++ b/src/community/jdbcconfig/src/main/resources/applicationContext.xml
@@ -42,6 +42,7 @@
 
   <bean id="JDBCGeoServerFacade" class="org.geoserver.jdbcconfig.config.JDBCGeoServerFacade">
     <constructor-arg ref="JDBCConfigDB" />
+    <property name="resourceLoader" ref="resourceLoader" />
   </bean>
 
   <bean id="JDBCGeoServerLoader" class="org.geoserver.jdbcconfig.JDBCGeoServerLoader">

--- a/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
@@ -7,9 +7,11 @@ package org.geoserver.logging;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.Nullable;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
@@ -65,18 +67,11 @@ public class LoggingStartupContextListener implements ServletContextListener {
                 GeoServerResourceLoader loader = new GeoServerResourceLoader(baseDir);
                 
                 File f= loader.find( "logging.xml" );
-                if ( f != null ) {
-                    XStreamPersister xp = new XStreamPersisterFactory().createXMLPersister();
-                    BufferedInputStream in = new BufferedInputStream( new FileInputStream( f ) );
-                    try {
-                        LoggingInfo loginfo = xp.load(in,LoggingInfo.class);
-                        final String location = LoggingUtils.getLogFileLocation(loginfo.getLocation(), event.getServletContext());
-                        LoggingUtils.initLogging(loader, loginfo.getLevel(), !loginfo.isStdOutLogging(),
-                            location);
-                    }
-                    finally {
-                        in.close();
-                    }
+                LoggingInfo loginfo = getLogging(loader);
+                if ( loginfo != null ) {
+                    final String location = LoggingUtils.getLogFileLocation(loginfo.getLocation(), event.getServletContext());
+                    LoggingUtils.initLogging(loader, loginfo.getLevel(), !loginfo.isStdOutLogging(),
+                        location);
                 }
                 else {
                     //check for old style data directory
@@ -98,6 +93,34 @@ public class LoggingStartupContextListener implements ServletContextListener {
         }
     }
 
+    /**
+     * Get the LoggingInfo used at startup before the regular configuration system is available.
+     * 
+     * You probably want {@link org.geoserver.config.GeoServer#getLogging} instead
+     * @return LoggingInfo loaded directly from logging.xml. Returns null if logging.xml does not 
+     * exist
+     */
+    @Deprecated
+    public static @Nullable LoggingInfo getLogging(GeoServerResourceLoader loader) throws IOException {
+        // Exposing this is a hack to provide JDBCConfig with the information it needs to compute
+        // the "change" between logging.xml and the versions stored in JDBC. KS
+        // TODO find a better solution than re-initializing on JDBCCOnfig startup.
+        File f= loader.find( "logging.xml" );
+        if ( f != null ) {
+            XStreamPersister xp = new XStreamPersisterFactory().createXMLPersister();
+            BufferedInputStream in = new BufferedInputStream( new FileInputStream( f ) );
+            try {
+                LoggingInfo loginfo = xp.load(in,LoggingInfo.class);
+                return loginfo;
+            }
+            finally {
+                in.close();
+            }
+        } else {
+            return null;
+        }
+    }
+    
     Logger getLogger() {
         if(LOGGER == null) {
             LOGGER = Logging.getLogger("org.geoserver.logging");


### PR DESCRIPTION
This doesn't completely resolve the issue, but it does mitigate it.  Immedately after start up, logging will still be using the settings in `logging.xml`, but this will update the setting to the ones in JDBCConfig, which is the expected behaviour, once JDBCConfig is available.  A prominent WARN level message  is also added to the log when the configurations differ to make sure anyone viewing the log is aware of the change.
