### PR TITLE
[GEOS-6805] Support for WCS 2.0 request without defining workspace in coverageId(Backport 2.6.x)

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/util/NCNameResourceCodec.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/util/NCNameResourceCodec.java
@@ -93,21 +93,33 @@ public class NCNameResourceCodec {
             String namespace = mapEntry.getKey();
             String covName = mapEntry.getValue();
 
-            LOGGER.info(" Checking pair " + namespace + " : " + covName );
+            if (namespace == null || namespace.isEmpty()) {
+                LOGGER.info(" Checking coverage name " + covName);
 
-            String fullName = namespace+":"+covName;
-            NamespaceInfo nsInfo = catalog.getNamespaceByPrefix(namespace);
-            if(nsInfo != null) {
-                LOGGER.info(" - Namespace found " + namespace);
-                LayerInfo layer = catalog.getLayerByName(fullName);
-                if(layer != null) {
+                LayerInfo layer = catalog.getLayerByName(covName);
+                if (layer != null) {
                     LOGGER.info(" - Collecting layer " + layer.prefixedName());
                     ret.add(layer);
                 } else {
-                    LOGGER.info(" - Ignoring layer " + fullName);
+                    LOGGER.info(" - Ignoring layer " + covName);
                 }
             } else {
-                LOGGER.info(" - Namespace not found " + namespace);
+                LOGGER.info(" Checking pair " + namespace + " : " + covName);
+
+                String fullName = namespace + ":" + covName;
+                NamespaceInfo nsInfo = catalog.getNamespaceByPrefix(namespace);
+                if (nsInfo != null) {
+                    LOGGER.info(" - Namespace found " + namespace);
+                    LayerInfo layer = catalog.getLayerByName(fullName);
+                    if (layer != null) {
+                        LOGGER.info(" - Collecting layer " + layer.prefixedName());
+                        ret.add(layer);
+                    } else {
+                        LOGGER.info(" - Ignoring layer " + fullName);
+                    }
+                } else {
+                    LOGGER.info(" - Namespace not found " + namespace);
+                }
             }
         }
 
@@ -120,11 +132,13 @@ public class NCNameResourceCodec {
      */
     public static List<MapEntry<String,String>> decode(String qualifiedName) {
         int lastPos = qualifiedName.lastIndexOf(DELIMITER);
-
-        if( lastPos == -1)
-            return Collections.EMPTY_LIST;
-
         List<MapEntry<String,String>> ret = new ArrayList<MapEntry<String, String>>();
+
+        if (lastPos == -1) {
+            ret.add(new MapEntry<String, String>(null, qualifiedName));
+            return ret;
+        }
+
         while (lastPos > -1) {
             String ws   = qualifiedName.substring(0, lastPos);
             String name = qualifiedName.substring(lastPos+DELIMITER.length());

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/CoverageIdConverterTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/CoverageIdConverterTest.java
@@ -20,6 +20,7 @@
 package org.geoserver.wcs2_0;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
@@ -80,6 +81,8 @@ public class CoverageIdConverterTest {
     public void testDecodeBad() {
         String qualifiedName = "bad_qualified_name";
         List<MapEntry<String, String>> decode = NCNameResourceCodec.decode(qualifiedName);
-        assertEquals(0, decode.size());
+        assertEquals(1, decode.size());
+        assertNull(decode.get(0).getKey());
+        assertEquals("bad_qualified_name", decode.get(0).getValue());
     }
 }

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/LayerCodecTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/LayerCodecTest.java
@@ -7,7 +7,9 @@ import static org.junit.Assert.assertNull;
 import java.util.List;
 
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.wcs2_0.util.NCNameResourceCodec;
 import org.junit.Test;
@@ -27,7 +29,8 @@ public class LayerCodecTest extends GeoServerSystemTestSupport {
     public void testBasicKVP() throws Exception {
         {
             List<LayerInfo> list0 = NCNameResourceCodec.getLayers(getCatalog(), "pippo_topo");
-            assertNull(list0);
+            assertNotNull(list0);
+            assertEquals(0, list0.size());
         }
 
         {
@@ -38,6 +41,24 @@ public class LayerCodecTest extends GeoServerSystemTestSupport {
 
         {
             List<LayerInfo> list = NCNameResourceCodec.getLayers(getCatalog(), "wcs__BlueMarble");
+            assertNotNull(list);
+            assertEquals(1, list.size());
+        }
+
+        {
+            // Setting the LocalWorkspace to WCS
+            WorkspaceInfo ws = getCatalog().getWorkspaceByName("wcs");
+            assertNotNull(ws);
+            WorkspaceInfo oldWs = LocalWorkspace.get();
+            LocalWorkspace.set(ws);
+            List<LayerInfo> list = NCNameResourceCodec.getLayers(getCatalog(), "BlueMarble");
+            assertNotNull(list);
+            assertEquals(1, list.size());
+            LocalWorkspace.set(oldWs);
+        }
+
+        {
+            List<LayerInfo> list = NCNameResourceCodec.getLayers(getCatalog(), "BlueMarble");
             assertNotNull(list);
             assertEquals(1, list.size());
         }

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/DescribeCoverageTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/DescribeCoverageTest.java
@@ -108,7 +108,29 @@ public class DescribeCoverageTest extends WCSTestSupport {
         assertXpathEvaluatesTo("9", "count(//wcs:CoverageDescription//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);        
         assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions//wcs:CoverageDescription[1]//wcs:ServiceParameters//wcs:nativeFormat", dom);
     }
-    
+
+    @Test
+    public void testMultiBandKVPNoWs() throws Exception {
+        Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=multiband");
+        assertNotNull(dom);
+        // print(dom, System.out);
+
+        checkValidationErrors(dom, WCS20_SCHEMA);       
+        assertXpathEvaluatesTo("9", "count(//wcs:CoverageDescription//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);        
+        assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions//wcs:CoverageDescription[1]//wcs:ServiceParameters//wcs:nativeFormat", dom);
+    }
+
+    @Test
+    public void testMultiBandKVPLocalWs() throws Exception {
+        Document dom = getAsDOM("wcs/" + DESCRIBE_URL + "&coverageId=multiband");
+        assertNotNull(dom);
+        // print(dom, System.out);
+
+        checkValidationErrors(dom, WCS20_SCHEMA);       
+        assertXpathEvaluatesTo("9", "count(//wcs:CoverageDescription//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);        
+        assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions//wcs:CoverageDescription[1]//wcs:ServiceParameters//wcs:nativeFormat", dom);
+    }
+
     @Test
     public void testMultipleCoverages() throws Exception {
         Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=wcs__multiband,wcs__BlueMarble");
@@ -124,7 +146,39 @@ public class DescribeCoverageTest extends WCSTestSupport {
         assertXpathEvaluatesTo("3", "count(//wcs:CoverageDescription[2]//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);
         assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions/wcs:CoverageDescription[2]//wcs:ServiceParameters//wcs:nativeFormat", dom);
     }
-    
+
+    @Test
+    public void testMultipleCoveragesNoWs() throws Exception {
+        Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=multiband,wcs__BlueMarble");
+        assertNotNull(dom);
+        // print(dom, System.out);
+
+        checkValidationErrors(dom, WCS20_SCHEMA);       
+        assertXpathEvaluatesTo("2", "count(//wcs:CoverageDescription)", dom);        
+        assertXpathEvaluatesTo("wcs__multiband", "//wcs:CoverageDescriptions/wcs:CoverageDescription[1]/@gml:id", dom);
+        assertXpathEvaluatesTo("9", "count(//wcs:CoverageDescription[1]//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);
+        assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions/wcs:CoverageDescription[1]//wcs:ServiceParameters//wcs:nativeFormat", dom);
+        assertXpathEvaluatesTo("wcs__BlueMarble", "//wcs:CoverageDescriptions/wcs:CoverageDescription[2]/@gml:id", dom);
+        assertXpathEvaluatesTo("3", "count(//wcs:CoverageDescription[2]//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);
+        assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions/wcs:CoverageDescription[2]//wcs:ServiceParameters//wcs:nativeFormat", dom);
+    }
+
+    @Test
+    public void testMultipleCoveragesLocalWs() throws Exception {
+        Document dom = getAsDOM("wcs/" + DESCRIBE_URL + "&coverageId=multiband,BlueMarble");
+        assertNotNull(dom);
+        // print(dom, System.out);
+
+        checkValidationErrors(dom, WCS20_SCHEMA);       
+        assertXpathEvaluatesTo("2", "count(//wcs:CoverageDescription)", dom);        
+        assertXpathEvaluatesTo("wcs__multiband", "//wcs:CoverageDescriptions/wcs:CoverageDescription[1]/@gml:id", dom);
+        assertXpathEvaluatesTo("9", "count(//wcs:CoverageDescription[1]//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);
+        assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions/wcs:CoverageDescription[1]//wcs:ServiceParameters//wcs:nativeFormat", dom);
+        assertXpathEvaluatesTo("wcs__BlueMarble", "//wcs:CoverageDescriptions/wcs:CoverageDescription[2]/@gml:id", dom);
+        assertXpathEvaluatesTo("3", "count(//wcs:CoverageDescription[2]//gmlcov:rangeType//swe:DataRecord//swe:field)", dom);
+        assertXpathEvaluatesTo("image/tiff", "//wcs:CoverageDescriptions/wcs:CoverageDescription[2]//wcs:ServiceParameters//wcs:nativeFormat", dom);
+    }
+
     @Test
     public void testMultipleCoveragesOneNotExists() throws Exception {
         MockHttpServletResponse response = getAsServletResponse(DESCRIBE_URL + "&coverageId=wcs__multiband,wcs__IAmNotThere");

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/GetCoverageKvpTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/GetCoverageKvpTest.java
@@ -34,7 +34,23 @@ public class GetCoverageKvpTest extends WCSKVPTestSupport {
         
         assertEquals("theCoverage", gc.getCoverageId());
     }
-    
+
+    @Test
+    public void testGetCoverageNoWs() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1" +
+                "&coverageId=BlueMarble&&Format=image/tiff");  
+
+        assertEquals("image/tiff", response.getContentType());      
+    }
+
+    @Test
+    public void testGetCoverageLocalWs() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse("wcs/wcs?request=GetCoverage&service=WCS&version=2.0.1" +
+                "&coverageId=BlueMarble&&Format=image/tiff");  
+
+        assertEquals("image/tiff", response.getContentType());      
+    }
+
     @Test
     public void testNotExistent() throws Exception {
         MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1" +


### PR DESCRIPTION
Backport on 2.6.x branch of the fix for JIRA: https://jira.codehaus.org/browse/GEOS-6805