### PR TITLE
[GEOS-7133] Community modules adding gdal_translate output formats to WCS/WPS

### DIFF
--- a/doc/en/user/source/community/gdal/index.rst
+++ b/doc/en/user/source/community/gdal/index.rst
@@ -1,0 +1,115 @@
+.. _gdal_wcs_output_format:
+
+GDAL based WCS Output Format
+============================
+
+The gdal_translate based output format leverages the availability of the gdal_translate command to allow the generation of more output formats than GeoServer can natively produce.
+The basic idea is to dump to the file system a file that gdal_translate can translate, invoke it, zip and return the output of the translation.
+
+This extension is thus the equivalent of the :ref:`OGR extension <ogr_extension>` for raster data. 
+
+
+Out of the box behaviour
+------------------------
+
+Out of the box the plugin assumes the following:
+
+* gdal_translate is available in the path
+* the GDAL_DATA variable is pointing to the GDAL data directory (which stores the spatial reference information for GDAL)
+
+In the default configuration the following formats are supported:
+
+* JPEG-2000 part 1 (ISO/IEC 15444-1)
+* Geospatial PDF
+* Arc/Info ASCII Grid
+* ASCII Gridded XYZ
+
+The list might be shorter if gdal_translate has not been built with support for the above formats (for example, the default JPEG-2000 format relies on the `JasPer-based GDAL driver <http://www.gdal.org/frmt_jpeg2000.html>`_).
+
+Once installed in GeoServer, a bunch of new supported formats will be listed in the ``ServiceMetadata`` section of the WCS 2.0 GetCapabilities document, e.g. ``image/jp2`` and ``application/pdf``.
+
+gdal_translate conversion abilities
+-----------------------------------
+
+The gdal_translate utility is usually able to convert more formats than the default setup of this output format allows for, but the exact list depends on how the utility was built from sources. To get a full list of the formats available by your ogr2ogr build just run::
+
+   gdal_translate --long-usage 
+
+and you'll get the full set of options usable by the program, along with the supported formats.
+
+.. include:: usage_example.rst
+
+The full list of formats that gdal_translate is able to support is available on the `GDAL site <http://www.gdal.org/formats_list.html>`_. Mind that this output format can handle only outputs that are file based and that do support creation. So, for example, you won't be able to use the PostGIS Raster output (since it's database based) or the Arc/Info Binary Grid (creation not supported).
+
+Customisation
+-------------
+
+If gdal_translate is not available in the default path, the GDAL_DATA environment variable is not set, or if the output formats needs tweaking, a ``gdal_translate.xml`` configuration file can be created to customize the output format. The file should be put inside a ``gdal`` folder in the root of the GeoServer data directory.
+
+.. note:: GeoServer will automatically detect any change to the file and reload the configuration, without a need to restart.
+
+
+The default configuration is equivalent to the following xml file:
+
+.. code-block:: xml
+
+   <ToolConfiguration>
+     <executable>gdal_translate</executable>
+     <environment>
+       <variable name="GDAL_DATA" value="/usr/local/share/gdal" />
+     </environment>
+     <formats>
+       <Format>
+         <toolFormat>JPEG2000</toolFormat>
+         <geoserverFormat>GDAL-JPEG2000</geoserverFormat>
+         <fileExtension>.jp2</fileExtension>
+         <singleFile>true</singleFile>
+         <mimeType>image/jp2</mimeType>
+         <type>binary</type> <!-- not really needed, it's the default -->
+	 <option>-co</option>
+	 <option>FORMAT=JP2</option>
+       </Format>
+       <Format>
+         <toolFormat>PDF</toolFormat>
+         <geoserverFormat>GDAL-PDF</geoserverFormat>
+         <fileExtension>.pdf</fileExtension>
+         <singleFile>true</singleFile>
+         <mimeType>application/pdf</mimeType>
+       </Format>
+       <Format>
+         <toolFormat>AAIGrid</toolFormat>
+         <geoserverFormat>GDAL-ArcInfoGrid</geoserverFormat>
+         <fileExtension>.asc</fileExtension>
+         <singleFile>false</singleFile>
+       </Format>
+       <Format>
+         <toolFormat>XYZ</toolFormat>
+         <geoserverFormat>GDAL-XYZ</geoserverFormat>
+         <fileExtension>.txt</fileExtension>
+         <singleFile>true</singleFile>
+         <mimeType>text/plain</mimeType>
+         <type>text</type>
+       </Format>
+     </formats>
+   </ToolConfiguration>
+
+The file showcases all possible usage of the configuration elements:
+
+*  ``executable`` can be just gdal_translate if the command is in the path, otherwise it should be the full path to the executable. For example, on a Linux box with a custom build GDAL library might be::
+
+      <executable>/usr/local/bin/gdal_translate</executable>
+
+*  ``environment`` contains a list of ``variable`` elements, which can be used to define environment variables that should be set prior to invoking gdal_translate. For example, to setup a GDAL_DATA environment variable pointing to the GDAL data directory, the configuration might be::
+
+      <environment>
+       <variable name="GDAL_DATA" value="/usr/local/share/gdal" />
+      </environment>
+
+*  ``Format`` defines a single format, which is defined by the following tags:
+
+          * ``toolFormat``: the name of the format to be passed to gdal_translate with the -of option (case insensitive).
+          * ``geoserverFormat``: is the name of the output format as advertised by GeoServer
+          * ``fileExtension``: is the extension of the file generated after the translation, if any (can be omitted)
+          * ``option``: can be used to add one or more options to the gdal_translate command line. As you can see by the JPEG2000 example, each item must be contained in its own ``option`` tag. You can get a full list of options by running ``gdal_translate --help`` or by visiting the `GDAL web site <http://www.gdal.org>`_). Also, consider that each format supports specific creation options, listed in the description page for each format (for example, here is the `JPEG2000 one <http://www.gdal.org/frmt_jpeg2000.html>`_).
+          * ``singleFile``: if true the output of the conversion is supposed to be a single file that can be streamed directly back without the need to wrap it into a zip file
+          * ``mimeType``: the mime type of the file returned when using ``singleFile``. If not specified ``application/octet-stream`` will be used as a default.

--- a/doc/en/user/source/community/gdal/usage_example.rst
+++ b/doc/en/user/source/community/gdal/usage_example.rst
@@ -1,0 +1,77 @@
+For example, the above produces the following output using gdal 1.11.2 compiled with libgeotiff 1.4.0, libpng 1.6,  libjpeg-turbo 1.3.1, libjasper 1.900.1 and libecwj2 3.3::
+
+   Usage: gdal_translate [--help-general] [--long-usage]
+       [-ot {Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/
+             CInt16/CInt32/CFloat32/CFloat64}] [-strict]
+       [-of format] [-b band] [-mask band] [-expand {gray|rgb|rgba}]
+       [-outsize xsize[%] ysize[%]]
+       [-unscale] [-scale[_bn] [src_min src_max [dst_min dst_max]]]* [-exponent[_bn] exp_val]*
+       [-srcwin xoff yoff xsize ysize] [-projwin ulx uly lrx lry] [-epo] [-eco]
+       [-a_srs srs_def] [-a_ullr ulx uly lrx lry] [-a_nodata value]
+       [-gcp pixel line easting northing [elevation]]*
+       [-mo "META-TAG=VALUE"]* [-q] [-sds]
+       [-co "NAME=VALUE"]* [-stats] [-norat]
+       src_dataset dst_dataset
+
+   GDAL 1.11.2, released 2015/02/10
+
+   The following format drivers are configured and support output:
+     VRT: Virtual Raster
+     GTiff: GeoTIFF
+     NITF: National Imagery Transmission Format
+     HFA: Erdas Imagine Images (.img)
+     ELAS: ELAS
+     AAIGrid: Arc/Info ASCII Grid
+     DTED: DTED Elevation Raster
+     PNG: Portable Network Graphics
+     JPEG: JPEG JFIF
+     MEM: In Memory Raster
+     GIF: Graphics Interchange Format (.gif)
+     XPM: X11 PixMap Format
+     BMP: MS Windows Device Independent Bitmap
+     PCIDSK: PCIDSK Database File
+     PCRaster: PCRaster Raster File
+     ILWIS: ILWIS Raster Map
+     SGI: SGI Image File Format 1.0
+     SRTMHGT: SRTMHGT File Format
+     Leveller: Leveller heightfield
+     Terragen: Terragen heightfield
+     ISIS2: USGS Astrogeology ISIS cube (Version 2)
+     ERS: ERMapper .ers Labelled
+     ECW: ERDAS Compressed Wavelets (SDK 3.x)
+     JP2ECW: ERDAS JPEG2000 (SDK 3.x)
+     FIT: FIT Image
+     JPEG2000: JPEG-2000 part 1 (ISO/IEC 15444-1)
+     RMF: Raster Matrix Format
+     RST: Idrisi Raster A.1
+     INGR: Intergraph Raster
+     GSAG: Golden Software ASCII Grid (.grd)
+     GSBG: Golden Software Binary Grid (.grd)
+     GS7BG: Golden Software 7 Binary Grid (.grd)
+     R: R Object Data Store
+     PNM: Portable Pixmap Format (netpbm)
+     ENVI: ENVI .hdr Labelled
+     EHdr: ESRI .hdr Labelled
+     PAux: PCI .aux Labelled
+     MFF: Vexcel MFF Raster
+     MFF2: Vexcel MFF2 (HKV) Raster
+     BT: VTP .bt (Binary Terrain) 1.3 Format
+     LAN: Erdas .LAN/.GIS
+     IDA: Image Data and Analysis
+     LCP: FARSITE v.4 Landscape File (.lcp)
+     GTX: NOAA Vertical Datum .GTX
+     NTv2: NTv2 Datum Grid Shift
+     CTable2: CTable2 Datum Grid Shift
+     KRO: KOLOR Raw
+     ARG: Azavea Raster Grid format
+     USGSDEM: USGS Optional ASCII DEM (and CDED)
+     ADRG: ARC Digitized Raster Graphics
+     BLX: Magellan topo (.blx)
+     Rasterlite: Rasterlite
+     PostGISRaster: PostGIS Raster driver
+     SAGA: SAGA GIS Binary Grid (.sdat)
+     KMLSUPEROVERLAY: Kml Super Overlay
+     XYZ: ASCII Gridded XYZ
+     HF2: HF2/HFZ heightfield raster
+     PDF: Geospatial PDF
+     ZMap: ZMap Plus Grid

--- a/doc/en/user/source/community/index.rst
+++ b/doc/en/user/source/community/index.rst
@@ -37,4 +37,4 @@ officially part of the GeoServer releases. They are however built along with the
    geomesa/index
    gwc-distributed/index
    geofence-server/index
-
+   gdal/index

