### PR TITLE
GEOS-6970 Support store creation in Import

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
@@ -137,9 +137,21 @@ public class ImportProcess implements GSProcess {
         		storeInfo = catalog.getCoverageStoreByName(ws.getName(), store);
         	}
             if (storeInfo == null) {
-                throw new ProcessException("Could not find store " + store + " in workspace "
-                        + workspace);
-                // TODO: support store creation
+                // mirroring "features != null" below
+                if (features != null) {
+                    storeInfo = catalog.getDefaultDataStore(ws);
+                    if (storeInfo == null) {
+                        throw new ProcessException("Could not find a default store in workspace "
+                                + ws.getName());
+                    }
+                }
+                else if (coverage != null) {
+                    // since the store doesn't exist, create it
+                    // mirroring "create a new coverage store" below
+                    storeInfo = cb.buildCoverageStore((store));
+                    add = true;
+                    LOGGER.info("Creating store " + store + " since it did not exist");
+                }
             }
         } else if (features != null) {
             storeInfo = catalog.getDefaultDataStore(ws);

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
@@ -7,13 +7,17 @@ package org.geoserver.wps.gs;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 
 import java.io.IOException;
 
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wps.WPSTestSupport;
+import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.Query;
 import org.geotools.data.crs.ForceCoordinateSystemFeatureResults;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -31,6 +35,10 @@ public class ImportProcessTest extends WPSTestSupport {
     @After 
     public void removeNewLayers() {
         removeLayer(SystemTestData.CITE_PREFIX, "Buildings2");
+        removeLayer(SystemTestData.CITE_PREFIX, "Buildings4");
+        removeLayer(SystemTestData.CITE_PREFIX, "Buildings5");
+        removeStore(SystemTestData.CITE_PREFIX, SystemTestData.CITE_PREFIX + "data");
+        removeStore(SystemTestData.CITE_PREFIX, SystemTestData.CITE_PREFIX + "raster");
     }
 
     /**
@@ -103,4 +111,42 @@ public class ImportProcessTest extends WPSTestSupport {
             assertEquals("114", f.getAttribute("FID"));
             assertEquals("215 Main Street", f.getAttribute("ADDRESS"));
 	}
+
+    /**
+     * Test creating a coverage store when a store name is specified but does not exist
+     */
+    @Test
+    public void testCreateCoverageStore() throws Exception {
+        String storeName = SystemTestData.CITE_PREFIX + "raster";
+        // use Coverage2RenderedImageAdapterTest's method, just need any sample raster
+        GridCoverage2D sampleCoverage = Coverage2RenderedImageAdapterTest.createTestCoverage(500, 500, 0,0, 10,10);
+        CoverageStoreInfo storeInfo = catalog.getCoverageStoreByName(storeName);
+        assertNull("Store already exists " + storeInfo, storeInfo);
+        ImportProcess importer = new ImportProcess(getCatalog());
+        String result = importer.execute(null, sampleCoverage, SystemTestData.CITE_PREFIX, storeName,
+                "Buildings4", CRS.decode("EPSG:4326"), null, null);
+        // expect workspace:layername
+        assertEquals(result, SystemTestData.CITE_PREFIX + ":" + "Buildings4");
+    }
+
+    /**
+     * Test creating a vector store when a store name is specified but does not exist
+     */
+    @Test
+    public void testCreateDataStore() throws Exception {
+        FeatureTypeInfo ti = getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
+        SimpleFeatureCollection rawSource = (SimpleFeatureCollection) ti.getFeatureSource(null,
+                null).getFeatures();
+        ForceCoordinateSystemFeatureResults sampleData = new ForceCoordinateSystemFeatureResults(
+                rawSource, CRS.decode("EPSG:4326"));
+        String storeName = SystemTestData.CITE_PREFIX + "data";
+        DataStoreInfo storeInfo = catalog.getDataStoreByName(storeName);
+        assertNull("Store already exists " + storeInfo, storeInfo);
+        ImportProcess importer = new ImportProcess(getCatalog());
+        String result = importer.execute(sampleData, null, SystemTestData.CITE_PREFIX, storeName,
+                "Buildings5", CRS.decode("EPSG:4326"), null, null);
+        // expect workspace:layername
+        assertEquals(result, SystemTestData.CITE_PREFIX + ":" + "Buildings5");
+
+    }
 }

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.


### PR DESCRIPTION
If the store does not exist but a store name is provided, create it.
The functionality is virtually identical to not providing a store name,
  except the provided store name is used instead of a default