### PR TITLE
Enforce that store and layer names are xml-safe at the catalog level

### DIFF
--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -238,4 +238,5 @@
 
   <!-- JDBC VirtualTable callback -->
   <bean id="virtualTableCallback" class="org.geoserver.catalog.VirtualTableCallback"/>
+  <bean id="xmlSafeNameValidator" class="org.geoserver.catalog.impl.XMLSafeNameValidator"/>
 </beans>

--- a/src/main/src/main/java/org/geoserver/catalog/Catalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Catalog.java
@@ -165,7 +165,7 @@ public interface Catalog extends CatalogInfo {
      * 
      * @returns List<RuntimeException> non-empty if validation fails
      */
-    List<RuntimeException> validate(StoreInfo store, boolean isNew);
+    ValidationResult validate(StoreInfo store, boolean isNew);
 
     /**
      * Removes an existing store.
@@ -631,7 +631,7 @@ public interface Catalog extends CatalogInfo {
      * 
      * @returns List<RuntimeException> non-empty if validation fails
      */
-    List<RuntimeException> validate(ResourceInfo resource, boolean isNew);
+    ValidationResult validate(ResourceInfo resource, boolean isNew);
 
     /**
      * Removes an existing resource.
@@ -1069,7 +1069,7 @@ public interface Catalog extends CatalogInfo {
      * 
      * @returns List<RuntimeException> non-empty if validation fails
      */
-    List<RuntimeException> validate(LayerInfo layer, boolean isNew);
+    ValidationResult validate(LayerInfo layer, boolean isNew);
 
     /**
      * Removes an existing layer.
@@ -1209,7 +1209,7 @@ public interface Catalog extends CatalogInfo {
      * 
      * @returns List<RuntimeException> non-empty if validation fails
      */
-    List<RuntimeException> validate(LayerGroupInfo layerGroup, boolean isNew);
+    ValidationResult validate(LayerGroupInfo layerGroup, boolean isNew);
     
     /**
      * Removes a layer group from the catalog.
@@ -1309,7 +1309,7 @@ public interface Catalog extends CatalogInfo {
      * 
      * @returns List<RuntimeException> non-empty if validation fails
      */
-    List<RuntimeException> validate(StyleInfo style, boolean isNew);
+    ValidationResult validate(StyleInfo style, boolean isNew);
 
     /**
      * Removes a style.
@@ -1408,7 +1408,7 @@ public interface Catalog extends CatalogInfo {
      * 
      * @returns List<RuntimeException> non-empty if validation fails
      */
-    List<RuntimeException> validate(NamespaceInfo namespace, boolean isNew);
+    ValidationResult validate(NamespaceInfo namespace, boolean isNew);
 
     /**
      * Removes an existing namespace.
@@ -1493,7 +1493,7 @@ public interface Catalog extends CatalogInfo {
      * 
      * @returns List<RuntimeException> non-empty if validation fails
      */
-    List<RuntimeException> validate(WorkspaceInfo workspace, boolean isNew);
+    ValidationResult validate(WorkspaceInfo workspace, boolean isNew);
 
     /**
      * Removes an existing workspace.

--- a/src/main/src/main/java/org/geoserver/catalog/ValidationResult.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ValidationResult.java
@@ -1,0 +1,37 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * ValidationResult encapsulates the result of running Catalog::validate(),
+ * accounting for the fact that there may be multiple validation errors.
+ */
+public class ValidationResult {
+    private final List<RuntimeException> errorList;
+
+    public ValidationResult(List<RuntimeException> errors) {
+        if (errors == null) {
+            this.errorList = Collections.emptyList();
+        } else {
+            this.errorList = Collections.unmodifiableList(new ArrayList<RuntimeException>(errors));
+        }
+    }
+
+    public boolean isValid() {
+        return errorList.isEmpty();
+    }
+
+    public void throwIfInvalid() {
+        if (!isValid()){
+            int n = errorList.size();
+            String msg = errorList.get(0).getMessage();
+            throw new RuntimeException("Validation failed with " + n + " errors.  First error message is: " + msg);
+        }
+    }
+}

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogDecorator.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogDecorator.java
@@ -26,6 +26,7 @@ import org.geoserver.catalog.ResourcePool;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.ValidationResult;
 import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.platform.GeoServerResourceLoader;
@@ -88,10 +89,10 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.save(store);
     }
     
