### PR TITLE
[GEOS-6688] Addition to support more interpolation types.

### DIFF
--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/DefaultWebCoverageService111.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/DefaultWebCoverageService111.java
@@ -888,7 +888,7 @@ public class DefaultWebCoverageService111 implements WebCoverageService111 {
             boolean interpolationSupported = false;
 
             if (interpolation.equalsIgnoreCase("nearest")) {
-                interpolation = "nearest neighbor";
+                interpolation = "nearest";
             } else if (interpolation.equalsIgnoreCase("cubic") || interpolation.equalsIgnoreCase("bicubic")) {
                 interpolation = "bicubic";
             } else if (interpolation.equalsIgnoreCase("linear") || interpolation.equalsIgnoreCase("bilinear")) {
@@ -896,7 +896,7 @@ public class DefaultWebCoverageService111 implements WebCoverageService111 {
             }
 
             for (String method : info.getInterpolationMethods()) {
-                if (interpolation.equalsIgnoreCase(method)) {
+                if (interpolation.startsWith(method.toLowerCase())) {
                     interpolationSupported = true;
                     break;
                 }


### PR DESCRIPTION
The nearest neighbor interpolation type was not working because of an issue regarding spelling of the word neighbor. When enforcing one style of spelling we potentially break a lot of existing configurations in GeoServer. That's why it is more convenient to check with startsWith() instead of equalsIngoreCase(). This way all of the existing interpolation methods are working while maintaining compatibility with the differences in spelling.

I have also raised this issue on the mailing list of geoserver-devel. 
