### PR TITLE
[GEOS-7143] Add option to disable INSPIRE capabilities

### DIFF
--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/InspireMetadata.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/InspireMetadata.java
@@ -6,8 +6,11 @@
 package org.geoserver.inspire;
 
 public enum InspireMetadata {
-    LANGUAGE("inspire.language"), SERVICE_METADATA_URL("inspire.metadataURL"), SERVICE_METADATA_TYPE(
-            "inspire.metadataURLType"), SPATIAL_DATASET_IDENTIFIER_TYPE("inspire.spatialDatasetIdentifier");
+    CREATE_EXTENDED_CAPABILITIES("inspire.createExtendedCapabilities"),
+    LANGUAGE("inspire.language"), 
+    SERVICE_METADATA_URL("inspire.metadataURL"), 
+    SERVICE_METADATA_TYPE("inspire.metadataURLType"), 
+    SPATIAL_DATASET_IDENTIFIER_TYPE("inspire.spatialDatasetIdentifier");
 
     public String key;
 

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/web/InspireAdminPanel.html
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/web/InspireAdminPanel.html
@@ -1,28 +1,41 @@
 <html xmlns:wicket="http://wicket.apache.org/">
 <head></head>
 <body>
-
   <wicket:panel>
     <ul>
     <li>  
       <fieldset>
         <legend><span><wicket:message key="inspire">INSPIRE</wicket:message></span></legend>
         <ul>
-          <li>
-            <label for="language"><wicket:message key="language">Language</wicket:message></label> 
-            <select wicket:id="language"></select>
-          </li>
-          <li>
-            <label for="metadataURL"><wicket:message key="metadataURL">Metadata URL</wicket:message></label> 
-            <input type="text" wicket:id="metadataURL" size="50 "></input>
-          </li>
-          <li>
-            <label for="metadataURLType"><wicket:message key="metadataURLType">metadataURLType</wicket:message></label> 
-            <select wicket:id="metadataURLType"></select>
-          </li>
-          <li wicket:id="datasetIdentifiersContainer">
-            <label for="spatialDatasetIdentifiers"><wicket:message key="spatialDatasetIdentifiers">spatialDatasetIdentifiers</wicket:message></label> 
-            <div wicket:id="spatialDatasetIdentifiers"></div>
+        <li>
+          <input id="createExtendedCapabilities" class="field checkbox" type="checkbox" wicket:id="createExtendedCapabilities" />
+          <label class="choice">
+            <wicket:message key="createExtendedCapabilities">Create INSPIRE ExtendedCapabilities element</wicket:message>
+          </label>
+        </li>
+          <li wicket:id="container">
+            <div wicket:id="configs">
+              <ul>
+                <li>
+                  <label for="language"><wicket:message key="language">Language</wicket:message></label> 
+                  <select wicket:id="language"></select>
+                </li>
+                <li>
+                  <span wicket:id="border">
+                  <label for="metadataURL"><wicket:message key="metadataURL">Metadata URL</wicket:message></label> 
+                  <input type="text" wicket:id="metadataURL" size="50 "></input>
+                  </span>
+                </li>
+                <li>
+                  <label for="metadataURLType"><wicket:message key="metadataURLType">metadataURLType</wicket:message></label> 
+                  <select wicket:id="metadataURLType"></select>
+                </li>
+                <li wicket:id="datasetIdentifiersContainer">
+                  <label for="spatialDatasetIdentifiers"><wicket:message key="spatialDatasetIdentifiers">spatialDatasetIdentifiers</wicket:message></label> 
+                  <div wicket:id="spatialDatasetIdentifiers"></div>
+                </li>
+              </ul>
+            </div>
           </li>
         </ul>
       </fieldset>

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesProvider.java
@@ -5,9 +5,10 @@
  */
 package org.geoserver.inspire.wfs;
 
-import static org.geoserver.inspire.InspireMetadata.LANGUAGE;
+import static org.geoserver.inspire.InspireMetadata.CREATE_EXTENDED_CAPABILITIES;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_TYPE;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
+import static org.geoserver.inspire.InspireMetadata.LANGUAGE;
 import static org.geoserver.inspire.InspireMetadata.SPATIAL_DATASET_IDENTIFIER_TYPE;
 import static org.geoserver.inspire.InspireSchema.COMMON_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.DLS_NAMESPACE;
@@ -25,6 +26,7 @@ import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.NamespaceSupport;
 
 import java.io.IOException;
+import org.geoserver.catalog.MetadataMap;
 
 public class WFSExtendedCapabilitiesProvider implements
         org.geoserver.wfs.WFSExtendedCapabilitiesProvider {
@@ -50,15 +52,19 @@ public class WFSExtendedCapabilitiesProvider implements
         if ("1.0.0".equals(version)) {
             return;
         }
-        String metadataURL = (String) wfs.getMetadata().get(SERVICE_METADATA_URL.key);
-        String mediaType = (String) wfs.getMetadata().get(SERVICE_METADATA_TYPE.key);
-        String language = (String) wfs.getMetadata().get(LANGUAGE.key);
-        UniqueResourceIdentifiers ids = (UniqueResourceIdentifiers) wfs.getMetadata().get(SPATIAL_DATASET_IDENTIFIER_TYPE.key, UniqueResourceIdentifiers.class);
+        MetadataMap serviceMetadata = wfs.getMetadata();
+        Boolean createExtendedCapabilities = (Boolean) serviceMetadata.get(CREATE_EXTENDED_CAPABILITIES.key);
+        String metadataURL = (String) serviceMetadata.get(SERVICE_METADATA_URL.key);
+        String mediaType = (String) serviceMetadata.get(SERVICE_METADATA_TYPE.key);
+        String language = (String) serviceMetadata.get(LANGUAGE.key);
+        UniqueResourceIdentifiers ids = (UniqueResourceIdentifiers) serviceMetadata.get(SPATIAL_DATASET_IDENTIFIER_TYPE.key, UniqueResourceIdentifiers.class);
         //Don't create extended capabilities element if mandatory content not present
-        if (metadataURL == null) {
-            return;
-        }
-        if (ids == null || ids.isEmpty()) {
+        //or turned off
+        if (metadataURL == null
+                || ids == null
+                || ids.isEmpty()
+                || createExtendedCapabilities != null
+                && !createExtendedCapabilities) {
             return;
         }
 

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
@@ -5,9 +5,10 @@
  */
 package org.geoserver.inspire.wms;
 
-import static org.geoserver.inspire.InspireMetadata.LANGUAGE;
+import static org.geoserver.inspire.InspireMetadata.CREATE_EXTENDED_CAPABILITIES;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_TYPE;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
+import static org.geoserver.inspire.InspireMetadata.LANGUAGE;
 import static org.geoserver.inspire.InspireSchema.COMMON_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_SCHEMA;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MetadataMap;
 import org.geoserver.wms.ExtendedCapabilitiesProvider;
 import org.geoserver.wms.GetCapabilitiesRequest;
 import org.geoserver.wms.WMS;
@@ -70,13 +72,18 @@ public class WMSExtendedCapabilitiesProvider implements ExtendedCapabilitiesProv
         if (!WMS.VERSION_1_3_0.equals(requestVersion)) {
             return;
         }
-        String metadataURL = (String) wms.getMetadata().get(SERVICE_METADATA_URL.key);
-        String mediaType = (String) wms.getMetadata().get(SERVICE_METADATA_TYPE.key);
-        String language = (String) wms.getMetadata().get(LANGUAGE.key);
+        MetadataMap serviceMetadata = wms.getMetadata();
+        Boolean createExtendedCapabilities = (Boolean) serviceMetadata.get(CREATE_EXTENDED_CAPABILITIES.key);
+        String metadataURL = (String) serviceMetadata.get(SERVICE_METADATA_URL.key);
         //Don't create extended capabilities element if mandatory content not present
-        if (metadataURL == null) {
+        //or turned off
+        if (metadataURL == null
+                || createExtendedCapabilities != null
+                && !createExtendedCapabilities) {
             return;
         }
+        String mediaType = (String) serviceMetadata.get(SERVICE_METADATA_TYPE.key);
+        String language = (String) serviceMetadata.get(LANGUAGE.key);
 
         // IGN : INSPIRE SCENARIO 1
         tx.start("inspire_vs:ExtendedCapabilities");

--- a/src/extension/inspire/src/main/resources/GeoServerApplication.properties
+++ b/src/extension/inspire/src/main/resources/GeoServerApplication.properties
@@ -7,6 +7,7 @@ InspireAdminPanel.metadataURLType=Service Metadata Type
 InspireAdminPanel.metadataURLType.application/vnd.ogc.csw.GetRecordByIdResponse_xml=CSW GetRecord by ID request
 InspireAdminPanel.metadataURLType.application/vnd.iso.19139+xml=Online ISO 19139 ServiceMetadata document
 InspireAdminPanel.spatialDatasetIdentifiers=Spatial Dataset Identifiers
+InspireAdminPanel.createExtendedCapabilities=Create INSPIRE ExtendedCapabilities element
 
 UniqueResourceIdentifiersEditor.noIdentifiersSoFar=No identifiers so far
 UniqueResourceIdentifiersEditor.th.code=Code

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/InspireTestSupport.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/InspireTestSupport.java
@@ -1,0 +1,128 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.inspire;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.geoserver.catalog.MetadataMap;
+import org.geoserver.config.ServiceInfo;
+import static org.geoserver.inspire.InspireSchema.COMMON_NAMESPACE;
+import static org.geoserver.inspire.InspireSchema.DLS_NAMESPACE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class InspireTestSupport {
+
+    public static void clearInspireMetadata(MetadataMap metadata) {
+        for (InspireMetadata item : InspireMetadata.values()) {
+            metadata.remove(item.key);
+        }
+    }
+
+    public static void assertSchemaLocationContains(String schemaLocation, String namespace, String url) {
+        assertTrue(schemaLocation.contains(namespace));
+
+        String[] schemaLocationParts = schemaLocation.split("\\s+");
+        for (int i = 0; i < schemaLocationParts.length; i++) {
+            if (schemaLocationParts[i].equals(namespace)) {
+                assertTrue(schemaLocationParts[i + 1].equals(url));
+            }
+        }
+    }
+
+    public static void assertInspireCommonScenario1Response(final Element extendedCapabilities,
+            final String metadataUrl, final String mediaType, final String language) {
+
+        NodeList nodeList = extendedCapabilities.getElementsByTagNameNS(COMMON_NAMESPACE, "MetadataUrl");
+        assertEquals("Number of MetadataUrl elements", 1, nodeList.getLength());
+        final Element mdUrl = (Element) nodeList.item(0);
+
+        assertInspireMetadataUrlResponse(mdUrl, metadataUrl, mediaType);
+
+        nodeList = extendedCapabilities.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguages");
+        assertEquals("Number of SupportedLanguages elements", 1, nodeList.getLength());
+        final Element suppLangs = (Element) nodeList.item(0);
+
+        nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "DefaultLanguage");
+        assertEquals("Number of DefaultLanguage elements", 1, nodeList.getLength());
+        final Element defLang = (Element) nodeList.item(0);
+
+        nodeList = defLang.getElementsByTagNameNS(COMMON_NAMESPACE, "Language");
+        assertEquals("Number of DefaultLanguage/Language elements", 1, nodeList.getLength());
+        final Element defLangVal = (Element) nodeList.item(0);
+        assertEquals("DefaultLanguage/Language", language, defLangVal.getFirstChild().getNodeValue());
+
+        nodeList = extendedCapabilities.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage");
+        assertEquals("Number of ResponseLanguage elements", 1, nodeList.getLength());
+        final Element respLang = (Element) nodeList.item(0);
+
+        nodeList = respLang.getElementsByTagNameNS(COMMON_NAMESPACE, "Language");
+        assertEquals("Number of ResponseLanguage/Language elements", 1, nodeList.getLength());
+        final Element respLangVal = (Element) nodeList.item(0);
+        assertEquals("ResponseLanguage/Language", language, respLangVal.getFirstChild().getNodeValue());
+
+    }
+
+    public static void assertInspireMetadataUrlResponse(final Element mdUrl,
+            final String metadataUrl, final String mediaType) {
+
+        NodeList nodeList = mdUrl.getElementsByTagNameNS(COMMON_NAMESPACE, "URL");
+        assertEquals("Number of URL elements", 1, nodeList.getLength());
+        final Element url = (Element) nodeList.item(0);
+        assertEquals("MetadataUrl/URL", metadataUrl, url.getFirstChild().getNodeValue());
+
+        nodeList = mdUrl.getElementsByTagNameNS(COMMON_NAMESPACE, "MediaType");
+        if (mediaType == null) {
+            assertEquals("Number of MediaType elements", 0, nodeList.getLength());
+        } else {
+            assertEquals("Number of MediaType elements", 1, nodeList.getLength());
+            assertEquals("MediaType", mediaType, ((Element) nodeList.item(0)).getFirstChild().getNodeValue());
+        }
+
+    }
+
+    public static void assertInspireDownloadSpatialDataSetIdentifierResponse(
+            final Element extendedCapabilities, final UniqueResourceIdentifiers ids) {
+
+        final NodeList spatialDataSetIdentifiers = extendedCapabilities.getElementsByTagNameNS(DLS_NAMESPACE, "SpatialDataSetIdentifier");
+        assertEquals("Number of SpatialDataSetIdentifer elements", ids.size(), spatialDataSetIdentifiers.getLength());
+
+        final Map<String, UniqueResourceIdentifier> idMap = new HashMap<String, UniqueResourceIdentifier>();
+
+        for (UniqueResourceIdentifier id : ids) {
+            idMap.put(id.getCode(), id);
+        }
+
+        for (int i = 0; i < spatialDataSetIdentifiers.getLength(); i++) {
+            Element sdi = (Element) spatialDataSetIdentifiers.item(i);
+            NodeList nodeList = sdi.getElementsByTagNameNS(COMMON_NAMESPACE, "Code");
+            assertEquals("Number of Code elements", 1, nodeList.getLength());
+            String code = ((Element) nodeList.item(0)).getFirstChild().getNodeValue();
+            assertTrue("Should be an identifier with code " + code, idMap.containsKey(code));
+            nodeList = sdi.getElementsByTagNameNS(COMMON_NAMESPACE, "Namespace");
+            String expectedNamespace = idMap.get(code).getNamespace();
+            if (expectedNamespace == null) {
+                assertEquals("Number of Namespace elements for identifier with code " + code,
+                        0, nodeList.getLength());
+            } else {
+                assertEquals("Number of Namespace elements for identifier with code " + code,
+                        1, nodeList.getLength());
+                String actualNamespace = ((Element) nodeList.item(0)).getFirstChild().getNodeValue();
+                assertEquals("Namespace for identifier with code " + code,
+                        expectedNamespace, actualNamespace);
+            }
+            String expectedMetadataUrl = idMap.get(code).getMetadataURL();
+            String actualMetadataUrl = sdi.getAttribute("metadataURL");
+            if (expectedMetadataUrl == null) {
+                expectedMetadataUrl = "";
+            }
+            assertEquals("metadataURL attribute for identifer with code" + code,
+                    expectedMetadataUrl, actualMetadataUrl);
+        }
+    }
+}

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/web/UniqueResourceIdentifiersEditorTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/web/UniqueResourceIdentifiersEditorTest.java
@@ -4,12 +4,8 @@
  */
 package org.geoserver.inspire.web;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertNull;
-
 import java.io.Serializable;
 import java.util.List;
-
 import org.apache.wicket.Component;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.form.Form;
@@ -22,6 +18,9 @@ import org.geoserver.web.FormTestPage;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.geoserver.web.wicket.ParamResourceModel;
 import org.geotools.util.Converters;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
@@ -5,17 +5,22 @@
  */
 package org.geoserver.inspire.wms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.geoserver.inspire.InspireMetadata;
+import org.geoserver.catalog.MetadataMap;
+import org.geoserver.config.ServiceInfo;
+import static org.geoserver.inspire.InspireMetadata.CREATE_EXTENDED_CAPABILITIES;
+import static org.geoserver.inspire.InspireMetadata.LANGUAGE;
+import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_TYPE;
+import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
 import static org.geoserver.inspire.InspireSchema.COMMON_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_SCHEMA;
+import static org.geoserver.inspire.InspireTestSupport.assertInspireCommonScenario1Response;
+import static org.geoserver.inspire.InspireTestSupport.assertInspireMetadataUrlResponse;
+import static org.geoserver.inspire.InspireTestSupport.assertSchemaLocationContains;
+import static org.geoserver.inspire.InspireTestSupport.clearInspireMetadata;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.wms.WMSInfo;
-import static org.junit.Assert.assertTrue;
-import org.junit.Before;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -26,144 +31,180 @@ public class WMSExtendedCapabilitiesTest extends GeoServerSystemTestSupport {
         private static final String WMS_1_1_1_GETCAPREQUEST = "wms?request=GetCapabilities&service=WMS&version=1.1.1";
         private static final String WMS_1_3_0_GETCAPREQUEST = "wms?request=GetCapabilities&service=WMS&version=1.3.0";
 
-    @Before
-    public void clearMetadata() {
-        WMSInfo wfs = getGeoServer().getService(WMSInfo.class);
-        wfs.getMetadata().clear();
-        getGeoServer().save(wfs);
-    }
-
     @Test
-    public void testNoInspireElementWhenNoMetadata() throws Exception {
-        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
-
-        final NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
-        assertEquals(0, nodeList.getLength());
-    }
-
-    @Test
-    public void testNoInspireElementWhenNoMetadataUrl() throws Exception {
-        WMSInfo wms = getGeoServer().getService(WMSInfo.class);
-        wms.getMetadata().put(InspireMetadata.LANGUAGE.key, "fre");
-        getGeoServer().save(wms);
+    public void testNoInspireSettings() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        getGeoServer().save(serviceInfo);
 
         final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
 
         final NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
-        assertEquals(0, nodeList.getLength());
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 0, nodeList.getLength());
+    }
+
+    @Test
+    public void testCreateExtCapsOff() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, false);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
+        
+        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
+
+        final NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 0, nodeList.getLength());
+    }
+
+    @Test
+    public void testExtCaps130WithFullSettings() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
+
+        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
+        
+        NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 1, nodeList.getLength());
+        
+        String schemaLocation = dom.getDocumentElement().getAttribute("xsi:schemaLocation");
+        assertSchemaLocationContains(schemaLocation, VS_NAMESPACE, VS_SCHEMA);
+
+        final Element extendedCaps = (Element) nodeList.item(0);
+        
+        assertInspireCommonScenario1Response(extendedCaps, 
+                "http://foo.com?bar=baz", "application/vnd.iso.19139+xml", "fre");
+
     }
 
     /* There is an INSPIRE DTD for WMS 1.1.1 but not implementing this */
     @Test
