### PR TITLE
Accepts check box clicks outside the boxes [GEOS-6948]

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -382,19 +382,43 @@ padding: 0 0 1px;
 }
 
 label.choice {
-color: #222;
 display: block;
-font-weight: normal;
-font-size: 100%;
-line-height: 1.5em;
 margin: -1.65em 0 0 25px;
 padding: 0.44em 0 0.5em;
 width: 90%;
+line-height: 1.5em;
 }
 
-ul.choiceList>li>label, ul.choiceList>li>input[type=checkbox] {
-display:inline;
+label.choice,ul.choiceList>li>label {
+color: #222; 
+font-weight: normal;
+font-size: 100%;
 }
+
+
+/* For a "choiceList" create padding down leading side to act as a "hanging indent" then move the checkbox/radio into that padding. This allows the label to remain inline so it doesn't produce clickable whitespace. */
+ul.choiceList>li {
+position: relative;
+padding-left: 2 em; 
+}
+ul.choiceList>li:dir(rtl){
+padding-left: 0;
+padding-right: 2 em;
+}
+ul.choiceList>li>label {
+display: inline;
+}
+ul.choiceList>li>input[type=checkbox],ul.choiceList>li>input[type=radio] {
+display: block;
+position: absolute;
+left: 0;
+}
+ul.choiceList>li:dir(rtl)>input[type=checkbox],ul.choiceList>li:dir(rtl)>input[type=radio] {
+left: auto;
+right: 0;
+}
+
+
 
 textarea.small {
 height: 3em;

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
@@ -7,16 +7,16 @@
     <li>
       <fieldset>
         <legend><span><wicket:message key="defaultTitle">Default Title</wicket:message></span></legend>
-        <ul>
+        <ul class="choiceList">
           <li>
-            <input id="queryableEnabled" class="field checkbox" type="checkbox" wicket:id="queryableEnabled"></input>
-            <label for="queryableEnabled" class="choice"><wicket:message key="queryable">Queryable</wicket:message></label>
+            <input id="queryableEnabled" type="checkbox" wicket:id="queryableEnabled"></input>
+            <label for="queryableEnabled"><wicket:message key="queryable">Queryable</wicket:message></label>
           </li>
         </ul>
-        <ul>
+        <ul class="choiceList">
           <li>
-            <input id="opaqueEnabled" class="field checkbox" type="checkbox" wicket:id="opaqueEnabled"></input>
-            <label for="opaqueEnabled" class="choice"><wicket:message key="opaque">Opaque</wicket:message></label>
+            <input id="opaqueEnabled" type="checkbox" wicket:id="opaqueEnabled"></input>
+            <label for="opaqueEnabled"><wicket:message key="opaque">Opaque</wicket:message></label>
           </li>
         </ul>
         <ul wicket:id="styles">


### PR DESCRIPTION
Applied a class to the list rather than to the label allowing for manipulation of the CSS higher up the tree.

Retains the pseudo-hanging indent so long labels won't wrap underneath the checkbox while also making the label an inline element so it doesn't result in clicking on the whitespace toggling the input.