### PR TITLE
[GEOS-7085] 2.7.x Backport patch to add the proxy base URL to WCS/WFS metadata links

### DIFF
--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10CapsTransformer.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10CapsTransformer.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -38,7 +38,6 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.ows.URLMangler.URLType;
-import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.wcs.WCSInfo;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.factory.GeoTools;
@@ -47,6 +46,7 @@ import org.geotools.util.logging.Logging;
 import org.geotools.xml.transform.TransformerBase;
 import org.geotools.xml.transform.Translator;
 import org.vfny.geoserver.global.CoverageInfoLabelComparator;
+import org.vfny.geoserver.util.ResponseUtils;
 import org.vfny.geoserver.wcs.WcsException;
 import org.vfny.geoserver.wcs.WcsException.WcsExceptionCode;
 import org.xml.sax.ContentHandler;
@@ -294,7 +294,7 @@ public class Wcs10CapsTransformer extends TransformerBase {
 
             if ((mdl.getContent() != null) && (mdl.getContent() != "")) {
                 attributes.addAttribute("", "xlink:href", "xlink:href", 
-                        "", mdl.getContent());
+                        "", ResponseUtils.proxifyMetadataLink(mdl, request.getBaseUrl()));
             }
 
             if (attributes.getLength() > 0) {
@@ -491,7 +491,7 @@ public class Wcs10CapsTransformer extends TransformerBase {
 
             // String baseURL = RequestUtils.proxifiedBaseURL(request.getBaseUrl(),
             // wcs.getGeoServer().getGlobal().getProxyBaseUrl());
-            String url = ResponseUtils.buildURL(request.getBaseUrl(), "wcs", null, URLType.SERVICE);
+            String url = buildURL(request.getBaseUrl(), "wcs", null, URLType.SERVICE);
             attributes.addAttribute("", "xlink:href", "xlink:href", "", url+"?");
 
             start("wcs:Get");

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10DescribeCoverageTransformer.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10DescribeCoverageTransformer.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -54,6 +54,7 @@ import org.opengis.coverage.grid.GridEnvelope;
 import org.opengis.coverage.grid.GridGeometry;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.vfny.geoserver.util.ResponseUtils;
 import org.vfny.geoserver.wcs.WcsException;
 import org.vfny.geoserver.wcs.WcsException.WcsExceptionCode;
 import org.xml.sax.ContentHandler;
@@ -248,7 +249,7 @@ public class Wcs10DescribeCoverageTransformer extends TransformerBase {
 
             if ((mdl.getContent() != null) && (mdl.getContent() != "")) {
                 attributes.addAttribute("", "xlink:href", "xlink:href", 
-                        "", mdl.getContent());
+                        "", ResponseUtils.proxifyMetadataLink(mdl, request.getBaseUrl()));
             }
 
             if (attributes.getLength() > 0) {

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/DescribeCoverageTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/DescribeCoverageTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -21,6 +21,7 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wcs.test.WCSTestSupport;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,14 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 public class DescribeCoverageTest extends WCSTestSupport {
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        GeoServerInfo global = getGeoServer().getGlobal();
+        global.getSettings().setProxyBaseUrl("src/test/resources/geoserver");
+        getGeoServer().save(global);
+    }
 
     @Before
     public void revertTasmaniaDem() throws IOException {
@@ -127,6 +136,28 @@ public class DescribeCoverageTest extends WCSTestSupport {
         assertXpathEvaluatesTo("FGDC", "//wcs:metadataLink/@metadataType", dom);
         assertXpathEvaluatesTo("simple", "//wcs:metadataLink/@xlink:type", dom);
         assertXpathEvaluatesTo("http://www.geoserver.org/tasmania/dem.xml", "//wcs:metadataLink/@xlink:href", dom);
+    }
+
+    @Test
+    public void testMetadataLinksTransormToProxyBaseURL() throws Exception {
+        Catalog catalog = getCatalog();
+        CoverageInfo ci = catalog.getCoverageByName(getLayerId(TASMANIA_DEM));
+        MetadataLinkInfo ml = catalog.getFactory().createMetadataLink();
+        ml.setContent("/metadata?key=value");
+        ml.setMetadataType("FGDC");
+        ml.setAbout("http://www.geoserver.org");
+        ci.getMetadataLinks().add(ml);
+        catalog.save(ci);
+
+        String proxyBaseUrl = getGeoServer().getGlobal().getSettings().getProxyBaseUrl();
+        Document dom = getAsDOM(BASEPATH
+                + "?request=DescribeCoverage&service=WCS&version=1.0.0&coverage="
+                + getLayerId(TASMANIA_DEM));
+        checkValidationErrors(dom, WCS10_DESCRIBECOVERAGE_SCHEMA);
+        assertXpathEvaluatesTo("http://www.geoserver.org", "//wcs:metadataLink/@about", dom);
+        assertXpathEvaluatesTo("FGDC", "//wcs:metadataLink/@metadataType", dom);
+        assertXpathEvaluatesTo("simple", "//wcs:metadataLink/@xlink:type", dom);
+        assertXpathEvaluatesTo(proxyBaseUrl + "/metadata?key=value", "//wcs:metadataLink/@xlink:href", dom);
     }
 
     @Test

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/DescribeCoverageTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/DescribeCoverageTransformer.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -37,6 +37,7 @@ import org.geotools.xml.transform.Translator;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.Matrix;
+import org.vfny.geoserver.util.ResponseUtils;
 import org.vfny.geoserver.wcs.WcsException;
 import org.vfny.geoserver.wcs.WcsException.WcsExceptionCode;
 import org.xml.sax.ContentHandler;
@@ -204,7 +205,7 @@ public class DescribeCoverageTransformer extends TransformerBase {
 
             if ((mdl.getContent() != null) && (mdl.getContent() != "")) {
                 attributes.addAttribute("", "xlink:href", "xlink:href", 
-                        "", mdl.getContent());
+                        "", ResponseUtils.proxifyMetadataLink(mdl, request.getBaseUrl()));
             }
 
             if (attributes.getLength() > 0) {

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -35,6 +35,7 @@ import org.geotools.util.logging.Logging;
 import org.geotools.xml.transform.TransformerBase;
 import org.geotools.xml.transform.Translator;
 import org.vfny.geoserver.global.CoverageInfoLabelComparator;
+import org.vfny.geoserver.util.ResponseUtils;
 import org.vfny.geoserver.wcs.WcsException;
 import org.vfny.geoserver.wcs.WcsException.WcsExceptionCode;
 import org.xml.sax.ContentHandler;
@@ -485,7 +486,7 @@ public class WCSCapsTransformer extends TransformerBase {
 
             if ((mdl.getContent() != null) && (mdl.getContent() != "")) {
                 attributes.addAttribute("", "xlink:href", "xlink:href", 
-                        "", mdl.getContent());
+                        "", ResponseUtils.proxifyMetadataLink(mdl, request.getBaseUrl()));
                 element("ows:Metadata", null, attributes);
             }
         }

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/GetCapabilitiesTest.java
@@ -422,8 +422,8 @@ public class GetCapabilitiesTest extends WCSTestSupport {
         String proxyBaseUrl = getGeoServer().getGlobal().getSettings().getProxyBaseUrl();
         Document dom = getAsDOM("wcs?request=GetCapabilities");
         checkValidationErrors(dom, WCS11_SCHEMA);
-        String xpathBase = "//wcs:CoverageSummary[wcs:Identifier = '" + TASMANIA_DEM.getLocalPart()
-                + "']/ows:Metadata";
+        String xpathBase = "//wcs:CoverageSummary[wcs:Identifier = '" + TASMANIA_DEM.getPrefix() 
+                + ":" + TASMANIA_DEM.getLocalPart() + "']/ows:Metadata";
         assertXpathEvaluatesTo("http://www.geoserver.org", xpathBase + "/@about", dom);
         assertXpathEvaluatesTo("simple", xpathBase + "/@xlink:type", dom);
         assertXpathEvaluatesTo(proxyBaseUrl + "/metadata?key=value", xpathBase + "/@xlink:href", dom);

--- a/src/wfs/src/main/java/org/geoserver/wfs/CapabilitiesTransformer.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/CapabilitiesTransformer.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -1629,9 +1629,11 @@ public abstract class CapabilitiesTransformer extends TransformerBase {
                             + VALID_LINKS_METADATATYPES);
                     return;
                 }
-                
+                if ((link.getContent() == null) || link.getContent().isEmpty()) {
+                    return;
+                }
                 AttributesImpl mtAtts = attributes("type", metadataType, "format", format);
-                element("MetadataURL", link.getContent(), mtAtts);
+                element("MetadataURL", ResponseUtils.proxifyMetadataLink(link, request.getBaseUrl()), mtAtts);
             }
             
             /**
@@ -1965,7 +1967,10 @@ public abstract class CapabilitiesTransformer extends TransformerBase {
                         protected void metadataLink(MetadataLinkInfo link) {
                             // WFS 2.0 metadata url is different than the v1.1 one, indeed it just
                             // has an href
-                            AttributesImpl mtAtts = attributes("xlink:href", link.getContent());
+                            if ((link.getContent() == null) || link.getContent().isEmpty()) {
+                                return;
+                            }
+                            AttributesImpl mtAtts = attributes("xlink:href", ResponseUtils.proxifyMetadataLink(link, request.getBaseUrl()));
                             start("MetadataURL", mtAtts);
                             end("MetadataURL");
                         }


### PR DESCRIPTION
[GEOS-7085] Add the proxy base URL to metadata links, if necessary, in WCS DescribeCoverage and WCS/WFS GetCapabilities responses.