### PR TITLE
Open STRICT_STYLE=false to account for clients using restricted characters [GEOS-6811]

### DIFF
--- a/doc/en/user/source/security/tutorials/cert/index.rst
+++ b/doc/en/user/source/security/tutorials/cert/index.rst
@@ -78,7 +78,13 @@ Users authenticated via a X.509 certificate must be configured in GeoServer. For
 
    .. figure:: images/cert9.jpg
 
-#. Click :guilabel:`Save`.
+#. Click :guilabel:`Close`.
+
+#. You will be returned to the previous page. Click :guilabel:`Save`.
+
+   .. warning::
+
+      This last change requires both :guilabel:`Close` and then :guilabel:`Save` to be clicked. You may wish to return to the :guilabel:`web` dialog to verify that the change was made.
 
 Download sample certificate files
 ---------------------------------

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/AppSchemaTestOracleSetup.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/AppSchemaTestOracleSetup.java
@@ -163,7 +163,7 @@ public class AppSchemaTestOracleSetup extends ReferenceDataOracleSetup {
                 .append("END DROP_TABLE_OR_VIEW;\n"); 
 
         for (String fileName : propertyFiles.keySet()) {
-            File file = new File(fileName);
+            File file = new File(propertyFiles.get(fileName), fileName);
             
             try ( PropertyFeatureReader reader = new PropertyFeatureReader("test", file ) ){            
                 SimpleFeatureType schema = reader.getFeatureType();

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/AppSchemaTestPostgisSetup.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/AppSchemaTestPostgisSetup.java
@@ -125,7 +125,7 @@ public class AppSchemaTestPostgisSetup extends ReferenceDataPostgisSetup {
         buf.append("DROP SCHEMA IF EXISTS ").append(ONLINE_DB_SCHEMA).append(" CASCADE;\n");
         buf.append("CREATE SCHEMA ").append(ONLINE_DB_SCHEMA).append(";\n");
         for (String fileName : propertyFiles.keySet()) {
-            File file = new File(fileName);
+            File file = new File(propertyFiles.get(fileName), fileName);
             
             try (PropertyFeatureReader reader = new PropertyFeatureReader("test", file ) ){
                 SimpleFeatureType schema = reader.getFeatureType();

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
@@ -126,6 +126,9 @@ public class Paths {
             if (!VALID.matcher(item).matches()) {
                 throw new IllegalArgumentException("Contains invalid " + item + " path: " + buf);
             }
+            if (!WARN.matcher(item).matches()) {
+                // to do warning 
+            }
             buf.append(item);
             if (i < LIMIT - 1) {
                 buf.append("/");
@@ -151,13 +154,15 @@ public class Paths {
         if (!VALID.matcher(path).matches()) {
             throw new IllegalArgumentException("Contains invalid chracters " + path);
         }
+        if (!WARN.matcher(path).matches()) {
+            // todo warning
+        }
         return path;
     }
 
     /**
      * Pattern used to check for invalid file characters.
      * <ul>
-     * <li>backslash (sorry windows users we are following linux conventions here)
      * <li>colon
      * <li>star
      * <li>question mark
@@ -167,7 +172,14 @@ public class Paths {
      * <li>bar
      * </ul>
      */
-    static final Pattern VALID = Pattern.compile("^[^\\\\\\:*?\"<>|]*$");
+    static final Pattern VALID = Pattern.compile("^[^\\\\\\*?\"<>|]*$");
+    /**
+     * Pattern used to check for ill-advised file characters:
+     * <ul>
+     * <li>colon - potential conflict with xml prefix separator and workspace style separator
+     * </ul> 
+     */
+    static final Pattern WARN = Pattern.compile("^[:*?\"<>|]*$");
 
     /**
      * Set of invalid resource names (currently used to quickly identify relative paths).

--- a/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
@@ -62,12 +62,12 @@ public class PathsTest {
 
     @Test
     public void validTest() {
-        List<String> valid = Arrays.asList(new String[] { "foo","foo.txt","directory/bar" });
+        List<String> valid = Arrays.asList(new String[] { "foo","foo.txt","directory/bar"});
         for (String name : valid) {
             assertEquals(name, Paths.valid(name));
         }
         
-        List<String> invalid = Arrays.asList(new String[] { ".", "..", "foo?", "foo:", "foo*",
+        List<String> invalid = Arrays.asList(new String[] { ".", "..", "foo?", "foo*",
                 "foo\"", "foo<", "foo>?", "foo|", "foo\\" });
         for (String name : invalid) {
             try {
@@ -75,6 +75,10 @@ public class PathsTest {
                 fail("invalid:" + name);
             } catch (IllegalArgumentException expected) {
             }
+        }
+        
+        for( String name : new String[]{"foo::bar"}){
+            assertEquals(name, Paths.valid(name));
         }
     }
 


### PR DESCRIPTION
Two part fix:

* Change Paths to allow some invalid characters with a warning. This allows GeoServer 2.5.x data directories to load (for manual fix)
* Introduce -DSTRICT_STYLE=FALSE allowing GetMap and GetLegendGraphic lookup to try replacing invalid characters with _ (to account for styles that hae been fixed)