--- a/src/community/gdal/gdal-wcs/pom.xml
+++ b/src/community/gdal/gdal-wcs/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Copyright (C) 2015 Open Source Geospatial Foundation. All rights reserved. 
+    This code is licensed under the GPL 2.0 license, available at the root application 
+    directory. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-gdal</artifactId>
+        <version>2.8-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.geoserver.community</groupId>
+    <artifactId>gs-gdal-wcs</artifactId>
+    <packaging>jar</packaging>
+    <name>GDAL translate WCS</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-ogr-core</artifactId>
+            <version>${gs.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-wcs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-wcs2_0</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-wcs2_0</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-main</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-ows</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mockrunner</groupId>
+            <artifactId>mockrunner</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/community/gdal/gdal-wcs/src/main/java/applicationContext.xml
+++ b/src/community/gdal/gdal-wcs/src/main/java/applicationContext.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2015 Open Source Geospatial Foundation. All rights
+    reserved. This code is licensed under the GPL 2.0 license, available at the
+    root application directory. -->
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+
+    <bean id="gdalWrapperFactory" class="org.geoserver.wcs.response.GdalWrapperFactory" />
+    <bean id="gdalCoverageResponseDelegate" class="org.geoserver.wcs.response.GdalCoverageResponseDelegate">
+        <constructor-arg ref="geoServer" />
+        <constructor-arg ref="gdalWrapperFactory" />
+    </bean>
+    <bean id="gdalConfigurator" class="org.geoserver.wcs.response.GdalConfigurator">
+        <constructor-arg>
+            <ref local="gdalCoverageResponseDelegate" />
+        </constructor-arg>
+        <constructor-arg ref="gdalWrapperFactory" />
+    </bean>
+
+</beans>

--- a/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalConfigurator.java
+++ b/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalConfigurator.java
@@ -1,0 +1,55 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.response;
+
+import java.util.HashMap;
+
+import org.geoserver.ogr.core.AbstractToolConfigurator;
+import org.geoserver.ogr.core.Format;
+import org.geoserver.ogr.core.FormatConverter;
+import org.geoserver.ogr.core.OutputType;
+import org.geoserver.ogr.core.ToolConfiguration;
+import org.geoserver.ogr.core.ToolWrapperFactory;
+
+/**
+ * Loads the gdal_translate.xml configuration file and configures the output format accordingly.
+ *
+ * <p>Also keeps tabs on the configuration file, reloading the file as needed.
+ * 
+ * @author Stefano Costa, GeoSolutions
+ *
+ */
+public class GdalConfigurator extends AbstractToolConfigurator {
+
+    public static final ToolConfiguration DEFAULT;
+    static {
+        // assume it's in the classpath and GDAL_DATA is properly set in the enviroment
+        // and add some default formats
+        DEFAULT = new ToolConfiguration(
+                "gdal_translate",
+                new HashMap<String, String>(),
+                new Format[] {
+                    new Format("JPEG2000", "GDAL-JPEG2000", ".jp2", true, "image/jp2"),
+                    new Format("PDF", "GDAL-PDF", ".pdf", true, "application/pdf"),
+                    new Format("AAIGrid", "GDAL-ArcInfoGrid", ".asc", false, null),
+                    new Format("XYZ", "GDAL-XYZ", ".txt", true, "text/plain", OutputType.TEXT)
+                });
+    }
+
+    public GdalConfigurator(FormatConverter format, ToolWrapperFactory wrapperFactory) {
+        super(format, wrapperFactory);
+    }
+
+    @Override
+    protected String getConfigurationFile() {
+        return "gdal/gdal_translate.xml";
+    }
+
+    @Override
+    protected ToolConfiguration getDefaultConfiguration() {
+        return DEFAULT;
+    }
+
+}

--- a/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalCoverageResponseDelegate.java
+++ b/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalCoverageResponseDelegate.java
@@ -1,0 +1,435 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.response;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.zip.ZipOutputStream;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.data.util.IOUtils;
+import org.geoserver.ogr.core.Format;
+import org.geoserver.ogr.core.FormatConverter;
+import org.geoserver.ogr.core.ToolWrapper;
+import org.geoserver.ogr.core.ToolWrapperFactory;
+import org.geoserver.platform.ServiceException;
+import org.geoserver.wcs.WCSInfo;
+import org.geoserver.wcs.responses.CoverageResponseDelegate;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.gce.geotiff.GeoTiffFormat;
+import org.geotools.gce.geotiff.GeoTiffWriteParams;
+import org.geotools.gce.geotiff.GeoTiffWriter;
+import org.geotools.util.Utilities;
+import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.vfny.geoserver.wcs.WcsException;
+
+/**
+ * Implementation of {@link CoverageResponseDelegate} that leverages the gdal_translate utility to encode coverages in any output format supported by the
+ * GDAL library available on the system where GeoServer is running.
+ * 
+ * <p>
+ * The encoding process involves two steps:
+ * <ol>
+ * <li>the coverage passed as input to the <code>encode()</code> method is dumped to a temporary file on disk in GeoTIFF format</li>
+ * <li>the <code>gdal_translate</code> command is invoked with the provided options to convert the dumped GeoTIFF file to the desired format</li>
+ * </ol>
+ * </p>
+ * 
+ * <p>
+ * Configuration for the supported output formats must be passed to the class via its {@link #addFormat(GdalFormat)} method.
+ * </p>
+ * 
+ * @author Stefano Costa, GeoSolutions
+ */
+public class GdalCoverageResponseDelegate implements CoverageResponseDelegate, FormatConverter {
+
+    private static final GeoTiffFormat GEOTIF_FORMAT = new GeoTiffFormat();
+
+    /**
+     * Facade to GeoServer's configuration
+     */
+    GeoServer geoServer;
+
+    /**
+     * Factory to create the gdal_translate wrapper.
+     */
+    ToolWrapperFactory gdalWrapperFactory;
+
+    /**
+     * The fs path to gdal_translate. If null, we'll assume gdal_translate is in the PATH and that we can execute it just by running gdal_translate
+     */
+    String gdalTranslatePath = null;
+
+    /**
+     * The full path to gdal_translate
+     */
+    String gdalTranslateExecutable = "gdal_translate";
+
+    /**
+     * The environment variables to set before invoking gdal_translate
+     */
+    Map<String, String> environment = null;
+
+    /**
+     * Map holding the descriptors of the supported GDAL formats (keyed by format name).
+     */
+    static Map<String, Format> formats = new HashMap<String, Format>();
+    /**
+     * Map holding the descriptors of the supported GDAL formats (keyed by mime type).
+     */
+    static Map<String, Format> formatsByMimeType = new HashMap<String, Format>();
+
+    /**
+     * Lock guarding concurrent access to the maps holding the format descriptors.
+     */
+    private ReadWriteLock formatsLock;
+
+    /**
+     * @param gs
+     */
+    public GdalCoverageResponseDelegate(GeoServer gs, ToolWrapperFactory wrapperFactory) {
+        this.formatsLock = new ReentrantReadWriteLock();
+        this.geoServer = gs;
+        this.gdalWrapperFactory = wrapperFactory;
+        this.environment = new HashMap<String, String>();
+    }
+
+    /**
+     * Returns the gdal_translate executable full path.
+     * 
+     * @return
+     */
+    @Override
+    public String getExecutable() {
+        return gdalTranslateExecutable;
+    }
+
+    /**
+     * Sets the gdal_translate executable full path. The default value is simply "gdal_translate", which will work if gdal_translate is in the path.
+     * 
+     * @param gdalTranslate
+     */
+    @Override
+    public void setExecutable(String gdalTranslate) {
+        this.gdalTranslateExecutable = gdalTranslate;
+    }
+
+    /**
+     * Returns the environment variables that are set prior to invoking gdal_translate.
+     * 
+     * @return
+     */
+    @Override
+    public Map<String, String> getEnvironment() {
+        return environment;
+    }
+
+    /**
+     * Provides the environment variables that are set prior to invoking gdal_translate (notably the GDAL_DATA variable, specifying the location of
+     * GDAL's data directory).
+     * 
+     * @param environment
+     */
+    @Override
+    public void setEnvironment(Map<String, String> environment) {
+        if (environment != null) {
+            this.environment.clear();
+            this.environment.putAll(environment);
+        }
+    }
+
+    /**
+     * Adds a GDAL format among the supported ones
+     * 
+     * @param format
+     */
+    @Override
+    public void addFormat(Format format) {
+        if (format == null) {
+            throw new IllegalArgumentException("No format provided");
+        }
+
+        formatsLock.writeLock().lock();
+        try {
+            addFormatInternal(format);
+        } finally {
+            formatsLock.writeLock().unlock();
+        }
+    }
+
+    private void addFormatInternal(Format format) {
+        formats.put(format.getGeoserverFormat().toUpperCase(), format);
+        if (format.getMimeType() != null) {
+            formatsByMimeType.put(format.getMimeType().toUpperCase(), format);
+        }
+    }
+
+    /**
+     * Get a list of supported GDAL formats
+     *
+     * @return the list of supported formats
+     */
+    @Override
+    public List<Format> getFormats() {
+        formatsLock.readLock().lock();
+        try {
+            return new ArrayList<Format>(formats.values());
+        } finally {
+            formatsLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Programmatically removes all formats
+     */
+    @Override
+    public void clearFormats() {
+        formatsLock.writeLock().lock();
+        try {
+            clearFormatsInternal();
+        } finally {
+            formatsLock.writeLock().unlock();
+        }
+    }
+
+    private void clearFormatsInternal() {
+        formats.clear();
+        formatsByMimeType.clear();
+    }
+
+    /**
+     * Replaces currently supported formats with the provided list.
+     *  
+     * @param formats
+     */
+    @Override
+    public void replaceFormats(List<Format> formats) {
+        if (formats == null || formats.isEmpty()) {
+            throw new IllegalArgumentException("No formats provided");
+        }
+
+        formatsLock.writeLock().lock();
+        try {
+            clearFormatsInternal();
+            for (Format format: formats) {
+                if (format != null) {
+                    addFormatInternal(format);
+                }
+            }
+        } finally {
+            formatsLock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean canProduce(String outputFormat) {
+        try {
+            return getGdalFormat(outputFormat) != null;
+        } catch (WcsException e) {
+            // format was not found
+            return false;
+        }
+    }
+
+    @Override
+    public String getMimeType(String outputFormat) {
+        String mimeType = "";
+
+        Format format = getGdalFormat(outputFormat);
+        if (format.isSingleFile()) {
+            if (format.getMimeType() != null) {
+                mimeType = format.getMimeType();
+            } else {
+                // use a default binary blob
+                mimeType = "application/octet-stream";
+            }
+        } else {
+            mimeType = "application/zip";
+        }
+
+        return mimeType;
+    }
+
+    @Override
+    public String getFileExtension(String outputFormat) {
+        String extension = "";
+
+        Format format = getGdalFormat(outputFormat);
+        if (format.isSingleFile()) {
+            if (format.getFileExtension() != null) {
+                extension = format.getFileExtension();
+            } else {
+                // default to .bin
+                extension = "bin";
+            }
+        } else {
+            extension = "zip";
+        }
+
+        // strip initial '.' character
+        if (extension.charAt(0) == '.') {
+            extension = extension.substring(1);
+        }
+
+        return extension;
+    }
+
+    private Format getGdalFormat(String outputFormat) {
+        Format format = null;
+
+        formatsLock.readLock().lock();
+        try {
+            format = formats.get(outputFormat.toUpperCase());
+            if (format == null) {
+                // try to look it up by mime type
+                format = formatsByMimeType.get(outputFormat.toUpperCase());
+            }
+        } finally {
+            formatsLock.readLock().unlock();
+        }
+
+        if (format == null) {
+            throw new WcsException("Unknown output format: " + outputFormat);
+        }
+
+        return format;
+    }
+
+    @Override
+    public void encode(GridCoverage2D coverage, String outputFormat,
+            Map<String, String> econdingParameters, OutputStream output) throws ServiceException,
+            IOException {
+        Utilities.ensureNonNull("sourceCoverage", coverage);
+
+        // figure out which output format we're going to generate
+        Format format = getGdalFormat(outputFormat);
+
+        // create the first temp directory, used for dumping gs generated
+        // content
+        File tempGS = org.geoserver.data.util.IOUtils.createTempDirectory("gdaltmpin");
+        File tempGDAL = org.geoserver.data.util.IOUtils.createTempDirectory("gdaltmpout");
+
+        // build the gdal wrapper used to run the gdal_translate commands
+        ToolWrapper wrapper = gdalWrapperFactory.createWrapper(gdalTranslateExecutable, environment);
+
+        // actually export the coverage
+        try {
+            File outputFile = null;
+
+            // write out the coverage
+            File intermediate = writeToDisk(tempGS, coverage);
+
+            // convert with gdal_translate
+            final CoordinateReferenceSystem crs = coverage.getCoordinateReferenceSystem();
+            outputFile = wrapper.convert(intermediate, tempGDAL, coverage.getName().toString(),
+                    format, crs);
+
+            // wipe out the input dir contents
+            IOUtils.emptyDirectory(tempGS);
+
+            // was it a single file output?
+            if(format.isSingleFile()) {
+                try (FileInputStream fis = new FileInputStream(outputFile)) {
+                    org.apache.commons.io.IOUtils.copy(fis, output);
+                }
+            } else {
+                // scan the output directory and zip it all
+                try (ZipOutputStream zipOut = new ZipOutputStream(output)) {
+                    IOUtils.zipDirectory(tempGDAL, zipOut, null);
+                    zipOut.finish();
+                }
+            }
+        } catch (Exception e) {
+            throw new ServiceException("Exception occurred during output generation", e);
+        } finally {
+            // delete the input and output directories
+            IOUtils.delete(tempGS);
+            IOUtils.delete(tempGDAL);
+        }
+    }
+
+    /**
+     * Writes to disk using GeoTIFF format.
+     *  
+     * @param tempDir
+     * @param coverage
+     * @return
+     */
+    private File writeToDisk(File tempDir, GridCoverage2D coverage) throws Exception {
+        // create the temp file for this output
+        // TODO: sanitize temp file name
+        File outFile = new File(tempDir, coverage.getName().toString() + ".tiff");
+
+        // write out
+        GeoTiffWriter writer = null;
+        try {
+            writer = (GeoTiffWriter) GEOTIF_FORMAT.getWriter(outFile);
+
+            // using default encoding parameters
+            final GeoTiffWriteParams wp = new GeoTiffWriteParams();
+
+            final ParameterValueGroup writerParams = GEOTIF_FORMAT.getWriteParameters();
+            writerParams.parameter(AbstractGridFormat.GEOTOOLS_WRITE_PARAMS.getName().toString()).setValue(wp);
+
+            WCSInfo wcsService = geoServer.getService(WCSInfo.class);
+            if(wcsService != null && wcsService.isLatLon()){
+                writerParams.parameter(GeoTiffFormat.RETAIN_AXES_ORDER.getName().toString()).setValue(true);
+            }
+
+            // write down
+            if (writer != null)
+                writer.write(coverage, (GeneralParameterValue[]) writerParams.values()
+                        .toArray(new GeneralParameterValue[1]));
+        } finally {
+            try {
+                if (writer != null)
+                    writer.dispose();
+            } catch (Throwable e) {
+                // eating exception
+            }
+            coverage.dispose(false);
+        }
+
+        return outFile;
+    }
+
+    @Override
+    public List<String> getOutputFormats() {
+        List<String> outputFormats = null;
+        formatsLock.readLock().lock();
+        try {
+            outputFormats = new ArrayList<String>(formats.keySet());
+        } finally {
+            formatsLock.readLock().unlock();
+        }
+        Collections.sort(outputFormats);
+
+        return outputFormats;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        ToolWrapper gdal = gdalWrapperFactory.createWrapper(gdalTranslateExecutable, environment);
+        return gdal.isAvailable();
+    }
+
+    @Override
+    public String getConformanceClass(String format) {
+        return "http://www.opengis.net/spec/WCS_coverage-encoding-x" + getMimeType(format);
+    }
+
+}

--- a/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalWrapper.java
+++ b/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalWrapper.java
@@ -1,0 +1,132 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.response;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.geoserver.ogr.core.AbstractToolWrapper;
+import org.geoserver.ogr.core.Format;
+import org.geotools.util.logging.Logging;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * Helper used to invoke gdal_translate.
+ * 
+ * @author Stefano Costa, GeoSolutions
+ * 
+ */
+public class GdalWrapper extends AbstractToolWrapper {
+
+    private static final Logger LOGGER = Logging.getLogger(GdalWrapper.class);
+
+    private File crsFile;
+
+    public GdalWrapper(String executable, Map<String, String> environment) {
+        super(executable, environment);
+    }
+
+    /**
+     * Returns a list of the gdal_translate supported formats (i.e. what must be passed to gdal_translate via its -of parameter)
+     * 
+     * @return
+     */
+    public Set<String> getSupportedFormats() {
+        try {
+            // this works with gdal_translate v. 1.11.2
+            // TODO: test with other GDAL versions
+            List<String> commands = new ArrayList<String>();
+            commands.add(getExecutable());
+            commands.add("--long-usage");
+
+            Set<String> formats = new HashSet<String>();
+            addFormats(commands, formats);
+
+            return formats;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE,
+                    "Could not get the list of output formats supported by gdal_translate", e);
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * Runs the provided command and parses its output to extract a set of supported formats. 
+     *  
+     * @param commands the command to run
+     * @param formats the parsed formats will be added to this set 
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    private void addFormats(List<String> commands, Set<String> formats) throws IOException,
+            InterruptedException {
+        StringBuilder sb = new StringBuilder();
+        run(commands, sb);
+
+        Pattern formatRegExp = Pattern.compile("^\\s{2}(\\w+)\\:\\s");
+        String[] lines = sb.toString().split("\n");
+        for (String line : lines) {
+            Matcher formatMatcher = formatRegExp.matcher(line);
+            if (formatMatcher.find()) {
+                String format = formatMatcher.group(1);
+                formats.add(format);
+            }
+        }
+    }
+
+    /**
+     * Returns true if gdal_translate is available, that is, if executing
+     * "gdal_translate --version" returns 0 as the exit code.
+     * 
+     * @return
+     */
+    public boolean isAvailable() {
+        List<String> commands = new ArrayList<String>();
+        commands.add(getExecutable());
+        commands.add("--version");
+
+        try {
+            return run(commands, null) == 0;
+        } catch(Exception e) {
+            LOGGER.log(Level.SEVERE, "gdal_translate is not available", e);
+            return false;
+        }
+    }
+
+    @Override
+    public String getToolFormatParameter() {
+        return "-of";
+    }
+
+    @Override
+    protected void onBeforeRun(List<String> cmd, File inputData, File outputDirectory,
+            String typeName, Format format, CoordinateReferenceSystem crs) throws IOException {
+        crsFile = dumpCrs(inputData.getParentFile(), crs);
+
+        if (crsFile != null) {
+            cmd.add("-a_srs");
+            cmd.add(crsFile.getAbsolutePath());
+        }
+    }
+
+    @Override
+    protected void onAfterRun(int exitCode) throws IOException {
+        if (crsFile != null) {
+            crsFile.delete();
+            crsFile = null;
+        }
+    }
+
+}

--- a/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalWrapperFactory.java
+++ b/src/community/gdal/gdal-wcs/src/main/java/org/geoserver/wcs/response/GdalWrapperFactory.java
@@ -1,0 +1,24 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.response;
+
+import java.util.Map;
+
+import org.geoserver.ogr.core.ToolWrapper;
+import org.geoserver.ogr.core.ToolWrapperFactory;
+
+/**
+ * Factory to create {@link GdalWrapper} instances.
+ * 
+ * @author Stefano Costa, GeoSolutions
+ */
+public class GdalWrapperFactory implements ToolWrapperFactory {
+
+    @Override
+    public ToolWrapper createWrapper(String executable, Map<String, String> environment) {
+        return new GdalWrapper(executable, environment);
+    }
+
+}

--- a/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalFormatTest.java
+++ b/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalFormatTest.java
@@ -1,0 +1,133 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.response;
+
+import static org.geoserver.wcs.response.GdalTestUtil.TEST_RESOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.geoserver.config.impl.GeoServerImpl;
+import org.geoserver.ogr.core.Format;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.gce.geotiff.GeoTiffReader;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GdalFormatTest {
+
+    GdalCoverageResponseDelegate gdalCovRespDelegate;
+
+    @Before
+    public void setUp() throws Exception {
+        // check if we can run the tests
+        Assume.assumeTrue(GdalTestUtil.isGdalAvailable());
+
+        // the coverage response delegate
+        gdalCovRespDelegate = new GdalCoverageResponseDelegate(new GeoServerImpl(), new GdalWrapperFactory());
+        // add default formats
+        for (Format format : GdalConfigurator.DEFAULT.getFormats()) {
+            gdalCovRespDelegate.addFormat(format);
+        }
+
+        gdalCovRespDelegate.setExecutable(GdalTestUtil.getGdalTranslate());
+        gdalCovRespDelegate.setEnvironment(GdalTestUtil.getGdalData());
+    }
+
+    @Test
+    public void testCanProduce() {
+        assertTrue(gdalCovRespDelegate.canProduce("GDAL-JPEG2000"));
+        assertTrue(gdalCovRespDelegate.canProduce("GDAL-XYZ"));
+        // not among default formats
+        assertFalse(gdalCovRespDelegate.canProduce("GDAL-MrSID"));
+    }
+
+    @Test
+    public void testContentTypeZip() {
+        assertEquals("application/zip", gdalCovRespDelegate.getMimeType("GDAL-ArcInfoGrid"));
+        assertEquals("zip", gdalCovRespDelegate.getFileExtension("GDAL-ArcInfoGrid"));
+    }
+
+    @Test
+    public void testContentTypeJP2K() {
+        assertEquals("image/jp2", gdalCovRespDelegate.getMimeType("GDAL-JPEG2000"));
+        assertEquals("jp2", gdalCovRespDelegate.getFileExtension("GDAL-JPEG2000"));
+    }
+
+    @Test
+    public void testContentTypePDF() {
+        assertEquals("application/pdf", gdalCovRespDelegate.getMimeType("GDAL-PDF"));
+        assertEquals("pdf", gdalCovRespDelegate.getFileExtension("GDAL-PDF"));
+    }
+
+    @Test
+    public void testContentTypeText() {
+        assertEquals("text/plain", gdalCovRespDelegate.getMimeType("GDAL-XYZ"));
+        assertEquals("txt", gdalCovRespDelegate.getFileExtension("GDAL-XYZ"));
+    }
+
+    @Test
+    public void testXYZ() throws Exception {
+        // prepare input
+        File tempFile = prepareInput();
+        try {
+            GridCoverage2DReader covReader = new GeoTiffReader(tempFile);
+            GridCoverage2D cov = covReader.read(null);
+
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                // write out
+                gdalCovRespDelegate.encode(cov, "GDAL-XYZ", null, bos);
+
+                // parse the text output to check it's really XYZ data
+                try (InputStream is = new ByteArrayInputStream(bos.toByteArray())) {
+                    GdalTestUtil.checkXyzData(is);
+                }
+            }
+        } finally {
+            if (tempFile != null) {
+                tempFile.delete();
+            }
+        }
+    }
+
+    @Test
+    public void testZippedGrid() throws Exception {
+        // prepare input
+        File tempFile = prepareInput();
+        try {
+            GridCoverage2DReader covReader = new GeoTiffReader(tempFile);
+            GridCoverage2D cov = covReader.read(null);
+
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                // write out
+                gdalCovRespDelegate.encode(cov, "GDAL-ArcInfoGrid", null, bos);
+
+                GdalTestUtil.checkZippedGridData(new ByteArrayInputStream(bos.toByteArray()));
+            }
+        } finally {
+            if (tempFile != null) {
+                tempFile.delete();
+            }
+        }
+    }
+
+    private File prepareInput() throws IOException {
+        File tempFile = File.createTempFile("gdal_wcs_", "_test_data");
+        IOUtils.copy(getClass().getResourceAsStream(TEST_RESOURCE), new FileOutputStream(tempFile));
+        
+        return tempFile;
+    }
+
+}

--- a/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalTestUtil.java
+++ b/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalTestUtil.java
@@ -1,0 +1,168 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.geotools.referencing.CRS;
+import org.geotools.util.logging.Logging;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+public class GdalTestUtil {
+    private static Logger LOGGER = Logging.getLogger(GdalTestUtil.class);
+
+    static final String TEST_RESOURCE = "/org/geoserver/data/test/tazdem.tiff";
+
+    static final double[][] TEST_XYZ_DATA = new double[][] {
+            { 145.004166666664673, -41.004166666654271, 75 },
+            { 145.012499999997999, -41.004166666654271, 64 },
+            { 145.020833333331325, -41.004166666654271, 66 },
+            { 145.029166666664679, -41.004166666654271, 52 },
+            { 145.037499999998005, -41.004166666654271, 53 } };
+
+    static final int TEST_GRID_COLS = 120;
+    static final double TEST_GRID_NODATA = -9999;
+    static final String[] TEST_GRID_HEADER_LABEL = new String[] {
+        "ncols", "nrows", "xllcorner", "yllcorner", "cellsize", "NODATA_value"
+    };
+    static final double[] TEST_GRID_HEADER_DATA = new double[] {
+        TEST_GRID_COLS, 240, 144.999999999998, -42.999999999987, 0.008333333333, TEST_GRID_NODATA
+    };
+
+    static final double EQUALS_TOLERANCE = 1E-12;
+
+    private static Boolean IS_GDAL_AVAILABLE;
+    private static String GDAL_TRANSLATE;
+    private static String GDAL_DATA;
+
+    public static boolean isGdalAvailable() {
+
+        // check this just once
+        if (IS_GDAL_AVAILABLE == null) {
+            try {
+                InputStream conf = GdalTestUtil.class.getResourceAsStream("/gdal_translate.properties");
+                Properties p = new Properties();
+                if (conf != null) {
+                    p.load(conf);
+                }
+                
+                GDAL_TRANSLATE = p.getProperty("gdal_translate");
+                // assume it's in the path if the property file hasn't been configured
+                if(GDAL_TRANSLATE == null)
+                    GDAL_TRANSLATE = "gdal_translate";
+                GDAL_DATA = p.getProperty("gdalData");
+                
+                GdalWrapper gdal = new GdalWrapper(GDAL_TRANSLATE, Collections.singletonMap("GDAL_DATA", GDAL_DATA));
+                IS_GDAL_AVAILABLE = gdal.isAvailable();
+            } catch (Exception e) {
+                IS_GDAL_AVAILABLE = false;
+                e.printStackTrace();
+                LOGGER.log(Level.SEVERE,
+                        "Disabling gdal_translate output format tests, as gdal_translate lookup failed", e);
+            }
+        }
+
+        return IS_GDAL_AVAILABLE;
+    }
+    
+    public static String getGdalTranslate() {
+        if(isGdalAvailable())
+            return GDAL_TRANSLATE;
+        else
+            return null;
+    }
+    
+    public static Map<String, String> getGdalData() {
+        if(isGdalAvailable())
+            return Collections.singletonMap("GDAL_DATA", GDAL_DATA);
+        else
+            return Collections.emptyMap();
+    }
+    
+
+    public static void checkXyzData(InputStream is) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+        int maxCount = 5, count = 0;
+        String line = null;
+        while ((line = reader.readLine()) != null && count < maxCount) {
+            String[] cols = line.trim().split(" ");
+            assertTrue(cols.length == 3);
+            assertEquals(TEST_XYZ_DATA[count][0], (double) Double.valueOf(cols[0]),
+                    EQUALS_TOLERANCE);
+            assertEquals(TEST_XYZ_DATA[count][1], (double) Double.valueOf(cols[1]),
+                    EQUALS_TOLERANCE);
+            assertEquals(TEST_XYZ_DATA[count][2], (double) Double.valueOf(cols[2]),
+                    EQUALS_TOLERANCE);
+            count++;
+        }
+    }
+
+    public static void checkZippedGridData(InputStream input) throws Exception {
+        try (ZipInputStream zis = new ZipInputStream(input)) {
+            // unzip the result
+            // check contents
+            boolean gridFileFound = false, auxFileFound = false, prjFileFound = false;
+            ZipEntry entry = null;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (entry.getName().matches("^\\w+.asc.aux.xml$")) {
+                    auxFileFound = true;
+//                } else if ("tazdem.prj".equals(entry.getName())) {
+                } else if (entry.getName().matches("^\\w+.prj$")) {
+                    prjFileFound = true;
+                    // check projection
+                    checkGridProjection(zis);
+//                } else if ("tazdem.asc".equals(entry.getName())) {
+                } else if (entry.getName().matches("^\\w+.asc$")) {
+                    gridFileFound = true;
+                    // check grid content
+                    checkGridContent(zis);
+                }
+            }
+            assertTrue(gridFileFound);
+            assertTrue(auxFileFound);
+            assertTrue(prjFileFound);
+        }
+    }
+
+    private static void checkGridProjection(InputStream is) throws Exception {
+        String wkt = IOUtils.readLines(is).get(0);
+        CoordinateReferenceSystem crs = CRS.parseWKT(wkt);
+        assertNotNull(crs);
+        assertEquals("GCS_WGS_1984", crs.getName().getCode());
+    }
+
+    private static void checkGridContent(InputStream is) throws Exception {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+        int row = 0, maxRow = 7;
+        String line = null;
+        while ((line = reader.readLine()) != null && row < maxRow) {
+            String[] cols = line.trim().replaceAll("\\s+", " ").split(" ");
+            if (row < TEST_GRID_HEADER_LABEL.length) {
+                assertEquals(2, cols.length);
+                assertEquals(TEST_GRID_HEADER_LABEL[row], cols[0].trim());
+                assertEquals(TEST_GRID_HEADER_DATA[row], Double.valueOf(cols[1].trim()), EQUALS_TOLERANCE);
+            } else {
+                assertEquals(TEST_GRID_COLS, cols.length);
+                assertEquals(75.0, Double.valueOf(cols[0].trim()), EQUALS_TOLERANCE);
+            }
+            row++;
+        }
+    }
+}

--- a/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalWcsTest.java
+++ b/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalWcsTest.java
@@ -1,0 +1,105 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wcs.response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import org.geoserver.wcs2_0.kvp.WCSKVPTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
+
+public class GdalWcsTest extends WCSKVPTestSupport {
+
+    @Before
+    public void setup() {
+        assumeTrue(GdalTestUtil.isGdalAvailable());
+        GdalConfigurator.DEFAULT.setExecutable(GdalTestUtil.getGdalTranslate());
+        GdalConfigurator.DEFAULT.setEnvironment(GdalTestUtil.getGdalData());
+
+        // force reload of the config, some tests may alter it
+        GdalConfigurator configurator = applicationContext.getBean(GdalConfigurator.class);
+        configurator.loadConfiguration();
+    }
+
+    public boolean isFormatSupported(String mimeType) throws Exception {
+        Document dom = getAsDOM("wcs?request=GetCapabilities&service=WCS");
+
+        String exprResult = xpath.evaluate(
+                "count(//wcs:ServiceMetadata/wcs:formatSupported[text()='" + mimeType + "'])", dom);
+        return "1".equals(exprResult);
+    }
+
+    @Test
+    public void testUnsupportedFormat() throws Exception {
+        // MrSID format is not among the default ones
+        MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                + "&coverageId=BlueMarble&Format=image/x-mrsid");
+
+        checkOws20Exception(response, 400, "InvalidParameterValue", "format");
+    }
+
+    @Test
+    public void testGetCoverageJP2K() throws Exception {
+        assumeTrue(isFormatSupported("image/jp2"));
+
+        MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                + "&coverageId=BlueMarble&Format=image/jp2");
+
+        assertEquals("image/jp2", response.getContentType());
+    }
+
+    @Test
+    public void testGetCoveragePdfByMimeType() throws Exception {
+        assumeTrue(isFormatSupported("application/pdf"));
+
+        MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                + "&coverageId=BlueMarble&Format=application/pdf");
+
+        assertEquals("application/pdf", response.getContentType());
+    }
+
+    @Test
+    public void testGetCoveragePdfByName() throws Exception {
+        assumeTrue(isFormatSupported("application/pdf"));
+
+        MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                + "&coverageId=BlueMarble&Format=gdal-pdf");
+
+        //assertEquals("application/pdf", response.getContentType());
+        assertEquals("gdal-pdf", response.getContentType());
+    }
+
+    @Test
+    public void testGetCoverageArcInfoGrid() throws Exception {
+        assumeTrue(isFormatSupported("application/zip"));
+
+        MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                + "&coverageId=DEM&Format=GDAL-ArcInfoGrid");
+
+        //assertEquals("application/zip", response.getContentType());
+        assertEquals("GDAL-ArcInfoGrid", response.getContentType());
+
+        GdalTestUtil.checkZippedGridData(getBinaryInputStream(response));
+    }
+
+    @Test
+    public void testGetCoverageXyzGrid() throws Exception {
+        assumeTrue(isFormatSupported("text/plain"));
+
+        MockHttpServletResponse response = getAsServletResponse("wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                + "&coverageId=DEM&Format=GDAL-XYZ");
+
+        //assertEquals("text/plain", response.getContentType());
+        assertEquals("GDAL-XYZ", response.getContentType());
+
+        GdalTestUtil.checkXyzData(getBinaryInputStream(response));
+    }
+
+}

