### PR TITLE
Regularize WebAdmin Data documentation

### DIFF
--- a/doc/en/user/source/webadmin/basics.rst
+++ b/doc/en/user/source/webadmin/basics.rst
@@ -38,3 +38,45 @@ When logged on, additional options will be presented.
    *Additional options when logged in*
 
 Geoserver Web Coverage Service (WCS), Web Feature Service (WFS), and Web Map Service (WMS) configuration specifications can be accessed from this welcome page as well. For further information, please see the section on :ref:`services`.
+
+.. _webadmin_lists:
+
+List Pages
+----------
+
+Some web admin pages show list views of configuration data type items available in the GeoServer instance.
+The page displays links to the items, and where applicable their parent items as well.
+To facilitate working with large sets of items, list views allow sorting and searching across all items in the data type.
+
+In the example below, the :ref:`webadmin_layers` page displays a list of layers along with links to their parent :ref:`webadmin_stores` and :ref:`webadmin_workspaces`. 
+
+.. figure:: images/data_layers.png
+   :align: center
+
+   *Layers list page*
+
+Sorting
+^^^^^^^
+
+To sort a column alphabetically, click the column header. 
+
+.. figure:: images/data_sort.png
+   :align: center
+
+   *Unsorted (left) and sorted (right) columns*
+
+Searching
+^^^^^^^^^
+
+Searching can be used to filter the number of items displayed.  This is useful for working with data types that contain a large number of items.
+
+To search data type items, enter the search string in the search box and click Enter. GeoServer will search the data type for items that match your query, and display a list view showing the search results.
+
+
+.. figure:: images/data_search_results.png
+   :align: center
+   
+   *Search results for the query "top" on the Workspace page*
+
+
+

--- a/doc/en/user/source/webadmin/data/index.rst
+++ b/doc/en/user/source/webadmin/data/index.rst
@@ -17,8 +17,8 @@ Each subsection describes a data type page which provides add, view, edit, and d
    layergroups
    styles
    
-Using Data type List views
---------------------------
+**Using Data type List views**
+
 
 The main page for each data type is a list view showing the items of that data type configured in the GeoServer instance.
 The page displays links to the data type items, and where applicable their parent data types.
@@ -31,8 +31,7 @@ In the example below, the :guilabel:`Layers` list page displays a table of layer
 
    *Layers list page*
 
-Sorting
-^^^^^^^
+**Sorting**
 
 To sort a data type alphabetically, click the column header. 
 
@@ -41,8 +40,7 @@ To sort a data type alphabetically, click the column header.
 
    *Unsorted (left) and sorted (right) columns*
 
-Searching
-^^^^^^^^^
+**Searching**
 
 To search data type items, enter the search string in the search box and click Enter. GeoServer will search the data type for items that match your query, and display a list view showing the search results.
 Searching is useful for working with data types that contain a large number of items.

--- a/doc/en/user/source/webadmin/data/index.rst
+++ b/doc/en/user/source/webadmin/data/index.rst
@@ -3,10 +3,12 @@
 Data
 ====
 
-
 This section is the largest and perhaps the most important section of the Web Administration Interface. 
 It describes the core configuration data types that GeoServer uses to access and publish geospatial information.
-Each subsection describes a data type page which provides add, view, edit, and delete capabilities.
+Each subsection describes the data type pages which provide add, view, edit, and delete capabilities.
+
+The main page for each data type is a list view showing the items of that data type configured in the GeoServer instance.
+For information on how to use these pages see :ref:`webadmin_lists`.
 
 .. toctree::
    :maxdepth: 2
@@ -17,38 +19,9 @@ Each subsection describes a data type page which provides add, view, edit, and d
    layergroups
    styles
    
-**Using Data type List views**
 
 
-The main page for each data type is a list view showing the items of that data type configured in the GeoServer instance.
-The page displays links to the data type items, and where applicable their parent data types.
-To facilitate working with large sets of items, the list allows sorting and searching across all items in the data type.
 
