### PR TITLE
[GEOS-7155] Handle null store names in importer

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
@@ -89,6 +89,10 @@ public class DataStoreFormat extends VectorFormat {
         CatalogBuilder cb = new CatalogBuilder(catalog);
         cb.setWorkspace(workspace);
         DataStoreInfo store  = cb.buildDataStore(data.getName());
+        DataStoreFactorySpi factory = factory();
+        if (store.getName() == null) {
+            store.setName(factory.getDisplayName());
+        }
         store.setType(factory().getDisplayName());
         store.getConnectionParameters().putAll(params);
         return store;


### PR DESCRIPTION
For certain formats (eg. MongoDB), data.getName() returns null in importer. In these cases, we should populate the store name using the DataStoreFactory name. 
See https://osgeo-org.atlassian.net/browse/GEOS-7155

Since this only occurs with certain extensions, an automated test case is not really viable. This has been tested against the mongodb extension and works fine.