### PR TITLE
Test fixes for gt-property-ng migration

### DIFF
--- a/src/main/src/test/java/org/geoserver/data/test/MockCatalogBuilder.java
+++ b/src/main/src/test/java/org/geoserver/data/test/MockCatalogBuilder.java
@@ -132,6 +132,7 @@ public class MockCatalogBuilder {
         expect(ns.getName()).andReturn(name).anyTimes();
         expect(ns.getPrefix()).andReturn(name).anyTimes();
         expect(ns.getMetadata()).andReturn(new MetadataMap()).anyTimes();
+        expect(ns.getURI()).andReturn(uri).anyTimes();
     
         expect(catalog.getNamespace(nsId)).andReturn(ns).anyTimes();
         expect(catalog.getNamespaceByPrefix(name)).andReturn(ns).anyTimes();

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/FeatureTypeTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/FeatureTypeTest.java
@@ -34,6 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.Name;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -423,6 +424,7 @@ public class FeatureTypeTest extends CatalogRESTTestSupport {
         FeatureTypeInfo featureType = catalog.getFeatureTypeByName("sf", "PrimitiveGeoFeature");
         String featureTypeId = featureType.getId();
         String dataStoreId = featureType.getStore().getId();
+        Name name = featureType.getFeatureType().getName();
         
         assertNotNull( "PrmitiveGeoFeature available", featureType );
         for (LayerInfo l : catalog.getLayers( featureType ) ) {
@@ -438,8 +440,8 @@ public class FeatureTypeTest extends CatalogRESTTestSupport {
         }
         if( catalog.getResourcePool().getDataStoreCache().containsKey( dataStoreId ) ){
             DataAccess dataStore = catalog.getResourcePool().getDataStoreCache().get( dataStoreId );
-            List<String> names = dataStore.getNames();
-            assertTrue( names.contains("PrimativeGeoFeature"));
+            List<Name> names = dataStore.getNames();
+            assertTrue( names.contains(name));
         }
     }
     


### PR DESCRIPTION
Some minor test fixes required for compatibility with the geotools property-ng migration:
Added namespace.getURI to MockCatalogBuilder
Removed instanceof test to support new implementation
Fixed spelling mistake