### PR TITLE
Only exit this method when none of the extended capabilities provider…

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -595,11 +595,15 @@ public class GetCapabilitiesTransformer extends TransformerBase {
              * need to output the VendorSpecificCapabilities element. Moreover, the document will
              * not validate if it's there but not declared in the internal DTD
              */
+            int numberRoots = 0;
             for (ExtendedCapabilitiesProvider cp : extCapsProviders) {
                 List<String> roots = cp.getVendorSpecificCapabilitiesRoots(request);
-                if (roots == null || roots.size() == 0) {
-                    return;
+                if (roots != null) {
+                  numberRoots += roots.size();
                 }
+            }
+            if (numberRoots == 0) {
+               return;
             }
 
             start("VendorSpecificCapabilities");


### PR DESCRIPTION
The execution of the method handleVendorSpecificCapabilities should only be stopped if the method getVendorSpecificCapabilitiesRoots returns null or an empty list for all ExtendedCapabilitiesProviders.

Without this fix, if one of the ExtendedCapabilitiesProviders returns null or an empty list, the vendor specific capabilities provided by the other ExtendedCapabilitiesProviders will not be included in the Capabilities.

Example: when using the INSPIRE plugin and activating "GeoWebCache direct integration with GeoServer WMS", the Capabilities retrieved using the URL http://localhost:8080/geoserver/ows?service=wms&version=1.1.1&request=GetCapabilities&tiled=true do not contain TileSet elements.
Reason: the ExtendedCapabilitiesProvider for the INSPIRE plugin returns an empty list and therefore the vendor specific capabilities provided by GeoWebCache (the TileSet-elements) are not included.