### PR TITLE
[GEOS-6745] Copy style needs to copy content and format

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/style/StyleDetachableModel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/style/StyleDetachableModel.java
@@ -22,4 +22,10 @@ public class StyleDetachableModel extends LoadableDetachableModel {
         return GeoServerApplication.get().getCatalog().getStyle( id );
     }
 
+    @Override
+    protected void onDetach() {
+        // TODO Auto-generated method stub
+        super.onDetach();
+    }
+
 }

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
@@ -88,7 +88,9 @@ public class StyleEditPage extends AbstractStylePage {
         // write out the file and save name modifications
         try {
             StyleInfo style = (StyleInfo) styleForm.getModelObject();
-            Version version = Styles.handler(formatChoice.getModelObject()).version(rawStyle);
+            String format = formatChoice.getModelObject();
+            style.setFormat(format);
+            Version version = Styles.handler(format).version(rawStyle);
             style.setSLDVersion(version);
             
             // write out the SLD

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleNewPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleNewPage.java
@@ -15,7 +15,6 @@ import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StyleHandler;
 import org.geoserver.catalog.StyleInfo;
-import org.geoserver.catalog.Styles;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geotools.util.Version;
 
@@ -50,6 +49,7 @@ public class StyleNewPage extends AbstractStylePage {
         // add the style
         Catalog catalog = getCatalog();
         StyleInfo s = (StyleInfo) styleForm.getModelObject();
+        s.setFormat(format);
 
         StyleHandler styleHandler = styleHandler();
 


### PR DESCRIPTION
Since I cannot find a way to write a test for this one, I submitted a pull request in case someone wants to review. The trick to make it work was to move the format into a field, since we cannot keep the format in the html and get it back when the format dropdown gets disabled (disabled fields are not posted back, by HTML standard)