### PR TITLE
Update JDBCConfig documentation to warn of security risks

### DIFF
--- a/doc/en/user/source/community/jdbcconfig/configuration.rst
+++ b/doc/en/user/source/community/jdbcconfig/configuration.rst
@@ -14,7 +14,17 @@ The following properties may be set:
 
 - ``initScript``: Path to initialisation script .sql file. Only used if initdb = true.
 
+JNDI
+~~~~
+
+Get the database connection from the application server via JNDI lookup. 
+
 - ``jndiName``: The JNDI name for the data source. Only set this if you want to use JNDI, the JDBC configuration properties may still be set for in case the JNDI Lookup fails. 
+
+Direct JDBC Connection
+~~~~~~~~~~~~~~~~~~~~~~
+
+Provide the connection parameters directly in the configuration file. This includes the password in the clear which is a potential security risk.  To avoid this use JNDI instead.
 
 - ``jdbcUrl``: JDBC direct connection parameters. 
 

--- a/doc/en/user/source/community/jdbcconfig/installing.rst
+++ b/doc/en/user/source/community/jdbcconfig/installing.rst
@@ -13,7 +13,7 @@ To install the JDBCConfig module:
 
 #. Verify that the configuration directory was created to be sure installation worked then turn off GeoServer.
 
-#. Configure JDBCConfig (:ref:'community_jdbcconfig_config'), being sure to set ``enabled``, ``initdb``, and ``import`` to ``true``, and to provide the connection information for an empty database.
+#. Configure JDBCConfig (:ref:`community_jdbcconfig_config`), being sure to set ``enabled``, ``initdb``, and ``import`` to ``true``, and to provide the connection information for an empty database.
 
 #. Start GeoServer again.  This time JDBCConfig will connect to the specified database, initialize it, import the old catalog into it, and take over from the old catalog. Subsequent start ups will skip the initialize and import steps unless you re-enable them in ``jdbcconfig.properties``.
 


### PR DESCRIPTION
The password in jdbcconfig.properties is unencrypted and using the password encryption mechanism that's normally used for datastores, etc doesn't work due to circular dependencies.   (The password is needed to get the configuration, but the configuration is needed to set up the key store needed to decrypt the password)

JNDI avoids this issue by offloading the problem of securing the password to the application server. Documenting that direct connection is provided as a convenience and has security implications which can be avoided with JNDI seems the best resolution.
