### PR TITLE
[GEOS-7151] Fix code not closing CloseableIterator warnings

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -64,7 +64,6 @@ import org.springframework.util.Assert;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 
 /**
  * Wraps the catalog and applies the security directives provided by a {@link ResourceAccessManager}
@@ -1412,8 +1411,8 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         // Function. When the AccessLevel is HIDDEN and a layer gets filtered 
         // out via a CatalogFilter - for example, this can happen with a
         // LocalWorkspaceCatalogFilter and a virtual service request
-        return new CloseableIteratorAdapter(Iterators.filter(filteredWrapped,
-                com.google.common.base.Predicates.notNull()));
+        return CloseableIteratorAdapter.filter(filteredWrapped,
+                com.google.common.base.Predicates.<T> notNull());
     }
 
     /**


### PR DESCRIPTION
Updated SecureCatalogImpl to use the factory method instead of the constructor to create the CloseableIteratorAdapter to ensure that the wrapped CloseableIterator is closed properly.