### PR TITLE
[GEOS-7013] 2.7.x Fixed dynamic legend size calculation for raster styles.

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/LegendSampleImpl.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/LegendSampleImpl.java
@@ -212,6 +212,7 @@ public class LegendSampleImpl implements CatalogListener, LegendSample,
         GetLegendGraphicRequest legendGraphicRequest = new GetLegendGraphicRequest();
         File sampleLegendFolder = getSamplesFolder(); 
         
+        legendGraphicRequest.setStrict(false);
         legendGraphicRequest.setLayers(Arrays.asList((FeatureType) null));
         legendGraphicRequest.setStyles(Arrays.asList(style.getStyle()));
         legendGraphicRequest.setFormat(pngOutputFormat.getContentType());

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/LegendSampleImpl.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/LegendSampleImpl.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
@@ -102,6 +102,7 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
     /** Test layers */
     public static QName SQUARES = new QName(MockData.CITE_URI, "squares", MockData.CITE_PREFIX);
     public static QName STATES = new QName(MockData.CITE_URI, "states", MockData.CITE_PREFIX);
+    public static QName WORLD = new QName("http://www.geo-solutions.it", "world", "gs");
     
     
     /**
@@ -128,6 +129,11 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
         testData.addVectorLayer(STATES,properties,"states.properties",
                 GetCapabilitiesLegendURLTest.class,catalog);
         LocalWorkspace.set(null);
+
+        testData.addStyle("temperature", "temperature.sld", WMSTestSupport.class, catalog);
+        properties = new HashMap<LayerProperty, Object>();
+        properties.put(LayerProperty.STYLE, "temperature");
+        testData.addRasterLayer(WORLD, "world.tiff", null, properties, SystemTestData.class, catalog);
     }
     
     @Before
@@ -256,6 +262,25 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
         assertFalse("20".equals(legendURL.getAttribute("height")));
         
         File sampleFile = getSampleFile("squares");
+        assertTrue(sampleFile.exists());
+    }
+
+    @Test
+    public void testCreatedRasterLegendURLSize() throws Exception {
+        TransformerBase tr = createTransformer();
+        tr.setIndentation(2);
+        Document dom = WMSTestSupport.transform(req, tr);
+
+        NodeList legendURLs = XPATH.getMatchingNodes(
+                getLegendURLXPath("gs:world"), dom);
+        assertEquals(1, legendURLs.getLength());
+        Element legendURL = (Element) legendURLs.item(0);
+        assertTrue(legendURL.hasAttribute("width"));
+        assertFalse("20".equals(legendURL.getAttribute("width")));
+        assertTrue(legendURL.hasAttribute("height"));
+        assertFalse("20".equals(legendURL.getAttribute("height")));
+
+        File sampleFile = getSampleFile("temperature");
         assertTrue(sampleFile.exists());
     }
 

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.


### PR DESCRIPTION
Attempting to backport this bug fix to 2.7.x.
[GEOS-7013] Fixed dynamic legend size calculation for raster styles.