### PR TITLE
GEOS-6555: bounded FormatOptionsKvpParsers implementations to their service, to avoid wrong parser usage

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
@@ -372,7 +372,8 @@ public class KvpUtils {
     }
     
     /**
-     * Parses a map of key value pairs.
+     * Parses a map of key value pairs, using the given service, version, request
+     * to constrain the used parsers list.
      * <p>
      * Important: This method modifies the map, overriding original values with
      * parsed values.  
@@ -390,15 +391,9 @@ public class KvpUtils {
      * 
      * @return A list of errors that occured.
      */
-    public static List<Throwable> parse(Map kvp) {
-
+    public static List<Throwable> parse(Map kvp, String service, String request, String version) {
         // look up parser objects
         List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
-
-        //strip out parsers which do not match current service/request/version
-        String service = KvpUtils.getSingleValue(kvp, "service");
-        String version = KvpUtils.getSingleValue(kvp, "version");
-        String request = KvpUtils.getSingleValue(kvp, "request");
         
         purgeParsers(parsers, service, version, request);
 
@@ -441,6 +436,34 @@ public class KvpUtils {
         }
 
         return errors;
+    }
+    
+    /**
+     * Parses a map of key value pairs.
+     * <p>
+     * Important: This method modifies the map, overriding original values with
+     * parsed values.  
+     * </p>
+     * <p>
+     * This routine performs a lookup of {@link KvpParser} to parse the kvp 
+     * entries.
+     * </p>
+     * <p>
+     * If an individual parse fails, this method saves the exception, and adds
+     * it to the list that is returned.
+     * </p>
+     * 
+     * @param rawKvp raw or unparsed kvp.
+     * 
+     * @return A list of errors that occured.
+     */
+    public static List<Throwable> parse(Map kvp) {
+        //strip out parsers which do not match current service/request/version
+        String service = KvpUtils.getSingleValue(kvp, "service");
+        String version = KvpUtils.getSingleValue(kvp, "version");
+        String request = KvpUtils.getSingleValue(kvp, "request");
+        
+        return parse(kvp, service, version, request);
     }
 
     /**

--- a/src/ows/src/test/java/applicationContext-test.xml
+++ b/src/ows/src/test/java/applicationContext-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ Copyright (c) 2001 - 2013 OpenPlans - www.openplans.org. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+    
+
+    <!-- kvp parsers -->
+    <bean id="testKvpParser" class="org.geoserver.ows.kvp.FakeKvpParser">
+        <constructor-arg index="0" value="test"/>
+        <constructor-arg index="1" value="java.util.List"/>
+        <property name="request" value="TestRequest"/>
+        <property name="service" value="TestService"/>
+        <property name="version" value="TestVersion"/>
+    </bean>
+    
+</beans>

--- a/src/ows/src/test/java/org/geoserver/ows/kvp/FakeKvpParser.java
+++ b/src/ows/src/test/java/org/geoserver/ows/kvp/FakeKvpParser.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2014 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows.kvp;
+
+import java.util.Arrays;
+
+import org.geoserver.ows.KvpParser;
+
+/**
+ * Fake KvpParser implementation, used to test parsers filtering
+ * by service - request - version.
+ * 
+ * @author mauro.bartolomeoli at geo-solutions.it
+ *
+ */
+public class FakeKvpParser extends KvpParser {
+
+    public FakeKvpParser(String key, Class binding) {
+        super(key, binding);
+    }
+
+    @Override
+    public Object parse(String value) throws Exception {
+        return Arrays.asList(value);
+    }
+}

--- a/src/wfs/src/main/java/applicationContext.xml
+++ b/src/wfs/src/main/java/applicationContext.xml
@@ -386,7 +386,10 @@
     <bean id="strictKvpParser" class="org.geoserver.ows.kvp.BooleanKvpParser">
         <constructor-arg value="strict"/>
     </bean>
-    <bean id="wfsFormatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser"/>
+    <bean id="wfsFormatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser">
+        <constructor-arg index="0" value="format_options"/>
+        <property name="service" value="WFS"/>
+    </bean>
     <bean id="charsetKvpParser" class="org.geoserver.ows.kvp.CharsetKVPParser">
         <constructor-arg value="charset"/>
     </bean>

--- a/src/wms/src/main/java/applicationContext.xml
+++ b/src/wms/src/main/java/applicationContext.xml
@@ -230,12 +230,17 @@
  	<bean id="heightKvpParser" class="org.geoserver.ows.kvp.IntegerKvpParser">
 		<constructor-arg value="height"/>
  	</bean>
- 	<bean id="wmsFormatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser"/>
+ 	<bean id="wmsFormatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser">
+ 	  <constructor-arg index="0" value="format_options"/>
+ 	  <property name="service" value="WMS"/>
+ 	</bean>
  	<bean id="wmsEnviromentKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser">
  		<constructor-arg index="0" value="env"/>
+ 		<property name="service" value="WMS"/>
  	</bean>
  	<bean id="wmsLegendOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser">
  		<constructor-arg index="0" value="legend_options"/>
+ 		<property name="service" value="WMS"/>
  	</bean>
   <bean id="wmsSqlViewKvpParser" class="org.geoserver.ows.kvp.ViewParamsKvpParser">
     <!-- cannot set the service or it won't work for the reflectors -->


### PR DESCRIPTION
Refactored FormatOptionsKvpParsers to use a new KvpUtils.parse helper method to optionally use service-bound parsers only.
Configured existing implementations to bound to their respective service (WMS or WFS)
