### PR TITLE
Add documentation for non standard auto CRS namespace in WMS

### DIFF
--- a/doc/en/user/source/services/wms/index.rst
+++ b/doc/en/user/source/services/wms/index.rst
@@ -11,6 +11,7 @@ Web Map Service
    time
    outputformats
    vendor
+   nonstandardautonamespace
    configuration
    global
    get_legend_graphic/legendgraphic

--- a/doc/en/user/source/services/wms/nonstandardautonamespace.rst
+++ b/doc/en/user/source/services/wms/nonstandardautonamespace.rst
@@ -1,0 +1,50 @@
+.. _non_standard_auto_namespace:
+
+Non Standard AUTO Namespace
+===========================
+
+The WMS standard supports a small number of "automatic" coordinate reference systems that include a user-selected centre of projection.  These are specified using::
+
+    AUTO:auto_crs_id,factor,lon0,lat0
+
+for example::
+
+    CRS=AUTO:42003,1,-100,45
+
+.. note::   in GeoTools 13 AUTO and AUTO2 namespaces are treated identically.
+.. note::   in GeoTools 13 the factor parameter in the AUTO namespace is ignored.  The BBOX parameter to GetMap must therefore be specified in metres.
+    
+The WMS standard provide projections with IDs in the range 42001 to 42005.
+
+.. list-table::
+    :widths: 20 80
+    
+    * - ID
+      - Projection
+    * - 42001   
+      - Universal Transverse Mercator
+    * - 42002   
+      - Transverse Mercator
+    * - 42003   
+      - Orthographic
+    * - 42004   
+      - Equirectangular
+    * - 42005
+      - Mollweide   (not supported in GeoTools 13)
+
+GeoServer also supports some non-standard coordinate reference systems.
+These are
+
+.. list-table::
+    :widths: 20 80
+    
+    * - ID
+      - Projection
+    * - 97001 
+      - Gnomonic 
+    * - 97002
+      - Stereographic
+
+.. note::   the auto stereographic  projection uses a sphere.  It does this by setting the semi minor axis to the same value as the semi major axis.
+
+

--- a/doc/en/user/source/services/wms/nonstandardautonamespace.rst
+++ b/doc/en/user/source/services/wms/nonstandardautonamespace.rst
@@ -2,7 +2,6 @@
 
 Non Standard AUTO Namespace
 ===========================
-
 The WMS standard supports a small number of "automatic" coordinate reference systems that include a user-selected centre of projection.  These are specified using::
 
     AUTO:auto_crs_id,factor,lon0,lat0
@@ -11,8 +10,8 @@ for example::
 
     CRS=AUTO:42003,1,-100,45
 
-.. note::   in GeoTools 13 AUTO and AUTO2 namespaces are treated identically.
-.. note::   in GeoTools 13 the factor parameter in the AUTO namespace is ignored.  The BBOX parameter to GetMap must therefore be specified in metres.
+.. note::   in GeoServer 2.8.x AUTO and AUTO2 namespaces are treated identically.
+.. note::   in GeoServer 2.8.x the factor parameter in the AUTO namespace is ignored.  The BBOX parameter to GetMap must therefore be specified in metres.
     
 The WMS standard provide projections with IDs in the range 42001 to 42005.
 
@@ -30,7 +29,7 @@ The WMS standard provide projections with IDs in the range 42001 to 42005.
     * - 42004   
       - Equirectangular
     * - 42005
-      - Mollweide   (not supported in GeoTools 13)
+      - Mollweide   (not supported in GeoServer 2.8.x)
 
 GeoServer also supports some non-standard coordinate reference systems.
 These are


### PR DESCRIPTION
I have added a couple of notes that refer to the version of GeoTools.  This might be confusing in GeoServer documentation but I felt they were needed.