### PR TITLE
GEOS-6668: Fix WMS 1.1.1 CITE failure.

### DIFF
--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/InputLimitsTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/InputLimitsTest.java
@@ -16,7 +16,7 @@ import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
-import org.geoserver.data.test.MockTestData;
+import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wps.validator.MaxSizeValidator;
 import org.geoserver.wps.validator.MultiplicityValidator;
@@ -46,6 +46,8 @@ public class InputLimitsTest extends WPSTestSupport {
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         super.onSetUp(testData);
+
+        addWcs11Coverages(testData);
 
         // add some limits to the processes
         WPSInfo wps = getGeoServer().getService(WPSInfo.class);
@@ -420,7 +422,7 @@ public class InputLimitsTest extends WPSTestSupport {
                 + "        <wps:Body>\n"
                 + "          <wcs:GetCoverage service=\"WCS\" version=\"1.1.1\">\n"
                 + "            <ows:Identifier>"
-                + getLayerId(MockTestData.TASMANIA_DEM)
+                + getLayerId(MockData.TASMANIA_DEM)
                 + "</ows:Identifier>\n"
                 + "            <wcs:DomainSubset>\n"
                 + "              <gml:BoundingBox crs=\"http://www.opengis.net/gml/srs/epsg.xml#4326\">\n"
@@ -491,7 +493,7 @@ public class InputLimitsTest extends WPSTestSupport {
                 + "        <wps:Body>\n"
                 + "          <wcs:GetCoverage service=\"WCS\" version=\"1.1.1\">\n"
                 + "            <ows:Identifier>"
-                + getLayerId(MockTestData.TASMANIA_DEM)
+                + getLayerId(MockData.TASMANIA_DEM)
                 + "</ows:Identifier>\n"
                 + "            <wcs:DomainSubset>\n"
                 + "              <gml:BoundingBox crs=\"http://www.opengis.net/gml/srs/epsg.xml#4326\">\n"

--- a/src/wms/src/test/java/org/geoserver/wms/dimension/RasterTimeDimensionDefaultValueTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/dimension/RasterTimeDimensionDefaultValueTest.java
@@ -142,7 +142,10 @@ public class RasterTimeDimensionDefaultValueTest extends WMSTestSupport {
         cal.set(Calendar.MINUTE, cal.getActualMinimum(Calendar.MINUTE));
         cal.set(Calendar.SECOND, cal.getActualMinimum(Calendar.SECOND));
         cal.set(Calendar.MILLISECOND, cal.getActualMinimum(Calendar.MILLISECOND));
-
+        // This is what the test data setup does, and it makes a difference at the
+        // end of the month (e.g. 29 Jan)
+        cal.set(Calendar.MONTH, cal.get(Calendar.MONTH) + 1);
+        cal.set(Calendar.MONTH, cal.get(Calendar.MONTH) - 1);
         cal.set(Calendar.YEAR, cal.get(Calendar.YEAR) + 1);
         long oneYearInFuture = cal.getTimeInMillis();
 


### PR DESCRIPTION
This modifies the DTD to match the new CITE requirements (per CITE-866).

An alternative implementation would be to get the http://schemas.opengis.net/wms/1.1.1/capabilities_1_1_1.dtd
version and copy that in, instead of modifying the existing file. Slightly different implementation, same effect.