### PR TITLE
[GEOS-7038] Added support for prettyPrint to REST GET Style

### DIFF
--- a/doc/en/user/source/rest/api/styles.rst
+++ b/doc/en/user/source/rest/api/styles.rst
@@ -97,7 +97,7 @@ Controls a given style.
      - 200
      - SLD, HTML, XML, JSON
      - HTML
-     - :ref:`quietOnNotFound <rest_api_styles_quietOnNotFound>`
+     - :ref:`quietOnNotFound <rest_api_styles_quietOnNotFound>` :ref:`pretty <rest_api_styles_pretty>`
    * - POST
      - 
      - 405
@@ -148,6 +148,13 @@ The ``purge`` parameter specifies whether the underlying SLD file for the style 
 ^^^^^^^^^^^^^^^^^^^^
 
 The ``quietOnNotFound`` parameter avoids to log an Exception when the style is not present. Note that 404 status code will be returned anyway.
+
+.. _rest_api_styles_pretty:
+
+``pretty``
+^^^^^^^^^^
+
+The ``pretty`` parameter returns the style in a human-readable format, with proper whitespace and indentation. This parameter has no effect if you request a style in its native format - in this case the API returns the exact content of the underlying file. The HTML, XML, and JSON formats do not support this parameter.
 
 ``/workspaces/<ws>/styles[.<format>]``
 --------------------------------------

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/StyleResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/StyleResource.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -29,9 +29,11 @@ import org.geoserver.rest.format.DataFormat;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.styling.SLDParser;
 import org.geotools.styling.Style;
+import org.geotools.util.Converters;
 import org.geotools.util.Version;
 import org.restlet.Context;
 import org.restlet.data.MediaType;
+import org.restlet.data.Form;
 import org.restlet.data.Request;
 import org.restlet.data.Response;
 import org.restlet.data.Status;
@@ -49,14 +51,20 @@ public class StyleResource extends AbstractCatalogResource {
     @Override
     protected List<DataFormat> createSupportedFormats(Request request,Response response) {
         List<DataFormat> formats =  super.createSupportedFormats(request,response);
-
+        boolean prettyPrint = isPrettyPrint(request);
         for (StyleHandler sh : Styles.handlers()) {
             for (Version ver : sh.getVersions()) {
-                formats.add(new StyleFormat(sh.mimeType(ver), ver, false, sh, request));
+                formats.add(new StyleFormat(sh.mimeType(ver), ver, prettyPrint, sh, request));
             }
         }
 
         return formats;
+    }
+    
+    boolean isPrettyPrint(Request request) {
+        Form q = request.getResourceRef().getQueryAsForm();
+        String pretty = q.getFirstValue("pretty");
+        return pretty != null && Boolean.TRUE.equals(Converters.convert(pretty, Boolean.class));
     }
     
     @Override


### PR DESCRIPTION
No test case for this one since the parameter only really has any effect when using extended style formats such as CSS (eg convert a CSS style to SLD, or vise-versa). This change was tested upstream with a style extension and did work correctly.