### PR TITLE
[GEOS-7037] Intermittent build failures in gs-web-sec-core under load

### DIFF
--- a/src/web/security/core/src/test/java/org/geoserver/security/web/data/DataSecurityPageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/data/DataSecurityPageTest.java
@@ -70,14 +70,17 @@ public class DataSecurityPageTest extends AbstractListPageTest<DataAccessRule> {
     
     @Override
     protected void simulateDeleteSubmit() throws Exception {
-        
+
+        DataAccessRuleDAO.get().reload();
         assertTrue (DataAccessRuleDAO.get().getRules().size()>0);
         
         SelectionDataRuleRemovalLink link = (SelectionDataRuleRemovalLink) getRemoveLink();
         Method m = link.delegate.getClass().getDeclaredMethod("onSubmit", AjaxRequestTarget.class,Component.class);
         m.invoke(link.delegate, null,null);
-        
-        assertEquals(0,DataAccessRuleDAO.get().getRules().size());        
+
+        DataAccessRuleDAO.get().reload();
+        // if there are no rules, DataAccessRuleDAO.loadRules adds two basic rules
+        assertEquals(2,DataAccessRuleDAO.get().getRules().size());        
     }
 
     @Test

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/data/EditDataAccessRulePageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/data/EditDataAccessRulePageTest.java
@@ -111,6 +111,7 @@ public class EditDataAccessRulePageTest extends AbstractSecurityWicketTestSuppor
     }
 
     DataAccessRule getRule(String key) {
+        DataAccessRuleDAO.get().reload();
         for (DataAccessRule rule : DataAccessRuleDAO.get().getRules()) {
             if (key.equals(rule.getKey())) {
                 return rule;

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/data/NewDataAccessRulePageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/data/NewDataAccessRulePageTest.java
@@ -158,7 +158,7 @@ public class NewDataAccessRulePageTest extends AbstractSecurityWicketTestSupport
         form.select("workspace", index);
         tester.executeAjaxEvent("form:workspace", "onchange");
         form = tester.newFormTester("form");
-        index = indexOf(page.layerChoice.getChoices(),MockData.STREAMS.getLocalPart());
+        index = indexOf(page.layerChoice.getChoices(),DataAccessRule.ANY);
         form.select("layer", index);
         
         index = page.accessModeChoice.getChoices().indexOf(AccessMode.ADMIN);
@@ -186,13 +186,14 @@ public class NewDataAccessRulePageTest extends AbstractSecurityWicketTestSupport
         
         DataAccessRuleDAO dao = DataAccessRuleDAO.get();
 
-        DataAccessRule rule = new DataAccessRule(MockData.CITE_PREFIX, MockData.STREAMS.getLocalPart(), AccessMode.ADMIN);
+        DataAccessRule rule = new DataAccessRule(MockData.CITE_PREFIX, DataAccessRule.ANY, AccessMode.ADMIN);
         assertFalse(dao.getRules().contains(rule));
        
         // now save
         form=tester.newFormTester("form");
         form.submit("save");
 
+        dao.reload();
         assertTrue(dao.getRules().contains(rule));
     }
 


### PR DESCRIPTION
@mcrmcr @aaime please see discussion:
https://osgeo-org.atlassian.net/browse/GEOS-7037

A race condition in PropertyFileWatcher caused by file second timestamp precision in Linux on Java 7 revealed two defects in tests: (1) an invalid layer admin rule used in a test, and (2) failure to add two basic rules to a test. This pull requests adds some forced reloads to ensure consistent behaviour between Linux  Java 7 and other platforms and fixes the two incorrect tests which only passed elsewhere because caching allowed them to circumvent property file loading and validation.