### PR TITLE
Allowing multiplexing password encoder to encode passwords.

### DIFF
--- a/src/main/src/test/java/org/geoserver/security/password/GeoServerMultiplexingPasswordEncoderTest.java
+++ b/src/main/src/test/java/org/geoserver/security/password/GeoServerMultiplexingPasswordEncoderTest.java
@@ -1,0 +1,22 @@
+package org.geoserver.security.password;
+
+import org.geoserver.test.GeoServerMockTestSupport;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class GeoServerMultiplexingPasswordEncoderTest
+    extends GeoServerMockTestSupport {
+
+    @Test
+    public void testEncode() {
+        GeoServerMultiplexingPasswordEncoder pwe =
+            new GeoServerMultiplexingPasswordEncoder(getSecurityManager());
+        try {
+            pwe.encodePassword("foo", null);
+        }
+        catch(Exception e) {
+            fail("Multiplexing encoder should be capabile of encoding");
+        }
+    }
+}


### PR DESCRIPTION
Rationale for this change was recently trying an upgrade to the latest stable spring (and spring security) releases. The newer version of spring security needs to encode a "dummy" password which fails (causing failure on startup and corruption of security configuration) because of the multiplexing encoder. 
