### PR TITLE
[GEOS-6445] IOUtils.xStreamPersist fails if /tmp on different filesystem

### DIFF
--- a/src/main/src/main/java/org/geoserver/data/util/IOUtils.java
+++ b/src/main/src/main/java/org/geoserver/data/util/IOUtils.java
@@ -474,7 +474,8 @@ public final class IOUtils {
         }
         // make sure the rename actually succeeds
         if(!source.renameTo(dest)) {
-            throw new IOException("Failed to rename " + source.getAbsolutePath() + " to " + dest.getAbsolutePath());
+            FileUtils.deleteQuietly(dest);
+            FileUtils.moveFile(source, dest);
         }
     }
 }


### PR DESCRIPTION
See: https://jira.codehaus.org/browse/GEOS-6445
