### PR TITLE
Validate content of MetadataLinkInfo as a URL

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/MetadataLinkInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/MetadataLinkInfoImpl.java
@@ -4,6 +4,12 @@
  */
 package org.geoserver.catalog.impl;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
 import org.geoserver.catalog.MetadataLinkInfo;
 
 public class MetadataLinkInfoImpl implements MetadataLinkInfo {
@@ -67,10 +73,47 @@ public class MetadataLinkInfoImpl implements MetadataLinkInfo {
         return content;
     }
 
+    static final List<String> protocols = Arrays.asList("http", "https", "ftp");
+    /**
+     * @throws IllegalArgumentException if the url is invalid for use as a Metadata Link
+     * @param url
+     */
+    public static void validate(String url) {
+        if (url==null) return;
+        URL dummy;
+        try {
+            dummy = new URL("http://dummy/");
+        } catch (MalformedURLException ex) {
+            throw new IllegalStateException("Could not parse dummy context URL", ex);
+        }
+        try {
+            // Doing this with exceptions isn't ideal but it works, and we're throwing an
+            // exception anyway
+            
+            // The dummy context will allow it to parse relative URLs, which should be allowed.
+            URL parsed = new URL(dummy, url);
+            String protocol = parsed.getProtocol();
+            
+            // Converting to URI forces validation
+            parsed.toURI();
+            
+            if(!protocols.contains(protocol)){
+                throw new IllegalArgumentException("Protocol "+protocol+" is not supported in url "+url);
+            }
+        } catch (MalformedURLException | URISyntaxException ex) {
+            throw new IllegalArgumentException("Not a valid URL: "+url, ex);
+        }
+    }
+    
     public void setContent(String content) {
+        validate(content);
         this.content = content;
     }
-
+    
+    private Object readResolve() {
+        validate(content);
+        return this;
+    }
     @Override
     public int hashCode() {
         final int PRIME = 31;
@@ -123,4 +166,6 @@ public class MetadataLinkInfoImpl implements MetadataLinkInfo {
                 .append(']').toString();
     }
     
+    
+
 }

--- a/src/main/src/test/java/org/geoserver/catalog/impl/MetadataLinkInfoImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/MetadataLinkInfoImplTest.java
@@ -1,0 +1,86 @@
+package org.geoserver.catalog.impl;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class MetadataLinkInfoImplTest {
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
+    
+    @Test
+    public void testSetAbsoluteHttp() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        info.setContent("http://example.com/foo");
+    }
+    
+    @Test
+    public void testSetAbsoluteHttps() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        info.setContent("https://example.com/foo");
+    }
+    
+    @Test
+    public void testSetAbsoluteFtp() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        info.setContent("ftp://example.com/foo");
+    }
+    
+    @Test
+    public void testSetAbsoluteTelnet() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        thrown.expect(IllegalArgumentException.class);
+        
+        info.setContent("telnet:example.com");
+    }
+    
+    @Test
+    public void testSetRelativeUrlAbsolutePath() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        info.setContent("/foo");
+    }
+    
+    @Test
+    public void testSetRelativeUrlRelativePath() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        info.setContent("foo/bar");
+    }
+    
+    @Test
+    public void testSetRelativeUrlRelativeCurrentPath() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        info.setContent("./foo");
+    }
+    
+    @Test
+    public void testSetRelativeUrlRelativeParentPath() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        info.setContent("../foo");
+    }
+    
+    @Test
+    public void testSetNotAURL() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        thrown.expect(IllegalArgumentException.class);
+        
+        info.setContent("::^%/[*] FOO ::");
+    }
+    
+    @Test
+    public void testNotAURLButStartsOK() {
+        MetadataLinkInfoImpl info = new MetadataLinkInfoImpl();
+        
+        thrown.expect(IllegalArgumentException.class);
+        
+        info.setContent("https://example.com/::^%/[*] FOO ::");
+    }
+}

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/MetadataLinkEditor.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/MetadataLinkEditor.java
@@ -23,9 +23,11 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.validation.validator.UrlValidator;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.validator.AbstractValidator;
 import org.geoserver.catalog.MetadataLinkInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.impl.MetadataLinkInfoImpl;
 
 /**
  * Shows and allows editing of the {@link MetadataLinkInfo} attached to a
@@ -42,7 +44,7 @@ public class MetadataLinkEditor extends Panel {
      */
     private static final List<String> LINK_TYPES = Arrays.asList("ISO19115:2003", "FGDC",
             "TC211", "19139", "other");
