### PR TITLE
[GEOS-7151] 2.7.x Backport patch to fix CloseableIterator warnings

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -64,7 +64,6 @@ import org.springframework.util.Assert;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 
 /**
  * Wraps the catalog and applies the security directives provided by a {@link ResourceAccessManager}
@@ -1412,8 +1411,8 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         // Function. When the AccessLevel is HIDDEN and a layer gets filtered 
         // out via a CatalogFilter - for example, this can happen with a
         // LocalWorkspaceCatalogFilter and a virtual service request
-        return new CloseableIteratorAdapter(Iterators.filter(filteredWrapped,
-                com.google.common.base.Predicates.notNull()));
+        return CloseableIteratorAdapter.filter(filteredWrapped,
+                com.google.common.base.Predicates.<T> notNull());
     }
 
     /**

--- a/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -7,7 +7,9 @@ package org.geoserver.security.impl;
 
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -478,6 +480,36 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
 
         assertEquals(1, sc.getLayers().size());
         assertEquals(statesLayer.getName(), sc.getLayers().get(0).getName());
+    }
+
+    @Test
+    public void testCatalogCloseWrappedIterator() throws Exception {
+        // create a mock CloseableIterator that expects to be closed
+        final CloseableIterator<?> mockIterator = createNiceMock(CloseableIterator.class);
+        mockIterator.close();
+        expectLastCall().once();
+        replay(mockIterator);
+
+        // make a catalog that uses the mock CloseableIterator
+        Catalog withLayers = new AbstractCatalogDecorator(catalog) {
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T extends CatalogInfo> CloseableIterator<T> list(Class<T> of, Filter filter, Integer offset, Integer count, SortBy sortBy) {
+                return (CloseableIterator<T>) mockIterator;
+            }
+        };
+        this.catalog = withLayers;
+        GeoServerExtensionsHelper.singleton("catalog", catalog, Catalog.class);
+        buildManager("publicRead.properties");
+
+        // get the CloseableIterator from SecureCatalogImpl and close it
+        CloseableIterator<LayerInfo> iterator;
+        iterator = sc.list(LayerInfo.class, Predicates.acceptAll());
+        iterator.close();
+
+        // verify that the mock CloseableIterator was closed
+        verify(mockIterator);
     }
 
     @Test


### PR DESCRIPTION
Use the factory method instead of the constructor to create the CloseableIteratorAdapter to ensure that the wrapped CloseableIterator is closed properly.