### PR TITLE
Handling multi part form upload to the dispatcher.

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/FakeHttpServletRequest.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/FakeHttpServletRequest.java
@@ -181,7 +181,7 @@ class FakeHttpServletRequest implements HttpServletRequest {
     }
 
     public String getContentType() {
-        throw new ServletDebugException();
+        return null;
     }
 
     public ServletInputStream getInputStream() throws IOException {

--- a/src/ows/pom.xml
+++ b/src/ows/pom.xml
@@ -28,6 +28,14 @@
    <artifactId>commons-lang</artifactId>
   </dependency>
   <dependency>
+   <groupId>commons-io</groupId>
+   <artifactId>commons-io</artifactId>
+  </dependency>
+  <dependency>
+   <groupId>commons-fileupload</groupId>
+   <artifactId>commons-fileupload</artifactId>
+  </dependency>
+  <dependency>
    <groupId>org.geoserver</groupId>
    <artifactId>gs-platform</artifactId>
   </dependency>
@@ -64,6 +72,11 @@
   <dependency>
    <groupId>xalan</groupId>
    <artifactId>xalan</artifactId>
+   <scope>test</scope>
+  </dependency>
+  <dependency>
+   <groupId>javax.mail</groupId>
+   <artifactId>mail</artifactId>
    <scope>test</scope>
   </dependency>
  </dependencies>

--- a/src/ows/src/main/java/org/geoserver/ows/Request.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Request.java
@@ -266,10 +266,28 @@ public class Request {
 
     /**
      * Allows callbacks to change the parsed KVP map
-     * @param kvp
+     * <p>
+     * Clients should consider calling {@link #setOrAppendKvp(java.util.Map)} to retain the
+     * existing kvp map.
+     * </p>
+     * @param kvp Parsed kvp values.
      */
     public void setKvp(Map kvp) {
         this.kvp = kvp;
+    }
+
+    /**
+     * Sets the parsed kvp map, appending/overwriting to any previously set values.
+     *
+     * @param kvp Parsed kvp values.
+     */
+    public void setOrAppendKvp(Map kvp) {
+        if (this.kvp == null) {
+            setKvp(kvp);
+        }
+        else {
+            this.kvp.putAll(kvp);
+        }
     }
 
     /**


### PR DESCRIPTION
This change allows the dispatcher to be invoked with a multipart form upload, in addition to a straight GET/POST and form encoded request. The idea is to allow for easier access from web applications that may need to load the request payload from a file form field in the browser. The change falls back to allow a field named "body" to be treated as the request payload. 

This change could also replace the "TestWfsPost" servlet that currently allows for the same functionality. 
