### PR TITLE
[GEOS-6499] Upgrade ImageIO-Ext version from 1.1.9 to 1.1.10 on GeoServer.

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1526,7 +1526,7 @@
   <poi.version>3.8</poi.version>
   <wicket.version>1.4.12</wicket.version>
   <ant.version>1.8.4</ant.version>
-  <imageio-ext.version>1.1.9</imageio-ext.version>
+  <imageio-ext.version>1.1.10</imageio-ext.version>
   <java.awt.headless>true</java.awt.headless>
   <jvm.opts></jvm.opts>
   <jalopy.phase>disabled</jalopy.phase>


### PR DESCRIPTION
Please look at the following JIRA: http://jira.codehaus.org/browse/GEOS-6499. 

The new ImageIO-Ext release is equal to the 1.1.9 with an additional bug fix for the PNG encoder.
