### PR TITLE
Improved strict path testability and coverage

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
@@ -93,6 +93,17 @@ public class Paths {
      * @return path Path used to identify a Resource
      */
     public static String path(String... path) {
+        return path(STRICT_PATH, path);
+    }
+
+     /**
+     * Path construction.
+     * 
+     * @param strictPath whether problematic characters are an error
+     * @param path Items defining a Path
+     * @return path Path used to identify a Resource
+     */
+    static String path(boolean strictPath, String... path) {
         if (path == null || (path.length == 1 && path[0] == null)) {
             return null;
         }
@@ -100,7 +111,7 @@ public class Paths {
         for (String item : path) {
             names.addAll(names(item));
         }
-        return toPath(names);
+        return toPath(strictPath, names);
     }
     
     // runtime flag which, if true, throws an error for the WARN characters
@@ -138,15 +149,14 @@ public class Paths {
             Arrays.asList(new String[] { "..", "." }));
     
     /**
-     * Internal method used to convert a lit of names to a normal Resource path.
-     * <p>
-     * If any {@link #INVALID} names are foun
+     * Internal method used to convert a list of names to a normal Resource path.
      * 
+     * @param strictPath whether problematic characters are an error
      * @param names List of resource names forming a path
      * @return resource path composed of provided names
      * @throws IllegalArgumentException If names includes any {@link #INVALID} chracters
      */
-    private static String toPath(List<String> names) {
+    private static String toPath(boolean strictPath, List<String> names) {
         StringBuilder buf = new StringBuilder();
         final int LIMIT = names.size();
         for (int i = 0; i < LIMIT; i++) {
@@ -161,7 +171,7 @@ public class Paths {
                 throw new IllegalArgumentException("Contains invalid " + item + " path: " + buf);
             }
             if (!WARN.matcher(item).matches()) {
-                if (STRICT_PATH == true) {
+                if (strictPath) {
                     throw new IllegalArgumentException("Contains invalid " + item + " path: " + buf);
                 }
             }
@@ -180,7 +190,19 @@ public class Paths {
      * @return path
      * @throws IllegalArgumentException If path fails {@link #VALID} check
      */
-    static public String valid(String path) {
+    public static String valid(String path) {
+        return path(STRICT_PATH, path);
+    }
+
+    /**
+     * Quick check of path for invalid characters
+     * 
+     * @param strictPath whether problematic characters are an error
+     * @param path
+     * @return path
+     * @throws IllegalArgumentException If path fails {@link #VALID} check
+     */
+    static String valid(boolean strictPath, String path) {
         if (path == null) {
             throw new NullPointerException("Resource path required");
         }
@@ -191,7 +213,7 @@ public class Paths {
             throw new IllegalArgumentException("Contains invalid chracters " + path);
         }
         if (!WARN.matcher(path).matches()) {
-            if (STRICT_PATH == true) {
+            if (strictPath) {
                 throw new IllegalArgumentException("Contains invalid chracters " + path);
             }
         }
@@ -290,7 +312,7 @@ public class Paths {
             }
             resolvedPath.add(item);
         }
-        return toPath(resolvedPath);
+        return toPath(STRICT_PATH, resolvedPath);
     }
 
     /**
@@ -328,7 +350,7 @@ public class Paths {
             }
             resolvedPath.add(item);
         }
-        return toPath(resolvedPath);
+        return toPath(STRICT_PATH, resolvedPath);
     }
 
     /**
@@ -390,7 +412,7 @@ public class Paths {
             }
             resolvedPath.add(item);
         }
-        return toPath(resolvedPath);
+        return toPath(STRICT_PATH, resolvedPath);
     }
 
     /**

--- a/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
@@ -53,40 +53,78 @@ public class PathsTest {
         } catch (IllegalArgumentException expected) {
         }
 
-        if (Paths.STRICT_PATH == true) {
+        // test path elements that are always valid regardless of strictPath
+        for (String name : new String[] { "foo", "foo.txt", "directory/bar" }) {
+            assertEquals(name, Paths.path(true, name));
+            assertEquals(name, Paths.path(false, name));
+        }
+        // test path elements that are always invalid regardless of strictPath
+        for (String name : new String[] { ".", "..", "foo\\" }) {
             try {
-                assertEquals("foo?", path("foo?"));
-                fail("? invalid character");
+                assertEquals(name, Paths.path(true, name));
+                fail("invalid: " + name);
             } catch (IllegalArgumentException expected) {
+                // ignore
+            }
+            try {
+                assertEquals(name, Paths.path(false, name));
+                fail("invalid: " + name);
+            } catch (IllegalArgumentException expected) {
+                // ignore
+            }
+        }
+        // test path elements that are invalid if and only if strictPath is true
+        for (char c : "*:,'&?\"<>|".toCharArray()) {
+            for (String prefix : new String[] { "foo", "" }) {
+                for (String suffix : new String[] { "bar", "" }) {
+                    String name = prefix + c + suffix;
+                    try {
+                        assertEquals(name, Paths.path(true, name));
+                        fail("invalid: " + name);
+                    } catch (IllegalArgumentException expected) {
+                        // ignore
+                    }
+                    assertEquals(name, Paths.path(false, name));
+                }
             }
         }
     }
 
     @Test
     public void validTest() {
-        List<String> valid = Arrays.asList(new String[] { "foo","foo.txt","directory/bar" });
-        for (String name : valid) {
-            assertEquals(name, Paths.valid(name));
+        // test path elements that are always valid regardless of strictPath
+        for (String name : new String[] { "foo", "foo.txt", "directory/bar" }) {
+            assertEquals(name, Paths.valid(true, name));
+            assertEquals(name, Paths.valid(false, name));
         }
-        
-        List<String> invalid = Arrays.asList(new String[] { ".", "..", "foo\\" });
-        for (String name : invalid) {
+        // test path elements that are always invalid regardless of strictPath
+        for (String name : new String[] { ".", "..", "foo\\" }) {
             try {
-                assertEquals(name, Paths.valid(name));
-                fail("invalid:" + name);
+                assertEquals(name, Paths.valid(true, name));
+                fail("invalid: " + name);
             } catch (IllegalArgumentException expected) {
+                // ignore
+            }
+            try {
+                assertEquals(name, Paths.valid(false, name));
+                fail("invalid: " + name);
+            } catch (IllegalArgumentException expected) {
+                // ignore
             }
         }
-        
-        for (String name : new String[]{"foo:*,\'&?\"<>|bar"}) {
-            if (Paths.STRICT_PATH == true) {
-                try {
-                    assertEquals(name, Paths.valid(name));
-                    fail("invalid:" + name);
-                } catch (IllegalArgumentException expected) {
+        // test path elements that are invalid if and only if strictPath is true
+        for (char c : "*:,'&?\"<>|".toCharArray()) {
+            for (String prefix : new String[] { "foo", "" }) {
+                for (String suffix : new String[] { "bar", "" }) {
+                    String name = prefix + c + suffix;
+                    try {
+                        assertEquals(name, Paths.valid(true, name));
+                        fail("invalid: " + name);
+                    } catch (IllegalArgumentException expected) {
+                        // ignore
+                    }
+                    assertEquals(name, Paths.valid(false, name));
                 }
-            } else {
-                assertEquals(name, Paths.valid(name));
             }
         }
     }


### PR DESCRIPTION
@jodygarnett @travislbrundage this pull request refactors strict path handling to permit testing both with and without strict path, and increases test coverage. (Current tests depend on STRICT_PATH which will always be false, so strict path behaviour is never tested.) Full build passes on master. Not yet tested on 2.7.x or 2.6.x but backport would improve maintainability.