### PR TITLE
[GEOS-7003] Fixed the layer preview search not searching layer titles and keywords and layer group titles and abstracts in 2.7.0.

### DIFF
--- a/src/main/src/main/resources/org/geoserver/catalog/impl/CatalogPropertyAccessor_FullTextProperties.properties
+++ b/src/main/src/main/resources/org/geoserver/catalog/impl/CatalogPropertyAccessor_FullTextProperties.properties
@@ -13,20 +13,21 @@
  org.geoserver.catalog.StoreInfo=description,name,type
  
  org.geoserver.catalog.FeatureTypeInfo=abstract,description,name,nativeName,prefixedName,projectionPolicy,SRS,\
-  title,namespace.name,namespace.prefix,store.name
+  title,namespace.name,namespace.prefix,store.name,keywords.value
  
  org.geoserver.catalog.CoverageInfo= abstract,defaultInterpolationMethod,description,name,nativeFormat,nativeName, \
-  prefixedName,projectionPolicy,SRS,title,store.name,namespace.prefix,namespace.name
+  prefixedName,projectionPolicy,SRS,title,store.name,namespace.prefix,namespace.name,keywords.value
  
  org.geoserver.catalog.WMSLayerInfo= abstract,description,name,nativeName,prefixedName,projectionPolicy,SRS, \
-  title,namespace.prefix,store.name,namespace.name
+  title,namespace.prefix,store.name,namespace.name,keywords.value
  
- org.geoserver.catalog.ResourceInfo=abstract,description,name,nativeName,prefixedName,projectionPolicy,SRS,title
+ org.geoserver.catalog.ResourceInfo=abstract,description,name,nativeName,prefixedName,projectionPolicy,SRS, \
+  title,keywords.value
  
  org.geoserver.catalog.LayerInfo=name,path,type,resource.store.name,resource.SRS,resource.store.workspace.name, \
-  resource.abstract,resource.description
+  resource.abstract,resource.description,resource.title,resource.keywords.value
  
- org.geoserver.catalog.LayerGroupInfo=name,workspace.name
+ org.geoserver.catalog.LayerGroupInfo=name,workspace.name,title,abstract
  
  org.geoserver.catalog.MapInfo=name
  

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -2714,6 +2714,67 @@ public class CatalogImplTest {
         catalog.add(lg);
         filter = Predicates.fullTextSearch("Group");
         assertEquals(newHashSet(lg), asSet(catalog.list(LayerGroupInfo.class, filter)));
+
+        // test layer group title and abstract search
+        lg.setTitle("LayerGroup title");
+        filter = Predicates.fullTextSearch("title");
+        assertEquals(newHashSet(lg), asSet(catalog.list(LayerGroupInfo.class, filter)));
+
+        lg.setAbstract("GeoServer OpenSource GIS");
+        filter = Predicates.fullTextSearch("geoserver");
+        assertEquals(newHashSet(lg), asSet(catalog.list(LayerGroupInfo.class, filter)));
+
+        // test layer title search
+        ft.setTitle("Global .5 deg Air Temperature [C]");
+        cv.setTitle("Global .5 deg Dewpoint Depression [C]");
+
+        filter = Predicates.fullTextSearch("Global");
+        assertEquals(newHashSet(l, l2), asSet(catalog.list(LayerInfo.class, filter)));
+
+        filter = Predicates.fullTextSearch("Temperature");
+        assertEquals(newHashSet(l), asSet(catalog.list(LayerInfo.class, filter)));
+
+        filter = Predicates.fullTextSearch("Depression");
+        assertEquals(newHashSet(l2), asSet(catalog.list(LayerInfo.class, filter)));
+    }
+
+    @Test
+    public void testFullTextSearchKeywords() {
+        l.setResource(ft);
+        addLayer();
+        catalog.add(cs);
+        catalog.add(cv);
+        LayerInfo l2 = newLayer(cv, s);
+        catalog.add(l2);
+
+        ft.getKeywords().add(new Keyword("air_temp"));
+        ft.getKeywords().add(new Keyword("temperatureAir"));
+        cv.getKeywords().add(new Keyword("dwpt_dprs"));
+        cv.getKeywords().add(new Keyword("temperatureDewpointDepression"));
+
+        Filter filter = Predicates.fullTextSearch("temperature");
+        assertEquals(newHashSet(l, l2), asSet(catalog.list(LayerInfo.class, filter)));
+        assertEquals(newHashSet(ft, cv), asSet(catalog.list(ResourceInfo.class, filter)));
+        assertEquals(newHashSet(ft), asSet(catalog.list(FeatureTypeInfo.class, filter)));
+        assertEquals(newHashSet(cv), asSet(catalog.list(CoverageInfo.class, filter)));
+
+        filter = Predicates.fullTextSearch("air");
+        assertEquals(newHashSet(l), asSet(catalog.list(LayerInfo.class, filter)));
+        assertEquals(newHashSet(ft), asSet(catalog.list(ResourceInfo.class, filter)));
+        assertEquals(newHashSet(ft), asSet(catalog.list(FeatureTypeInfo.class, filter)));
+        assertEquals(newHashSet(), asSet(catalog.list(CoverageInfo.class, filter)));
+
+        filter = Predicates.fullTextSearch("dewpoint");
+        assertEquals(newHashSet(l2), asSet(catalog.list(LayerInfo.class, filter)));
+        assertEquals(newHashSet(cv), asSet(catalog.list(ResourceInfo.class, filter)));
+        assertEquals(newHashSet(), asSet(catalog.list(FeatureTypeInfo.class, filter)));
+        assertEquals(newHashSet(cv), asSet(catalog.list(CoverageInfo.class, filter)));
+
+        filter = Predicates.fullTextSearch("pressure");
+        assertEquals(newHashSet(), asSet(catalog.list(LayerInfo.class, filter)));
+        assertEquals(newHashSet(), asSet(catalog.list(ResourceInfo.class, filter)));
+        assertEquals(newHashSet(), asSet(catalog.list(FeatureTypeInfo.class, filter)));
+        assertEquals(newHashSet(), asSet(catalog.list(CoverageInfo.class, filter)));
     }
 
     private <T> Set<T> asSet(CloseableIterator<T> list) {


### PR DESCRIPTION
[GEOS-7003] Fixed the layer preview search not searching layer titles and keywords and layer group titles and abstracts in 2.7.0.