### PR TITLE
Fix leaking jdbc connection when 'Return bounding box' is selected for WFS se...

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/FeatureBoundsFeatureCollection.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/FeatureBoundsFeatureCollection.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.wfs;
 
+import java.io.Closeable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -47,7 +48,7 @@ class FeatureBoundsFeatureCollection extends AbstractFeatureCollection {
      * @author Andrea Aime - TOPP
      *
      */
-    private static class BoundsIterator implements Iterator<SimpleFeature> {
+    private static class BoundsIterator implements Iterator<SimpleFeature>, Closeable {
         SimpleFeatureIterator wrapped;
         SimpleFeatureType targetSchema;
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureBoundedTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureBoundedTest.java
@@ -1,0 +1,81 @@
+/* Copyright (c) 2001 - 2014 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wfs.request.FeatureCollectionResponse;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
+
+public class GetFeatureBoundedTest extends WFSTestSupport {
+    
+    @Override
+    protected void setUpInternal(SystemTestData data) throws Exception {
+        WFSInfo wfs = getWFS();
+        wfs.setFeatureBounding(true);
+        getGeoServer().save(wfs);
+    }
+       
+    @Test
+    public void testCloseIterators() throws Exception {
+        // build a wfs response with an iterator that will mark if close has been called, or not
+        FeatureTypeInfo fti = getCatalog().getFeatureTypeByName(getLayerId(MockData.POLYGONS));
+        FeatureSource fs = fti.getFeatureSource(null, null);
+        SimpleFeatureCollection fc = (SimpleFeatureCollection) fs.getFeatures();
+        final AtomicInteger openIterators = new AtomicInteger(0);
+        
+        SimpleFeatureCollection decorated = new org.geotools.feature.collection.DecoratingSimpleFeatureCollection(
+                fc) {
+            @Override
+            public SimpleFeatureIterator features() {
+                openIterators.incrementAndGet();
+                final SimpleFeature f = DataUtilities.first(delegate);
+                return new SimpleFeatureIterator() {
+                    
+                    @Override
+                    public SimpleFeature next() throws NoSuchElementException {
+                        return f;
+                    }
+                    
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+                    
+                    @Override
+                    public void close() {
+                        openIterators.decrementAndGet();
+                    }
+                };
+            }
+        };
+        
+        FeatureBoundsFeatureCollection fbc = new FeatureBoundsFeatureCollection(decorated, decorated.getSchema());
+        FeatureIterator<?> i = fbc.features();
+        i.close();
+         
+        assertEquals(0, openIterators.get());
+    }
+    
+
+}


### PR DESCRIPTION
...rvice

This issue occurred for us when requesting specific properties using the csv output format in Geoserver 2.4.2 against a postgis jdbc store but the problem also occurs in the latest nightly build for other output formats.  For example, the following request in a test instance:

http://localhost:8080/geoserver/tiger/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=tiger:profiles&propertyName=platform_number&maxFeatures=50&outputFormat=GML2

resulted in the following message in the log (when freeing memory)

[geotools.jdbc] - There is code leaving feature readers/iterators open, this is leaking statements and connections!

We eventually turned off 'return bounding box' to resolve this problem as we did not need this, but not before I'd worked out enough about what was happening to prepare this fix.   I thought it may be useful for someone else.

The reason why the underlying jdbc Feature reader  was not being closed was because in this instance it was being wrapped up by a FeatureBoundsFeatureCollection which did not implement Closeable.   When using fc.getFeatures in the CSVOutputFormat the iterator returned uses DataUtilities.close to close the wrapped Iterator which checks for Closeable being implemented before closing the wrapped iterator (yes  featureBoundsFeatureCollection is wrapped by another iterator). 

Not sure if this is an appropriate fix or test, but you get the idea.
