### PR TITLE
[GEOS-6807] WCS GetCapabilties requests with Sections parameter throws an exception

### DIFF
--- a/src/wcs1_1/src/main/java/applicationContext.xml
+++ b/src/wcs1_1/src/main/java/applicationContext.xml
@@ -85,7 +85,17 @@
   <!-- kvp parsers -->
   <bean id="ows11AcceptVersionsKvpParser" class="org.geoserver.wcs.kvp.AcceptVersionsKvpParser" />
 
-  <bean id="ows11SectionsKvpParser" class="org.geoserver.wcs.kvp.SectionsKvpParser" />
+  <bean id="ows110SectionsKvpParser" class="org.geoserver.wcs.kvp.SectionsKvpParser">
+    <property name="version" value="1.1.0"/>
+  </bean>
+
+  <bean id="ows111SectionsKvpParser" class="org.geoserver.wcs.kvp.SectionsKvpParser">
+    <property name="version" value="1.1.1"/>
+  </bean>
+
+  <bean id="ows11SectionsKvpParser" class="org.geoserver.wcs.kvp.SectionsKvpParser">
+    <property name="version" value="1.1"/>
+  </bean>  
 
   <bean id="wcs111RangeSubsetKvpParser" class="org.geoserver.wcs.kvp.RangeSubsetKvpParser" />
 

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
@@ -294,7 +294,7 @@ public class GetCapabilitiesTest extends WCSTestSupport {
 
     @Test
     public void testSectionsAll() throws Exception {
-        Document dom = getAsDOM(BASEPATH + "?request=GetCapabilities&service=WCS&sections=All");
+        Document dom = getAsDOM(BASEPATH + "?request=GetCapabilities&service=WCS&sections=All&version=1.1");
         checkValidationErrors(dom, WCS11_SCHEMA);
         assertXpathEvaluatesTo("1", "count(//ows:ServiceIdentification)", dom);
         assertXpathEvaluatesTo("1", "count(//ows:ServiceProvider)", dom);
@@ -312,7 +312,7 @@ public class GetCapabilitiesTest extends WCSTestSupport {
     @Test
     public void testOneSection() throws Exception {
         Document dom = getAsDOM(BASEPATH
-                + "?request=GetCapabilities&service=WCS&sections=ServiceProvider");
+                + "?request=GetCapabilities&service=WCS&sections=ServiceProvider&version=1.1");
         checkValidationErrors(dom, WCS11_SCHEMA);
         assertXpathEvaluatesTo("0", "count(//ows:ServiceIdentification)", dom);
         assertXpathEvaluatesTo("1", "count(//ows:ServiceProvider)", dom);
@@ -323,7 +323,7 @@ public class GetCapabilitiesTest extends WCSTestSupport {
     @Test
     public void testTwoSection() throws Exception {
         Document dom = getAsDOM(BASEPATH
-                + "?request=GetCapabilities&service=WCS&sections=ServiceProvider,Contents");
+                + "?request=GetCapabilities&service=WCS&sections=ServiceProvider,Contents&version=1.1");
         checkValidationErrors(dom, WCS11_SCHEMA);
         assertXpathEvaluatesTo("0", "count(//ows:ServiceIdentification)", dom);
         assertXpathEvaluatesTo("1", "count(//ows:ServiceProvider)", dom);

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/kvp/SectionsKvpParserTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/kvp/SectionsKvpParserTest.java
@@ -1,0 +1,60 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.kvp;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import net.opengis.ows11.SectionsType;
+
+import org.geoserver.ows.KvpParser;
+import org.geoserver.ows.util.KvpUtils;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.wcs.test.WCSTestSupport;
+import org.junit.Test;
+/**
+ * Tests the parser for the "Sections" parameter. Version 1.1
+ * 
+ * @author Nicola Lagomarsini GeoSolutions
+ */
+public class SectionsKvpParserTest extends WCSTestSupport {
+
+    @Test
+    public void testParserForVersion() {
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+        // Version 2.0.0
+        KvpParser parser = KvpUtils.findParser("sections", "WCS", null, "1.1.0", parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), SectionsKvpParser.class);
+        // Version 2.0.1
+        parser = KvpUtils.findParser("sections", "WCS", null, "1.1.1", parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), SectionsKvpParser.class);
+        // Version not defined
+        parser = KvpUtils.findParser("sections", "WCS", "1.1", null, parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), SectionsKvpParser.class);
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+        // Get the parser
+        SectionsKvpParser parser = (SectionsKvpParser) KvpUtils.findParser("sections", "WCS", null,
+                "1.1.1", parsers);
+        // Parse the object
+        Object parsed = parser.parse("all");
+        // Ensure the object is not null and is an instance of the SectionsType class
+        assertNotNull(parsed);
+        assertTrue(parsed instanceof SectionsType);
+    }
+}

--- a/src/wcs2_0/src/main/java/applicationContext.xml
+++ b/src/wcs2_0/src/main/java/applicationContext.xml
@@ -107,6 +107,15 @@
     <property name="version" value="2.0.1" />
   </bean>
 
+  <bean id="wcs200SectionsKvpParser" class="org.geoserver.wcs2_0.kvp.SectionsKvpParser">
+    <property name="version" value="2.0.0"/>
+  </bean>
+
+  <bean id="wcs201SectionsKvpParser" class="org.geoserver.wcs2_0.kvp.SectionsKvpParser">
+    <property name="version" value="2.0.1"/>
+  </bean>    
+
+  <bean id="wcsDefaultSectionsKvpParser" class="org.geoserver.wcs2_0.kvp.SectionsKvpParser"/>
 
   <bean id="wcs20getCoverageKvpParser" class="org.geoserver.wcs2_0.kvp.WCS20GetCoverageRequestReader" />
 

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/kvp/SectionsKvpParser.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/kvp/SectionsKvpParser.java
@@ -1,0 +1,28 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs2_0.kvp;
+
+import net.opengis.ows20.Ows20Factory;
+import net.opengis.ows20.SectionsType;
+
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * Parses the "sections" GetCapabilities kvp argument in WCS 2.0
+ * 
+ * @author Nicola Lagomarsini GeoSolutions
+ */
+public class SectionsKvpParser extends org.geoserver.ows.kvp.SectionsKvpParser {
+
+    public SectionsKvpParser() {
+        super(SectionsType.class);
+    }
+
+    @Override
+    protected EObject createObject() {
+        return Ows20Factory.eINSTANCE.createSectionsType();
+    }
+}

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/SectionsKvpParserTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/SectionsKvpParserTest.java
@@ -1,0 +1,59 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs2_0.kvp;
+
+import static org.junit.Assert.*;
+import java.util.List;
+
+import net.opengis.ows20.SectionsType;
+
+import org.geoserver.ows.KvpParser;
+import org.geoserver.ows.util.KvpUtils;
+import org.geoserver.platform.GeoServerExtensions;
+import org.junit.Test;
+
+/**
+ * Tests the parser for the "Sections" parameter. Version 2.0
+ * 
+ * @author Nicola Lagomarsini GeoSolutions
+ */
+public class SectionsKvpParserTest extends WCSKVPTestSupport {
+
+    @Test
+    public void testParserForVersion() {
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+        // Version 2.0.0
+        KvpParser parser = KvpUtils.findParser("sections", "WCS", null, "2.0.0", parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), SectionsKvpParser.class);
+        // Version 2.0.1
+        parser = KvpUtils.findParser("sections", "WCS", null, "2.0.1", parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), SectionsKvpParser.class);
+        // Version not defined
+        parser = KvpUtils.findParser("sections", "WCS", null, null, parsers);
+        assertNotNull(parser);
+        // Ensure the correct parser is taken
+        assertEquals(parser.getClass(), SectionsKvpParser.class);
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        // look up parser objects
+        List<KvpParser> parsers = GeoServerExtensions.extensions(KvpParser.class);
+        // Get the parser
+        SectionsKvpParser parser = (SectionsKvpParser) KvpUtils.findParser("sections", "WCS", null,
+                "2.0.0", parsers);
+        // Parse the object
+        Object parsed = parser.parse("all");
+        // Ensure the object is not null and is an instance of the SectionsType class
+        assertNotNull(parsed);
+        assertTrue(parsed instanceof SectionsType);
+    }
+}


### PR DESCRIPTION
Please look at the following JIRA: https://jira.codehaus.org/browse/GEOS-6807. Note that the following PR will set as default parser the one for WCS 2.0.1 version.
