### PR TITLE
[GEOS-7043] - Enable to set the SpatialDataSetIdentifier/@metadataURL

### DIFF
--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/web/UniqueResourceIdentifiersProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/web/UniqueResourceIdentifiersProvider.java
@@ -28,9 +28,7 @@ public class UniqueResourceIdentifiersProvider extends
         return Arrays.asList(
                 new BeanProperty<UniqueResourceIdentifier>("code", "code"),
                 new BeanProperty<UniqueResourceIdentifier>("namespace", "namespace"),
-                // for the moment we leave this one out, while it's in the XSD no example
-                // ever shows how to use it, it's most likely used somewhere else in INSPIRE, not in DLS
-                // new BeanProperty<UniqueResourceIdentifier>("metadataURL", "metadataURL"),
+                new BeanProperty<UniqueResourceIdentifier>("metadataURL", "metadataURL"),
                 new PropertyPlaceholder<UniqueResourceIdentifier>("remove")
                 );
     }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/web/InspirePanelTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/web/InspirePanelTest.java
@@ -51,7 +51,7 @@ public class InspirePanelTest extends GeoServerWicketTestSupport {
         wfs.getMetadata().put(InspireMetadata.SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
         wfs.getMetadata().put(InspireMetadata.SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
         wfs.getMetadata().put(InspireMetadata.SPATIAL_DATASET_IDENTIFIER_TYPE.key,
-                "one,http://www.geoserver.org/one;two,http://www.geoserver.org/two");
+                "one,http://www.geoserver.org/one;two,http://www.geoserver.org/two,http://metadata.geoserver.org/id?two");
         getGeoServer().save(wfs);
 
         tester.startPage(new FormTestPage(new ComponentBuilder() {
@@ -110,7 +110,7 @@ public class InspirePanelTest extends GeoServerWicketTestSupport {
 
         // the spatial identifiers editor
         tester.assertComponent("form:panel:datasetIdentifiersContainer:spatialDatasetIdentifiers", UniqueResourceIdentifiersEditor.class);
-        UniqueResourceIdentifiers expected = Converters.convert("one,http://www.geoserver.org/one;two,http://www.geoserver.org/two", UniqueResourceIdentifiers.class);
+        UniqueResourceIdentifiers expected = Converters.convert("one,http://www.geoserver.org/one;two,http://www.geoserver.org/two,http://metadata.geoserver.org/id?two", UniqueResourceIdentifiers.class);
         tester.assertModelValue("form:panel:datasetIdentifiersContainer:spatialDatasetIdentifiers", expected);
     }
     

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/web/UniqueResourceIdentifiersEditorTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/web/UniqueResourceIdentifiersEditorTest.java
@@ -32,7 +32,7 @@ public class UniqueResourceIdentifiersEditorTest extends GeoServerWicketTestSupp
     @Before
     public void setupPanel() {
         identifiers = Converters.convert(
-                "one,http://www.geoserver.org/one;two,http://www.geoserver.org/two",
+                "one,http://www.geoserver.org/one;two,http://www.geoserver.org/two,http://metadata.geoserver.org/id?two",
                 UniqueResourceIdentifiers.class);
         tester.startPage(new FormTestPage(new ComponentBuilder() {
 
@@ -50,8 +50,10 @@ public class UniqueResourceIdentifiersEditorTest extends GeoServerWicketTestSupp
         
         tester.assertModelValue("form:panel:container:identifiers:listContainer:items:1:itemProperties:0:component:border:txt", "one");
         tester.assertModelValue("form:panel:container:identifiers:listContainer:items:1:itemProperties:1:component:border:txt", "http://www.geoserver.org/one");
+        tester.assertModelValue("form:panel:container:identifiers:listContainer:items:1:itemProperties:2:component:border:txt", null);
         tester.assertModelValue("form:panel:container:identifiers:listContainer:items:2:itemProperties:0:component:border:txt", "two");
         tester.assertModelValue("form:panel:container:identifiers:listContainer:items:2:itemProperties:1:component:border:txt", "http://www.geoserver.org/two");
+        tester.assertModelValue("form:panel:container:identifiers:listContainer:items:2:itemProperties:2:component:border:txt", "http://metadata.geoserver.org/id?two");
     }
     
     @Test
@@ -63,12 +65,12 @@ public class UniqueResourceIdentifiersEditorTest extends GeoServerWicketTestSupp
         tester.assertModelValue("form:panel:container:identifiers:listContainer:items:2:itemProperties:0:component:border:txt", "two");
 
         // remove the first identifier
-        tester.executeAjaxEvent("form:panel:container:identifiers:listContainer:items:1:itemProperties:2:component:remove", "onclick");
+        tester.executeAjaxEvent("form:panel:container:identifiers:listContainer:items:1:itemProperties:3:component:remove", "onclick");
         assertNull(tester.getLastRenderedPage().get("form:panel:container:identifiers:listContainer:items:1:itemProperties:0:component:border:txt"));
         tester.assertModelValue("form:panel:container:identifiers:listContainer:items:2:itemProperties:0:component:border:txt", "two");
         
         // remove the second as well
-        tester.executeAjaxEvent("form:panel:container:identifiers:listContainer:items:2:itemProperties:2:component:remove", "onclick");
+        tester.executeAjaxEvent("form:panel:container:identifiers:listContainer:items:2:itemProperties:3:component:remove", "onclick");
         assertNull(tester.getLastRenderedPage().get("form:panel:container:identifiers:listContainer:items:1:itemProperties:0:component:border:txt"));
         assertNull(tester.getLastRenderedPage().get("form:panel:container:identifiers:listContainer:items:2:itemProperties:0:component:border:txt"));
         
@@ -118,7 +120,21 @@ public class UniqueResourceIdentifiersEditorTest extends GeoServerWicketTestSupp
         ft.submit();
         tester.assertNoErrorMessage();
         tester.assertModelValue("form:panel:container:identifiers:listContainer:items:3:itemProperties:1:component:border:txt", "http://www.geoserver.org/meta");
-    }
+
+        // now provide an invalid metadataURL (not a valid URI)
+        ft = tester.newFormTester("form");
+        ft.setValue("panel:container:identifiers:listContainer:items:3:itemProperties:2:component:border:txt", "invalid uri");
+        ft.submit();
+        messages = tester.getMessages(FeedbackMessage.ERROR);
+        assertEquals(1, messages.size());
+        
+        // finally, set a valid metadataURL
+        ft = tester.newFormTester("form");
+        ft.setValue("panel:container:identifiers:listContainer:items:3:itemProperties:2:component:border:txt", "http://www.geoserver.org/meta");
+        ft.submit();
+        tester.assertNoErrorMessage();
+        tester.assertModelValue("form:panel:container:identifiers:listContainer:items:3:itemProperties:2:component:border:txt", "http://www.geoserver.org/meta");
+}
 
 
 }


### PR DESCRIPTION
This capability was commented out in code as no known examples but
there are possible uses and the element exists in INSPIRE schema.