-    private ListView links;
+    private ListView<MetadataLinkInfo> links;
     private Label noMetadata;
     private WebMarkupContainer table;
 
@@ -50,7 +52,7 @@ public class MetadataLinkEditor extends Panel {
      * @param id
      * @param model Must return a {@link ResourceInfo}
      */
-    public MetadataLinkEditor(String id, final IModel resourceModel) {
+    public MetadataLinkEditor(String id, final IModel<ResourceInfo> resourceModel) {
         super(id, resourceModel);
         
         // container for ajax updates
@@ -62,32 +64,33 @@ public class MetadataLinkEditor extends Panel {
         table = new WebMarkupContainer("table");
         table.setOutputMarkupId(true);
         container.add(table);
-        links = new ListView("links", new PropertyModel(resourceModel, "metadataLinks")) {
+        links = new ListView<MetadataLinkInfo>("links", new PropertyModel<List<MetadataLinkInfo>>(resourceModel, "metadataLinks")) {
 
             @Override
-            protected void populateItem(ListItem item) {
+            protected void populateItem(ListItem<MetadataLinkInfo> item) {
                 
                 // odd/even style
                 item.add(new SimpleAttributeModifier("class",
                         item.getIndex() % 2 == 0 ? "even" : "odd"));
 
                 // link info
-                DropDownChoice dropDownChoice = new DropDownChoice("type",
-                        new PropertyModel(item.getModel(), "metadataType"), LINK_TYPES);
+                DropDownChoice<String> dropDownChoice = new DropDownChoice<>("type",
+                        new PropertyModel<String>(item.getModel(), "metadataType"), LINK_TYPES);
                 dropDownChoice.setRequired(true);
                 item.add(dropDownChoice);
                 FormComponentFeedbackBorder urlBorder = new FormComponentFeedbackBorder("urlBorder");
                 item.add(urlBorder);
-                TextField format = new TextField("format", new PropertyModel(item.getModel(), "type"));
+                TextField<String> format = new TextField<>("format", new PropertyModel<String>(item.getModel(), "type"));
                 format.setRequired(true);
                 item.add(format);
-                TextField url = new TextField("metadataLinkURL", new PropertyModel(item.getModel(), "content"));
+                TextField<String> url = new TextField<>("metadataLinkURL", new PropertyModel<String>(item.getModel(), "content"));
                 url.add(new UrlValidator());
                 url.setRequired(true);
                 urlBorder.add(url);
                 
                 // remove link
-                AjaxLink link = new AjaxLink("removeLink", item.getModel()) {
+                AjaxLink<MetadataLinkInfo> link = 
+                        new AjaxLink<MetadataLinkInfo>("removeLink", item.getModel()) {
 
                     @Override
                     public void onClick(AjaxRequestTarget target) {
@@ -100,7 +103,6 @@ public class MetadataLinkEditor extends Panel {
                 };
                 item.add(link);
             }
-
         };
         // this is necessary to avoid loosing item contents on edit/validation checks
         links.setReuseItems(true);
@@ -115,7 +117,7 @@ public class MetadataLinkEditor extends Panel {
         AjaxButton button = new AjaxButton("addlink") {
 
             @Override
-            protected void onSubmit(AjaxRequestTarget target, Form form) {
+            protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
                 ResourceInfo ri = (ResourceInfo) resourceModel.getObject();
                 MetadataLinkInfo link = ri.getCatalog().getFactory().createMetadataLink();;
                 link.setMetadataType(LINK_TYPES.get(0));
@@ -135,5 +137,20 @@ public class MetadataLinkEditor extends Panel {
         boolean anyLink = ri.getMetadataLinks().size() > 0;
         table.setVisible(anyLink);
         noMetadata.setVisible(!anyLink);
+    }
+    
+    public class UrlValidator extends AbstractValidator<String>{
+        @Override
+        protected void onValidate(IValidatable<String> validatable) {
+            String url = validatable.getValue();
+            if (url != null )
+            {
+                try {
+                    MetadataLinkInfoImpl.validate(url);
+                } catch (IllegalArgumentException ex) {
+                    error(validatable);
+                }
+            }
+        }
     }
 }

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -868,3 +868,6 @@ SRSListTextArea.unknownEPSGCodes = The following codes are not known to the EPSG
 
 PropertyEditorFormComponent.KeyRequired=Property name required
 PropertyEditorFormComponent.ValueRequired=Property value required
+
+MetadataLinkEditor$UrlValidator = Invalid metadata link URL
+


### PR DESCRIPTION
Added validation when Metadata Link is changed via REST. Changed Web UI validation to match, allowing relative URLs.
