### PR TITLE
[GEOS-6865] Allow wms extension capabilities providers to customize the root crs list and the layer scale ranges

### DIFF
--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,19 +6,22 @@
 package org.geoserver.inspire.wms;
 
 import static org.geoserver.inspire.InspireMetadata.LANGUAGE;
-import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_TYPE;
+import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.wms.ExtendedCapabilitiesProvider;
 import org.geoserver.wms.GetCapabilitiesRequest;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSInfo;
+import org.geotools.util.NumberRange;
 import org.geotools.util.Version;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
@@ -137,6 +140,17 @@ public class WMSExtendedCapabilitiesProvider implements ExtendedCapabilitiesProv
             attributes.addAttribute(null, atts[i], atts[i], null, atts[i + 1]);
         }
         return attributes;
+    }
+
+    @Override
+    public void customizeRootCrsList(Set<String> srs) {
+        // nothing to do
+    }
+
+    @Override
+    public NumberRange<Double> overrideScaleDenominators(LayerInfo layer,
+            NumberRange<Double> scaleDenominators) {
+        return scaleDenominators;
     }
 
 }

--- a/src/gwc/src/main/java/org/geoserver/gwc/wms/CachingExtendedCapabilitiesProvider.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/wms/CachingExtendedCapabilitiesProvider.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -9,7 +9,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.gwc.GWC;
 import org.geoserver.ows.LocalWorkspace;
@@ -17,6 +19,7 @@ import org.geoserver.wms.ExtendedCapabilitiesProvider;
 import org.geoserver.wms.GetCapabilitiesRequest;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSInfo;
+import org.geotools.util.NumberRange;
 import org.geotools.util.Version;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSubset;
@@ -199,5 +202,16 @@ public class CachingExtendedCapabilitiesProvider implements ExtendedCapabilities
         String[] bs = { Double.toString(bbox.getMinX()), Double.toString(bbox.getMinY()),
                 Double.toString(bbox.getMaxX()), Double.toString(bbox.getMaxY()) };
         return bs;
+    }
+
+    @Override
+    public void customizeRootCrsList(Set<String> srs) {
+        // nothing to do
+    }
+
+    @Override
+    public NumberRange<Double> overrideScaleDenominators(LayerInfo layer,
+            NumberRange<Double> scaleDenominators) {
+        return scaleDenominators;
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/ExtendedCapabilitiesProvider.java
+++ b/src/wms/src/main/java/org/geoserver/wms/ExtendedCapabilitiesProvider.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,6 +6,10 @@
 package org.geoserver.wms;
 
 import java.util.List;
+import java.util.Set;
+
+import org.geoserver.catalog.LayerInfo;
+import org.geotools.util.NumberRange;
 
 /**
  * Extension point that allows plugins to dynamically contribute extended properties
@@ -36,12 +40,30 @@ public interface ExtendedCapabilitiesProvider extends org.geoserver.ExtendedCapa
      * Returns the list of internal DTD element declarations contributed to WMS 1.1.1 DOCTYPE
      * GetCapabilities document.
      * <p>
-     * Example DTD element declaration that could be a memeber of the returned list: "
+     * Example DTD element declaration that could be a member of the returned list: "
      * {@code <!ELEMENT Resolutions (#PCDATA) >}"
      * </p>
      * 
      * @return the list of GetCapabilities internal DTD elements declarations, may be empty.
      */
     List<String> getVendorSpecificCapabilitiesChildDecls(GetCapabilitiesRequest request);
+
+    /**
+     * Allows the provider to customize the srs list. For example, it can be used to provide
+     * a user specific srs list
+     * @param srs
+     */
+    void customizeRootCrsList(Set<String> srs);
+
+    /**
+     * Allows the provider to customize the layer scale range, this can be used to advertise limited
+     * visibility of the layer on a user by users basis.
+     * 
+     * @param layer
+     * @param scaleDenominators
+     * @return
+     */
+    NumberRange<Double> overrideScaleDenominators(LayerInfo layer,
+            NumberRange<Double> scaleDenominators);
     
 }

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
@@ -16,6 +16,7 @@ import org.geoserver.catalog.StyleInfo;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.Rule;
 import org.geotools.styling.Style;
+import org.geotools.util.NumberRange;
 
 /**
  * Provides utility methods required to build the capabilities document.
@@ -45,10 +46,7 @@ final class CapabilityUtil {
 	 * @return Max and Min denominator
 	 * @throws IOException 
 	 */
