### PR TITLE
[GEOS-7227] Defer bounds calculation during import

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/DataStoreFormat.java
@@ -123,7 +123,11 @@ public class DataStoreFormat extends VectorFormat {
                     featureType.setNamespace(null);
     
                     SimpleFeatureSource featureSource = dataStore.getFeatureSource(typeName); 
-                    cb.setupBounds(featureType, featureSource);
+                    
+                    //Defer bounds calculation
+                    featureType.setNativeBoundingBox(EMPTY_BOUNDS);
+                    featureType.setLatLonBoundingBox(EMPTY_BOUNDS);
+                    featureType.getMetadata().put("recalculate-bounds", Boolean.TRUE);
     
                     //add attributes
                     CatalogFactory factory = catalog.getFactory();

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RESTDataTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RESTDataTest.java
@@ -232,15 +232,12 @@ public class RESTDataTest extends ImporterTestSupport {
 
         task = getTask(0, 0);
         assertEquals("READY", task.get("state"));
-        context = importer.getContext(context.getId());
-        ReferencedEnvelope latLonBoundingBox = 
-            context.getTasks().get(0).getLayer().getResource().getLatLonBoundingBox();
-        assertFalse("expected not empty bbox",latLonBoundingBox.isEmpty());
 
         DataStore store = (DataStore) ds.getDataStore(null);
         assertEquals(store.getTypeNames().length, 0);
 
         postImport(0);
+        
         assertEquals(store.getTypeNames().length, 1);
         assertEquals("archsites", store.getTypeNames()[0]);
     }

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/TaskResourceTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/TaskResourceTest.java
@@ -427,10 +427,7 @@ public class TaskResourceTest extends ImporterTestSupport {
         setSRSRequest("/rest/imports/1/tasks/0","EPSG:26713");
         
         ImportContext context = importer.getContext(1);
-        ReferencedEnvelope latLonBoundingBox = 
-            context.getTasks().get(0).getLayer().getResource().getLatLonBoundingBox();
-        assertFalse("expected not empty bbox",latLonBoundingBox.isEmpty());
-
+        
         json = (JSONObject) getAsJSON("/rest/imports/1/tasks/0?expand=2");
         task = json.getJSONObject("task");
         assertEquals("READY", task.get("state"));


### PR DESCRIPTION
Moved bounds calculation from `createContext()` to `doImport()` (DataStoreFormat only)
See https://osgeo-org.atlassian.net/browse/GEOS-7227

Some changes to test cases:
* Removed checks for null bounds; no longer applicible
* Added check to confirm a user-defined CRS is preserved after bounds are calculated