### PR TITLE
GEOS-4858 Added meta tag with charset UTF-8 to ol3 template [2.7.x]

### DIFF
--- a/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
+++ b/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="${baseUrl}/openlayers3/ol.css" type="text/css">
     <style>
         .ol-zoom {


### PR DESCRIPTION
Added meta tag with charset UTF-8 to ol3 template to correctly instruct browsers how to interpret the layer preview document.