-In the example below, the :guilabel:`Layers` list page displays a table of layers and their parent Store and Workspace. 
-
-.. figure:: ../images/data_layers.png
-   :align: center
-
-   *Layers list page*
-
-**Sorting**
-
-To sort a data type alphabetically, click the column header. 
-
-.. figure:: ../images/data_sort.png
-   :align: center
-
-   *Unsorted (left) and sorted (right) columns*
-
-**Searching**
-
-To search data type items, enter the search string in the search box and click Enter. GeoServer will search the data type for items that match your query, and display a list view showing the search results.
-Searching is useful for working with data types that contain a large number of items.
-
-.. figure:: ../images/data_search_results.png
-   :align: center
-   
-   *Search results for the query "top" on the Workspace page*
 
 
 

--- a/doc/en/user/source/webadmin/data/index.rst
+++ b/doc/en/user/source/webadmin/data/index.rst
@@ -4,31 +4,9 @@ Data
 ====
 
 
-This section is the largest and perhaps the most important section of the Web Administration Interface. Each subsection links directly to a data type page with add, edit, and delete capabilities.
-
-In the example below, the data view page displays a table of indexed data. 
-
-.. figure:: ../images/data_layers.png
-   :align: center
-
-   *Layers page*
-   
-To sort a data type alphabetically, click the column header. 
-
-.. figure:: ../images/data_sort.png
-   :align: center
-
-   *Unsorted (left) and sorted (right) columns*
-
-For simple searching of data type contents, enter the search criteria in the search box and click Enter. GeoServer will search the data types that are relevant to your query, and return a Search Results page.
-
-.. figure:: ../images/data_search_results.png
-   :align: center
-   
-   *Search results for the query "top"*
-
-Specific details for adding, editing and deleting various data types are discussed in the following sections. 
-
+This section is the largest and perhaps the most important section of the Web Administration Interface. 
+It describes the core configuration data types that GeoServer uses to access and publish geospatial information.
+Each subsection describes a data type page which provides add, view, edit, and delete capabilities.
 
 .. toctree::
    :maxdepth: 2
@@ -38,3 +16,42 @@ Specific details for adding, editing and deleting various data types are discuss
    layers
    layergroups
    styles
+   
+Using Data type List views
+--------------------------
+
+The main page for each data type is a list view showing the items of that data type configured in the GeoServer instance.
+The page displays links to the data type items, and where applicable their parent data types.
+To facilitate working with large sets of items, the list allows sorting and searching across all items in the data type.
+
+In the example below, the :guilabel:`Layers` list page displays a table of layers and their parent Store and Workspace. 
+
+.. figure:: ../images/data_layers.png
+   :align: center
+
+   *Layers list page*
+
+Sorting
+^^^^^^^
+
+To sort a data type alphabetically, click the column header. 
+
+.. figure:: ../images/data_sort.png
+   :align: center
+
+   *Unsorted (left) and sorted (right) columns*
+
+Searching
+^^^^^^^^^
+
+To search data type items, enter the search string in the search box and click Enter. GeoServer will search the data type for items that match your query, and display a list view showing the search results.
+Searching is useful for working with data types that contain a large number of items.
+
+.. figure:: ../images/data_search_results.png
+   :align: center
+   
+   *Search results for the query "top" on the Workspace page*
+
+
+
+

--- a/doc/en/user/source/webadmin/data/layergroups.rst
+++ b/doc/en/user/source/webadmin/data/layergroups.rst
@@ -6,7 +6,7 @@ Layer Groups
 A layer group is a container in which layers and other layer groups can be organized in a hierarchical structure. A layer group can be referred to by a single name in WMS requests.  This allows simpler requests, as one layer can be specified instead of multiple individual layers.
 A layer group also provides a consistent, fixed ordering of the layers it contains, and can specify alternate (non-default) styles for layers.
 
-Layer Group Modes
+Layer Group modes
 -----------------
 
 Layer group behaviour can be configured by setting its :guilabel:`mode`. There are 4 available values:
@@ -24,9 +24,9 @@ If a layer is included in any non *single* mode group, it will no longer be list
    *Layer Groups page*
 
 Edit a Layer Group
-----------------
+------------------
 
