### PR TITLE
GEOS-4834: original patch to fix transparency in animaged gif + tests (backport to 2.5.x)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/GIFMapResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GIFMapResponse.java
@@ -4,8 +4,10 @@
  */
 package org.geoserver.wms.map;
 
-import java.awt.image.BufferedImage;
+import java.awt.Transparency;                                                   
+import java.awt.image.BufferedImage;                                            
 import java.awt.image.IndexColorModel;
+
 import java.awt.image.RenderedImage;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -78,6 +80,7 @@ public final class GIFMapResponse extends RenderedImageMapResponse {
     private static MapProducerCapabilities CAPABILITIES = new MapProducerCapabilities(true, false,
             true, true, MIME_TYPE);
 
+    
     /**
      * Default capabilities for GIF animated.
      * 
@@ -91,7 +94,7 @@ public final class GIFMapResponse extends RenderedImageMapResponse {
      * 
      * <p>
      * We should soon support multipage tiff.
-     */
+     */    
     private static MapProducerCapabilities CAPABILITIES_ANIM = new MapProducerCapabilities(true,
             true, true, true, MIME_TYPE);
 
@@ -196,8 +199,8 @@ public final class GIFMapResponse extends RenderedImageMapResponse {
                 if (ri != null) {
                     // prepare metadata and write param
                     final IIOMetadata imageMetadata = gifWriter.getDefaultImageMetadata(
-                            new ImageTypeSpecifier(ri), param);
-                    prepareMetadata(imageMetadata, loopContinuosly, delay);
+                    	new ImageTypeSpecifier(ri), param);
+                    prepareMetadata(ri, imageMetadata, loopContinuosly, delay);
 
                     // write
                     gifWriter.writeToSequence(new IIOImage(ri, null, imageMetadata), param);
@@ -252,6 +255,7 @@ public final class GIFMapResponse extends RenderedImageMapResponse {
      * Prepare imagemetadata for writing an animated GIF.
      * <p>
      * This process involves setting the continuos looping mode as well the delay between frames
+     * @param ri The {@link RenderedImage} for which we are setting metadata.
      * 
      * @param imageMetadata original {@link IIOMetadata} instance to modify.
      * @param loopContinuously <code>yes</code> in case we want to loop continuosly,
@@ -259,21 +263,29 @@ public final class GIFMapResponse extends RenderedImageMapResponse {
      * @param timeBetweenFramesMS the delay in ms between two frames when looping.
      * @throws IOException in case an error occurs.
      */
-    private void prepareMetadata(IIOMetadata imageMetadata, boolean loopContinuously,
+    private static void prepareMetadata(RenderedImage ri, IIOMetadata imageMetadata, boolean loopContinuously,
             int timeBetweenFramesMS) throws IOException {
 
         String metaFormatName = imageMetadata.getNativeMetadataFormatName();
 
         IIOMetadataNode root = (IIOMetadataNode) imageMetadata.getAsTree(metaFormatName);
-
         IIOMetadataNode graphicsControlExtensionNode = getNode(root, "GraphicControlExtension");
-
         graphicsControlExtensionNode.setAttribute("disposalMethod", "none");
         graphicsControlExtensionNode.setAttribute("userInputFlag", "FALSE");
-        graphicsControlExtensionNode.setAttribute("transparentColorFlag", "FALSE");
-        graphicsControlExtensionNode.setAttribute("delayTime", Integer
-                .toString(timeBetweenFramesMS / 10));
-        graphicsControlExtensionNode.setAttribute("transparentColorIndex", "0");
+        graphicsControlExtensionNode.setAttribute("delayTime", Integer.toString(timeBetweenFramesMS / 10));
+        
+        
+        // transparency support
+        final IndexColorModel icm= (IndexColorModel) ri.getColorModel();
+        int transparentColorIndex=-1;
+        
+        if(icm.getTransparency()==Transparency.BITMASK&&(transparentColorIndex=icm.getTransparentPixel())>=0){
+            graphicsControlExtensionNode.setAttribute("transparentColorIndex", String.valueOf(transparentColorIndex));
+            graphicsControlExtensionNode.setAttribute("transparentColorFlag", "TRUE");              
+        } else {
+            graphicsControlExtensionNode.setAttribute("transparentColorIndex", "0");
+            graphicsControlExtensionNode.setAttribute("transparentColorFlag", "FALSE");              
+        }
 
         IIOMetadataNode commentsNode = getNode(root, "CommentExtensions");
         commentsNode.setAttribute("CommentExtension", "Created by MAH");
@@ -285,8 +297,8 @@ public final class GIFMapResponse extends RenderedImageMapResponse {
         child.setAttribute("authenticationCode", "2.0");
 
         int loop = loopContinuously ? 0 : 1;
-
-        child.setUserObject(new byte[] { 0x1, (byte) (loop & 0xFF), (byte) ((loop >> 8) & 0xFF) });
+        final byte[] userObject=new byte[] { 0x1, (byte) (loop & 0xFF), (byte) ((loop >> 8) & 0xFF) };
+        child.setUserObject(userObject);
         appEntensionsNode.appendChild(child);
 
         imageMetadata.setFromTree(metaFormatName, root);

--- a/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapResponse.java
@@ -154,8 +154,10 @@ public abstract class RenderedImageMapResponse extends AbstractMapResponse {
                 || !supportsTranslucency
                 || (method == null && image.getColorModel().getTransparency() != Transparency.TRANSLUCENT);
 
+
+        // format: split on ';' to handle subtypes like 'image/gif;subtype=animated'
+        final String format = request.getFormat().split(";")[0];
         // do we have to use the bitmask quantizer?
-        final String format = request.getFormat();
         IndexColorModel icm = mapContent.getPalette();
         if (useBitmaskQuantizer) {
             // user provided palette?

--- a/src/wms/src/test/java/org/geoserver/wms/WMSTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSTestSupport.java
@@ -471,6 +471,17 @@ public abstract class WMSTestSupport extends GeoServerSystemTestSupport {
 
         assertEquals(color, actual);
     }
+    
+    /**
+     * Checks the pixel i/j is fully transparent
+     * @param image
+     * @param i
+     * @param j
+     */
+    protected void assertPixelIsTransparent(BufferedImage image, int i, int j) {
+  	    int pixel = image.getRGB(i,j);
+        assertEquals(true, (pixel>>24) == 0x00);
+    }
 
     /**
      * Gets a specific pixel color from the specified buffered image

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorGetMapTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorGetMapTest.java
@@ -5,9 +5,15 @@
 package org.geoserver.wms.wms_1_1_1;
 
 import static org.junit.Assert.*;
+
 import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Transparency;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.IndexColorModel;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -235,6 +241,101 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
         assertEquals(3, reader.getNumImages(true));
     }
 
+    @Test
+    public void testTimeListAnimatedNonTransparent() throws Exception {
+        // testing NON transparency in animated gif, with RED bgcolor
+        setupVectorDimension(ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        MockHttpServletResponse response = getAsServletResponse("wms?service=WMS&version=1.1.1&request=GetMap"
+                + "&bbox=-180,-90,180,90&styles=&Format=image/png&width=80&height=40&srs=EPSG:4326"
+                + "&layers=" + getLayerId(V_TIME_ELEVATION)
+                + "&time=2011-05-02,2011-05-04,2011-05-10&format=" + GIFMapResponse.IMAGE_GIF_SUBTYPE_ANIMATED 
+                + "&TRANSPARENT=false&BGCOLOR=0xff0000");
+
+        // check we did not get a service exception
+        assertEquals("image/gif", response.getContentType());
+        
+        // check it is a animated gif with three frames
+        ByteArrayInputStream bis = getBinaryInputStream(response);
+        ImageInputStream iis = ImageIO.createImageInputStream(bis);
+        ImageReader reader = ImageIO.getImageReadersBySuffix("gif").next();
+        reader.setInput(iis);
+        assertEquals(3, reader.getNumImages(true));
+        
+        // creating film strip to be able to test different frames of animated gif
+        // http://stackoverflow.com/questions/18908217/losing-transparency-when-using-imageinputstream-and-bufferedimage-to-create-png
+        int h = reader.getHeight(0);
+        int w = reader.getWidth(0);
+        int n = reader.getNumImages(true);
+        BufferedImage image = new BufferedImage(w * n, h, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();       
+        for (int i = 0; i < n; i++) {
+            BufferedImage img = reader.read(i);
+            g.drawImage(img, w * i, 0, null);     
+            // want to see the individual frame images and the filmstrip? uncomment below
+            //File outputfile = new File("/tmp/geoserveranimatednontransparentframe"+i+".gif");
+            //ImageIO.write(img, "gif", outputfile);
+        }
+        //File outputfile = new File("/tmp/geoserveranimatedstripnontransparent.gif");
+        //ImageIO.write(image, "gif", outputfile);
+        
+        // actual check for NON transparency and colored background
+        assertPixel(image, 20, 10, Color.RED);
+        assertPixel(image, 60, 10, Color.BLACK);
+        assertPixel(image, 100, 10, Color.RED);
+        assertPixel(image, 140, 30, Color.BLACK);
+    }
+    
+    @Test
+    public void testTimeListAnimatedTransparent() throws Exception {
+    	// testing transparency in animated gif
+    	// note only by truly visual test you can test if animated gif is truly transparent
+    	// note that in this test BGCOLOR should be white, else ALL is transparent
+    	// note by uncommenting lines below you can see actual output
+        setupVectorDimension(ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        MockHttpServletResponse response = getAsServletResponse("wms?service=WMS&version=1.1.1&request=GetMap"
+                + "&bbox=-180,-90,180,90&styles=&Format=image/png&width=80&height=40&srs=EPSG:4326"
+                + "&layers=" + getLayerId(V_TIME_ELEVATION)
+                + "&time=2011-05-02,2011-05-04,2011-05-10&format=" + GIFMapResponse.IMAGE_GIF_SUBTYPE_ANIMATED 
+                + "&TRANSPARENT=true&BGCOLOR=0xfffff");
+
+        // check we did not get a service exception
+        assertEquals("image/gif", response.getContentType());
+        
+        // check it is a animated gif with three frames
+        ByteArrayInputStream bis = getBinaryInputStream(response);
+        ImageInputStream iis = ImageIO.createImageInputStream(bis);
+        ImageReader reader = ImageIO.getImageReadersBySuffix("gif").next();
+        reader.setInput(iis);
+        assertEquals(3, reader.getNumImages(true));
+        
+        // creating film strip to be able to test different frames of animated gif
+        // http://stackoverflow.com/questions/18908217/losing-transparency-when-using-imageinputstream-and-bufferedimage-to-create-png
+        int h = reader.getHeight(0);
+        int w = reader.getWidth(0);
+        int n = reader.getNumImages(true);
+        BufferedImage image = new BufferedImage(w * n, h, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();       
+        for (int i = 0; i < n; i++) {
+            BufferedImage img = reader.read(i);
+            g.drawImage(img, w * i, 0, null);     
+            // want to see the individual frame images and the filmstrip? uncomment below
+            //File outputfile = new File("/tmp/geoserveranimatedtransparentframe"+i+".gif");
+           //ImageIO.write(img, "gif", outputfile);
+        }
+        //File outputfile = new File("/tmp/geoserveranimatedstriptransparent.gif");
+        //ImageIO.write(image, "gif", outputfile);
+               
+        ColorModel cm = image.getColorModel();
+        assertTrue(cm.hasAlpha());
+        assertEquals(3, cm.getNumColorComponents()); 
+        
+        // actual check for transparency and color
+        assertPixelIsTransparent(image, 20, 10);
+        assertPixel(image, 60, 10, Color.BLACK);
+        assertPixelIsTransparent(image, 100, 10);
+        assertPixel(image, 140, 30, Color.BLACK);
+    }
+    
     @Test
     public void testTimeInterval() throws Exception {
         // adding a extra elevation that is simply not there, should not break


### PR DESCRIPTION
this is actually the patch from Simone Giannecchini, with one little
fix in RenderedImageMapResponse to make it work (again).
see: https://jira.codehaus.org/browse/GEOS-4834
