### PR TITLE
Removing dead maven repo.

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -88,20 +88,6 @@
    </repository>
  </repositories>
 
- <pluginRepositories>
-  <pluginRepository>
-   <id>codehaus-snapshot-plugins</id>
-   <name>codehaus-shapshot-plugins</name>
-   <url>http://snapshots.repository.codehaus.org/</url>
-   <snapshots>
-    <enabled>true</enabled>
-   </snapshots>
-   <releases>
-    <enabled>false</enabled>
-   </releases>
-  </pluginRepository>
- </pluginRepositories>
-
  <dependencyManagement>
   <dependencies>
    <dependency>


### PR DESCRIPTION
Codehaus has shutdown, this repository no longer exists.