### PR TITLE
[GEOS-7128] Catch/Log DispatcherCallback Exceptions on fireFinishedCallback

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -307,7 +307,11 @@ public class Dispatcher extends AbstractController {
 
     void fireFinishedCallback(Request req) {
         for ( DispatcherCallback cb : callbacks ) {
-            cb.finished( req );
+            try {
+                cb.finished( req );
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Error firing finished callback for "+cb.getClass(), e);
+            }
         }
     }
     

--- a/src/ows/src/test/java/org/geoserver/ows/TestDispatcherCallback.java
+++ b/src/ows/src/test/java/org/geoserver/ows/TestDispatcherCallback.java
@@ -1,0 +1,54 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows;
+
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.Service;
+import org.geoserver.platform.ServiceException;
+
+public class TestDispatcherCallback implements DispatcherCallback {
+    public enum Status {
+        INIT, SERVICE_DISPATCHED, OPERATION_DISPATCHED, OPERATION_EXECUTED, RESPONSE_DISPATCHED, FINISHED
+    }
+    
+    public ThreadLocal<Status> dispatcherStatus = new ThreadLocal<Status>();
+    
+    
+    @Override
+    public Request init(Request request) {
+        dispatcherStatus.set(Status.INIT);
+        return request;
+    }
+
+    @Override
+    public Service serviceDispatched(Request request, Service service) throws ServiceException {
+        dispatcherStatus.set(Status.SERVICE_DISPATCHED);
+        return service;
+    }
+
+    @Override
+    public Operation operationDispatched(Request request, Operation operation) {
+        dispatcherStatus.set(Status.OPERATION_DISPATCHED);
+        return operation;
+    }
+
+    @Override
+    public Object operationExecuted(Request request, Operation operation, Object result) {
+        dispatcherStatus.set(Status.OPERATION_EXECUTED);
+        return result;
+    }
+
+    @Override
+    public Response responseDispatched(Request request, Operation operation, Object result, Response response) {
+        dispatcherStatus.set(Status.RESPONSE_DISPATCHED);
+        return response;
+    }
+
+    @Override
+    public void finished(Request request) {
+        dispatcherStatus.set(Status.FINISHED);
+    }
+
+}


### PR DESCRIPTION
Fix for [GEOS-7128](https://osgeo-org.atlassian.net/browse/GEOS-7128), to ensure all callbacks are handled if an exception is thrown in fireFinishedCallback. The other callbacks (init, serviceDispatched, ...) will not catch exceptions, but in this case the exceptions are caught at a higher level, and returned as an <ows:Exception> response. However, for the finished() callback, the (valid) reponse has already been written, so we cannot return an Exception response, hence this fix.
Note that this means that if an exception is thrown from any fire___Callback other than fireFinishedCallback(), subsequent callbacks of that type will not be fired, and the request will terminate with an OWS Exception response. 

I have an alternate fix that catches and logs all exceptions fired by callbacks here: https://github.com/tbarsballe/geoserver/tree/callback-all (As it stands, this fails some OWS tests that expect an error response on a failing callback)
However, I think the current fix (this PR) is probably closer to what we want, since it actually reports the failures to the user where possible. My only concern is if there are callbacks other than finished that do important configuration/cleanup (the finished callbacks will be called even if we are returning an exception response).

I've added test cases for all the callbacks, just to make sure everything behaves as expected even when an error is thrown while handling callbacks.