-    public void testNoInspireElement111() throws Exception {
-        WMSInfo wms = getGeoServer().getService(WMSInfo.class);
-        wms.getMetadata().put(InspireMetadata.LANGUAGE.key, "fre");
-        wms.getMetadata().put(InspireMetadata.SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
-        getGeoServer().save(wms);
+    public void testExtCaps111WithFullSettings() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
 
         final Document dom = getAsDOM(WMS_1_1_1_GETCAPREQUEST);
 
         final NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
-        assertTrue(nodeList.getLength() == 0);
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 0, nodeList.getLength());
     }
 
+    // Test ExtendedCapabilities is not produced if required settings missing
+    
     @Test
-    public void testNoMediaTypeElement() throws Exception {
-        WMSInfo wms = getGeoServer().getService(WMSInfo.class);
-        wms.getMetadata().put(InspireMetadata.LANGUAGE.key, "fre");
-        wms.getMetadata().put(InspireMetadata.SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
-        getGeoServer().save(wms);
+    public void testNoMetadataUrl() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
 
         final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
 
-        final NodeList nodeList = dom.getElementsByTagNameNS(COMMON_NAMESPACE, "MediaType");
-        assertEquals(0, nodeList.getLength());
+        final NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 0, nodeList.getLength());
     }
 
