### PR TITLE
[GEOS-7217] Ensure we provide a Title element for the Style in Capabilities document

### DIFF
--- a/src/main/src/test/java/org/geoserver/data/test/tiger_roads.sld
+++ b/src/main/src/test/java/org/geoserver/data/test/tiger_roads.sld
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+	xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+	xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer> <Name> area landmarks </Name>
+    <UserStyle>
+         <FeatureTypeStyle>
+            <FeatureTypeName>Feature</FeatureTypeName>
+			<Rule>  
+	               <MinScaleDenominator>32000</MinScaleDenominator>
+	    		   <LineSymbolizer>
+	    		       <Stroke>
+	    				<CssParameter name="stroke">
+	    					<ogc:Literal>#666666</ogc:Literal>
+	    				</CssParameter>
+	    				<CssParameter name="stroke-width">
+	    					<ogc:Literal>2</ogc:Literal>
+	    				</CssParameter>
+	    			</Stroke>
+	    		   </LineSymbolizer>
+            </Rule>
+
+            <Rule>	<!-- thick line drawn first-->
+				<MaxScaleDenominator>32000</MaxScaleDenominator>
+				<LineSymbolizer>
+					<Stroke>
+						<CssParameter name="stroke">
+							<ogc:Literal>#666666</ogc:Literal>
+						</CssParameter>
+						<CssParameter name="stroke-width">
+							<ogc:Literal>7</ogc:Literal>
+						</CssParameter>
+					</Stroke>
+				</LineSymbolizer>
+            </Rule>
+        </FeatureTypeStyle>
+        <FeatureTypeStyle>
+           <FeatureTypeName>Feature</FeatureTypeName>
+           <Rule>	<!-- thin line drawn second -->
+				<MaxScaleDenominator>32000</MaxScaleDenominator>
+	            <LineSymbolizer>
+	    		       <Stroke>
+	    				<CssParameter name="stroke">
+	    					<ogc:Literal>#FFFFFF</ogc:Literal>
+	    				</CssParameter>
+	    				<CssParameter name="stroke-width">
+	    					<ogc:Literal>4</ogc:Literal>
+	    				</CssParameter>
+	    			</Stroke>
+				</LineSymbolizer>
+            </Rule> 
+            <!-- label -->     
+			<Rule>
+				<MaxScaleDenominator>32000</MaxScaleDenominator>
+				<TextSymbolizer>
+					<Label>
+						<ogc:PropertyName>NAME</ogc:PropertyName>
+					</Label>
+
+					<Font>
+						<CssParameter name="font-family">Times New Roman</CssParameter>
+						<CssParameter name="font-style">Normal</CssParameter>
+						<CssParameter name="font-size">14</CssParameter>
+						<CssParameter name="font-weight">bold</CssParameter>
+					</Font>
+					
+					<LabelPlacement>
+					  <LinePlacement>
+					  </LinePlacement>
+					</LabelPlacement>
+					<Halo>
+						<Radius>
+							<ogc:Literal>2</ogc:Literal>
+						</Radius>
+						<Fill>
+							<CssParameter name="fill">#FFFFFF</CssParameter>
+							<CssParameter name="fill-opacity">0.85</CssParameter>				
+						</Fill>
+					</Halo>
+					
+					<Fill>
+						<CssParameter name="fill">#000000</CssParameter>
+					</Fill>
+					
+					<VendorOption name="group">true</VendorOption>
+					
+				</TextSymbolizer>
+			</Rule>
+        </FeatureTypeStyle>
+        
+    </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -939,34 +939,13 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                     throw new NullPointerException("Layer " + layer.getName()
                             + " has no default style");
                 }
