### PR TITLE
[GEOS-6964] Collapse zero-length date ranges to just a date when formatting

### DIFF
--- a/src/main/src/main/java/org/geoserver/util/ISO8601Formatter.java
+++ b/src/main/src/main/java/org/geoserver/util/ISO8601Formatter.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -41,19 +41,22 @@ public class ISO8601Formatter {
         }
         buf.append(value);
     }
-    
+
     /**
      * Formats the specified object either as a single time, if it's a Date, or as a continuous
      * interval, if it's a DateRange (and will throw an {@link IllegalArgumentException} otherwise)
      * 
-     * @param date
-     * @return
+     * @param date the Date or DateRange to format
+     * @return string containing representation of date / date range in ISO8601 format (as modified by OGC WMS)
      */
     public String format(Object date) {
-        if(date instanceof Date) {
+        if (date instanceof Date) {
             return format((Date) date);
-        } else if(date instanceof DateRange){
+        } else if (date instanceof DateRange) {
             DateRange range = (DateRange) date;
+            if (range.getMinValue().compareTo(range.getMaxValue()) == 0) {
+                return format(range.getMinValue());
+            }
             StringBuilder sb = new StringBuilder();
             format(range.getMinValue(), sb);
             sb.append("/");
@@ -69,8 +72,8 @@ public class ISO8601Formatter {
     /**
      * Formats the specified Date in ISO8601 format
      * 
-     * @param date
-     * @return
+     * @param date the Date to format
+     * @return string containing representation of date in ISO8601 format (as modified by OGC WMS)
      */
     public String format(Date date) {
         return format(date, new StringBuilder()).toString();

--- a/src/main/src/test/java/org/geoserver/util/ISO8601FormatterTest.java
+++ b/src/main/src/test/java/org/geoserver/util/ISO8601FormatterTest.java
@@ -1,0 +1,83 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.geotools.util.DateRange;
+
+import org.junit.Test;
+
+public class ISO8601FormatterTest {
+
+    @Test
+    public void testDate() throws Exception {
+        Date date = generateDate();
+        ISO8601Formatter formatter = new ISO8601Formatter();
+        String formattedDate = formatter.format(date);
+        assertEquals("2015-03-28T23:03:18.000Z", formattedDate);
+    }
+
+    @Test
+    public void testDateObject() throws Exception {
+        Date date = generateDate();
+        Object dateObj = date;
+        ISO8601Formatter formatter = new ISO8601Formatter();
+        String formattedDate = formatter.format(dateObj);
+        assertEquals("2015-03-28T23:03:18.000Z", formattedDate);
+    }
+
+    @Test 
+    public void testUnsupportedObject() throws Exception {
+        try {
+            ISO8601Formatter formatter = new ISO8601Formatter();
+            formatter.format(Locale.US);
+            fail("formatter should have thrown IllegalArgumentException");
+        }
+        catch(IllegalArgumentException e) {
+            assertEquals("Date argument should be either a Date or a DateRange, however this one is neither: en_US", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDateRange() throws Exception {
+        DateRange dateRange = new DateRange(generateDate(), generateDate(5));
+        ISO8601Formatter formatter = new ISO8601Formatter();
+        String formattedDateRange = formatter.format(dateRange);
+        assertEquals("2015-03-28T23:03:18.000Z/2015-03-28T23:03:23.000Z/PT1S", formattedDateRange);
+    }
+
+    @Test
+    public void testDateRangeZeroLength() throws Exception {
+        DateRange dateRange = new DateRange(generateDate(1), generateDate(1));
+        ISO8601Formatter formatter = new ISO8601Formatter();
+        String formattedDateRange = formatter.format(dateRange);
+        assertEquals("2015-03-28T23:03:19.000Z", formattedDateRange);
+    }
+
+    private Date generateDate() {
+        return generateDate(0);
+    }
+
+    private Date generateDate(int offset) {
+        GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"), new Locale("en", "aus"));
+        cal.clear();
+        cal.set(2015, Calendar.MARCH, 28, 23, 3, 18 + offset);
+        return cal.getTime();
+    }
+    
+    
+    
+    
+    
+    
+}


### PR DESCRIPTION
Also adds unit tests for existing ISO8601Formatter functionality.