### PR TITLE
Match release tag as a string rather than regular expression

### DIFF
--- a/build/functions
+++ b/build/functions
@@ -104,7 +104,7 @@ function get_pom_version() {
 # gets the jira id for a version named <tag>
 function get_jira_id() {
   local tag=$1
-  local jira_id=`curl -s -G $JIRA_REST/project/$JIRA_PROJ/versions | tr "{" "\n" | grep "\"$tag\"" | tr "," "\n" | grep "\"id\"" | sed 's/"id": *"\([0-9]\+\).*/\1/g'`
+  local jira_id=`curl -s -G $JIRA_REST/project/$JIRA_PROJ/versions | tr "{" "\n" | grep "\"$tag\"" | tr "," "\n" | grep -F "\"id\"" | sed 's/"id": *"\([0-9]\+\).*/\1/g'`
 
   #sed 's/"id": *\([0-9]*\).*/\1/g'`
   if [ ! -z $jira_id ]; then


### PR DESCRIPTION
Release script was treating the `.`s in version numbers as wild cards when searching through JIRA releases.

For instance, 2.5.5 matched the string 20515, which was the JIRA release ID for the 2.5.3 release.