+    // Test ExtendedCapabilities response when optional settings missing
+    
     @Test
-    public void testExtendedCaps() throws Exception {
-        WMSInfo wms = getGeoServer().getService(WMSInfo.class);
-        wms.getSRS().add("EPSG:4326");
-        wms.getMetadata().put(InspireMetadata.LANGUAGE.key, "fre");
-        wms.getMetadata().put(InspireMetadata.SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
-        getGeoServer().save(wms);
+    public void testNoMediaType() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
 
-        Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
-        assertEquals(VS_NAMESPACE, dom.getDocumentElement().getAttribute("xmlns:inspire_vs"));
-        
-        String schemaLocation = dom.getDocumentElement().getAttribute("xsi:schemaLocation"); 
-        assertTrue(schemaLocation.contains(VS_NAMESPACE));
-        
-        String[] schemaLocationParts = schemaLocation.split("\\s+");
-        for (int i = 0; i < schemaLocationParts .length; i++) {
-            if (schemaLocationParts[i].equals(VS_NAMESPACE)) {
-                assertTrue(schemaLocationParts[i+1].equals(VS_SCHEMA));
-            }
-        }
+        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
 
-        final Element extendedCaps = getFirstElementByTagName(dom,
-                "inspire_vs:ExtendedCapabilities");
-        assertNotNull(extendedCaps);
+        NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 1, nodeList.getLength());
 
-        final Element mdUrl = getFirstElementByTagName(extendedCaps, "inspire_common:MetadataUrl");
-        assertNotNull(mdUrl);
-
-        final Element url = getFirstElementByTagName(mdUrl, "inspire_common:URL");
-        assertNotNull(url);
-        assertEquals("http://foo.com?bar=baz", url.getFirstChild().getNodeValue());
-
-        final Element suppLangs = getFirstElementByTagName(extendedCaps,
-                "inspire_common:SupportedLanguages");
-        assertNotNull(suppLangs);
-        final Element defLang = getFirstElementByTagName(suppLangs,
-                "inspire_common:DefaultLanguage");
-        assertNotNull(defLang);
-        final Element defLangVal = getFirstElementByTagName(defLang, "inspire_common:Language");
-        assertEquals("fre", defLangVal.getFirstChild().getNodeValue());
-
-        final Element respLang = getFirstElementByTagName(extendedCaps,
-                "inspire_common:ResponseLanguage");
-        assertNotNull(respLang);
-        final Element respLangVal = getFirstElementByTagName(defLang, "inspire_common:Language");
-        assertEquals("fre", respLangVal.getFirstChild().getNodeValue());
+        nodeList = dom.getElementsByTagNameNS(COMMON_NAMESPACE, "MediaType");
+        assertEquals("Number of MediaType elements", 0, nodeList.getLength());
     }
 
