### PR TITLE
Fix a NPE when changing a SQL view for a layer.

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.java
@@ -205,7 +205,9 @@ public class FeatureResourceConfigurationPanel extends ResourceConfigurationPane
     
     @Override
     public void resourceUpdated(AjaxRequestTarget target) {
-        target.addComponent(attributePanel);
+        if (target != null) {
+            target.addComponent(attributePanel);
+        }
     }
 
     static class ReloadWarningDialog extends WebPage {

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanelTest.java
@@ -1,0 +1,32 @@
+package org.geoserver.web.data.resource;
+
+import org.apache.wicket.model.IModel;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
+import org.geoserver.data.test.MockData;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.junit.Test;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public class FeatureResourceConfigurationPanelTest extends GeoServerWicketTestSupport {
+    @Test()
+    public void testResourceUpdatedAcceptsNull() {
+        FeatureResourceConfigurationPanel panel = new FeatureResourceConfigurationPanel("toto", new IModel() {
+            @Override
+            public FeatureTypeInfo getObject() {
+                return getCatalog().getResourceByName(MockData.BRIDGES.getLocalPart(), FeatureTypeInfo.class);
+            }
+
+            @Override
+            public void setObject(Object o) {
+                throw new NotImplementedException();
+            }
+
+            @Override
+            public void detach() {
+                throw new NotImplementedException();
+            }
+        });
+        panel.resourceUpdated(null);
+    }
+}

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanelTest.java
@@ -1,8 +1,11 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+* This code is licensed under the GPL 2.0 license, available at the root
+* application directory.
+*/
 package org.geoserver.web.data.resource;
 
 import org.apache.wicket.model.IModel;
 import org.geoserver.catalog.FeatureTypeInfo;
-import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.data.test.MockData;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.junit.Test;

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorRenderingLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorRenderingLayerIdentifier.java
@@ -127,7 +127,7 @@ public class VectorRenderingLayerIdentifier extends AbstractVectorLayerIdentifie
     @Override
     public List<FeatureCollection> identify(FeatureInfoRequestParameters params,
             final int maxFeatures) throws Exception {
-        LOGGER.log(Level.FINER, "Appliying rendering based feature info identifier");
+        LOGGER.log(Level.FINER, "Applying rendering based feature info identifier");
         
         // at the moment the new identifier works only with simple features due to a limitation
         // in the StreamingRenderer


### PR DESCRIPTION
ResourceConfigurationPage#updateResource can be called with target==null.
So we need to check for it.

A NPE was always raised when the user edits an existing SQL view and was hitting
the save button. So he was never able to go back to the layer edition, making
impossible to change a SQL view.

Fixed a small typo in a log while I was at it.