### PR TITLE
The Scripting app resource throws null pointer exception is main script isn't found

### DIFF
--- a/src/community/script/core/src/main/java/org/geoserver/script/rest/ScriptListResource.java
+++ b/src/community/script/core/src/main/java/org/geoserver/script/rest/ScriptListResource.java
@@ -82,9 +82,11 @@ public class ScriptListResource extends ReflectiveResource {
             for (File f : dir.listFiles(filter)) {
                 if (path.equals("apps")) {
                     File mainScript = scriptMgr.findAppMainScript(f);
-                    String name = mainScript.getAbsolutePath().substring(
-                            f.getParentFile().getAbsolutePath().length() + 1).replace("\\", "/");
-                    scripts.add(new Script(name));
+                    if (mainScript != null) {
+                        String name = mainScript.getAbsolutePath().substring(
+                                f.getParentFile().getAbsolutePath().length() + 1).replace("\\", "/");
+                        scripts.add(new Script(name));
+                    }
                 } else if (path.equals("wps")) {
                     if (f.isDirectory()) {
                         String namespace = f.getName();


### PR DESCRIPTION
Check to make sure that the main script file is not null before proceeding.  Fixes issue GEOS-6676.

Thanks!
Jared
