### PR TITLE
Fixing unused/broken test

### DIFF
--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleNewPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleNewPageTest.java
@@ -56,11 +56,12 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
         tester.assertModelValue("form:styleEditor", sld);
     }
     
+    @Test
     public void testMissingName() throws Exception {
         FormTester form = tester.newFormTester("form");
         File styleFile = new File(new java.io.File(getClass().getResource("default_point.sld").toURI()));
         String sld = IOUtils.toString(new FileReader(styleFile)).replaceAll("\r\n", "\n").replaceAll("\r", "\n");
-        form.setValue("styleEditor:editorContainer:editor", sld);
+        form.setValue("styleEditor:editorContainer:editorParent:editor", sld);
         form.submit();
        
         


### PR DESCRIPTION
The testMissingName() test in StyleNewPageTest was not actually being executed before. Further, it's call to form.setValue() was incorrect and caused a failure. The test has been updated to run and passes correctly.