### PR TITLE
Rework of patch GEOS-6655: Add text/xml MIME-types to WMS

### DIFF
--- a/src/wms/src/main/java/applicationContext.xml
+++ b/src/wms/src/main/java/applicationContext.xml
@@ -72,8 +72,16 @@
     <bean id="wmsGetFeatureInfoGML2" class="org.geoserver.wms.featureinfo.GML2FeatureInfoOutputFormat">
       <constructor-arg ref="wms" />
     </bean>
+
+    <bean id="wmsGetFeatureInfoXML2" class="org.geoserver.wms.featureinfo.XML2FeatureInfoOutputFormat">
+      <constructor-arg ref="wms" />
+    </bean>
     
     <bean id="wmsGetFeatureInfoGML3" class="org.geoserver.wms.featureinfo.GML3FeatureInfoOutputFormat">
+      <constructor-arg ref="wms" />
+    </bean>
+
+    <bean id="wmsGetFeatureInfoXML311" class="org.geoserver.wms.featureinfo.XML311FeatureInfoOutputFormat">
       <constructor-arg ref="wms" />
     </bean>
     

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/GML2FeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/GML2FeatureInfoOutputFormat.java
@@ -44,7 +44,7 @@ public class GML2FeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
     /**
      * The MIME type of the format this response produces: <code>"application/vnd.ogc.gml"</code>
      */
-    private static final String FORMAT = "application/vnd.ogc.gml";
+    public static final String FORMAT = "application/vnd.ogc.gml";
 
     private WMS wms;
 
