### PR TITLE
[GEOS-6688-2] Fix for nearest neighbor interpolation.

### DIFF
--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/DefaultWebCoverageService111.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/DefaultWebCoverageService111.java
@@ -896,7 +896,7 @@ public class DefaultWebCoverageService111 implements WebCoverageService111 {
             }
 
             for (String method : info.getInterpolationMethods()) {
-                if (interpolation.startsWith(method.toLowerCase())) {
+                if (method.toLowerCase().startsWith(interpolation)) {
                     interpolationSupported = true;
                     break;
                 }

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -531,4 +531,28 @@ public class GetCoverageTest extends AbstractGetCoverageTest {
         assertTrue(image.getHeight() < 1000);
     }
 
+    @Test
+    public void testBicubicInterpolation() throws Exception {
+        this.testInterpolationMethods("cubic");
+    }
+
+    @Test
+    public void testBilinearInterpolation() throws Exception {
+        this.testInterpolationMethods("linear");
+    }
+
+    @Test
+    public void testNearestNeighborInterpolation() throws Exception {
+        this.testInterpolationMethods("nearest");
+    }
+
+    private void testInterpolationMethods(String method) throws Exception {
+        String queryString = "wcs?identifier=" + getLayerId(MOSAIC) + "&request=getcoverage"
+                + "&service=wcs&version=1.1.1&&format=image/tiff"
+                + "&BoundingBox=0,0,1,1,urn:ogc:def:crs:EPSG:6.6:4326"
+                + "&RangeSubset=contents:" + method;
+
+        MockHttpServletResponse response = getAsServletResponse(queryString);
+    }
+
 }

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/publish/WCSLayerConfig.java
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/publish/WCSLayerConfig.java
@@ -32,7 +32,7 @@ import org.geoserver.web.wicket.SimpleChoiceRenderer;
 public class WCSLayerConfig extends LayerConfigurationPanel {
 
     private static final List<String> WCS_FORMATS = Arrays.asList("GIF","PNG","JPEG","TIFF","GTOPO30","GEOTIFF","IMAGEMOSAIC","ARCGRID");
-    private static final List<String> INTERPOLATIONS = Arrays.asList("nearest neighbour","bilinear","bicubic");
+    private static final List<String> INTERPOLATIONS = Arrays.asList("nearest neighbor","bilinear","bicubic");
     
     private List<String> selectedRequestSRSs;
     private List<String> selectedResponseSRSs;


### PR DESCRIPTION
Apparently my earlier fix wasn't sufficient and didn't work all that well. That's why I changed the order of the check in the String which makes the check more stable.  Also I've added an extra test for RangeSubset with interpolation in GetCoverage (where it belongs).

Finally I've renamed Nearest Neighbour in the web interface to Nearest Neighbor which seems to fix the web interface from not displaying this interpolation method when loading a new layer. Now it works properly.
