### PR TITLE
Use CoverageResourceListener to call CoverageCleanerCallback

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/applicationContext.xml
+++ b/src/extension/wps/wps-core/src/main/java/applicationContext.xml
@@ -295,6 +295,7 @@
 
     <bean id="coverageResourceListener" class="org.geoserver.wps.resource.CoverageResourceListener">
       <constructor-arg ref="wpsResourceManager"/>
+      <constructor-arg ref="coverageCleaner"/>
     </bean>
     
     <!-- Input limits support -->

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/resource/CoverageResourceListener.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/resource/CoverageResourceListener.java
@@ -7,6 +7,7 @@ package org.geoserver.wps.resource;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.geoserver.wcs.CoverageCleanerCallback;
 import org.geoserver.wps.ProcessListenerAdapter;
 import org.geoserver.wps.ProcessEvent;
 import org.geoserver.wps.WPSException;
@@ -32,11 +33,13 @@ public class CoverageResourceListener extends ProcessListenerAdapter {
     }
 
     WPSResourceManager resourceManager;
-
+    CoverageCleanerCallback  cleaner;
+    
     Map<String, ResourceStatus> resourceStates = new ConcurrentHashMap<>();
 
-    public CoverageResourceListener(WPSResourceManager resourceManager) {
+    public CoverageResourceListener(WPSResourceManager resourceManager, CoverageCleanerCallback cleaner) {
         this.resourceManager = resourceManager;
+        this.cleaner = cleaner;
     }
 
     @Override
@@ -90,6 +93,7 @@ public class CoverageResourceListener extends ProcessListenerAdapter {
     @Override
     public void failed(ProcessEvent event) {
         cleanResourceStatus(event);
+        cleaner.clean();
     }
 
     private void cleanResourceStatus(ProcessEvent event) {

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/CropCoverageTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/CropCoverageTest.java
@@ -7,17 +7,22 @@ package org.geoserver.wps.gs;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 
 import java.io.InputStream;
 
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wps.WPSTestSupport;
 import org.geotools.gce.arcgrid.ArcGridFormat;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridCoverage;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 import com.mockrunner.mock.web.MockHttpServletResponse;
 import com.vividsolutions.jts.geom.Envelope;
@@ -77,5 +82,48 @@ public class CropCoverageTest extends WPSTestSupport {
         double[] valueOutside = (double[]) gc.evaluate(new DirectPosition2D(145.57, -41.9));
         // this should really be NaN...
         assertEquals(0.0, valueOutside[0]);
+    }
+    
+    @Test
+    public void invalidCoverage() throws Exception {
+        // See GEOS-6921
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
+                + "  <ows:Identifier>gs:CropCoverage</ows:Identifier>\n"
+                + "  <wps:DataInputs>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>coverage</ows:Identifier>\n"
+                + "      <wps:Reference mimeType=\"image/tiff\" xlink:href=\"http://geoserver/wcs\" method=\"POST\">\n"
+                + "        <wps:Body>\n"
+                + "          <wcs:GetCoverage service=\"WCS\" version=\"1.1.1\">\n"
+                + "            <ows:Identifier>" + getLayerId(MockData.TASMANIA_DEM) + "</ows:Identifier>\n"
+                + "            <wcs:DomainSubset>\n"
+                + "              <gml:BoundingBox crs=\"http://www.opengis.net/gml/srs/epsg.xml#4326\">\n"
+                + "                <ows:LowerCorner>180.0 -90.0</ows:LowerCorner>\n"
+                + "                <ows:UpperCorner>200.0 90.0</ows:UpperCorner>\n"
+                + "              </gml:BoundingBox>\n"
+                + "            </wcs:DomainSubset>\n"
+                + "            <wcs:Output format=\"image/tiff\"/>\n"
+                + "          </wcs:GetCoverage>\n"
+                + "        </wps:Body>\n"
+                + "      </wps:Reference>\n"
+                + "    </wps:Input>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>cropShape</ows:Identifier>\n"
+                + "      <wps:Data>\n"
+                + "        <wps:ComplexData mimeType=\"application/wkt\"><![CDATA[POLYGON((145.5 -41.9, 145.5 -42.1, 145.6 -42, 145.5 -41.9))]]></wps:ComplexData>\n"
+                + "      </wps:Data>\n" + "    </wps:Input>\n" + "  </wps:DataInputs>\n"
+                + "  <wps:ResponseForm>\n"
+                + "    <wps:RawDataOutput mimeType=\"application/arcgrid\">\n"
+                + "      <ows:Identifier>result</ows:Identifier>\n" + "    </wps:RawDataOutput>\n"
+                + "  </wps:ResponseForm>\n" + "</wps:Execute>\n" + "\n" + "";
+
+        MockHttpServletResponse response = postAsServletResponse(root(), xml);
+        InputStream is = getBinaryInputStream(response);
+        
+        Document dom = dom(is);
+        Element status = (Element) dom.getDocumentElement().getElementsByTagName("wps:Status").item(0);
+        Node child = status.getChildNodes().item(0);
+        assertEquals("wps:ProcessFailed", child.getNodeName() );
     }
 }

--- a/src/wcs/src/main/java/org/geoserver/wcs/CoverageCleanerCallback.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/CoverageCleanerCallback.java
@@ -43,23 +43,14 @@ public class CoverageCleanerCallback extends AbstractDispatcherCallback {
 
     @Override
     public void finished(Request request) {
-        try {
-            List<GridCoverage> coverages = COVERAGES.get();
-            if (coverages != null) {
-                for (GridCoverage coverage : coverages) {
-                    try {
-                        disposeCoverage(coverage);
-                    } catch (Exception e) {
-                        LOGGER.log(Level.WARNING, "Failed to fully dispose coverage: " + coverage,
-                                e);
-                    }
-                }
-            }
-        } finally {
-            COVERAGES.remove();
-        }
+        clean();
     }
 
+    /**
+     * Mark coverage for cleaning.
+     * 
+     * @param coverages
+     */
     public static void addCoverages(GridCoverage... coverages) {
         List<GridCoverage> list = COVERAGES.get();
         if (list == null) {
@@ -81,6 +72,27 @@ public class CoverageCleanerCallback extends AbstractDispatcherCallback {
         }
         if (ri instanceof PlanarImage) {
             ImageUtilities.disposePlanarImageChain((PlanarImage) ri);
+        }
+    }
+
+    /**
+     * Clean up any coverages collected by {@link #addCoverages(GridCoverage...)}
+     */
+    public void clean() {
+        try {
+            List<GridCoverage> coverages = COVERAGES.get();
+            if (coverages != null) {
+                for (GridCoverage coverage : coverages) {
+                    try {
+                        disposeCoverage(coverage);
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, "Failed to fully dispose coverage: " + coverage,
+                                e);
+                    }
+                }
+            }
+        } finally {
+            COVERAGES.remove();
         }
     }
 }


### PR DESCRIPTION
Allows CoverageResourceListener to clean up after any coverages that failed to load (due to invalid crop).

See https://jira.codehaus.org/browse/GEOS-6921