-To bring up the layer group edit page, click a layer group name. The initial fields allow you to configure the name, title, abstract, workspace, bounds, projection and mode of the layer group. To automatically set the bounding box, select the :guilabel:`Generate Bounds` button. You may also provide your own custom bounding box extents. To select an appropriate projection click the :guilabel:`Find` button.
+To view or edit a layer group, click the layer group name.  A layer group configuration page will be displayed.  The initial fields allow you to configure the name, title, abstract, workspace, bounds, projection and mode of the layer group. To automatically set the bounding box, select the :guilabel:`Generate Bounds` button. You may also provide your own custom bounding box extents. To select an appropriate projection click the :guilabel:`Find` button.
 
 .. note:: A layer group can contain layers with dissimilar bounds and projections. GeoServer automatically reprojects all layers to the projection of the layer group.
 
@@ -98,7 +98,7 @@ When finished, click :guilabel:`Submit`. You will be redirected to an empty laye
 Remove a Layer Group
 --------------------
 
-To remove a layer group, click the check box next to the layer group. Multiple layer groups can be selected for batch removal. Click the :guilabel:`remove selected layer group(s)` link. You will be asked to confirm or cancel the deletion. Selecting :guilabel:`OK` successfully removes the layer group. 
+To remove a layer group, select it by clicking the checkbox next to the layer group. Multiple layer groups can be selected, or all can be selected by clicking the checkbox in the header.  Click the :guilabel:`Remove selected layer group(s)` link. You will be asked to confirm or cancel the deletion. Selecting :guilabel:`OK` removes the selected layer group(s). 
  
 .. figure:: ../images/data_layergroups_delete.png
    :align: center

--- a/doc/en/user/source/webadmin/data/layers.rst
+++ b/doc/en/user/source/webadmin/data/layers.rst
@@ -3,9 +3,9 @@
 Layers
 ======
 
-In GeoServer, the term "layer" refers to raster or vector data that contains a collection of geographic features. Vector layers are analogous to "featureTypes" and raster layers are analogous to "coverages". All layers have a source of data, known as a Store.
+In GeoServer, the term "layer" refers to a raster or vector dataset that represents a collection of geographic features. Vector layers are analogous to "featureTypes" and raster layers are analogous to "coverages". All layers have a source of data, known as a Store. The layer is associated with the Workspace in which the Store is defined.
 
-In the Layers section of the web interface, you can view and edit existing layer, add (register) a new layer, or delete (unregister) a layer. The Layers View page displays the not only the list of layers, but the Store and Workspace where those layers are contained. The View page also displays the layer's status and native SRS.
+In the Layers section of the web interface, you can view and edit existing layers, add (register) a new layer, or remove (unregister) a layer. The Layers View page displays the list of layers, and the Store and Workspace in which each layer is contained. The View page also displays the layer's status and native SRS.
 
 .. figure:: ../images/data_layers.png
 
@@ -28,17 +28,14 @@ Layers can be divided into two types of data: raster and vector. These two forma
      - vector (feature)  
 
 
-Add or delete a layer
----------------------
+Add a Layer
+-----------
 
-At the upper left-hand corner of the layers view page there are two buttons for the adding and deletion of layers. The green plus button allows you to add a new layer, referred to as resource. The red minus button allows you to remove selected layers. 
+At the upper left-hand corner of the layers view page there are two buttons for the adding and removal of layers. The green plus button allows you to add a new layer (referred to as *resource*). The red minus button allows you to remove selected layers. 
 
 .. figure:: ../images/data_layers_add_remove.png
    
-   *Buttons to Add or Remove a Layer*
-
-Add a Layer
-^^^^^^^^^^^
+   *Buttons to Add and Remove a Layer*
 
 Clicking the :guilabel:`Add a new resource` button brings up a :guilabel:`New Layer Chooser` panel. The menu displays all currently enabled stores. From this menu, select the Store where the layer should be added. 
 
@@ -60,29 +57,29 @@ To add a new layer for a published resource click :guilabel:`Publish Again`.
 (Note that when re-publishing the name of the new layer may have to be modified to avoid conflict with an existing layer.)
 The actions display an :ref:`Edit Layer<webadmin_layers_edit_data>` page to enter the definition of the new layer.
 
-Delete a Layer
-^^^^^^^^^^^^^^
+Remove a Layer
+--------------
 
