### PR TITLE
Added missing escape symbol

### DIFF
--- a/src/web/wfs/src/main/resources/GeoServerApplication.properties
+++ b/src/web/wfs/src/main/resources/GeoServerApplication.properties
@@ -42,7 +42,7 @@ WFSLayerConfig.skipNumberMatched.message=To enhance the performance of large que
   also break pagination for client applications, since numberMatched will always evaluate to 'unknown'.
 WFSLayerConfig.otherSRS.message=A comma separated list of EPSG codes, e.g. 4326,3857,3003. The \
    corresponding codes will be added to each FeatureType declaration in the GetCapabilities \
-   response. The list can be left empty to have no extra SRS declared for this specific type, in
+   response. The list can be left empty to have no extra SRS declared for this specific type, in \
    override to a list of values specified in the WFS service configuration.
 
 


### PR DESCRIPTION
This caused transifex to think, that another property has began with key "override"