### PR TITLE
Hide WMS errors related to SLD lookup that can leak local network info

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -428,7 +428,89 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
             // System.out.println(e);
         }
     }
+    
+    public void testSldConnectionFailure() throws Exception {
+        // Connection for specified external SLD fails while retrieving SLD
+        HashMap kvp = new HashMap();
+        
+        URL url = new URL("http://hostthatdoesnotexist/");
+        
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("layers",
+                MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
+        kvp.put("styles", "ThisStyleDoesNotExists");
 
+        GetMapRequest request = (GetMapRequest) reader.createRequest();
+        try {
+            reader.setLaxStyleMatchAllowed(false);
+            request = (GetMapRequest) reader.read(request, parseKvp(kvp), caseInsensitiveKvp(kvp));
+            fail("The style looked up, 'ThisStyleDoesNotExists', should not have been found");
+        } catch (ServiceException e) {
+            assertTrue("Exception should not reveal its cause", e.getCause()==null);
+        }
+    }
+    public void testSldNotExist() throws Exception {
+        // Specified external SLD does not exist
+        HashMap kvp = new HashMap();
+        
+        URL url = new URL(GetMapKvpRequestReaderTest.class.getResource(""), "does-not-exist");
+        
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("layers",
+                MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
+        kvp.put("styles", "ThisStyleDoesNotExists");
+
+        GetMapRequest request = (GetMapRequest) reader.createRequest();
+        try {
+            reader.setLaxStyleMatchAllowed(false);
+            request = (GetMapRequest) reader.read(request, parseKvp(kvp), caseInsensitiveKvp(kvp));
+            fail("The style looked up, 'ThisStyleDoesNotExists', should not have been found");
+        } catch (ServiceException e) {
+            assertTrue("Exception should not reveal its cause", e.getCause()==null);
+        }
+    }
+    
+    public void testSldNotXML() throws Exception {
+        // Specified external SLD is not XML
+        HashMap kvp = new HashMap();
+        
+        URL url = GetMapKvpRequestReaderTest.class.getResource("paletted.tif");
+        
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("layers",
+                MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
+        kvp.put("styles", "ThisStyleDoesNotExists");
+
+        GetMapRequest request = (GetMapRequest) reader.createRequest();
+        try {
+            reader.setLaxStyleMatchAllowed(false);
+            request = (GetMapRequest) reader.read(request, parseKvp(kvp), caseInsensitiveKvp(kvp));
+            fail("The style looked up, 'ThisStyleDoesNotExists', should not have been found");
+        } catch (ServiceException e) {
+            assertTrue("Exception should not reveal its cause", e.getCause()==null);
+        }
+    }
+    public void testSldNotSld() throws Exception {
+        // Specified external SLD is XML that is not SLD
+        HashMap kvp = new HashMap();
+        
+        URL url = GetMapKvpRequestReaderTest.class.getResource("WMSPostLayerGroupNonDefaultStyle.xml");
+        
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("layers",
+                MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
+        kvp.put("styles", "ThisStyleDoesNotExists");
+
+        GetMapRequest request = (GetMapRequest) reader.createRequest();
+        try {
+            reader.setLaxStyleMatchAllowed(false);
+            request = (GetMapRequest) reader.read(request, parseKvp(kvp), caseInsensitiveKvp(kvp));
+            fail("The style looked up, 'ThisStyleDoesNotExists', should not have been found");
+        } catch (ServiceException e) {
+            assertTrue("Exception should not reveal its cause", e.getCause()==null);
+        }
+    }
+    
     public void testSldFeatureTypeConstraints() throws Exception {
         // no styles, no layer, the full definition is in the sld
         HashMap kvp = new HashMap();

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
@@ -961,7 +961,7 @@ public class GetMapIntegrationTest extends WMSTestSupport {
             // if the file is found, its content will be used to replace the entity
             // if the file is not found the parser will throw a FileNotFoundException
             String response = getAsString(url);            
-            assertTrue(response.indexOf("java.io.FileNotFoundException") > -1);
+            assertTrue(response.indexOf("Error while getting SLD.") > -1);
             
             // disable entities
             geoserverInfo.setXmlExternalEntitiesEnabled(false);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
@@ -369,7 +369,7 @@ public class GetMapIntegrationTest extends WMSTestSupport {
             // if the file is found, its content will be used to replace the entity
             // if the file is not found the parser will throw a FileNotFoundException
             String response = getAsString(url);            
-            assertTrue(response.indexOf("java.io.FileNotFoundException") > -1);
+            assertTrue(response.indexOf("Error while getting SLD.") > -1);
             
             // disable entities
             geoserverInfo.setXmlExternalEntitiesEnabled(false);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/WMSCascadeTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/WMSCascadeTest.java
@@ -6,7 +6,11 @@
 package org.geoserver.wms.wms_1_3;
 
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.custommonkey.xmlunit.NamespaceContext;
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.data.test.SystemTestData;
@@ -56,7 +60,15 @@ public class WMSCascadeTest extends WMSCascadeTestSupport {
     @Test
     public void testCascadeCapabilitiesClientNoGetFeatureInfo() throws Exception {
         Document dom = getAsDOM("wms?request=GetCapabilities&version=1.3.0&service=wms");
-        //print(dom);
+        print(dom);
+        
+        Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("wms", "http://www.opengis.net/wms");
+        namespaces.put("link", "http://www.w3.org/1999/xlink");
+        namespaces.put("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+        NamespaceContext newNsCtxt = new SimpleNamespaceContext(namespaces);
+        
+        xpath.setNamespaceContext(newNsCtxt);
         
         xpath.evaluate("//wms:Layer[name='" + WORLD4326_110_NFI + "']", dom);
     }


### PR DESCRIPTION
As discussed at PSC meeting.  Backports cleanly to 2.7 and 2.6.