### PR TITLE
GEOS-6374 GetMapXmlReader always uses default style for layergroup layers

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapXmlReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapXmlReader.java
@@ -320,12 +320,19 @@ public class GetMapXmlReader extends org.geoserver.ows.XmlRequestReader {
             } else {
 
                 LayerGroupInfo layerGroup = getWMS().getLayerGroupByName(layerName);
-
+                
                 if (layerGroup != null) {
-                    for (LayerInfo layer : layerGroup.layers()) {
+                    List<LayerInfo> layerGroupLayers = layerGroup.layers();
+                    List<StyleInfo> layerGroupStyles = layerGroup.getStyles();
+                    for (int j = 0; j < layerGroupStyles.size(); j++) {
+                        StyleInfo si = layerGroupStyles.get(j);
+                        LayerInfo layer = layerGroupLayers.get(j);
                         currLayer = new MapLayerInfo(layer);
+                        if (si != null){
+                            currLayer.setStyle(si.getStyle());
+                        }
                         addStyles(wms, getMapRequest, currLayer, styledLayers[i], layers, styles);
-                    }
+                    }                    
                 } else {
                     LayerInfo layerInfo = getWMS().getLayerByName(layerName);
                     if (layerInfo == null) {
@@ -373,6 +380,9 @@ public class GetMapXmlReader extends org.geoserver.ows.XmlRequestReader {
         if (layer instanceof NamedLayer) {
             ftcs = ((NamedLayer) layer).getLayerFeatureConstraints();
             layerStyles = ((NamedLayer) layer).getStyles();
+            if (shouldUseLayerStyle(layerStyles, currLayer)) {
+                layerStyles = new Style[]{currLayer.getStyle()};
+            }
         } else if (layer instanceof UserLayer) {
             ftcs = ((UserLayer) layer).getLayerFeatureConstraints();
             layerStyles = ((UserLayer) layer).getUserStyles();
@@ -434,6 +444,21 @@ public class GetMapXmlReader extends org.geoserver.ows.XmlRequestReader {
                 styles.add(layerStyles[t]);
             }
         }
+    }
+
+    /**
+     * Performs a check to see if we should use the style from the layer 
+     * info or from the given set of styles from the request.
+     * @param layerStyles
+     * @param currLayer
+     * @return
+     */
+    private static boolean shouldUseLayerStyle(Style[] layerStyles,
+            MapLayerInfo currLayer) {
+        boolean noSldLayerStyles = (layerStyles == null || layerStyles.length == 0);
+        boolean layerHasStyle = currLayer.getStyle() != null;
+        boolean shouldUseLayerStyle = noSldLayerStyles && layerHasStyle;
+        return shouldUseLayerStyle;
     }
 
     private static MapLayerInfo initializeInlineFeatureLayer(UserLayer ul,
@@ -774,6 +799,11 @@ public class GetMapXmlReader extends org.geoserver.ows.XmlRequestReader {
 
             throw new ServiceException(e, msg, "GETMAP validator");
         }
+    }
+
+    public GetMapRequest createRequest() {
+        GetMapRequest request = new GetMapRequest();
+        return request;
     }
 
 }

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapXmlReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapXmlReaderTest.java
@@ -1,0 +1,93 @@
+/* (c) 2013-2014 Open Source Geospatial Foundation - all rights reserved
+* This code is licensed under the GPL 2.0 license, available at the root
+* application directory.
+*/
+package org.geoserver.wms.map;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+
+import junit.framework.Test;
+
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.config.GeoServerLoader;
+import org.geoserver.data.test.MockData;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.test.ows.KvpRequestReaderTestSupport;
+import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.WMS;
+import org.geotools.styling.Style;
+
+public class GetMapXmlReaderTest extends KvpRequestReaderTestSupport {
+    GetMapXmlReader reader;
+    Dispatcher dispatcher;
+    
+    /**
+     * This is a READ ONLY TEST so we can use one time setup
+     */
+    public static Test suite() {
+        return new OneTimeTestSetup(new GetMapXmlReaderTest());
+    }
+
+    @Override
+    protected void oneTimeSetUp() throws Exception {
+        super.oneTimeSetUp();
+
+        CatalogFactory cf = getCatalog().getFactory();
+        CatalogBuilder cb = new CatalogBuilder(getCatalog());
+        LayerGroupInfo gi = cf.createLayerGroup();
+        gi.setName("testGroup");
+        gi.getLayers().add(getCatalog().getLayerByName(MockData.BASIC_POLYGONS.getLocalPart()));
+        gi.getStyles().add(getCatalog().getStyleByName("polygon"));
+        cb.calculateLayerGroupBounds(gi);
+        getCatalog().add(gi);
+    }
+    
+    @Override
+    protected void oneTimeTearDown() throws Exception {
+        super.oneTimeTearDown();
+        // reset the legacy flag so that other tests are not getting affected by it
+        GeoServerLoader.setLegacy(false);
+    }
+
+    protected void setUpInternal() throws Exception {
+        super.setUpInternal();
+
+        dispatcher = (Dispatcher) applicationContext.getBean("dispatcher");
+        WMS wms = new WMS(getGeoServer());
+        reader = new GetMapXmlReader(wms);
+    }
+    
+    public void testCreateRequest() throws Exception {
+        GetMapRequest request = (GetMapRequest) reader.createRequest();
+        assertNotNull(request);
+    }
+    
+    public void testResolveStylesForLayerGroup() throws Exception {
+        GetMapRequest request = (GetMapRequest) reader.createRequest();
+        BufferedReader input = getResourceInputStream("WMSPostLayerGroupNonDefaultStyle.xml");
+
+        request = (GetMapRequest) reader.read(request, input, new HashMap());
+        
+        String layer = MockData.BASIC_POLYGONS.getLocalPart();
+        assertEquals(1, request.getLayers().size());
+        assertTrue(request.getLayers().get(0).getName().endsWith(layer));
+
+        assertEquals(1, request.getStyles().size());
+        Style expected = getCatalog().getStyleByName("polygon").getStyle();
+        Style style = request.getStyles().get(0);
+        assertEquals(expected, style);
+    }
+
+    private BufferedReader getResourceInputStream(String classRelativePath) throws IOException {
+        InputStream resourceStream = getClass().getResource(classRelativePath).openStream();
+        BufferedReader input = new BufferedReader(new InputStreamReader(resourceStream));
+        return input;
+    }
+
+}

--- a/src/wms/src/test/resources/org/geoserver/wms/map/WMSPostLayerGroupNonDefaultStyle.xml
+++ b/src/wms/src/test/resources/org/geoserver/wms/map/WMSPostLayerGroupNonDefaultStyle.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ows:GetMap xmlns="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:se="http://www.opengis.net/se" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ows="http://www.opengis.net/ows" service="WMS" version="1.1.1" format="image/png" crs="EPSG:4326">
+    <StyledLayerDescriptor version="1.0.0">
+        <NamedLayer>
+            <Name>testGroup</Name>
+        </NamedLayer>
+    </StyledLayerDescriptor>
+    <BoundingBox srsName="http://www.opengis.net/gml/srs/epsg.xml#4326">
+        <gml:coord>
+            <gml:X>-74.08349171875</gml:X>
+            <gml:Y>40.634971066406</gml:Y>
+        </gml:coord>
+        <gml:coord>
+            <gml:X>-73.943530351562</gml:X>
+            <gml:Y>40.837401066406</gml:Y>
+        </gml:coord>
+    </BoundingBox>
+    <Output>
+        <Format>image/png</Format>
+        <Transparent>false</Transparent>
+        <Size>
+            <Width>354</Width>
+            <Height>512</Height>
+        </Size>
+    </Output>
+    <Exceptions>XML</Exceptions>>
+</ows:GetMap>


### PR DESCRIPTION
As code from an old version of GetMapKvpRequestReader.java was copied into GetMapXmlReader.java I followed suite and copied/looked at the newer version applying fixes for layergroup.
Added new test file as I could find no existing test for GetMapXmlReader.

I bet the overlapping functionality could be separated into a common class. Although, I'm not comfortable with that since there are no regression tests for that refactor.
