### PR TITLE
GEOS-7189: Fix deserialization of boolean metadata parameter.

### DIFF
--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesProvider.java
@@ -53,7 +53,7 @@ public class WFSExtendedCapabilitiesProvider implements
             return;
         }
         MetadataMap serviceMetadata = wfs.getMetadata();
-        Boolean createExtendedCapabilities = (Boolean) serviceMetadata.get(CREATE_EXTENDED_CAPABILITIES.key);
+        Boolean createExtendedCapabilities = serviceMetadata.get(CREATE_EXTENDED_CAPABILITIES.key, Boolean.class);
         String metadataURL = (String) serviceMetadata.get(SERVICE_METADATA_URL.key);
         String mediaType = (String) serviceMetadata.get(SERVICE_METADATA_TYPE.key);
         String language = (String) serviceMetadata.get(LANGUAGE.key);

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
@@ -73,7 +73,7 @@ public class WMSExtendedCapabilitiesProvider implements ExtendedCapabilitiesProv
             return;
         }
         MetadataMap serviceMetadata = wms.getMetadata();
-        Boolean createExtendedCapabilities = (Boolean) serviceMetadata.get(CREATE_EXTENDED_CAPABILITIES.key);
+        Boolean createExtendedCapabilities = serviceMetadata.get(CREATE_EXTENDED_CAPABILITIES.key, Boolean.class);
         String metadataURL = (String) serviceMetadata.get(SERVICE_METADATA_URL.key);
         //Don't create extended capabilities element if mandatory content not present
         //or turned off

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesTest.java
@@ -135,6 +135,25 @@ public class WFSExtendedCapabilitiesTest extends GeoServerSystemTestSupport {
         
     }
 
+    @Test
+    public void testReloadSettings() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WFSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        metadata.put(SPATIAL_DATASET_IDENTIFIER_TYPE.key,
+                "one,http://www.geoserver.org/one;two,http://www.geoserver.org/two,http://metadata.geoserver.org/id?two");
+        getGeoServer().save(serviceInfo);
+        getGeoServer().reload();
+        final Document dom = getAsDOM(WFS_2_0_0_GETCAPREQUEST);
+
+        NodeList nodeList = dom.getElementsByTagNameNS(DLS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements after settings reload", 1, nodeList.getLength());
+    }
+
     // No INSPIRE ExtendedCapabilities should be returned in a WFS 1.0.0 response
     @Test
     public void testExtCaps100WithFullSettings() throws Exception {

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
@@ -87,6 +87,23 @@ public class WMSExtendedCapabilitiesTest extends GeoServerSystemTestSupport {
 
     }
 
+    @Test
+    public void testReloadSettings() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
+        getGeoServer().reload();
+        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST);
+        
+        NodeList nodeList = dom.getElementsByTagNameNS(VS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements after settings reload", 1, nodeList.getLength());
+    }
+
     /* There is an INSPIRE DTD for WMS 1.1.1 but not implementing this */
     @Test
     public void testExtCaps111WithFullSettings() throws Exception {


### PR DESCRIPTION
This is just the same as https://github.com/geoserver/geoserver/pull/1217 but branched from master rather than 2.8.x in case that is the preferred way round to do things. Would like it cherry-picked back to 2.8.x branch though as it fixes bug.