### PR TITLE
resolve conflict between printing and monitor extension

### DIFF
--- a/src/extension/monitor/core/src/main/resources/org/geoserver/monitor/filter.properties
+++ b/src/extension/monitor/core/src/main/resources/org/geoserver/monitor/filter.properties
@@ -12,3 +12,4 @@
 /rest/monitor/**
 /web
 /web/**
+/pdf/**


### PR DESCRIPTION
From Javier Avalos on mailing list:

> I answered myself : 
> adding the following line:
> /pdf/ **
> to the filter.properties configuration file of the monitoring module and restart geoserver the error disappears .
> Cheers!