### PR TITLE
[GEOS-6979] GWC caching with CQL_FILTER returns no parameter filter exists for FILTER (Backport 2.6.x)

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -838,7 +838,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             }
         }
         if (null != request.getFilter() && !request.getFilter().isEmpty()) {
-            if (!filterApplies(filters, request, "FILTER", requestMistmatchTarget)) {
+            boolean sameFilters = checkFilter(request.getFilter(), request.getCQLFilter(), filters);
+            if (!sameFilters && !filterApplies(filters, request, "FILTER", requestMistmatchTarget)) {
                 return false;
             }
         }
@@ -888,6 +889,41 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         }
 
         return true;
+    }
+
+    /**
+     * Method for checking if CQL_FILTER list and FILTER lists are equals
+     * 
+     * @param filter
+     * @param cqlFilter
+     * @param filters
+     * @return
+     */
+    private boolean checkFilter(List filter, List cqlFilter, Map<String, ParameterFilter> filters) {
+        // Check if the two filters are equals and the FILTER parameter is not a ParameterFilter
+        // Check is done only if the FILTER parameter is not present
+        if (!filters.containsKey("FILTER")) {
+            // Check if the filter List and cqlFilter lists are not null and not empty
+            boolean hasFilter = filter != null && !filter.isEmpty();
+            boolean hasCQLFilter = cqlFilter != null && !cqlFilter.isEmpty();
+            // If the filters are present, check if they are equals.
+            // In this case the Filter List has been taken from the CQL_FILTER list
+            if (hasCQLFilter && hasFilter) {
+                // First check on the size
+                int size = filter.size();
+                if (size == cqlFilter.size()) {
+                    // Check same elements
+                    boolean equals = true;
+                    // Loop on the elements
+                    for (int i = 0; i < size; i++) {
+                        equals &= filter.get(i).equals(cqlFilter.get(i));
+                    }
+                    return equals;
+                }
+            }
+        }
+        // By default return false
+        return false;
     }
 
     private boolean filterApplies(Map<String, ParameterFilter> filters, GetMapRequest request,

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,8 +56,11 @@ import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.util.CaseInsensitiveMap;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.config.SecurityManagerConfig;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.WMS;
 import org.geoserver.wms.kvp.PaletteManager;
+import org.geoserver.wms.map.GetMapKvpRequestReader;
 import org.geotools.filter.identity.FeatureIdImpl;
 import org.geotools.filter.text.cql2.CQL;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -75,6 +79,7 @@ import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.grid.SRS;
+import org.geowebcache.io.Resource;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.mime.MimeType;
@@ -90,6 +95,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.opengis.filter.Filter;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -932,6 +938,49 @@ public class GWCTest {
         cachingPossible = mediator.isCachingPossible(tileLayer, request, target);
         assertTrue(cachingPossible);
         assertEquals(0, target.length());
+    }
+
+    /**
+     * Since GeoServer sets a new FILTER parameter equal to an input CQL_FILTER parameter (if present) for each WMS requests (using direct WMS
+     * integration), this may result in a caching error. This test ensures that no error is thrown and caching is allowed.
+     */
+    @Test
+    public void testCQLFILTERParameters() throws Exception {
+        // Define a CQL_FILTER
+        TileLayerInfoUtil.updateAcceptAllRegExParameterFilter(tileLayerInfo, "CQL_FILTER", true);
+        tileLayer = new GeoServerTileLayer(layer, gridSetBroker, tileLayerInfo);
+        // Create the new GetMapRequest
+        GetMapRequest request = new GetMapRequest();
+        @SuppressWarnings("unchecked")
+        Map<String, String> rawKvp = new CaseInsensitiveMap(new HashMap<String, String>());
+        rawKvp.put("CQL_FILTER", "include");
+        request.setRawKvp(rawKvp);
+        StringBuilder target = new StringBuilder();
+
+        // Setting CQL FILTER
+        List<Filter> cqlFilters = Arrays.asList(CQL.toFilter("include"));
+        request.setCQLFilter(cqlFilters);
+        // Checking if caching is possible
+        assertTrue(mediator.isCachingPossible(tileLayer, request, target));
+        // Ensure No error is logged
+        assertEquals(0, target.length());
+
+        // Setting FILTER parameter equal to CQL FILTER (GeoServer does it internally)
+        request.setFilter(cqlFilters);
+        // Checking if caching is possible
+        assertTrue(mediator.isCachingPossible(tileLayer, request, target));
+        // Ensure No error is logged
+        assertEquals(0, target.length());
+
+        // Ensure that if another filter is set an error is thrown
+        List filters = new ArrayList(cqlFilters);
+        filters.add(Filter.INCLUDE);
+        request.setFilter(filters);
+
+        // Ensuring caching is not possible
+        assertFalse(mediator.isCachingPossible(tileLayer, request, target));
+        // Ensure No error is logged
+        assertFalse(0 == target.length());
     }
 
     private void assertDispatchMismatch(GetMapRequest request, String expectedReason) {


### PR DESCRIPTION
Backport on 2.6.x of the fix for JIRA: https://osgeo-org.atlassian.net/browse/GEOS-6979