### PR TITLE
GEOS-6394 import can fail on windows

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Directory.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Directory.java
@@ -95,7 +95,9 @@ public class Directory extends FileData {
             vfs.extractTo(file, this.file);
 
             LOGGER.fine("deleting " + file.getAbsolutePath());
-            file.delete();
+            if (!file.delete()) {
+                throw new IOException("unable to delete file");
+            }
         }
     }
     
@@ -443,7 +445,9 @@ public class Directory extends FileData {
                     if (LOGGER.isLoggable(Level.FINE)) {
                         LOGGER.fine("Deleting file " + f.getAbsolutePath());
                     }
-                    f.delete();
+                    if (!f.delete()) {
+                        throw new IOException("unable to delete " + f);
+                    }
                 }
             }
         }

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/VFSWorker.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/VFSWorker.java
@@ -182,6 +182,8 @@ public class VFSWorker {
             }
         };
         target.copyFrom(source, selector);
+        source.close();
+        manager.closeFileSystem(source.getFileSystem());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/mosaic/MosaicIndex.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/mosaic/MosaicIndex.java
@@ -88,7 +88,12 @@ public class MosaicIndex {
                     || shpFileType != null;
             }
         })) {
-            f.delete();
+            if (!f.delete()) {
+                // throwing exception here caused sporadic test failures on
+                // windows related to file locking but only in the cleanup
+                // method SystemTestData.tearDown
+                 LOGGER.warning("unable to delete mosaic file " + f.getAbsolutePath());
+            }
         }
     }
 

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTestUtils.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTestUtils.java
@@ -37,7 +37,10 @@ public class ImporterTestUtils {
         File file = file(path, dir);
         
         new VFSWorker().extractTo(file, dir);
-        file.delete();
+        if (!file.delete()) {
+            // fail early as tests will expect it's deleted
+            throw new IOException("deletion failed during extraction");
+        }
         
         return dir;
     }


### PR DESCRIPTION
Due to file locking, when uploading a zip file, the file can fail to be
deleted and is erroneously scanned as part of the import causing an
unrecognized task.
