### PR TITLE
[GEOS-6712]Add charset definition in HTTP headers when returning textbased responses

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -966,6 +966,12 @@ public class Dispatcher extends AbstractController {
                 req.getHttpResponse().setContentType(mimeType);
             }
 
+            //set the charset
+            String charset = response.getCharset(opDescriptor);
+            if(charset != null){
+                req.getHttpResponse().setCharacterEncoding(charset);
+            }
+            
             setHeaders(req,opDescriptor,result,response);
             
             OutputStream output = outputStrategy.getDestination(req.getHttpResponse());

--- a/src/ows/src/main/java/org/geoserver/ows/Response.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Response.java
@@ -215,4 +215,14 @@ public abstract class Response {
         }
         return name;
     }
+    
+    /**
+     * Returns the charset for this response, the Dispatcher will set it in the ServletResponse.
+     * The default implementation returns <code>null</code>, in this case no encoding should be set.
+     * Subclasses returning text documents (CSV,HTML,JSON) should override taking into account SettingsInfo.getCharset()
+     * as well as the specific encoding requirements of the returned format.
+     */
+    public String getCharset(Operation operation){ 
+       return null;
+    }
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -142,7 +142,7 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
         }
         
         try {
-            osw = new OutputStreamWriter(output, gs.getSettings().getCharset());
+            osw = new OutputStreamWriter(output, gs.getGlobal().getSettings().getCharset());
             outWriter = new BufferedWriter(osw);
 
             if (jsonp) {
@@ -441,5 +441,10 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
         }
 
         return totalCount;
+    }
+    
+    @Override
+    public String getCharset(Operation operation){
+        return gs.getGlobal().getSettings().getCharset();
     }
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
@@ -88,7 +88,7 @@ public class CSVOutputFormat extends WFSGetFeatureOutputFormat {
     	   //write out content here
         
         //create a writer
-        BufferedWriter w = new BufferedWriter( new OutputStreamWriter( output ) );
+        BufferedWriter w = new BufferedWriter( new OutputStreamWriter( output, gs.getGlobal().getSettings().getCharset() ) );
                    
         //get the feature collection
         FeatureCollection<?, ?> fc = 
@@ -248,6 +248,11 @@ public class CSVOutputFormat extends WFSGetFeatureOutputFormat {
     @Override
     public String getCapabilitiesElementName() {
     	return "CSV";
+    }
+    
+    @Override
+    public String getCharset(Operation operation){
+        return gs.getGlobal().getSettings().getCharset();
     }
 
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
@@ -133,8 +133,9 @@ public class GeoJSONTest extends WFSTestSupport {
     
     @Test
     public void testGetSimpleJson() throws Exception {    
-        MockHttpServletResponse response = getAsServletResponse("wfs?request=GetFeature&version=1.0.0&typename=sf:PrimitiveGeoFeature&maxfeatures=1&outputformat="+JSONType.simple_json);
+        MockHttpServletResponse response = getAsServletResponse("wfs?request=GetFeature&version=1.0.0&typename=sf:PrimitiveGeoFeature&maxfeatures=1&outputformat="+JSONType.simple_json,"");
         assertEquals("application/json", response.getContentType());
+        assertEquals("UTF-8", response.getCharacterEncoding());
         String out = response.getOutputStreamContent();
         
         JSONObject rootObject = JSONObject.fromObject( out );

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
@@ -42,7 +42,7 @@ public class CSVOutputFormatTest extends WFSTestSupport {
 
 	@Test
     public void testFullRequest() throws Exception {
-        MockHttpServletResponse resp = getAsServletResponse("wfs?version=1.1.0&request=GetFeature&typeName=sf:PrimitiveGeoFeature&outputFormat=csv");
+        MockHttpServletResponse resp = getAsServletResponse("wfs?version=1.1.0&request=GetFeature&typeName=sf:PrimitiveGeoFeature&outputFormat=csv","");
         
         FeatureSource fs = getFeatureSource(MockData.PRIMITIVEGEOFEATURE);
         
@@ -50,6 +50,9 @@ public class CSVOutputFormatTest extends WFSTestSupport {
         
         // check the mime type
         assertEquals("text/csv", resp.getContentType());
+        
+        // check the charset encoding
+        assertEquals("UTF-8", resp.getCharacterEncoding());
         
         // check the content disposition
         assertEquals("attachment; filename=PrimitiveGeoFeature.csv", resp.getHeader("Content-Disposition"));

--- a/src/wms/src/main/java/org/geoserver/wms/describelayer/JSONDescribeLayerResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/describelayer/JSONDescribeLayerResponse.java
@@ -20,6 +20,7 @@ import net.sf.json.util.JSONBuilder;
 import org.apache.commons.io.IOUtils;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
+import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.DescribeLayerRequest;
@@ -99,7 +100,7 @@ public class JSONDescribeLayerResponse extends DescribeLayerResponse {
             IOUtils.closeQuietly(osw);
         }
     }
-
+    
     private void writeJSON(Writer outWriter, DescribeLayerModel description) throws IOException {
 
         try {
@@ -137,4 +138,8 @@ public class JSONDescribeLayerResponse extends DescribeLayerResponse {
         }
     }
 
+    @Override
+    public String getCharset(Operation operation){
+        return wms.getGeoServer().getSettings().getCharset();
+    }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/GeoJSONFeatureInfoResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/GeoJSONFeatureInfoResponse.java
@@ -10,7 +10,6 @@ import java.io.OutputStream;
 
 import net.opengis.wfs.FeatureCollectionType;
 
-import org.geoserver.config.GeoServer;
 import org.geoserver.wfs.json.GeoJSONGetFeatureResponse;
 import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geoserver.wms.WMS;
@@ -49,4 +48,8 @@ public class GeoJSONFeatureInfoResponse extends GetFeatureInfoOutputFormat {
         format.write(features, out, null);
     }
 
+    @Override
+    public String getCharset(){ 
+        return wms.getGeoServer().getSettings().getCharset();
+    }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/GetFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/GetFeatureInfoOutputFormat.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 
 import net.opengis.wfs.FeatureCollectionType;
 
+import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geotools.util.logging.Logging;
@@ -91,5 +92,15 @@ public abstract class GetFeatureInfoOutputFormat {
 
     public String getContentType() {
         return contentType;
+    }
+    
+    /**
+     * Returns the charset for this outputFormat.
+     * The default implementation returns <code>null</code>, in this case no encoding should be set.
+     * Subclasses returning text documents (CSV,HTML,JSON) should override taking into account SettingsInfo.getCharset()
+     * as well as the specific encoding requirements of the returned format.
+     */
+    public String getCharset(){ 
+       return null;
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/GetFeatureInfoResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/GetFeatureInfoResponse.java
@@ -131,4 +131,13 @@ public class GetFeatureInfoResponse extends Response {
         return format;
 
     }
+    
+    @Override
+    public String getCharset(Operation operation) {
+        Assert.notNull(operation, "operation is null");
+        GetFeatureInfoRequest request = (GetFeatureInfoRequest) OwsUtils.parameter(
+                operation.getParameters(), GetFeatureInfoRequest.class);
+        GetFeatureInfoOutputFormat outputFormat = getRequestedOutputFormat(request);
+        return outputFormat.getCharset();
+    }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
@@ -11,11 +11,10 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.List;
 
-
 import net.opengis.wfs.FeatureCollectionType;
+
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.ows.Dispatcher;
-import org.geoserver.ows.Request;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.template.DirectTemplateFeatureCollectionFactory;
 import org.geoserver.template.FeatureWrapper;
@@ -202,5 +201,10 @@ public class HTMLFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
             t.setEncoding(charset.name());
             return t;
         }
+    }
+    
+    @Override
+    public String getCharset(){ 
+        return wms.getGeoServer().getSettings().getCharset();
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/TextFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/TextFeatureInfoOutputFormat.java
@@ -155,4 +155,9 @@ public class TextFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
 
         writer.flush();
     }
+    
+    @Override
+    public String getCharset(){ 
+        return wms.getGeoServer().getSettings().getCharset();
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerJsonTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerJsonTest.java
@@ -17,6 +17,8 @@ import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.WMSTestSupport;
 import org.junit.Test;
 
+import com.mockrunner.mock.web.MockHttpServletResponse;
+
 /**
  * Unit test suite for {@link JSONDescribeLayerResponse}
  * 
@@ -139,4 +141,17 @@ public class DescribeLayerJsonTest extends WMSTestSupport {
         assertEquals(layerDesc.get("owsType"), "WFS");
 
     }
+    
+    @Test
+    public void testJSONDescribeLayerCharset() throws Exception {
+        String layer = MockData.FORESTS.getPrefix() + ":" + MockData.FORESTS.getLocalPart();
+        String request = "wms?version=1.1.1" + "&request=DescribeLayer" + "&layers=" + layer
+                + "&query_layers=" + layer + "&width=20&height=20" + "&outputFormat="
+                + JSONType.json;
+
+        MockHttpServletResponse result = getAsServletResponse(request,"");
+        assertTrue("UTF-8".equals(result.getCharacterEncoding()));
+
+    }
+    
 }

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/GetFeatureInfoJSONTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/GetFeatureInfoJSONTest.java
@@ -35,12 +35,15 @@ public class GetFeatureInfoJSONTest extends GetFeatureInfoTest {
 
         // JSONP
         JSONType.setJsonpEnabled(true);
-        MockHttpServletResponse response = getAsServletResponse(request);
+        MockHttpServletResponse response = getAsServletResponse(request,"");
         JSONType.setJsonpEnabled(false);
 
         // MimeType
         assertEquals(JSONType.jsonp, response.getContentType());
 
+        // Check if the character encoding is the one expected
+        assertTrue("UTF-8".equals(response.getCharacterEncoding()));
+        
         // Content
         String result = response.getOutputStreamContent();
 
@@ -74,17 +77,20 @@ public class GetFeatureInfoJSONTest extends GetFeatureInfoTest {
                 + "&format_options=" + JSONType.CALLBACK_FUNCTION_KEY + ":custom";
         // JSONP
         JSONType.setJsonpEnabled(true);
-        MockHttpServletResponse response = getAsServletResponse(request);
+        MockHttpServletResponse response = getAsServletResponse(request,"");
         JSONType.setJsonpEnabled(false);
 
         // MimeType
         assertEquals(JSONType.jsonp, response.getContentType());
 
+        // Check if the character encoding is the one expected
+        assertTrue("UTF-8".equals(response.getCharacterEncoding()));
+        
         // Content
         String result = response.getOutputStreamContent();
 
         assertNotNull(result);
-
+        
         assertTrue(result.startsWith("custom("));
         assertTrue(result.endsWith(")"));
         assertTrue(result.indexOf("Green Forest") > 0);
@@ -112,11 +118,14 @@ public class GetFeatureInfoJSONTest extends GetFeatureInfoTest {
                 + "&width=20&height=20&x=10&y=10" + "&info_format=" + JSONType.json;
 
         // JSON
-        MockHttpServletResponse response = getAsServletResponse(request);
+        MockHttpServletResponse response = getAsServletResponse(request,"");
 
         // MimeType
         assertEquals(JSONType.json, response.getContentType());
 
+        // Check if the character encoding is the one expected
+        assertTrue("UTF-8".equals(response.getCharacterEncoding()));
+        
         // Content
         String result = response.getOutputStreamContent();
 
@@ -139,11 +148,14 @@ public class GetFeatureInfoJSONTest extends GetFeatureInfoTest {
                 + "&propertyName=NAME";
 
         // JSON
-        MockHttpServletResponse response = getAsServletResponse(request);
+        MockHttpServletResponse response = getAsServletResponse(request,"");
 
         // MimeType
         assertEquals(JSONType.json, response.getContentType());
 
+        // Check if the character encoding is the one expected
+        assertTrue("UTF-8".equals(response.getCharacterEncoding()));
+        
         // Content
         String result = response.getOutputStreamContent();
 

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
@@ -7,6 +7,7 @@
 package org.geoserver.wms.featureinfo;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -20,6 +21,8 @@ import java.util.Map;
 
 import net.opengis.wfs.FeatureCollectionType;
 import net.opengis.wfs.WfsFactory;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
 
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -32,11 +35,14 @@ import org.geoserver.data.test.MockData;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.template.GeoServerTemplateLoader;
+import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geoserver.wms.MapLayerInfo;
 import org.geoserver.wms.WMSTestSupport;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
 
 public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
     private HTMLFeatureInfoOutputFormat outputFormat;
@@ -146,5 +152,21 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
             error = true;
         }
         assertTrue(error); 
+    }
+    
+    @Test
+    public void testHTMLGetFeatureInfoCharset() throws Exception {
+        String layer = getLayerId(MockData.FORESTS);
+        String request = "wms?version=1.1.1&bbox=-0.002,-0.002,0.002,0.002&styles=&format=jpeg"
+                + "&request=GetFeatureInfo&layers=" + layer + "&query_layers=" + layer
+                + "&width=20&height=20&x=10&y=10" + "&info_format=text/html";
+
+        MockHttpServletResponse response = getAsServletResponse(request,"");
+
+        // MimeType
+        assertEquals("text/html", response.getContentType());
+
+        // Check if the character encoding is the one expected
+        assertTrue("UTF-8".equals(response.getCharacterEncoding()));
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -48,6 +48,8 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.w3c.dom.Document;
 
+import com.mockrunner.mock.web.MockHttpServletResponse;
+
 public class GetFeatureInfoTest extends WMSTestSupport {
     
     public static String WCS_PREFIX = "wcs";
@@ -325,10 +327,14 @@ public class GetFeatureInfoTest extends WMSTestSupport {
                 "&info_format=text/html&request=GetFeatureInfo&layers="
                 + layer + "&query_layers=" + layer + "&width=20&height=20&x=10&y=10";
         Document dom = getAsDOM(request);
-        
+      
         // count lines that do contain a forest reference
         XMLAssert.assertXpathEvaluatesTo("1",
                 "count(/html/body/table/tr/td[starts-with(.,'Forests.')])", dom);
+        
+        MockHttpServletResponse response = getAsServletResponse(request,"");
+        // Check if the character encoding is the one expected
+        assertTrue("UTF-8".equals(response.getCharacterEncoding()));
     }
     
     /**


### PR DESCRIPTION
this pull request is to fix GEOS-6712 (http://jira.codehaus.org/browse/GEOS-6712)

This implementation add a default method **getCharset(Operation operation)** in the Response.java class.
The default implementation always return null (we don't want to return the charset for binaries output format) and all Response subclasses are responsible for override it in case the output format is text format (jsnon,csv, html ecc...).

The Dispatcher.java now check for the charset: if it is not null set it in the httpResponse

The responses subclasses has been changed (getCharset method has been overridden) in this pull req are:
GeoJSONGetFeatureResponse.java
CSVOutputFormat.java
JSONDescribeLayerResponse.java
GeoJSONFeatureInfoResponse.java
HTMLFeatureInfoOutputFormat.java
TextFeatureInfoOutputFormat.java

This pull req contains also new tests for each changed Response (or one more assert when a test is already present)
