### PR TITLE
[GEOS-7087] App-schema mapping file upload via REST

### DIFF
--- a/src/restconfig/pom.xml
+++ b/src/restconfig/pom.xml
@@ -92,6 +92,12 @@
      <groupId>commons-lang</groupId>
      <artifactId>commons-lang</artifactId>
    </dependency>
+   <dependency>
+    <groupId>org.geotools</groupId>
+    <artifactId>gt-app-schema</artifactId>
+    <version>${gt.version}</version>
+    <scope>test</scope>
+   </dependency>
  </dependencies>
 
 </project>

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
@@ -22,7 +21,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
@@ -33,19 +31,20 @@ import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.rest.RestletException;
 import org.geoserver.rest.format.StreamDataFormat;
 import org.geoserver.rest.util.RESTUtils;
+import org.geotools.data.DataAccess;
 import org.geotools.data.DataAccessFactory;
+import org.geotools.data.DataAccessFactory.Param;
 import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFactorySpi;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.DefaultTransaction;
 import org.geotools.data.FeatureSource;
-import org.geotools.data.DataAccessFactory.Param;
 import org.geotools.data.FeatureStore;
 import org.geotools.data.FileDataStoreFactorySpi;
 import org.geotools.data.Transaction;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.restlet.data.Form;
 import org.restlet.data.MediaType;
@@ -62,6 +61,7 @@ public class DataStoreFileResource extends StoreFileResource {
         formatToDataStoreFactory.put( "properties", "org.geotools.data.property.PropertyDataStoreFactory");
         formatToDataStoreFactory.put( "h2", "org.geotools.data.h2.H2DataStoreFactory");
         formatToDataStoreFactory.put( "spatialite", "org.geotools.data.spatialite.SpatiaLiteDataStoreFactory");
+        formatToDataStoreFactory.put( "appschema", "org.geotools.data.complex.AppSchemaDataAccessFactory");
     }
     
     protected static final HashMap<String,Map> dataStoreFactoryToDefaultParams = new HashMap();
@@ -79,13 +79,13 @@ public class DataStoreFileResource extends StoreFileResource {
         dataStoreFactoryToDefaultParams.put("org.geotools.data.spatialite.SpatiaLiteDataStoreFactory", map);
     }
     
