### PR TITLE
Fix build (tests) on Windows with Java 8

### DIFF
--- a/src/kml/src/test/java/org/geoserver/kml/KMLTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/KMLTest.java
@@ -171,13 +171,13 @@ public class KMLTest extends WMSTestSupport {
         assertXpathEvaluatesTo("1", "count(//kml:Placemark)", doc);
         assertXpathEvaluatesTo("RoadSegments.1107532045088", "//kml:Placemark/@id", doc);
         assertXpathEvaluatesTo("RoadSegments.1107532045088", "//kml:Placemark/kml:name", doc);
-        String expectedDescription = String.format("<h4>RoadSegments</h4>%n" + 
-                "%n" + 
-                "<ul class=\"textattributes\">%n" + 
-                "  %n" + 
-                "  <li><strong><span class=\"atr-name\">FID</span>:</strong> <span class=\"atr-value\">102</span></li>%n" + 
-                "  <li><strong><span class=\"atr-name\">NAME</span>:</strong> <span class=\"atr-value\">Route 5</span></li>%n" + 
-                "</ul>%n");
+        String expectedDescription = String.format("<h4>RoadSegments</h4>\n" + 
+                "\n" + 
+                "<ul class=\"textattributes\">\n" + 
+                "  \n" + 
+                "  <li><strong><span class=\"atr-name\">FID</span>:</strong> <span class=\"atr-value\">102</span></li>\n" + 
+                "  <li><strong><span class=\"atr-name\">NAME</span>:</strong> <span class=\"atr-value\">Route 5</span></li>\n" + 
+                "</ul>\n");
         assertXpathEvaluatesTo(expectedDescription, "//kml:Placemark/kml:description", doc);
         // check look-at
         assertXpathEvaluatesTo("-0.0020000000000095497", "//kml:Placemark/kml:LookAt/kml:longitude", doc);

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/FeatureTemplateTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/FeatureTemplateTest.java
@@ -115,7 +115,7 @@ public class FeatureTemplateTest extends WMSTestSupport {
         SimpleFeatureSource source = getFeatureSource(MockData.PRIMITIVEGEOFEATURE);
 
         FeatureTemplate template = new FeatureTemplate();
-        assertTrue(template.isTemplateEmpty(source.getSchema(), "height.ftl", FeatureTemplate.class, "0" + System.getProperty("line.separator")));
+        assertTrue(template.isTemplateEmpty(source.getSchema(), "height.ftl", FeatureTemplate.class, "0\n"));
         assertTrue(template.isTemplateEmpty(source.getSchema(), "time.ftl", FeatureTemplate.class, null));
         assertFalse(template.isTemplateEmpty(source.getSchema(), "title.ftl", FeatureTemplate.class, null));
     }


### PR DESCRIPTION
I think both these fixes are Windows specific. They were done with java 8 though, which might have exposed the issues.