### PR TITLE
[GEOS-7216] WFS GetCapabilities throws NPE if published layer has no geometry

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -83,6 +83,9 @@ public class CatalogBuilder {
 
     static final Logger LOGGER = Logging.getLogger(CatalogBuilder.class);
 
+    /** Default SRS; will be set on the provided feature type by lookupSRS methods if none was found */
+    public static final String DEFAULT_SRS = "EPSG:404000";
+
     /**
      * the catalog
      */
@@ -658,6 +661,8 @@ public class CatalogBuilder {
             } catch (FactoryException e) {
                 throw (IOException) new IOException().initCause(e);
             }
+        } else {
+            ftinfo.setSRS(DEFAULT_SRS);
         }
     }
 

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
@@ -79,8 +79,8 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
         cb.setStore(cat.getDataStoreByName(MockData.BRIDGES.getPrefix()));
         FeatureTypeInfo fti = cb.buildFeatureType(toName(MockData.BRIDGES));
 
-        // perform basic checks, this has no srs so no lat/lon bbox computation possible
-        assertNull(fti.getSRS());
+        // perform basic checks, this has no srs, so default one will be set
+        assertEquals(CatalogBuilder.DEFAULT_SRS, fti.getSRS());
         assertNull(fti.getNativeCRS());
         assertNull(fti.getNativeBoundingBox());
         assertNull(fti.getLatLonBoundingBox());
@@ -89,7 +89,7 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
         cb.setupBounds(fti);
         assertNotNull(fti.getNativeBoundingBox());
         assertNull(fti.getNativeBoundingBox().getCoordinateReferenceSystem());
-        assertNull(fti.getLatLonBoundingBox());
+        assertNotNull(fti.getLatLonBoundingBox());
     }
 
     
@@ -141,10 +141,11 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
         cb.setupBounds(fti);
 
         // perform basic checks
-        assertNull(fti.getCRS());
-        // ... not so sure about this one, null would seem more natural
+        assertEquals(CatalogBuilder.DEFAULT_SRS, fti.getSRS());
+        assertNotNull(fti.getNativeBoundingBox());
         assertTrue(fti.getNativeBoundingBox().isEmpty());
-        assertNull(fti.getLatLonBoundingBox());
+        assertNotNull(fti.getLatLonBoundingBox());
+        assertFalse(fti.getLatLonBoundingBox().isEmpty());
         assertNull(layer.getDefaultStyle());
     }
 


### PR DESCRIPTION
Fix acts on `CatalogBuilder` to make sure even geometryless layers are assigned a (fake) SRS and lat/lon BBOX.

See [related Mailing list discussion](http://osgeo-org.1560.x6.nabble.com/Should-CatalogBuilder-set-a-default-SRS-if-none-was-found-td5226811.html).