### PR TITLE
Swapping out wfs for wfs-ng

### DIFF
--- a/src/community/geopkg/pom.xml
+++ b/src/community/geopkg/pom.xml
@@ -62,11 +62,6 @@
    <artifactId>gt-render</artifactId>
    <version>${gt.version}</version>
   </dependency>
-  <dependency>
-   <groupId>org.geotools</groupId>
-   <artifactId>gt-wfs</artifactId>
-   <version>${gt.version}</version>
-  </dependency>  
  <dependency>
    <groupId>org.geoserver.extension</groupId>
    <artifactId>gs-wps-core</artifactId>

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -192,7 +192,7 @@
   </dependency>
   <dependency>
    <groupId>org.geotools</groupId>
-   <artifactId>gt-wfs</artifactId>
+   <artifactId>gt-wfs-ng</artifactId>
    <scope>test</scope>
   </dependency>
   <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -392,6 +392,11 @@
    </dependency>
    <dependency>
     <groupId>org.geotools</groupId>
+    <artifactId>gt-wfs-ng</artifactId>
+    <version>${gt.version}</version>
+   </dependency>
+   <dependency>
+    <groupId>org.geotools</groupId>
     <artifactId>gt-wms</artifactId>
     <version>${gt.version}</version>
    </dependency>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -139,7 +139,7 @@
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
-      <artifactId>gt-wfs</artifactId>
+      <artifactId>gt-wfs-ng</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -102,7 +102,7 @@
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
-      <artifactId>gt-wfs</artifactId>
+      <artifactId>gt-wfs-ng</artifactId>
     </dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>

--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
-      <artifactId>gt-wfs</artifactId>
+      <artifactId>gt-wfs-ng</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>


### PR DESCRIPTION
This changes replaces the wfs dependency with wfs-ng. All tests pass, including the remote ows tests (requires  #637 be applied). 
