### PR TITLE
Resources: closing outputstream bug, recursive delete

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
@@ -228,13 +228,16 @@ public class FileSystemResourceStore implements ResourceStore {
                     @Override
                     public void close() throws IOException {
                         delegate.close();
-                        Lock lock = lock();
-                        try {
-                            // no errors, overwrite the original file
-                            Files.move(temp, actualFile);
-                        }
-                        finally {
-                            lock.release();
+                        //if already closed, there should be no exception (see spec Closeable)
+                        if (temp.exists()) {
+                            Lock lock = lock();
+                            try {
+                                // no errors, overwrite the original file
+                                Files.move(temp, actualFile);
+                            }
+                            finally {
+                                lock.release();
+                            }
                         }
                     }
                 
@@ -429,7 +432,7 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public boolean delete() {
-            return file.delete();
+            return file.exists() && Files.delete(file);
         }
 
         @Override

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -105,7 +105,10 @@ public final class Files {
                     @Override
                     public void close() throws IOException {
                         delegate.close();
-                        Files.move(temp, file);
+                        //if already closed, there should be no exception (see spec Closeable)
+                        if (temp.exists()) {
+                            Files.move(temp, file);
+                        }
                     }
                 
                     @Override

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
@@ -111,6 +111,12 @@ public class FileWrapperResourceTheoryTest extends ResourceTheoryTest {
             throws Exception {
         
     }
+
+    @Override @Ignore
+    public void theoryRecursiveDelete(String path)
+            throws Exception {
+        
+    }
     
     // paths for file wrapper are special so ignore this test
     @Override @Ignore

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -486,4 +486,27 @@ public abstract class ResourceTheoryTest {
         assertThat(resultContent, anyOf(equalTo(thread1Content), equalTo(thread2Content)));
         
     }
+    
+    @Theory
+    public void theoryDoubleClose(String path) throws Exception {
+        final Resource res = getResource(path);
+        assumeThat(res, is(resource()));
+        
+        OutputStream os = res.out();
+        os.close();
+        os.close();
+    }
+    
+    @Theory
+    public void theoryRecursiveDelete(String path) throws Exception {
+        final Resource res = getResource(path);
+        assumeThat(res, is(directory()));
+        assumeThat(res, is(directory()));
+        
+        Collection<Resource> result = res.list();        
+        assumeThat(result.size(), greaterThan(0));
+        
+        assertTrue(res.delete());
+        
+    }
 }


### PR DESCRIPTION
According to the Closeable API (http://docs.oracle.com/javase/7/docs/api/java/io/Closeable.html#close%28%29 ) the close method should not throw (or cause, in this case) an exception when called on an already closed resource. The FileSystemResource and ResourceWrapper do do this.

Furthermore, I propose support for recursively deleting directories with their contents. This is already the case for the store.remove() function, but not resource.delete(). Note that the rule on whether to return true/false when the resource doesn't exist is different for remove and delete. Only for remove this appears to be documented.