### PR TITLE
GEOS-6905 support WCS 2.0 requests embedded in WPS

### DIFF
--- a/src/extension/wps/wps-core/pom.xml
+++ b/src/extension/wps/wps-core/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>org.geoserver</groupId>
+            <artifactId>gs-wcs2_0</artifactId>
+            <version>${gs.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
             <artifactId>gs-wcs1_1</artifactId>
             <version>${gs.version}</version>
         </dependency>

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/executor/InternalWCSInputProvider.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/executor/InternalWCSInputProvider.java
@@ -12,6 +12,7 @@ import net.opengis.wps10.MethodType;
 import org.geoserver.ows.KvpRequestReader;
 import org.geoserver.wcs.WebCoverageService100;
 import org.geoserver.wcs.WebCoverageService111;
+import org.geoserver.wcs2_0.WebCoverageService20;
 import org.geoserver.wps.WPSException;
 import org.geoserver.wps.ppio.ProcessParameterIO;
 import org.opengis.util.ProgressListener;
@@ -45,6 +46,9 @@ public class InternalWCSInputProvider extends AbstractInputProvider {
             KvpRequestReader reader;
             if (version.equals("1.0.0") || version.equals("1.0")) {
                 reader = (KvpRequestReader) context.getBean("wcs100GetCoverageRequestReader");
+                
+            } else if(version.equals("2.0.1") ){
+        	reader = (KvpRequestReader) context.getBean("wcs20getCoverageKvpParser");
             } else {
                 reader = (KvpRequestReader) context.getBean("wcs111GetCoverageRequestReader");
             }
@@ -61,7 +65,12 @@ public class InternalWCSInputProvider extends AbstractInputProvider {
             WebCoverageService100 wcs = (WebCoverageService100) context
                     .getBean("wcs100ServiceTarget");
             return wcs.getCoverage((net.opengis.wcs10.GetCoverageType) getCoverage)[0];
-        } else {
+        } else if (getCoverage instanceof net.opengis.wcs20.GetCoverageType) {
+            WebCoverageService20 wcs = (WebCoverageService20) context
+                    .getBean("wcs20ServiceTarget");
+            return wcs.getCoverage((net.opengis.wcs20.GetCoverageType) getCoverage);
+        } 
+        else {
             throw new WPSException("Unrecognized request type " + getCoverage);
         }
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/executor/InternalWCSInputProvider.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/executor/InternalWCSInputProvider.java
@@ -44,14 +44,13 @@ public class InternalWCSInputProvider extends AbstractInputProvider {
             // what WCS version?
             String version = getVersion(ref.getHref());
             KvpRequestReader reader;
-            if (version.equals("1.0.0") || version.equals("1.0")) {
-                reader = (KvpRequestReader) context.getBean("wcs100GetCoverageRequestReader");
-                
-            } else if(version.equals("2.0.1") ){
-        	reader = (KvpRequestReader) context.getBean("wcs20getCoverageKvpParser");
-            } else {
-                reader = (KvpRequestReader) context.getBean("wcs111GetCoverageRequestReader");
-            }
+	    if ("1.0.0".equals(version) || "1.0".equals(version)) {
+		reader = (KvpRequestReader) context.getBean("wcs100GetCoverageRequestReader");
+	    } else if ("2.0.1".equals(version) || "2.0.0".equals(version)) {
+		reader = (KvpRequestReader) context.getBean("wcs20getCoverageKvpParser");
+	    } else {
+		reader = (KvpRequestReader) context.getBean("wcs111GetCoverageRequestReader");
+	    }
 
             getCoverage = kvpParse(ref.getHref(), reader);
         }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/xml/WPSConfiguration.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/xml/WPSConfiguration.java
@@ -24,5 +24,6 @@ public class WPSConfiguration extends org.geotools.wps.WPSConfiguration {
 
         container.registerComponentInstance(new org.geoserver.wcs.xml.v1_1_1.WCSParserDelegate());
         container.registerComponentInstance(new org.geoserver.wcs.xml.v1_0_0.WCSParserDelegate());
+        container.registerComponentInstance(new org.geoserver.wcs2_0.xml.WCSParserDelegate());
     }
 }

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteOnCoverageTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteOnCoverageTest.java
@@ -1,0 +1,103 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wcs2_0.WCS2GetCoverageRequestBuilder;
+import org.geotools.gce.arcgrid.ArcGridFormat;
+import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.opengis.coverage.grid.GridCoverage;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
+import com.vividsolutions.jts.geom.Envelope;
+
+/**
+ * Test to check if multiple versions of WCS are supported inside WPS requests.
+ * @author driesj
+ *
+ */
+@RunWith(Parameterized.class)
+public class ExecuteOnCoverageTest extends WPSTestSupport {
+    
+    private final String version;
+
+    @Parameters
+    public static Collection<Object[]> getParameters(){	
+	return Arrays.asList(new Object[]{"1.1.1"},new Object[]{"2.0.0"});
+    }
+    
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        
+        addWcs11Coverages(testData);
+    }
+    
+    
+    public ExecuteOnCoverageTest(String version) {
+	this.version = version;
+    }
+    
+    /**
+     * We use the crop process as a simple test to see if we requesting a coverage using different WCS versions works.
+     * @throws Exception
+     */
+    @Test
+    public void testCrop() throws Exception {
+	String wcsRequest = WCS2GetCoverageRequestBuilder.newBuilder()
+		.coverageId(getLayerId(MockData.TASMANIA_DEM))
+		.bbox(130.0, 150,-44., -40)
+		.asXML(version);
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
+                + "  <ows:Identifier>gs:CropCoverage</ows:Identifier>\n"
+                + "  <wps:DataInputs>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>coverage</ows:Identifier>\n"
+                + "      <wps:Reference mimeType=\"image/tiff\" xlink:href=\"http://geoserver/wcs\" method=\"POST\">\n"
+                + "        <wps:Body>\n"
+                + 		wcsRequest
+                + "        </wps:Body>\n"
+                + "      </wps:Reference>\n"
+                + "    </wps:Input>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>cropShape</ows:Identifier>\n"
+                + "      <wps:Data>\n"
+                + "        <wps:ComplexData mimeType=\"application/wkt\"><![CDATA[POLYGON((145.5 -41.9, 145.5 -42.1, 145.6 -42, 145.5 -41.9))]]></wps:ComplexData>\n"
+                + "      </wps:Data>\n" + "    </wps:Input>\n" + "  </wps:DataInputs>\n"
+                + "  <wps:ResponseForm>\n"
+                + "    <wps:RawDataOutput mimeType=\"application/arcgrid\">\n"
+                + "      <ows:Identifier>result</ows:Identifier>\n" + "    </wps:RawDataOutput>\n"
+                + "  </wps:ResponseForm>\n" + "</wps:Execute>\n" + "\n" + "";
+
+        MockHttpServletResponse response = postAsServletResponse(root(), xml);
+        InputStream is = getBinaryInputStream(response);
+        
+        ArcGridFormat format = new ArcGridFormat();
+        GridCoverage gc = format.getReader(is).read(null);
+        
+        assertTrue(new Envelope(-145.4, 145.6, -41.8, -42.1).contains(new ReferencedEnvelope(gc.getEnvelope())));
+        
+        double[] valueInside = (double[]) gc.evaluate(new DirectPosition2D(145.55, -42));
+        assertEquals(615.0, valueInside[0]);
+        double[] valueOutside = (double[]) gc.evaluate(new DirectPosition2D(145.57, -41.9));
+        // this should really be NaN...
+        assertEquals(0.0, valueOutside[0]);
+    }
+}

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCS2GetCoverageRequestBuilder.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCS2GetCoverageRequestBuilder.java
@@ -1,0 +1,154 @@
+package org.geoserver.wcs2_0;
+import java.io.IOException;
+import java.util.Arrays;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import net.opengis.ows11.BoundingBoxType;
+import net.opengis.ows11.CodeType;
+import net.opengis.ows11.Ows11Factory;
+import net.opengis.wcs11.DomainSubsetType;
+import net.opengis.wcs11.OutputType;
+import net.opengis.wcs11.TimeSequenceType;
+import net.opengis.wcs11.Wcs11Factory;
+import net.opengis.wcs20.DimensionSliceType;
+import net.opengis.wcs20.DimensionTrimType;
+import net.opengis.wcs20.GetCoverageType;
+import net.opengis.wcs20.Wcs20Factory;
+
+import org.geotools.wcs.v2_0.WCS;
+import org.geotools.wcs.v2_0.WCSConfiguration;
+import org.geotools.xml.Encoder;
+
+/**
+ * A simple helper class to build WCS 1.1.1 and WCS 2.0 requests.
+ *
+ */
+public class WCS2GetCoverageRequestBuilder {
+    
+    private GetCoverageType getCoverageType;
+    private net.opengis.wcs11.GetCoverageType wcs111GetCoverage;
+
+    private WCS2GetCoverageRequestBuilder(){
+	getCoverageType = Wcs20Factory.eINSTANCE.createGetCoverageType();
+	wcs111GetCoverage = Wcs11Factory.eINSTANCE.createGetCoverageType();
+	
+	wcs111GetCoverage.setVersion("1.1.1");
+	OutputType outputType = Wcs11Factory.eINSTANCE.createOutputType();
+	outputType.setFormat("image/tiff");
+	wcs111GetCoverage.setOutput(outputType);
+	
+	getCoverageType.setVersion("2.0.0");
+	getCoverageType.setFormat("image/tiff");
+    }
+    
+    /**
+     * Sets the id of the coverage to request.
+     * @param coverageId A coverage id
+     * 
+     * @return this builder
+     */
+    public WCS2GetCoverageRequestBuilder coverageId(String coverageId){
+	getCoverageType.setCoverageId(coverageId);
+	CodeType codeType = Ows11Factory.eINSTANCE.createCodeType();
+	codeType.setValue(coverageId);
+	wcs111GetCoverage.setIdentifier(codeType);
+	return this;
+    }
+    
+    /**
+     * Request only a given date, currently fails for WCS 1.1.1
+     * @param date
+     * @return this builder
+     */
+    public WCS2GetCoverageRequestBuilder date(XMLGregorianCalendar date){
+	DimensionSliceType dimensionTrim = Wcs20Factory.eINSTANCE.createDimensionSliceType();
+	dimensionTrim.setSlicePoint(date.toXMLFormat());
+	dimensionTrim.setDimension("time");
+	dimensionTrim.setCRS("http://www.opengis.net/def/trs/ISO-8601/0/Gregorian UTC");
+	getCoverageType.getDimensionSubset().add(dimensionTrim);
+	
+	TimeSequenceType timeSequenceType = Wcs11Factory.eINSTANCE.createTimeSequenceType();
+	timeSequenceType.getTimePosition().add(date);
+	//TODO the encoder throws an exception on this one
+	//getWCS11DomainSubset().setTemporalSubset(timeSequenceType);
+	return this;
+    }
+    
+    /**
+     * Sets a lat/lon bounding box.
+     * @param minLat
+     * @param maxLat
+     * @param minLon
+     * @param maxLon
+     * @return
+     */
+    public WCS2GetCoverageRequestBuilder bbox(double minLon,double maxLon,double minLat, double maxLat){
+	DimensionTrimType latTrim = Wcs20Factory.eINSTANCE.createDimensionTrimType();
+	latTrim.setCRS("http://www.opengis.net/def/crs/EPSG/0/4326");	
+	latTrim.setTrimLow(minLat+"");
+	latTrim.setTrimHigh(maxLat+"");
+	latTrim.setDimension("Lat");
+	getCoverageType.getDimensionSubset().add(latTrim);
+	
+	DimensionTrimType lonTrim = Wcs20Factory.eINSTANCE.createDimensionTrimType();
+	lonTrim.setCRS("http://www.opengis.net/def/crs/EPSG/0/4326");	
+	lonTrim.setTrimLow(minLon+"");
+	lonTrim.setTrimHigh(maxLon+"");
+	lonTrim.setDimension("Long");
+	getCoverageType.getDimensionSubset().add(lonTrim);
+	
+	
+	DomainSubsetType domainSubset = getWCS11DomainSubset();
+	BoundingBoxType boundingbox = Ows11Factory.eINSTANCE.createBoundingBoxType();
+	boundingbox.setCrs("http://www.opengis.net/def/crs/EPSG/0/4326");
+	boundingbox.setLowerCorner(Arrays.asList(minLat,minLon));
+	boundingbox.setUpperCorner(Arrays.asList(maxLat,maxLon));
+	domainSubset.setBoundingBox(boundingbox);
+	return this;
+    }
+
+    private DomainSubsetType getWCS11DomainSubset() {
+	DomainSubsetType domainSubset = wcs111GetCoverage.getDomainSubset();	
+	if(domainSubset==null){
+	    domainSubset = Wcs11Factory.eINSTANCE.createDomainSubsetType();
+	    wcs111GetCoverage.setDomainSubset(domainSubset);	    
+	}
+	return domainSubset;
+    }
+         
+    /**
+     * Returns the xml encoding of the created request.
+     * @param version
+     * @return
+     * @throws IOException
+     */
+    public String asXML(String version) throws IOException{
+	if("1.1.1".equals(version)){
+	    Encoder encoder = new Encoder(new org.geoserver.wcs.xml.v1_1_1.WCSConfiguration());
+	    encoder.setIndenting(true);
+	    encoder.setOmitXMLDeclaration(true);
+	    //prefix is set to 'null' if we don't declare it explicitly
+	    encoder.getNamespaces().declarePrefix("ows", "http://www.opengis.net/ows/1.1");
+	    return encoder.encodeAsString(wcs111GetCoverage, org.geoserver.wcs.xml.v1_1_1.WCS.GetCoverage);		    
+	}else{	    
+	    Encoder encoder = new Encoder(new WCSConfiguration());
+	    encoder.setIndenting(true);	
+	    encoder.setOmitXMLDeclaration(true);
+	    return encoder.encodeAsString(getCoverageType, WCS.GetCoverage);	
+	}
+    }    
+    
+    
+        
+    /**
+     * Create a new builder
+     * @return a new builder
+     */
+    public static WCS2GetCoverageRequestBuilder newBuilder(){
+	return new WCS2GetCoverageRequestBuilder();
+    }
+    
+    
+
+}


### PR DESCRIPTION
Added support for embedding WCS 2.0 in WPS, also a basic unit tests which checks that an 1.1 and 2.0.1 xml request can be embedded in a WPS request.