### PR TITLE
Fix failing RestConfig StyleTest due to file locking issues on Windows

### DIFF
--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/StyleTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/StyleTest.java
@@ -490,7 +490,7 @@ public class StyleTest extends CatalogRESTTestSupport {
         in = style.in();
         try {
             out = new StringWriter();
-            IOUtils.copy(style.in(), out);
+            IOUtils.copy(in, out);
             assertFalse(out.toString().startsWith("#comment!"));
         }
         finally {
@@ -518,7 +518,7 @@ public class StyleTest extends CatalogRESTTestSupport {
         InputStream in = style.in();
         try {
             out = new StringWriter();
-            IOUtils.copy(style.in(), out);
+            IOUtils.copy(in, out);
             assertTrue(out.toString().startsWith("#comment!"));
         }
         finally {
@@ -563,7 +563,7 @@ public class StyleTest extends CatalogRESTTestSupport {
         in = style.in();
         try {
             out = new StringWriter();
-            IOUtils.copy(style.in(), out);
+            IOUtils.copy(in, out);
             assertFalse(out.toString().startsWith("#comment!"));
         }
         finally {
@@ -600,7 +600,7 @@ public class StyleTest extends CatalogRESTTestSupport {
         in = style.in();
         try {
             out = new StringWriter();
-            IOUtils.copy(style.in(), out);
+            IOUtils.copy(in, out);
             assertTrue(out.toString().startsWith("#comment!"));
         }
         finally {


### PR DESCRIPTION
4 RestConfig StyleTests fail due to file locking issues because an extra/duplicate input stream is opened and not closed.  This fixes ISSUE GEOS-6663.
