### PR TITLE
[GEOS-7025] Stopped GeoServerDataDirectory.parsedStyle from creating files for nonexistant URLs

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -1234,7 +1234,9 @@ public class GeoServerDataDirectory implements ResourceStore {
             public URL locateResource(String uri) {
                 URL url = super.locateResource(uri);
                 if(url.getProtocol().equalsIgnoreCase("resource")) {
-                    return fileToUrlPreservingCqlTemplates(urlToResource(url).file());
+                    //GEOS-7025: Just get the path; don't try to create the file
+                    return fileToUrlPreservingCqlTemplates(
+                            Paths.toFile(root(), urlToResource(url).path()));
                 } else {
                     return url;
                 }

--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest-applicationContext.xml
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest-applicationContext.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+  <bean id="geoserverExtensions" class="org.geoserver.platform.GeoServerExtensions" />
+  <bean id="sldHandler" class="org.geoserver.catalog.SLDHandler" />
+</beans>

--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
@@ -1,0 +1,84 @@
+package org.geoserver.config;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.impl.CatalogFactoryImpl;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.catalog.impl.StyleInfoImpl;
+import org.geotools.styling.ExternalGraphic;
+import org.geotools.styling.Graphic;
+import org.geotools.styling.PointSymbolizer;
+import org.geotools.styling.Style;
+import org.geotools.styling.Symbolizer;
+import org.geotools.util.Version;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opengis.style.GraphicalSymbol;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+
+public class GeoServerDataDirectoryTest {
+    
+    ClassPathXmlApplicationContext ctx;
+    
+    GeoServerDataDirectory dataDir;
+    CatalogFactory factory = new CatalogFactoryImpl(new CatalogImpl());
+    
+    
+    @Before
+    public void setUp() throws Exception {
+        
+        ctx = new ClassPathXmlApplicationContext(
+            "GeoServerDataDirectoryTest-applicationContext.xml", getClass());
+        ctx.refresh();
+        
+        dataDir = new GeoServerDataDirectory(Files.createTempDirectory("data").toFile());
+        dataDir.root().deleteOnExit();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        ctx.destroy();
+    }
+    
+    @Test
+    public void testParsedStyle() throws IOException {
+        File styleDir = new File(dataDir.root(), "styles");
+        styleDir.mkdir();
+        
+        //Copy the sld to the temp style dir
+        File styleFile = new File(styleDir, "external.sld");
+        Files.copy(this.getClass().getResourceAsStream("external.sld"), styleFile.toPath());
+        
+        File iconFile = new File(styleDir, "icon.png");
+        assertFalse(iconFile.exists());
+        
+        StyleInfoImpl si = new StyleInfoImpl(null);
+        si.setName("");
+        si.setId("");
+        si.setFormat("sld");
+        si.setFormatVersion(new Version("1.0.0"));
+        si.setFilename(styleFile.getName());
+        
+        Style s = dataDir.parsedStyle(si);
+        //Verify style is actually parsed correctly
+        Symbolizer symbolizer = s.featureTypeStyles().get(0).rules().get(0).symbolizers().get(0);
+        assertTrue(symbolizer instanceof PointSymbolizer);
+        GraphicalSymbol graphic = ((PointSymbolizer) symbolizer).getGraphic().graphicalSymbols().get(0);
+        assertTrue(graphic instanceof ExternalGraphic);
+        assertEquals(((ExternalGraphic) graphic).getLocation(), iconFile.toURI().toURL());
+        
+        //GEOS-7025: verify the icon file is not created if it doesn't already exist
+        assertFalse(iconFile.exists());
+    }
+}

--- a/src/main/src/test/java/org/geoserver/config/external.sld
+++ b/src/main/src/test/java/org/geoserver/config/external.sld
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>external</Name>
+    <UserStyle>
+      <Name>external</Name>
+      <Title>An external graphic</Title>
+      <Abstract>A sample point symbolizer with an external graphic</Abstract>
+
+      <FeatureTypeStyle>
+        <Rule>
+          <Title>Red flag</Title>
+          <PointSymbolizer>
+            <Graphic>
+              <ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="icon.png" />
+                <Format>image/png</Format>
+              </ExternalGraphic>
+              <Size>
+                <ogc:Literal>20</ogc:Literal>
+              </Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor> 


### PR DESCRIPTION
Resource.file() will create the file if it doesn't exist. Changed to use a method that does not create the file, only generates the correct path.