### PR TITLE
Corrected error in user manual

### DIFF
--- a/doc/en/user/source/services/wms/basics.rst
+++ b/doc/en/user/source/services/wms/basics.rst
@@ -51,6 +51,6 @@ For example, consider the WMS 1.1 request using the WGS84 SRS (EPSG:4326)::
 
 The equivalent WMS 1.3 request is::
 
-   geoserver/wms?VERSION=1.1.1&REQUEST=GetMap&CRS=epsg:4326&BBOX=-90,-180,90,180&...
+   geoserver/wms?VERSION=1.3.0&REQUEST=GetMap&CRS=epsg:4326&BBOX=-90,-180,90,180&...
 
 Note that the coordinates specified in the ``BBOX`` parameter are reversed.


### PR DESCRIPTION
Corrected error in user manual. WMS Basics section incorrectly specifies WMS version 1.1.1 instead of 1.3.0 in an example request. (Example shows different axis order between 1.1.1 and 1.3, but passes version 1.1.1
in both requests.)
