### PR TITLE
Avoid declaring XML namespace in WFS 1.1 capabilities

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/CapabilitiesTransformer.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/CapabilitiesTransformer.java
@@ -939,6 +939,7 @@ public abstract class CapabilitiesTransformer extends TransformerBase {
                 Enumeration prefixes = getNamespaceSupport().getPrefixes();
                 while (prefixes.hasMoreElements()) {
                     String prefix = (String) prefixes.nextElement();
+                    if ("xml".equals(prefix)) continue;
                     attributes.addAttribute(null, null, "xmlns:" + prefix, null,
                             getNamespaceSupport().getURI(prefix));
                 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetCapabilitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetCapabilitiesTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.wfs.v1_1;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
@@ -53,12 +54,14 @@ public class GetCapabilitiesTest extends WFSTestSupport {
     @Test
     public void testGet() throws Exception {
         Document doc = getAsDOM("wfs?service=WFS&request=getCapabilities&version=1.1.0");
+        String docText = getAsString("wfs?service=WFS&request=GetCapabilities&version=1.1.0");
 
         assertEquals("wfs:WFS_Capabilities", doc.getDocumentElement()
                 .getNodeName());
         assertEquals("1.1.0", doc.getDocumentElement().getAttribute("version"));
         XpathEngine xpath =  XMLUnit.newXpathEngine();
         assertTrue(xpath.getMatchingNodes("//wfs:FeatureType", doc).getLength() > 0);
+        assertFalse(docText, docText.contains("xmlns:xml="));
     }
     
     @Test


### PR DESCRIPTION
Without this change, older versions of IE cannot parse the capabilities document.
