### PR TITLE
[GEOS-7095] Fix for exploitable bypass for XXE fix

### DIFF
--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
@@ -102,7 +102,7 @@ public class ExecuteTest extends WPSTestSupport {
         String xml =  
           "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" +
           "<!DOCTYPE foo [<!ELEMENT foo ANY >\n" + 
-          "  <!ENTITY xxe SYSTEM \"file:///file/not/there\" >]>\n" +
+          "  <!ENTITY xxe SYSTEM \"file:///file/not/there?.xsd\" >]>\n" +
           "<wps:Execute service='WPS' version='1.0.0' xmlns:wps='http://www.opengis.net/wps/1.0.0' " + 
               "xmlns:ows='http://www.opengis.net/ows/1.1'>" + 
             "<ows:Identifier>JTS:buffer</ows:Identifier>" + 

--- a/src/main/src/main/java/org/geoserver/util/NoExternalEntityResolver.java
+++ b/src/main/src/main/java/org/geoserver/util/NoExternalEntityResolver.java
@@ -34,8 +34,8 @@ public class NoExternalEntityResolver implements EntityResolver {
             LOGGER.finest("resolveEntity request: publicId=" + publicId + ", systemId=" + systemId);
         }
         
-        // allow schema parsing for validation
-        if (systemId != null && systemId.endsWith(".xsd")) {
+        // allow schema parsing for validation (jar or external only)
+        if (systemId != null && systemId.endsWith(".xsd") && !systemId.startsWith("file")) {
             return null;
         }
         

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -330,7 +330,7 @@ public class GetCoverageTest extends WCSTestSupport {
                 + "            version CDATA #FIXED \"1.0.0\"\n" 
                 + "            xmlns CDATA #FIXED \"http://www.opengis.net/wcs\">\n"
                 + "  <!ELEMENT sourceCoverage (#PCDATA) >\n"
-                + "  <!ENTITY xxe SYSTEM \"file:///file/not/there\" >]>\n"
+                + "  <!ENTITY xxe SYSTEM \"file:///file/not/there?.xsd\" >]>\n"
                 + "<GetCoverage version=\"1.0.0\" service=\"WCS\""
                 + " xmlns=\"http://www.opengis.net/wcs\" >\n"
                 + "  <sourceCoverage>&xxe;</sourceCoverage>\n" 

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -478,7 +478,7 @@ public class GetCoverageTest extends AbstractGetCoverageTest {
                 + "            xmlns:ows CDATA #FIXED \"http://www.opengis.net/ows/1.1\"\n"
                 + "            xmlns:wcs CDATA #FIXED \"http://www.opengis.net/wcs/1.1.1\">\n"
                 + "  <!ELEMENT ows:Identifier (#PCDATA) >\n"
-                + "  <!ENTITY xxe SYSTEM \"file:///file/not/there\" >]>\n"
+                + "  <!ENTITY xxe SYSTEM \"file:///file/not/there?.xsd\" >]>\n"
                 + "  <wcs:GetCoverage service=\"WCS\" version=\"1.1.1\" "
                 + "                   xmlns:ows=\"http://www.opengis.net/ows/1.1\"\n"
                 + "                   xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\">\n"

--- a/src/wcs2_0/src/test/resources/testDescribeCoverageEntityExpansion.xml
+++ b/src/wcs2_0/src/test/resources/testDescribeCoverageEntityExpansion.xml
@@ -6,7 +6,7 @@
             version CDATA #FIXED "2.0.1"
             xmlns:wcs CDATA #FIXED "http://www.opengis.net/wcs/2.0">
   <!ELEMENT wcs:CoverageId (#PCDATA)>
-  <!ENTITY xxe SYSTEM "file:///file/not/there.txt" >]>
+  <!ENTITY xxe SYSTEM "file:///file/not/there?.xsd" >]>
 <wcs:DescribeCoverage 
 	xmlns:wcs='http://www.opengis.net/wcs/2.0' 
 	service="WCS" 

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/WFS.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/WFS.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -299,7 +299,7 @@ public class WFS extends XSD {
      * Returns the location of 'wfs.xsd'
      */
     public String getSchemaLocation() {
-        return getClass().getResource( "wfs.xsd" ).toString();
+        return org.geotools.wfs.v1_1.WFS.class.getResource( "wfs.xsd" ).toString();
     }
     
     /**

--- a/src/wfs/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
@@ -25,7 +25,7 @@ public class ExternalEntitiesTest extends WFSTestSupport {
 
     private static final String WFS_1_0_0_REQUEST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + 
     		"<!DOCTYPE wfs:GetFeature [\r\n" + 
-    		"<!ENTITY c SYSTEM \"file:///this/file/does/not/exist\">\r\n" + 
+    		"<!ENTITY c SYSTEM \"file:///this/file/does/not/exist?.xsd\">\r\n" + 
     		"]>\r\n" + 
     		"<wfs:GetFeature service=\"WFS\" version=\"1.0.0\" \r\n" + 
     		"  outputFormat=\"GML2\"\r\n" + 
@@ -63,7 +63,7 @@ public class ExternalEntitiesTest extends WFSTestSupport {
     		"<!ELEMENT ogc:FeatureId EMPTY>\r\n" + 
     		"<!ATTLIST ogc:FeatureId fid CDATA #FIXED \"states.3\">\r\n" + 
     		"\r\n" + 
-    		"<!ENTITY passwd  SYSTEM \"file:///this/file/does/not/exist\">]>\r\n" + 
+    		"<!ENTITY passwd  SYSTEM \"file:///this/file/does/not/exist?.xsd\">]>\r\n" + 
     		"<wfs:GetFeature service=\"WFS\" version=\"1.1.0\" \r\n" + 
     		"  xmlns:wfs=\"http://www.opengis.net/wfs\"\r\n" + 
     		"  xmlns:ogc=\"http://www.opengis.net/ogc\">\r\n" + 
@@ -92,7 +92,7 @@ public class ExternalEntitiesTest extends WFSTestSupport {
     		"<!ELEMENT fes:ResourceId EMPTY>\r\n" + 
     		"<!ATTLIST fes:ResourceId rid CDATA #FIXED \"states.3\">\r\n" + 
     		"\r\n" + 
-    		"<!ENTITY passwd  SYSTEM \"file:///thisfiledoesnotexist\">\r\n" + 
+    		"<!ENTITY passwd  SYSTEM \"file:///thisfiledoesnotexist?.xsd\">\r\n" + 
     		"]>\r\n" + 
     		"<wfs:GetFeature service=\"WFS\" version=\"2.0.0\" outputFormat=\"application/gml+xml; version=3.2\"\r\n" + 
     		"        xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"\r\n" + 


### PR DESCRIPTION
In order to get the test cases to pass, WFS 1.1 uses the wfs.xsd from geotools (This is because maven/eclipse will use `file:` paths for resources in the current module, instead of the `jar:` paths used when the module is packaged).
Depends on https://github.com/geoserver/geoserver/pull/1129 to pass tests.