### PR TITLE
[GEOS-7140] WCS 1.1 now advertises workspace prefixes

### DIFF
--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/CoveragesTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/CoveragesTransformer.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -124,7 +124,7 @@ public class CoveragesTransformer extends TransformerBase {
             start("wcs:Coverage");
             element("ows:Title", ci.getTitle());
             element("ows:Abstract", ci.getDescription());
-            element("ows:Identifier", ci.getName());
+            element("ows:Identifier", ci.prefixedName());
             final AttributesImpl attributes = new AttributesImpl();
             attributes.addAttribute("", "xlink:href", "xlink:href", "", coverageLocation);
             element("ows:Reference", "", attributes);

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
@@ -452,7 +452,7 @@ public class WCSCapsTransformer extends TransformerBase {
             handleKeywords(cv.getKeywords());
             handleMetadataLinks(cv.getMetadataLinks(), "simple");
             handleEnvelope(cv.getLatLonBoundingBox());
-            element("wcs:Identifier", cv.getName());
+            element("wcs:Identifier", cv.prefixedName());
 
             end("wcs:CoverageSummary");
         }

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/DescribeCoverageTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/DescribeCoverageTest.java
@@ -37,7 +37,9 @@ import org.w3c.dom.NodeList;
 public class DescribeCoverageTest extends WCSTestSupport {
 
     public static QName NO_RANGE = new QName(MockData.WCS_URI, "NoRange", MockData.WCS_PREFIX);
-
+    private static final QName SF_RAIN = new QName(MockData.SF_URI, "rain", MockData.SF_PREFIX);
+    private static final QName GS_RAIN = new QName(MockData.DEFAULT_URI, "rain", MockData.DEFAULT_PREFIX);
+    
     // @Override
     // protected String getDefaultLogConfiguration() {
     // return "/DEFAULT_LOGGING.properties";
@@ -52,6 +54,8 @@ public class DescribeCoverageTest extends WCSTestSupport {
     protected void onSetUp(SystemTestData testData) throws Exception {
         super.onSetUp(testData);
 
+        testData.addRasterLayer(SF_RAIN, "rain.zip", "asc", getCatalog());
+        testData.addRasterLayer(GS_RAIN, "rain.zip", "asc", getCatalog());
         testData.addRasterLayer(NO_RANGE, "norange.tiff", null, null, DescribeCoverageTest.class,
                 getCatalog());
         // the GUI builds the dimension without range, let's do the same here
@@ -78,6 +82,27 @@ public class DescribeCoverageTest extends WCSTestSupport {
         Element element = (Element) dom.getElementsByTagName("ows:Exception").item(0);
         assertEquals("MissingParameterValue", element.getAttribute("exceptionCode"));
         assertEquals("identifiers", element.getAttribute("locator"));
+    }
+    
+    @Test
+    public void testDescribeByIdentifiers() throws Exception {
+        String queryString = "&request=getcoverage&service=wcs&version=1.1.1&&format=image/geotiff"
+                + "&BoundingBox=-45,146,-42,149,urn:ogc:def:crs:EPSG:6.6:4326";
+        //Get identifiers from getCapabilities
+        Document dom = getAsDOM("wcs?request=GetCapabilities&service=WCS");
+        NodeList nodes = xpath.getMatchingNodes("//wcs:CoverageSummary/wcs:Identifier[text()[contains(.,'rain')]]", dom);
+        assertTrue(nodes.getLength() >= 2);
+        
+        for (int i = 0; i < nodes.getLength(); i++) {
+            String identifier = nodes.item(i).getTextContent();
+            dom = getAsDOM("wcs?request=DescribeCoverage&service=WCS&version=1.1.1&identifiers="
+                    + identifier);
+            //Response should be a valid document consisting of 1 coverage with a matching identifier
+            print(dom);
+            assertEquals("wcs:CoverageDescriptions", dom.getDocumentElement().getNodeName());
+            assertEquals(1, dom.getElementsByTagName("wcs:CoverageDescription").getLength());
+            assertEquals(identifier, dom.getElementsByTagName("wcs:Identifier").item(0).getTextContent());
+        }
     }
 
     @Test

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
@@ -401,8 +401,8 @@ public class GetCapabilitiesTest extends WCSTestSupport {
         Document dom = getAsDOM("wcs?request=GetCapabilities");
         // print(dom);
         checkValidationErrors(dom, WCS11_SCHEMA);
-        String xpathBase = "//wcs:CoverageSummary[wcs:Identifier = '" + TASMANIA_DEM.getLocalPart()
-                + "']/ows:Metadata";
+        String xpathBase = "//wcs:CoverageSummary[wcs:Identifier = '" + TASMANIA_DEM.getPrefix() 
+                + ":" + TASMANIA_DEM.getLocalPart() + "']/ows:Metadata";
         assertXpathEvaluatesTo("http://www.geoserver.org", xpathBase + "/@about", dom);
         assertXpathEvaluatesTo("simple", xpathBase + "/@xlink:type", dom);
         assertXpathEvaluatesTo("http://www.geoserver.org/tasmania/dem.xml", xpathBase
@@ -422,8 +422,8 @@ public class GetCapabilitiesTest extends WCSTestSupport {
         String proxyBaseUrl = getGeoServer().getGlobal().getSettings().getProxyBaseUrl();
         Document dom = getAsDOM("wcs?request=GetCapabilities");
         checkValidationErrors(dom, WCS11_SCHEMA);
-        String xpathBase = "//wcs:CoverageSummary[wcs:Identifier = '" + TASMANIA_DEM.getLocalPart()
-                + "']/ows:Metadata";
+        String xpathBase = "//wcs:CoverageSummary[wcs:Identifier = '" + TASMANIA_DEM.getPrefix() 
+                + ":" + TASMANIA_DEM.getLocalPart() + "']/ows:Metadata";
         assertXpathEvaluatesTo("http://www.geoserver.org", xpathBase + "/@about", dom);
         assertXpathEvaluatesTo("simple", xpathBase + "/@xlink:type", dom);
         assertXpathEvaluatesTo(proxyBaseUrl + "/metadata?key=value", xpathBase + "/@xlink:href", dom);


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-7140
WCS 1.1 now advertises workspace prefixes
* Updated GetCapabilitiesTest to account for this
* Added test case to check that identifiers returned by DescribeCoverage match those returned by GetCapapabilites, and that two coverages with the same name in different workspaces do not cause conflicts.