### PR TITLE
[GEOS-7191] Update POMs that point to old Codehaus Maven repositories.

### DIFF
--- a/src/community/geoserver-sync/pom.xml
+++ b/src/community/geoserver-sync/pom.xml
@@ -54,14 +54,6 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>codehaus</name>
-            <url>http://snapshots.repository.codehaus.org/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
 			<id>osgeo</id>
 			<name>Open Source Geospatial Foundation Repository</name>
 			<url>http://download.osgeo.org/webdav/geotools/</url>

--- a/src/community/spatialite/pom.xml
+++ b/src/community/spatialite/pom.xml
@@ -21,13 +21,13 @@
 
 
 <repositories>
-   <repository>
-     <id>codehaus</id>
-     <name>codehaus</name>
-     <url>http://snapshots.repository.codehaus.org/</url>
-     <snapshots>
-      <enabled>true</enabled>
-     </snapshots>
+    <repository>
+        <id>boundless</id>
+        <name>Boundless Maven Repository</name>
+        <url>http://repo.boundlessgeo.com/main</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
     </repository>
     <repository>
       <id>opengeo</id>

--- a/src/extension/charts/pom.xml
+++ b/src/extension/charts/pom.xml
@@ -14,9 +14,9 @@
 
   <repositories>
     <repository>
-      <id>codehaus</id>
-      <name>codehaus</name>
-      <url>http://snapshots.repository.codehaus.org/</url>
+      <id>osgeo</id>
+      <name>Open Source Geospatial Foundation Repository</name>
+      <url>http://download.osgeo.org/webdav/geotools/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/src/extension/excel/pom.xml
+++ b/src/extension/excel/pom.xml
@@ -18,17 +18,6 @@
   <packaging>jar</packaging>
   <name>Excel Output Format</name>
 
-  <repositories>
-    <repository>
-      <id>codehaus</id>
-      <name>codehaus</name>
-      <url>http://snapshots.repository.codehaus.org/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/maven/archetype/wfsOutputFormat/src/main/resources/archetype-resources/pom.xml
+++ b/src/maven/archetype/wfsOutputFormat/src/main/resources/archetype-resources/pom.xml
@@ -7,14 +7,6 @@
  <name>My Output Format</name>
 
   <repositories>
-   <repository>
-     <id>codehaus</id>
-     <name>codehaus</name>
-     <url>http://snapshots.repository.codehaus.org/</url>
-     <snapshots>
-      <enabled>true</enabled>
-     </snapshots>
-    </repository>
     <repository>
       <id>opengeo</id>
       <name>opengeo</name>
@@ -22,6 +14,14 @@
        <snapshots>
         <enabled>true</enabled>
        </snapshots>
+    </repository>
+    <repository>
+      <id>osgeo</id>
+      <name>Open Source Geospatial Foundation Repository</name>
+      <url>http://download.osgeo.org/webdav/geotools/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Compile tested the Excel and Charts extensions. Compile tested the spatialite
community module.

The sync community module partly builds but fails some tests in geoserver-sync-server,
which appears unrelated to this change.