### PR TITLE
2.7.x

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/format/GeoJSONFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/format/GeoJSONFormat.java
@@ -51,6 +51,7 @@ import com.google.common.collect.Iterables;
 public class GeoJSONFormat extends VectorFormat {
 
     static Logger LOG = Logging.getLogger(GeoJSONFormat.class);
+    private static ReferencedEnvelope EMPTY_BOUNDS = new ReferencedEnvelope();
 
     @Override
     public FeatureReader read(ImportData data, ImportTask item) throws IOException {
@@ -197,16 +198,9 @@ public class GeoJSONFormat extends VectorFormat {
         }
 
         // bounds
-        ReferencedEnvelope bounds = new ReferencedEnvelope(crs);
-
-        FeatureJSON reader = new FeatureJSON();
-        reader.setFeatureType(featureType);
-        FeatureIterator<SimpleFeature> it = reader.streamFeatureCollection(file);
-        while(it.hasNext()) {
-            SimpleFeature f = it.next();
-            bounds.include(f.getBounds());
-        }
-        ft.setNativeBoundingBox(bounds);
+        ft.setNativeBoundingBox(EMPTY_BOUNDS);
+        ft.setLatLonBoundingBox(EMPTY_BOUNDS);
+        ft.getMetadata().put("recalculate-bounds", Boolean.TRUE);
 
         LayerInfo layer = catalogBuilder.buildLayer((ResourceInfo) ft);
 

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportResourceTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportResourceTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.importer.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -46,6 +47,9 @@ public class ImportResourceTest extends ImporterTestSupport {
         
         dir = unpack("shape/archsites_no_crs.zip");
         importer.createContext(new SpatialFile(new File(dir, "archsites.shp")));
+
+        dir = unpack("geojson/point.json.zip");
+        importer.createContext(new SpatialFile(new File(dir, "point.json")));
     }
     
     @After
@@ -60,7 +64,7 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertNotNull(json.get("imports"));
 
         JSONArray imports = (JSONArray) json.get("imports");
-        assertEquals(3, imports.size());
+        assertEquals(4, imports.size());
 
         JSONObject imprt = imports.getJSONObject(0);
         assertEquals(0, imprt.getInt("id"));
@@ -165,6 +169,31 @@ public class ImportResourceTest extends ImporterTestSupport {
         assertEquals("file", source.getString("type"));
         assertEquals("Shapefile", source.getString("format"));
         assertEquals("archsites.shp", source.getString("file"));
+    }
+
+    @Test
+    public void testGetImportGeoJSON() throws Exception {
+        JSONObject json = (JSONObject) getAsJSON("/rest/imports/3?expand=3");
+        assertNotNull(json);
+
+        JSONObject imprt = json.optJSONObject("import");
+        assertEquals(3, imprt.getInt("id"));
+
+        JSONArray tasks = imprt.getJSONArray("tasks");
+        assertEquals(1, tasks.size());
+
+        JSONObject task = tasks.getJSONObject(0);
+
+        JSONObject source = task.getJSONObject("data");
+        assertEquals("file", source.getString("type"));
+        assertEquals("GeoJSON", source.getString("format"));
+        assertEquals("point.json", source.getString("file"));
+
+        JSONObject layer = task.getJSONObject("layer");
+        JSONArray attributes = layer.getJSONArray("attributes");
+        assertNotEquals(0, attributes.size());
+
+        assertTrue(layer.containsKey("bbox"));
     }
 
     @Test


### PR DESCRIPTION
using the rest api to import geojson was failing because the LayerInfo object return by the importer was not properly populated. The importer was working through geoserver but attempting to import from geonode exposed the issues. for example, the following expand=3 would cause geoserver to throw an exception as listed in [GEOS-7012]. 
http://localhost:8080/geoserver/rest/imports/1/tasks/0?expand=3

Second commit computes the bounds properly as well. These changes are safe for 2.6/2.7/master as well since GeoJSONFormat has not changed. Will generate a pull request for each branch. 