### PR TITLE
JSON matched features count bug with spatial filter

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -430,14 +430,11 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
             }
             
             int count = 0;
-            count = source.getCount(countQuery);
-            if (count == -1) {
-                // information was not available in the header!
-                org.geotools.data.Query gtQuery = new org.geotools.data.Query(countQuery);
-                FeatureCollection<? extends FeatureType, ? extends Feature> features = source
-                        .getFeatures(gtQuery);
-                count = features.size();
-            }
+            // information was not available in the header!
+            org.geotools.data.Query gtQuery = new org.geotools.data.Query(countQuery);
+            FeatureCollection<? extends FeatureType, ? extends Feature> features = source
+                    .getFeatures(gtQuery);
+            count = features.size();
             totalCount +=count;
         }
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
@@ -338,6 +338,31 @@ public class GeoJSONTest extends WFSTestSupport {
         JSONObject rootObject4 = JSONObject.fromObject( out4 );
         assertEquals(rootObject4.get("totalFeatures"),3);
         
+        //post with spatial-filter in another projection than layer-projection
+        String xml = "<wfs:GetFeature " + "service=\"WFS\" " + "outputFormat=\""+JSONType.json+"\" "
+                + "version=\"1.1.0\" "
+                + "xmlns:cdf=\"http://www.opengis.net/cite/data\" "
+                + "xmlns:ogc=\"http://www.opengis.net/ogc\" "
+                + "xmlns:wfs=\"http://www.opengis.net/wfs\" " + "> "
+                + "<wfs:Query typeName=\"sf:AggregateGeoFeature\" srsName=\"EPSG:900913\"> "
+                + "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\"> "
+                + "<ogc:Intersects> "
+                + "<ogc:PropertyName></ogc:PropertyName> "
+                + "<gml:Polygon xmlns:gml=\"http://www.opengis.net/gml\" srsName=\"EPSG:900913\"> "
+                + "<gml:exterior> "
+                + "<gml:LinearRing> "
+                + "<gml:posList>7666573.330932751 3485566.812628661 8010550.557483965 3485566.812628661 8010550.557483965 3788277.001334882 7666573.330932751 3788277.001334882 7666573.330932751 3485566.812628661</gml:posList> "
+                + "</gml:LinearRing> "
+                + "</gml:exterior> "
+                + "</gml:Polygon> "
+                + "</ogc:Intersects> "
+                + "</ogc:Filter> "
+                + "</wfs:Query> " + "</wfs:GetFeature>";
+
+        String out5 = postAsServletResponse( "wfs", xml ).getOutputStreamContent();
+        
+        JSONObject rootObject5 = JSONObject.fromObject( out5 );
+        assertEquals(rootObject5.get("totalFeatures"),1);
     }
 
     @Test


### PR DESCRIPTION
Patch for  JSON matched features count.bug when applying a spatial filter in a different projection than layer-projection.

See https://osgeo-org.atlassian.net/browse/GEOS-7075 for more information.