### PR TITLE
[GEOS-6808] WCS-EO DescribeEOCoverageSet should be more lenient (Backport on 2.6.x)

### DIFF
--- a/src/extension/wcs2_0-eo/core/src/main/java/org/geoserver/wcs2_0/eo/response/DescribeEOCoverageSetTransformer.java
+++ b/src/extension/wcs2_0-eo/core/src/main/java/org/geoserver/wcs2_0/eo/response/DescribeEOCoverageSetTransformer.java
@@ -506,8 +506,9 @@ public class DescribeEOCoverageSetTransformer extends TransformerBase {
         private DateRange parseDateRange(DimensionTrimType trim) {
             DatatypeConverterImpl xmlTimeConverter = DatatypeConverterImpl.getInstance();
             try {
-                final Date low = xmlTimeConverter.parseDateTime(trim.getTrimLow()).getTime();
-                final Date high = xmlTimeConverter.parseDateTime(trim.getTrimHigh()).getTime();
+                // Use the lenient parameter
+                final Date low = xmlTimeConverter.parseDateTime(trim.getTrimLow(), true).getTime();
+                final Date high = xmlTimeConverter.parseDateTime(trim.getTrimHigh(), true).getTime();
 
                 // low > high???
                 if (low.compareTo(high) > 0) {

--- a/src/extension/wcs2_0-eo/core/src/test/java/org/geoserver/wcs2_0/eo/DescribeOECoverageSetTest.java
+++ b/src/extension/wcs2_0-eo/core/src/test/java/org/geoserver/wcs2_0/eo/DescribeOECoverageSetTest.java
@@ -304,6 +304,22 @@ public class DescribeOECoverageSetTest extends WCSEOTestSupport {
         assertEquals("4", xpath.evaluate("count(//wcs:CoverageDescriptions/wcs:CoverageDescription)", dom));
         assertEquals("1", xpath.evaluate("count(//wcseo:DatasetSeriesDescriptions)", dom));
     }
+
+    @Test
+    public void testTimeIntervalTrimContainsLenient() throws Exception {
+        // overlaps with some, contains none (dates are incomplete, we use the lenient parameter)
+        Document dom = getAsDOM("wcs?request=DescribeEOCoverageSet&version=2.0.1&service=WCS&eoid=sf__timeranges_dss" + 
+           "&subset=phenomenonTime(\"2008-10-31T00:00Z\",\"2008-10-31T23:59Z\")&containment=contains");
+        assertEquals("0", xpath.evaluate("count(//wcs:CoverageDescriptions/wcs:CoverageDescription)", dom));
+        assertEquals("0", xpath.evaluate("count(//wcseo:DatasetSeriesDescriptions)", dom));
+        
+        // contains a bunch 
+        dom = getAsDOM("wcs?request=DescribeEOCoverageSet&version=2.0.1&service=WCS&eoid=sf__timeranges_dss" +
+                "&subset=phenomenonTime(\"2008-10-30T00:00Z\",\"2008-11-03T00:00Z\")&containment=contains");
+        // print(dom);
+        assertEquals("4", xpath.evaluate("count(//wcs:CoverageDescriptions/wcs:CoverageDescription)", dom));
+        assertEquals("1", xpath.evaluate("count(//wcseo:DatasetSeriesDescriptions)", dom));
+    }    
     
     @Test
     public void testMixedTrim() throws Exception {


### PR DESCRIPTION
Backport on 2.6.x branch of the fix for JIRA: https://jira.codehaus.org/browse/GEOS-6808. Notice that this pull request requires to merge the related GT counterpart on 12.x branch: https://github.com/geotools/geotools/pull/684. 