### PR TITLE
[GEOS-6579] Wrong kvp parser for interpolation for WCS version 1.0.0 (2.5.x)

### DIFF
--- a/src/wcs1_0/src/main/java/applicationContext.xml
+++ b/src/wcs1_0/src/main/java/applicationContext.xml
@@ -60,7 +60,10 @@
 
   <bean id="wcs100BBoxKvpParser" class="org.geoserver.wcs.kvp.BBoxKvpParser" />
   
-  <bean id="wcs100InterpolationKvpParser" class="org.geoserver.wcs.kvp.InterpolationMethodKvpParser" />
+  <bean id="wcs100InterpolationKvpParser" class="org.geoserver.wcs.kvp.InterpolationMethodKvpParser" >
+      <property name="service" value="WCS" />
+      <property name="version" value="1.0.0" />
+   </bean>
 
 
 

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/InterpolationMethodKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/InterpolationMethodKvpParser.java
@@ -19,7 +19,7 @@ import org.vfny.geoserver.wcs.WcsException;
 public class InterpolationMethodKvpParser extends KvpParser {
 
     public InterpolationMethodKvpParser() {
-        super("interpolationMethod", InterpolationMethodType.class);
+        super("interpolation", InterpolationMethodType.class);
     }
 
     @Override

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
@@ -24,6 +24,7 @@ import net.opengis.gml.VectorType;
 import net.opengis.wcs10.AxisSubsetType;
 import net.opengis.wcs10.DomainSubsetType;
 import net.opengis.wcs10.GetCoverageType;
+import net.opengis.wcs10.InterpolationMethodType;
 import net.opengis.wcs10.IntervalType;
 import net.opengis.wcs10.OutputType;
 import net.opengis.wcs10.RangeSubsetType;
@@ -101,6 +102,11 @@ public class Wcs10GetCoverageRequestReader extends EMFKvpRequestReader {
                     WcsExceptionCode.InvalidParameterValue, "version");
         }
         getCoverage.setVersion(Wcs10GetCoverageRequestReader.VERSION);
+
+        // build interpolation
+        if (!getCoverage.isSetInterpolationMethod()) {
+            getCoverage.setInterpolationMethod(parseInterpolation(kvp));
+        }
 
         // build the domain subset
         getCoverage.setDomainSubset(parseDomainSubset(kvp));
@@ -489,4 +495,16 @@ public class Wcs10GetCoverageRequestReader extends EMFKvpRequestReader {
 
     }
 