+    // If settings were created with older version of INSPIRE extension before
+    // the on/off check box setting existed we create the extended capabilities
+    // if the other required settings exist and don't if they don't
+    
+    @Test
+    public void testCreateExtCapMissingWithRequiredSettings() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
+        
+        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
+
+        NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 1, nodeList.getLength());
+    }
+    
+    @Test
+    public void testCreateExtCapMissingWithoutRequiredSettings() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
+
+        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
+
+        final NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 0, nodeList.getLength());
+    }
+    
     @Test
     public void testChangeMediaType() throws Exception {
-        WMSInfo wms = getGeoServer().getService(WMSInfo.class);
-        wms.getSRS().add("EPSG:4326");
-        wms.getMetadata().put(InspireMetadata.LANGUAGE.key, "fre");
-        wms.getMetadata().put(InspireMetadata.SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
-        wms.getMetadata().put(InspireMetadata.SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
-        getGeoServer().save(wms);
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
 
         Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
-        assertEquals(VS_NAMESPACE, dom.getDocumentElement().getAttribute("xmlns:inspire_vs"));
-        assertMetadataUrlAndMediaType(dom, "http://foo.com?bar=baz", "application/vnd.iso.19139+xml");
+        
+        NodeList nodeList = dom.getElementsByTagNameNS(COMMON_NAMESPACE, "MetadataUrl");
+        assertEquals("Number of MediaType elements", 1, nodeList.getLength());
+        Element mdUrl = (Element) nodeList.item(0);
+        assertInspireMetadataUrlResponse(mdUrl, "http://foo.com?bar=baz", "application/vnd.iso.19139+xml");
 
-        wms.getMetadata().put(InspireMetadata.SERVICE_METADATA_TYPE.key, "application/xml");
-        getGeoServer().save(wms);
+        serviceInfo.getMetadata().put(SERVICE_METADATA_TYPE.key, "application/vnd.ogc.csw.GetRecordByIdResponse_xml");
+        getGeoServer().save(serviceInfo);
 
         dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
-        assertEquals(VS_NAMESPACE, dom.getDocumentElement().getAttribute("xmlns:inspire_vs"));
-        assertMetadataUrlAndMediaType(dom, "http://foo.com?bar=baz", "application/xml");
-    }
-
-    void assertMetadataUrlAndMediaType(Document dom, String metadataUrl, String metadataMediaType) {
-        final Element extendedCaps = getFirstElementByTagName(dom,
-                "inspire_vs:ExtendedCapabilities");
-        assertNotNull(extendedCaps);
-
-        final Element mdUrl = getFirstElementByTagName(extendedCaps, "inspire_common:MetadataUrl");
-        assertNotNull(mdUrl);
-
-        final Element url = getFirstElementByTagName(mdUrl, "inspire_common:URL");
-        assertNotNull(url);
-        assertEquals(metadataUrl, url.getFirstChild().getNodeValue());
-
-        final Element mediaType = getFirstElementByTagName(mdUrl, "inspire_common:MediaType");
-        assertNotNull(mediaType);
-        assertEquals(metadataMediaType, mediaType.getFirstChild().getNodeValue());
-
+        
+        nodeList = dom.getElementsByTagNameNS(COMMON_NAMESPACE, "MetadataUrl");
+        assertEquals("Number of MediaType elements", 1, nodeList.getLength());
+        mdUrl = (Element) nodeList.item(0);
+        assertInspireMetadataUrlResponse(mdUrl, "http://foo.com?bar=baz", "application/vnd.ogc.csw.GetRecordByIdResponse_xml");
     }
 }


### PR DESCRIPTION
Replacing https://github.com/geoserver/geoserver/pull/1174.

Now addressing https://osgeo-org.atlassian.net/browse/GEOS-7143 by having a check-box to enable or disable the INSPIRE extended capabilities so, if you don't have the required parameters for creating an INSPIRE extended capabilities you can just switch it off. You still get the validation errors if switched on.

Re-organised the tests quite a bit in the process of adding new ones for the on/off behaviour.