### PR TITLE
OWS FilePublisherTest fails on Windows due to file encoding issues

### DIFF
--- a/src/ows/src/test/java/org/geoserver/ows/FilePublisherTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/FilePublisherTest.java
@@ -56,7 +56,7 @@ public class FilePublisherTest {
         File file = new File(parent, fname);
         file.deleteOnExit();
         FileOutputStream fout = new FileOutputStream(file);
-        fout.write(fname.getBytes());
+        fout.write(fname.getBytes("UTF-8"));
         fout.close();
         return path;
     }


### PR DESCRIPTION
On Windows, we need to specify UTF-8.  This solves issue GEOS-6664.

Thanks!
Jared
