### PR TITLE
update link to rgeoserver gem

### DIFF
--- a/doc/en/user/source/rest/examples/ruby.rst
+++ b/doc/en/user/source/rest/examples/ruby.rst
@@ -3,7 +3,7 @@
 Ruby
 ====
 
-The examples in this section use `rest-client <http://github.com/archiloque/rest-client>`_, a REST client for Ruby. There is also a project to create a GeoServer-specific REST client in Ruby: `RGeoServer <https://github.com/rnz0/rgeoserver>`_.
+The examples in this section use `rest-client <http://github.com/archiloque/rest-client>`_, a REST client for Ruby. There is also a GeoServer-specific REST client in Ruby: `RGeoServer <https://github.com/sul-dlss/rgeoserver>`_.
 
 Once installed on a system, ``rest-client`` can be included in a Ruby script by adding ``require 'rest-client'``.
 


### PR DESCRIPTION
Active development of the rgeoserver gem referenced in the documentation has moved to a new repository and is now maintained by @drh-stanford. Rubygems points to this repo as well. The examples provided on the old gem repo are broken.