### PR TITLE
[GEOS-6627]GWC causes a wrong handling of the ImageIO and ImageIO-Ext plugins (Backport on 2.6.x branch)

### DIFF
--- a/src/gwc/src/main/resources/geowebcache-wmsservice-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-wmsservice-context.xml
@@ -40,6 +40,14 @@
   </bean>
   <alias name="gwcServiceWMSProxy" alias="gwcServiceWMS"/>
 
+    <bean id="ioInitializer" class="org.geowebcache.io.ImageIOInitializer" factory-method="getInstance">
+  		<constructor-arg index="0">
+			<list>
+				<value>com.sun.media.imageioimpl.plugins.tiff.TIFFImageWriterSpi</value>
+				<value>com.sun.media.imageioimpl.plugins.tiff.TIFFImageReaderSpi</value>
+			</list>
+		</constructor-arg>
+  	</bean>
 
 	<!--Encoders -->
 
@@ -58,9 +66,8 @@
 				<entry key="COMPRESSION_RATE" value="0.75" />
 			</map>
 		</constructor-arg>
-		<property name="disablePNG">
-			<value>FALSE</value>
-		</property>
+		<constructor-arg index="4" value="false" />
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="GIFEncoder" class="org.geowebcache.io.ImageEncoderImpl">
@@ -82,6 +89,7 @@
 				<entry key="COMPRESSION_RATE" value="NULL" />
 			</map>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="JPEGEncoder" class="org.geowebcache.io.ImageEncoderImpl">
@@ -103,6 +111,7 @@
 				<entry key="COMPRESSION_RATE" value="0.75" />
 			</map>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="TIFFEncoder" class="org.geowebcache.io.ImageEncoderImpl">
@@ -124,6 +133,7 @@
 				<entry key="COMPRESSION_RATE" value="0.75" />
 			</map>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="BMPEncoder" class="org.geowebcache.io.ImageEncoderImpl">
@@ -145,6 +155,7 @@
 				<entry key="COMPRESSION_RATE" value="NULL" />
 			</map>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<!--Decoders -->
@@ -163,6 +174,7 @@
 				<value>com.sun.imageio.plugins.png.PNGImageReaderSpi</value>
 			</list>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="GIFDecoder" class="org.geowebcache.io.ImageDecoderImpl">
@@ -177,6 +189,7 @@
 				<value>com.sun.imageio.plugins.gif.GIFImageReaderSpi</value>
 			</list>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="JPEGDecoder" class="org.geowebcache.io.ImageDecoderImpl">
@@ -192,6 +205,7 @@
 				<value>com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi</value>
 			</list>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="TIFFDecoder" class="org.geowebcache.io.ImageDecoderImpl">
@@ -207,6 +221,7 @@
 				<value>com.sun.media.imageioimpl.plugins.tiff.TIFFImageReaderSpi</value>
 			</list>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="BMPDecoder" class="org.geowebcache.io.ImageDecoderImpl">
@@ -222,6 +237,7 @@
 				<value>com.sun.imageio.plugins.bmp.BMPImageReaderSpi</value>
 			</list>
 		</constructor-arg>
+		<constructor-arg ref="ioInitializer" />
 	</bean>
 
 	<bean id="decoderContainer" class="org.geowebcache.io.ImageDecoderContainer" />

--- a/src/gwc/src/test/java/org/geoserver/gwc/wms/TestFullWMSBeans.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/wms/TestFullWMSBeans.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2014 OpenPlans - www.openplans.org. All rights reserved.
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.wms;
+
+import java.util.List;
+
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geowebcache.io.ImageDecoderContainer;
+import org.geowebcache.io.ImageDecoderImpl;
+import org.geowebcache.io.ImageIOInitializer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Test class ensuring that the GWC beans stored in the geowebcache-wmsservice-context.xml file are correctly loaded.
+ * 
+ * @author Nicola Lagomarsini geosolutions
+ * 
+ */
+public class TestFullWMSBeans extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testBeanSelection() {
+        // Selection of the test application context
+        ApplicationContext context = applicationContext;
+        // Check that the initializer is present
+        Object obj = context.getBean("ioInitializer");
+        Assert.assertNotNull(obj);
+        Assert.assertTrue(obj instanceof ImageIOInitializer);
+
+        // Ensure that the excluded spis are present
+        ImageIOInitializer init = (ImageIOInitializer) obj;
+        List<String> excluded = init.getExcludedSpis();
+        Assert.assertNotNull(excluded);
+        Assert.assertTrue(excluded.size() > 0);
+
+        // Ensure that a decoder is present
+        Object obj2 = context.getBean("TIFFDecoder");
+        Assert.assertNotNull(obj2);
+        Assert.assertTrue(obj2 instanceof ImageDecoderImpl);
+
+        // Test if the container has been created
+        ImageDecoderContainer container = context.getBean(ImageDecoderContainer.class);
+        Assert.assertNotNull(container);
+    }
+}


### PR DESCRIPTION
Please look at the following JIRA: https://jira.codehaus.org/browse/GEOS-6627. Note that the following pull request requires that the https://github.com/GeoWebCache/geowebcache/pull/272 pull request has been already merged in GWC.
