### PR TITLE
Case insensitive XXE fix (whitelist)

### DIFF
--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
@@ -102,7 +102,7 @@ public class ExecuteTest extends WPSTestSupport {
         String xml =  
           "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" +
           "<!DOCTYPE foo [<!ELEMENT foo ANY >\n" + 
-          "  <!ENTITY xxe SYSTEM \"file:///file/not/there?.xsd\" >]>\n" +
+          "  <!ENTITY xxe SYSTEM \"FILE:///file/not/there?.XSD\" >]>\n" +
           "<wps:Execute service='WPS' version='1.0.0' xmlns:wps='http://www.opengis.net/wps/1.0.0' " + 
               "xmlns:ows='http://www.opengis.net/ows/1.1'>" + 
             "<ows:Identifier>JTS:buffer</ows:Identifier>" + 

--- a/src/main/src/main/java/org/geoserver/util/NoExternalEntityResolver.java
+++ b/src/main/src/main/java/org/geoserver/util/NoExternalEntityResolver.java
@@ -35,7 +35,7 @@ public class NoExternalEntityResolver implements EntityResolver {
         }
         
         // allow schema parsing for validation (jar or external only)
-        if (systemId != null && systemId.endsWith(".xsd") && !systemId.startsWith("file")) {
+        if (systemId != null && systemId.matches("^(?i)(jar:file|http).*\\.xsd$")) {
             return null;
         }
         

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -330,7 +330,7 @@ public class GetCoverageTest extends WCSTestSupport {
                 + "            version CDATA #FIXED \"1.0.0\"\n" 
                 + "            xmlns CDATA #FIXED \"http://www.opengis.net/wcs\">\n"
                 + "  <!ELEMENT sourceCoverage (#PCDATA) >\n"
-                + "  <!ENTITY xxe SYSTEM \"file:///file/not/there?.xsd\" >]>\n"
+                + "  <!ENTITY xxe SYSTEM \"FILE:///file/not/there?.XSD\" >]>\n"
                 + "<GetCoverage version=\"1.0.0\" service=\"WCS\""
                 + " xmlns=\"http://www.opengis.net/wcs\" >\n"
                 + "  <sourceCoverage>&xxe;</sourceCoverage>\n" 

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -478,7 +478,7 @@ public class GetCoverageTest extends AbstractGetCoverageTest {
                 + "            xmlns:ows CDATA #FIXED \"http://www.opengis.net/ows/1.1\"\n"
                 + "            xmlns:wcs CDATA #FIXED \"http://www.opengis.net/wcs/1.1.1\">\n"
                 + "  <!ELEMENT ows:Identifier (#PCDATA) >\n"
-                + "  <!ENTITY xxe SYSTEM \"file:///file/not/there?.xsd\" >]>\n"
+                + "  <!ENTITY xxe SYSTEM \"FILE:///file/not/there?.XSD\" >]>\n"
                 + "  <wcs:GetCoverage service=\"WCS\" version=\"1.1.1\" "
                 + "                   xmlns:ows=\"http://www.opengis.net/ows/1.1\"\n"
                 + "                   xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\">\n"

--- a/src/wfs/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
@@ -25,7 +25,7 @@ public class ExternalEntitiesTest extends WFSTestSupport {
 
     private static final String WFS_1_0_0_REQUEST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + 
     		"<!DOCTYPE wfs:GetFeature [\r\n" + 
-    		"<!ENTITY c SYSTEM \"file:///this/file/does/not/exist?.xsd\">\r\n" + 
+    		"<!ENTITY c SYSTEM \"FILE:///this/file/does/not/exist?.XSD\">\r\n" + 
     		"]>\r\n" + 
     		"<wfs:GetFeature service=\"WFS\" version=\"1.0.0\" \r\n" + 
     		"  outputFormat=\"GML2\"\r\n" + 
@@ -63,7 +63,7 @@ public class ExternalEntitiesTest extends WFSTestSupport {
     		"<!ELEMENT ogc:FeatureId EMPTY>\r\n" + 
     		"<!ATTLIST ogc:FeatureId fid CDATA #FIXED \"states.3\">\r\n" + 
     		"\r\n" + 
-    		"<!ENTITY passwd  SYSTEM \"file:///this/file/does/not/exist?.xsd\">]>\r\n" + 
+    		"<!ENTITY passwd  SYSTEM \"FILE:///this/file/does/not/exist?.XSD\">]>\r\n" + 
     		"<wfs:GetFeature service=\"WFS\" version=\"1.1.0\" \r\n" + 
     		"  xmlns:wfs=\"http://www.opengis.net/wfs\"\r\n" + 
     		"  xmlns:ogc=\"http://www.opengis.net/ogc\">\r\n" + 
@@ -92,7 +92,7 @@ public class ExternalEntitiesTest extends WFSTestSupport {
     		"<!ELEMENT fes:ResourceId EMPTY>\r\n" + 
     		"<!ATTLIST fes:ResourceId rid CDATA #FIXED \"states.3\">\r\n" + 
     		"\r\n" + 
-    		"<!ENTITY passwd  SYSTEM \"file:///thisfiledoesnotexist?.xsd\">\r\n" + 
+    		"<!ENTITY passwd  SYSTEM \"FILE:///thisfiledoesnotexist?.XSD\">\r\n" + 
     		"]>\r\n" + 
     		"<wfs:GetFeature service=\"WFS\" version=\"2.0.0\" outputFormat=\"application/gml+xml; version=3.2\"\r\n" + 
     		"        xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"\r\n" + 


### PR DESCRIPTION
Using a whitelist of `systemId.matches("^(?i)(jar:file|http).*\\.xsd$")` to test for valid schema URLs

Updated test cases with `FILE://` and `.XSD` in place of `file://` and `.xsd` to confirm case insensitivity.

Old blacklist approach, with case instensitive fix, here: https://github.com/geoserver/geoserver/compare/master...tbarsballe:xxe-blacklist