+    /**
+     * Parses the interpolation parameter from the kvp. If nothing is present the default nearest neighbor is set.
+     * 
+     * @param kvp
+     * @return
+     */
+    private InterpolationMethodType parseInterpolation(Map kvp) {
+        if (kvp.containsKey("interpolation")) {
+            return (InterpolationMethodType) kvp.get("interpolation");
+        }
+        return InterpolationMethodType.NEAREST_NEIGHBOR_LITERAL;
+    }
 }

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/kvp/GetCoverageReaderTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/kvp/GetCoverageReaderTest.java
@@ -125,7 +125,7 @@ public class GetCoverageReaderTest extends WCSTestSupport {
         raw.put("CRS", "EPSG:4326");
         raw.put("width", "150");
         raw.put("height", "150");
-        raw.put("interpolationMethod", "nearest neighbor");
+        raw.put("interpolation", "nearest neighbor");
 
         GetCoverageType getCoverage = (GetCoverageType) reader.read(reader.createRequest(),parseKvp(raw), raw);
         assertEquals(layerId, getCoverage.getSourceCoverage());
@@ -141,7 +141,7 @@ public class GetCoverageReaderTest extends WCSTestSupport {
         raw.put("CRS", "EPSG:4326");
         raw.put("width", "150");
         raw.put("height", "150");
-        raw.put("interpolationMethod", "bilinear");
+        raw.put("interpolation", "bilinear");
 
         getCoverage = (GetCoverageType) reader.read(reader.createRequest(),parseKvp(raw), raw);
         assertEquals(layerId, getCoverage.getSourceCoverage());
@@ -157,7 +157,7 @@ public class GetCoverageReaderTest extends WCSTestSupport {
         raw.put("CRS", "EPSG:4326");
         raw.put("width", "150");
         raw.put("height", "150");
-        raw.put("interpolationMethod", "nearest");
+        raw.put("interpolation", "nearest");
 
         getCoverage = (GetCoverageType) reader.read(reader.createRequest(),parseKvp(raw), raw);
         assertEquals(layerId, getCoverage.getSourceCoverage());
@@ -174,11 +174,12 @@ public class GetCoverageReaderTest extends WCSTestSupport {
         raw.put("CRS", "EPSG:4326");
         raw.put("width", "150");
         raw.put("height", "150");
-        raw.put("interpolationMethod", "bicubic");
+        raw.put("interpolation", "bicubic");
 
         getCoverage = (GetCoverageType) reader.read(reader.createRequest(),parseKvp(raw), raw);
         assertEquals(layerId, getCoverage.getSourceCoverage());
         assertEquals("image/tiff", getCoverage.getOutput().getFormat().getValue());
+        assertEquals("bicubic", getCoverage.getInterpolationMethod().toString());
     }
 
     @Test

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/kvp/InterpolationParserTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/kvp/InterpolationParserTest.java
@@ -1,0 +1,35 @@
+/* Copyright (c) 2014 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.kvp;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.geoserver.ows.KvpParser;
+import org.geoserver.ows.util.KvpUtils;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+
+/**
+ * Simple test class to use for checking that the interpolation parser used by the version 1.0.0 is correct.
+ * 
+ * @author Nicola Lagomarsini geosolutions
+ * 
+ */
+public class InterpolationParserTest extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testParserForVersion() {
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+        KvpParser parser = KvpUtils.findParser("interpolation", "WCS", null, "1.0.0", parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), InterpolationMethodKvpParser.class);
+    }
+
+}

--- a/src/wcs2_0/src/main/java/applicationContext.xml
+++ b/src/wcs2_0/src/main/java/applicationContext.xml
@@ -89,7 +89,14 @@
   <bean id="wcs20scaleAxesKvpParser" class="org.geoserver.wcs2_0.kvp.ScaleAxesKvpParser" />
   <bean id="wcs20scaleSizeKvpParser" class="org.geoserver.wcs2_0.kvp.ScaleSizeKvpParser" />
   <bean id="wcs20scaleExtentKvpParser" class="org.geoserver.wcs2_0.kvp.ScaleExtentKvpParser" />
-  <bean id="wcs20interpolationKvpParser" class="org.geoserver.wcs2_0.kvp.InterpolationKvpParser" />
+  <bean id="wcs200interpolationKvpParser" class="org.geoserver.wcs2_0.kvp.InterpolationKvpParser" >
+      <property name="service" value="WCS" />
+      <property name="version" value="2.0.0" />
+   </bean>
+   <bean id="wcs201interpolationKvpParser" class="org.geoserver.wcs2_0.kvp.InterpolationKvpParser" >
+      <property name="service" value="WCS" />
+      <property name="version" value="2.0.1" />
+   </bean>
   <bean id="wcs20rangeSubsetKvpParser" class="org.geoserver.wcs2_0.kvp.RangeSubsetKvpParser">
     <property name="service" value="WCS" />
     <property name="version" value="2.0.0" />

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/InterpolationKvpParserTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/InterpolationKvpParserTest.java
@@ -1,14 +1,21 @@
 package org.geoserver.wcs2_0.kvp;
 
 import static org.junit.Assert.*;
+
+import java.util.List;
+
 import net.opengis.wcs20.InterpolationAxisType;
 import net.opengis.wcs20.InterpolationType;
 
 import org.eclipse.emf.common.util.EList;
+import org.geoserver.ows.KvpParser;
+import org.geoserver.ows.util.KvpUtils;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.OWS20Exception;
+import org.geoserver.test.GeoServerSystemTestSupport;
 import org.junit.Test;
 
-public class InterpolationKvpParserTest {
+public class InterpolationKvpParserTest extends GeoServerSystemTestSupport{
 
     InterpolationKvpParser parser = new InterpolationKvpParser();
     
@@ -72,6 +79,21 @@ public class InterpolationKvpParserTest {
         assertEquals("http://www.opengis.net/def/axis/OGC/1/longitude", axes.get(1).getAxis());
         assertEquals("http://www.opengis.net/def/interpolation/OGC/1/nearest", axes.get(1).getInterpolationMethod());
     }
-    
+
+    @Test
+    public void testParserForVersion() throws Exception {
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+        KvpParser parser = KvpUtils.findParser("interpolation", "WCS", null, "2.0.0", parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), InterpolationKvpParser.class);
+        // Version 2.0.1
+        parser = KvpUtils.findParser("interpolation", "WCS", null, "2.0.1", parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), InterpolationKvpParser.class);
+    }
+
 }
 


### PR DESCRIPTION
Backport on 2.5.x for JIRA: http://jira.codehaus.org/browse/GEOS-6579
