### PR TITLE
GEOS-6426 Internet Explorer 11 does not work properly with admin UI

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
@@ -2,6 +2,7 @@
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <wicket:head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title wicket:id="pageTitle">GeoServer</title>
     <link href="#" rel="shortcut icon" wicket:id="faviconLink"/>


### PR DESCRIPTION
Added meta tag to tell IE11 to render as IE10. This overcomes the sensitivity for using src="//:" for the wicket-modal iframe.
