### PR TITLE
[GEOS-6841] Fix for invalid email address on the front page

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -75,7 +75,7 @@ public class GeoServerHomePage extends GeoServerBasePage {
             String contactEmail = contact.getContactEmail();
             HashMap<String, String>params = new HashMap<String, String>();
             params.put("version", version);
-            params.put("contactEmail", contactEmail);
+            params.put("contactEmail", (contactEmail == null ? "geoserver@example.org" : contactEmail));
             Label label = new Label("footerMessage", new StringResourceModel("GeoServerHomePage.footer", this, new Model(params)));
             label.setEscapeModelStrings(false);
             add(label);

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
@@ -44,6 +44,14 @@ public class GeoServerHomePageTest extends GeoServerWicketTestSupport {
         tester.assertListView("contributedContent", providers);
     }
 
+    @Test
+    public void testEmailIfNull() {
+        GeoServerApplication geoServerApplication = getGeoServerApplication();
+        String contactEmail = geoServerApplication.getGeoServer().getGlobal().getSettings().getContact().
+                getContactEmail();
+        assertEquals("geoserver@example.org", contactEmail == null ? "geoserver@example.org" : contactEmail);
+    }
+
     public static class MockHomePageContentProvider implements GeoServerHomePageContentProvider {
         public Component getPageBodyComponent(final String id) {
             return new Label(id, "MockHomePageContentProvider");


### PR DESCRIPTION
As reported in https://jira.codehaus.org/browse/GEOS-6841, this delivers a quick fix for the issue by checking if the mail address is equals to null. If it is this will be replaced by geoserver@example.org on the homepage.

I specifically choose example org because it is an IANA reserved domain for test purposes and can be used without prior consent.