### PR TITLE
GEOS-6668: Fix WMS 1.1.1 CITE failure.

### DIFF
--- a/src/wms/src/main/resources/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd
+++ b/src/wms/src/main/resources/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd
@@ -189,7 +189,9 @@ in units of the specified spatial reference system. -->
 <!ATTLIST Extent
           name CDATA #REQUIRED
           default CDATA #IMPLIED
-          nearestValue (0 | 1) "0">
+          nearestValue (0 | 1) "0"
+          multipleValues (0 | 1) "0"
+          current (0 | 1) "0">
 
 <!-- Attribution indicates the provider of a Layer or collection of Layers.
 The provider's URL, descriptive title string, and/or logo image URL may be

--- a/src/wms/src/test/resources/geoserver/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd
+++ b/src/wms/src/test/resources/geoserver/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd
@@ -189,7 +189,9 @@ in units of the specified spatial reference system. -->
 <!ATTLIST Extent
           name CDATA #REQUIRED
           default CDATA #IMPLIED
-          nearestValue (0 | 1) "0">
+          nearestValue (0 | 1) "0"
+          multipleValues (0 | 1) "0"
+          current (0 | 1) "0">
 
 <!-- Attribution indicates the provider of a Layer or collection of Layers.
 The provider's URL, descriptive title string, and/or logo image URL may be


### PR DESCRIPTION
This modifies the DTD to match the new CITE requirements (per CITE-866).

An alternative implementation would be to get the http://schemas.opengis.net/wms/1.1.1/capabilities_1_1_1.dtd
version and copy that in, instead of modifying the existing file. Slightly different implementation, same effect.
