### PR TITLE
Accepts check box clicks outside the boxes [GEOS-6948]

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
@@ -10,13 +10,13 @@
         <ul>
           <li>
             <input id="queryableEnabled" class="field checkbox" type="checkbox" wicket:id="queryableEnabled"></input>
-            <label for="queryableEnabled" class="choice"><wicket:message key="queryable">Queryable</wicket:message></label>
+            <label class="choice"><wicket:message key="queryable">Queryable</wicket:message></label>
           </li>
         </ul>
         <ul>
           <li>
             <input id="opaqueEnabled" class="field checkbox" type="checkbox" wicket:id="opaqueEnabled"></input>
-            <label for="opaqueEnabled" class="choice"><wicket:message key="opaque">Opaque</wicket:message></label>
+            <label class="choice"><wicket:message key="opaque">Opaque</wicket:message></label>
           </li>
         </ul>
         <ul wicket:id="styles">


### PR DESCRIPTION
We have had an issue with label spanning preventing the of checkboxes. This issue has been held open due to two checkboxes in WMSLayerConfig - which provide the same behavior due to correctly marking a label as for an assoicated checkbox.

This pull request removes the assoication until such time as the CSS can be fixed.

For details: https://osgeo-org.atlassian.net/browse/GEOS-6948