### PR TITLE
Ldap Security: authorities populator fails when colon in password

### DIFF
--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
@@ -151,7 +151,23 @@ public class BindingLdapAuthoritiesPopulator implements
      * @return the set of roles granted to the user.
      */
     public final Collection<GrantedAuthority> getGrantedAuthorities(
-            final DirContextOperations user, String username) {
+            final DirContextOperations user, final String username) {
+        return getGrantedAuthorities(user, username, null);
+    }
+
+    /**
+     * Obtains the authorities for the user who's directory entry is represented
+     * by the supplied LdapUserDetails object.
+     * 
+     * @param user
+     *            the user who's authorities are required 
+     * @param pw be used to bind to ldap server prior to the search
+     *            operations, null otherwise
+     * 
+     * @return the set of roles granted to the user.
+     */
+    public final Collection<GrantedAuthority> getGrantedAuthorities(
+            final DirContextOperations user, final String username, final String password) {
         final String userDn = user.getNameInNamespace();
 
         if (logger.isDebugEnabled()) {
@@ -160,12 +176,8 @@ public class BindingLdapAuthoritiesPopulator implements
 
         final List<GrantedAuthority> result = new ArrayList<GrantedAuthority>();
 
-        // username is in the form username:password -> authenticate before
-        // search
-        if (username.indexOf(":") != -1) {
-            String[] userAndPassword = username.split(":");
-            final String userName = userAndPassword[0];
-            String password = userAndPassword[1];
+        // password included -> authenticate before search
+        if (password != null) {
             // authenticate and execute role extraction in the authenticated
             // context
             ldapTemplate.authenticate(DistinguishedName.EMPTY_PATH, userDn,
@@ -174,7 +186,7 @@ public class BindingLdapAuthoritiesPopulator implements
                         @Override
                         public void executeWithContext(DirContext ctx,
                                 LdapEntryIdentification ldapEntryIdentification) {
-                            getAllRoles(user, userDn, result, userName, ctx);
+                            getAllRoles(user, userDn, result, username, ctx);
                         }
                     });
         } else {

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPSecurityProvider.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPSecurityProvider.java
@@ -107,15 +107,14 @@ public class LDAPSecurityProvider extends GeoServerSecurityProvider {
                         authPopulator) {
                     /**
                      * We need to give authoritiesPopulator both username and
-                     * password, so it can bind to the LDAP server. We encode
-                     * them in the username:password format.
+                     * password, so it can bind to the LDAP server. 
                      */
                     @Override
                     protected Collection<? extends GrantedAuthority> loadUserAuthorities(
                             DirContextOperations userData, String username,
                             String password) {
-                        return getAuthoritiesPopulator().getGrantedAuthorities(
-                                userData, username + ":" + password);
+                        return ((BindingLdapAuthoritiesPopulator) getAuthoritiesPopulator())
+                                .getGrantedAuthorities(userData, username, password);
                     }
                 };
             } else {

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPAuthenticationProviderTest.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPAuthenticationProviderTest.java
@@ -14,6 +14,7 @@ import org.geoserver.security.impl.MemoryRoleService;
 import org.geoserver.security.impl.MemoryRoleStore;
 import org.junit.Assume;
 import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -210,6 +211,26 @@ public class LDAPAuthenticationProviderTest extends LDAPBaseTest {
         assertTrue(result.getAuthorities().contains(role));
         assertEquals(3, result.getAuthorities().size());
         
+    }
+    
+    /**
+     * Test that LDAPAuthenticationProvider finds roles even if there is a colon in 
+     * the password
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testColonPassword() throws Exception {
+        Assume.assumeTrue(LDAPTestUtils.initLdapServer(true, ldapServerUrl,
+                basePath, "data3.ldif"));
+        ((LDAPSecurityServiceConfig)config).setUserDnPattern("uid={0},ou=People");
+        
+        createAuthenticationProvider();
+
+        authentication = new UsernamePasswordAuthenticationToken("colon","da:da");
+        
+        Authentication result = authProvider.authenticate(authentication);
+        assertEquals(2, result.getAuthorities().size());
     }
     
 

--- a/src/security/ldap/src/test/resources/data3.ldif
+++ b/src/security/ldap/src/test/resources/data3.ldif
@@ -1,0 +1,45 @@
+dn: dc=example,dc=com
+objectClass: domain
+objectClass: top
+dc: example
+
+dn: ou=People,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: People
+description: Container for user entries
+
+dn: ou=Groups,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=admin,ou=Groups,dc=example,dc=com
+objectClass: top
+objectClass: organizationalRole
+objectClass: groupOfNames
+cn: admin
+member: cn=admin
+member: cn=colon
+telephoneNumber: 10
+
+dn: uid=admin,ou=People,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: admin
+sn: admin
+uid: admin
+cn: uid=admin,ou=People,dc=example,dc=com
+userPassword: {SHA}0DPiKuNIrrVmD8IUCuw1hQxNqZc=
+telephoneNumber: 1
+
+dn: uid=colon,ou=People,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+givenName: colon
+sn: colon
+uid: colon
+cn: uid=colon,ou=People,dc=example,dc=com
+userPassword: da:da
+telephoneNumber: 2
+


### PR DESCRIPTION
LDAP Authorities Populator was failing to authenticate (and load roles) when there is a user with a colon in their password, because it attaches password to username with colon and then splits again.