### PR TITLE
Update configuration doc to incluse gs- prefix for web jars

### DIFF
--- a/doc/en/user/source/production/config.rst
+++ b/doc/en/user/source/production/config.rst
@@ -72,5 +72,5 @@ Disable the GeoServer web administration interface
 In some circumstances, you might want to completely disable the web administration interface.  There are two ways of doing this:
 
 * Set the Java system property GEOSERVER_CONSOLE_DISABLED to true by adding -DGEOSERVER_CONSOLE_DISABLED=true to your container's JVM options
-* Remove all of the web*-.jar files from WEB-INF/lib
+* Remove all of the gs-web*-.jar files from WEB-INF/lib
 


### PR DESCRIPTION
I recently tried to remove web-*.jar files from a GeoServer 2.7.1 installation and I figured out the docs are outdated.