### PR TITLE
(GEOS 6868) Upgrade to commons-lang 2.6

### DIFF
--- a/src/community/jms-cluster/activemqBroker/src/main/webapp/META-INF/MANIFEST.MF
+++ b/src/community/jms-cluster/activemqBroker/src/main/webapp/META-INF/MANIFEST.MF
@@ -38,7 +38,7 @@ Bundle-ClassPath: .,WEB-INF/classes,WEB-INF/lib/commons-management-1.0
  ib/gentlyweb-utils-1.5.jar,WEB-INF/lib/xstream-1.3.1.jar,WEB-INF/lib/
  spring-expression-3.0.3.RELEASE.jar,WEB-INF/lib/spring-aop-3.0.3.RELE
  ASE.jar,WEB-INF/lib/spring-webmvc-3.0.3.RELEASE.jar,WEB-INF/lib/activ
- emq-console-5.5.1.jar,WEB-INF/lib/commons-lang-2.4.jar,WEB-INF/lib/se
+ emq-console-5.5.1.jar,WEB-INF/lib/commons-lang-2.6.jar,WEB-INF/lib/se
  rvlet-api-2.5.jar,WEB-INF/lib/commons-collections-3.2.1.jar,WEB-INF/l
  ib/standard-1.1.2.jar,WEB-INF/lib/jasypt-1.7.jar,WEB-INF/lib/jaxb-imp
  l-2.1.6.jar,WEB-INF/lib/commons-logging-1.1.jar,WEB-INF/lib/jetty-ser

--- a/src/community/jms-cluster/activemqBroker/src/main/webapp/WEB-INF/classes/META-INF/DEPENDENCIES
+++ b/src/community/jms-cluster/activemqBroker/src/main/webapp/WEB-INF/classes/META-INF/DEPENDENCIES
@@ -129,7 +129,7 @@ From: 'The Apache Software Foundation' (http://www.apache.org)
 From: 'The Apache Software Foundation' (http://www.apache.org/)
   - Commons Collections (http://commons.apache.org/collections/) commons-collections:commons-collections:jar:3.2.1
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Commons Lang (http://commons.apache.org/lang/) commons-lang:commons-lang:jar:2.4
+  - Commons Lang (http://commons.apache.org/lang/) commons-lang:commons-lang:jar:2.6
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
   - Commons Net (http://commons.apache.org/net/) commons-net:commons-net:jar:2.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/src/community/jms-cluster/activemqBroker/src/main/webapp/WEB-INF/classes/META-INF/MANIFEST.MF
+++ b/src/community/jms-cluster/activemqBroker/src/main/webapp/WEB-INF/classes/META-INF/MANIFEST.MF
@@ -34,7 +34,7 @@ Bundle-ClassPath: .,WEB-INF/classes,WEB-INF/lib/commons-management-1.0
  ib/gentlyweb-utils-1.5.jar,WEB-INF/lib/xstream-1.3.1.jar,WEB-INF/lib/
  spring-expression-3.0.3.RELEASE.jar,WEB-INF/lib/spring-aop-3.0.3.RELE
  ASE.jar,WEB-INF/lib/spring-webmvc-3.0.3.RELEASE.jar,WEB-INF/lib/activ
- emq-console-5.5.1.jar,WEB-INF/lib/commons-lang-2.4.jar,WEB-INF/lib/se
+ emq-console-5.5.1.jar,WEB-INF/lib/commons-lang-2.6.jar,WEB-INF/lib/se
  rvlet-api-2.5.jar,WEB-INF/lib/commons-collections-3.2.1.jar,WEB-INF/l
  ib/standard-1.1.2.jar,WEB-INF/lib/jasypt-1.7.jar,WEB-INF/lib/jaxb-imp
  l-2.1.6.jar,WEB-INF/lib/commons-logging-1.1.jar,WEB-INF/lib/jetty-ser

--- a/src/extension/app-schema/pom.xml
+++ b/src/extension/app-schema/pom.xml
@@ -35,7 +35,6 @@
 	    <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.1</version>
         </dependency>
 	    </dependencies>
    </profile>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -699,7 +699,7 @@
    <dependency>
     <groupId>commons-lang</groupId>
     <artifactId>commons-lang</artifactId>
-    <version>2.1</version>
+    <version>2.6</version>
    </dependency>
    <dependency>
     <groupId>commons-validator</groupId>


### PR DESCRIPTION
For https://jira.codehaus.org/browse/GEOS-6868
Tested full build; no failures.

See also: https://github.com/geotools/geotools/pull/728