@@ -53,6 +53,11 @@ public class GML2FeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
      */
     public GML2FeatureInfoOutputFormat(final WMS wms) {
         super(FORMAT);
+        this.wms = wms;
+    }
+
+    protected GML2FeatureInfoOutputFormat(WMS wms, String format) {
+        super(format);
         this.wms = wms;
     }
 

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/XML2FeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/XML2FeatureInfoOutputFormat.java
@@ -1,0 +1,36 @@
+/* Copyright (c) 2014 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.featureinfo;
+
+import org.geoserver.wms.WMS;
+
+/**
+ * A GetFeatureInfo response handler specialized in producing GML 2 data for a GetFeatureInfo request.
+ *
+ * <p>
+ *     This class is an alternative to <code>GML2FeatureInfoOutputFormat</code>.
+ * </p>
+ *
+ * @see GML3FeatureInfoOutputFormat
+ * @author Alex van den Hoogen (Geodan)
+ */
+public class XML2FeatureInfoOutputFormat extends GML2FeatureInfoOutputFormat {
+
+    /**
+     * The MIME type of the format this response produces: <code>"text/xml"</code>. This is
+     * an alternative format for GML2: <code>"application/vnd.ogc.gml"</code>.
+     */
+    public static final String FORMAT = "text/xml";
+
+    /**
+     * Default constructor, sets up the supported output format String.
+     *
+     * @param wms WMS to use.
+     */
+    public XML2FeatureInfoOutputFormat(WMS wms) {
+        super(wms, FORMAT);
+    }
+
+}

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/XML311FeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/XML311FeatureInfoOutputFormat.java
@@ -1,0 +1,36 @@
+/* Copyright (c) 2014 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.featureinfo;
+
+import org.geoserver.wms.WMS;
+
+/**
+ * A GetFeatureInfo response handler specialized in producing GML 3.1.1 data for a GetFeatureInfo request.
+ *
+ * <p>
+ *     This class is an alternative to <code>GML3FeatureInfoOutputFormat</code>.
+ * </p>
+ *
+ * @see GML3FeatureInfoOutputFormat
+ * @author Alex van den Hoogen (Geodan)
+ */
+public class XML311FeatureInfoOutputFormat extends GML3FeatureInfoOutputFormat {
+
+    /**
+     * The MIME type of the format this response produces: <code>"text/xml; subtype=gml/3.1.1"</code>. This is
+     * an alternative format for GML3: <code>"application/vnd.ogc.gml/3.1.1"</code>.
+     */
+    public static final String FORMAT = "text/xml; subtype=gml/3.1.1";
+
+    /**
+     * Default constructor, sets up the supported output format String.
+     *
+     * @param wms WMS to use.
+     */
+    public XML311FeatureInfoOutputFormat(WMS wms) {
+        super(wms, FORMAT);
+    }
+
+}

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -33,9 +33,7 @@ import org.geoserver.test.RemoteOWSTestSupport;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSTestSupport;
-import org.geoserver.wms.featureinfo.GML3FeatureInfoOutputFormat;
-import org.geoserver.wms.featureinfo.GetFeatureInfoOutputFormat;
-import org.geoserver.wms.featureinfo.TextFeatureInfoOutputFormat;
+import org.geoserver.wms.featureinfo.*;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope3D;
@@ -181,18 +179,54 @@ public class GetFeatureInfoTest extends WMSTestSupport {
 	/**
      * Tests GML output does not break when asking for an area that has no data with
      * GML feature bounding enabled
-     * 
-     * @throws Exception
+     *
+     * @param contentType Content-type (MIME-type) to test on.
+     * @throws Exception When an XPath Exception occurs.
      */
-    @Test 
-    public void testGMLNoData() throws Exception {
+    private void testGMLNoData(String contentType) throws Exception {
         String layer = getLayerId(MockData.PONDS);
         String request = "wms?version=1.1.1&bbox=-0.002,-0.002,0.002,0.002&styles=&format=jpeg" +
-                "&info_format=application/vnd.ogc.gml&request=GetFeatureInfo&layers="
+                "&info_format=" + contentType +"&request=GetFeatureInfo&layers="
                 + layer + "&query_layers=" + layer + "&width=20&height=20&x=20&y=20";
         Document dom = getAsDOM(request);
         XMLAssert.assertXpathEvaluatesTo("1", "count(//wfs:FeatureCollection)", dom);
         XMLAssert.assertXpathEvaluatesTo("0", "count(//gml:featureMember)", dom);
+    }
+
+    /**
+     * Tests GML output does not break when asking for an area that has no data with
+     * GML feature bounding enabled. This method tests GML 2 with Content-Type:
+     * <code>application/vnd.ogc.gml</code>.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGMLNoData() throws Exception {
+        this.testGMLNoData(GML2FeatureInfoOutputFormat.FORMAT);
+    }
+
+    /**
+     * Tests GML output does not break when asking for an area that has no data with
+     * GML feature bounding enabled. This method tests GML 2 with Content-Type:
+     * <code>text/xml</code>.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testXMLNoData() throws Exception {
+        this.testGMLNoData(XML2FeatureInfoOutputFormat.FORMAT);
+    }
+
+    /**
+     * Tests GML output does not break when asking for an area that has no data with
+     * GML feature bounding enabled. This method tests GML 3.1.1 with Content-Type:
+     * <code>text/xml; subtype=gml/3.1.1</code>.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testXML311NoData() throws Exception {
+        this.testGMLNoData(XML311FeatureInfoOutputFormat.FORMAT);
     }
     
     /**

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetFeatureInfoIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetFeatureInfoIntegrationTest.java
@@ -30,10 +30,7 @@ import org.geoserver.data.test.SystemTestData.LayerProperty;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSTestSupport;
-import org.geoserver.wms.featureinfo.GML3FeatureInfoOutputFormat;
-import org.geoserver.wms.featureinfo.GetFeatureInfoKvpReader;
-import org.geoserver.wms.featureinfo.GetFeatureInfoOutputFormat;
-import org.geoserver.wms.featureinfo.TextFeatureInfoOutputFormat;
+import org.geoserver.wms.featureinfo.*;
 import org.geoserver.wms.wms_1_1_1.CapabilitiesTest;
 import org.geotools.util.logging.Logging;
 import org.junit.Test;
@@ -254,9 +251,14 @@ public class GetFeatureInfoIntegrationTest extends WMSTestSupport {
         request = "wms?version=1.3.0&bbox=-0.002,-0.002,0.002,0.002&styles=&format=jpeg&info_format="+GML3FeatureInfoOutputFormat.FORMAT+"&request=GetFeatureInfo&layers="
                 + layer + "&query_layers=" + layer + "&width=20&height=20&i=10&j=10";
         result = getAsString(request);
-        assertTrue(result.indexOf("Green Forest") > 0);        
+        assertTrue(result.indexOf("Green Forest") > 0);
 
-
+        // GML 3.1.1 as text/xml; subtype=gml/3.1.1
+        request = "wms?version=1.3.0&bbox=-0.002,-0.002,0.002,0.002&styles=&format=jpeg&info_format=" +
+                XML311FeatureInfoOutputFormat.FORMAT + "&request=GetFeatureInfo&layers=" + layer +
+                "&query_layers=" + layer + "&width=20&height=20&i=10&j=10";
+        result = getAsString(request);
+        assertTrue(result.indexOf("Green Forest") > 0);
     }
 
     


### PR DESCRIPTION
Rework of https://github.com/geoserver/geoserver/pull/763 -- pull request 763 will be closed. 

Original text:
This commit adds "text/xml" and "text/xml; subtype=gml/3.1.1" MIME-types
to WMS 1.1.1 and 1.3.0. These MIME-types are similar to the already
existing GML2 and GML3.1.1 MIME-types that are already present in
GeoServer.

The main reasons for adding those two MIME-types is 1) compatibility
with the OGC WMS standard, which defines that text/xml should be
expected on a textual output, and 2) supporting the Dutch national
profile for maps. Both documents are linked on JIRA.