--- a/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalWrapperTest.java
+++ b/src/community/gdal/gdal-wcs/src/test/java/org/geoserver/wcs/response/GdalWrapperTest.java
@@ -1,0 +1,46 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wcs.response;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GdalWrapperTest {
+
+    private GdalWrapper gdal;
+
+    @Before
+    public void setUp() throws Exception {
+        Assume.assumeTrue(GdalTestUtil.isGdalAvailable());
+        gdal = new GdalWrapper(GdalTestUtil.getGdalTranslate(), GdalTestUtil.getGdalData());
+    }
+
+    @Test
+    public void testAvaialable() {
+        // kind of a smoke test, since GdalTestUtils uses the same command!
+        gdal.isAvailable();
+    }
+
+    @Test
+    public void testFormats() {
+        Set<String> formats = gdal.getSupportedFormats();
+        // well, we can't know which formats GDAL was complied with, but at least there will be one, right?
+        assertTrue(formats.size() > 0);
+
+        // these work on my machine, with gdal 1.11.2, libgeotiff 1.4.0, libpng 1.6
+        // and libjpeg-turbo 1.3.1
+        assertTrue(formats.contains("GTiff"));
+        assertTrue(formats.contains("PNG"));
+        assertTrue(formats.contains("JPEG"));
+        assertTrue(formats.contains("PDF"));
+        assertTrue(formats.contains("AAIGrid"));
+    }
+}

