### PR TITLE
[GEOS-6468] (2.6.x) Make GWCLifeCycleHandler behave correctly on application shutdown.

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -553,13 +553,20 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         }
     }
 
+    public static void tryReload() {
+        GWC instance = GWC.INSTANCE;
+        if (instance != null) {
+            instance.reload();
+        }
+    }
+
     /**
      * Reloads the configuration and notifies GWC of any externally removed layer.
      * @throws IOException 
      * @throws ConfigurationException 
      * @throws InterruptedException 
      */
-    public void reload() {
+    void reload() {
         final Set<String> currLayerNames = new HashSet<String>(getTileLayerNames());
         try {
             tld.reInit();
@@ -1976,12 +1983,18 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     public static String tileLayerName(LayerGroupInfo lgi) {
         return lgi.prefixedName();
     }
-    
+
+    public static void tryReset() {
+        GWC instance = GWC.INSTANCE;
+        if (instance != null) {
+            GWC.INSTANCE.reset();
+        }
+    }
 
     /**
      * Flush caches
      */
-    public void reset() {
+    void reset() {
         CatalogConfiguration c = GeoServerExtensions.bean(CatalogConfiguration.class);
         if (c != null) {
             c.reset();

--- a/src/gwc/src/main/java/org/geoserver/gwc/config/GWCLifeCycleHandler.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/config/GWCLifeCycleHandler.java
@@ -4,30 +4,16 @@
  */
 package org.geoserver.gwc.config;
 
-import java.util.logging.Logger;
-
 import org.geoserver.config.impl.GeoServerLifecycleHandler;
 import org.geoserver.gwc.GWC;
-import org.geotools.util.logging.Logging;
-import org.springframework.beans.factory.InitializingBean;
 
 /**
  * GeoServer life cycle listener that reloads the gwc configuration
- * <p>
- * Note: this class implements {@link InitializingBean} to force spring to create it once its
- * {@link GWC} dependency is ready. Otherwise it may not be created until the application is in the
- * process of shutting down, which causes an exception as the GWC instance cannot be provided by
- * then (see GEOS-6468).
  */
-public class GWCLifeCycleHandler implements GeoServerLifecycleHandler, InitializingBean {
+public class GWCLifeCycleHandler implements GeoServerLifecycleHandler {
 
-    private static final Logger LOGGER = Logging.getLogger(GWCLifeCycleHandler.class);
-
-    private final GWC mediator;
-
-    public GWCLifeCycleHandler(GWC mediator) {
-        this.mediator = mediator;
-        LOGGER.fine("GWC life cycle handler created.");
+    public GWCLifeCycleHandler() {
+        // nothing to do
     }
 
     public void beforeReload() {
@@ -36,22 +22,16 @@ public class GWCLifeCycleHandler implements GeoServerLifecycleHandler, Initializ
 
     @Override
     public void onReload() {
-        mediator.reload();
+        GWC.tryReload();
     }
 
     @Override
     public void onReset() {
-        mediator.reset();
+        GWC.tryReset();
     }
 
     @Override
     public void onDispose() {
         onReset();
     }
-
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        // Do nothing, just forcing the bean to be created
-    }
-
 }

--- a/src/gwc/src/main/resources/applicationContext.xml
+++ b/src/gwc/src/main/resources/applicationContext.xml
@@ -12,7 +12,6 @@
 
   <bean id="GWCLifeCycleHandler" class="org.geoserver.gwc.config.GWCLifeCycleHandler">
     <description>Reloads the GWC config when GeoServer is called for a reload</description>
-    <constructor-arg ref="gwcFacade" />
   </bean>
   
   <bean id="gwcJdbcConfigurationStorage" class="org.geoserver.gwc.JDBCConfigurationStorage">


### PR DESCRIPTION
GWCLifeCycleHandler is created dynamically when GeoServer requires
it by looking for beans implementing the GeoServerLifecycleHandler
extension point. It used to require a handle to the GWC mediator,
which is fine when the application is running and GeoServer is required
to either reload the configuration or reset its caches, but fails
at application shutdown since the GWC mediator has already been
disposed and can't be re-created at that stage. The collateral damage
is that this failure to instantiate GWCLifeCycleHandler prevents
GeoServer from calling onDispose() in the other extension point
implementations.

This patch makes it so that onReset() and onReload() call a static
tryReset() and tryReload() method in GWC accordingly, which in turn
will perform the required action as long as the GWC mediator instance
is 'alive'. If it's not, it means that it's own destroy() method has
already been called and hence there's no need for GWC.reset()/reload()
to run at all.