-    public static DataStoreFactorySpi lookupDataStoreFactory(String format) {
+    public static DataAccessFactory lookupDataStoreFactory(String format) {
         // first try and see if we know about this format directly
         String factoryClassName = formatToDataStoreFactory.get(format);
         if (factoryClassName != null) {
             try {
                 Class factoryClass = Class.forName(factoryClassName);
-                DataStoreFactorySpi factory = (DataStoreFactorySpi) factoryClass.newInstance();
+                DataAccessFactory factory = (DataAccessFactory) factoryClass.newInstance();
                 return factory;
             } catch (Exception e) {
                 throw new RestletException("Datastore format unavailable: " + factoryClassName,
@@ -111,11 +111,11 @@ public class DataStoreFileResource extends StoreFileResource {
     
     public static String lookupDataStoreFactoryFormat(String type) {
         for (DataAccessFactory factory : DataStoreUtils.getAvailableDataStoreFactories()) {
-            if (!(factory instanceof DataStoreFactorySpi)) {
+            if (!(factory instanceof DataAccessFactory)) {
                 continue;
             }
             
-            if (factory.getDisplayName().equals(type)) {
+            if (factory.getDisplayName() != null && factory.getDisplayName().equals(type)) {
                 for(Map.Entry e: formatToDataStoreFactory.entrySet()) {
                     if (e.getValue().equals(factory.getClass().getCanonicalName())) {
                         return (String) e.getKey();
@@ -130,8 +130,8 @@ public class DataStoreFileResource extends StoreFileResource {
     }
     
     String dataStoreFormat;
-    DataStoreFactorySpi factory;
-    
+    DataAccessFactory factory;
+
     public DataStoreFileResource( Request request, Response response, String dataStoreFormat, Catalog catalog ) {
         super( request, response, catalog );
         this.dataStoreFormat = dataStoreFormat;
@@ -254,7 +254,7 @@ public class DataStoreFileResource extends StoreFileResource {
             if (charset != null && charset.length() > 0) {
                 info.getConnectionParameters().put("charset", charset);
             }
-            DataStoreFactorySpi targetFactory = factory;
+            DataAccessFactory targetFactory = factory;
             if (!targetDataStoreFormat.equals(sourceDataStoreFormat)) {
                 //target is different, we need to create it
                 targetFactory = lookupDataStoreFactory(targetDataStoreFormat);
@@ -302,86 +302,95 @@ public class DataStoreFileResource extends StoreFileResource {
                 catalog.save( info );
             }
         }
-        
-        //create an instanceof the source datastore
-        HashMap params = new HashMap();
-        if (charset != null && charset.length() > 0) {
-            params.put("charset",charset);	
-        }
-        updateParameters(params, factory, uploadedFile);
-        DataStore source;
+
+        boolean createNewSource = false;
+        DataAccess<?, ?> source = null;
         try {
-            source = factory.createDataStore(params);
+            HashMap params = new HashMap();
+            if (charset != null && charset.length() > 0) {
+                params.put("charset", charset);
+            }
+            params.put( "namespace", namespace.getURI() );
+            updateParameters(params, factory, uploadedFile);
+
+            createNewSource = !sameTypeAndUrl(params, info.getConnectionParameters());
+            // this is a bit hacky, but makes sure that a datastore is not created
+            // twice with the same "dbtype" and "url" connection parameters, which
+            // would result in a "duplicated mapping" exception for an app-schema
+            // datastore.
+            source = (createNewSource) ? factory.createDataStore(params) : info.getDataStore(null);
         } catch (IOException e) {
             throw new RuntimeException("Unable to create source data store", e);
         }
-        
+
         try {
-            DataStore ds = (DataStore) info.getDataStore(null);
+            DataAccess ds = info.getDataStore(null);
             //synchronized(ds) {
             //if it is the case that the source does not match the target we need to 
             // copy the data into the target
-            if (!targetDataStoreFormat.equals(sourceDataStoreFormat)) {
-                //copy over the feature types
-                for (String featureTypeName : source.getTypeNames()) {
+            if (!targetDataStoreFormat.equals(sourceDataStoreFormat)
+                    && (source instanceof DataStore && ds instanceof DataStore)) {
+                // copy over the feature types
+                DataStore sourceDataStore = (DataStore) source;
+                DataStore targetDataStore = (DataStore) ds;
+                for (String featureTypeName : sourceDataStore.getTypeNames()) {
                     SimpleFeatureType featureType = null;
-                    
-                    //does the feature type already exist in the target?
+
+                    // does the feature type already exist in the target?
                     try {
-                        featureType = ds.getSchema(featureTypeName); 
+                        featureType = targetDataStore.getSchema(featureTypeName);
+                    } catch (Exception e) {
+                        LOGGER.info(featureTypeName
+                                + " does not exist in data store " + datastore
+                                + ". Attempting to create it");
+
+                        // schema does not exist, create it by first creating an instance
+                        // of the source datastore and copying over its schema
+                        targetDataStore.createSchema(sourceDataStore.getSchema(featureTypeName));
+                        featureType = sourceDataStore.getSchema(featureTypeName);
                     }
-                    catch(Exception e) {
-                        LOGGER.info(featureTypeName + " does not exist in data store " + datastore +
-                            ". Attempting to create it");
-                        
-                        //schema does not exist, create it by first creating an instance of 
-                        // the source datastore and copying over its schema
-                        ds.createSchema(source.getSchema(featureTypeName));
-                        featureType = source.getSchema(featureTypeName);
-                    }
-    
-                    FeatureSource featureSource = ds.getFeatureSource(featureTypeName);
+
+                    FeatureSource featureSource = targetDataStore.getFeatureSource(featureTypeName);
                     if (!(featureSource instanceof FeatureStore)) {
                         LOGGER.warning(featureTypeName + " is not writable, skipping");
                         continue;
                     }
-                    
+
                     Transaction tx = new DefaultTransaction();
                     FeatureStore featureStore = (FeatureStore) featureSource;
                     featureStore.setTransaction(tx);
-                    
+
                     try {
-                        //figure out update mode, whether we should kill existing data or append
+                        // figure out update mode, whether we should kill existing data or append
                         String update = form.getFirstValue("update");
                         if ("overwrite".equalsIgnoreCase(update)) {
                             LOGGER.fine("Removing existing features from " + featureTypeName);
-                            //kill all features
+                            // kill all features
                             featureStore.removeFeatures(Filter.INCLUDE);
                         }
-                        
+
                         LOGGER.fine("Adding features to " + featureTypeName);
-                        FeatureCollection features = source.getFeatureSource(featureTypeName).getFeatures();
+                        FeatureCollection features = sourceDataStore
+                                .getFeatureSource(featureTypeName).getFeatures();
                         featureStore.addFeatures(features);
-                        
+
                         tx.commit();
-                    }
-                    catch(Exception e) {
+                    } catch (Exception e) {
                         tx.rollback();
-                    }
-                    finally {
+                    } finally {
                         tx.close();
                     }
                 }
             }
 
-            //check configure parameter, if set to none to not try to configure
+            //check configure parameter, if set to none do not try to configure
             // data feature types
             String configure = form.getFirstValue( "configure" );
             if ( "none".equalsIgnoreCase( configure ) ) {
                 getResponse().setStatus( Status.SUCCESS_CREATED );
                 return;
             }
-            
+
             //load the target datastore
             //DataStore ds = (DataStore) info.getDataStore(null);
             Map<String, FeatureTypeInfo> featureTypesByNativeName =
@@ -389,18 +398,18 @@ public class DataStoreFileResource extends StoreFileResource {
             for (FeatureTypeInfo ftInfo : catalog.getFeatureTypesByDataStore(info)) {
                 featureTypesByNativeName.put(ftInfo.getNativeName(), ftInfo);
             }
-            
-            String[] featureTypeNames = source.getTypeNames();
-            for ( int i = 0; i < featureTypeNames.length; i++ ) {
+
+            List<Name> featureTypeNames = source.getNames();
+            for ( int i = 0; i < featureTypeNames.size(); i++ ) {
                 
                 //unless configure specified "all", only configure the first feature type
                 if ( !"all".equalsIgnoreCase( configure ) && i > 0 ) {
                     break;
                 }
-                
-                FeatureSource fs = ds.getFeatureSource(featureTypeNames[i]); 
-                FeatureTypeInfo ftinfo = featureTypesByNativeName.get(featureTypeNames[i]);
-                
+
+                FeatureSource fs = ds.getFeatureSource(featureTypeNames.get(i));
+                FeatureTypeInfo ftinfo = featureTypesByNativeName.get(featureTypeNames.get(i).getLocalPart());
+
                 if ( ftinfo == null) {
                     //auto configure the feature type as well
                     ftinfo = builder.buildFeatureType(fs);
@@ -424,10 +433,10 @@ public class DataStoreFileResource extends StoreFileResource {
                         int x = 1;
                         String originalName = ftinfo.getName();
                         do {
-                            ftinfo.setName(originalName + i);
-                            i++;
+                            ftinfo.setName(originalName + x);
+                            x++;
                         }
-                        while(i < 10 && catalog.getFeatureTypeByName(namespace, ftinfo.getName()) != null);
+                        while(x < 10 && catalog.getFeatureTypeByName(namespace, ftinfo.getName()) != null);
                     }
                     catalog.validate(ftinfo, true).throwIfInvalid();
                     catalog.add( ftinfo );
@@ -464,8 +473,10 @@ public class DataStoreFileResource extends StoreFileResource {
             //TODO: report a proper error code
             throw new RuntimeException ( e );
         } finally {
-            //dispose the datastore
-            source.dispose();
+            //dispose the source datastore, if needed
+            if (createNewSource) {
+                source.dispose();
+            }
             
             //clean up the files if we can
             if (isInlineUpload(method) && canRemoveFiles) {
@@ -479,7 +490,7 @@ public class DataStoreFileResource extends StoreFileResource {
         				LOGGER.log(Level.FINE, "", ie);
         			}
         		}
-            }        	
+            }
         }
     }
 
@@ -496,7 +507,7 @@ public class DataStoreFileResource extends StoreFileResource {
         }
     }
     
-    void updateParameters(DataStoreInfo info, NamespaceInfo namespace, DataStoreFactorySpi factory, File uploadedFile) {
+    void updateParameters(DataStoreInfo info, NamespaceInfo namespace, DataAccessFactory factory, File uploadedFile) {
         Map connectionParameters = info.getConnectionParameters();
         updateParameters(connectionParameters, factory, uploadedFile);
 
@@ -508,7 +519,7 @@ public class DataStoreFileResource extends StoreFileResource {
         }
     }
     
-    void updateParameters(Map connectionParameters, DataStoreFactorySpi factory, File uploadedFile) {
+    void updateParameters(Map connectionParameters, DataAccessFactory factory, File uploadedFile) {
 
         for ( Param p : factory.getParametersInfo() ) {
             //the nasty url / file hack
@@ -552,7 +563,7 @@ public class DataStoreFileResource extends StoreFileResource {
         }
     }
     
-    void autoCreateParameters(DataStoreInfo info, NamespaceInfo namespace, DataStoreFactorySpi factory) {
+    void autoCreateParameters(DataStoreInfo info, NamespaceInfo namespace, DataAccessFactory factory) {
         Map defaultParams = dataStoreFactoryToDefaultParams.get(factory.getClass().getCanonicalName());
         if (defaultParams == null) {
             throw new RuntimeException("Unable to auto create parameters for " + factory.getDisplayName());
@@ -575,5 +586,16 @@ public class DataStoreFileResource extends StoreFileResource {
         params.put("namespace", namespace.getURI());
         info.getConnectionParameters().putAll(params);
         
+    }
+
+    private boolean sameTypeAndUrl(Map sourceParams, Map targetParams) {
+        boolean sameType = sourceParams.get("dbtype") != null
+                && targetParams.get("dbtype") != null
+                && sourceParams.get("dbtype").equals(targetParams.get("dbtype"));
+        boolean sameUrl = sourceParams.get("url") != null
+                && targetParams.get("url") != null
+                && sourceParams.get("url").equals(targetParams.get("url"));
+
+        return sameType && sameUrl;
     }
 }

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreFileResourceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreFileResourceTest.java
@@ -46,7 +46,7 @@ public class DataStoreFileResourceTest extends CatalogRESTTestSupport {
 
     @Test
     public void testLookupDataStoreFactoryKnownExtension() throws Exception {
-        DataStoreFactorySpi factory = DataStoreFileResource.lookupDataStoreFactory("shp");
+        DataAccessFactory factory = DataStoreFileResource.lookupDataStoreFactory("shp");
         assertEquals("Shapefile", factory.getDisplayName());
     }
 

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreFileUploadTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreFileUploadTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -29,8 +30,14 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.NamespaceInfoImpl;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
 import org.geoserver.filters.LoggingFilter;
+import org.geoserver.platform.GeoServerResourceLoader;
 import org.geotools.data.DataUtilities;
 import org.h2.tools.DeleteDbFiles;
 import org.junit.After;
@@ -38,10 +45,27 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import com.mockrunner.mock.web.MockHttpServletResponse;
 
 public class DataStoreFileUploadTest extends CatalogRESTTestSupport {
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        NamespaceInfo gsmlNamespace = new NamespaceInfoImpl();
+        gsmlNamespace.setPrefix("gsml");
+        gsmlNamespace.setURI("http://www.cgi-iugs.org/xml/GeoSciML/2");
+
+        WorkspaceInfo gsmlWorkspace = new WorkspaceInfoImpl();
+        gsmlWorkspace.setName("gsml");
+
+        getCatalog().add(gsmlNamespace);
+        getCatalog().add(gsmlWorkspace);
+    }
 
     @Override
     protected List<Filter> getFilters() {
@@ -307,4 +331,154 @@ public class DataStoreFileUploadTest extends CatalogRESTTestSupport {
         assertNotNull( entry );
         assertEquals( "pds.properties", entry.getName() );
     }
+
+    @Test
+    public void testAppSchemaMappingFileUpload() throws Exception {
+        byte[] bytes = appSchemaMappingAsBytes();
+        if (bytes == null) {
+            // skip test
+            LOGGER.warning("app-schema test data not available: skipping test");
+            return;
+        }
+
+        // copy necessary .properties files from classpath
+        loadAppSchemaTestData();
+
+        // upload mapping file (datastore is created implicitly)
+        put( "/rest/workspaces/gsml/datastores/mappedPolygons/file.appschema", bytes, "text/xml");
+        Document dom = getAsDOM( "wfs?request=getfeature&typename=gsml:MappedFeature" );
+
+        // print(dom);
+
+        assertEquals( "wfs:FeatureCollection", dom.getDocumentElement().getNodeName() );
+        NodeList mappedFeatureNodes = dom.getDocumentElement().getElementsByTagNameNS(
+                "http://www.cgi-iugs.org/xml/GeoSciML/2", "MappedFeature");
+        assertNotNull(mappedFeatureNodes);
+        assertEquals(2, mappedFeatureNodes.getLength());
+
+        int namesCount = countNameAttributes(mappedFeatureNodes.item(0));
+        assertEquals(2, namesCount);
+
+        // upload alternative mapping file
+        bytes = appSchemaAlternativeMappingAsBytes();
+        put("/rest/workspaces/gsml/datastores/mappedPolygons/file.appschema?configure=none",
+                bytes, "text/xml");
+        dom = getAsDOM( "wfs?request=getfeature&typename=gsml:MappedFeature" );
+
+        // print(dom);
+
+        assertEquals( "wfs:FeatureCollection", dom.getDocumentElement().getNodeName() );
+        mappedFeatureNodes = dom.getDocumentElement().getElementsByTagNameNS(
+                "http://www.cgi-iugs.org/xml/GeoSciML/2", "MappedFeature");
+        assertNotNull(mappedFeatureNodes);
+        assertEquals(2, mappedFeatureNodes.getLength());
+
+        namesCount = countNameAttributes(mappedFeatureNodes.item(0));
+        // just one name should be found
+        assertEquals(1, namesCount);
+    }
+
+    private int countNameAttributes(Node mappedFeatureNode) {
+        NodeList attrNodes = mappedFeatureNode.getChildNodes();
+        int namesCount = 0;
+        for (int i=0; i<attrNodes.getLength(); i++) {
+            Node attribute = attrNodes.item(i);
+            if ("name".equals(attribute.getLocalName())) {
+                namesCount++;
+            }
+        }
+
+        return namesCount;
+    }
+
+    private void loadAppSchemaTestData() throws IOException {
+        GeoServerResourceLoader loader = new GeoServerResourceLoader(getTestData()
+                .getDataDirectoryRoot());
+        loader.copyFromClassPath("test-data/mappedPolygons.properties",
+                "data/gsml/mappedPolygons.properties");
+        loader.copyFromClassPath("test-data/mappedPolygons.oasis.xml",
+                "data/gsml/mappedPolygons.oasis.xml");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/CGI_basicTypes.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/CGI_basicTypes.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/CGI_Value.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/CGI_Value.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/earthMaterial.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/earthMaterial.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/fossil.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/fossil.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/geologicStructure.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/geologicStructure.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/geologicUnit.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/geologicUnit.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/geosciml.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/geosciml.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/Gsml.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/Gsml.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/metadata.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/metadata.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/ObsAndMeas.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/ObsAndMeas.xsd");
+        loader.copyFromClassPath(
+                "test-data/commonSchemas_new/GeoSciML/vocabulary.xsd",
+                "data/gsml/commonSchemas_new/GeoSciML/vocabulary.xsd");
+    }
+
+    private byte[] appSchemaMappingAsBytes() throws IOException {
+        InputStream in = getClass().getResourceAsStream( "/test-data/mappedPolygons.xml" );
+        if (in != null) {
+            byte[] original = toBytes(in);
+            byte[] modified = null;
+
+            String originalAsString = new String(original, Charset.forName("UTF-8"));
+            // modify paths in the original mapping file
+            String modifiedAsString = originalAsString.replace("file:./", "file:../")
+                    .replace("commonSchemas_new/", "../commonSchemas_new/")
+                    .replace("mappedPolygons.oasis", "../mappedPolygons.oasis");
+
+            modified = modifiedAsString.getBytes(Charset.forName("UTF-8"));
+
+            return modified;
+        } else {
+            return null;
+        }
+    }
+
+    private byte[] appSchemaAlternativeMappingAsBytes() throws Exception {
+        byte[] mapping = appSchemaMappingAsBytes();
+        if (mapping != null) {
+            Document mappingDom = dom(new ByteArrayInputStream(mapping));
+
+            // remove mapping for MappedFeature/gml:name[2] attribute
+            NodeList attrMappingNodes = mappingDom.getDocumentElement()
+                    .getElementsByTagName("AttributeMapping");
+            for (int i=0; i<attrMappingNodes.getLength(); i++) {
+                Node attrMapping = attrMappingNodes.item(i);
+                NodeList children = attrMapping.getChildNodes();
+                for (int j=0; j<children.getLength(); j++) {
+                    if ("MappedFeature/gml:name[2]".equals(children.item(j).getTextContent())) {
+                        attrMapping.getParentNode().removeChild(attrMapping);
+                        break;
+                    }
+                }
+            }
+
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            print(mappingDom, output);
+
+            return output.toByteArray();
+        } else {
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
Refactored `DataStoreFileResource` to let `AppSchemaDataAccess` fit in. Basically, it was necessary to substitute `DataStore/DataStoreFactorySpi` interfaces with `DataAccess/DataAccessFactory`. The functionality of the service should be unaffected by the change.