### PR TITLE
2.6.x backport of GEOS-6426 Internet Explorer 11 does not work properly with admin UI 

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
@@ -2,6 +2,7 @@
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <wicket:head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title wicket:id="pageTitle">GeoServer</title>
     <link href="#" rel="shortcut icon" wicket:id="faviconLink"/>


### PR DESCRIPTION
Backport to stable branch of the meta tag fix to allow IE11 users to use the admin UI.
