### PR TITLE
Ensuring importer doesn't create illegal layer names.

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
@@ -1209,6 +1209,15 @@ public class Importer implements DisposableBean, ApplicationListener {
         NamespaceInfo ns = catalog.getNamespaceByPrefix(store.getWorkspace().getName());
         
         String name = resource.getName();
+
+        // make sure the name conforms to a legal layer name
+        if (!Character.isLetter(name.charAt(0))) {
+            name = "a_" + name;
+        }
+
+        // strip out any non-word characters
+        name = name.replaceAll("\\W", "_");
+
         if (catalog.getResourceByName(ns, name, ResourceInfo.class) != null) {
             int i = 0;
             name += i;

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDataTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDataTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.geoserver.catalog.Catalog;
@@ -767,5 +768,24 @@ public class ImporterDataTest extends ImporterTestSupport {
         runChecks("point");
         runChecks("line");
         runChecks("polygon");
+    }
+
+    @Test
+    public void testIllegalNames() throws Exception {
+        File dir = unpack("shape/archsites_epsg_prj.zip");
+        for (File f : dir.listFiles()) {
+            String ext = FilenameUtils.getExtension(f.getName());
+            String base = FilenameUtils.getBaseName(f.getName());
+
+            f.renameTo(new File(dir, "1-." + ext));
+        }
+
+        ImportContext imp = importer.createContext(new Directory(dir));
+        importer.run(imp);
+
+        ImportTask task = imp.getTasks().get(0);
+
+        assertEquals("a_1_", task.getLayer().getName());
+        assertEquals("a_1_", task.getLayer().getResource().getName());
     }
 }


### PR DESCRIPTION
This patch massages the names of layers that have illegal names, similar to how it tacks on numbers to avoid layer name conflicts. The heuristic is:
- If layer name starts with a non character, prepend an 'a'
- For all illegal word characters replace them with a '_'

Not tied in any way to this heuristic so better suggestions are welcomed.
