### PR TITLE
GEOS-6994, Cache provider conflict resolution

### DIFF
--- a/src/community/hz-cluster/src/main/java/org/geoserver/cluster/hazelcast/HzExtensionFilter.java
+++ b/src/community/hz-cluster/src/main/java/org/geoserver/cluster/hazelcast/HzExtensionFilter.java
@@ -1,0 +1,46 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.hazelcast;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.geoserver.platform.ExtensionFilter;
+import org.geoserver.util.CacheProvider;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Filter to exclude extensions that conflict with hz-cluster.
+ * 
+ * @author Kevin Smith, Boundless
+ *
+ */
+public class HzExtensionFilter implements ExtensionFilter {
+    HzCluster cluster;
+    
+    protected static Logger LOGGER = Logging.getLogger("org.geoserver.cluster.hazelcast");
+    
+    public HzExtensionFilter(HzCluster cluster) {
+        this.cluster = cluster;
+    }
+    
+    @Override
+    public boolean exclude(String beanId, Object bean) {
+        if(cluster.isEnabled()) {
+            if((bean instanceof CacheProvider) && !(bean instanceof HzCacheProvider)) {
+                // If another extension does this too then we're in trouble as only the default will be used.
+                LOGGER.log(Level.INFO, "hz-cluster module is supressing conflicting CacheProvider {0}", new Object[]{beanId});
+                return true;
+            }
+        } else {
+            if(bean instanceof HzCacheProvider) {
+                LOGGER.log(Level.CONFIG, "Supressing HzCacheProvider as it is not needed when hz-cluster is disabled.");
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/community/hz-cluster/src/main/resources/applicationContext.xml
+++ b/src/community/hz-cluster/src/main/resources/applicationContext.xml
@@ -21,4 +21,8 @@
    <bean id="hzCacheProvider" class="org.geoserver.cluster.hazelcast.HzCacheProvider">
       <constructor-arg ref="xstreamPersisterFactory"/>
    </bean>
+   
+   <bean id="hzExtensionFilter" class="org.geoserver.cluster.hazelcast.HzExtensionFilter">
+      <constructor-arg ref="hzCluster"/>
+   </bean>
 </beans>

--- a/src/community/hz-cluster/src/test/java/org/geoserver/cluster/hazelcast/HzExtensionFilterTest.java
+++ b/src/community/hz-cluster/src/test/java/org/geoserver/cluster/hazelcast/HzExtensionFilterTest.java
@@ -1,0 +1,73 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cluster.hazelcast;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.*;
+
+import org.easymock.EasyMock;
+import org.geoserver.platform.ExtensionFilter;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.util.CacheProvider;
+import org.geoserver.util.DefaultCacheProvider;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class HzExtensionFilterTest {
+    
+    @Rule
+    public GeoServerExtensionsHelper.ExtensionsHelperRule extensions =
+        new GeoServerExtensionsHelper.ExtensionsHelperRule();
+    
+    @Test
+    public void testActive() {
+        CacheProvider rivalProvider = EasyMock.createMock("rivalProvider", CacheProvider.class);
+        CacheProvider hzProvider = EasyMock.createMock("hzProvider", HzCacheProvider.class);
+        HzCluster cluster = EasyMock.createMock("cluster", HzCluster.class);
+        
+        EasyMock.expect(cluster.isEnabled()).andStubReturn(true); // Cluster is enabled
+        
+        EasyMock.replay(rivalProvider, hzProvider, cluster);
+        
+        ExtensionFilter filter = new HzExtensionFilter(cluster);
+        
+        extensions.singleton("filter", filter, ExtensionFilter.class);
+        
+        extensions.singleton("rivalProvider", rivalProvider, CacheProvider.class);
+        extensions.singleton("hzProvider", hzProvider, CacheProvider.class, HzCacheProvider.class);
+        
+        CacheProvider result = DefaultCacheProvider.findProvider();
+        
+        assertThat(result, sameInstance(hzProvider)); // Clustered provider used
+        
+        EasyMock.verify(rivalProvider, hzProvider, cluster);
+    }
+    
+    @Test
+    public void testInactive() {
+        CacheProvider rivalProvider = EasyMock.createMock("rivalProvider", CacheProvider.class);
+        CacheProvider hzProvider = EasyMock.createMock("hzProvider", HzCacheProvider.class);
+        HzCluster cluster = EasyMock.createMock("cluster", HzCluster.class);
+        
+        EasyMock.expect(cluster.isEnabled()).andStubReturn(false); // Cluster is disabled
+        
+        EasyMock.replay(rivalProvider, hzProvider, cluster);
+        
+        ExtensionFilter filter = new HzExtensionFilter(cluster);
+        
+        extensions.singleton("filter", filter, ExtensionFilter.class);
+        
+        extensions.singleton("rivalProvider", rivalProvider, CacheProvider.class);
+        extensions.singleton("hzProvider", hzProvider, CacheProvider.class, HzCacheProvider.class);
+        
+        CacheProvider result = DefaultCacheProvider.findProvider();
+        
+        assertThat(result, sameInstance(rivalProvider)); // Other provider used
+        
+        EasyMock.verify(rivalProvider, hzProvider, cluster);
+    }
+    
+}

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -31,6 +31,12 @@
    <scope>test</scope>
   </dependency>
   <dependency>
+   <groupId>org.geoserver</groupId>
+   <artifactId>gs-platform</artifactId>
+   <classifier>tests</classifier>
+   <scope>test</scope>
+  </dependency>
+  <dependency>
    <groupId>javax.servlet</groupId>
    <artifactId>servlet-api</artifactId>
   </dependency>

--- a/src/main/src/main/java/org/geoserver/util/DefaultCacheProvider.java
+++ b/src/main/src/main/java/org/geoserver/util/DefaultCacheProvider.java
@@ -7,19 +7,27 @@ package org.geoserver.util;
 
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import org.apache.commons.lang.StringUtils;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerExtensions.MultipleBeansException;
+import org.geotools.util.logging.Logging;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 public class DefaultCacheProvider implements CacheProvider {
+    private static final Logger LOGGER = Logging.getLogger(DefaultCacheProvider.class);
 
     public static final int DEFAULT_CONCURRENCY_LEVEL = 4;
 
     public static final int DEFAULT_EXPIRATION_MINUTES = 20;
 
     public static final int DEFAULT_MAX_ENTRIES = 25000;
+
+    public static final String BEAN_NAME_PROPERTY = "GEOSERVER_DEFAULT_CACHE_PROVIDER";
 
     @Override
     public <K extends Serializable, V extends Serializable> Cache<K, V> getCache(String cacheName) {
@@ -31,9 +39,39 @@ public class DefaultCacheProvider implements CacheProvider {
 
         return cache;
     }
-
+    
+    
     public static CacheProvider findProvider() {
-        CacheProvider cacheProvider = GeoServerExtensions.bean(CacheProvider.class);
+        CacheProvider cacheProvider = null;
+        // Check for a named bean
+        String providerNames = GeoServerExtensions.getProperty(BEAN_NAME_PROPERTY);
+        if(providerNames!=null) {
+            for(String providerName: providerNames.split("\\s*,\\s*")) {
+                cacheProvider = (CacheProvider) (CacheProvider) GeoServerExtensions.bean(providerName);
+                if(cacheProvider!=null) {
+                    LOGGER.log(Level.INFO, "Using specified Cache Provider ", providerName);
+                    break;
+                }
+            }
+            if(cacheProvider == null) {
+                LOGGER.log(Level.INFO, "{0} was specified but no beans matched it.", BEAN_NAME_PROPERTY);
+            }
+        }
+        // Find a bean by interface
+        if (cacheProvider == null) {
+            try {
+                cacheProvider = GeoServerExtensions.bean(CacheProvider.class);
+            } catch (MultipleBeansException ex) {
+                String providerName = ex.getAvailableBeans().iterator().next();
+                if(LOGGER.isLoggable(Level.WARNING)){
+                    String available = StringUtils.join(ex.getAvailableBeans(), ", ");
+                    LOGGER.log(Level.WARNING, "Multiple Cache Providers in context: {0}\n\tUsing {1}.  Override by setting system property {2}", new Object[]{available, providerName, BEAN_NAME_PROPERTY});
+                }
+                cacheProvider = (CacheProvider) (CacheProvider) GeoServerExtensions.bean(providerName);
+            }
+        }
+        
+        // Use the default
         if (cacheProvider == null) {
             cacheProvider = new DefaultCacheProvider();
         }

--- a/src/main/src/test/java/org/geoserver/platform/GeoServerExtensionsHelperTest.java
+++ b/src/main/src/test/java/org/geoserver/platform/GeoServerExtensionsHelperTest.java
@@ -6,9 +6,12 @@
 package org.geoserver.platform;
 
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 
@@ -50,6 +53,21 @@ public class GeoServerExtensionsHelperTest {
         GeoServerExtensionsHelper.clear();
         assertNull(GeoServerExtensions.bean("bean"));
         assertNull(GeoServerExtensions.bean(GeoServerExtensionsHelperTest.class));
+    }
+    
+    class TestClass {
+        
+    }
+    @SuppressWarnings("unchecked")
+    @Test
+    public void helperMultipleSingleton() {
+        TestClass o1 = new TestClass();
+        TestClass o2 = new TestClass();
+        GeoServerExtensionsHelper.singleton("o1", o1, TestClass.class);
+        GeoServerExtensionsHelper.singleton("o2", o2, TestClass.class);
+        
+        assertThat(GeoServerExtensions.extensions(TestClass.class), 
+                containsInAnyOrder(sameInstance(o1), sameInstance(o2)));
     }  
     
     @Test

--- a/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -63,6 +63,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
@@ -74,6 +75,10 @@ import com.google.common.collect.Iterators;
 public class SecureCatalogImplTest extends AbstractAuthorizationTest {
     
     public final static Logger LOGGER = Logging.getLogger(SecureCatalogImplTest.class);
+    
+    @Rule
+    public GeoServerExtensionsHelper.ExtensionsHelperRule extensions = 
+        new GeoServerExtensionsHelper.ExtensionsHelperRule();
 
     @Before
     public void setUp() throws Exception {
@@ -461,7 +466,7 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
             }
         };
         this.catalog = withLayers;
-        GeoServerExtensionsHelper.singleton("catalog", catalog, Catalog.class);
+        extensions.singleton("catalog", catalog, Catalog.class);
 
         // and the secure catalog with the filter
         buildManager("publicRead.properties", filter);
@@ -577,7 +582,7 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
         expect(eoCatalog.getLayerGroupByName("topp", eoStatesLayerGroup.getName())).andReturn(eoStatesLayerGroup).anyTimes();        
         replay(eoCatalog);
         this.catalog = eoCatalog;
-        GeoServerExtensionsHelper.singleton("catalog", eoCatalog, Catalog.class);
+        extensions.singleton("catalog", eoCatalog, Catalog.class);
         
         buildManager("lockedLayerInLayerGroup.properties");
         SecurityContextHolder.getContext().setAuthentication(roUser);

--- a/src/main/src/test/java/org/geoserver/util/DefaultCacheProviderTest.java
+++ b/src/main/src/test/java/org/geoserver/util/DefaultCacheProviderTest.java
@@ -1,0 +1,145 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.util;
+
+import static org.easymock.classextension.EasyMock.replay;
+import static org.easymock.classextension.EasyMock.reset;
+import static org.easymock.classextension.EasyMock.verify;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.*;
+
+import java.util.logging.Level;
+
+import org.apache.commons.lang.StringUtils;
+import org.easymock.classextension.EasyMock;
+import org.geoserver.platform.GeoServerExtensionsHelper.ExtensionsHelperRule;
+import org.geotools.util.logging.Logging;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DefaultCacheProviderTest {
+    
+    @Rule
+    public ExtensionsHelperRule extensions = new ExtensionsHelperRule();
+    
+    @Rule 
+    public LoggerRule logging = new LoggerRule(Logging.getLogger(DefaultCacheProvider.class), Level.WARNING);
+    
+    @Test
+    public void testDefault() {
+        CacheProvider provider = DefaultCacheProvider.findProvider();
+        
+        assertThat(provider, instanceOf(DefaultCacheProvider.class));
+    }
+    
+    private CacheProvider addMockProvider(String name) {
+        CacheProvider provider = 
+                EasyMock.createMock(name, CacheProvider.class);
+        extensions.singleton(name, provider, CacheProvider.class);
+        return provider;
+    }
+    
+    @Test
+    public void testFindInContext() {
+        CacheProvider testCacheProvider1 = addMockProvider("testCacheProvider1");
+        
+        replay(testCacheProvider1);
+        
+        CacheProvider provider = DefaultCacheProvider.findProvider();
+        
+        assertThat(provider, sameInstance(testCacheProvider1));
+        
+        verify(testCacheProvider1);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testFindTwoInContext() {
+        CacheProvider testCacheProvider1 = addMockProvider("testCacheProvider1");
+        CacheProvider testCacheProvider2 = addMockProvider("testCacheProvider2");
+        
+        replay(testCacheProvider1, testCacheProvider2);
+        
+        CacheProvider provider = DefaultCacheProvider.findProvider();
+        
+        assertThat(provider, anyOf(sameInstance(testCacheProvider1),sameInstance(testCacheProvider2)));
+        
+        String providerName = "testCacheProvider2";
+        if(provider==testCacheProvider1) {
+            providerName = "testCacheProvider1";
+        }
+        logging.assertLogged(allOf(
+                    hasProperty("level", is(Level.WARNING)),
+                    hasProperty("parameters", arrayContainingInAnyOrder(
+                            // Name of the provider being used
+                            equalTo(providerName),
+                            // Available providers
+                            anyOf(equalTo("testCacheProvider1, testCacheProvider2"), 
+                                    equalTo("testCacheProvider2, testCacheProvider1")),
+                            // The system property to override
+                            equalTo("GEOSERVER_DEFAULT_CACHE_PROVIDER")
+                    ))
+                ));
+        verify(testCacheProvider1, testCacheProvider2);
+    }
+    
+    @Test
+    public void testResolveWithProperty() {
+        CacheProvider testCacheProvider1 = addMockProvider("testCacheProvider1");
+        CacheProvider testCacheProvider2 = addMockProvider("testCacheProvider2");
+        
+        // Test that the bean specified in the property is used
+        
+        extensions.property(DefaultCacheProvider.BEAN_NAME_PROPERTY, "testCacheProvider1");
+        
+        replay(testCacheProvider1, testCacheProvider2);
+        
+        CacheProvider provider = DefaultCacheProvider.findProvider();
+        
+        assertThat(provider, sameInstance(testCacheProvider1));
+        
+        verify(testCacheProvider1, testCacheProvider2);
+        
+        // Retry with the property changed to ensure we weren't jsut lucky before
+        reset(testCacheProvider1, testCacheProvider2);
+        
+        extensions.property(DefaultCacheProvider.BEAN_NAME_PROPERTY, "testCacheProvider2");
+        
+        replay(testCacheProvider1, testCacheProvider2);
+        
+        provider = DefaultCacheProvider.findProvider();
+        
+        assertThat(provider, sameInstance(testCacheProvider2));
+        
+        verify(testCacheProvider1, testCacheProvider2);
+    }
+    
+    @Test
+    public void testPropertyPriority() {
+        CacheProvider testCacheProvider3 = addMockProvider("testCacheProvider3");
+        CacheProvider testCacheProvider2 = addMockProvider("testCacheProvider2");
+        
+        // Test that the bean specified in the property is used
+        
+        extensions.property(DefaultCacheProvider.BEAN_NAME_PROPERTY, "testCacheProvider1,testCacheProvider2,testCacheProvider3");
+        
+        replay(testCacheProvider3, testCacheProvider2);
+        
+        CacheProvider provider = DefaultCacheProvider.findProvider();
+        
+        assertThat(provider, sameInstance(testCacheProvider2));
+        
+        verify(testCacheProvider3, testCacheProvider2);
+    }
+}

--- a/src/platform/pom.xml
+++ b/src/platform/pom.xml
@@ -76,6 +76,11 @@
   </dependency>
   <dependency>
    <groupId>org.easymock</groupId>
+   <artifactId>easymockclassextension</artifactId>
+   <scope>test</scope>
+  </dependency>
+  <dependency>
+   <groupId>org.easymock</groupId>
    <artifactId>easymock</artifactId>
    <scope>test</scope>
   </dependency>

--- a/src/platform/src/test/java/org/geoserver/util/LoggerRule.java
+++ b/src/platform/src/test/java/org/geoserver/util/LoggerRule.java
@@ -1,0 +1,162 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.util;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.geotools.util.logging.LoggerAdapter;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.Assume;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+
+/**
+ * JUnit Rule to test that logging occurs.  The instrumentation will be removed when complete and 
+ * any changes to log level will be reverted.
+ * <p/>
+ * Note: that this works by adding a Handler to the Logger.
+ * 
+ * @author Kevin Smith, Boundless
+ *
+ */
+public class LoggerRule extends java.util.logging.Handler implements TestRule {
+    private Logger log;
+    private LinkedList<LogRecord> records = new LinkedList<>();
+    private Level newLevel = null;
+    private Level oldLevel = null;
+    
+    /**
+     * Test logging for the given logger
+     * @param log Logger to monitor
+     */
+    public LoggerRule(Logger log) {
+        super();
+        this.log = log;
+    }
+    
+    /**
+     * Test logging for the given logger
+     * @param log Logger to monitor
+     * @param level Set the log level for the tests
+     */
+    public LoggerRule(Logger log, Level level) {
+        super();
+        this.log = log;
+        super.setLevel(level);
+        this.newLevel = level;
+    }
+    
+    
+
+    @Override
+    public boolean isLoggable(LogRecord record) {
+        return true;
+    }
+
+    @Override
+    public Statement apply(final Statement base, final org.junit.runner.Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                
+                oldLevel=log.getLevel();
+                if(newLevel!=null){
+                    log.setLevel(newLevel);
+                }
+                log.addHandler(LoggerRule.this);
+                try {
+                    base.evaluate();
+                } finally {
+                    log.removeHandler(LoggerRule.this);
+                    log.setLevel(oldLevel);
+                    oldLevel=null;
+                }
+            }
+            
+        };
+    }
+    
+    @Override
+    public void publish(LogRecord record) {
+        records.add(record);
+    }
+    
+    @Override
+    public void flush() {
+        // Do Nothing
+    }
+    
+    @Override
+    public void close() throws SecurityException {
+        // Do Nothing
+    }
+    
+    /**
+     * Clear all recorded log records
+     */
+    public void clear() {
+        records.clear();
+    }
+    
+    private void assumeCaptureWorks() {
+        // FIXME: LoggerAdapter overrides addHandler to do nothing which prevents LoggerRule from
+        // capturing records.
+        Assume.assumeFalse("LoggerRule can't capture logs for LoggerAdapter", log instanceof LoggerAdapter);
+    }
+    
+    /**
+     * Get the captured log records
+     * @return
+     */
+    public List<LogRecord> records() {
+        assumeCaptureWorks();
+        return records;
+    }
+    
+    /**
+     * Set the level of the logger.  Will be reverted when the test is complete.
+     */
+    public void setTestLevel(Level testLevel) {
+        log.setLevel(testLevel);
+        newLevel=testLevel;
+        super.setLevel(testLevel);
+    }
+    
+    /**
+     * Assert that a record was logged that matches the given conditions 
+     * @param matcher Condition to match against
+     */
+    public void assertLogged (Matcher<? super LogRecord> matcher) {
+        assertLogged ("",  matcher);
+    }
+    
+    /**
+     * Assert that a record was logged that matches the given conditions 
+     * @param reason Message to add to the failure report
+     * @param matcher Condition to match against
+     */
+    public void assertLogged (String reason, Matcher<? super LogRecord> matcher) {
+        assumeCaptureWorks();
+        for(LogRecord r: records) {
+            if(matcher.matches(r)){
+                return;
+            }
+        }
+        Description desc = new StringDescription();
+        desc.appendText(reason);
+        desc.appendText("\nExpected record: ");
+        desc.appendDescriptionOf(matcher);
+        desc.appendText("\n\tbut it was not logged");
+        throw new AssertionError(desc.toString());
+    }
+}

--- a/src/platform/src/test/java/org/geoserver/util/LoggerRuleTest.java
+++ b/src/platform/src/test/java/org/geoserver/util/LoggerRuleTest.java
@@ -1,0 +1,297 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.util;
+
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.classextension.EasyMock.createMock;
+import static org.easymock.classextension.EasyMock.replay;
+import static org.easymock.classextension.EasyMock.reset;
+import static org.easymock.classextension.EasyMock.verify;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.*;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.easymock.Capture;
+import org.easymock.IAnswer;
+import org.geotools.util.logging.LoggerAdapter;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class LoggerRuleTest {
+    
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    
+    @Test
+    public void testDoNothingUntilRun() {
+        Logger log = createMock("log",Logger.class);
+        Description desc = createMock("desc",Description.class);
+        Statement base = createMock("base", Statement.class);
+        
+        replay(log, desc, base);
+        LoggerRule rule = new LoggerRule(log, Level.FINE);
+        rule.apply(base, desc);
+        verify(log, desc, base);
+    }
+    
+    @Test
+    public void testCleansUp() throws Throwable {
+        final Logger log = createMock("log",Logger.class);
+        Description desc = createMock("desc",Description.class);
+        Statement base = createMock("base", Statement.class);
+        
+        expect(log.getLevel()).andReturn(Level.OFF);
+        log.setLevel(Level.FINE); expectLastCall().once();
+        final Capture<Handler> handlerCap = new Capture<>();
+        log.addHandler(capture(handlerCap)); expectLastCall().once();
+        base.evaluate();expectLastCall().andAnswer(new IAnswer<Void>(){
+            
+            @Override
+            public Void answer() throws Throwable {
+                verify(log);
+                reset(log);
+                
+                log.removeHandler(handlerCap.getValue()); expectLastCall().once();
+                log.setLevel(Level.OFF); expectLastCall().once();
+                
+                replay(log);
+                return null;
+            }
+            
+        });
+        replay(log, desc, base);
+        LoggerRule rule = new LoggerRule(log, Level.FINE);
+        Statement s = rule.apply(base, desc);
+        s.evaluate();
+        verify(log, desc, base);
+    }
+    
+    @Test
+    public void testCleansUpAfterException() throws Throwable {
+        final Logger log = createMock("log",Logger.class);
+        Description desc = createMock("desc",Description.class);
+        Statement base = createMock("base", Statement.class);
+        
+        expect(log.getLevel()).andReturn(Level.OFF);
+        log.setLevel(Level.FINE); expectLastCall().once();
+        final Capture<Handler> handlerCap = new Capture<>();
+        final Exception ex = new IllegalArgumentException();
+        log.addHandler(capture(handlerCap)); expectLastCall().once();
+        base.evaluate();expectLastCall().andAnswer(new IAnswer<Void>(){
+            
+            @Override
+            public Void answer() throws Throwable {
+                verify(log);
+                reset(log);
+                
+                log.removeHandler(handlerCap.getValue()); expectLastCall().once();
+                log.setLevel(Level.OFF); expectLastCall().once();
+                
+                replay(log);
+                throw ex;
+            }
+            
+        });
+        replay(log, desc, base);
+        LoggerRule rule = new LoggerRule(log, Level.FINE);
+        Statement s = rule.apply(base, desc);
+        
+        exception.expect(sameInstance(ex));
+        try {
+            s.evaluate();
+        } finally {
+            verify(log, desc, base);
+        }
+    }
+    
+    @Test
+    public void testRecordsLogs() throws Throwable {
+        final Logger log = createMock("log",Logger.class);
+        Description desc = createMock("desc",Description.class);
+        Statement base = createMock("base", Statement.class);
+        
+        expect(log.getLevel()).andReturn(Level.OFF);
+        log.setLevel(Level.FINE); expectLastCall().once();
+        final Capture<Handler> handlerCap = new Capture<>();
+        final Exception ex = new IllegalArgumentException();
+        
+        final LogRecord record = createMock("record1", LogRecord.class);
+        
+        log.addHandler(capture(handlerCap)); expectLastCall().once();
+        base.evaluate();expectLastCall().andAnswer(new IAnswer<Void>(){
+            
+            @Override
+            public Void answer() throws Throwable {
+                verify(log);
+                reset(log);
+                
+                log.removeHandler(handlerCap.getValue()); expectLastCall().once();
+                log.setLevel(Level.OFF); expectLastCall().once();
+                
+                handlerCap.getValue().publish(record);
+                assertThat(((LoggerRule)handlerCap.getValue()).records(), contains(record));
+                replay(log);
+                return null;
+            }
+            
+        });
+        replay(log, desc, base);
+        LoggerRule rule = new LoggerRule(log, Level.FINE);
+        Statement s = rule.apply(base, desc);
+        
+        s.evaluate();
+        verify(log, desc, base);
+    }
+    
+    @Test
+    public void testAssertFail() throws Throwable {
+        final Logger log = createMock("log",Logger.class);
+        Description desc = createMock("desc",Description.class);
+        Statement base = createMock("base", Statement.class);
+        
+        expect(log.getLevel()).andReturn(Level.OFF);
+        log.setLevel(Level.FINE); expectLastCall().once();
+        final Capture<Handler> handlerCap = new Capture<>();
+        
+        final LogRecord record = createMock("record1", LogRecord.class);
+        
+        log.addHandler(capture(handlerCap)); expectLastCall().once();
+        base.evaluate();expectLastCall().andAnswer(new IAnswer<Void>(){
+            
+            @Override
+            public Void answer() throws Throwable {
+                verify(log);
+                reset(log);
+                
+                log.removeHandler(handlerCap.getValue()); expectLastCall().once();
+                log.setLevel(Level.OFF); expectLastCall().once();
+                replay(log);
+                
+                handlerCap.getValue().publish(record);
+                ((LoggerRule)handlerCap.getValue()).assertLogged(sameInstance(record));
+                ((LoggerRule)handlerCap.getValue()).assertLogged(not(anything()));
+                return null;
+            }
+            
+        });
+        replay(log, desc, base);
+        LoggerRule rule = new LoggerRule(log, Level.FINE);
+        Statement s = rule.apply(base, desc);
+        
+        try {
+            s.evaluate();
+            fail("Expected Assertion Exception");
+        } catch (AssertionError ex){
+            assertThat(ex, hasProperty("message", containsString("Expected record")));
+        } finally {
+            verify(log, desc, base);
+        }
+    }
+    
+    @Test
+    public void testAssertPass() throws Throwable {
+        final Logger log = createMock("log",Logger.class);
+        Description desc = createMock("desc",Description.class);
+        Statement base = createMock("base", Statement.class);
+        
+        expect(log.getLevel()).andReturn(Level.OFF);
+        log.setLevel(Level.FINE); expectLastCall().once();
+        final Capture<Handler> handlerCap = new Capture<>();
+        
+        final LogRecord record = createMock("record1", LogRecord.class);
+        
+        log.addHandler(capture(handlerCap)); expectLastCall().once();
+        base.evaluate();expectLastCall().andAnswer(new IAnswer<Void>(){
+            
+            @Override
+            public Void answer() throws Throwable {
+                verify(log);
+                reset(log);
+                
+                log.removeHandler(handlerCap.getValue()); expectLastCall().once();
+                log.setLevel(Level.OFF); expectLastCall().once();
+                replay(log);
+                
+                handlerCap.getValue().publish(record);
+                ((LoggerRule)handlerCap.getValue()).assertLogged(sameInstance(record));
+                return null;
+            }
+            
+        });
+        replay(log, desc, base);
+        LoggerRule rule = new LoggerRule(log, Level.FINE);
+        Statement s = rule.apply(base, desc);
+        
+        try {
+            s.evaluate();
+        } finally {
+            verify(log, desc, base);
+        }
+    }
+    
+    @Test
+    public void testAdapter() throws Throwable {
+        final Logger log = createMock("log",LoggerAdapter.class);
+        Description desc = createMock("desc",Description.class);
+        Statement base = createMock("base", Statement.class);
+        
+        expect(log.getLevel()).andReturn(Level.OFF);
+        log.setLevel(Level.FINE); expectLastCall().once();
+        final Capture<Handler> handlerCap = new Capture<>();
+        
+        final LogRecord record = createMock("record1", LogRecord.class);
+        
+        log.addHandler(capture(handlerCap)); expectLastCall().once();
+        base.evaluate();expectLastCall().andAnswer(new IAnswer<Void>(){
+            
+            @Override
+            public Void answer() throws Throwable {
+                verify(log);
+                reset(log);
+                
+                log.removeHandler(handlerCap.getValue()); expectLastCall().once();
+                log.setLevel(Level.OFF); expectLastCall().once();
+                replay(log);
+                
+                handlerCap.getValue().publish(record);
+                ((LoggerRule)handlerCap.getValue()).assertLogged(sameInstance(record));
+                return null;
+            }
+            
+        });
+        replay(log, desc, base);
+        LoggerRule rule = new LoggerRule(log, Level.FINE);
+        Statement s = rule.apply(base, desc);
+        
+        try {
+            s.evaluate();
+        } catch (AssumptionViolatedException ex) {
+            if(!ex.getMessage().equals("LoggerRule can't capture logs for LoggerAdapter")) {
+                throw ex;
+            }
+            // Eventually hopefully we can handle this case and we can fail if this particular 
+            // assumption failure occurs.  For now it's a pass rather than an ignore.
+        } finally {
+            verify(log, desc, base);
+        }
+    }
+}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -102,6 +102,12 @@
    </dependency>
    <dependency>
     <groupId>org.geoserver</groupId>
+    <artifactId>gs-platform</artifactId>
+    <version>${gs.version}</version>
+    <classifier>tests</classifier>
+   </dependency>
+   <dependency>
+    <groupId>org.geoserver</groupId>
     <artifactId>gs-ows</artifactId>
     <version>${gs.version}</version>
    </dependency>


### PR DESCRIPTION
Resolve conflicts between CacheProviders by picking one and then logging a warning.  The user can specify priority with a system property.

This was tricky to test so i made some changes to unit testing support.

I also added automatic conflict resolution for hz-cluster without the need for user action.

See: https://osgeo-org.atlassian.net/browse/GEOS-6994