### PR TITLE
Updating community module process

### DIFF
--- a/doc/en/developer/source/policies/community-modules.rst
+++ b/doc/en/developer/source/policies/community-modules.rst
@@ -51,7 +51,7 @@ The following outlines the steps to be taken in order to add a new community mod
 
 #. **Get version control access**
 
-   The next step is to create the community module in the subversion 
+   The next step is to create the community module in the git 
    repository. To do this it is necessary to be granted commit status. The 
    process for signing up for version control access is defined in the 
    :ref:`comitting` section.
@@ -61,13 +61,14 @@ The following outlines the steps to be taken in order to add a new community mod
    Once commit access is obtained the module can be added. All community 
    modules live under the directory ``community``, directly under the root of
    the source tree. The community modules on trunk can be found 
-   `here <http://svn.codehaus.org/geoserver/trunk/src/community>`_.
+   `here <https://github.com/geoserver/geoserver/tree/master/src/community>`_.
 
    For example, from the root of the GeoServer source tree::
 
-     [geoserver]% cd community
-     [geoserver/community]% svn mkdir myCommunityModule
-     [geoserver/community]% svn commit -m "adding my community module" myCommunityModule
+     [geoserver]% cd src/community
+     [geoserver/src/community]% mkdir myCommunityModule
+     [geoserver/src/community]% git add myCommunityModule
+     [geoserver/src/community]% git commit -m "adding my community module"
 
 #. **Add a Maven POM** 
   
@@ -223,16 +224,20 @@ Process
 
    Core modules live under the root of the source tree::
 
-     [geoserver]% svn move community/myCommunityModule .
-     [geoserver]% svn commit -m "promoting my community module to a core module" myCommunityModule community/
+     [geoserver]% mv src/community/myCommunityModule src/
+     [geoserver]% git add src/myCommunityModule
+     [geoserver]% git add --all src/community/myCommunityModule
+     [geoserver]% git commit -m "promoting my community module to a core module"
 
    *Extensions*
 
    Extension modules live under the extension directory, under the root of the
    source tree::
 
-     [geoserver]% svn move community/myCommunityModule extension
-     [geoserver]% svn commit -m "promoting my community module to an extension" extension community
+     [geoserver]% mv src/community/myCommunityModule src/extension
+     [geoserver]% git add src/extension/myCommunityModule
+     [geoserver]% git add --all src/community/myCommunityModule
+     [geoserver]% git commit -m "promoting my community module to an extension"
 
 #. **Update the build**
 
@@ -243,21 +248,21 @@ Process
    #. Edit ``community/pom.xml`` and remove the profile for the community 
       module
    #. Edit ``pom.xml`` under the root of the source tree and add a module 
-      enty::
+      entry::
 
             <modules>
               ...
               <module>myCommunityModule</module>
             </modules>
 
-     #. Edit ``web/app/pom.xml`` and move the dependency on the community module 
+   #. Edit ``web/app/pom.xml`` and move the dependency on the community module 
         into the main dependencies section of the pom. Then remove the profile
 
    *Extensions*
 
-     #. Copy the profile for the community module from ``community/pom.xml`` 
-        to ``extension/pom.xml``
-     #. Remove the profile from ``community/pom.xml``
+   #. Copy the profile for the community module from ``community/pom.xml`` 
+      to ``extension/pom.xml``
+   #. Remove the profile from ``community/pom.xml``
 
 #. **Update the release process**
 
@@ -380,7 +385,7 @@ Process
     #. Download the contributor agreement 
 
        The final step in the process is to download and fill out the 
-       `contributor agreement form <http://geoserver.org/download/attachments/819262/assignment_agreement.pdf?version=1>`_. Follow the instructions
+       `contributor agreement form <http://www.osgeo.org/sites/osgeo.org/files/Page/individual_contributor.txt>`_. Follow the instructions
        on the form to submit it.
      
 Demoting a community module


### PR DESCRIPTION
Updating the docs for contributing a community module. Some links were outdated and it needed to be updated to use git instead of subversion.