### PR TITLE
Render LinearRings in WPS WKT output as LineStrings

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/WKTPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/WKTPPIO.java
@@ -14,6 +14,7 @@ import java.io.StringReader;
 import java.io.Writer;
 
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.io.WKTReader;
 import com.vividsolutions.jts.io.WKTWriter;
 
@@ -42,7 +43,11 @@ public class WKTPPIO extends CDataPPIO {
     public void encode(Object value, OutputStream os) throws IOException {
         Writer w = new OutputStreamWriter(os);
         try {
-            new WKTWriter().write((Geometry) value, w);
+            Geometry g = (Geometry) value;
+            if (g instanceof LinearRing) {
+                g = g.getFactory().createLineString(((LinearRing)g).getCoordinateSequence());
+            }
+            new WKTWriter().write(g, w);
         } finally {
             w.flush();
         }

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/jts/GeometryProcessWPSTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/jts/GeometryProcessWPSTest.java
@@ -13,6 +13,8 @@ import org.w3c.dom.Document;
 
 import com.mockrunner.mock.web.MockHttpServletResponse;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.io.WKTReader;
 
@@ -84,6 +86,14 @@ public class GeometryProcessWPSTest extends WPSTestSupport {
           assertEquals("application/wkt", response.getContentType());
           Geometry g = new WKTReader().read(response.getOutputStreamContent());
           assertTrue(g instanceof Polygon);
-
 	}
+
+    @Test
+    public void testLinearRingHandling() throws Exception {
+        String xml = "<p0:Execute xmlns:p0=\"http://www.opengis.net/wps/1.0.0\" service=\"WPS\" version=\"1.0.0\"><p1:Identifier xmlns:p1=\"http://www.opengis.net/ows/1.1\">geo:boundary</p1:Identifier><p0:DataInputs><p0:Input><p1:Identifier xmlns:p1=\"http://www.opengis.net/ows/1.1\">geom</p1:Identifier><p0:Data><p0:ComplexData mimeType=\"application/wkt\">POLYGON((-7748880.179438027 939258.2035682453,-704443.6526761837 1956787.9241005117,-626172.1357121635 -4070118.8821290648,-8375052.315150191 -4539747.983913188,-7748880.179438027 939258.2035682453))</p0:ComplexData></p0:Data></p0:Input></p0:DataInputs><p0:ResponseForm><p0:RawDataOutput mimeType=\"application/wkt\"><p1:Identifier xmlns:p1=\"http://www.opengis.net/ows/1.1\">result</p1:Identifier></p0:RawDataOutput></p0:ResponseForm></p0:Execute>";
+        MockHttpServletResponse response = postAsServletResponse("wps", xml);
+        Geometry g = new WKTReader().read(response.getOutputStreamContent());
+        assertTrue(g instanceof LineString); // will actually produce a LinearRing.
+        assertFalse(g instanceof LinearRing); // got to explicitly check since LineString is a supertype of LinearRing
+    }
 }


### PR DESCRIPTION
The JTS library defines a LinearRing geometry type; however, this
geometry type is not defined in WKT.  As noted in the API documentation
for JTS' WKTWRiter:

> A non-standard LINEARRING tag is used for LinearRings. The SFS WKT spec
> does not define a special tag for LinearRings. Under it, rings are
> output using LINESTRING.

In my use case OpenLayers does not account for this nonstandard encoding
and I believe the best fix is for GeoServer to ensure standard compliant
output.
