### PR TITLE
Update to Oracle 12 driver (ojdbc7)

### DIFF
--- a/doc/en/developer/source/maven-guide/index.rst
+++ b/doc/en/developer/source/maven-guide/index.rst
@@ -223,7 +223,7 @@ To configure GeoServer to include the Oracle datastore extension module, do the 
 Obtain the appropriate Oracle JDBC driver (possibly by downloading from Oracle or from the Geoserver ORACLE-extension on http://geoserver.org/release/stable/).
 Install it in the Maven repository using the command::
 	
-  mvn install:install-file -Dfile=ojdbc14.jar -DgroupId=com.oracle -DartifactId=ojdbc14 -Dversion=10.2.0.3.0 -Dpackaging=jar -DgeneratePom=true
+  mvn install:install-file -Dfile=ojdbc7.jar -DgroupId=com.oracle -DartifactId=ojdbc7 -Dversion=12.1.0.2 -Dpackaging=jar -DgeneratePom=true
   
 Configure the Eclipse project using::
 

--- a/doc/en/developer/source/programming-guide/app-schema/index.rst
+++ b/doc/en/developer/source/programming-guide/app-schema/index.rst
@@ -10,7 +10,7 @@ Prerequisites
 
 This requires installation of Oracle driver in Maven repository::       
                                   
-    mvn install:install-file -Dfile=ojdbc14.jar -DgroupId=com.oracle -DartifactId=ojdbc14 -Dversion=10.2.0.3.0 -Dpackaging=jar 
+    mvn install:install-file -Dfile=ojdbc7.jar -DgroupId=com.oracle -DartifactId=ojdbc7 -Dversion=12.1.0.2 -Dpackaging=jar 
 
 You would also need to have test databases for both Oracle and Postgis. Then follow these steps:
 

--- a/src/community/jdbcconfig/pom.xml
+++ b/src/community/jdbcconfig/pom.xml
@@ -97,9 +97,8 @@
           <dependencies>
             <dependency>
                 <groupId>com.oracle</groupId>
-                <artifactId>ojdbc14</artifactId>
+                <artifactId>ojdbc7</artifactId>
                 <scope>test</scope>
-                <version>10.2.0.3.0</version>
             </dependency>
           </dependencies>
       </profile>

--- a/src/extension/app-schema/app-schema-oracle-test/pom.xml
+++ b/src/extension/app-schema/app-schema-oracle-test/pom.xml
@@ -160,8 +160,7 @@
         <!-- Must ensure this has been installed in M2 repository -->
         <dependency>
             <groupId>com.oracle</groupId>
-            <artifactId>ojdbc14</artifactId> 
-            <version>10.2.0.3.0</version>
+            <artifactId>ojdbc7</artifactId> 
         </dependency>
 	</dependencies>  
 	

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -203,8 +203,7 @@
 	        <dependencies>
                 <dependency>
                     <groupId>com.oracle</groupId>
-                    <artifactId>ojdbc14</artifactId> 
-                    <version>10.2.0.3.0</version>
+                    <artifactId>ojdbc7</artifactId> 
                 </dependency>
             </dependencies>
         </profile>

--- a/src/extension/importer/core/pom.xml
+++ b/src/extension/importer/core/pom.xml
@@ -65,8 +65,7 @@
       <dependencies>
         <dependency>
           <groupId>com.oracle</groupId>
-          <artifactId>ojdbc14</artifactId>
-          <version>10.2.0.3.0</version>
+          <artifactId>ojdbc7</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/src/extension/oracle/pom.xml
+++ b/src/extension/oracle/pom.xml
@@ -32,8 +32,7 @@
       <dependencies>
         <dependency>
           <groupId>com.oracle</groupId>
-          <artifactId>ojdbc14</artifactId> 
-          <version>10.2.0.3.0</version>
+          <artifactId>ojdbc7</artifactId> 
         </dependency>
       </dependencies>
     </profile>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -581,6 +581,14 @@
     <version>${gwc.version}</version>
    </dependency>
 
+   <!-- ORACLE -->
+   <!-- Download and install into your own repo -->
+   <dependency>
+     <groupId>com.oracle</groupId>
+     <artifactId>ojdbc7</artifactId>
+     <version>12.1.0.2</version>
+   </dependency>
+
    <dependency>
     <groupId>org.wkb4j</groupId>
     <artifactId>wkb4j</artifactId>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -414,8 +414,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle</groupId>
-            <artifactId>ojdbc14</artifactId>
-            <version>10.2.0.3.0</version>
+            <artifactId>ojdbc7</artifactId>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
This change is primarily intended for use with app-schema online tests, but I upgraded everything that used the old ojdbc.jar for consistency.