### PR TITLE
Fixing outdated remote ows tests

### DIFF
--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
@@ -301,8 +301,7 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
         CatalogBuilder cb = new CatalogBuilder(cat);
         WMSStoreInfo wms = cb.buildWMSStore("demo");
         wms.setCapabilitiesURL(RemoteOWSTestSupport.WMS_SERVER_URL
-                + "service=WMS&request=GetCapabilities");
-        cat.save(wms);
+                + "service=WMS&request=GetCapabilities&version=1.1.0");
 
         cb.setStore(wms);
         WMSLayerInfo wmsLayer = cb.buildWMSLayer("topp:states");
@@ -323,7 +322,7 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
         assertEquals("topp:states", wmsLayer.getNativeName());
         assertEquals("EPSG:4326", wmsLayer.getSRS());
         assertEquals("USA Population", wmsLayer.getTitle());
-        assertEquals("This is some census data on the states.", wmsLayer.getAbstract());
+        assertEquals("2000 census data for United States.", wmsLayer.getAbstract());
         
         assertEquals(CRS.decode("EPSG:4326"), wmsLayer.getNativeCRS());
         assertNotNull(wmsLayer.getNativeBoundingBox());

--- a/src/main/src/test/java/org/geoserver/test/RemoteOWSTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/RemoteOWSTestSupport.java
@@ -54,7 +54,7 @@ public class RemoteOWSTestSupport {
                 try {
                     WFSDataStoreFactory factory = new WFSDataStoreFactory();
                     Map<String, Serializable> params = new HashMap(factory.getImplementationHints());
-                    URL url = new URL(WFS_SERVER_URL + "service=WFS&request=GetCapabilities");
+                    URL url = new URL(WFS_SERVER_URL + "service=WFS&request=GetCapabilities&version=1.1.0");
                     params.put(WFSDataStoreFactory.URL.key, url);
                     params.put(WFSDataStoreFactory.TRY_GZIP.key, Boolean.TRUE);
                     //give it five seconds to respond...

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/WMSLayerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/WMSLayerTest.java
@@ -14,6 +14,7 @@ import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ProjectionPolicy;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.data.test.SystemTestData;
@@ -74,6 +75,18 @@ public class WMSLayerTest extends CatalogRESTTestSupport {
         }
     }
 
+    @Before
+    public void removeBugsites() throws Exception {
+        LayerInfo l = catalog.getLayerByName(new NameImpl("sf", "bugsites"));
+        if(l != null) {
+            catalog.remove(l);
+        }
+
+        ResourceInfo r = catalog.getResourceByName("sf", "bugsites", WMSLayerInfo.class);
+        if (r != null) {
+            catalog.remove(r);
+        }
+    }
     @Test
     public void testGetAllByWorkspace() throws Exception {
         Document dom = getAsDOM( "/rest/workspaces/sf/wmslayers.xml");

--- a/src/wms/src/test/java/org/geoserver/wms/ResourceAccessManagerWMSTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/ResourceAccessManagerWMSTest.java
@@ -238,13 +238,13 @@ public class ResourceAccessManagerWMSTest extends WMSTestSupport {
         // a Texas one
         int[] pixel = new int[4];
         image.getData().getPixel(368, 227, pixel);
-        assertEquals(77, pixel[0]);
-        assertEquals(77, pixel[1]);
+        assertEquals(130, pixel[0]);
+        assertEquals(130, pixel[1]);
         assertEquals(255, pixel[2]);
         // a California one
         image.getData().getPixel(191, 178, pixel);
-        assertEquals(77, pixel[0]);
-        assertEquals(77, pixel[1]);
+        assertEquals(130, pixel[0]);
+        assertEquals(130, pixel[1]);
         assertEquals(255, pixel[2]);
     }
 
@@ -282,8 +282,8 @@ public class ResourceAccessManagerWMSTest extends WMSTestSupport {
         // a Texas one
         int[] pixel = new int[4];
         image.getData().getPixel(368, 227, pixel);
-        assertEquals(77, pixel[0]);
-        assertEquals(77, pixel[1]);
+        assertEquals(130, pixel[0]);
+        assertEquals(130, pixel[1]);
         assertEquals(255, pixel[2]);
         // a California one, this one should be white
         image.getData().getPixel(191, 178, pixel);


### PR DESCRIPTION
Doesn't seem that remote ows tests have been for a while, this PR contains some changes to make them pass locally for me. The pixel assertions in ResourceAccessManagerWMSTest take into account a new style on the demo server. 
