### PR TITLE
[GEOS-7139] Add vfs to supported protocols

### DIFF
--- a/src/main/src/main/java/org/geoserver/util/NoExternalEntityResolver.java
+++ b/src/main/src/main/java/org/geoserver/util/NoExternalEntityResolver.java
@@ -35,7 +35,7 @@ public class NoExternalEntityResolver implements EntityResolver {
         }
         
         // allow schema parsing for validation (jar or external only)
-        if (systemId != null && systemId.matches("(?i)(jar:file|http)[^?#;]*\\.xsd")) {
+        if (systemId != null && systemId.matches("(?i)(jar:file|http|vfs)[^?#;]*\\.xsd")) {
             return null;
         }
         


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-7139

Adds vfs (Virtual File System) to the allowed protocols
Since the vfs protocol is only used by JBOSS, this change will not affect the security of non-JBOSS servers.

For JBOSS servers:
* The existing [^?#;] clause in the filter prevents using escapes to access non-xsd files.
* I tested the basic XXE exploit in to view etc/password in JBOSS and determined GeoServer is still secure against this attack after this change
* Note that third parties can still view _any_ *.xsd file that the JBOSS user has permissions for (since vfs encompasses the whole filesystem). This (most likely) includes any *.xsd files inside any JAR on the JBOSS classpath (assuming the attacker knows the structure of the JAR).

JBOSS is a bit more strict about enforcing its own user/permissions, so this seems safe enough.

(Note: this PR is against 2.7.x since that was what I was building/testing against. If this gets merged, I can cherry-pick to master) 
