### PR TITLE
[GEOS-7226] GML links in Layer Preview don't work for app-schema layers

### DIFF
--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -163,6 +163,14 @@
             <version>2.0.0-1</version>
             <scope>test</scope>
         </dependency>
+        <!-- required for Web UI tests -->
+        <dependency>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-demo</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
     <profiles>

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -166,6 +166,19 @@
         <!-- required for Web UI tests -->
         <dependency>
             <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-demo</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.web</groupId>
             <artifactId>gs-web-demo</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/AbstractMapPreviewPageTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/AbstractMapPreviewPageTest.java
@@ -17,7 +17,6 @@ import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.repeater.data.DataView;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.geoserver.web.demo.MapPreviewPage;
-import org.junit.Test;
 
 public class AbstractMapPreviewPageTest extends GeoServerWicketTestSupport {
 
@@ -27,13 +26,6 @@ public class AbstractMapPreviewPageTest extends GeoServerWicketTestSupport {
         this.EXPECTED_GML_LINKS = expectedGmlLinks;
     }
 
-    @Test
-    public void testValues() throws Exception {
-        tester.startPage(MapPreviewPage.class);
-        tester.assertRenderedPage(MapPreviewPage.class);
-    }
-
-    @Test
     public void testAppSchemaGmlLinks() {
         tester.startPage(MapPreviewPage.class);
         tester.assertRenderedPage(MapPreviewPage.class);

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/AbstractMapPreviewPageTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/AbstractMapPreviewPageTest.java
@@ -1,0 +1,58 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.test.web;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.markup.repeater.data.DataView;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.demo.MapPreviewPage;
+import org.junit.Test;
+
+public class AbstractMapPreviewPageTest extends GeoServerWicketTestSupport {
+
+    protected List<String> EXPECTED_GML_LINKS = new ArrayList<String>();
+
+    protected AbstractMapPreviewPageTest(List<String> expectedGmlLinks) {
+        this.EXPECTED_GML_LINKS = expectedGmlLinks;
+    }
+
+    @Test
+    public void testValues() throws Exception {
+        tester.startPage(MapPreviewPage.class);
+        tester.assertRenderedPage(MapPreviewPage.class);
+    }
+
+    @Test
+    public void testAppSchemaGmlLinks() {
+        tester.startPage(MapPreviewPage.class);
+        tester.assertRenderedPage(MapPreviewPage.class);
+        
+        DataView items = (DataView) tester.getComponentFromLastRenderedPage("table:listContainer:items");
+        assertNotNull(items);
+        assertEquals(EXPECTED_GML_LINKS.size(), items.size());
+
+        // collect GML links model objects
+        List<String> gmlLinks = new ArrayList<String>();
+        for (int i=1; i<=EXPECTED_GML_LINKS.size(); i++) {
+            ExternalLink gmlLink = (ExternalLink) items.get(i + ":itemProperties:3:component:gml");
+            assertNotNull(gmlLink);
+            gmlLinks.add(gmlLink.getDefaultModelObjectAsString());
+        }
+
+        Collections.sort(EXPECTED_GML_LINKS);
+        Collections.sort(gmlLinks);
+        // check the two lists match
+        assertArrayEquals(EXPECTED_GML_LINKS.toArray(new String[] {}), gmlLinks.toArray(new String[] {}));
+    }
+}

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml311LinksTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml311LinksTest.java
@@ -1,0 +1,28 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.test.web;
+
+import java.util.Arrays;
+
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.FeatureChainingMockData;
+
+public class Gml311LinksTest extends AbstractMapPreviewPageTest {
+
+    public Gml311LinksTest() {
+        super(Arrays.asList("../ows?service=WFS&amp;version=1.1.0&amp;request=GetFeature&amp;typeName=gsml:MappedFeature&amp;outputFormat=gml3&amp;maxFeatures=50",
+                "../ows?service=WFS&amp;version=1.1.0&amp;request=GetFeature&amp;typeName=gsml:GeologicUnit&amp;outputFormat=gml3&amp;maxFeatures=50",
+                "../ows?service=WFS&amp;version=1.1.0&amp;request=GetFeature&amp;typeName=ex:FirstParentFeature&amp;outputFormat=gml3&amp;maxFeatures=50",
+                "../ows?service=WFS&amp;version=1.1.0&amp;request=GetFeature&amp;typeName=ex:SecondParentFeature&amp;outputFormat=gml3&amp;maxFeatures=50",
+                "../ows?service=WFS&amp;version=1.1.0&amp;request=GetFeature&amp;typeName=om:Observation&amp;outputFormat=gml3&amp;maxFeatures=50"));
+    }
+
+    @Override
+    protected SystemTestData createTestData() throws Exception {
+        return new FeatureChainingMockData();
+    }
+
+}

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml311LinksTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml311LinksTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.test.FeatureChainingMockData;
+import org.junit.Test;
 
 public class Gml311LinksTest extends AbstractMapPreviewPageTest {
 
@@ -23,6 +24,11 @@ public class Gml311LinksTest extends AbstractMapPreviewPageTest {
     @Override
     protected SystemTestData createTestData() throws Exception {
         return new FeatureChainingMockData();
+    }
+
+    @Test
+    public void testGml311Links() {
+        super.testAppSchemaGmlLinks();
     }
 
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml32LinksTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml32LinksTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.test.Gsml30MockData;
+import org.junit.Test;
 
 public class Gml32LinksTest extends AbstractMapPreviewPageTest {
 
@@ -19,6 +20,11 @@ public class Gml32LinksTest extends AbstractMapPreviewPageTest {
     @Override
     protected SystemTestData createTestData() throws Exception {
         return new Gsml30MockData();
+    }
+
+    @Test
+    public void testGml32Links() {
+        super.testAppSchemaGmlLinks();
     }
 
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml32LinksTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/Gml32LinksTest.java
@@ -1,0 +1,24 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.test.web;
+
+import java.util.Arrays;
+
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.Gsml30MockData;
+
+public class Gml32LinksTest extends AbstractMapPreviewPageTest {
+
+    public Gml32LinksTest() {
+        super(Arrays.asList("../ows?service=WFS&amp;version=1.1.0&amp;request=GetFeature&amp;typeName=gsml:MappedFeature&amp;outputFormat=gml32&amp;maxFeatures=50"));
+    }
+
+    @Override
+    protected SystemTestData createTestData() throws Exception {
+        return new Gsml30MockData();
+    }
+
+}

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
@@ -1,17 +1,21 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.web.demo;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.wicket.ResourceReference;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedType;
@@ -19,12 +23,18 @@ import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.web.CatalogIconFactory;
 import org.geoserver.web.GeoServerApplication;
+import org.geoserver.wfs.xml.GML32OutputFormat;
 import org.geoserver.wms.DefaultWebMapService;
 import org.geoserver.wms.GetMapRequest;
 import org.geoserver.wms.MapLayerInfo;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.gml2.bindings.GML2EncodingUtils;
+import org.geotools.util.NullProgressListener;
+import org.geotools.util.ProgressListener;
 import org.geotools.util.logging.Logging;
+import org.opengis.feature.type.AttributeType;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.Name;
 
 import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Envelope;
@@ -181,15 +191,19 @@ public class PreviewLayer {
     }
     
     String getBaseUrl(String service) {
+        return getBaseUrl(service, false);
+    }
+
+    String getBaseUrl(String service, boolean useGlobalRef) {
         String ws = getWorkspace();
-        if(ws == null) {
+        if(ws == null || useGlobalRef) {
             // global reference
             return ResponseUtils.buildURL("../", service, null, URLType.SERVICE);
         } else {
             return ResponseUtils.buildURL("../", ws + "/" + service, null, URLType.SERVICE);
         }
     }
-    
+
     /**
      * Given a request and a target format, builds the WMS request
      * 
@@ -210,5 +224,155 @@ public class PreviewLayer {
                 + "," + bbox.getMaxX() + "," + bbox.getMaxY() //
                 + "&width=" + request.getWidth() //
                 + "&height=" + request.getHeight() + "&srs=" + request.getSRS();
+    }
+
+    /**
+     * Returns the default GML link for this layer.
+     *
+     * @param gmlParamsCache optional map where computed GML output params are cached
+     * @return
+     */
+    public String getGmlLink(Map<String, GMLOutputParams> gmlParamsCache) {
+        GMLOutputParams gmlParams = new GMLOutputParams();
+
+        if (layerInfo != null) {
+            if (layerInfo.getResource() instanceof FeatureTypeInfo) {
+                FeatureTypeInfo ftInfo = (FeatureTypeInfo) layerInfo.getResource();
+                if (ftInfo.getStore() != null) {
+                    Map<String, Serializable> connParams = ftInfo.getStore()
+                            .getConnectionParameters();
+                    if (connParams != null) {
+                        String dbtype = (String) connParams.get("dbtype");
+                        // app-schema feature types need special treatment
+                        if ("app-schema".equals(dbtype)) {
+                            String mappingUrl = connParams.get("url").toString();
+                            if (gmlParamsCache != null && gmlParamsCache.containsKey(mappingUrl)) {
+                                // avoid looking up the GML version again
+                                gmlParams = gmlParamsCache.get(mappingUrl);
+                            } else {
+                                // use global OWS service to make sure all secondary namespaces
+                                // are accessible
+                                gmlParams.baseUrl = getBaseUrl("ows", true);
+                                // always use WFS 1.1.0 for app-schema layers
+                                gmlParams.wfsVersion = org.geotools.wfs.v1_1.WFS.getInstance()
+                                        .getVersion();
+                                // determine GML version by inspecting the feature type and its super types
+                                try {
+                                    gmlParams.gmlVersion = findGmlVersion(ftInfo);
+                                } catch (IOException e) {
+                                    LOGGER.log(Level.FINE, "Could not determine GML version, using default", e);
+                                    gmlParams.gmlVersion = null;
+                                }
+                                // store params in cache
+                                if (gmlParamsCache != null) {
+                                    gmlParamsCache.put(mappingUrl, gmlParams);
+                                }
+                            }
+                        }
+                        // TODO: do other data stores have any special needs?
+                        else {
+                        }
+                    }
+                }
+            }
+        }
+
+        return buildGmlLink(gmlParams);
+    }
+
+    /**
+     * Returns the GML version used in the feature type's definition.
+     *
+     * <p>
+     * The method recursively climbs up the type hierarchy of the provided feature type, until it finds AbstractFeatureType. Then, the GML version is
+     * determined by looking at the namespace URI.
+     * </p>
+     *
+     * <p>
+     * Please note that this method does not differentiate between GML 2 and GML 3.1.1, but assumes that "http://www.opengis.net/gml" namespace always
+     * refers to GML 3.1.1.
+     * </p>
+     *
+     * @param ftInfo the feature type info
+     * @return the GML version used in the feature type definition
+     * @throws IOException if the underlying datastore instance cannot be retrieved
+     */
+    String findGmlVersion(FeatureTypeInfo ftInfo) throws IOException {
+        ProgressListener listener = new NullProgressListener();
+        Name qName = ftInfo.getQualifiedName();
+        FeatureType fType = ftInfo.getStore().getDataStore(listener).getSchema(qName);
+        return findFeatureTypeGmlVersion(fType);
+    }
+
+    private String findFeatureTypeGmlVersion(AttributeType featureType) {
+        if (featureType == null) {
+            return null;
+        }
+
+        if (isAbstractFeatureType(featureType)) {
+            String gmlNamespace = featureType.getName().getNamespaceURI();
+            if (org.geotools.gml3.GML.NAMESPACE.equals(gmlNamespace)) {
+                // GML 3.1.1
+                return "gml3";
+            } else if (org.geotools.gml3.v3_2.GML.NAMESPACE.equals(gmlNamespace)) {
+                // GML 3.2
+                return GML32OutputFormat.FORMATS.get(0);
+            } else {
+                // should never happen
+                LOGGER.log(Level.FINE, "Cannot determine GML version from AbstractFeatureType type");
+                return null;
+            }
+        }
+
+        // recursively check super types
+        AttributeType parent = featureType.getSuper();
+        return findFeatureTypeGmlVersion(parent);
+    }
+
+    private boolean isAbstractFeatureType(AttributeType type) {
+        if (type == null) {
+            return false;
+        }
+
+        Name qName = type.getName();
+        String localPart = qName.getLocalPart();
+        String ns = qName.getNamespaceURI();
+        if ("AbstractFeatureType".equals(localPart) &&
+                (org.geotools.gml3.GML.NAMESPACE.equals(ns) || org.geotools.gml3.v3_2.GML.NAMESPACE
+                        .equals(ns))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    String buildGmlLink(GMLOutputParams gmlParams) {
+        StringBuilder urlBuilder = new StringBuilder();
+        urlBuilder.append(gmlParams.baseUrl).append("?");
+        urlBuilder.append("service=WFS").append("&");
+        urlBuilder.append("version=").append(gmlParams.wfsVersion).append("&");
+        urlBuilder.append("request=GetFeature").append("&");
+        urlBuilder.append("typeName=").append(getName());
+        if (gmlParams.gmlVersion != null) {
+            urlBuilder.append("&");
+            urlBuilder.append("outputFormat=").append(gmlParams.gmlVersion);
+        }
+
+        return urlBuilder.toString();
+    }
+
+    class GMLOutputParams {
+        String wfsVersion;
+        String gmlVersion;
+        String baseUrl;
+
+        private GMLOutputParams() {
+            // by default, use WFS 1.0.0
+            wfsVersion = org.geotools.wfs.v1_0.WFS.getInstance().getVersion();
+            // by default, infer GML version from WFS version
+            gmlVersion = null;
+            // by default, use virtual ows services
+            baseUrl = getBaseUrl("ows");
+        }
     }
 }


### PR DESCRIPTION
A couple of test classes extending `GeoServerWicketTestSupport` have been added to `gs-app-schema-test` module.