### PR TITLE
[GEOS-6979] GWC caching with CQL_FILTER returns no parameter filter exists for FILTER (Backport 2.7.x)

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -835,7 +835,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             }
         }
         if (null != request.getFilter() && !request.getFilter().isEmpty()) {
-            if (!filterApplies(filters, request, "FILTER", requestMistmatchTarget)) {
+            boolean sameFilters = checkFilter(request.getFilter(), request.getCQLFilter(), filters);
+            if (!sameFilters && !filterApplies(filters, request, "FILTER", requestMistmatchTarget)) {
                 return false;
             }
         }
@@ -885,6 +886,41 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         }
 
         return true;
+    }
+
+    /**
+     * Method for checking if CQL_FILTER list and FILTER lists are equals
+     * 
+     * @param filter
+     * @param cqlFilter
+     * @param filters
+     * @return
+     */
+    private boolean checkFilter(List filter, List cqlFilter, Map<String, ParameterFilter> filters) {
+        // Check if the two filters are equals and the FILTER parameter is not a ParameterFilter
+        // Check is done only if the FILTER parameter is not present
+        if (!filters.containsKey("FILTER")) {
+            // Check if the filter List and cqlFilter lists are not null and not empty
+            boolean hasFilter = filter != null && !filter.isEmpty();
+            boolean hasCQLFilter = cqlFilter != null && !cqlFilter.isEmpty();
+            // If the filters are present, check if they are equals.
+            // In this case the Filter List has been taken from the CQL_FILTER list
+            if (hasCQLFilter && hasFilter) {
+                // First check on the size
+                int size = filter.size();
+                if (size == cqlFilter.size()) {
+                    // Check same elements
+                    boolean equals = true;
+                    // Loop on the elements
+                    for (int i = 0; i < size; i++) {
+                        equals &= filter.get(i).equals(cqlFilter.get(i));
+                    }
+                    return equals;
+                }
+            }
+        }
+        // By default return false
+        return false;
     }
 
     private boolean filterApplies(Map<String, ParameterFilter> filters, GetMapRequest request,


### PR DESCRIPTION
Backport on 2.7.x of the fix for JIRA: https://osgeo-org.atlassian.net/browse/GEOS-6979