--- a/src/community/gdal/gdal-wcs/src/test/resources/gdal_translate.properties
+++ b/src/community/gdal/gdal-wcs/src/test/resources/gdal_translate.properties
@@ -1,0 +1,3 @@
+# define this if gdal_translate is not in your PATH
+gdal_translate=gdal_translate
+gdalData=

--- a/src/community/gdal/gdal-wcs/src/test/resources/gdal_translate.xml
+++ b/src/community/gdal/gdal-wcs/src/test/resources/gdal_translate.xml
@@ -1,0 +1,37 @@
+<ToolConfiguration>
+    <executable>gdal_translate</executable>
+    <!-- <environment>
+      <variable name="GDAL_DATA" value="/usr/local/share/gdal" />
+    </environment> -->
+    <formats>
+        <Format>
+            <toolFormat>JP2ECW</toolFormat>
+            <geoserverFormat>GDAL-JPEG2000</geoserverFormat>
+            <fileExtension>.jp2</fileExtension>
+            <singleFile>true</singleFile>
+            <mimeType>image/jp2</mimeType>
+            <type>binary</type> <!-- not really required, it’s the default -->
+        </Format>
+        <Format>
+            <toolFormat>PDF</toolFormat>
+            <geoserverFormat>GDAL-PDF</geoserverFormat>
+            <fileExtension>.pdf</fileExtension>
+            <singleFile>true</singleFile>
+            <mimeType>application/pdf</mimeType>
+        </Format>
+        <Format>
+            <toolFormat>AAIGrid</toolFormat>
+            <geoserverFormat>GDAL-ArcInfoGrid</geoserverFormat>
+            <fileExtension>.asc</fileExtension>
+            <singleFile>false</singleFile>
+        </Format>
+        <Format>
+            <toolFormat>XYZ</toolFormat>
+            <geoserverFormat>GDAL-XYZ</geoserverFormat>
+            <fileExtension>.txt</fileExtension>
+            <singleFile>true</singleFile>
+            <mimeType>text/plain</mimeType>
+            <type>text</type>
+        </Format>
+    </formats>
+</ToolConfiguration>

