### PR TITLE
[GEOS-7190] Fix script community module build

### DIFF
--- a/src/community/script/groovy/pom.xml
+++ b/src/community/script/groovy/pom.xml
@@ -44,7 +44,7 @@
         <plugin>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-eclipse-compiler</artifactId>
-            <version>2.9.0-01-SNAPSHOT</version>
+            <version>2.9.2-01</version>
             <extensions>true</extensions>
         </plugin>
 		<plugin>
@@ -61,12 +61,12 @@
 				<dependency>
 					<groupId>org.codehaus.groovy</groupId>
 					<artifactId>groovy-eclipse-compiler</artifactId>
-					<version>2.9.0-01-SNAPSHOT</version>
+					<version>2.9.2-01</version>
 				</dependency>
 				<dependency>
 					<groupId>org.codehaus.groovy</groupId>
 					<artifactId>groovy-eclipse-batch</artifactId>
-					<version>2.1.5-03</version>
+					<version>2.3.7-01</version>
 				</dependency>
 			</dependencies>
 		</plugin>
@@ -93,14 +93,4 @@
         </plugin>
    </plugins>
  </build>
- <pluginRepositories>
-      <!-- Required for groovy-eclipse-compiler snapshot --> 
-      <pluginRepository>
-          <id>nexus</id>
-          <url>http://nexus.codehaus.org/snapshots/</url>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-      </pluginRepository>
- </pluginRepositories>
 </project>


### PR DESCRIPTION
Removes a broken dependency on Codehaus. The groovy-eclipse-compiler
plugin is now in the main Nexus repo.