### PR TITLE
[GEOS-6785]WCS GetCapabilities 1.1.1 has invalid metadataType attribute

### DIFF
--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
@@ -478,11 +478,6 @@ public class WCSCapsTransformer extends TransformerBase {
             if ((mdl.getAbout() != null) && (mdl.getAbout() != "")) {
                 attributes.addAttribute("", "about", "about", "", mdl.getAbout());
             }
-            
-            if ((mdl.getMetadataType() != null) && (mdl.getMetadataType() != "")) {
-                attributes.addAttribute("", "metadataType", "metadataType", "", mdl
-                        .getMetadataType());
-            }
 
             if ((linkType != null) && (linkType != "")) {
                 attributes.addAttribute("", "xlink:type", "xlink:type", "", linkType);

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
@@ -394,4 +394,21 @@ public class GetCapabilitiesTest extends WCSTestSupport {
         assertXpathEvaluatesTo("http://www.geoserver.org/tasmania/dem.xml", xpathBase
                 + "/@xlink:href", dom);
     }
+
+    @Test
+    public void testNoMetadataTypeAttribute() throws Exception {
+        Catalog catalog = getCatalog();
+        CoverageInfo ci = catalog.getCoverageByName(getLayerId(TASMANIA_DEM));
+        MetadataLinkInfo ml = catalog.getFactory().createMetadataLink();
+        ml.setContent("http://www.geoserver.org/tasmania/dem.xml");
+        ml.setAbout("http://www.geoserver.org");
+        ci.getMetadataLinks().add(ml);
+        catalog.save(ci);
+
+        Document dom = getAsDOM("wcs?request=GetCapabilities");
+        checkValidationErrors(dom, WCS11_SCHEMA);
+        String xpathBase = "//wcs:CoverageSummary[wcs:Identifier = '" + TASMANIA_DEM.getLocalPart()
+                + "']/ows:Metadata";
+        assertXpathNotExists(xpathBase + "/@metadataType", dom);
+    }
 }


### PR DESCRIPTION
WCS GetCapabilities request had a metadataType attribute which isn't allowed according to the XSD (owsCommon 1.1.1). Thus I have removed this item from being generated.
