### PR TITLE
[GEOS-6679]: WCS20 GetCoverage multipart does encoding 2 times

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCoverageMultipartResponse.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCoverageMultipartResponse.java
@@ -134,9 +134,6 @@ public class WCS20GetCoverageMultipartResponse extends Response {
         } catch (MessagingException e) {
             throw new WcsException("Error occurred while encoding the mime multipart response", e);
         }
-        
-        
-        delegate.encode(coverage, format, encodingParameters, output);
     }
 
     @Override


### PR DESCRIPTION
[GEOS-6679]: WCS20 GetCoverage multipart does encoding 2 times