-To delete a layer, click the check box on the left side of each layer row. As shown below, multiple layers can be selected for removal on a single results page. It should be noted, however, that selections for removal will not persist from one results pages to the next. 
+To remove a layer, select it by clicking the checkbox next to the layer. As shown below, multiple layers can be selected for batch removal. Note that selections for removal will not persist from one results pages to the next. 
   
 .. figure:: ../images/data_layers_delete.png
    
-   *Some layers selected for deletion*
+   *Some layers selected for removal*
 
-All layers can be selected for removal by selecting the check box in the header row. 
+All layers can be selected for removal by clicking the checkbox in the header. 
 
 .. figure:: ../images/data_layers_delete_all.png
    
-   *All layers selected for deletion*
+   *All layers selected for removal*
 
-Once layer(s) are selected, the :guilabel:`Remove selected resources` link is activated. Once you've clicked the link, you will be asked to confirm or cancel the deletion. Selecting :guilabel:`OK` successfully deletes the layer. 
+Once layer(s) are selected, the :guilabel:`Remove selected resources` link is activated. Once you've clicked the link, you will be asked to confirm or cancel the removal. Selecting :guilabel:`OK` removes the selected layer(s). 
      
 .. _webadmin_layers_edit_data:
 
 Edit Layer: Data 
 ----------------
 
-Clicking the layer name opens a layer configuration panel. The :guilabel:`Data` tab, activated by default, allows you to define and change data parameters for a layer. 
+To view or edit a layer, click the layer name.  A layer configuration page will be displayed. The :guilabel:`Data` tab, activated by default, allows you to define and change data parameters for a layer. 
 
 .. figure:: ../images/data_layers_edit_data.png
    

--- a/doc/en/user/source/webadmin/data/stores.rst
+++ b/doc/en/user/source/webadmin/data/stores.rst
@@ -3,13 +3,15 @@
 Stores
 ======
 
-A store connects to a data source that contains raster or vector data. A data source can be a file or group of files, a table in a database, a single raster file, or a directory (for example, a Vector Product Format library). Using the store construct means that connection parameters are defined once, rather than for each dataset in a source. As such, it is necessary to register a store before configuring datasets within it.
+A store connects to a data source that contains raster or vector data. A data source can be a file or group of files, a table in a database, a single raster file, or a directory (for example, a Vector Product Format library). The store construct allows connection parameters to be defined once, rather than for each dataset in a source. As such, it is necessary to register a store before configuring datasets within it.
 
 .. figure:: ../images/data_stores.png
    :align: center
    
    *Stores View*
 
+Store types
+-----------
 While there are many potential formats for data sources, there are only four kinds of stores. For raster data, a store can be a file. For vector data, a store can be a file, database, or server. 
 
 .. list-table::
@@ -27,10 +29,10 @@ While there are many potential formats for data sources, there are only four kin
      - vector server (web feature server)
      
 
-Editing a Store
----------------
+Edit a Store
+------------
 
-To view and edit a store, click a store name. The exact contents of this page depend on the specific format of the store. See the sections :ref:`data_vector`, :ref:`data_raster`, and :ref:`data_database` for information about specific data formats. The example shows the configuration for the ``nurc:ArcGridSample`` store.
+To view or edit a store, click the store name. A store configuration page will be displayed.  The exact contents of this page depend on the specific format of the store. See the sections :ref:`data_vector`, :ref:`data_raster`, and :ref:`data_database` for information about specific data formats. The example shows the configuration for the ``nurc:ArcGridSample`` store.
 
 .. figure:: ../images/data_stores_edit.png
    :align: center
@@ -50,15 +52,15 @@ Connection Parameters
 ^^^^^^^^^^^^^^^^^^^^^
 The connection parameters vary depending on data format.
 
-Adding a Store
---------------
+Add a Store
+-----------
 
 The buttons for adding and removing a store can be found at the top of the Stores page. 
 
 .. figure:: ../images/data_stores_add_remove.png
    :align: center
    
-   *Buttons to add and remove stores*
+   *Buttons to add and remove a Store*
 
 To add a store, select the :guilabel:`Add new Store` button. You will be prompted to choose a data source. GeoServer natively supports many formats (with more available via extensions). Click the appropriate data source to continue. 
 
@@ -75,17 +77,17 @@ The example below shows the ArcGrid raster configuration page.
    
    *Configuration page for an ArcGrid raster data source*
 
-Removing a Store
-----------------
+Remove a Store
+--------------
    
