### PR TITLE
Allow StyleGenerator to create style inside of a workspace.

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/StyleGenerator.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/StyleGenerator.java
@@ -19,6 +19,7 @@ import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
 
@@ -60,6 +61,11 @@ public class StyleGenerator {
     private Catalog catalog;
 
     /**
+     * Workspace to create styles relative to
+     */
+    private WorkspaceInfo workspace;
+
+    /**
      * Builds a style generator with the default color ramp
      * @param catalog
      */
@@ -85,6 +91,10 @@ public class StyleGenerator {
 
         this.ramp = ramp;
         this.catalog = catalog;
+    }
+
+    public void setWorkspace(WorkspaceInfo workspace) {
+        this.workspace = workspace;
     }
 
     public StyleInfo createStyle(FeatureTypeInfo featureType) throws IOException {
@@ -120,7 +130,8 @@ public class StyleGenerator {
 
     StyleInfo doCreateStyle(StyleType styleType, ResourceInfo resource) throws IOException {
         // find a new style name
-        String styleName = findUniqueStyleName(resource);
+        String styleName = workspace != null ?
+            findUniqueStyleName(resource, workspace) : findUniqueStyleName(resource);
 
         // variable replacement
         String sld = loadSLDFromTemplate(styleType, ramp.next(), resource);
@@ -129,6 +140,10 @@ public class StyleGenerator {
         StyleInfo style = catalog.getFactory().createStyle();
         style.setName(styleName);
         style.setFilename(styleName + ".sld");
+        if (workspace != null) {
+            style.setWorkspace(workspace);
+        }
+
         catalog.getResourcePool().writeStyle(style, new ByteArrayInputStream(sld.getBytes()));
         
         //catalog.add(style);
@@ -136,6 +151,7 @@ public class StyleGenerator {
 
         return style;
     }
+
     String findUniqueStyleName(ResourceInfo resource) {
         String styleName = resource.getStore().getWorkspace().getName() + "_" + resource.getName();
         StyleInfo style = catalog.getStyleByName(styleName);
@@ -143,6 +159,18 @@ public class StyleGenerator {
         while(style != null) {
             styleName = resource.getStore().getWorkspace().getName() + "_" + resource.getName() + i;
             style = catalog.getStyleByName(styleName);
+            i++;
+        }
+        return styleName;
+    }
+
+    String findUniqueStyleName(ResourceInfo resource, WorkspaceInfo workspace) {
+        String styleName = resource.getName();
+        StyleInfo style = catalog.getStyleByName(workspace, styleName);
+        int i = 1;
+        while(style != null) {
+            styleName = resource.getName() + i;
+            style = catalog.getStyleByName(workspace, styleName);
             i++;
         }
         return styleName;

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/StyleGeneratorTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/StyleGeneratorTest.java
@@ -1,0 +1,48 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.importer;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.ResourcePool;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.CatalogFactoryImpl;
+import org.geotools.data.DataUtilities;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.classextension.EasyMock.createNiceMock;
+import static org.easymock.classextension.EasyMock.replay;
+import static org.junit.Assert.assertNotNull;
+
+public class StyleGeneratorTest {
+
+    @Test
+    public void testCreateInWorkspace() throws Exception {
+        ResourcePool rp = createNiceMock(ResourcePool.class);
+
+        Catalog cat = createNiceMock(Catalog.class);
+        expect(cat.getFactory()).andReturn(new CatalogFactoryImpl(null)).anyTimes();
+        expect(cat.getResourcePool()).andReturn(rp).anyTimes();
+
+        WorkspaceInfo ws = createNiceMock(WorkspaceInfo.class);
+
+        FeatureTypeInfo ft = createNiceMock(FeatureTypeInfo.class);
+        expect(ft.getName()).andReturn("foo").anyTimes();
+
+        replay(rp, ft, ws, cat);
+
+        StyleGenerator gen = new StyleGenerator(cat);
+        gen.setWorkspace(ws);
+
+        SimpleFeatureType schema = DataUtilities.createType("foo", "geom:Point");
+        StyleInfo style = gen.createStyle(ft, schema);
+        assertNotNull(style);
+        assertNotNull(style.getWorkspace());
+    }
+}


### PR DESCRIPTION
Adds option of creating styles local to a workspace. Doesn't change any current behaviour of the importer as that has backwards compatibility implications. But probably not a bad idea to have the importer set this at some point. 
