### PR TITLE
Store field deprecation, CQL filter in layers, and SOLR improvements

### DIFF
--- a/src/community/solr/src/main/java/applicationContext.xml
+++ b/src/community/solr/src/main/java/applicationContext.xml
@@ -8,7 +8,9 @@ This code is licensed under the GPL 2.0 license, available at the root applicati
 
 	<bean id="solrXStreamInitializer" class="org.geoserver.solr.SolrXStreamInitializer" />
 	
-	<bean id="solrFeatureTypeCallback" class="org.geoserver.solr.SolrFeatureTypeCallback" />
+	<bean id="solrFeatureTypeCallback" class="org.geoserver.solr.SolrFeatureTypeCallback" >
+      <constructor-arg index="0" ref="catalog" />
+    </bean>
 
 	<bean id="solrConfigPanel" class="org.geoserver.solr.SolrConfigurationPanelInfo">
 		<property name="id" value="solr" />

--- a/src/community/solr/src/main/java/org/geoserver/solr/SolrConfigurationPage.java
+++ b/src/community/solr/src/main/java/org/geoserver/solr/SolrConfigurationPage.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -31,13 +31,9 @@ import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
-import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
-import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.GeoServerDataProvider.Property;
 import org.geoserver.web.wicket.GeoServerTablePanel;
 import org.geoserver.web.wicket.ParamResourceModel;
