### PR TITLE
[GEOS-6778] Added support for relative time keywords in WMS/WCS TIME parameter

### DIFF
--- a/doc/en/user/source/services/wms/time.rst
+++ b/doc/en/user/source/services/wms/time.rst
@@ -117,6 +117,33 @@ Examples
    In practice, GeoServer and many data storage engines have limited resolution in their representations, so approximating a range to the nearest millisecond is 'as good as we can do.'
    It is possible that this technical constraint may be lifted at some point in the future.
 
+Specifying a Relative Interval
+------------------------------
+
+A client may request information over a relative time interval instead of a set time range by specifying a start or end time with an associated duration, separated by a ``/`` character.
+One end of the interval must be a time value, but the other may be a duration value as defined by the ISO 8601 standard.  The special keyword PRESENT may be used to specify a time relative to the present server time.
+
+Examples
+........
+
+
+.. list-table::
+
+   * - Description
+     - Time specification
+   * - The month of September 2002
+     - ``2002-09-01T00:00:00.0Z/P1M``
+   * - The entire day of December 25, 2010
+     - ``2010-12-25T00:00:00.0Z/P1D``
+   * - The entire day preceding December 25, 2010
+     - ``P1D/2010-12-25T00:00:00.0Z``
+   * - 36 hours preceding the present time
+     - ``PT36H/PRESENT``
+
+.. note::
+   
+    The final example could be paired with the KML service to provide a Google Earth network link always updated with the last 36 hours of data.
+
 Reduced Accuracy Times
 ----------------------
 

--- a/src/ows/src/test/java/org/geoserver/ows/kvp/TimeKvpParserTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/kvp/TimeKvpParserTest.java
@@ -26,6 +26,7 @@ import org.geotools.util.DateRange;
  * 
  * @author Cedric Briancon
  * @author Simone Giannecchini, GeoSolutions SAS
+ * @author Jonathan Meyer, Applied Information Sciences, jon@gisjedi.com
  */
 public class TimeKvpParserTest extends TestCase {
     /**
@@ -34,6 +35,10 @@ public class TimeKvpParserTest extends TestCase {
     private final static String PERIOD = "2007-01-01T12Z/2007-01-31T12Z/P1DT12H";
     
     private final static String CONTINUOUS_PERIOD = "2007-01-01T12Z/2007-01-31T12Z";
+    
+    private final static String CONTINUOUS_RELATIVE_PERIOD_H = "BACK2H/PRESENT";
+    private final static String CONTINUOUS_RELATIVE_PERIOD_D = "BACK10D/PRESENT";
+    private final static String CONTINUOUS_RELATIVE_PERIOD_W = "BACK400W/PRESENT";
     
     /**
      * Format of dates.
@@ -200,6 +205,49 @@ public class TimeKvpParserTest extends TestCase {
         end.setTime(end.getTime() - 1);
         assertEquals(end, range.getMaxValue());
     }
+	
+	public void testContinuousRelativeInterval() throws ParseException {
+		TimeKvpParser timeKvpParser = new  TimeKvpParser("TIME");
+		Calendar back = Calendar.getInstance();
+		Calendar now = Calendar.getInstance();
+			
+        List l = new ArrayList((Collection)  timeKvpParser.parse(CONTINUOUS_RELATIVE_PERIOD_H));
+        // Verify that the list contains at least one element.
+        now.set(Calendar.MILLISECOND, 0);
+        back.set(Calendar.MILLISECOND, 0);
+        back.add(Calendar.HOUR, -2);
+        assertFalse(l.isEmpty());
+        assertTrue(l.get(0) instanceof DateRange);
+        DateRange range=(DateRange) l.get(0);
+        assertEquals(back.getTime(), range.getMinValue());
+        assertEquals(now.getTime(), range.getMaxValue());
+        
+        back = Calendar.getInstance();
+        now = Calendar.getInstance();
+        l = new ArrayList((Collection)  timeKvpParser.parse(CONTINUOUS_RELATIVE_PERIOD_D));
+        // Verify that the list contains at least one element.
+        now.set(Calendar.MILLISECOND, 0);
+        back.set(Calendar.MILLISECOND, 0);
+        back.add(Calendar.DAY_OF_YEAR, -10);
+        assertFalse(l.isEmpty());
+        assertTrue(l.get(0) instanceof DateRange);
+        range=(DateRange) l.get(0);
+        assertEquals(back.getTime(), range.getMinValue());
+        assertEquals(now.getTime(), range.getMaxValue());
+        
+        back = Calendar.getInstance();
+        now = Calendar.getInstance();
+        l = new ArrayList((Collection)  timeKvpParser.parse(CONTINUOUS_RELATIVE_PERIOD_W));
+        // Verify that the list contains at least one element.
+        now.set(Calendar.MILLISECOND, 0);
+        back.set(Calendar.MILLISECOND, 0);
+        back.add(Calendar.DAY_OF_YEAR, -400 * 7);
+        assertFalse(l.isEmpty());
+        assertTrue(l.get(0) instanceof DateRange);
+        range=(DateRange) l.get(0);
+        assertEquals(back.getTime(), range.getMinValue());
+        assertEquals(now.getTime(), range.getMaxValue());
+	}
     
     public void testMixedValues() throws ParseException {
         TimeKvpParser timeKvpParser = new TimeKvpParser("TIME");
@@ -311,4 +359,3 @@ public class TimeKvpParserTest extends TestCase {
     	assertEquals("Range " + range + " should have end", expectedEnd, range.getMaxValue());
     }
 }
-


### PR DESCRIPTION
Patch to provide support within WMS/WCS services for TIME parameter handling of relative time keywords 'back' and 'present'.  See JIRA for more details. 

https://jira.codehaus.org/browse/GEOS-6778

Proposal:
https://github.com/geoserver/geoserver/wiki/GSIP-124---WMS-WCS-Relative-Time-Support