### PR TITLE
[GEOS-6776]: Restoring grib community module in the release, previously ...

### DIFF
--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -103,11 +103,11 @@
      <artifactId>gs-mbtiles</artifactId>
      <version>${project.version}</version>
    </dependency>
-   <!--dependency>
+   <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-grib</artifactId>
      <version>${project.version}</version>
-   </dependency-->
+   </dependency>
     <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-dyndimension</artifactId>


### PR DESCRIPTION
...removed due to issues with the opengeo to boundless switch