-    public List<RuntimeException> validate(StoreInfo store, boolean isNew) {
+    public ValidationResult validate(StoreInfo store, boolean isNew) {
         return delegate.validate(store, isNew);
     }
-    
+
     public <T extends StoreInfo> T detach(T store) {
         return delegate.detach(store);
     }
@@ -211,10 +212,10 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.save(resource);
     }
     
-    public List<RuntimeException> validate(ResourceInfo resource, boolean isNew) {
+    public ValidationResult validate(ResourceInfo resource, boolean isNew) {
         return delegate.validate(resource, isNew);
     }
-    
+
     public <T extends ResourceInfo> T detach(T resource) {
         return delegate.detach(resource);
     }
@@ -363,7 +364,7 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.save(layer);
     }
     
-    public List<RuntimeException> validate(LayerInfo layer, boolean isNew) {
+    public ValidationResult validate(LayerInfo layer, boolean isNew) {
         return delegate.validate(layer, isNew);
     }
     
@@ -445,7 +446,7 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.save(layerGroup);
     }
     
-    public List<RuntimeException> validate(LayerGroupInfo layerGroup, boolean isNew) {
+    public ValidationResult validate(LayerGroupInfo layerGroup, boolean isNew) {
         return delegate.validate(layerGroup, isNew);
     }
     
@@ -496,7 +497,7 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.save(style);
     }
     
-    public List<RuntimeException> validate(StyleInfo style, boolean isNew) {
+    public ValidationResult validate(StyleInfo style, boolean isNew) {
         return delegate.validate(style, isNew);
     }
     
@@ -547,7 +548,7 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.save(namespace);
     }
     
-    public List<RuntimeException> validate(NamespaceInfo namespace, boolean isNew) {
+    public ValidationResult validate(NamespaceInfo namespace, boolean isNew) {
         return delegate.validate(namespace, isNew);
     }
     
@@ -594,7 +595,7 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.save(workspace);
     }
     
-    public List<RuntimeException> validate(WorkspaceInfo workspace, boolean isNew) {
+    public ValidationResult validate(WorkspaceInfo workspace, boolean isNew) {
         return delegate.validate(workspace, isNew);
     }
     

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractFilteredCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractFilteredCatalog.java
@@ -26,6 +26,7 @@ import org.geoserver.catalog.ResourcePool;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.ValidationResult;
 import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
@@ -540,7 +541,7 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         delegate.add(layerGroup);
     }
 
-    public List<RuntimeException> validate(LayerGroupInfo layerGroup, boolean isNew) {
+    public ValidationResult validate(LayerGroupInfo layerGroup, boolean isNew) {
         return delegate.validate(layerGroup, isNew);
     }
 
@@ -556,7 +557,7 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         return delegate.detach(layer);
     }    
     
-    public List<RuntimeException> validate(LayerInfo layer, boolean isNew) {
+    public ValidationResult validate(LayerInfo layer, boolean isNew) {
         return delegate.validate(layer, isNew);
     }
     
@@ -572,7 +573,7 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         delegate.add(namespace);
     }
 
-    public List<RuntimeException> validate(NamespaceInfo namespace, boolean isNew) {
+    public ValidationResult validate(NamespaceInfo namespace, boolean isNew) {
         return delegate.validate(namespace, isNew);
     }
 
@@ -584,7 +585,7 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         delegate.add(resource);
     }
 
-    public List<RuntimeException> validate(ResourceInfo resource, boolean isNew) {
+    public ValidationResult validate(ResourceInfo resource, boolean isNew) {
         return delegate.validate(resource, isNew);
     }
 
@@ -596,7 +597,7 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         delegate.add(store);
     }
 
-    public List<RuntimeException> validate(StoreInfo store, boolean isNew) {
+    public ValidationResult validate(StoreInfo store, boolean isNew) {
         return delegate.validate(store, isNew);
     }
     
@@ -608,7 +609,7 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         delegate.add(style);
     }
 
-    public List<RuntimeException> validate(StyleInfo style, boolean isNew) {
+    public ValidationResult validate(StyleInfo style, boolean isNew) {
         return delegate.validate(style, isNew);
     }
 
@@ -620,7 +621,7 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         delegate.add(workspace);
     }
 
