### PR TITLE
Restconfig: add GeoPackage format for store file upload

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/DataStoreFileResource.java
@@ -62,6 +62,7 @@ public class DataStoreFileResource extends StoreFileResource {
         formatToDataStoreFactory.put( "h2", "org.geotools.data.h2.H2DataStoreFactory");
         formatToDataStoreFactory.put( "spatialite", "org.geotools.data.spatialite.SpatiaLiteDataStoreFactory");
         formatToDataStoreFactory.put( "appschema", "org.geotools.data.complex.AppSchemaDataAccessFactory");
+        formatToDataStoreFactory.put( "gpkg", "org.geotools.geopkg.GeoPkgDataStoreFactory");
     }
     
     protected static final HashMap<String,Map> dataStoreFactoryToDefaultParams = new HashMap();


### PR DESCRIPTION
Allows direct geopackage file upload through restconfig. Depends on https://github.com/geotools/geotools/pull/896 (not to build, but to work).