### PR TITLE
[GEOS-7167] GML2 xlinks import diverge fixed

### DIFF
--- a/src/main/src/main/resources/schemas/gml/2.1.2/geometry.xsd
+++ b/src/main/src/main/resources/schemas/gml/2.1.2/geometry.xsd
@@ -7,7 +7,7 @@
     </documentation>
   </annotation>
   <!-- bring in the XLink attributes -->
-  <import namespace="http://www.w3.org/1999/xlink" schemaLocation="../../xlink/1.0.0/xlinks.xsd"/>
+  <import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlinks.xsd"/>
   <!-- ==============================================================
        global declarations
   =================================================================== -->


### PR DESCRIPTION
Now both feature.xsd and geometry.xsd imports the same xlinks.xsd and the XSD validates correctly.