-    public List<RuntimeException> validate(WorkspaceInfo workspace, boolean isNew) {
+    public ValidationResult validate(WorkspaceInfo workspace, boolean isNew) {
         return delegate.validate(workspace, isNew);
     }
 

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -42,6 +42,7 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.ResourcePool;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.ValidationResult;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -165,7 +166,7 @@ public class CatalogImpl implements Catalog {
         added(added);
     }
 
-    public List<RuntimeException> validate(StoreInfo store, boolean isNew) {
+    public ValidationResult validate(StoreInfo store, boolean isNew) {
         if ( isNull(store.getName()) ) {
             throw new IllegalArgumentException( "Store name must not be null");
         }
@@ -182,7 +183,7 @@ public class CatalogImpl implements Catalog {
 
         return postValidate(store, isNew);
     }
-    
+
     public void remove(StoreInfo store) {
         if ( !getResourcesByStore(store, ResourceInfo.class).isEmpty() ) {
             throw new IllegalArgumentException( "Unable to delete non-empty store.");
@@ -384,11 +385,12 @@ public class CatalogImpl implements Catalog {
         added(added);
     }
 
-    public List<RuntimeException> validate(ResourceInfo resource, boolean isNew) {
+    public ValidationResult validate(ResourceInfo resource, boolean isNew) {
         if ( isNull(resource.getName()) ) {
             throw new NullPointerException( "Resource name must not be null");
         }
-        if ( isNull(resource.getNativeName())) {
+        
+        if ( isNull(resource.getNativeName()) && !(resource instanceof CoverageInfo && ((CoverageInfo)resource).getNativeCoverageName() != null)) {
             throw new NullPointerException( "Resource native name must not be null");
         }
         if ( resource.getStore() == null ) {
@@ -415,7 +417,7 @@ public class CatalogImpl implements Catalog {
         validateKeywords(resource.getKeywords());
         return postValidate(resource, isNew);
     }
-    
+
     public void remove(ResourceInfo resource) {
         //ensure no references to the resource
         if ( !getLayers( resource ).isEmpty() ) {
@@ -638,7 +640,7 @@ public class CatalogImpl implements Catalog {
         added(added);
     }
 
-    public List<RuntimeException> validate( LayerInfo layer, boolean isNew) {
+    public ValidationResult validate( LayerInfo layer, boolean isNew) {
         // TODO: bring back when the layer/publishing split is in act
 //        if ( isNull(layer.getName()) ) {
 //            throw new NullPointerException( "Layer name must not be null" );
@@ -804,7 +806,7 @@ public class CatalogImpl implements Catalog {
         added( added );
     }
     
-    public List<RuntimeException> validate( LayerGroupInfo layerGroup, boolean isNew ) {
+    public ValidationResult validate( LayerGroupInfo layerGroup, boolean isNew ) {
         if( isNull(layerGroup.getName()) ) {
             throw new NullPointerException( "Layer group name must not be null");
         }
@@ -1072,7 +1074,7 @@ public class CatalogImpl implements Catalog {
         added(added);
     }
 
-    public List<RuntimeException> validate(NamespaceInfo namespace, boolean isNew) {
+    public ValidationResult validate(NamespaceInfo namespace, boolean isNew) {
         if ( isNull(namespace.getPrefix()) ) {
             throw new NullPointerException( "Namespace prefix must not be null");
         }
@@ -1180,7 +1182,7 @@ public class CatalogImpl implements Catalog {
         added( added );
     }
     
-    public List<RuntimeException> validate(WorkspaceInfo workspace, boolean isNew) {
+    public ValidationResult validate(WorkspaceInfo workspace, boolean isNew) {
         if ( isNull(workspace.getName()) ) {
             throw new NullPointerException( "workspace name must not be null");
         }
@@ -1328,7 +1330,7 @@ public class CatalogImpl implements Catalog {
         added(added);
     }
 
-    public List<RuntimeException> validate( StyleInfo style, boolean isNew ) {
+    public ValidationResult validate( StyleInfo style, boolean isNew ) {
         if ( isNull(style.getName()) ) {
             throw new NullPointerException( "Style name must not be null");
         }
@@ -1644,11 +1646,11 @@ public class CatalogImpl implements Catalog {
         return detached != null ? detached : original;
     }
     
-    protected List<RuntimeException> postValidate(CatalogInfo info, boolean isNew) {
+    protected ValidationResult postValidate(CatalogInfo info, boolean isNew) {
         List<RuntimeException> errors = new ArrayList<RuntimeException>();
 
         if (!extendedValidation) {
-            return errors; 
+            return new ValidationResult(null);
         }
 
         for (CatalogValidator constraint : getValidators()) {
@@ -1658,7 +1660,7 @@ public class CatalogImpl implements Catalog {
                 errors.add(e);
             }
         }
-        return errors;
+        return new ValidationResult(errors);
     }
     
     static class CatalogValidatorVisitor implements CatalogVisitor {

--- a/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
@@ -16,6 +16,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.ValidationResult;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
 import org.geoserver.config.GeoServer;
@@ -139,7 +140,7 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
     }
 
     @Override
-    public List<RuntimeException> validate(LayerInfo layer, boolean isNew) {
+    public ValidationResult validate(LayerInfo layer, boolean isNew) {
         return super.validate(unwrap(layer), isNew);
     }
 
@@ -225,7 +226,7 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
         return super.detach(unwrap(layerGroup));
     }
 
-    public List<RuntimeException> validate(LayerGroupInfo layerGroup, boolean isNew) {
+    public ValidationResult validate(LayerGroupInfo layerGroup, boolean isNew) {
         return super.validate(unwrap(layerGroup), isNew);
     }
 

--- a/src/main/src/main/java/org/geoserver/catalog/impl/XMLSafeNameValidator.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/XMLSafeNameValidator.java
@@ -1,0 +1,78 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import org.geoserver.catalog.CatalogValidator;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import java.util.regex.Pattern;
+
+/**
+ * Ensure that Catalog objects in GeoServer have names that can safely be used
+ * in XML output.
+ *
+ * XML specification info for this code comes from http://www.w3.org/TR/REC-xml/
+ * 
+ * @author David Winslow, Boundless
+ */
+
+public class XMLSafeNameValidator implements CatalogValidator {
+    private static Pattern XML_NAME_PATTERN;
+
+    static {
+        // Definitions coming from
+        // NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] |
+        // [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] |
+        // [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
+        // NameChar ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
+        // Name ::= NameStartChar (NameChar)*
+        String nameStartCharSet = "A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F"
+                + "\u1FFF\u200C\u200D\u2070-\u218F\u2C00\u2FEF\u3001\uD7FF\uF900-\uFDCF"
+                + "\uFDF0-\uFFFD";
+        String nameStartChar = "[" + nameStartCharSet + "]";
+        String nameChar = ("[" + nameStartCharSet + "\\-.0-9\u0087\u0300-\u036F\u203F-\u2040]");
+        String name = "(?:" + nameStartChar + nameChar + "*)";
+        XML_NAME_PATTERN = Pattern.compile(name, Pattern.CASE_INSENSITIVE);
+
+    }
+
+    private boolean safeName(String name) {
+        return XML_NAME_PATTERN.matcher(name).matches();
+    }
+
+    public void validate(ResourceInfo resource, boolean isNew) {
+        if (!safeName(resource.getName())) throw new RuntimeException("Name '" + resource.getName() + "' is not legal XML'");
+    }
+
+    public void validate(StoreInfo store, boolean isNew) {
+        if (!safeName(store.getName())) throw new RuntimeException("Name '" + store.getName() + "' is not legal XML'");
+    }
+
+    public void validate(WorkspaceInfo workspace, boolean isNew) {
+        if (!safeName(workspace.getName())) throw new RuntimeException("Name '" + workspace.getName() + "' is not legal XML'");
+    }
+
+    public void validate(LayerInfo layer, boolean isNew) {
+        if (!safeName(layer.getName())) throw new RuntimeException("Name '" + layer.getName() + "' is not legal XML'");
+    }
+
+    public void validate(StyleInfo style, boolean isNew) {
+        if (!safeName(style.getName())) throw new RuntimeException("Name '" + style.getName() + "' is not legal XML'");
+    }
+
+    public void validate(LayerGroupInfo layerGroup, boolean isNew) {
+        if (!safeName(layerGroup.getName())) throw new RuntimeException("Name '" + layerGroup.getName() + "' is not legal XML'");
+    }
+
+    public void validate(NamespaceInfo namespace, boolean isNew) {
+        if (!safeName(namespace.getName())) throw new RuntimeException("Name '" + namespace.getName() + "' is not legal XML'");
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -36,6 +36,7 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.ValidationResult;
 import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.impl.AbstractDecorator;
 import org.geoserver.catalog.util.CloseableIterator;
@@ -1111,7 +1112,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.add(unwrap(layerGroup));
     }
 
-    public List<RuntimeException> validate(LayerGroupInfo layerGroup, boolean isNew) {
+    public ValidationResult validate(LayerGroupInfo layerGroup, boolean isNew) {
         return delegate.validate(unwrap(layerGroup), isNew);
     }
 
@@ -1123,7 +1124,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.add(unwrap(layer));
     }
 
-    public List<RuntimeException> validate(LayerInfo layer, boolean isNew) {
+    public ValidationResult validate(LayerInfo layer, boolean isNew) {
         return delegate.validate(unwrap(layer), isNew);
     }
 
@@ -1143,7 +1144,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.add(namespace);
     }
 
-    public List<RuntimeException> validate(NamespaceInfo namespace, boolean isNew) {
+    public ValidationResult validate(NamespaceInfo namespace, boolean isNew) {
         return delegate.validate(namespace, isNew);
     }
 
@@ -1155,7 +1156,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.add(unwrap(resource));
     }
 
-    public List<RuntimeException> validate(ResourceInfo resource, boolean isNew) {
+    public ValidationResult validate(ResourceInfo resource, boolean isNew) {
         return delegate.validate(unwrap(resource), isNew);
     }
 
@@ -1167,10 +1168,9 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.add(unwrap(store));
     }
 
-    public List<RuntimeException> validate(StoreInfo store, boolean isNew) {
+    public ValidationResult validate(StoreInfo store, boolean isNew) {
         return delegate.validate(unwrap(store), isNew);
     }
-
     
     public <T extends StoreInfo> T detach(T store) {
         return delegate.detach(store);
@@ -1180,7 +1180,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.add(style);
     }
 
-    public List<RuntimeException> validate(StyleInfo style, boolean isNew) {
+    public ValidationResult validate(StyleInfo style, boolean isNew) {
         return delegate.validate(style, isNew);
     }
 
@@ -1192,7 +1192,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.add(workspace);
     }
 
-    public List<RuntimeException> validate(WorkspaceInfo workspace, boolean isNew) {
+    public ValidationResult validate(WorkspaceInfo workspace, boolean isNew) {
         return delegate.validate(workspace, isNew);
     }
 

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -667,8 +667,7 @@ public class XStreamPersisterTest {
         Assert.assertEquals(LayerGroupInfo.Mode.SINGLE, group.getMode());
         
         Catalog catalog = new CatalogImpl();
-        List<RuntimeException> errors = catalog.validate(group, false);
-        Assert.assertTrue(errors == null || errors.size() == 0);
+        Assert.assertTrue(catalog.validate(group, false).isValid());
     }
     
     @Test

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/CoverageResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/CoverageResource.java
@@ -105,6 +105,7 @@ public class CoverageResource extends AbstractCatalogResource {
         }
         
         coverage.setEnabled(true);
+        catalog.validate(coverage, true).throwIfInvalid();
         catalog.add( coverage );
         
         //create a layer for the coverage
@@ -151,6 +152,7 @@ public class CoverageResource extends AbstractCatalogResource {
         CoverageInfo original = catalog.getCoverageByCoverageStore( cs,  coverage );
         new CatalogBuilder(catalog).updateCoverage(original,c);
         calculateOptionalFields(c, original);
+        catalog.validate(original, false).throwIfInvalid();
         catalog.save( original );
         
         clear(original);

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/CoverageStoreFileResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/CoverageStoreFileResource.java
@@ -182,9 +182,15 @@ public class CoverageStoreFileResource extends StoreFileResource {
         
         //add or update the datastore info
         if ( add ) {
+        	if (!catalog.validate(info, true).isValid()) {
+        		throw new RuntimeException("Validation failed");
+        	}
             catalog.add( info );
         }
         else {
+        	if (!catalog.validate(info, false).isValid()) {
+        		throw new RuntimeException("Validation failed");
+        	}
             catalog.save( info );
         }
         
@@ -298,6 +304,7 @@ public class CoverageStoreFileResource extends StoreFileResource {
             
             if ( existing != null ) {
                 builder.updateCoverage(existing,cinfo);
+                catalog.validate(existing, false).throwIfInvalid();
                 catalog.save( existing );
                 cinfo = existing;
             }
@@ -315,6 +322,7 @@ public class CoverageStoreFileResource extends StoreFileResource {
 
         //add/save
         if ( add ) {
+            catalog.validate(cinfo, true).throwIfInvalid();
             catalog.add( cinfo );
             
             LayerInfo layerInfo = builder.buildLayer( cinfo );
@@ -343,7 +351,7 @@ public class CoverageStoreFileResource extends StoreFileResource {
 
             boolean valid = true;
             try {
-                if (!catalog.validate(layerInfo, true).isEmpty()) {
+                if (!catalog.validate(layerInfo, true).isValid()) {
                     valid = false;
                 }
             } catch (Exception e) {

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/CoverageStoreResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/CoverageStoreResource.java
@@ -67,6 +67,7 @@ public class CoverageStoreResource extends AbstractCatalogResource {
     @Override
     protected String handleObjectPost(Object object) throws Exception {
         CoverageStoreInfo coverageStore = (CoverageStoreInfo) object;
+        catalog.validate(coverageStore, true).throwIfInvalid();
         catalog.add( coverageStore );
         
         LOGGER.info( "POST coverage store " + coverageStore.getName() );
@@ -86,7 +87,8 @@ public class CoverageStoreResource extends AbstractCatalogResource {
         CoverageStoreInfo cs = (CoverageStoreInfo) object;
         CoverageStoreInfo original = catalog.getCoverageStoreByName(workspace, coveragestore);
         new CatalogBuilder( catalog ).updateCoverageStore( original, cs );
-        
+
+        catalog.validate(original, false).throwIfInvalid();
         catalog.save( original );
         clear(original);
         

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
@@ -15,6 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.zip.ZipEntry;
@@ -292,10 +293,12 @@ public class DataStoreFileResource extends StoreFileResource {
         
         //add or update the datastore info
         if ( add ) {
+            catalog.validate(info, true).throwIfInvalid();
             catalog.add( info );
         }
         else {
             if (save) {
+                catalog.validate(info, false).throwIfInvalid();
                 catalog.save( info );
             }
         }
@@ -426,6 +429,7 @@ public class DataStoreFileResource extends StoreFileResource {
                         }
                         while(i < 10 && catalog.getFeatureTypeByName(namespace, ftinfo.getName()) != null);
                     }
+                    catalog.validate(ftinfo, true).throwIfInvalid();
                     catalog.add( ftinfo );
                     
                     //add a layer for the feature type as well
@@ -433,7 +437,7 @@ public class DataStoreFileResource extends StoreFileResource {
 
                     boolean valid = true;
                     try { 
-                        if (!catalog.validate(layer, true).isEmpty()) {
+                        if (!catalog.validate(layer, true).isValid()) {
                             valid = false;
                         }
                     } catch (Exception e) {
@@ -448,6 +452,7 @@ public class DataStoreFileResource extends StoreFileResource {
                 }
                 else {
                     LOGGER.info("Updated feature type " + ftinfo.getName());
+                    catalog.validate(ftinfo, false).throwIfInvalid();
                     catalog.save( ftinfo );
                 }
                 

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreResource.java
@@ -105,6 +105,7 @@ public class DataStoreResource extends AbstractCatalogResource {
             }
         }
         
+        catalog.validate((DataStoreInfo)object, false).throwIfInvalid();
         catalog.add( (DataStoreInfo) object );
         
         LOGGER.info( "POST data store " + ds.getName() );
@@ -134,6 +135,7 @@ public class DataStoreResource extends AbstractCatalogResource {
         
         new CatalogBuilder( catalog ).updateDataStore( original, ds );
         
+        catalog.validate(original, false).throwIfInvalid();
         catalog.save( original );
         
         clear(original);

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/FeatureTypeResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/FeatureTypeResource.java
@@ -192,6 +192,7 @@ public class FeatureTypeResource extends AbstractCatalogResource {
         }
         
         featureType.setEnabled(true);
+        catalog.validate(featureType, true).throwIfInvalid();
         catalog.add( featureType );
         
         //create a layer for the feature type
@@ -254,6 +255,7 @@ public class FeatureTypeResource extends AbstractCatalogResource {
         CatalogBuilder helper = new CatalogBuilder(catalog);
         helper.updateFeatureType(featureTypeInfo,featureTypeUpdate);
         calculateOptionalFields(featureTypeUpdate, featureTypeInfo);
+        catalog.validate(featureTypeInfo, false).throwIfInvalid();
         catalog.save( featureTypeInfo );
         catalog.getResourcePool().clear(featureTypeInfo);
         

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/WMSLayerResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/WMSLayerResource.java
@@ -112,6 +112,7 @@ public class WMSLayerResource extends AbstractCatalogResource {
         cb.initWMSLayer( wml );
         
         wml.setEnabled(true);
+        catalog.validate(wml, true).throwIfInvalid();
         catalog.add( wml );
         
         // create a layer for the feature type
@@ -137,6 +138,7 @@ public class WMSLayerResource extends AbstractCatalogResource {
         WMSStoreInfo wms = catalog.getStoreByName(workspace, wmsstore, WMSStoreInfo.class);
         WMSLayerInfo original = catalog.getResourceByStore( wms,  wmslayer, WMSLayerInfo.class );
         new CatalogBuilder(catalog).updateWMSLayer(original,wml);
+        catalog.validate(original, false).throwIfInvalid();
         catalog.save( original );
         
         LOGGER.info( "PUT wms layer " + wmsstore + "," + wmslayer );

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/WMSStoreResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/WMSStoreResource.java
@@ -74,7 +74,8 @@ public class WMSStoreResource extends AbstractCatalogResource {
              wms.setWorkspace( catalog.getWorkspaceByName( workspace ) );
         } 
         wms.setEnabled(true);
-
+        
+        catalog.validate(wms, false).throwIfInvalid();
         catalog.add( wms );
         
         LOGGER.info( "POST WSM store " + wms.getName() );
@@ -104,6 +105,7 @@ public class WMSStoreResource extends AbstractCatalogResource {
         
         new CatalogBuilder( catalog ).updateWMSStore( original, wms );
         
+        catalog.validate(original, false).throwIfInvalid();
         catalog.save( original );
         
         LOGGER.info( "PUT wms store " + workspace + "," + wmsstore );

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/CoverageStoreFileUploadTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/CoverageStoreFileUploadTest.java
@@ -68,16 +68,7 @@ public class CoverageStoreFileUploadTest extends CatalogRESTTestSupport {
         
         MockHttpServletResponse response = 
             putAsServletResponse( "/rest/workspaces/gs/coveragestores/store%20with%20spaces/file.worldimage", bytes, "application/zip");
-        assertEquals( 201, response.getStatusCode() );
-        
-        String content = response.getOutputStreamContent();
-        Document d = dom( new ByteArrayInputStream( content.getBytes() ));
-        assertEquals( "coverageStore", d.getDocumentElement().getNodeName());
-        
-        CoverageStoreInfo cs = getCatalog().getCoverageStoreByName("gs", "store with spaces");
-        assertNotNull(cs);
-        CoverageInfo ci = getCatalog().getCoverageByName("gs", "usa");
-        assertNotNull(ci);
+        assertEquals(500, response.getStatusCode());
     }
     
     @Test

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreFileUploadTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreFileUploadTest.java
@@ -252,8 +252,7 @@ public class DataStoreFileUploadTest extends CatalogRESTTestSupport {
         put( "/rest/workspaces/gs/datastores/store%20with%20spaces/file.shp", bytes, "application/zip");
         
         DataStoreInfo ds = cat.getDataStoreByName("gs", "store with spaces"); 
-        assertNotNull(ds);
-        assertFalse(cat.getFeatureTypesByDataStore(ds).isEmpty());
+        assertNull(ds);
     }
  
     @Test

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
@@ -293,6 +293,7 @@ public class ResourceConfigurationPage extends GeoServerSecuredPage {
                     }
                 }
 
+                catalog.validate(resourceInfo, true).throwIfInvalid();
                 catalog.add(resourceInfo);
                 try {
                     catalog.add(getLayerInfo());
@@ -303,6 +304,8 @@ public class ResourceConfigurationPage extends GeoServerSecuredPage {
             } else {
                 ResourceInfo oldState = catalog.getResource(resourceInfo.getId(),
                         ResourceInfo.class);
+                
+                catalog.validate(resourceInfo, true).throwIfInvalid();
                 catalog.save(resourceInfo);
                 try {
                     LayerInfo layer = getLayerInfo();

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/CoverageStoreEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/CoverageStoreEditPage.java
@@ -197,6 +197,7 @@ public class CoverageStoreEditPage extends AbstractCoverageStorePage {
 
             ResourcePool resourcePool = catalog.getResourcePool();
             resourcePool.clear(info);
+            catalog.validate(info, false).throwIfInvalid();
             catalog.save(info);
 
             for (CoverageInfo coverage : alreadyConfigured) {

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/CoverageStoreNewPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/CoverageStoreNewPage.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.web.data.store;
 
+import java.util.List;
 import java.util.logging.Level;
 
 import javax.management.RuntimeErrorException;
@@ -58,6 +59,7 @@ public class CoverageStoreNewPage extends AbstractCoverageStorePage {
         // of a failure!... strange, why a save can't fail?
         // Still, be cautious and wrap it in a try/catch block so the page does not blow up
         try {
+            catalog.validate(savedStore, false).throwIfInvalid();
             catalog.save(savedStore);
         } catch (RuntimeException e) {
             LOGGER.log(Level.INFO, "Adding the store for " + info.getURL(), e);

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DataAccessEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DataAccessEditPage.java
@@ -211,6 +211,7 @@ public class DataAccessEditPage extends AbstractDataAccessPage implements Serial
 
             ResourcePool resourcePool = catalog.getResourcePool();
             resourcePool.clear(info);
+            catalog.validate(info, false).throwIfInvalid();
             catalog.save(info);
             // save the resources after saving the store
             for (FeatureTypeInfo alreadyConfigured : configuredResources) {

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DataAccessNewPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DataAccessNewPage.java
@@ -6,6 +6,7 @@
 package org.geoserver.web.data.store;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.logging.Level;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -106,6 +107,7 @@ public class DataAccessNewPage extends AbstractDataAccessPage {
         DataStoreInfo savedStore = catalog.getFactory().createDataStore();
         clone(info, savedStore);
         try {
+            catalog.validate(savedStore, true).throwIfInvalid();
             catalog.add(savedStore);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error adding data store to catalog", e);

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreEditPage.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.web.data.store;
 
+import java.util.List;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.PageParameters;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -64,6 +66,7 @@ public class WMSStoreEditPage extends AbstractWMSStorePage {
      * </p>
      */
     protected void doSaveStore(WMSStoreInfo info) {
+        getCatalog().validate(info, false).throwIfInvalid();
         getCatalog().save(info);
         doReturn(StorePage.class);
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreNewPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreNewPage.java
@@ -8,6 +8,7 @@ package org.geoserver.web.data.store;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 
 import javax.management.RuntimeErrorException;
@@ -50,6 +51,7 @@ public class WMSStoreNewPage extends AbstractWMSStorePage {
         // case of a failure!... strange, why a save can't fail?
         // Still, be cautious and wrap it in a try/catch block so the page does not blow up
         try {
+            getCatalog().validate(savedStore, false).throwIfInvalid();
             getCatalog().save(savedStore);
         } catch (RuntimeException e) {
             LOGGER.log(Level.INFO, "Adding the store for " + info.getCapabilitiesURL(), e);


### PR DESCRIPTION
As discussed on the mailing list, it is problematic to have layer name that are not XML-safe in GeoServer.  This patch adds a validator to reject such names, and ensures that such validators are enforced in the REST API and web interface.  I think that it still needs a little work to give better errors (right now any validation is reported with a generic "Validation failed" message) but here is the approach.
