### PR TITLE
[GEOS-6958] Use relative paths when importing from data directory

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/DataFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/DataFormat.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -20,6 +20,8 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.importer.job.ProgressMonitor;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.Paths;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.GridFormatFinder;
 import org.geotools.coverage.grid.io.UnknownFormat;
@@ -103,6 +105,20 @@ public abstract class DataFormat implements Serializable {
             return new DataStoreFormat(factory);
         }
         return null;
+    }
+    
+    /**
+     * Converts an absolute URL to a resource to be relative to the data directory if applicable.
+     * @return The relative path, or the original path if it does not contain the data directory
+     */
+    protected String relativeDataFileURL(String url, Catalog catalog) {
+        if (catalog == null) {
+            return url;
+        }
+        File baseDirectory = catalog.getResourceLoader().getBaseDirectory();
+        File f = Files.url(baseDirectory, url);
+  
+        return f == null ? url : "file:"+Paths.convert(baseDirectory, f);
     }
 
     public abstract String getName();

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -81,7 +81,7 @@ public class DataStoreFormat extends VectorFormat {
     }
 
     public DataStoreInfo createStore(ImportData data, WorkspaceInfo workspace, Catalog catalog) throws IOException {
-        Map<String,Serializable> params = createConnectionParameters(data);
+        Map<String,Serializable> params = createConnectionParameters(data, catalog);
         if (params == null) {
             return null;
         }
@@ -191,7 +191,7 @@ public class DataStoreFormat extends VectorFormat {
     public DataStore createDataStore(ImportData data) throws IOException {
         DataStoreFactorySpi dataStoreFactory = factory();
 
-        Map<String,Serializable> params = createConnectionParameters(data);
+        Map<String,Serializable> params = createConnectionParameters(data, null);
         if (params != null && dataStoreFactory.canProcess(params)) {
             DataStore dataStore = dataStoreFactory.createDataStore(params); 
             if (dataStore != null) {
@@ -202,7 +202,7 @@ public class DataStoreFormat extends VectorFormat {
         return null;
     }
 
-    public Map<String,Serializable> createConnectionParameters(ImportData data) throws IOException {
+    public Map<String,Serializable> createConnectionParameters(ImportData data, Catalog catalog) throws IOException {
         //try file based
         if (dataStoreFactory instanceof FileDataStoreFactorySpi) {
             File f = null;
@@ -215,7 +215,7 @@ public class DataStoreFormat extends VectorFormat {
 
             if (f != null) {
                 Map<String,Serializable> map = new HashMap<String, Serializable>();
-                map.put("url", f.toURI().toURL());
+                map.put("url", relativeDataFileURL(f.toURI().toURL().toString(), catalog));
                 if (data.getCharsetEncoding() != null) {
                     // @todo this map only work for shapefile
                     map.put("charset",data.getCharsetEncoding());

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/GridFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/GridFormat.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -70,7 +70,7 @@ public class GridFormat extends RasterFormat {
         cb.setWorkspace(workspace);
         
         CoverageStoreInfo store = cb.buildCoverageStore(data.getName());
-        store.setURL(f.toURI().toURL().toString());
+        store.setURL(relativeDataFileURL(f.toURI().toURL().toString(), catalog));
         store.setType(gridFormat().getName());
         
         return store;

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDataTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDataTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -18,6 +18,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -94,6 +95,31 @@ public class ImporterDataTest extends ImporterTestSupport {
 
         assertEquals(ImportTask.State.COMPLETE, task.getState());
 
+        runChecks("archsites");
+    }
+    
+    @Test
+    public void testImportShapefileFromDataDir() throws Exception {
+        File dataDir = getCatalog().getResourceLoader().getBaseDirectory();
+        
+        File dir = unpack("shape/archsites_epsg_prj.zip", dataDir);
+        
+        ImportContext context = 
+                importer.createContext(new SpatialFile(new File(dir, "archsites.shp")));
+        assertEquals(1, context.getTasks().size());
+        
+        ImportTask task = context.getTasks().get(0);
+        assertEquals(ImportTask.State.READY, task.getState());
+        assertEquals("archsites", task.getLayer().getResource().getName());
+        
+        importer.run(context);
+        
+        Catalog cat = getCatalog();
+        assertNotNull(cat.getLayerByName("archsites"));
+        
+        assertEquals(ImportTask.State.COMPLETE, task.getState());
+        assertEquals("file:archsites.shp", task.getLayer().getResource().getStore().getConnectionParameters().get("url"));
+        
         runChecks("archsites");
     }
 
@@ -430,6 +456,32 @@ public class ImporterDataTest extends ImporterTestSupport {
         assertNotNull(cat.getLayerByName("EmissiveCampania"));
 
         assertEquals(ImportTask.State.COMPLETE, task.getState());
+
+        runChecks("EmissiveCampania");
+    }
+    
+    @Test
+    public void testImportGeoTIFFFromDataDir() throws Exception {
+        File dataDir = getCatalog().getResourceLoader().getBaseDirectory();
+        
+        File dir = unpack("geotiff/EmissiveCampania.tif.bz2", dataDir);
+        
+        ImportContext context = 
+                importer.createContext(new SpatialFile(new File(dir, "EmissiveCampania.tif")));
+        assertEquals(1, context.getTasks().size());
+        
+        ImportTask task = context.getTasks().get(0);
+        assertEquals(ImportTask.State.READY, task.getState());
+        
+        assertEquals("EmissiveCampania", task.getLayer().getResource().getName());
+        
+        importer.run(context);
+        
+        Catalog cat = getCatalog();
+        assertNotNull(cat.getLayerByName("EmissiveCampania"));
+
+        assertEquals(ImportTask.State.COMPLETE, task.getState());
+        assertEquals("file:EmissiveCampania.tif", ((CoverageStoreInfo)task.getLayer().getResource().getStore()).getURL());
 
         runChecks("EmissiveCampania");
     }


### PR DESCRIPTION
See https://jira.codehaus.org/browse/GEOS-6958

While this is technicaly a bugfix, it affects the Catalog, so it might be an idea to keep this fix just on master for a bit before any backporting is considered.

In addition to the automated tests, I have tested this manually, and have not seen any detrimental effects to the catalog.