### PR TITLE
[GEOS-6379] Unable to add new default gridsets (Backport on 2.5.x)

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/DefaultGridsetsEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/DefaultGridsetsEditor.java
@@ -158,7 +158,8 @@ class DefaultGridsetsEditor extends FormComponentPanel<Set<String>> {
 
                 List<String> selectedIds = selection.getObject();
                 selectedIds.add(selectedGridset);
-
+                // Execute setPageable() in order to re-create the inner record list updated.
+                defaultGridsetsTable.setPageable(false);
                 target.addComponent(defaultGridsetsTable);
                 target.addComponent(availableGridSets);
             }


### PR DESCRIPTION
Backport on the 2.5.x of the fix for JIRA: https://jira.codehaus.org/browse/GEOS-6379.
