### PR TITLE
GEOS-7203, Disabling Caching for a layer causes NPE

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
@@ -264,7 +264,11 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
 
             @Override
             public void validate(IValidatable<GeoServerTileLayerInfo> validatable) {
-                if (enabled.getConvertedInput() && !isBlobStoreEnabled(blobStoreId.getConvertedInput())) {
+                final Boolean createVal = createLayer.getConvertedInput();
+                final Boolean enabledVal = enabled.getConvertedInput();
+                final String blobStoreIdVal = blobStoreId.getConvertedInput();
+                
+                if (createVal && enabledVal && !isBlobStoreEnabled(blobStoreIdVal)) {
                     error(new ParamResourceModel("enabledError", GeoServerTileLayerEditor.this).getString());
                 }
             }

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerCacheOptionsTabPanelTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerCacheOptionsTabPanelTest.java
@@ -184,16 +184,25 @@ public class LayerCacheOptionsTabPanelTest extends GeoServerWicketTestSupport {
         }));
 
         tester.assertComponent("form:panel", LayerCacheOptionsTabPanel.class);
-
+        
+        tester.isVisible("form:panel:tileLayerEditor:container:configs");
+        
         // Avoid saving the Layer
         FormTester formTester = tester.newFormTester("form");
         formTester.setValue("panel:tileLayerEditor:createTileLayer", false);
 
-        formTester.submit();
+        tester.executeAjaxEvent("form:panel:tileLayerEditor:createTileLayer", "onchange");
+        
 
+        tester.isInvisible("form:panel:tileLayerEditor:container:configs");
+        
         LayerCacheOptionsTabPanel panel = (LayerCacheOptionsTabPanel) tester
                 .getComponentFromLastRenderedPage("form:panel");
-
+        
+        formTester.getForm().onFormSubmitted(); // This is an utter hack but is the only way I could
+                                                // figure out to exercise the validators the same 
+                                                // way that happens in a live GeoServer
+        
         panel.save();
 
         // Ensure the GeoServerTileLayerInfoModel is updated


### PR DESCRIPTION
Fix is simple, if the create flag is not set, then the enabled one may be null and should be ignored.

Updating the test that should have caught this was harder.  Wicket is doing something funny and I don't entirely understand what.  This tweak involves calling an internal Wicket method that's not part of the official API to trigger validation where the error occurs.  The test now fails when the fix isn't in place, but it's somewhat questionable in its own right.