### PR TITLE
GEOS-6059 Allow user specification of aliases for localhost

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSURIHandler.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSURIHandler.java
@@ -13,9 +13,14 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -26,6 +31,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.ows.util.KvpMap;
 import org.geoserver.ows.util.KvpUtils;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.Service;
 import org.geoserver.wfs.DescribeFeatureType;
@@ -35,6 +41,7 @@ import org.geoserver.wfs.kvp.DescribeFeatureTypeKvpRequestReader;
 import org.geoserver.wfs.request.DescribeFeatureTypeRequest;
 import org.geoserver.wfs.xml.v1_1_0.XmlSchemaEncoder;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.Parser;
 
 /**
  * URI handler that handles reflective references back to the server to avoid processing them in 
@@ -51,32 +58,95 @@ public class WFSURIHandler extends URIHandlerImpl {
     }
 
     static final List<InetAddress> ADDRESSES = new ArrayList<InetAddress>();
-    static {
-        if (!DISABLED) {
-            // in order to determine if a request is reflective we need to know what all the 
-            // addresses and hostnames that we are addressable on. Since hostnames are expensive we 
-            // do it once and cache the results
+    
+    static final Set<String> ADDITIONAL_HOSTNAMES = new HashSet<String>();
+    
+    public static void addToParser(GeoServer geoServer, Parser parser) {
+        parser.getURIHandlers().add(0, new WFSURIHandler(geoServer));
+    }
+    
+    // Allows for unit testing.
+    static class InitStrategy {
+        public Collection<NetworkInterface> getNetworkInterfaces(){
             Enumeration<NetworkInterface> e = null;
             try {
                 e = NetworkInterface.getNetworkInterfaces();
             } catch (SocketException ex) {
                 LOGGER.log(Level.WARNING, "Unable to determine network interface info", ex);
             } 
-            while(e != null && e.hasMoreElements()) {
-                NetworkInterface ni = e.nextElement();
-                Enumeration<InetAddress> f = ni.getInetAddresses();
-                while(f.hasMoreElements()) {
-                    InetAddress add = f.nextElement();
+            
+            return Collections.list(e);
+        }
+        
+    }
     
-                    //do the hostname lookup, these are cached after the first call so we only pay the
-                    // price now
-                    add.getHostName();
-                    ADDRESSES.add(add);
-                }
-            }
+    static {
+        init(new InitStrategy());
+    }
+
+    static void init(InitStrategy strategy) {
+        if (!DISABLED) {
+            initAddresses(strategy);
+            initAliases();
+            initLog();
         }
     }
 
+    private static void initLog() {
+        // Log hostnames being treated as reflexive
+        if(LOGGER.isLoggable(Level.INFO)){
+            StringBuilder builder = new StringBuilder("Identified addresses and hostnames for local interfaces: ");
+            boolean first = true;
+            for(InetAddress add: ADDRESSES) {
+                if(!first){
+                    builder.append(", ");
+                }
+                first = false;
+                builder.append(add.getHostAddress());
+                builder.append(" ");
+                builder.append(add.getHostName());
+            }
+            LOGGER.log(Level.INFO, builder.toString());
+            
+            builder = new StringBuilder("Additional aliases for local host: ");
+            for(String alias: ADDITIONAL_HOSTNAMES) {
+                builder.append(alias);
+                builder.append(" ");
+            }
+            LOGGER.log(Level.INFO, builder.toString());
+        }
+    }
+
+    private static void initAliases() {
+        assert ADDITIONAL_HOSTNAMES.isEmpty();
+        // User configurable hostnames
+        String additional = GeoServerExtensions.getProperty(WFSURIHandler.class.getName()+".additionalHostnames");
+        if(additional==null){
+            additional="localhost";
+        }
+        ADDITIONAL_HOSTNAMES.addAll(Arrays.asList(additional.split("\\s*,\\s*|\\s+")));
+    }
+
+    private static void initAddresses(InitStrategy strategy) {
+        assert ADDRESSES.isEmpty();
+        // in order to determine if a request is reflective we need to know what all the 
+        // addresses and hostnames that we are addressable on. Since hostnames are expensive we 
+        // do it once and cache the results
+        
+        ADDRESSES.clear();
+        for(NetworkInterface ni: strategy.getNetworkInterfaces()) {
+            for(InetAddress add: Collections.list(ni.getInetAddresses())) {
+                
+                //do the hostname lookup, these are cached after the first call so we only pay the
+                // price now
+                add.getHostName();
+                
+                ADDRESSES.add(add);
+            }
+        }
+    }
+    
+    
     GeoServer geoServer;
    
     public WFSURIHandler(GeoServer geoServer) {
@@ -125,13 +195,18 @@ public class WFSURIHandler extends URIHandlerImpl {
                 LOGGER.fine("Unable to parse proxy base url to a uri: " + proxyBaseUrl);
             }
         }
-        
+        if (ADDITIONAL_HOSTNAMES.contains(uri.host())) {
+            LOGGER.log(Level.FINE, "Hostname {0} is in known aliases for self", new Object[]{uri.host()});
+            return true;
+        }
         //check the network interfaces to see if the host matches
         for (InetAddress add : ADDRESSES) {
             if (uri.host().equals(add.getHostAddress()) || uri.host().equals(add.getHostName())) {
+                LOGGER.log(Level.FINE, "Hostname {0} identifies local network interface {1} {2}", new Object[]{uri.host(), add.getHostAddress(), add.getHostName()});
                 return true;
             }
         }
+        LOGGER.log(Level.FINE, "Assuming hostname {0} does not refer to self.  If this is wrong may lead to deadlock.", new Object[]{uri.host()});
         return false;
     }
 

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
@@ -61,7 +61,7 @@ public class WFSXmlUtils {
             strict = Boolean.TRUE;
         }
         parser.setValidating(strict.booleanValue());
-        parser.getURIHandlers().add(0, new WFSURIHandler(geoServer));
+        WFSURIHandler.addToParser(geoServer, parser);
 
         Catalog catalog = geoServer.getCatalog();
 

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_0_0/WfsXmlReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_0_0/WfsXmlReader.java
@@ -73,7 +73,7 @@ public class WfsXmlReader extends XmlRequestReader {
 
         //set validation based on strict or not
         parser.setValidating(strict.booleanValue());
-        parser.getURIHandlers().add(0, new WFSURIHandler(geoServer));
+        WFSURIHandler.addToParser(geoServer, parser);
 
         //parse
         Object parsed = parser.parse(reader); 

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/PropertyRule.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/PropertyRule.java
@@ -1,0 +1,58 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wfs.xml;
+
+import java.util.Properties;
+
+/**
+ * Rule which allows a property to be set, and will return it to its original value.
+ * 
+ * @author Kevin Smith, Boundless
+ *
+ */
+class PropertyRule extends org.junit.rules.ExternalResource {
+    final Properties props;
+    final String name;
+    String oldValue;
+    
+    public static PropertyRule system(String name) {
+        return new PropertyRule(System.getProperties(), name);
+    }
+    
+    public PropertyRule(Properties props, String name) {
+        super();
+        this.props = props;
+        this.name = name;
+    }
+
+    public Object getOldValue() {
+        return oldValue;
+    }
+
+    public void setValue(String value) {
+        props.setProperty(name, value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        this.oldValue = props.getProperty(name);
+    }
+
+    @Override
+    protected void after() {
+        if(this.oldValue==null) {
+            props.remove(name);
+        } else {
+            props.setProperty(name, oldValue);
+        }
+    }
+    
+}

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/WFSURIHandlerTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/WFSURIHandlerTest.java
@@ -1,0 +1,173 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wfs.xml;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.classextension.EasyMock.replay;
+import static org.easymock.classextension.EasyMock.reset;
+import static org.easymock.classextension.EasyMock.verify;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import java.net.NetworkInterface;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.easymock.classextension.EasyMock;
+import org.eclipse.emf.common.util.URI;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.wfs.xml.WFSURIHandler.InitStrategy;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WFSURIHandlerTest {
+    
+    @Rule
+    public PropertyRule aliases = PropertyRule.system("org.geoserver.wfs.xml.WFSURIHandler.additionalHostnames");
+    
+    InitStrategy strategy;
+
+    private GeoServer gs;
+
+    private GeoServerInfo config;
+    
+    @SuppressWarnings("deprecation")
+    @Before
+    public void setUp() {
+        WFSURIHandler.ADDITIONAL_HOSTNAMES.clear();
+        WFSURIHandler.ADDRESSES.clear();
+        
+        // Suppress the network interface interrogation so it doesn't interfere with other tests
+        strategy = new InitStrategy() {
+            public Collection<NetworkInterface> getNetworkInterfaces(){
+                return Collections.emptyList();
+            }
+        };
+        
+        gs = EasyMock.createMock(GeoServer.class);
+        config = EasyMock.createMock(GeoServerInfo.class);
+        expect(gs.getGlobal()).andStubReturn(config);
+        expect(config.getProxyBaseUrl()).andStubReturn(null);
+        replay(gs, config);
+    }
+    
+    @After
+    public void tearDown() {
+        verify(gs, config);
+    }
+    
+    @Test
+    @Ignore
+    public void testFromNetworkInterfaces() {
+        // Was unable to mock NetworkInterfaces
+    }
+    
+    @Test
+    public void testDefaultAliases() {
+        
+        WFSURIHandler.init(strategy);
+        
+        assertThat(WFSURIHandler.ADDRESSES, empty());
+        assertThat(WFSURIHandler.ADDITIONAL_HOSTNAMES, contains("localhost"));
+        
+    }
+
+    @Test
+    public void testOverrideAliasesComma() {
+        
+        
+        aliases.setValue("foo,bar , baz");
+        
+        WFSURIHandler.init(strategy);
+        
+        assertThat(WFSURIHandler.ADDRESSES, empty());
+        assertThat(WFSURIHandler.ADDITIONAL_HOSTNAMES, containsInAnyOrder("foo", "bar", "baz"));
+        
+    }
+
+    @Test
+    public void testOverrideAliasesSpace() {
+        
+        aliases.setValue("foo bar  baz ");
+        
+        WFSURIHandler.init(strategy);
+        
+        assertThat(WFSURIHandler.ADDRESSES, empty());
+        assertThat(WFSURIHandler.ADDITIONAL_HOSTNAMES, containsInAnyOrder("foo", "bar", "baz"));
+        
+    }
+    
+    @SuppressWarnings("deprecation")
+    protected void setProxyBase(String url) {
+        reset(config); {
+            expect(config.getProxyBaseUrl()).andStubReturn(url);
+        }replay(config);
+    }
+    
+    @Test
+    public void testRecognizeReflexiveSimple() {
+        
+        WFSURIHandler.init(strategy);
+        
+        WFSURIHandler handler = new WFSURIHandler(gs);
+        
+        final URI wrongHost = URI.createURI("http://example.com/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        final URI notDFT = URI.createURI("http://localhost/geoserver/wfs?service=wfs&version=2.0.0&request=GetCapabilities");
+        final URI localDFT = URI.createURI("http://localhost/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        assertThat(handler.canHandle(wrongHost), is(false));
+        assertThat(handler.canHandle(notDFT), is(false));
+        assertThat(handler.canHandle(localDFT), is(true));
+    }
+
+    @Test
+    public void testRecognizeReflexiveUserAliases() {
+        
+        aliases.setValue("foo bar baz");
+        
+        WFSURIHandler.init(strategy);
+        
+        WFSURIHandler handler = new WFSURIHandler(gs);
+        
+        final URI wrongHost = URI.createURI("http://example.com/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        final URI notDFT = URI.createURI("http://foo/geoserver/wfs?service=wfs&version=2.0.0&request=GetCapabilities");
+        final URI fooDFT = URI.createURI("http://foo/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        final URI barDFT = URI.createURI("http://bar/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        final URI bazDFT = URI.createURI("http://baz/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        final URI localhostDFT = URI.createURI("http://localhost/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        assertThat(handler.canHandle(wrongHost), is(false));
+        assertThat(handler.canHandle(notDFT), is(false));
+        assertThat(handler.canHandle(fooDFT), is(true));
+        assertThat(handler.canHandle(barDFT), is(true));
+        assertThat(handler.canHandle(bazDFT), is(true));
+        assertThat(handler.canHandle(localhostDFT), is(false));
+    }
+
+    @Test
+    public void testRecognizeReflexiveProxy() {
+        
+        this.setProxyBase("http://foo/geoserver");
+        
+        WFSURIHandler.init(strategy);
+        
+        WFSURIHandler handler = new WFSURIHandler(gs);
+        
+        final URI wrongHost = URI.createURI("http://example.com/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        final URI notDFT = URI.createURI("http://foo/geoserver/wfs?service=wfs&version=2.0.0&request=GetCapabilities");
+        final URI fooDFT = URI.createURI("http://foo/geoserver/wfs?service=wfs&version=2.0.0&request=DescribeFeatureType");
+        assertThat(handler.canHandle(wrongHost), is(false));
+        assertThat(handler.canHandle(notDFT), is(false));
+        assertThat(handler.canHandle(fooDFT), is(true));
+    }
+
+}


### PR DESCRIPTION
Adds mechanism to specify hostnames that are aliases for the local host as well as logging to aid in diagnosing issues.

Provided unit tests for aliases and proxy baseurl but was unable to mock the NetworkInterface discovery as NetworkInterface is final and has no public constructor.