### PR TITLE
[GEOS-7102] Importer support for non-JDBC databases

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
@@ -238,6 +238,19 @@ public class DataStoreFormat extends VectorFormat {
                 return db.getParameters();
             }
         }
+        
+        //try non-jdbc db
+        Database db = null;
+        if (data instanceof Database) {
+            db = (Database) data;
+        }
+        if (data instanceof Table) {
+            db = ((Table) data).getDatabase();
+        }
+        if (db != null) {
+            return db.getParameters();
+        }
+        
         return null;
     }
 


### PR DESCRIPTION
Add support for non-JDBC databases to GeoServer Importer.

No test case, because the only example of such a database I know of is the gt-mongodb extension, an unsupported geotools module. The fact that it passes the pre-existing test cases should be sufficient.
Manual tests appeared to work fine.
