### PR TITLE
Added possibility to set only metric or only imperial units on scaleline...

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/decoration/ScaleLineDecorationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/decoration/ScaleLineDecorationTest.java
@@ -31,6 +31,61 @@ public class ScaleLineDecorationTest extends DecorationTestSupport {
         assertPixel(bi2, 180, 160, new Color(0, 0, 0, 0));
     }
 
+    @Test
+    public void testMeasurementOption() throws Exception {
+        ScaleLineDecoration d = new ScaleLineDecoration();
+        
+        // setup for metric
+        Map<String, String> options = new HashMap<String, String>();
+        options.put("measurement-system", "metric");
+        d.loadOptions(options);
+        BufferedImage bi = paintOnImage(d);
+
+        //ImageIO.write(bi, "PNG", new File("/tmp/test1.png"));
+        //Check for metric
+        assertPixel(bi, 109, 139, Color.black);
+        //Check that we do not have imperial
+        assertPixel(bi, 109, 157, Color.white);
+        
+        
+        // setup for imperial
+        options.clear();
+        options.put("measurement-system", "imperial");
+        d.loadOptions(options);
+        bi = paintOnImage(d);
+
+        //ImageIO.write(bi, "PNG", new File("/tmp/test2.png"));
+        //Check for imperial
+        assertPixel(bi, 109, 157, Color.black);
+        //Check that we do not have metric
+        assertPixel(bi, 109, 139, Color.white);
+        
+        
+        // setup for both
+        options.clear();
+        options.put("measurement-system", "both");
+        d.loadOptions(options);
+        bi = paintOnImage(d);
+        
+        //ImageIO.write(bi, "PNG", new File("/tmp/test3.png"));
+        //Check for imperial
+        assertPixel(bi, 109, 157, Color.black);
+        //Check for metric
+        assertPixel(bi, 109, 139, Color.black);
+        
+        
+        // setup for default(both)
+        options.clear();
+        d.loadOptions(options);
+        bi = paintOnImage(d);
+
+        //ImageIO.write(bi, "PNG", new File("/tmp/test4.png"));
+        //Check for imperial
+        assertPixel(bi, 109, 157, Color.black);
+        //Check for metric
+        assertPixel(bi, 109, 139, Color.black);
+    }
+
     private BufferedImage paintOnImage(ScaleLineDecoration d) throws Exception {
         BufferedImage bi = new BufferedImage(300, 300, BufferedImage.TYPE_4BYTE_ABGR);
         Graphics2D g2d = bi.createGraphics();


### PR DESCRIPTION
.... Default behaviour is not changed and defaults to both.

Uncomment in test to view generation outputs.

Related JIRA: GEOS-4607