### PR TITLE
fix jetty log versions and deps

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -902,11 +902,6 @@
     <version>1.0.1</version>
    </dependency>
    <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-simple</artifactId>
-    <version>1.0.1</version>
-   </dependency>
-   <dependency>
     <groupId>javax.media</groupId>
     <artifactId>jai_core</artifactId>
     <version>1.1.3</version>

--- a/src/release/bin.xml
+++ b/src/release/bin.xml
@@ -43,7 +43,6 @@
     <include>jetty-util-*.jar</include>
     <include>jsp-api-*.jar</include>
     <include>servlet-api-*.jar</include>
-    <include>slf4j-simple-*.jar</include>
     <include>xercesImpl-*.jar</include>
     <include>xmlParserAPIs-*.jar</include>
    </includes>

--- a/src/release/pom.xml
+++ b/src/release/pom.xml
@@ -47,10 +47,6 @@
    <artifactId>commons-el</artifactId>
   </dependency>
   <dependency>
-   <groupId>commons-logging</groupId>
-   <artifactId>commons-logging</artifactId>
-  </dependency>
-  <dependency>
    <groupId>log4j</groupId>
    <artifactId>log4j</artifactId>
   </dependency>
@@ -61,16 +57,16 @@
   <dependency>
    <groupId>org.apache.ant</groupId>
    <artifactId>ant</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>org.slf4j</groupId>
-   <artifactId>slf4j-simple</artifactId>
+   <exclusions>
+    <exclusion>
+     <groupId>commons-logging</groupId>
+     <artifactId>commons-logging</artifactId>
+    </exclusion>
+   </exclusions>
   </dependency>
   <dependency>
    <groupId>commons-logging</groupId>
    <artifactId>commons-logging</artifactId>
-   <version>1.0</version>
-   <scope>provided</scope>
   </dependency>
   <dependency>
    <groupId>org.geotools</groupId>


### PR DESCRIPTION
I've removed the slf4j-simple lib which was quite old and definitely not necessary (since jetty can use commons-logging + log4j).
Changed the <scope>provided</scope> which actually didn't works (we have commons-loggin-1.0.jar into di lib) into and exclusion so now we have in the shared jetty lib folder:
commons-logging-1.1.1.jar
log4j-1.12.14.jar
... (others not related to log)...