@@ -82,7 +78,8 @@ public abstract class SolrConfigurationPage extends Panel {
      * @see {@link SolrAttribute}
      * 
      */
-    public SolrConfigurationPage(String panelId, final IModel model) {
+    public SolrConfigurationPage(String panelId,
+            final IModel model) {
         super(panelId, model);
 
         ResourceInfo ri = (ResourceInfo) model.getObject();
@@ -130,7 +127,7 @@ public abstract class SolrConfigurationPage extends Panel {
      * Do nothing
      */
     protected void onCancel(AjaxRequestTarget target) {
-        done(target, null, null);
+        done(target, null);
     }
 
     /**
@@ -178,29 +175,9 @@ public abstract class SolrConfigurationPage extends Panel {
                 target.addComponent(feedbackPanel);
                 return;
             }
-
-            Catalog catalog = ((GeoServerApplication) this.getPage().getApplication()).getCatalog();
-            LayerInfo layerInfo = catalog.getLayerByName(ri.getQualifiedName());
-            FeatureTypeInfo typeInfo;
-            Boolean isNew = true;
-            if (layerInfo == null) {
-                // New
-                DataStoreInfo dsInfo = catalog.getStore(ri.getStore().getId(), DataStoreInfo.class);
-                SolrDataStore ds = (SolrDataStore) dsInfo.getDataStore(null);
-                CatalogBuilder builder = new CatalogBuilder(catalog);
-                builder.setStore(dsInfo);
-                ds.setSolrConfigurations(layerConfiguration);
-                typeInfo = builder.buildFeatureType(ds.getFeatureSource(ri.getQualifiedName()));
-                typeInfo.getMetadata().put(SolrLayerConfiguration.KEY, layerConfiguration);
-                layerInfo = builder.buildLayer(typeInfo);
-            } else {
-                // Update
-                isNew = false;
-                ResourceInfo resourceInfo = layerInfo.getResource();
-                FeatureTypeInfo featureTypeInfo = (FeatureTypeInfo) resourceInfo;
-                featureTypeInfo.getMetadata().put(SolrLayerConfiguration.KEY, layerConfiguration);
-            }
-            done(target, layerInfo, isNew);
+            ri.getMetadata().put(SolrLayerConfiguration.KEY, layerConfiguration);
+            
+            done(target, ri);
 
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
@@ -354,6 +331,6 @@ public abstract class SolrConfigurationPage extends Panel {
      * @see {@link #onCancel}
      * 
      */
-    abstract void done(AjaxRequestTarget target, LayerInfo layerInfo, Boolean isNew);
+    abstract void done(AjaxRequestTarget target, ResourceInfo layerInfo);
 
 }

--- a/src/community/solr/src/main/java/org/geoserver/solr/SolrConfigurationPanel.java
+++ b/src/community/solr/src/main/java/org/geoserver/solr/SolrConfigurationPanel.java
@@ -1,12 +1,9 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 
 package org.geoserver.solr;
-
-import java.io.IOException;
-import java.util.logging.Level;
 
 import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -22,7 +19,6 @@ import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.data.resource.ResourceConfigurationPage;
 import org.geoserver.web.data.resource.ResourceConfigurationPanel;
 import org.geoserver.web.wicket.ParamResourceModel;
-import org.geotools.data.solr.SolrLayerConfiguration;
 
 /**
  * Resource configuration panel to show a link to open SOLR attribute modal dialog <br>
@@ -49,7 +45,6 @@ public class SolrConfigurationPanel extends ResourceConfigurationPanel {
     public SolrConfigurationPanel(final String panelId, final IModel model) {
         super(panelId, model);
         final FeatureTypeInfo fti = (FeatureTypeInfo) model.getObject();
-        final ResourceConfigurationPanel current = this;
 
         final ModalWindow modal = new ModalWindow("modal");
         modal.setInitialWidth(800);
@@ -75,15 +70,16 @@ public class SolrConfigurationPanel extends ResourceConfigurationPanel {
             }
         });
 
-        if (fti.getMetadata().get(SolrLayerConfiguration.KEY) == null) {
+        if (fti.getId() == null) {
             modal.add(new OpenWindowOnLoadBehavior());
         }
 
         modal.setContent(new SolrConfigurationPage(panelId, model) {
             @Override
-            void done(AjaxRequestTarget target, LayerInfo layerInfo, Boolean isNew) {
-                _layerInfo = layerInfo;
-                _isNew = isNew;
+            void done(AjaxRequestTarget target, ResourceInfo resource) {
+                ResourceConfigurationPage page = (ResourceConfigurationPage) SolrConfigurationPanel.this
+                        .getPage();
+                page.updateResource(resource, target);
                 modal.close(target);
             }
         });
@@ -105,10 +101,15 @@ public class SolrConfigurationPanel extends ResourceConfigurationPanel {
      * Open modal dialog on window load
      */
     private class OpenWindowOnLoadBehavior extends AbstractDefaultAjaxBehavior {
+        boolean first = true;
+
         @Override
         protected void respond(AjaxRequestTarget target) {
-            ModalWindow window = (ModalWindow) getComponent();
-            window.show(target);
+            if (first) {
+                ModalWindow window = (ModalWindow) getComponent();
+                window.show(target);
+                first = false;
+            }
         }
 
         @Override

--- a/src/community/solr/src/main/java/org/geoserver/solr/SolrFeatureTypeCallback.java
+++ b/src/community/solr/src/main/java/org/geoserver/solr/SolrFeatureTypeCallback.java
@@ -1,13 +1,21 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.solr;
 
 import java.io.IOException;
+import java.io.Serializable;
 
-import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.FeatureTypeCallback;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geotools.data.DataAccess;
 import org.geotools.data.solr.SolrDataStore;
 import org.geotools.data.solr.SolrLayerConfiguration;
@@ -22,7 +30,14 @@ import org.opengis.feature.type.Name;
  * @see {@link FeatureTypeCallback}
  * 
  */
-public class SolrFeatureTypeCallback implements FeatureTypeCallback {
+public class SolrFeatureTypeCallback implements FeatureTypeCallback, CatalogListener {
+
+    Catalog catalog;
+
+    public SolrFeatureTypeCallback(Catalog catalog) {
+        this.catalog = catalog;
+        catalog.addListener(this);
+    }
 
     @Override
     public boolean canHandle(FeatureTypeInfo info,
@@ -61,6 +76,92 @@ public class SolrFeatureTypeCallback implements FeatureTypeCallback {
     @Override
     public void flush(FeatureTypeInfo info,
             DataAccess<? extends FeatureType, ? extends Feature> dataAccess) throws IOException {
+        // nothing to do
+    }
+
+    @Override
+    public void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+        if (event.getSource() instanceof FeatureTypeInfo) {
+            FeatureTypeInfo ft = (FeatureTypeInfo) event.getSource();
+            Serializable config = ft.getMetadata().get(SolrLayerConfiguration.KEY);
+            if (config instanceof SolrLayerConfiguration) {
+                updateSolrConfiguration(ft, (SolrLayerConfiguration) config);
+            }
+        }
+    }
+
+    @Override
+    public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
+        // remove the configuration if the layer is a SOLR one
+        if (event.getSource() instanceof FeatureTypeInfo) {
+            FeatureTypeInfo ft = (FeatureTypeInfo) event.getSource();
+            Serializable config = ft.getMetadata().get(SolrLayerConfiguration.KEY);
+            if (config instanceof SolrLayerConfiguration) {
+                SolrLayerConfiguration slc = (SolrLayerConfiguration) config;
+                // go directly to the resource pool to avoid security wrappers
+                try {
+                    DataAccess<? extends FeatureType, ? extends Feature> dataStore = catalog
+                            .getResourcePool()
+                            .getDataStore(ft.getStore());
+                    if (dataStore instanceof SolrDataStore) {
+                        SolrDataStore solr = (SolrDataStore) dataStore;
+                        solr.getSolrConfigurations().remove(slc.getLayerName());
+                    }
+                } catch (IOException e) {
+                    throw new CatalogException(
+                            "Failed to remove layer configuration from data store", e);
+                }
+            }
+        }
+
+    }
+
+    @Override
+    public void handleModifyEvent(CatalogModifyEvent event) throws CatalogException {
+        // nothing to do
+        System.out.println(event);
+    }
+
+    @Override
+    public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {
+        // remove the configuration if the layer is a SOLR one
+        if (event.getSource() instanceof FeatureTypeInfo) {
+            FeatureTypeInfo ft = (FeatureTypeInfo) event.getSource();
+            Serializable config = ft.getMetadata().get(SolrLayerConfiguration.KEY);
+            if (config instanceof SolrLayerConfiguration) {
+                SolrLayerConfiguration slc = (SolrLayerConfiguration) config;
+                if (!ft.getName().equals(slc.getLayerName())) {
+                    updateSolrConfiguration(ft, slc);
+                }
+
+            }
+        }
+
+    }
+
+    private void updateSolrConfiguration(FeatureTypeInfo ft, SolrLayerConfiguration slc) {
+        // go directly to the resource pool to avoid security wrappers
+        try {
+            DataAccess<? extends FeatureType, ? extends Feature> dataStore = catalog
+                    .getResourcePool().getDataStore(ft.getStore());
+            if (dataStore instanceof SolrDataStore) {
+                SolrDataStore solr = (SolrDataStore) dataStore;
+                solr.getSolrConfigurations().remove(slc.getLayerName());
+                slc.setLayerName(ft.getName());
+                solr.setSolrConfigurations(slc);
+            }
+        } catch (IOException e) {
+            throw new CatalogException(
+                    "Failed to remove layer configuration from data store", e);
+        }
+        FeatureTypeInfo proxy = catalog.getFeatureType(ft.getId());
+        proxy.setNativeName(ft.getName());
+        proxy.getMetadata().put(SolrLayerConfiguration.KEY, slc);
+        catalog.save(proxy);
+    }
+
+    @Override
+    public void reloaded() {
         // nothing to do
     }
 

--- a/src/community/solr/src/test/java/org/geoserver/solr/SolrStorePageTest.java
+++ b/src/community/solr/src/test/java/org/geoserver/solr/SolrStorePageTest.java
@@ -1,10 +1,16 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.solr;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.util.List;
 
+import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.StoreInfo;
@@ -13,9 +19,7 @@ import org.geoserver.web.GeoServerWicketTestSupport;
 import org.geoserver.web.data.store.DataAccessNewPage;
 import org.geoserver.web.data.workspace.WorkspacesModel;
 import org.geotools.data.solr.SolrDataStoreFactory;
-import org.junit.Ignore;
 import org.junit.Test;
-
 
 public class SolrStorePageTest extends GeoServerWicketTestSupport {
 
@@ -28,7 +32,23 @@ public class SolrStorePageTest extends GeoServerWicketTestSupport {
     }
 
     @Test
-    @Ignore
+    public void testDeprecatedParamsHidden() throws Exception {
+        startPage();
+
+        // print(tester.getLastRenderedPage(), true, true);
+
+        // check the deprecated fields are not visible
+        MarkupContainer container = (MarkupContainer) tester
+                .getComponentFromLastRenderedPage("dataStoreForm:parametersPanel:parameters:1");
+        assertEquals("layer_mapper", container.getDefaultModelObject());
+        assertFalse(container.get("parameterPanel").isVisible());
+        container = (MarkupContainer) tester
+                .getComponentFromLastRenderedPage("dataStoreForm:parametersPanel:parameters:2");
+        assertEquals("layer_name_field", container.getDefaultModelObject());
+        assertFalse(container.get("parameterPanel").isVisible());
+    }
+
+    @Test
     public void testChangeWorkspaceNamespace() throws Exception {
         startPage();
 
@@ -39,13 +59,13 @@ public class SolrStorePageTest extends GeoServerWicketTestSupport {
         // configure the store
         FormTester ft = tester.newFormTester("dataStoreForm");
         ft.setValue("dataStoreNamePanel:border:paramValue", "testStore");
-        ft.setValue("parametersPanel:url:border:paramValue", "file://" + new File("./target").getCanonicalPath());
+        ft.setValue("parametersPanel:parameters:0:parameterPanel:border:paramValue",
+                "file://" + new File("./target").getCanonicalPath());
         ft.select("workspacePanel:border:paramValue", 2);
         ft.submit();
         tester.executeAjaxEvent("dataStoreForm:workspacePanel:border:paramValue", "onchange");
         tester.executeAjaxEvent("dataStoreForm:save", "onclick");
-        
-        
+
         // get the workspace we have just configured in the GUI
         WorkspacesModel wm = new WorkspacesModel();
         List<WorkspaceInfo> wl = (List<WorkspaceInfo>) wm.getObject();
@@ -53,6 +73,7 @@ public class SolrStorePageTest extends GeoServerWicketTestSupport {
 
         // check it's the same
         StoreInfo store = getCatalog().getStoreByName("testStore", DataStoreInfo.class);
-        assertEquals(getCatalog().getNamespaceByPrefix(ws.getName()).getURI(), store.getConnectionParameters().get("namespace"));
+        assertEquals(getCatalog().getNamespaceByPrefix(ws.getName()).getURI(),
+                store.getConnectionParameters().get("namespace"));
     }
 }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -231,7 +231,7 @@ public class CatalogLayerEventListener implements CatalogListener {
         PRE_MODIFY_EVENT.remove();
 
         if (tileLayerInfo == null && !(source instanceof WorkspaceInfo)) {
-            return;// no tile layer assiociated, no need to continue
+            return;// no tile layer associated, no need to continue
         }
         if (preModifyEvent == null) {
             throw new IllegalStateException(
@@ -245,6 +245,14 @@ public class CatalogLayerEventListener implements CatalogListener {
         log.finer("Handling modify event for " + source);
         if (source instanceof FeatureTypeInfo || source instanceof CoverageInfo
                 || source instanceof WMSLayerInfo || source instanceof LayerGroupInfo) {
+            /*
+             * Handle changing the filter definition, this is the kind of change that affects the
+             * full output contents
+             */
+            if (changedProperties.contains("cqlFilter") && source instanceof FeatureTypeInfo) {
+                mediator.truncate(((FeatureTypeInfo) source).prefixedName());
+            }
+
             /*
              * Handle the rename case. For LayerInfos it's actually the related ResourceInfo what
              * gets renamed, at least until the data/publish split is implemented in GeoServer. For

--- a/src/main/src/main/java/org/geoserver/catalog/FeatureTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/FeatureTypeInfo.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -58,17 +58,7 @@ public interface FeatureTypeInfo extends ResourceInfo {
      * @return A filter, or <code>null</code> if one not set.
      * @uml.property name="filter"
      */
-    Filter getFilter();
-
-    /**
-     * Sets a filter which should be applied to all queries of the dataset
-     * represented by the feature type.
-     * 
-     * @param filter
-     *                A filter, can be <code>null</code>
-     * @uml.property name="filter"
-     */
-    void setFilter(Filter filter);
+    Filter filter();
 
     /**
      * A cap on the number of features that a query against this type can return.
@@ -168,6 +158,18 @@ public interface FeatureTypeInfo extends ResourceInfo {
     FeatureType getFeatureType() throws IOException;
     
     /**
+     * Return the ECQL string used as default feature type filter
+     *
+     */
+    String getCqlFilter();
+
+    /**
+     * Set the ECQL string used as default featue type filter
+     *
+     */
+    void setCqlFilter(String cqlFilterString);
+    
+    /**
      * Returns the underlying feature source instance.
      * <p>
      * This method does I/O and is potentially blocking. The <tt>listener</tt>
@@ -191,9 +193,4 @@ public interface FeatureTypeInfo extends ResourceInfo {
 	
 	void setCircularArcPresent(boolean arcsPresent);
 
-    /**
-     * The live feature resource, an instance of of {@link FeatureResource}.
-     */
-    //FeatureResource getResource(ProgressListener listener)
-    //        throws IOException;
 }

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -1233,7 +1233,7 @@ public class ResourcePool {
                     try {
                     Method m = GS_VERSIONING_FS.getMethod( "create", VERSIONING_FS, 
                         SimpleFeatureType.class, Filter.class, CoordinateReferenceSystem.class, int.class );
-                    return (FeatureSource) m.invoke(null, fs, schema, info.getFilter(), 
+                        return (FeatureSource) m.invoke(null, fs, schema, info.filter(),
                         resultCRS, info.getProjectionPolicy().getCode());
                     }
                     catch( Exception e ) {
@@ -1260,7 +1260,7 @@ public class ResourcePool {
             }
 
             //return a normal 
-            return GeoServerFeatureLocking.create(fs, schema, info.getFilter(), resultCRS, info
+            return GeoServerFeatureLocking.create(fs, schema, info.filter(), resultCRS, info
                     .getProjectionPolicy().getCode(), getTolerance(info), info.getMetadata());
         }
     }

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingFeatureTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingFeatureTypeInfo.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -97,8 +97,8 @@ public abstract class DecoratingFeatureTypeInfo extends AbstractDecorator<Featur
         return delegate.getFeatureType();
     }
 
-    public Filter getFilter() {
-        return delegate.getFilter();
+    public Filter filter() {
+        return delegate.filter();
     }
 
     public String getId() {
@@ -212,10 +212,6 @@ public abstract class DecoratingFeatureTypeInfo extends AbstractDecorator<Featur
         delegate.setEnabled(enabled);
     }
 
-    public void setFilter(Filter filter) {
-        delegate.setFilter(filter);
-    }
-
     public void setLatLonBoundingBox(ReferencedEnvelope box) {
         delegate.setLatLonBoundingBox(box);
     }
@@ -322,4 +318,15 @@ public abstract class DecoratingFeatureTypeInfo extends AbstractDecorator<Featur
     public void setCircularArcPresent(boolean enabled) {
     	delegate.setCircularArcPresent(enabled);
     }
+    
+    @Override
+    public String getCqlFilter() {
+        return delegate.getCqlFilter();
+    }
+
+    @Override
+    public void setCqlFilter(String cqlFilter) {
+        delegate.setCqlFilter(cqlFilter);
+    }
+
 }

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.html
@@ -47,8 +47,12 @@
     </ul>
     </fieldset>
     </div>
-    </wicket:fragment>
+    </wicket:fragment>    
     <div wicket:id="reloadWarningDialog"></div>
+        
+    <label for="cqlFilter"><wicket:message key="cqlFilter">cqlFilter</wicket:message></label>
+    <textarea wicket:id="cqlFilter" style="margin-bottom:10px" class="field textarea" cols="40" rows="10"></textarea>
+    
 </wicket:panel>
 </body>
 </html>

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,11 +6,15 @@
 package org.geoserver.web.data.resource;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.beanutils.BeanToPropertyValueTransformer;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -21,6 +25,7 @@ import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.link.Link;
 import org.apache.wicket.markup.html.list.ListItem;
@@ -29,6 +34,9 @@ import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -39,10 +47,14 @@ import org.geoserver.web.data.layer.SQLViewEditPage;
 import org.geoserver.web.wicket.GeoServerAjaxFormLink;
 import org.geoserver.web.wicket.ParamResourceModel;
 import org.geotools.data.wfs.internal.v2_0.storedquery.StoredQueryConfiguration;
+import org.geotools.filter.FilterAttributeExtractor;
+import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.jdbc.VirtualTable;
 import org.geotools.measure.Measure;
 import org.geotools.util.logging.Logging;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.filter.Filter;
 
 @SuppressWarnings("serial")
 public class FeatureResourceConfigurationPanel extends ResourceConfigurationPanel {
@@ -105,6 +117,10 @@ public class FeatureResourceConfigurationPanel extends ResourceConfigurationPane
             
         };
         attributePanel.add(attributes);
+        
+        TextArea<String> cqlFilter = new TextArea<String>("cqlFilter");
+        cqlFilter.add(new CqlFilterValidator(model));
+        add(cqlFilter);
         
         // reload links
         WebMarkupContainer reloadContainer = new WebMarkupContainer("reloadContainer");
@@ -186,6 +202,62 @@ public class FeatureResourceConfigurationPanel extends ResourceConfigurationPane
     static class ReloadWarningDialog extends WebPage {
         public ReloadWarningDialog(StringResourceModel message) {
             add(new Label("message", message));
+        }
+    }
+ 
+    /*
+     * Wicket validator to check CQL filter string
+     */
+    private class CqlFilterValidator implements IValidator<String> {
+
+        private FeatureTypeInfo typeInfo;
+
+        public CqlFilterValidator(IModel model) {
+            this.typeInfo = (FeatureTypeInfo) model.getObject();
+        }
+
+        @Override
+        public void validate(IValidatable<String> validatable) {
+            try {
+                validateCqlFilter(typeInfo, validatable.getValue());
+            } catch (Exception e) {
+                ValidationError error = new ValidationError();
+                error.setMessage(e.getMessage());
+                validatable.error(error);
+            }
+
+        }
+
+    }
+
+    /*
+     * Validate that CQL filter syntax is valid, and attribute names used in the CQL filter are actually part of the layer
+     */
+    private void validateCqlFilter(FeatureTypeInfo typeInfo,
+            String cqlFilterString) throws Exception {
+        Filter cqlFilter = null;
+        if (cqlFilterString != null && !cqlFilterString.isEmpty()) {
+            cqlFilter = ECQL.toFilter(cqlFilterString);
+            FeatureType ft = typeInfo.getFeatureType();
+            if (ft instanceof SimpleFeatureType) {
+
+                SimpleFeatureType sft = (SimpleFeatureType) ft;
+                BeanToPropertyValueTransformer transformer = new BeanToPropertyValueTransformer(
+                        "localName");
+                Collection<String> featureAttributesNames = CollectionUtils.collect(
+                        sft.getAttributeDescriptors(), transformer);
+
+                FilterAttributeExtractor filterAttriubtes = new FilterAttributeExtractor(null);
+                cqlFilter.accept(filterAttriubtes, null);
+                Set<String> filterAttributesNames = filterAttriubtes.getAttributeNameSet();
+                for (String filterAttributeName : filterAttributesNames) {
+                    if (!featureAttributesNames.contains(filterAttributeName)) {
+                        throw new ResourceConfigurationException(
+                                ResourceConfigurationException.CQL_ATTRIBUTE_NAME_NOT_FOUND_$1,
+                                new Object[] { filterAttributeName });
+                    }
+                }
+            }
         }
     }
     

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.java
@@ -61,6 +61,10 @@ public class FeatureResourceConfigurationPanel extends ResourceConfigurationPane
     static final Logger LOGGER = Logging.getLogger(FeatureResourceConfigurationPanel.class);
 
     ModalWindow reloadWarningDialog;
+
+    ListView attributes;
+
+    private Fragment attributePanel;
     
     public FeatureResourceConfigurationPanel(String id, final IModel model) {
         super(id, model);
@@ -71,7 +75,7 @@ public class FeatureResourceConfigurationPanel extends ResourceConfigurationPane
         TextField<Measure> tolerance = new TextField<Measure>("linearizationTolerance", Measure.class);
         add(tolerance);
 
-        final Fragment attributePanel = new Fragment("attributePanel", "attributePanelFragment", this);
+        attributePanel = new Fragment("attributePanel", "attributePanelFragment", this);
         attributePanel.setOutputMarkupId(true);
         add(attributePanel);
         
@@ -81,7 +85,7 @@ public class FeatureResourceConfigurationPanel extends ResourceConfigurationPane
         // to the ResourcePoool
         
         // just use the direct attributes, this is not editable atm
-        ListView attributes = new ListView("attributes", new AttributeListModel()) {
+        attributes = new ListView("attributes", new AttributeListModel()) {
             @Override
             protected void populateItem(ListItem item) {
                 
@@ -199,6 +203,11 @@ public class FeatureResourceConfigurationPanel extends ResourceConfigurationPane
         cascadedStoredQueryContainer.setVisible(typeInfo.getMetadata().get(FeatureTypeInfo.STORED_QUERY_CONFIGURATION, StoredQueryConfiguration.class) != null);
     }
     
+    @Override
+    public void resourceUpdated(AjaxRequestTarget target) {
+        target.addComponent(attributePanel);
+    }
+
     static class ReloadWarningDialog extends WebPage {
         public ReloadWarningDialog(StringResourceModel message) {
             add(new Label("message", message));

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationException.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationException.java
@@ -1,0 +1,25 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.web.data.resource;
+
+import org.geoserver.platform.exception.GeoServerException;
+
+/**
+ * Base class for exceptions used for validation errors in resource configuration 
+ * 
+ */
+
+public class ResourceConfigurationException extends GeoServerException {
+
+    public static final String CQL_ATTRIBUTE_NAME_NOT_FOUND_$1 = "CQL_ATTRIBUTE_NAME_NOT_FOUND";
+
+    public ResourceConfigurationException(String id, Object[] args) {
+        super(id);
+        setId(id);
+        setArgs(args);
+    } 
+
+}

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 import org.apache.wicket.Component;
 import org.apache.wicket.PageParameters;
 import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
 import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
@@ -38,7 +39,6 @@ import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.web.ComponentAuthorizer;
-import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.GeoServerSecuredPage;
 import org.geoserver.web.data.layer.LayerPage;
 import org.geoserver.web.publish.LayerConfigurationPanel;
@@ -391,7 +391,7 @@ public class ResourceConfigurationPage extends GeoServerSecuredPage {
         }
 
         protected ListView createList(String id) {
-            List dataPanels = filterResourcePanels(((GeoServerApplication) getGeoServerApplication())
+            List dataPanels = filterResourcePanels(getGeoServerApplication()
                     .getBeansOfType(ResourceConfigurationPanelInfo.class));
             ListView dataPanelList = new ListView(id, dataPanels) {
                 @Override
@@ -426,7 +426,7 @@ public class ResourceConfigurationPage extends GeoServerSecuredPage {
 
         @Override
         public ListView createList(String id) {
-            List pubPanels = filterLayerPanels(((GeoServerApplication) getGeoServerApplication())
+            List pubPanels = filterLayerPanels(getGeoServerApplication()
                     .getBeansOfType(LayerConfigurationPanelInfo.class));
             ListView pubPanelList = new ListView(id, pubPanels) {
                 @Override
@@ -485,9 +485,33 @@ public class ResourceConfigurationPage extends GeoServerSecuredPage {
      * Allows collaborating pages to update the resource info object
      * 
      * @param info
+     * @param target
      */
     public void updateResource(ResourceInfo info) {
+        updateResource(info, null);
+    }
+
+    /**
+     * Allows collaborating pages to update the resource info object
+     * 
+     * @param info
+     * @param target
+     */
+    public void updateResource(ResourceInfo info, final AjaxRequestTarget target) {
         myResourceModel.setObject(info);
+        visitChildren(new IVisitor<Component>() {
+
+            @Override
+            public Object component(Component component) {
+                if (component instanceof ResourceConfigurationPanel) {
+                    ResourceConfigurationPanel rcp = (ResourceConfigurationPanel) component;
+                    rcp.resourceUpdated(target);
+                    return IVisitor.CONTINUE_TRAVERSAL_BUT_DONT_GO_DEEPER;
+                }
+                return IVisitor.CONTINUE_TRAVERSAL;
+            }
+        });
+
     }
 
     /**

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -7,6 +7,7 @@ package org.geoserver.web.data.resource;
 
 import java.util.logging.Logger;
 
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
@@ -34,4 +35,14 @@ public class ResourceConfigurationPanel extends Panel {
 	public ResourceInfo getResourceInfo(){
 		return (ResourceInfo)getDefaultModelObject();
 	}
+
+    /**
+     * Called when the resource gets updated in the main page. The ajax request target might be null
+     * in case there is none.
+     *
+     * @param target
+     */
+    public void resourceUpdated(AjaxRequestTarget target) {
+        // nothing to do;
+    }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -101,10 +101,9 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
             for (Param p : dsParams) {
                 ParamInfo paramInfo = new ParamInfo(p);
                 // hide the repository params, the resource pool will inject it transparently
-                if(!Repository.class.equals(paramInfo.getBinding())) {
+                if (!Repository.class.equals(paramInfo.getBinding())) {
                     paramsMetadata.put(p.key, paramInfo);
-                    if (isNew) {
-                        // set default value
+                    if (isNew && !p.isDeprecated()) {
                         applyParamDefault(paramInfo, info);
                     }
                 }
@@ -152,6 +151,7 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
         final String paramName = paramMetadata.getName();
         final String paramLabel = paramMetadata.getName();
         final boolean required = paramMetadata.isRequired();
+        final boolean deprecated = paramMetadata.isDeprecated();
         final Class<?> binding = paramMetadata.getBinding();
         final List<Serializable> options = paramMetadata.getOptions();
 
@@ -215,10 +215,26 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
             }
             parameterPanel = tp;
         }
+        
+        Object parameterValue = parameterPanel.getDefaultModelObject();
+        boolean visible = !(deprecated && isEmpty(parameterValue));
+        parameterPanel.setVisible(visible);
+        parameterPanel.setVisibilityAllowed(visible);
+        
         return parameterPanel;
     }   
 
     
+
+    private boolean isEmpty(Object value) {
+        if (value == null) {
+            return true;
+        } else if (value instanceof String) {
+            return ((String) value).isEmpty();
+        } else {
+            return false;
+        }
+    }
 
     /**
      * Makes sure the file path for shapefiles do start with file:// otherwise

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/ParamInfo.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/ParamInfo.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -36,6 +36,8 @@ public class ParamInfo implements Serializable {
     private Class<?> binding;
 
     private boolean required;
+    
+    private boolean deprecated;
 
     private Serializable value;
     
@@ -44,15 +46,17 @@ public class ParamInfo implements Serializable {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public ParamInfo(Param param) {
         this.name = param.key;
+        this.deprecated = param.isDeprecated();
         // the "short" Param constructor sets the title equal to the key, that's not
         // very useful, use the description in that case instead
         this.title = param.title != null && !param.title.toString().equals(param.key) ? param.title
                 .toString() : param.getDescription().toString();
         this.password = param.isPassword();
         this.largeText = param.metadata != null && Boolean.TRUE.equals(param.metadata.get(Param.IS_LARGE_TEXT));
+        Object defaultValue = this.deprecated ? null : param.sample;
         if (Serializable.class.isAssignableFrom(param.type)) {
             this.binding = param.type;
-            this.value = (Serializable) param.sample;
+            this.value = (Serializable) defaultValue;
         } else if (Repository.class.equals(param.type)) {
                 this.binding = param.type;
                 this.value = null;
@@ -60,7 +64,7 @@ public class ParamInfo implements Serializable {
             // handle the parameter as a string and let the DataStoreFactory
             // convert it to the appropriate type
             this.binding = String.class;
-            this.value = param.sample == null ? null : String.valueOf(param.sample);
+            this.value = defaultValue == null ? null : String.valueOf(defaultValue);
         }
         this.required = param.required;
         if (param.metadata != null) {
@@ -111,5 +115,13 @@ public class ParamInfo implements Serializable {
 
     public boolean isRequired() {
         return required;
+    }
+    
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+    
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
     }
 }

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -188,6 +188,7 @@ PointPanel.y  = y
 FeatureResourceConfigurationPanel.curves = Curved geometries control
 FeatureResourceConfigurationPanel.linestrings-are-curves = Linear geometries can contain circular arcs
 FeatureResourceConfigurationPanel.tolerance = Linearization tolerance (useful only if your data contains curved geometries)
+FeatureResourceConfigurationPanel.cqlFilter =  Restrict the features on layer by CQL filter
 FeatureResourceConfigurationPanel.featureTypeDetails = Feature Type Details
 FeatureResourceConfigurationPanel.minMaxOccurences   = Min/Max Occurences
 FeatureResourceConfigurationPanel.nillable           = Nillable

--- a/src/web/core/src/main/resources/GeoServerException.properties
+++ b/src/web/core/src/main/resources/GeoServerException.properties
@@ -1,0 +1,1 @@
+ResourceConfigurationException.CQL_ATTRIBUTE_NAME_NOT_FOUND = Error on CQL filter: the attribute with name {0} does not exist

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -8,6 +8,7 @@ package org.geoserver.wfs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -15,14 +16,19 @@ import java.util.Collections;
 
 import javax.xml.namespace.QName;
 
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wfs.json.JSONType;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -338,6 +344,31 @@ public class GetFeatureTest extends WFSTestSupport {
         XMLAssert.assertXpathEvaluatesTo("InvalidParameterValue", "//ogc:ServiceException/@code",
                 doc);
         XMLAssert.assertXpathEvaluatesTo("typeName", "//ogc:ServiceException/@locator", doc);
+    }
+    
+    /**
+     * Tests CQL filter
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCQLFilter() throws Exception {
+        String layer = getLayerId(MockData.FORESTS);
+
+        String request = "wfs?request=GetFeature&typename=" + layer + "&version=1.0.0&service=wfs";
+        Document doc = getAsDOM(request);
+        NodeList featureMembers = doc.getElementsByTagName("gml:featureMember");
+        assertTrue(featureMembers.getLength() > 0);
+
+        // Add CQL filter
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName(layer);
+        info.setCqlFilter("NAME LIKE 'Red%'");
+        getCatalog().save(info);
+
+        doc = getAsDOM(request);
+        featureMembers = doc.getElementsByTagName("gml:featureMember");
+        assertTrue(featureMembers.getLength() == 0);
+
     }
 
 }

--- a/src/wms/src/main/java/org/geoserver/wms/GetMap.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMap.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -667,7 +667,7 @@ public class GetMap {
             if (layer.getType() == MapLayerInfo.TYPE_REMOTE_VECTOR || layer.getType() == MapLayerInfo.TYPE_RASTER) {
                 combinedList[i] = userRequestedFilter;
             } else if (layer.getType() == MapLayerInfo.TYPE_VECTOR) {
-                layerDefinitionFilter = layer.getFeature().getFilter();
+                layerDefinitionFilter = layer.getFeature().filter();
 
                 // heck, how I wish we use the null objects more
                 if (layerDefinitionFilter == null) {


### PR DESCRIPTION
This one packs the work needed to deprecate the field strategy in the SOLR store in 3 separate commits, in particular, handling deprecacted store config fields, exposing the CQL filter, and updating the SORL configurations so that it can effectively replublish the same "root" layer over and over with different configurations (sql view like).

CQL filtering wise, we followed the advices on the list, and avoided parsing and generating the CQL from a Filter object representation, but storing the CQL instead and parsing it as needed.