### PR TITLE
[GEOS-6791] GeoServerTileLayers are saved even if _Create cached layer_ ...

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
@@ -174,6 +174,11 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
 
         add(new Label("createTileLayerLabel", createTileLayerLabelModel));
 
+        // Get the model and check if the Enabled parameter has been defined
+        GeoServerTileLayerInfoModel model = ((GeoServerTileLayerInfoModel)tileLayerModel);
+
+        boolean undefined = model.getEnabled() == null;
+        
         boolean doCreateTileLayer;
         if (tileLayerInfo.getId() != null) {
             doCreateTileLayer = true;
@@ -181,6 +186,10 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
             doCreateTileLayer = true;
         } else {
             doCreateTileLayer = false;
+        }
+        // Add the enabled/disabled parameter depending on the doCreateTileLayer variable if not already set
+        if (undefined) {
+            model.setEnabled(doCreateTileLayer);
         }
         add(createLayer = new CheckBox("createTileLayer", new Model<Boolean>(doCreateTileLayer)));
         createLayer.add(new AttributeModifier("title", true, new ResourceModel(
@@ -289,7 +298,9 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
         final CatalogInfo layer = layerModel.getObject();
         final GeoServerTileLayerInfo tileLayerInfo = getModelObject();
         final boolean tileLayerExists = gwc.hasTileLayer(layer);
-        final boolean createLayer = this.createLayer.getModelObject().booleanValue();
+        GeoServerTileLayerInfoModel model = (GeoServerTileLayerInfoModel) getModel();
+        final boolean createLayer = model.getEnabled() == null ? GWC.get().getConfig()
+                .isCacheLayersByDefault() : model.getEnabled();
 
         if (!createLayer) {
             if (tileLayerExists) {
@@ -390,7 +401,8 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
     protected void convertInput() {
         createLayer.processInput();
         final boolean createTileLayer = createLayer.getModelObject().booleanValue();
-
+        GeoServerTileLayerInfoModel model = ((GeoServerTileLayerInfoModel)getModel());
+        model.setEnabled(createTileLayer);
         GeoServerTileLayerInfo tileLayerInfo = getModelObject();
 
         if (createTileLayer) {

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerInfoModel.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerInfoModel.java
@@ -11,6 +11,8 @@ import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
 public class GeoServerTileLayerInfoModel extends Model<GeoServerTileLayerInfo> {
     private static final long serialVersionUID = 2246174669786551903L;
 
+    private Boolean enabled;
+
     private final boolean isNew;
 
     public GeoServerTileLayerInfoModel(GeoServerTileLayerInfo info, boolean isNew) {
@@ -20,5 +22,13 @@ public class GeoServerTileLayerInfoModel extends Model<GeoServerTileLayerInfo> {
 
     public boolean isNew() {
         return isNew;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
     }
 }


### PR DESCRIPTION
...is disabled

This pull request contains a fix for JIRA: https://jira.codehaus.org/browse/GEOS-6791