### PR TITLE
More permissive fix for [GEOS-6482] Scale line pixel wrong location caus...

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
@@ -235,7 +235,9 @@ public class GetMapIntegrationTest extends WMSTestSupport {
         
         // check the pixels that should be in the scale bar
         assertPixel(image, 56, 211, Color.WHITE);
-        assertPixel(image, 52, 222, Color.BLACK);
+        // see GEOS-6482
+        assertTrue(getPixelColor(image, 52, 221).equals(Color.BLACK)
+                || getPixelColor(image, 52, 222).equals(Color.BLACK));
     }
     
     @Test


### PR DESCRIPTION
...es failure in GetMapIntegrationTest

See: https://jira.codehaus.org/browse/GEOS-6482

Previous pull request: https://github.com/geoserver/geoserver/pull/588