-                Style ftStyle;
-                try {
-                    ftStyle = defaultStyle.getStyle();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                element("Name", defaultStyle.prefixedName());
-                if (ftStyle.getDescription() != null) {
-                    element("Title", ftStyle.getDescription().getTitle());
-                    element("Abstract", ftStyle.getDescription().getAbstract());
-                }
-                handleLegendURL(layer, layer.getLegend(), null ,layer.getDefaultStyle());
+                handleCommonStyleElements(defaultStyle);
+                handleLegendURL(layer, layer.getLegend(), null , defaultStyle);
                 end("Style");
 
-                Set<StyleInfo> styles = layer.getStyles();
-
-                for (StyleInfo styleInfo : styles) {
-                    try {
-                        ftStyle = styleInfo.getStyle();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
+                for (StyleInfo styleInfo : layer.getStyles()) {
                     start("Style");
-                    element("Name", styleInfo.prefixedName());
-                    if (ftStyle.getDescription() != null) {
-                        element("Title", ftStyle.getDescription().getTitle());
-                        element("Abstract", ftStyle.getDescription().getAbstract());
-                    }
+                    handleCommonStyleElements(styleInfo);
                     handleLegendURL(layer, null, styleInfo, styleInfo);
                     end("Style");
                 }
@@ -975,9 +954,28 @@ public class GetCapabilitiesTransformer extends TransformerBase {
 
             end("Layer");
         }
-        
 
-        
+        private void handleCommonStyleElements(StyleInfo styleInfo) {
+            Style ftStyle;
+            try {
+                ftStyle = styleInfo.getStyle();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            element("Name", styleInfo.prefixedName());
+            if (ftStyle.getDescription() != null) {
+                if (ftStyle.getDescription().getTitle() != null) {
+                    element("Title", ftStyle.getDescription().getTitle());
+                } else {
+                    // Title is not required by the SLD spec, but it is required
+                    // by the WMS 1.1 DTD so we have to provide something.
+                    element("Title", styleInfo.prefixedName());
+                }
+                element("Abstract", ftStyle.getDescription().getAbstract());
+            }
+        }
+
         private void element(String element, InternationalString is) {
             if (is != null) {
                 element(element, is.toString());

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
@@ -68,9 +68,12 @@ public class CapabilitiesTest extends WMSTestSupport {
         // add a workspace qualified style
         WorkspaceInfo ws = catalog.getWorkspaceByName(MockData.CITE_PREFIX);
         testData.addStyle(ws, "Lakes", "Lakes.sld", SystemTestData.class, catalog);
+        testData.addStyle(ws, "tiger_roads", "tiger_roads.sld", SystemTestData.class, catalog);
         StyleInfo lakesStyle = catalog.getStyleByName(ws, "Lakes");
         LayerInfo lakesLayer = catalog.getLayerByName(MockData.LAKES.getLocalPart());
         lakesLayer.setDefaultStyle(lakesStyle);
+        StyleInfo tigerRoadsStyle = catalog.getStyleByName(ws, "tiger_roads");
+        lakesLayer.getStyles().add(tigerRoadsStyle);
         catalog.save(lakesLayer);
     }
 
@@ -464,6 +467,20 @@ public class CapabilitiesTest extends WMSTestSupport {
 
         // check the style name got prefixed too
         assertXpathEvaluatesTo("cite:Lakes", "//Layer[Name='cite:Lakes']/Style[1]/Name", doc);
+        assertXpathEvaluatesTo("cite:tiger_roads", "//Layer[Name='cite:Lakes']/Style[2]/Name", doc);
     }
 
+    // GEOS-7217: Make sure Styles are valid to DTD
+    @Test
+    public void testStyleElementsValidity() throws Exception {
+        Document doc = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.1.1", true);
+
+        assertXpathExists("//Layer[Name='cite:Lakes']/Style[1]/Name", doc);
+        assertXpathExists("//Layer[Name='cite:Lakes']/Style[1]/Title", doc);
+        assertXpathExists("//Layer[Name='cite:Lakes']/Style[1]/LegendURL", doc);
+        
+        assertXpathExists("//Layer[Name='cite:Lakes']/Style[2]/Name", doc);
+        assertXpathExists("//Layer[Name='cite:Lakes']/Style[2]/Title", doc);
+        assertXpathExists("//Layer[Name='cite:Lakes']/Style[2]/LegendURL", doc);
+    }
 }


### PR DESCRIPTION
The WMS 1.1.1 DTD requires Style to match
"(Name,Title,Abstract?,LegendURL*,StyleSheetURL?,StyleURL?)". Adds
small test data file from the release data set.

Includes a small amount of refactoring to reduce code duplication.

More at https://osgeo-org.atlassian.net/browse/GEOS-7217