### PR TITLE
[GEOS-6971] Color-blending example doesn't validate in SLD

### DIFF
--- a/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
+++ b/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
@@ -240,6 +240,7 @@
                     maxOccurs="unbounded"/>
         <xsd:element ref="sld:Transformation" minOccurs="0"/>
         <xsd:element ref="sld:Rule" maxOccurs="unbounded"/>
+        <xsd:element ref="sld:VendorOption" minOccurs="0" maxOccurs="unbounded" />
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>

--- a/src/main/src/test/java/org/vfny/geoserver/util/valid.sld
+++ b/src/main/src/test/java/org/vfny/geoserver/util/valid.sld
@@ -22,6 +22,7 @@
       <Stroke/>
      </LineSymbolizer>
     </Rule>
+    <VendorOption name="composite">destination-in</VendorOption>
    </FeatureTypeStyle>
   </UserStyle>
  </NamedLayer>


### PR DESCRIPTION
Fix for [GEOS-6971](https://osgeo-org.atlassian.net/browse/GEOS-6971) by updating schema file.  Also updated test data to cover this case.