### PR TITLE
added documentation for featuretypecachesize

### DIFF
--- a/doc/en/user/source/webadmin/server/globalsettings.rst
+++ b/doc/en/user/source/webadmin/server/globalsettings.rst
@@ -95,7 +95,9 @@ This option is only useful with the application schema extensions.
 Feature type cache size
 -----------------------
 
-GeoServer can cache datastore connections and schemas in memory for performance reasons. The cache size should generally be greater than the number of distinct featuretypes that are expected to be accessed simultaneously. If possible, make this value larger than the total number of featuretypes on the server, but a setting too high may produce out-of-memory errors.
+GeoServer can cache datastore connections and schemas in memory for performance reasons. The cache size should generally be greater than the number of distinct featuretypes that are expected to be accessed simultaneously.
+If possible, make this value larger than the total number of featuretypes on the server, but a setting too high may produce out-of-memory errors. On the other hand, a value lower than the total number of your registered featuretypes may clear and reload the resource-cache more often, which can be expensive and e.g. delay WFS-Requests in the meantime.
+The default value for the Feature type cache size is 100.
 
 File Locking
 ------------


### PR DESCRIPTION
I added some more information regarding the featuretypecachesize parameter. I think its helpful to give the user advice what this parameter may cause when it is set to a too low value (lower than the number of all featuretypes). 
I also added information about the default value, but i am not absolutely sure with this one.
Hints i have found:
https://github.com/geoserver/geoserver/blob/master/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java#L152
It would also be useful to know how a value of 0 will behave here.
