### PR TITLE
GEOS-6550: updated printing plugin dependency to mapfish print-lib 2.1.0, that includes many bugfixes

### DIFF
--- a/doc/en/user/source/extensions/printing/configuration.rst
+++ b/doc/en/user/source/extensions/printing/configuration.rst
@@ -16,6 +16,9 @@ Here is the general structure:
   ?maxSvgHeight: 2048
   ?integerSvg: false # the library in MapServer <= 5.6 does not support floating point values in the SVG coordinate space, set this to true if using a WMS that does not support floating point values in SVG coordinates
 
+  ?ignoreCapabilities: false # assume client is correct and do not load capabilities.  This is not recommended to be used unless you it fails when false (false is default)
+  ?maxPrintTimeBeforeWarningInSeconds: 30 # if print jobs take longer than this then a warning in the logs will be written along with the spec.
+  ?printTimeoutMinutes: 5 # The maximum time to allow a print job to take before cancelling the print job.  The default is 5 (minutes)
   ?formats:
     - pdf
     - png
@@ -134,7 +137,6 @@ If the 'outputFilename' parameter is defined in the main body then that name wil
 
 "brokenUrlPlaceholder" the placeholder image to use in the case of a broken url.  By default, when a url request fails, an error is thrown and the pdf process terminates.  However if this parameter is set then instead a placeholder image is returned.
 Non-null values are:
-
   * "default" - use the system default image.
   * "throw" - throw an exception.
   * <url> - obtain the image from the supplied url.  If this url is broken then an exception will be thrown.  This can be anytype of valid url from a file url to https url.

--- a/doc/en/user/source/extensions/printing/protocol.rst
+++ b/doc/en/user/source/extensions/printing/protocol.rst
@@ -171,6 +171,67 @@ HTTP command::
 
 Returns the PDF. Can be called only during a limited time since the server side temporary file is deleted afterwards.
 
+Multiple maps on a single page
+******************************
+To print more than one map on a single page you need to:
+ * specify several map blocks in a page of the yaml file, each with a distinct name property value
+ * use a particular syntax in the spec to bind different rendering properties to each map block
+ 
+This is possible specifying a _maps_ object in spec root object with a distinct key - object pair for each map. The
+key will refer the map block name as defined in yaml file. The object will contain layers and srs for the named map.
+Another _maps_ object has to be specified inside the page object to describe positioning, scale and so on.
+
+.. code-block:: javascript
+
+    {
+        ...
+        maps: {
+            "main": {
+                layers: [
+                    ...
+                ],
+                srs: 'EPSG:4326'
+            },
+            "other": {
+                layers: [
+                    ...
+                ],
+                srs: 'EPSG:4326'
+            }
+        },
+        ...
+        pages: [
+            {
+                maps: {
+                    "main": {
+                        center: [6, 45.5],
+                        scale: 4000000,
+                        dpi: 190,
+                        geodetic: false,
+                        strictEpsg4326: false,
+                        ...CUSTOM_PARAMS...
+                    },
+                    "other": {
+                        center: [7.2, 38.6],
+                        scale: 1000000,
+                        dpi: 300,
+                        geodetic: false,
+                        strictEpsg4326: false,
+                        ...CUSTOM_PARAMS...
+                    }
+                }
+                
+            }
+        ],
+        ...
+    }
+
+Other config blocks have been enabled to multiple maps usage.
+The scalebar block can be bound to a specific map, specifying a name property that matches the map
+name.
+Also, in text blocks you can use the ${scale.<mapname>} placeholder to print the scale of the map
+whose name is <mapname>.
+
 Layers Params
 *************
 

--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.0.0</version>
+      <version>2.1.0</version>
     </dependency>
       
     <dependency>

--- a/src/extension/printing/src/main/resources/applicationContext.xml
+++ b/src/extension/printing/src/main/resources/applicationContext.xml
@@ -48,6 +48,12 @@
     
     <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
     <bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
+	<bean id="threadResources" class="org.mapfish.print.ThreadResources">
+        <property name="connectionTimeout" value="30000"/>
+        <property name="socketTimeout" value="30000" />
+        <property name="globalParallelFetches" value="200"/>
+        <property name="perHostParallelFetches" value="30" />
+	</bean>
 
     <!-- Define MapReaderFactories -->
     <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
@@ -116,4 +122,12 @@
     <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
     <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
     <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
+
+
+    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" lazy-init="false"/>
+    <bean id="healthCheckRegistry" class="com.codahale.metrics.health.HealthCheckRegistry" lazy-init="false"/>
+    <bean id="loggingMetricsConfigurator" class="org.mapfish.print.metrics.LoggingMetricsConfigurator"  lazy-init="false"/>
+    <bean id="jvmMetricsConfigurator" class="org.mapfish.print.metrics.JvmMetricsConfigurator" lazy-init="false"/>
+    <bean id="jmlMetricsReporter" class="org.mapfish.print.metrics.JmxMetricsReporter" lazy-init="false"/>
+
 </beans>

--- a/src/extension/printing/src/main/resources/org/geoserver/printing/default-config.yaml
+++ b/src/extension/printing/src/main/resources/org/geoserver/printing/default-config.yaml
@@ -92,7 +92,7 @@ layouts:
                 maxWidth: 100
                 maxHeight: 30
                 spacingAfter: 200
-                url: 'http://geoserver.org/download/attachments/10158143/pbGS-Bttn228x68.png'
+                url: 'http://geoserver.org/img/geoserver-logo.png'
 
     #-------------------------------------------------------------------------
     mainPage:

--- a/src/release/ext-printing.xml
+++ b/src/release/ext-printing.xml
@@ -9,12 +9,12 @@
       <directory>release/target/dependency</directory>
       <outputDirectory></outputDirectory>
       <includes>
-        <include>jtsio*</include>
+        <include>itextpdf*</include>
+        <include>metrics-*</include>
         <include>jyaml*</include>
         <include>mapfish-geo-lib*</include>
         <include>gs-printing-*.jar</include>
         <include>print-lib-*.jar</include>
-        <include>pvalsecc-*.jar</include>
         <include>xercesImpl-*.jar</include>
         <include>xml-apis-xerces-*.jar</include>
       </includes>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -503,7 +503,7 @@
       <id>printing</id>
       <dependencies>
         <dependency>
-          <groupId>org.geoserver.community</groupId>
+          <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-printing</artifactId>
           <version>${project.version}</version> 
         </dependency>


### PR DESCRIPTION
Updated print-lib dependency to include bug fixes related to thread leaks and unclosed files, and also to include latest improvements of mapfish-print.
