### PR TITLE
[GEOS-7098] Improve getStoreByName null handling

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/Catalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Catalog.java
@@ -1547,7 +1547,7 @@ public interface Catalog extends CatalogInfo {
     /**
      * Returns a workspace by name, or <code>null</code> if no such workspace
      * exists.
-     * @param The name of the store, or null or {@link #DEFAULT} to get the default workspace
+     * @param The name of the store, or {@code null} or {@link #DEFAULT} to get the default workspace
      */
     WorkspaceInfo getWorkspaceByName( String name );
 

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -241,8 +241,8 @@ public class CatalogImpl implements Catalog {
             ws = getDefaultWorkspace();
         }
         
-        if(DataStoreInfo.class == clazz && (name == null || name.equals(Catalog.DEFAULT))) {
-            return (T) getDefaultDataStore(workspace);
+        if(clazz != null && clazz.isAssignableFrom(DataStoreInfo.class) && (name == null || name.equals(Catalog.DEFAULT))) {
+            return (T)getDefaultDataStore(workspace);
         }
         
         T store = facade.getStoreByName(ws, name, clazz);
@@ -254,9 +254,6 @@ public class CatalogImpl implements Catalog {
 
     public <T extends StoreInfo> T getStoreByName(String workspaceName,
            String name, Class<T> clazz) {
-        if (workspaceName == null) {
-            return getStoreByName((WorkspaceInfo)null, name, clazz);
-        }
         
         WorkspaceInfo workspace = getWorkspaceByName(workspaceName);
         if (workspace != null) {

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -35,6 +35,7 @@ import org.geoserver.catalog.MetadataMap;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.Predicates;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
@@ -712,6 +713,41 @@ public class CatalogImplTest {
         assertNotNull(ds5);
         assertFalse( ds == ds5 );
         assertEquals( ds, ds5 );
+    }
+    
+    @Test
+    public void testGetStoreByName() {
+        addDataStore();
+        
+        StoreInfo ds2 = catalog.getStoreByName(ds.getName(), StoreInfo.class);
+        assertNotNull(ds2);
+        assertFalse( ds == ds2 );
+        assertEquals( ds, ds2 );
+        
+        StoreInfo ds3 = catalog.getStoreByName(ws, null, StoreInfo.class);
+        assertNotNull(ds3);
+        assertFalse( ds == ds3 );
+        assertEquals( ds, ds3 );
+        
+        StoreInfo ds4 = catalog.getStoreByName(ws, Catalog.DEFAULT, StoreInfo.class);
+        assertNotNull(ds4);
+        assertFalse( ds == ds4 );
+        assertEquals( ds, ds4 );
+        
+        StoreInfo ds5 = catalog.getStoreByName(Catalog.DEFAULT, Catalog.DEFAULT, StoreInfo.class);
+        assertNotNull(ds5);
+        assertFalse( ds == ds5 );
+        assertEquals( ds, ds5 );
+        
+        StoreInfo ds6 = catalog.getStoreByName((String)null, null, StoreInfo.class);
+        assertNotNull(ds6);
+        assertFalse( ds == ds6 );
+        assertEquals( ds, ds3 );
+        
+        StoreInfo ds7 = catalog.getStoreByName(Catalog.DEFAULT, Catalog.DEFAULT, StoreInfo.class);
+        assertNotNull(ds7);
+        assertFalse( ds == ds7 );
+        assertEquals( ds6, ds7 );
     }
     
     @Test


### PR DESCRIPTION
This fixes most of GEOS-7098; as long as there is a default store that matches the argument class, it will get returned. Default workspaces for getStoreByName have also been fixed.
Becuase CoverageStore and WMSStore do not support default store behavior, the behavior when trying to get the default stores of these classes is undefined.