-To remove a store, click the store's corresponding check box. Multiple stores can be selected for batch removal.
+To remove a store, click the checkbox next to the store. Multiple stores can be selected, or all can be selected by clicking the checkbox in the header.  
 
 .. figure:: ../images/data_stores_delete.png
    :align: center
    
    *Stores selected for removal*
 
-Click the :guilabel:`Remove selected Stores` button. You will be asked to confirm the deletion of the configuration for the store(s) and all resources defined under them. Selecting :guilabel:`OK` removes the store(s), and returns to the Stores page.
+Click the :guilabel:`Remove selected Stores` button. You will be asked to confirm the removal of the configuration for the store(s) and all resources defined under them. Clicking :guilabel:`OK` removes the selected store(s), and returns to the Stores page.
 
 .. figure:: ../images/data_stores_delete_confirm.png
    :align: center   

--- a/doc/en/user/source/webadmin/data/styles.rst
+++ b/doc/en/user/source/webadmin/data/styles.rst
@@ -5,17 +5,17 @@ Styles
 
 Styles render, or make available, geospatial data. Styles for GeoServer are written in Styled Layer Descriptor (SLD), a subset of XML. Please see the section on :ref:`styling` for more information on working with styles. 
 
-On the Styles page, you can register or create a new style, edit an existing style, or delete remove a style.
+On the Styles page, you can add a new style, view or edit an existing style, or remove a style.
 
 .. figure:: ../images/data_style.png
    :align: center
    
    *Styles page*
 
-Edit Styles
------------
+Edit a Style
+------------
 
-The :guilabel:`Style Editor` page presents options for configuring a style's name and code. SLD names are specified at the top in the name field. Typing or pasting of SLD code can be done in one of two modes. The first mode is an embedded `EditArea <http://www.cdolivet.com/index.php?page=editArea>`_ a rich editor. The second mode is an unformatted text editor. Check the :guilabel:`Toggle Editor` to switch between modes.
+To view or edit a style, click the style name. A :guilabel:`Style Editor` page will be diplayed.  The page presents options for configuring a style's name and code. Style names are specified at the top in the name field. Typing or pasting of SLD code can be done in one of two modes. The first mode is an embedded `EditArea <http://www.cdolivet.com/index.php?page=editArea>`_ a rich editor. The second mode is an unformatted text editor. Check the :guilabel:`Toggle Editor` to switch between modes.
 
 .. figure:: ../images/data_style_editor.png
    :align: center
@@ -77,7 +77,7 @@ The buttons for adding and removing a style can be found at the top of the :guil
 
    *Adding or removing a style*
    
-To add a new layer group, select the :guilabel:`Add a new style` button. You will be redirected to an editor page. Enter a name for the style. The editor page provides two options for submitting an SLD. You can paste the SLD directly into the editor, or you can select and upload a local file that contains the SLD.
+To add a new style, select the :guilabel:`Add a new style` button. You will be redirected to an editor page. Enter a name for the style. The editor page provides two options for submitting an SLD. You can paste the SLD directly into the editor, or you can select and upload a local file that contains the SLD.
 
 .. figure:: ../images/data_style_upload.png
    :align: center
@@ -89,7 +89,7 @@ Once a style is successfully submitted, you will be redirected to the main :guil
 Remove a Style
 --------------
 
-To remove a style, select the check box next to the style. Multiple layer groups can be selected for batch removal. Click the :guilabel:`Remove selected style(s)` link at the top of the page. You will be asked to confirm or cancel the deletion. Clicking :guilabel:`OK` removes the layer group. 
+To remove a style, select it by clicking the checkbox next to the style. Multiple styles can be selected, or all can be selected by clicking the checkbox in the header. Click the :guilabel:`Remove selected style(s)` link at the top of the page. You will be asked to confirm or cancel the removal. Clicking :guilabel:`OK` removes the selected style(s). 
  
 .. figure:: ../images/data_style_delete.png
    :align: center

--- a/doc/en/user/source/webadmin/data/workspaces.rst
+++ b/doc/en/user/source/webadmin/data/workspaces.rst
@@ -3,38 +3,41 @@
 Workspaces
 ==========
 
