### PR TITLE
Fix GeoServerPersisterTest and the build

### DIFF
--- a/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
@@ -696,7 +696,7 @@ public class GeoServerPersisterTest extends GeoServerSystemTestSupport {
         
         // Insert an absolute path to test
         String content = new String(Files.readAllBytes(styleFile.toPath()), StandardCharsets.UTF_8);
-        content = content.replaceAll("./burg03.svg", DataUtilities.fileToURL(target.getCanonicalFile()).toString());
+        content = content.replaceAll("./burg03.svg", "http://doesnotexist.example.org/burg03.svg");
         Files.write(styleFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
         new File( testData.getDataDirectoryRoot(), "styles/burg03.svg").delete();
         


### PR DESCRIPTION
Makes the change described here:
http://osgeo-org.1560.x6.nabble.com/Build-failed-in-Jenkins-geoserver-master-600-tp5147692p5148268.html

Kevin, if you have time, please review
GeoServerPersisterTest.testModifyStyleWithResourcesAbsoluteChangeWorkspace;
it appears that this failure triggers the others (which pass when run
alone in Eclipse). @Ignoreing this one method makes everything pass. Is
the persister smart enough to find burg03.svg and copy it even via an
absolute file: reference? Could this reference instead be changed to
something like "http://doesnotexist.example.org/burg03.svg"? I am not
sure what you are testing here.
