### PR TITLE
Relaxing Naming Restrictions with STRICT_PATH=false flag [GEOS-6811]

### DIFF
--- a/doc/en/user/source/datadirectory/migrating.rst
+++ b/doc/en/user/source/datadirectory/migrating.rst
@@ -153,4 +153,33 @@ Backup files
                config.xml.2.2.x
           config.xml.2.2.x        
 
-       
+Migrating between GeoServer 2.5.x and 2.6.x
+-------------------------------------------
+
+The catalog naming conventions became more strict in 2.6, invalidating certain characters within names. This is because certain protocols will not work correctly with certain characters in the name. In 2.6.3 and forward, the naming restrictions are automatically set to relaxed through the STRICT_PATH java system property variable. In order to ensure your names will work with all protocols, set this variable to true. ::
+
+    java -DSTRICT_PATH=true Start
+
+This will invalidate all of the following characters:
+  
+* star (*)
+
+* colon (:)
+
+* comma (,)
+
+* single quote (')
+
+* ampersand (&)
+  
+* question mark (?)
+  
+* double quote (")
+  
+* less than (<)
+  
+* greater than (>)
+  
+* bar (|)
+
+Be warned that some requests or protocols may behave unexpectedly when these characters are allowed. We recommend that you update your catalog and enable strict mode to ensure you follow appropriate naming conventions.

--- a/src/main/src/main/java/org/geoserver/catalog/CatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogFacade.java
@@ -712,6 +712,8 @@ public interface CatalogFacade {
     /**
      * Loads a style from persistent storage by specifying its name.
      * 
+     * This only checks the global styles directory.
+     * 
      * @param name The name of the style.
      * 
      * @return The style, or <code>null</code> if no such style exists

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
@@ -102,7 +102,41 @@ public class Paths {
         }
         return toPath(names);
     }
-
+    
+    // runtime flag which, if true, throws an error for the WARN characters
+    static final boolean STRICT_PATH = 
+            Boolean.valueOf(System.getProperty("STRICT_PATH", "false"));
+    
+    /**
+     * Pattern used to check for invalid file characters.
+     * <ul>
+     * <li> backslash
+     * </ul>
+     */
+    static final Pattern VALID = Pattern.compile("^[^\\\\]*$");
+    /**
+     * Pattern used to check for ill-advised file characters:
+     * <ul>
+     * <li> star
+     * <li> colon - potential conflict with xml prefix separator and workspace style separator
+     * <li> comma
+     * <li> single quote
+     * <li> ampersand
+     * <li> question mark
+     * <li> double quote
+     * <li> less than
+     * <li> greater than
+     * <li> bar
+     * </ul> 
+     * These characters can cause problems for different protocols.
+     */
+    static final Pattern WARN = Pattern.compile("^[^:*,\'&?\"<>|]*$");
+    /**
+     * Set of invalid resource names (currently used to quickly identify relative paths).
+     */
+    static final Set<String> INVALID = new HashSet<String>(
+            Arrays.asList(new String[] { "..", "." }));
+    
     /**
      * Internal method used to convert a lit of names to a normal Resource path.
      * <p>
@@ -125,6 +159,11 @@ public class Paths {
             }
             if (!VALID.matcher(item).matches()) {
                 throw new IllegalArgumentException("Contains invalid " + item + " path: " + buf);
+            }
+            if (!WARN.matcher(item).matches()) {
+                if (STRICT_PATH == true) {
+                    throw new IllegalArgumentException("Contains invalid " + item + " path: " + buf);
+                }
             }
             buf.append(item);
             if (i < LIMIT - 1) {
@@ -151,29 +190,13 @@ public class Paths {
         if (!VALID.matcher(path).matches()) {
             throw new IllegalArgumentException("Contains invalid chracters " + path);
         }
+        if (!WARN.matcher(path).matches()) {
+            if (STRICT_PATH == true) {
+                throw new IllegalArgumentException("Contains invalid chracters " + path);
+            }
+        }
         return path;
     }
-
-    /**
-     * Pattern used to check for invalid file characters.
-     * <ul>
-     * <li>backslash (sorry windows users we are following linux conventions here)
-     * <li>colon
-     * <li>star
-     * <li>question mark
-     * <li>double quote
-     * <li>less than
-     * <li>greater than
-     * <li>bar
-     * </ul>
-     */
-    static final Pattern VALID = Pattern.compile("^[^\\\\\\:*?\"<>|]*$");
-
-    /**
-     * Set of invalid resource names (currently used to quickly identify relative paths).
-     */
-    static final Set<String> INVALID = new HashSet<String>(
-            Arrays.asList(new String[] { "..", "." }));
 
     public static List<String> names(String path) {
         if (path == null || path.length() == 0) {

--- a/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
@@ -53,10 +53,12 @@ public class PathsTest {
         } catch (IllegalArgumentException expected) {
         }
 
-        try {
-            assertEquals("foo?", path("foo?"));
-            fail("? invalid character");
-        } catch (IllegalArgumentException expected) {
+        if (Paths.STRICT_PATH == true) {
+            try {
+                assertEquals("foo?", path("foo?"));
+                fail("? invalid character");
+            } catch (IllegalArgumentException expected) {
+            }
         }
     }
 
@@ -67,13 +69,24 @@ public class PathsTest {
             assertEquals(name, Paths.valid(name));
         }
         
-        List<String> invalid = Arrays.asList(new String[] { ".", "..", "foo?", "foo:", "foo*",
-                "foo\"", "foo<", "foo>?", "foo|", "foo\\" });
+        List<String> invalid = Arrays.asList(new String[] { ".", "..", "foo\\" });
         for (String name : invalid) {
             try {
                 assertEquals(name, Paths.valid(name));
                 fail("invalid:" + name);
             } catch (IllegalArgumentException expected) {
+            }
+        }
+        
+        for (String name : new String[]{"foo:*,\'&?\"<>|bar"}) {
+            if (Paths.STRICT_PATH == true) {
+                try {
+                    assertEquals(name, Paths.valid(name));
+                    fail("invalid:" + name);
+                } catch (IllegalArgumentException expected) {
+                }
+            } else {
+                assertEquals(name, Paths.valid(name));
             }
         }
     }


### PR DESCRIPTION
This is in response to a naming regression described in the following JIRA ticket: http://jira.codehaus.org/browse/GEOS-6811

The solution introduces a new Java System Property, STRICT_PATH, which if set to false, will relax the restrictions on names. The characters which are allowed with this flag set to false are:

* star (*)

* colon (:)

* comma (,)

* single quote (')

* ampersand (&)
  
* question mark (?)
  
* double quote (")
  
* less than (<)
  
* greater than (>)
  
* bar (|)

This will allow migration from geoserver 2.5.x to future versions for any catalogs which contained these characters.