### PR TITLE
[GEOS-7086] Backport to 2.6.x branch

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/NamespaceWorkspaceConsistencyListener.java
+++ b/src/main/src/main/java/org/geoserver/catalog/NamespaceWorkspaceConsistencyListener.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -124,9 +124,18 @@ public class NamespaceWorkspaceConsistencyListener implements CatalogListener {
         // ignore
     }
 
-
+    /**
+     * When a namespace is removed, makes sure the associated workspace is removed as well.
+     */
     public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
-        // ignore
+        if (event.getSource() instanceof NamespaceInfo) {
+            NamespaceInfo ns = (NamespaceInfo) event.getSource();
+
+            WorkspaceInfo ws = catalog.getWorkspaceByName(ns.getPrefix());
+            if(ws != null) {
+                catalog.remove(ws);
+            }
+        }
     }
 
     public void reloaded() {

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/NamespaceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/NamespaceTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -203,6 +203,8 @@ public class NamespaceTest extends CatalogRESTTestSupport {
         
         assertEquals( 200, deleteAsServletResponse( "/rest/namespaces/foo" ).getStatusCode() );
         assertEquals( 404, getAsServletResponse( "/rest/namespaces/foo.xml" ).getStatusCode() );
+        // verify associated workspace was deleted
+        assertEquals( 404, getAsServletResponse( "/rest/workspaces/foo.xml" ).getStatusCode() );
     }
     
     @Test


### PR DESCRIPTION
Makes sure when namespace is deleted via REST API, also associated workspace is deleted.