### PR TITLE
Remove META-INF/services reference to CSVDataStoreFactory [GEOS-6978]

### DIFF
--- a/src/extension/importer/core/src/main/resources/META-INF/services/org.geotools.data.DataStoreFactorySpi
+++ b/src/extension/importer/core/src/main/resources/META-INF/services/org.geotools.data.DataStoreFactorySpi
@@ -1,1 +1,0 @@
-org.geoserver.importer.csv.CSVDataStoreFactory

--- a/src/extension/importer/core/src/main/resources/META-INF/services/org.geotools.data.FileDataStoreFactorySpi
+++ b/src/extension/importer/core/src/main/resources/META-INF/services/org.geotools.data.FileDataStoreFactorySpi
@@ -1,1 +1,0 @@
-org.geoserver.importer.csv.CSVDataStoreFactory


### PR DESCRIPTION
The CSVDataStoreFactory has been moved to geotools and is no longer available under this name.

https://osgeo-org.atlassian.net/browse/GEOS-6978