### PR TITLE
Update Page Header for 2.7

### DIFF
--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -744,7 +744,7 @@ generateBounds = Generate Bounds
 
 global.title=Global
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = Information
 

--- a/src/web/core/src/main/resources/GeoServerApplication_ca.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_ca.properties
@@ -552,7 +552,7 @@ generateBounds = Genera l\u00EDmits
 
 global.title=Global
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = Information
 

--- a/src/web/core/src/main/resources/GeoServerApplication_de.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_de.properties
@@ -669,7 +669,7 @@ generateBounds = Ausdehnung generieren
 
 global.title=Global
 
-home = GeoServer 2.1
+home = GeoServer @project.version@
 
 information = Information
 

--- a/src/web/core/src/main/resources/GeoServerApplication_es.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_es.properties
@@ -560,7 +560,7 @@ generateBounds = Generar l\u00EDmites
 
 global.title=Global
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = Information
 

--- a/src/web/core/src/main/resources/GeoServerApplication_fr.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_fr.properties
@@ -700,7 +700,7 @@ generateBounds = Générer l'emprise
 
 global.title=Globale
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = Information
 

--- a/src/web/core/src/main/resources/GeoServerApplication_ja.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_ja.properties
@@ -669,7 +669,7 @@ generateBounds = \u77e9\u5f62\u3092\u751f\u6210
 
 global.title=\u30b0\u30ed\u30fc\u30d0\u30eb
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = \u8a73\u7d30\u60c5\u5831
 

--- a/src/web/core/src/main/resources/GeoServerApplication_ko.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_ko.properties
@@ -700,7 +700,7 @@ generateBounds = \ub370\uc774\ud130 \ucd5c\uc18c\uacbd\uacc4 \uc601\uc5ed \uacc4
 
 global.title=\uc804\uc5ed \ud658\uacbd\uc124\uc815
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = \uc815\ubcf4
 

--- a/src/web/core/src/main/resources/GeoServerApplication_nl.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_nl.properties
@@ -668,7 +668,7 @@ generateBounds = Begrenzingsrechthoek genereren
 
 global.title=Algemeen
 
-home = GeoServer 2.4
+home = GeoServer @project.version@
 
 information = Informatie
 

--- a/src/web/core/src/main/resources/GeoServerApplication_pl.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_pl.properties
@@ -697,7 +697,7 @@ generateBounds = Generate Bounds
 
 global.title=Global
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = Information
 

--- a/src/web/core/src/main/resources/GeoServerApplication_ro.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_ro.properties
@@ -700,7 +700,7 @@ generateBounds = Genereaz\u0103 limite
 
 global.title=Global
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = Informa\u021bii
 

--- a/src/web/core/src/main/resources/GeoServerApplication_ru.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_ru.properties
@@ -666,7 +666,7 @@ generateBounds = \u0413\u0435\u043d\u0435\u0440\u0438\u0440\u043e\u0432\u0430\u0
 
 global.title=\u0413\u043b\u043e\u0431\u0430\u043b\u044c\u043d\u044b\u0439
 
-home = GeoServer 2.2
+home = GeoServer @project.version@
 
 information = Information
 

--- a/src/web/core/src/main/resources/GeoServerApplication_tr.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_tr.properties
@@ -700,7 +700,7 @@ generateBounds = S\u0131n\u0131rlar\u0131 Olu\u015ftur
 
 global.title=Genel
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = Bilgi
 

--- a/src/web/core/src/main/resources/GeoServerApplication_zh.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_zh.properties
@@ -666,7 +666,7 @@ generateBounds = \u751f\u6210\u8fb9\u754c
 
 global.title=\u5168\u7403
 
-home = GeoServer 2.3
+home = GeoServer @project.version@
 
 information = \u4fe1\u606f
 


### PR DESCRIPTION
The GeoServer logo in the corner of each page has alt text of 'GeoServer 2.3'  This corrects the version number.

```
sed -i 's/home = GeoServer 2\../home = GeoServer 2.7/' *.properties
```