-This section describes how to view and configure workspaces. Analogous to a namespace, a workspace is a container which organizes other items. In GeoServer, a workspace is often used to group similar layers together. Individual layers are often referred to by their workspace name, colon, then store. For example, Ex: topp:states. Two different layers with the same name can exist as long as they exist in different workspaces. For example, Ex: sf:states, topp:states.
+This section describes how to view and configure workspaces. Analogous to a namespace, a workspace is a container which organizes other items. In GeoServer, a workspace is often used to group similar layers together. Layers may be referred to by their workspace name, colon, layer name (for example ``topp:states``). Two different layers can have the same name as long as they belong to different workspaces (for example ``sf:states`` and ``topp:states``).
 
 .. figure:: ../images/data_workspaces.png
    :align: center
    
    *Workspaces page*
 
-Edit Workspace
---------------
+Edit a Workspace
+----------------
 
-To view details and edit a workspace, click a workspace name.
+To view or edit a workspace, click the workspace name. A workspace configuration page will be displayed.
 
 .. figure:: ../images/data_workspaces_URI.png
    :align: center
    
    *Workspace named "topp"*
    
-A workspace consists of a name and a Namespace URI (Uniform Resource Identifier). The workspace name is limited of ten characters and may not contain space. A URI is similar to a URL, except URIs don't need to point to a location on the web, and only need to be a unique identifier. For a Workspace URI, we recommend using a URL associated with your project, with perhaps a different trailing identifier, such as ``http://www.openplans.org/topp`` for the "topp" workspace. 
-   
+A workspace is defined by a name and a Namespace URI (Uniform Resource Identifier). The workspace name is limited to ten characters and may not contain space. A URI is similar to a URL, except URIs do not need to point to a actual location on the web, and only need to be a unique identifier. For a Workspace URI, we recommend using a URL associated with your project, with perhaps a different trailing identifier. For example, ``http://www.openplans.org/topp`` is the URI for the "topp" workspace. 
+
+Root Directory for REST PathMapper 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 .. figure:: ../images/data_workspaces_ROOT.png
    :align: center
    
    *Workspace Root Directory parameter*
    
-This parameter is used by the RESTful API as the `Root Directory` for the newly uploaded files, following the structure::
+This parameter is used by the RESTful API as the `Root Directory` for uploaded files, following the structure::
 
 	${rootDirectory}/workspace/store[/<file>]
-	
+
 .. note:: This parameter is visible only when the **Enabled** parameter of the *Settings* section is checked. 
    
-Add or Remove a Workspace
--------------------------
+Add a Workspace
+---------------
 
 The buttons for adding and removing a workspace can be found at the top of the Workspaces view page. 
 
@@ -49,8 +52,11 @@ To add a workspace, select the :guilabel:`Add new workspace` button. You will be
    :align: center
    
    *New Workspace page with example*
- 
-To remove a workspace, click the workspace's corresponding check box. As with the layer deletion process, multiple workspaces can be checked for removal on a single results page. Click the :guilabel:`Remove selected workspaces(s)` button. You will be asked to confirm or cancel the deletion. Clicking :guilabel:`OK` will remove the workspace. 
+
+Remove a Workspace
+------------------
+
+To remove a workspace, select it by clicking the checkbox next to the workspace. Multiple workspaces can be selected, or all can be selected by clicking the checkbox in the header.  Click the :guilabel:`Remove selected workspaces(s)` button. You will be asked to confirm or cancel the removal. Clicking :guilabel:`OK` removes the selected workspace(s). 
 
 .. figure:: ../images/data_workspaces_rename_confirm.png
    :align: center

--- a/doc/en/user/source/webadmin/layerpreview/index.rst
+++ b/doc/en/user/source/webadmin/layerpreview/index.rst
@@ -8,7 +8,7 @@ This page provides layer views in various output formats. A layer must be enable
 .. figure:: ../images/preview_list.png
    :align: center
    
-   *Layer's Preview Page*
+   *Layer Preview Page*
    
 Each layer row consists of a type, name, title, and available formats for viewing.
 


### PR DESCRIPTION
This patch makes the structure of the WebAdmin Data data type pages all follow the same pattern.  It also makes section wording consistent, and clearer in some cases.  A few section headings have been added, to make structure clearer and allowing easier linking.