--- a/src/community/gdal/gdal-wps/pom.xml
+++ b/src/community/gdal/gdal-wps/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Copyright (C) 2015 Open Source Geospatial Foundation. All rights reserved.
+    This code is licensed under the GPL 2.0 license, available at the root application
+    directory. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.geoserver.community</groupId>
+        <artifactId>gs-gdal</artifactId>
+        <version>2.8-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.geoserver.community</groupId>
+    <artifactId>gs-gdal-wps</artifactId>
+    <packaging>jar</packaging>
+    <name>GDAL translate WPS</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-gdal-wcs</artifactId>
+            <version>${gs.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-gdal-wcs</artifactId>
+            <version>${gs.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-wps-core</artifactId>
+            <version>${gs.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-gdal-wcs</artifactId>
+            <version>${gs.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-main</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-wps-core</artifactId>
+            <version>${gs.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mockrunner</groupId>
+            <artifactId>mockrunner</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/community/gdal/gdal-wps/src/main/java/applicationContext.xml
+++ b/src/community/gdal/gdal-wps/src/main/java/applicationContext.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2015 Open Source Geospatial Foundation. All rights reserved.
+    This code is licensed under the GPL 2.0 license, available at the root application
+    directory. -->
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+
+    <bean id="gdalPPIOFactory" class="org.geoserver.wps.gdal.GdalPPIOFactory">
+        <constructor-arg>
+            <ref bean="gdalCoverageResponseDelegate" />
+        </constructor-arg>
+    </bean>
+
+</beans>

--- a/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalBinaryPPIO.java
+++ b/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalBinaryPPIO.java
@@ -1,0 +1,50 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wps.gdal;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.geoserver.wcs.response.GdalCoverageResponseDelegate;
+import org.geoserver.wps.ppio.BinaryPPIO;
+import org.geotools.coverage.grid.GridCoverage2D;
+
+/**
+ * Encode binary output parameter using gdal_translate command
+ */
+public class GdalBinaryPPIO extends BinaryPPIO {
+
+    private GdalCoverageResponseDelegate delegate;
+    private String outputFormat;
+    private String fileExtension;
+
+    protected GdalBinaryPPIO(String outputFormat, GdalCoverageResponseDelegate delegate, String mimeType) {
+        super(GridCoverage2D.class, GridCoverage2D.class, mimeType);
+        this.delegate = delegate;
+        this.outputFormat = outputFormat;
+        this.fileExtension = delegate.getFileExtension(outputFormat);
+    }
+
+    @Override
+    public Object decode(InputStream input) throws Exception {
+        return null;
+    }
+
+    @Override
+    public void encode(Object value, OutputStream os) throws Exception {
+        delegate.encode((GridCoverage2D) value, outputFormat, null, os);
+    }
+
+    @Override
+    public PPIODirection getDirection() {
+        return PPIODirection.ENCODING;
+    }
+
+    @Override
+    public String getFileExtension() {
+        return fileExtension;
+    }
+}

--- a/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalCDataPPIO.java
+++ b/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalCDataPPIO.java
@@ -1,0 +1,56 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wps.gdal;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.geoserver.wcs.response.GdalCoverageResponseDelegate;
+import org.geoserver.wps.ppio.CDataPPIO;
+import org.geotools.coverage.grid.GridCoverage2D;
+
+/**
+ * Encode text based output parameter using gdal_translate command
+ */
+public class GdalCDataPPIO extends CDataPPIO {
+
+    private GdalCoverageResponseDelegate delegate;
+    private String outputFormat;
+    private String fileExtension;
+
+    protected GdalCDataPPIO(String outputFormat, GdalCoverageResponseDelegate delegate, String mimeType) {
+        super(GridCoverage2D.class, GridCoverage2D.class, mimeType);
+        this.delegate = delegate;
+        this.outputFormat = outputFormat;
+        this.fileExtension = delegate.getFileExtension(outputFormat);
+    }
+
+    @Override
+    public void encode(Object value, OutputStream os) throws Exception {
+        delegate.encode((GridCoverage2D) value, outputFormat, null, os);
+    }
+
+    @Override
+    public String getFileExtension() {
+        return this.fileExtension;
+    }
+
+    @Override
+    public PPIODirection getDirection() {
+        return PPIODirection.ENCODING;
+    }
+
+    @Override
+    public Object decode(String input) throws Exception {
+        return null;
+    }
+
+    @Override
+    public Object decode(InputStream input) throws Exception {
+        return null;
+    }
+
+}

--- a/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalPPIOFactory.java
+++ b/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalPPIOFactory.java
@@ -1,0 +1,61 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wps.gdal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.geoserver.ogr.core.Format;
+import org.geoserver.wcs.response.GdalCoverageResponseDelegate;
+import org.geoserver.wps.ppio.PPIOFactory;
+import org.geoserver.wps.ppio.ProcessParameterIO;
+
+/**
+ * Factory to create an output PPIO for each GDAL format managed by gdal_translate command.
+ */
+public class GdalPPIOFactory implements PPIOFactory {
+
+    private GdalCoverageResponseDelegate delegate;
+
+    public GdalPPIOFactory(GdalCoverageResponseDelegate delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<ProcessParameterIO> getProcessParameterIO() {
+        List<ProcessParameterIO> gdalParams = new ArrayList<ProcessParameterIO>();
+        for (Format of : this.delegate.getFormats()) {
+            ProcessParameterIO ppio = null;
+            String computedMimeType = delegate.getMimeType(of.getGeoserverFormat());
+            if (of.getGeoserverFormat() != null && !of.getGeoserverFormat().isEmpty()) {
+                computedMimeType = computedMimeType + "; subtype=" + of.getGeoserverFormat();
+            }
+            if (of.getType() == null) {
+                // binary is the default type
+                ppio = new GdalBinaryPPIO(of.getGeoserverFormat(), delegate, computedMimeType);
+            } else {
+                switch (of.getType()) {
+                case BINARY:
+                    ppio = new GdalBinaryPPIO(of.getGeoserverFormat(), delegate, computedMimeType);
+                    break;
+                case TEXT:
+                    ppio = new GdalCDataPPIO(of.getGeoserverFormat(), delegate, computedMimeType);
+                    break;
+                case XML:
+                    ppio = new GdalXMLPPIO(of.getGeoserverFormat(), delegate);
+                    break;
+                default:
+                    break;
+                }
+            }
+            if (ppio != null) {
+                gdalParams.add(ppio);
+            }
+        }
+        return gdalParams;
+    }
+
+}

--- a/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalXMLPPIO.java
+++ b/src/community/gdal/gdal-wps/src/main/java/org/geoserver/wps/gdal/GdalXMLPPIO.java
@@ -1,0 +1,73 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wps.gdal;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.geoserver.wcs.response.GdalCoverageResponseDelegate;
+import org.geoserver.wps.ppio.XMLPPIO;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.gml4wcs.GML;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+/**
+ * Encode XML based output parameter using gdal_translate command
+ */
+public class GdalXMLPPIO extends XMLPPIO {
+
+    private GdalCoverageResponseDelegate delegate;
+    private String outputFormat;
+    private String fileExtension;
+
+    protected GdalXMLPPIO(String outputFormat, GdalCoverageResponseDelegate delegate) {
+        super(GridCoverage2D.class, GridCoverage2D.class, GML.RectifiedGridType);
+        this.delegate = delegate;
+        this.outputFormat = outputFormat;
+        this.fileExtension = delegate.getFileExtension(outputFormat);
+    }
+
+    @Override
+    public String getFileExtension() {
+        return this.fileExtension;
+    }
+
+    @Override
+    public PPIODirection getDirection() {
+        return PPIODirection.ENCODING;
+    }
+
+    @Override
+    public Object decode(InputStream input) throws Exception {
+        return null;
+    }
+
+    @Override
+    public void encode(Object value, OutputStream os) throws Exception {
+        delegate.encode((GridCoverage2D) value, outputFormat, null, os);
+    }
+
+    @Override
+    public void encode(Object value, ContentHandler handler) throws Exception {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        encode(value, os);
+
+        InputStream bis = new ByteArrayInputStream(os.toByteArray());
+        SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+        SAXParser saxParser = saxParserFactory.newSAXParser();
+        XMLReader parser = saxParser.getXMLReader();
+        parser.setContentHandler(handler);
+        parser.parse(new InputSource(bis));
+    }
+
+}

--- a/src/community/gdal/gdal-wps/src/test/java/org/geoserver/wps/gdal/GdalWpsTest.java
+++ b/src/community/gdal/gdal-wps/src/test/java/org/geoserver/wps/gdal/GdalWpsTest.java
@@ -1,0 +1,196 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wps.gdal;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ogr.core.Format;
+import org.geoserver.wcs.response.GdalConfigurator;
+import org.geoserver.wcs.response.GdalCoverageResponseDelegate;
+import org.geoserver.wcs.response.GdalTestUtil;
+import org.geoserver.wps.WPSTestSupport;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.gce.arcgrid.ArcGridFormat;
+import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
+import com.vividsolutions.jts.geom.Envelope;
+
+public class GdalWpsTest extends WPSTestSupport {
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        
+        addWcs11Coverages(testData);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Assume.assumeTrue(GdalTestUtil.isGdalAvailable());
+
+        GdalConfigurator.DEFAULT.setExecutable(GdalTestUtil.getGdalTranslate());
+        GdalConfigurator.DEFAULT.setEnvironment(GdalTestUtil.getGdalData());
+
+        // force reload of the config, some tests may alter it
+        GdalConfigurator configurator = applicationContext.getBean(GdalConfigurator.class);
+        configurator.loadConfiguration();
+    }
+
+    @Test
+    public void testDescribeProcess() throws Exception {
+        GdalCoverageResponseDelegate delegate = applicationContext.getBean(GdalCoverageResponseDelegate.class);
+
+        Document d = getAsDOM(root()
+                + "service=wps&request=describeprocess&identifier=gs:CropCoverage");
+        String base = "/wps:ProcessDescriptions/ProcessDescription/ProcessOutputs";
+        for (Format f : delegate.getFormats()) {
+            assertXpathExists(base + "/Output[1]/ComplexOutput/Supported/Format[MimeType='"
+                        + delegate.getMimeType(f.getGeoserverFormat()) + "; subtype=" + f.getGeoserverFormat() + "']", d);
+        }
+    }
+
+    @Test
+    public void testCrop() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
+                + "  <ows:Identifier>gs:CropCoverage</ows:Identifier>\n"
+                + "  <wps:DataInputs>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>coverage</ows:Identifier>\n"
+                + "      <wps:Reference mimeType=\"image/tiff\" xlink:href=\"http://geoserver/wcs\" method=\"POST\">\n"
+                + "        <wps:Body>\n"
+                + "          <wcs:GetCoverage service=\"WCS\" version=\"1.1.1\">\n"
+                + "            <ows:Identifier>" + getLayerId(MockData.TASMANIA_DEM) + "</ows:Identifier>\n"
+                + "            <wcs:DomainSubset>\n"
+                + "              <gml:BoundingBox crs=\"http://www.opengis.net/gml/srs/epsg.xml#4326\">\n"
+                + "                <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>\n"
+                + "                <ows:UpperCorner>180.0 90.0</ows:UpperCorner>\n"
+                + "              </gml:BoundingBox>\n"
+                + "            </wcs:DomainSubset>\n"
+                + "            <wcs:Output format=\"image/tiff\"/>\n"
+                + "          </wcs:GetCoverage>\n"
+                + "        </wps:Body>\n"
+                + "      </wps:Reference>\n"
+                + "    </wps:Input>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>cropShape</ows:Identifier>\n"
+                + "      <wps:Data>\n"
+                + "        <wps:ComplexData mimeType=\"application/wkt\"><![CDATA[POLYGON((145.5 -41.9, 145.5 -42.1, 145.6 -42, 145.5 -41.9))]]></wps:ComplexData>\n"
+                + "      </wps:Data>\n" + "    </wps:Input>\n" + "  </wps:DataInputs>\n"
+                + "  <wps:ResponseForm>\n"
+                + "    <wps:RawDataOutput mimeType=\"application/zip; subtype=GDAL-ArcInfoGrid\">\n"
+                + "      <ows:Identifier>result</ows:Identifier>\n" + "    </wps:RawDataOutput>\n"
+                + "  </wps:ResponseForm>\n" + "</wps:Execute>\n" + "\n" + "";
+
+        MockHttpServletResponse response = postAsServletResponse(root(), xml);
+
+        ZipInputStream is = new ZipInputStream(getBinaryInputStream(response));
+        ZipEntry entry = null;
+        boolean arcGridFound = false;
+        while ((entry = is.getNextEntry()) != null && !arcGridFound) {
+            if (entry.getName().endsWith(".asc")) {
+                ArcGridFormat format = new ArcGridFormat();
+                GridCoverage2D gc = format.getReader(is).read(null);
+
+                assertTrue(new Envelope(-145.4, 145.6, -41.8, -42.1).contains(new ReferencedEnvelope(gc.getEnvelope())));
+                
+                double[] valueInside = (double[]) gc.evaluate(new DirectPosition2D(145.55, -42));
+                assertEquals(615.0, valueInside[0], 1E-12);
+                double[] valueOutside = (double[]) gc.evaluate(new DirectPosition2D(145.57, -41.9));
+                // this should really be NoData... (-9999 & 0xFFFF)
+                assertEquals(55537.0, valueOutside[0], 1E-12);
+
+                gc.dispose(true);
+
+                arcGridFound = true;
+            }
+        }
+
+        assertTrue(arcGridFound);
+    }
+
+    @Test
+    public void testCropText() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
+                + "  <ows:Identifier>gs:CropCoverage</ows:Identifier>\n"
+                + "  <wps:DataInputs>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>coverage</ows:Identifier>\n"
+                + "      <wps:Reference mimeType=\"image/tiff\" xlink:href=\"http://geoserver/wcs\" method=\"POST\">\n"
+                + "        <wps:Body>\n"
+                + "          <wcs:GetCoverage service=\"WCS\" version=\"1.1.1\">\n"
+                + "            <ows:Identifier>" + getLayerId(MockData.TASMANIA_DEM) + "</ows:Identifier>\n"
+                + "            <wcs:DomainSubset>\n"
+                + "              <gml:BoundingBox crs=\"http://www.opengis.net/gml/srs/epsg.xml#4326\">\n"
+                + "                <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>\n"
+                + "                <ows:UpperCorner>180.0 90.0</ows:UpperCorner>\n"
+                + "              </gml:BoundingBox>\n"
+                + "            </wcs:DomainSubset>\n"
+                + "            <wcs:Output format=\"image/tiff\"/>\n"
+                + "          </wcs:GetCoverage>\n"
+                + "        </wps:Body>\n"
+                + "      </wps:Reference>\n"
+                + "    </wps:Input>\n"
+                + "    <wps:Input>\n"
+                + "      <ows:Identifier>cropShape</ows:Identifier>\n"
+                + "      <wps:Data>\n"
+                + "        <wps:ComplexData mimeType=\"application/wkt\"><![CDATA[POLYGON((145.5 -41.9, 145.5 -42.1, 145.6 -42, 145.5 -41.9))]]></wps:ComplexData>\n"
+                + "      </wps:Data>\n" + "    </wps:Input>\n" + "  </wps:DataInputs>\n"
+                + "  <wps:ResponseForm>\n"
+                + "    <wps:RawDataOutput mimeType=\"text/plain; subtype=GDAL-XYZ\">\n"
+                + "      <ows:Identifier>result</ows:Identifier>\n" + "    </wps:RawDataOutput>\n"
+                + "  </wps:ResponseForm>\n" + "</wps:Execute>\n" + "\n" + "";
+
+        MockHttpServletResponse response = postAsServletResponse(root(), xml);
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(getBinaryInputStream(response)));
+        String line = null;
+        boolean valueInsideFound = false, valueOutsideFound = false;
+        double x1 = -145.4, x2 = 145.6, y1 = -42.1, y2 = -41.8;
+        while ((line = reader.readLine()) != null) {
+           String[] cols = line.split(" ");
+           assertTrue(cols.length == 3);
+
+           double x = round(Double.valueOf(cols[0]));
+           double y = round(Double.valueOf(cols[1]));
+           double value = Double.valueOf(cols[2]);
+           assertTrue(x >= x1 && x <= x2);
+           assertTrue(y >= y1 && y <= y2);
+           if (x == 145.55 && y == -42 && !valueInsideFound) {
+                assertEquals(550.0, value, 1E-12);
+                valueInsideFound = true;
+           }
+           if (x == 145.57 && y == -41.9 && !valueOutsideFound) {
+                assertEquals(55537.0, value, 1E-12);
+                valueOutsideFound = true;
+           }
+        }
+
+        assertTrue(valueInsideFound);
+        assertTrue(valueOutsideFound);
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100) / 100.0;
+    }
+
+}

--- a/src/community/gdal/pom.xml
+++ b/src/community/gdal/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- 
+ Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.geoserver</groupId>
+    <artifactId>community</artifactId>
+    <version>2.8-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver.community</groupId>
+  <artifactId>gs-gdal</artifactId>
+  <packaging>pom</packaging>
+  <name>GDAL translate parent</name>
+
+  <modules>
+    <module>gdal-wcs</module> 
+    <module>gdal-wps</module>
+  </modules>
+</project>

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -62,7 +62,9 @@
           <descriptor>release/ext-sldservice.xml</descriptor>
           <descriptor>release/ext-rest-upload.xml</descriptor>
           <descriptor>release/ext-gwc-distributed.xml</descriptor>  
-          <descriptor>release/ext-geofence-server.xml</descriptor>	
+          <descriptor>release/ext-geofence-server.xml</descriptor>
+	  <descriptor>release/ext-gdal-wcs.xml</descriptor>
+	  <descriptor>release/ext-gdal-wps.xml</descriptor>
         </descriptors>
       </configuration>
      </plugin>
@@ -197,6 +199,7 @@
         <module>sldService</module>
         <module>release</module>
 	<module>gwc-distributed</module>
+	<module>gdal</module>
       </modules>
     </profile>
     <profile>
@@ -449,6 +452,12 @@
         <modules>
           <module>vectortiles</module>
         </modules>
-    </profile>    
+    </profile>
+    <profile>
+      <id>gdal-translate</id>
+        <modules>
+          <module>gdal</module>
+        </modules>
+    </profile>
   </profiles>
 </project>

--- a/src/community/release/ext-gdal-wcs.xml
+++ b/src/community/release/ext-gdal-wcs.xml
@@ -1,0 +1,17 @@
+<assembly>
+  <id>gdal-wcs-plugin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>release/target/dependency</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>gs-gdal-wcs-*.jar</include>
+	<include>gs-ogr-core-*.jar</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/community/release/ext-gdal-wps.xml
+++ b/src/community/release/ext-gdal-wps.xml
@@ -1,0 +1,16 @@
+<assembly>
+  <id>gdal-wps-plugin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>release/target/dependency</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>gs-gdal-wps-*.jar</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -173,6 +173,16 @@
       <artifactId>gs-gwc-distributed</artifactId>
      <version>${project.version}</version>
    </dependency>
+   <dependency>
+     <groupId>org.geoserver.community</groupId>
+     <artifactId>gs-gdal-wcs</artifactId>
+     <version>${project.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.geoserver.community</groupId>
+     <artifactId>gs-gdal-wps</artifactId>
+     <version>${project.version}</version>
+   </dependency>
 
  </dependencies>
  <build>

--- a/src/extension/ogr/ogr-core/pom.xml
+++ b/src/extension/ogr/ogr-core/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+ Copyright (C) 2015 Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.geoserver.extension</groupId>
+    <artifactId>gs-ogr</artifactId>
+    <version>2.8-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver.extension</groupId>
+  <artifactId>gs-ogr-core</artifactId>
+  <packaging>jar</packaging>
+  <name>OGR CORE</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/AbstractToolConfigurator.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/AbstractToolConfigurator.java
@@ -1,0 +1,153 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogr.core;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.geoserver.config.util.SecureXStream;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resource.Type;
+import org.geoserver.platform.resource.ResourceListener;
+import org.geoserver.platform.resource.ResourceNotification;
+import org.geotools.util.logging.Logging;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.extended.NamedMapConverter;
+
+/**
+ * Loads the tool configuration file and configures the output formats accordingly.
+ *
+ * <p>Also keeps tabs on the configuration file, reloading it as needed.
+ * 
+ * @author Andrea Aime, GeoSolutions
+ * @author Stefano Costa, GeoSolutions
+ */
+public abstract class AbstractToolConfigurator implements ApplicationListener<ContextClosedEvent> {
+    private static final Logger LOGGER = Logging.getLogger(AbstractToolConfigurator.class);
+
+    public FormatConverter of;
+
+    protected ToolWrapperFactory wrapperFactory;
+
+    protected Resource configFile;
+
+    // ConfigurationPoller
+    protected ResourceListener listener = new ResourceListener() {
+        public void changed(ResourceNotification notify) {
+            loadConfiguration();
+        }
+    };
+
+    /**
+     * @param formatConverter the format converter tool
+     */
+    public AbstractToolConfigurator(FormatConverter formatConverter, ToolWrapperFactory wrapperFactory) {
+        this.of = formatConverter;
+        this.wrapperFactory = wrapperFactory;
+
+        GeoServerResourceLoader loader = GeoServerExtensions.bean(GeoServerResourceLoader.class);
+        configFile = loader.get(getConfigurationFile());
+        loadConfiguration();
+        configFile.addListener( listener );
+    }
+
+    /**
+     * @return the name of the tool configuration file, relative to GeoServer's data directory.
+     */
+    protected abstract String getConfigurationFile();
+
+    /**
+     * @return the tool's default configuration
+     */
+    protected abstract ToolConfiguration getDefaultConfiguration();
+
+    /**
+     * Loads configuration from file, if any; otherwise, loads internal defaults.
+     */
+    public void loadConfiguration() {
+        // start with the default configuration, override if we can load the file
+        ToolConfiguration configuration = getDefaultConfiguration();
+        try {
+            if (configFile.getType() == Type.RESOURCE) {
+                InputStream in = configFile.in();
+                try {
+                    XStream xstream = buildXStream();
+                    configuration = (ToolConfiguration) xstream.fromXML( in);
+                }
+                finally {
+                    in.close();
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error reading the " + getConfigurationFile() + " configuration file", e);
+        }
+
+        if (configuration == null) {
+            LOGGER.log(Level.INFO,
+                            "Could not find/load the " + getConfigurationFile() + " configuration file, using internal defaults");
+            configuration = getDefaultConfiguration();
+        }
+
+        // should never happen, but just in case...
+        if (configuration == null) {
+            throw new IllegalStateException("No default configuration available, giving up");
+        }
+
+        // let's load the configuration
+        ToolWrapper wrapper = wrapperFactory.createWrapper(configuration.getExecutable(), configuration.getEnvironment());
+        Set<String> supported = wrapper.getSupportedFormats();
+        of.setExecutable(configuration.getExecutable());
+        of.setEnvironment(configuration.getEnvironment());
+        List<Format> toBeAdded = new ArrayList<Format>();
+        for (Format format : configuration.getFormats()) {
+            if (supported.contains(format.getToolFormat())) {
+                toBeAdded.add(format);
+            } else {
+                LOGGER.severe("Skipping '" + format.getGeoserverFormat() + "' as its tool format '"
+                        + format.getToolFormat() + "' is not among the ones supported by "
+                        + configuration.getExecutable());
+            }
+        }
+        // update configured formats at once, potentially alleviating locking overhead
+        of.replaceFormats(toBeAdded);
+    }
+
+    /**
+     * Builds and configures the XStream used for de-serializing the configuration
+     * @return
+     */
+    protected XStream buildXStream() {
+        XStream xstream = new SecureXStream();
+        xstream.alias("ToolConfiguration", ToolConfiguration.class);
+        xstream.alias("Format", Format.class);
+        xstream.allowTypes(new Class[] { ToolConfiguration.class, Format.class });
+        xstream.addImplicitCollection(Format.class, "options", "option", String.class);
+        NamedMapConverter environmentConverter = new NamedMapConverter(xstream
+                .getMapper(), "variable", "name", String.class, "value", String.class,
+                true, true, xstream.getConverterLookup());
+        xstream.registerConverter(environmentConverter);
+
+        return xstream;
+    }
+
+    /**
+     * Kill all threads on web app context shutdown to avoid permgen leaks
+     */
+    public void onApplicationEvent(ContextClosedEvent event) {
+        if( configFile != null ){
+            configFile.removeListener(listener);
+        }
+    }
+
+}

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/AbstractToolWrapper.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/AbstractToolWrapper.java
@@ -1,0 +1,222 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogr.core;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * Base class for helpers used to invoke an external tool.
+ * 
+ * @author Andrea Aime, GeoSolutions
+ * @author Stefano Costa, GeoSolutions
+ */
+public abstract class AbstractToolWrapper implements ToolWrapper {
+
+    private String executable;
+    private Map<String, String> environment;
+
+    public AbstractToolWrapper(String executable, Map<String, String> environment) {
+        this.executable = executable;
+        this.environment = new HashMap<String, String>();
+        if (environment != null) {
+            this.environment.putAll(environment);
+        }
+    }
+
+    @Override
+    public String getExecutable() {
+        return executable;
+    }
+
+    @Override
+    public Map<String, String> getEnvironment() {
+        return new HashMap<String, String>(environment);
+    }
+
+    @Override
+    public boolean isInputFirst() {
+        return true;
+    }
+
+    @Override
+    public File convert(File inputData, File outputDirectory, String typeName,
+            Format format, CoordinateReferenceSystem crs) throws IOException, InterruptedException {
+        // build the command line
+        List<String> cmd = new ArrayList<String>();
+        cmd.add(executable);
+
+        String toolFormatParameter = getToolFormatParameter();
+        if (toolFormatParameter != null) {
+            cmd.add(toolFormatParameter);
+            cmd.add(format.getToolFormat());
+        }
+
+        if (format.getOptions() != null) {
+            for (String option : format.getOptions()) {
+                cmd.add(option);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        String outFileName = null;
+        int exitCode = -1;
+        try {
+            onBeforeRun(cmd, inputData, outputDirectory, typeName, format, crs);
+
+            outFileName = setInputOutput(cmd, inputData, outputDirectory, typeName, format);
+
+            exitCode = run(cmd, sb);
+        } finally {
+            onAfterRun(exitCode);
+        }
+
+        if (exitCode != 0)
+            throw new IOException(executable + " did not terminate successfully, exit code " + exitCode
+                    + ". Was trying to run: " + cmd + "\nResulted in:\n" + sb);
+
+        // output may be a directory, handle that case gracefully
+        File output = new File(outputDirectory, outFileName);
+        if(output.isDirectory()) {
+            output = new File(output, outFileName);
+        }
+        return output;
+    }
+
+    /**
+     * Sets up input and output parameters.
+     * 
+     * <p>
+     * Uses {@link #isInputFirst()} internally to determine whether input or output should come first in the list of arguments.
+     * </p>
+     * 
+     * <p>
+     * May be overridden by subclasses, e.g. to support commands that modify the input file inline and thus need no output parameter.
+     * </p>
+     * 
+     * @param cmd the command to run and its arguments
+     * @param inputData the input file
+     * @param outputDirectory the output directory
+     * @param typeName the type name
+     * @param format the format descriptor
+     * @return the name of the (main) output file
+     */
+    protected String setInputOutput(List<String> cmd, File inputData, File outputDirectory, String typeName,
+            Format format) {
+        String outFileName = typeName;
+
+        if (format.getFileExtension() != null)
+            outFileName += format.getFileExtension();
+        if (isInputFirst()) {
+            cmd.add(inputData.getAbsolutePath());
+            cmd.add(new File(outputDirectory, outFileName).getAbsolutePath());
+        } else {
+            cmd.add(new File(outputDirectory, outFileName).getAbsolutePath());
+            cmd.add(inputData.getAbsolutePath());
+        }
+
+        return outFileName;
+    }
+
+    /**
+     * Utility method to dump a {@link CoordinateReferenceSystem} to a temporary file on disk.
+     * 
+     * @param parentDir
+     * @param crs
+     * @return the temp file containing the CRS definition in WKT format
+     * @throws IOException 
+     */
+    protected static File dumpCrs(File parentDir, CoordinateReferenceSystem crs) throws IOException {
+      File crsFile = null;
+      if (crs != null) {
+          // we don't use an EPSG code since there is no guarantee we'll be able to reverse
+          // engineer one. Using WKT also ensures the EPSG params such as the TOWGS84 ones are
+          // not lost in the conversion
+          // We also write to a file because some operating systems cannot take arguments with
+          // quotes and spaces inside (and/or ProcessBuilder is not good enough to escape them)
+          crsFile = File.createTempFile("srs", "wkt", parentDir);
+          String s = crs.toWKT();
+          s = s.replaceAll("\n\r", "").replaceAll("  ", "");
+          FileUtils.writeStringToFile(crsFile, s);
+      }
+
+      return crsFile;
+    }
+
+    /**
+     * Invoked by <code>convert()</code> before the command is actually run, but after the options specified in the format configuration have been
+     * added to the arguments list.
+     * 
+     * <p>
+     * Default implementation does nothing at all. May be implemented by subclasses to append additional arguments to <code>cmd</code>.
+     * </p>
+     * 
+     * @param cmd the command to run and its arguments
+     * @param inputData
+     * @param outputDirectory
+     * @param typeName
+     * @param format
+     * @param crs
+     * @throws IOException
+     */
+    protected void onBeforeRun(List<String> cmd, File inputData, File outputDirectory, String typeName,
+            Format format, CoordinateReferenceSystem crs) throws IOException {
+        // default implementation does nothing
+    }
+
+    /**
+     * Invoked by <code>convert()</code> after the command is run. Invocation is done inside a <code>try ... finally</code> block, so it happens even
+     * if an exception is thrown during command execution.
+     * 
+     * <p>
+     * Default implementation does nothing at all. May be implemented by subclasses to do some clean-up work.
+     * </p>
+     * 
+     * @param exitCode the exit code of the invoked command. Usually, 0 indicates normal termination
+     * @throws IOException
+     */
+    protected void onAfterRun(int exitCode) throws IOException {
+        // default implementation does nothing
+    }
+
+
+    /**
+     * Runs the specified command appending the output to the string builder and
+     * returning the exit code.
+     * 
+     * @param cmd the command to run and its arguments
+     * @param sb command output is appended here
+     * @return the exit code of the invoked command. Usually, 0 indicates normal termination
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    protected int run(List<String> cmd, StringBuilder sb) throws IOException, InterruptedException {
+        // run the process and grab the output for error reporting purposes
+        ProcessBuilder builder = new ProcessBuilder(cmd);
+        if(environment != null)
+            builder.environment().putAll(environment);
+        builder.redirectErrorStream(true);
+        Process p = builder.start();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+            if (sb != null) {
+                sb.append("\n");
+                sb.append(line);
+            }
+        }
+        return p.waitFor();
+    }
+
+}

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/Format.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/Format.java
@@ -1,0 +1,178 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogr.core;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parameters defining an output format generated using an external tool from either a GML or a shapefile
+ * or a GeoTIFF dump.
+ *
+ * @author Andrea Aime - OpenGeo
+ * @author Stefano Costa - GeoSolutions
+ */
+public class Format {
+    /**
+     * The tool output format name
+     */
+    private String toolFormat;
+
+    /**
+     * The GeoServer output format name
+     */
+    private String geoserverFormat;
+
+    /**
+     * The extension of the generated file, if any (shall include a dot, example, ".tab")
+     */
+    private String fileExtension;
+
+    /**
+     * The options that will be added to the command line
+     */
+    private List<String> options;
+
+    /**
+     * The type of format, used to instantiate the correct converter
+     */
+    private OutputType type;
+
+    /**
+     * If the output is a single file that can be streamed back. In that case we also need to know the mime type
+     */
+    private boolean singleFile;
+
+    /**
+     * The mime type of the single file output
+     */
+    private String mimeType;
+
+    public Format() {
+        this.options = Collections.emptyList();
+    }
+
+    public Format(String toolFormat, String formatName, String fileExtension, boolean singleFile,
+            String mimeType, OutputType type, String... options) {
+        this.toolFormat = toolFormat;
+        this.geoserverFormat = formatName;
+        this.fileExtension = fileExtension;
+        this.singleFile = singleFile;
+        this.mimeType = mimeType;
+        this.type = type;
+        if (options != null) {
+            this.options = new ArrayList<String>(Arrays.asList(options));
+        }
+        if (type == null) {
+            this.type = OutputType.BINARY;
+        }
+    }
+
+    public Format(String toolFormat, String formatName, String fileExtension, boolean singleFile,
+            String mimeType, String... options) {
+        this(toolFormat, formatName, fileExtension, singleFile, mimeType, OutputType.BINARY, options);
+    }
+
+    /**
+     * @return the toolFormat
+     */
+    public String getToolFormat() {
+        return toolFormat;
+    }
+
+    /**
+     * @param toolFormat the toolFormat to set
+     */
+    public void setToolFormat(String toolFormat) {
+        this.toolFormat = toolFormat;
+    }
+
+    /**
+     * @return the geoserverFormat
+     */
+    public String getGeoserverFormat() {
+        return geoserverFormat;
+    }
+
+    /**
+     * @param geoserverFormat the geoserverFormat to set
+     */
+    public void setGeoserverFormat(String geoserverFormat) {
+        this.geoserverFormat = geoserverFormat;
+    }
+
+    /**
+     * @return the fileExtension
+     */
+    public String getFileExtension() {
+        return fileExtension;
+    }
+
+    /**
+     * @param fileExtension the fileExtension to set
+     */
+    public void setFileExtension(String fileExtension) {
+        this.fileExtension = fileExtension;
+    }
+
+    /**
+     * @return the options
+     */
+    public List<String> getOptions() {
+        return options;
+    }
+
+    /**
+     * @param options the options to set
+     */
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+    /**
+     * @return the type
+     */
+    public OutputType getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(OutputType type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the singleFile
+     */
+    public boolean isSingleFile() {
+        return singleFile;
+    }
+
+    /**
+     * @param singleFile the singleFile to set
+     */
+    public void setSingleFile(boolean singleFile) {
+        this.singleFile = singleFile;
+    }
+
+    /**
+     * @return the mimeType
+     */
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    /**
+     * @param mimeType the mimeType to set
+     */
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+}

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/FormatConverter.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/FormatConverter.java
@@ -1,0 +1,71 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogr.core;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines the common interface of format conversion tools.
+ * 
+ * @author Stefano Costa, GeoSolutions
+ */
+public interface FormatConverter {
+
+    /**
+     * Returns the tool's executable full path.
+     * 
+     * @return
+     */
+    public String getExecutable();
+
+    /**
+     * Sets the tool's executable full path.
+     * 
+     * @param executable
+     */
+    public void setExecutable(String executable);
+
+    /**
+     * Returns the environment variables that are set prior to invoking the tool's executable.
+     * 
+     * @return
+     */
+    public Map<String, String> getEnvironment();
+
+    /**
+     * Provides the environment variables that are set prior to invoking the tool's executable.
+     * 
+     * @return
+     */
+    public void setEnvironment(Map<String, String> environment);
+
+    /**
+     * Adds an output format among the supported ones.
+     * 
+     * @param format
+     */
+    public void addFormat(Format format);
+
+    /**
+     * Get a list of supported output formats.
+     *
+     * @return
+     */
+    public List<Format> getFormats();
+
+    /**
+     * Programmatically removes all formats.
+     */
+    public void clearFormats();
+
+    /**
+     * Replaces currently supported formats with the provided list.
+     *  
+     * @param formats
+     */
+    public void replaceFormats(List<Format> formats);
+
+}

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/OutputType.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/OutputType.java
@@ -3,13 +3,12 @@
  * application directory.
  */
 
-package org.geoserver.wfs.response;
+package org.geoserver.ogr.core;
 
 /**
- * Enumeration to mapping possible OGR types
+ * Enumeration to mapping possible output types
  *
  */
-
-public enum OgrType {
+public enum OutputType {
     BINARY, TEXT, XML;
 }

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/ToolConfiguration.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/ToolConfiguration.java
@@ -1,0 +1,75 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogr.core;
+
+import java.util.Map;
+
+
+/**
+ * Represents the tool configuration as a whole.
+ * Only used for XStream driven de-serialization.
+ * 
+ * @author Andrea Aime - OpenGeo
+ * @author Stefano Costa - GeoSolutions
+ */
+public class ToolConfiguration {
+
+    protected String executable;
+    protected Map<String, String> environment;
+    protected Format[] formats;
+
+    public ToolConfiguration() {
+    }
+
+    public ToolConfiguration(String executable, Map<String, String> environment, Format[] formats) {
+        super();
+        this.executable = executable;
+        this.environment = environment;
+        this.formats = formats;
+    }
+
+    /**
+     * @return the executable
+     */
+    public String getExecutable() {
+        return executable;
+    }
+
+    /**
+     * @param executable the executable to set
+     */
+    public void setExecutable(String executable) {
+        this.executable = executable;
+    }
+
+    /**
+     * @return the environment
+     */
+    public Map<String, String> getEnvironment() {
+        return environment;
+    }
+
+    /**
+     * @param environment the environment to set
+     */
+    public void setEnvironment(Map<String, String> environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * @return the formats
+     */
+    public Format[] getFormats() {
+        return formats;
+    }
+
+    /**
+     * @param formats the formats to set
+     */
+    public void setFormats(Format[] formats) {
+        this.formats = formats;
+    }
+
+}

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/ToolWrapper.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/ToolWrapper.java
@@ -1,0 +1,80 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogr.core;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * Common interface for helper classes wrapping an external tool.
+ * 
+ * @author Stefano Costa, GeoSolutions
+ *
+ */
+public interface ToolWrapper {
+
+    /**
+     * Returns the full path to the executable to run.
+     *
+     * @return
+     */
+    public String getExecutable();
+
+    /**
+     * Returns the environment variables that should be set prior to invoking the tool.
+     *
+     * @return
+     */
+    public Map<String, String> getEnvironment();
+
+    /**
+     * Returns the command line parameter used to specify the output format.
+     * 
+     * @return
+     */
+    public String getToolFormatParameter();
+
+    /**
+     * If true, the input file should precede the output file in the list of arguments passed to the tool.
+     * 
+     * @return <code>true</code> if input comes first, <code>false</code> otherwise
+     */
+    public boolean isInputFirst();
+
+    /**
+     * Returns a list of the tool supported formats
+     * 
+     * @return
+     */
+    public Set<String> getSupportedFormats();
+
+    /**
+     * Returns true if the specified executable command is available and can be run.
+     * 
+     * @return
+     */
+    public boolean isAvailable();
+
+    /**
+     *
+     * Performs the conversion, returns the (main) output file
+     *
+     * @param inputData the input file
+     * @param outputDirectory the output directory
+     * @param typeName the type name
+     * @param format the format descriptor
+     * @param crs the coordinate reference system of the output
+     * @return the output file
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public File convert(File inputData, File outputDirectory, String typeName,
+            Format format, CoordinateReferenceSystem crs) throws IOException, InterruptedException;
+
+}

--- a/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/ToolWrapperFactory.java
+++ b/src/extension/ogr/ogr-core/src/main/java/org/geoserver/ogr/core/ToolWrapperFactory.java
@@ -1,0 +1,28 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogr.core;
+
+import java.util.Map;
+
+/**
+ * Interface for tool wrapper factories.
+ * 
+ * <p>Modules providing a {@link ToolWrapper} implementation, should also implement this interface.</p>
+ * 
+ * @author Stefano Costa, GeoSolutions
+ *
+ */
+public interface ToolWrapperFactory {
+
+    /**
+     * Creates a {@link ToolWrapper} instance.
+     * 
+     * @param executable the wrapped executable
+     * @param environment the environment variables that should be set prior to invoking the executable
+     * @return a {@link ToolWrapper} instance
+     */
+    public ToolWrapper createWrapper(String executable, Map<String, String> environment);
+
+}

--- a/src/extension/ogr/ogr-wfs/pom.xml
+++ b/src/extension/ogr/ogr-wfs/pom.xml
@@ -21,6 +21,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-ogr-core</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs</artifactId>
     </dependency>

--- a/src/extension/ogr/ogr-wfs/src/main/java/applicationContext.xml
+++ b/src/extension/ogr/ogr-wfs/src/main/java/applicationContext.xml
@@ -1,18 +1,21 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2014 - 2015 Open Source Geospatial Foundation. All rights
-    reserved. This code is licensed under the GPL 2.0 license, available at the
+<!-- Copyright (C) 2014 - 2015 Open Source Geospatial Foundation. All rights 
+    reserved. This code is licensed under the GPL 2.0 license, available at the 
     root application directory. -->
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
 
 <beans>
 
+    <bean id="ogrWrapperFactory" class="org.geoserver.wfs.response.OGRWrapperFactory" />
     <bean id="ogr2ogrOutputFormat" class="org.geoserver.wfs.response.Ogr2OgrOutputFormat">
         <constructor-arg ref="geoServer" />
+        <constructor-arg ref="ogrWrapperFactory" />
     </bean>
     <bean id="ogr2ogrConfigurator" class="org.geoserver.wfs.response.Ogr2OgrConfigurator">
         <constructor-arg>
             <ref local="ogr2ogrOutputFormat" />
         </constructor-arg>
+        <constructor-arg ref="ogrWrapperFactory" />
     </bean>
 
 </beans>

--- a/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/OGRWrapper.java
+++ b/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/OGRWrapper.java
@@ -1,24 +1,23 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.wfs.response;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
+import org.geoserver.ogr.core.AbstractToolWrapper;
+import org.geoserver.ogr.core.Format;
 import org.geotools.util.logging.Logging;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
@@ -26,71 +25,27 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  * Helper used to invoke ogr2ogr
  * 
  * @author Andrea Aime - OpenGeo
+ * @author Stefano Costa - GeoSolutions
  * 
  */
-public class OGRWrapper {
+public class OGRWrapper extends AbstractToolWrapper {
 
     private static final Logger LOGGER = Logging.getLogger(OGRWrapper.class);
 
-    private String ogrExecutable;
-    private String gdalData;
+    private File crsFile;
 
-    public OGRWrapper(String ogrExecutable, String gdalData) {
-        this.ogrExecutable = ogrExecutable;
-        this.gdalData = gdalData;
+    public OGRWrapper(String ogrExecutable, Map<String, String> environment) {
+        super(ogrExecutable, environment);
     }
 
-    /**
-     * Performs the conversion, returns the name of the (main) output file 
-     */
-    public File convert(File inputData, File outputDirectory, String typeName,
-            OgrFormat format, CoordinateReferenceSystem crs) throws IOException, InterruptedException {
-        // build the command line
-        List<String> cmd = new ArrayList<String>();
-        cmd.add(ogrExecutable);
-        cmd.add("-f");
-        cmd.add(format.ogrFormat);
-        File crsFile = null;
-        if (crs != null) {
-            // we don't use an EPSG code since there is no guarantee we'll be able to reverse
-            // engineer one. Using WKT also ensures the EPSG params such as the TOWGS84 ones are
-            // not lost in the conversion
-            // We also write to a file because some operating systems cannot take arguments with
-            // quotes and spaces inside (and/or ProcessBuilder is not good enough to escape them)
-            crsFile = File.createTempFile("gdal_srs", "wkt", inputData.getParentFile());
-            cmd.add("-a_srs");
-            String s = crs.toWKT();
-            s = s.replaceAll("\n\r", "").replaceAll("  ", "");
-            FileUtils.writeStringToFile(crsFile, s);
-            cmd.add(crsFile.getAbsolutePath());
-        }
-        if (format.options != null) {
-            for (String option : format.options) {
-                cmd.add(option);
-            }
-        }
-        String outFileName = typeName;
-        if (format.fileExtension != null)
-            outFileName += format.fileExtension;
-        cmd.add(new File(outputDirectory, outFileName).getAbsolutePath());
-        cmd.add(inputData.getAbsolutePath());
+    @Override
+    public String getToolFormatParameter() {
+        return "-f";
+    }
 
-        StringBuilder sb = new StringBuilder();
-        int exitCode = run(cmd, sb);
-        if(crsFile != null) {
-            crsFile.delete();
-        }
-
-        if (exitCode != 0)
-            throw new IOException("ogr2ogr did not terminate successfully, exit code " + exitCode
-                    + ". Was trying to run: " + cmd + "\nResulted in:\n" + sb);
-        
-        // csv output is a directory, handle that case gracefully
-        File output = new File(outputDirectory, outFileName);
-        if(output.isDirectory()) {
-            output = new File(output, outFileName);
-        }
-        return output;
+    @Override
+    public boolean isInputFirst() {
+        return false;
     }
 
     /**
@@ -102,7 +57,7 @@ public class OGRWrapper {
         try {
             // this one works up to ogr2ogr 1.7
             List<String> commands = new ArrayList<String>();
-            commands.add(ogrExecutable);
+            commands.add(getExecutable());
             commands.add("--help");
             
             Set<String> formats = new HashSet<String>();
@@ -110,7 +65,7 @@ public class OGRWrapper {
             
             // this one is required starting with ogr2ogr 1.8
             commands = new ArrayList<String>();
-            commands.add(ogrExecutable);
+            commands.add(getExecutable());
             commands.add("--long-usage");
             addFormats(commands, formats);
 
@@ -145,42 +100,34 @@ public class OGRWrapper {
      */
     public boolean isAvailable() {
         List<String> commands = new ArrayList<String>();
-        commands.add(ogrExecutable);
+        commands.add(getExecutable());
         commands.add("--version");
 
         try {
             return run(commands, null) == 0;
         } catch(Exception e) {
-            LOGGER.log(Level.SEVERE, "Ogr2Ogr is not available", e);
+            LOGGER.log(Level.SEVERE, getExecutable() + " is not available", e);
             return false;
         }
     }
 
-    /**
-     * Runs the specified command appending the output to the string builder and
-     * returning the exit code
-     * 
-     * @param cmd
-     * @param sb
-     * @return
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    int run(List<String> cmd, StringBuilder sb) throws IOException, InterruptedException {
-        // run the process and grab the output for error reporting purposes
-        ProcessBuilder builder = new ProcessBuilder(cmd);
-        if(gdalData != null)
-            builder.environment().put("GDAL_DATA", gdalData);
-        builder.redirectErrorStream(true);
-        Process p = builder.start();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-        String line = null;
-        while ((line = reader.readLine()) != null) {
-            if (sb != null) {
-                sb.append("\n");
-                sb.append(line);
-            }
+    @Override
+    public void onBeforeRun(List<String> cmd, File inputData, File outputDirectory,
+            String typeName, Format format, CoordinateReferenceSystem crs) throws IOException {
+        crsFile = dumpCrs(inputData.getParentFile(), crs);
+
+        if (crsFile != null) {
+            cmd.add("-a_srs");
+            cmd.add(crsFile.getAbsolutePath());
         }
-        return p.waitFor();
     }
+
+    @Override
+    public void onAfterRun(int exitCode) throws IOException {
+        if (crsFile != null) {
+            crsFile.delete();
+            crsFile = null;
+        }
+    }
+
 }

--- a/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/OGRWrapperFactory.java
+++ b/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/OGRWrapperFactory.java
@@ -1,0 +1,24 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.response;
+
+import java.util.Map;
+
+import org.geoserver.ogr.core.ToolWrapper;
+import org.geoserver.ogr.core.ToolWrapperFactory;
+
+/**
+ * Factory to create {@link OGRWrapper} instances.
+ * 
+ * @author Stefano Costa, GeoSolutions
+ */
+public class OGRWrapperFactory implements ToolWrapperFactory {
+
+    @Override
+    public ToolWrapper createWrapper(String executable, Map<String, String> environment) {
+        return new OGRWrapper(executable, environment);
+    }
+
+}

--- a/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrConfigurator.java
+++ b/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrConfigurator.java
@@ -5,21 +5,9 @@
  */
 package org.geoserver.wfs.response;
 
-import java.io.InputStream;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.geoserver.config.util.SecureXStream;
-import org.geoserver.platform.GeoServerExtensions;
-import org.geoserver.platform.GeoServerResourceLoader;
-import org.geoserver.platform.resource.Resource;
-import org.geoserver.platform.resource.Resource.Type;
-import org.geoserver.platform.resource.ResourceListener;
-import org.geoserver.platform.resource.ResourceNotification;
-import org.geotools.util.logging.Logging;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextClosedEvent;
+import org.geoserver.ogr.core.AbstractToolConfigurator;
+import org.geoserver.ogr.core.ToolConfiguration;
+import org.geoserver.ogr.core.ToolWrapperFactory;
 
 import com.thoughtworks.xstream.XStream;
 
@@ -30,91 +18,34 @@ import com.thoughtworks.xstream.XStream;
  * @author Administrator
  *
  */
-public class Ogr2OgrConfigurator implements ApplicationListener<ContextClosedEvent> {
-    private static final Logger LOGGER = Logging.getLogger(Ogr2OgrConfigurator.class);
+public class Ogr2OgrConfigurator extends AbstractToolConfigurator {
 
-    public Ogr2OgrOutputFormat of;
-
-    OGRWrapper wrapper;
-
-    Resource configFile;
-
-    // ConfigurationPoller
-    private ResourceListener listener = new ResourceListener() {
-        public void changed(ResourceNotification notify) {
-            loadConfiguration();
-        }
-    };
-
-    public Ogr2OgrConfigurator(Ogr2OgrOutputFormat format) {
-        this.of = format;
-
-        GeoServerResourceLoader loader = GeoServerExtensions.bean(GeoServerResourceLoader.class);
-        configFile = loader.get("ogr2ogr.xml");
-        loadConfiguration();
-        configFile.addListener( listener );
+    public Ogr2OgrConfigurator(Ogr2OgrOutputFormat format, ToolWrapperFactory wrapperFactory) {
+        super(format, wrapperFactory);
     }
 
-    public void loadConfiguration() {
-        // start with the default configuration, override if we can load the file
-        OgrConfiguration configuration = OgrConfiguration.DEFAULT;
-        try {
-            if (configFile.getType() == Type.RESOURCE) {
-                InputStream in = configFile.in();
-                try {
-                    XStream xstream = buildXStream();
-                    configuration = (OgrConfiguration) xstream.fromXML( in);
-                }
-                finally {
-                    in.close();
-                }
-            }
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Error reading the ogr2ogr.xml configuration file", e);
-        }
+    @Override
+    protected String getConfigurationFile() {
+        return "ogr2ogr.xml";
+    }
 
-        if (configuration == null) {
-            LOGGER.log(Level.INFO,
-                            "Could not find/load the ogr2ogr.xml configuration file, using internal defaults");
-        }
-
-        // let's load the configuration
-        OGRWrapper wrapper = new OGRWrapper(configuration.ogr2ogrLocation, configuration.gdalData);
-        Set<String> supported = wrapper.getSupportedFormats();
-        of.setOgrExecutable(configuration.ogr2ogrLocation);
-        of.setGdalData(configuration.gdalData);
-        of.clearFormats();
-        for (OgrFormat format : configuration.formats) {
-            if (supported.contains(format.ogrFormat)) {
-                of.addFormat(format);
-            } else {
-                LOGGER.severe("Skipping '" + format.formatName + "' as its OGR format '"
-                        + format.ogrFormat + "' is not among the ones supported by "
-                        + configuration.ogr2ogrLocation);
-            }
-        }
+    @Override
+    protected ToolConfiguration getDefaultConfiguration() {
+        return OgrConfiguration.DEFAULT;
     }
 
     /**
-     * Builds and configures the XStream used for de-serializing the configuration
-     * @return
+     * Ensures compatibility with old style configuration files.
      */
-    static XStream buildXStream() {
-        XStream xstream = new SecureXStream();
+    @Override
+    protected XStream buildXStream() {
+        XStream xstream = super.buildXStream();
+        // setup OGR-specific aliases
         xstream.alias("OgrConfiguration", OgrConfiguration.class);
         xstream.alias("Format", OgrFormat.class);
-        xstream.allowTypes(new Class[] { OgrConfiguration.class, OgrFormat.class });
-        xstream.addImplicitCollection(OgrFormat.class, "options", "option", String.class);
-        return xstream;
-    }
+	xstream.allowTypes(new Class[] { OgrConfiguration.class, OgrFormat.class });
 
-    /**
-     * Kill all threads on web app context shutdown to avoid permgen leaks
-     */
-    public void onApplicationEvent(ContextClosedEvent event) {
-        if( configFile != null ){
-            configFile.removeListener(listener);
-        }
+        return xstream;
     }
 
 }

--- a/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/OgrFormat.java
+++ b/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/OgrFormat.java
@@ -7,70 +7,54 @@ package org.geoserver.wfs.response;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+
+import org.geoserver.ogr.core.Format;
+import org.geoserver.ogr.core.OutputType;
 
 /**
  * Parameters defining an output format generated using ogr2ogr from either a GML or a shapefile
  * dump
  *
  * @author Andrea Aime - OpenGeo
+ * @author Stefano Costa - GeoSolutions
  *
  */
-public class OgrFormat {
+public class OgrFormat extends Format {
+    
+    public OgrFormat(String ogrFormat, String formatName, String fileExtension, boolean singleFile,
+            String mimeType, OutputType type, String... options) {
+        this.ogrFormat = ogrFormat;
+        this.formatName = formatName;
+        setFileExtension(fileExtension);
+        setSingleFile(singleFile);
+        setMimeType(mimeType);
+        setType(type);
+        if (options != null) {
+            setOptions(new ArrayList<String>(Arrays.asList(options)));
+        }
+        if (type == null) {
+            setType(OutputType.BINARY);
+        }
+    }
+
+    public OgrFormat(String toolFormat, String formatName, String fileExtension, boolean singleFile,
+            String mimeType, String... options) {
+        this(toolFormat, formatName, fileExtension, singleFile, mimeType, OutputType.BINARY, options);
+    }
+
     /**
      * The -f parameter
      */
-    public String ogrFormat;
+    private String ogrFormat;
+    private String formatName;
 
-    /**
-     * The GeoServer output format name
-     */
-    public String formatName;
-
-    /**
-     * The extension of the generated file, if any (shall include a dot, example, ".tab")
-     */
-    public String fileExtension;
-
-    /**
-     * The options that will be added to the command line
-     */
-    public List<String> options;
-
-    /**
-     * The type of format, used to instantiate the correct converter
-     */
-    public OgrType type;
-
-    /**
-     * If the output is a single file that can be streamed back. In that case we also need to know the mime type
-     */
-    public boolean singleFile;
-
-    /**
-     * The mime type of the single file output
-     */
-    public String mimeType;
-
-    public OgrFormat(String ogrFormat, String formatName, String fileExtension, boolean singleFile,
-            String mimeType, OgrType type, String... options) {
-        this.ogrFormat = ogrFormat;
-        this.formatName = formatName;
-        this.fileExtension = fileExtension;
-        this.singleFile = singleFile;
-        this.mimeType = mimeType;
-        this.type = type;
-        if (options != null) {
-            this.options = new ArrayList<String>(Arrays.asList(options));
-        }
-        if (type == null) {
-            this.type = OgrType.BINARY;
-        }
+    @Override
+    public String getToolFormat() {
+        return ogrFormat;
     }
 
-    public OgrFormat(String ogrFormat, String formatName, String fileExtension, boolean singleFile,
-            String mimeType, String... options) {
-        this(ogrFormat, formatName, fileExtension, singleFile, mimeType, OgrType.BINARY, options);
+    @Override
+    public String getGeoserverFormat() {
+        return formatName;
     }
-
 }

--- a/src/extension/ogr/ogr-wfs/src/test/java/org/geoserver/wfs/response/OGRWrapperTest.java
+++ b/src/extension/ogr/ogr-wfs/src/test/java/org/geoserver/wfs/response/OGRWrapperTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -7,6 +7,7 @@ package org.geoserver.wfs.response;
 
 import static org.junit.Assert.*;
 
+import java.util.Collections;
 import java.util.Set;
 
 import org.junit.Assume;
@@ -20,7 +21,8 @@ public class OGRWrapperTest {
     @Before
     public void setUp() throws Exception {
         Assume.assumeTrue(Ogr2OgrTestUtil.isOgrAvailable());
-        ogr = new OGRWrapper(Ogr2OgrTestUtil.getOgr2Ogr(), Ogr2OgrTestUtil.getGdalData());
+        ogr = new OGRWrapper(Ogr2OgrTestUtil.getOgr2Ogr(), Collections.singletonMap("GDAL_DATA",
+                Ogr2OgrTestUtil.getGdalData()));
     }
     
     @Test

--- a/src/extension/ogr/ogr-wfs/src/test/java/org/geoserver/wfs/response/Ogr2OgrFormatTest.java
+++ b/src/extension/ogr/ogr-wfs/src/test/java/org/geoserver/wfs/response/Ogr2OgrFormatTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -69,15 +70,15 @@ public class Ogr2OgrFormatTest {
         dataStore = new PropertyDataStore(new File("./src/test/java/org/geoserver/wfs/response"));
 
         // the output format (and let's add a few output formats to play with
-        ogr = new Ogr2OgrOutputFormat(new GeoServerImpl());
+        ogr = new Ogr2OgrOutputFormat(new GeoServerImpl(), new OGRWrapperFactory());
         ogr.addFormat(new OgrFormat("KML", "OGR-KML", ".kml", true, "application/vnd.google-earth.kml"));
         ogr.addFormat(new OgrFormat("KML", "OGR-KML-ZIP", ".kml", false, "application/vnd.google-earth.kml"));
         ogr.addFormat(new OgrFormat("CSV", "OGR-CSV", ".csv", true, "text/csv"));
         ogr.addFormat(new OgrFormat("SHP", "OGR-SHP", ".shp", false, null));
         ogr.addFormat(new OgrFormat("MapInfo File", "OGR-MIF", ".mif", false, null, "-dsco", "FORMAT=MIF"));
         
-        ogr.setOgrExecutable(Ogr2OgrTestUtil.getOgr2Ogr());
-        ogr.setGdalData(Ogr2OgrTestUtil.getGdalData());
+        ogr.setExecutable(Ogr2OgrTestUtil.getOgr2Ogr());
+        ogr.setEnvironment(Collections.singletonMap("GDAL_DATA", Ogr2OgrTestUtil.getGdalData()));
 
         // the EMF objects used to talk with the output format
         gft = WfsFactory.eINSTANCE.createGetFeatureType();

--- a/src/extension/ogr/ogr-wfs/src/test/java/org/geoserver/wfs/response/Ogr2OgrTestUtil.java
+++ b/src/extension/ogr/ogr-wfs/src/test/java/org/geoserver/wfs/response/Ogr2OgrTestUtil.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -7,6 +7,7 @@ package org.geoserver.wfs.response;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,7 +36,7 @@ public class Ogr2OgrTestUtil {
                     OGR2OGR = "ogr2ogr";
                 GDAL_DATA = p.getProperty("gdalData");
                 
-                OGRWrapper ogr = new OGRWrapper(OGR2OGR, GDAL_DATA);
+                OGRWrapper ogr = new OGRWrapper(OGR2OGR, Collections.singletonMap("GDAL_DATA", GDAL_DATA));
                 IS_OGR_AVAILABLE = ogr.isAvailable();
             } catch (Exception e) {
                 IS_OGR_AVAILABLE = false;

--- a/src/extension/ogr/ogr-wps/src/main/java/org/geoserver/wps/ogr/Ogr2OgrPPIOFactory.java
+++ b/src/extension/ogr/ogr-wps/src/main/java/org/geoserver/wps/ogr/Ogr2OgrPPIOFactory.java
@@ -12,10 +12,10 @@ import java.util.List;
 import net.opengis.wfs.GetFeatureType;
 import net.opengis.wfs.WfsFactory;
 
+import org.geoserver.ogr.core.Format;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.Service;
 import org.geoserver.wfs.response.Ogr2OgrOutputFormat;
-import org.geoserver.wfs.response.OgrFormat;
 import org.geoserver.wps.ppio.PPIOFactory;
 import org.geoserver.wps.ppio.ProcessParameterIO;
 import org.geotools.util.Version;
@@ -40,35 +40,35 @@ public class Ogr2OgrPPIOFactory implements PPIOFactory {
     @Override
     public List<ProcessParameterIO> getProcessParameterIO() {
         List<ProcessParameterIO> ogrParams = new ArrayList<ProcessParameterIO>();
-        for (OgrFormat of : this.ogr2OgrOutputFormat.getFormats()) {
+        for (Format of : this.ogr2OgrOutputFormat.getFormats()) {
             ProcessParameterIO ppio = null;
             GetFeatureType gft = WfsFactory.eINSTANCE.createGetFeatureType();
-            gft.setOutputFormat(of.formatName);
+            gft.setOutputFormat(of.getGeoserverFormat());
             Operation operation = new Operation("GetFeature", new Service("WFS", null, new Version(
                     "1.1.0"), Arrays.asList("GetFeature")), null, new Object[] { gft });
             // String computedMimeType = of.mimeType;
             // if (computedMimeType == null || computedMimeType.isEmpty()) {
             String computedMimeType = ogr2OgrOutputFormat.getMimeType(null, operation);
-            if (of.formatName != null && !of.formatName.isEmpty()) {
-                computedMimeType = computedMimeType + "; subtype=" + of.formatName;
+            if (of.getGeoserverFormat() != null && !of.getGeoserverFormat().isEmpty()) {
+                computedMimeType = computedMimeType + "; subtype=" + of.getGeoserverFormat();
             }
             // }
-            if (of.type == null) {
+            if (of.getType() == null) {
                 // Binary is default type
-                ppio = new OgrBinaryPPIO(computedMimeType, of.fileExtension, ogr2OgrOutputFormat,
+                ppio = new OgrBinaryPPIO(computedMimeType, of.getFileExtension(), ogr2OgrOutputFormat,
                         operation);
             } else {
-                switch (of.type) {
+                switch (of.getType()) {
                 case BINARY:
-                    ppio = new OgrBinaryPPIO(computedMimeType, of.fileExtension,
+                    ppio = new OgrBinaryPPIO(computedMimeType, of.getFileExtension(),
                             ogr2OgrOutputFormat, operation);
                     break;
                 case TEXT:
-                    ppio = new OgrCDataPPIO(computedMimeType, of.fileExtension,
+                    ppio = new OgrCDataPPIO(computedMimeType, of.getFileExtension(),
                             ogr2OgrOutputFormat, operation);
                     break;
                 case XML:
-                    ppio = new OgrXMLPPIO(computedMimeType, of.fileExtension, ogr2OgrOutputFormat,
+                    ppio = new OgrXMLPPIO(computedMimeType, of.getFileExtension(), ogr2OgrOutputFormat,
                             operation);
                     break;
                 default:

--- a/src/extension/ogr/ogr-wps/src/test/java/org/geoserver/wps/ogr/WPSOgrTest.java
+++ b/src/extension/ogr/ogr-wps/src/test/java/org/geoserver/wps/ogr/WPSOgrTest.java
@@ -22,6 +22,7 @@ import java.util.zip.ZipInputStream;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
+import org.geoserver.ogr.core.Format;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.wfs.response.Ogr2OgrConfigurator;
@@ -73,8 +74,8 @@ public class WPSOgrTest extends WPSTestSupport {
                     .getBean(Ogr2OgrConfigurator.class);
             configurator.loadConfiguration();
             List<String> formatNames = new ArrayList<>();
-            for (OgrFormat f : configurator.of.getFormats()) {
-                formatNames.add(f.formatName);
+            for (Format f : configurator.of.getFormats()) {
+                formatNames.add(f.getGeoserverFormat());
             }
             assertTrue(formatNames.contains("OGR-TAB"));
             assertTrue(formatNames.contains("OGR-MIF"));
@@ -98,10 +99,10 @@ public class WPSOgrTest extends WPSTestSupport {
         Document d = getAsDOM(root()
                 + "service=wps&request=describeprocess&identifier=gs:BufferFeatureCollection");
         String base = "/wps:ProcessDescriptions/ProcessDescription/ProcessOutputs";
-        for (OgrFormat f : OgrConfiguration.DEFAULT.formats) {
-            if (f.mimeType != null) {
+        for (Format f : OgrConfiguration.DEFAULT.getFormats()) {
+            if (f.getMimeType() != null) {
                 assertXpathExists(base + "/Output[1]/ComplexOutput/Supported/Format[MimeType='"
-                        + f.mimeType + "; subtype=" + f.formatName + "']", d);
+                        + f.getMimeType() + "; subtype=" + f.getGeoserverFormat() + "']", d);
             }
         }
     }

--- a/src/extension/ogr/pom.xml
+++ b/src/extension/ogr/pom.xml
@@ -20,6 +20,7 @@
   <name>OGR parent</name>
 
   <modules>
+    <module>ogr-core</module> 
     <module>ogr-wfs</module> 
     <module>ogr-wps</module>
   </modules>

--- a/src/release/ext-ogr-wfs.xml
+++ b/src/release/ext-ogr-wfs.xml
@@ -10,6 +10,7 @@
       <outputDirectory></outputDirectory>
       <includes>
         <include>gs-ogr-wfs-*.jar</include>
+	<include>gs-ogr-core-*.jar</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -1289,5 +1289,25 @@
         </dependency>              
       </dependencies>      
    </profile>
+   <profile>
+      <id>gdal-translate</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-gdal-wcs</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+   </profile>
+   <profile>
+      <id>gdal-translate-wps</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-gdal-wps</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+   </profile>
  </profiles>
 </project>


### PR DESCRIPTION
The new modules are very similar to the `gs-ogr-*` modules from the OGR extension, so a set of reusable superclasses / interfaces has been factored out and put in a shared module, `gs-ogr-core`.