-	public static Map<String,Double> searchMinMaxScaleDenominator(
-			final String minScaleDenominator, 
-			final String maxScaleDenominator, 
-			final LayerInfo layer) 
+	public static NumberRange<Double> searchMinMaxScaleDenominator(final LayerInfo layer) 
 		throws IOException{
 
 		Set<StyleInfo> stylesCopy;
@@ -62,9 +60,8 @@ final class CapabilityUtil {
 		}
 		
 		// searches the maximum and minimum denominator in the style's rules that are contained in the style set. 
-		Map<String,Double> scaleDenominator = new HashMap<String,Double>(2);
-		scaleDenominator.put(minScaleDenominator, Double.POSITIVE_INFINITY);
-		scaleDenominator.put(maxScaleDenominator, Double.NEGATIVE_INFINITY);
+		double minScaleDenominator =  Double.POSITIVE_INFINITY;
+		double maxScaleDenominator = Double.NEGATIVE_INFINITY;
 
 		for (StyleInfo styleInfo : stylesCopy) {
 
@@ -73,26 +70,26 @@ final class CapabilityUtil {
 		    	
 		        for ( Rule rule : fts.rules() ) {
 		       
-		            if ( rule.getMinScaleDenominator() < scaleDenominator.get(minScaleDenominator) ) {
-		            	scaleDenominator.put(minScaleDenominator,  rule.getMinScaleDenominator());
+		            if ( rule.getMinScaleDenominator() < minScaleDenominator ) {
+		            	minScaleDenominator = rule.getMinScaleDenominator();
 		            }
-		            if ( rule.getMaxScaleDenominator() > scaleDenominator.get(maxScaleDenominator) ) {
-		            	scaleDenominator.put(maxScaleDenominator,  rule.getMaxScaleDenominator());
+		            if ( rule.getMaxScaleDenominator() > maxScaleDenominator ) {
+		            	maxScaleDenominator = rule.getMaxScaleDenominator();
 		            }
 		        }
 		    }
 		}
 		// If the initial values weren't changed by any rule in the previous step, 
 		// then the default values, Min=0.0 and Max=infinity, are set. 
-		if(scaleDenominator.get(minScaleDenominator) ==  Double.POSITIVE_INFINITY){
-			scaleDenominator.put(minScaleDenominator,  0.0);
+		if(minScaleDenominator ==  Double.POSITIVE_INFINITY) {
+			minScaleDenominator = 0.0;
 		}
-		if( scaleDenominator.get(maxScaleDenominator) == Double.NEGATIVE_INFINITY){
-			scaleDenominator.put(maxScaleDenominator,  Double.POSITIVE_INFINITY);
+		if( maxScaleDenominator == Double.NEGATIVE_INFINITY) {
+			maxScaleDenominator = Double.POSITIVE_INFINITY;
 		}
-		assert scaleDenominator.get(minScaleDenominator) <= scaleDenominator.get(maxScaleDenominator) : "Min <= Max scale is expected";
+		assert minScaleDenominator <= maxScaleDenominator : "Min <= Max scale is expected";
 
-	    return scaleDenominator;
+	    return new NumberRange<Double>(Double.class, minScaleDenominator, maxScaleDenominator);
 	}
 
 	/**

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
@@ -1,12 +1,12 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.wms.capabilities;
 
-import static junit.framework.Assert.*;
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static junit.framework.Assert.assertEquals;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -21,6 +21,7 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.Keyword;
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
@@ -35,6 +36,7 @@ import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSInfoImpl;
 import org.geoserver.wms.WMSTestSupport;
 import org.geotools.referencing.CRS;
+import org.geotools.util.NumberRange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -282,6 +284,18 @@ public class GetCapabilitiesTransformerTest {
                 tx.end("TestElement");
             }
 
+            @Override
+            public void customizeRootCrsList(Set<String> srs) {
+                srs.clear();
+                srs.add("EPSG:4326");
+                
+            }
+
+            @Override
+            public NumberRange<Double> overrideScaleDenominators(LayerInfo layer,
+                    NumberRange<Double> scaleDenominators) {
+                return new NumberRange<Double>(Double.class, 0d, 1000d);
+            }
         };
 
         GetCapabilitiesTransformer tr;
@@ -289,6 +303,9 @@ public class GetCapabilitiesTransformerTest {
                 Collections.singletonList(vendorCapsProvider));
         tr.setIndentation(2);
         Document dom = WMSTestSupport.transform(req, tr);
+        assertXpathEvaluatesTo("1", "count(/WMT_MS_Capabilities/Capability/Layer/SRS)", dom);
+        assertXpathEvaluatesTo("1", "count(/WMT_MS_Capabilities/Capability/Layer[SRS='EPSG:4326'])", dom);
+
         NodeList list = XPATH.getMatchingNodes(
                 "/WMT_MS_Capabilities/Capability/VendorSpecificCapabilities/TestElement", dom);
         assertEquals(1, list.getLength());


### PR DESCRIPTION
This one follows up discussion on the mailing list. It is meant to be merged on the master branch once 2.7.x has been cut off