### PR TITLE
Fix an infinite loop in GeoServerPersister.renameStyle [GEOS-6983]

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerPersister.java
@@ -582,8 +582,8 @@ public class GeoServerPersister implements CatalogListener, ConfigurationListene
         Resource style = dd.style(s);
         String sldFileName = newName + ".sld";
         Resource target = style.parent().get(sldFileName);
-        int i = 1;
-        while(target.getType()!=Type.UNDEFINED && i <= MAX_RENAME_ATTEMPTS) {
+        int i = 0;
+        while(target.getType()!=Type.UNDEFINED && ++i <= MAX_RENAME_ATTEMPTS) {
             sldFileName = newName + i + ".sld";
             target = style.parent().get(sldFileName);
         }

--- a/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
@@ -571,6 +571,30 @@ public class GeoServerPersisterTest extends GeoServerSystemTestSupport {
         assertThat( sldFile, not(fileExists()) );
         assertThat( renamedSldFile, fileExists() );
     }
+    
+    @Test
+    public void testRenameStyleWithExistingIncrementedVersion() throws Exception {
+        testAddStyle();
+        File sldFile = new File(testData.getDataDirectoryRoot(), "styles/foostyle.sld");
+        sldFile.createNewFile();
+
+        File sldFile1 = new File(testData.getDataDirectoryRoot(), "styles/foostyle1.sld");
+        sldFile1.createNewFile();
+
+        File xmlFile1 = new File(testData.getDataDirectoryRoot(), "styles/foostyle1.xml");
+        xmlFile1.createNewFile();
+
+        StyleInfo s = catalog.getStyleByName("foostyle");
+        s.setName("foostyle");
+        catalog.save(s);
+
+        assertThat( sldFile, fileExists() );
+        assertThat( sldFile1, fileExists() );
+        assertThat( xmlFile1, fileExists() );
+
+        sldFile1.delete();
+        xmlFile1.delete();
+    }
 
     @Test
     public void testModifyStyleChangeWorkspace() throws Exception {


### PR DESCRIPTION
Variable "i" was never incremented while testing the existence of sld file.
It causes an infinite loop when file1.sld already exists.

Update: https://osgeo-org.atlassian.net/browse/GEOS-6983