### PR TITLE
Fix unit test failures

### DIFF
--- a/src/extension/ogr/ogr-wps/pom.xml
+++ b/src/extension/ogr/ogr-wps/pom.xml
@@ -49,6 +49,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-platform</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.geoserver.extension</groupId>
             <artifactId>gs-ogr-wfs</artifactId>
             <version>${gs.version}</version>

--- a/src/extension/ogr/ogr-wps/src/test/java/org/geoserver/wps/ogr/WPSOgrTest.java
+++ b/src/extension/ogr/ogr-wps/src/test/java/org/geoserver/wps/ogr/WPSOgrTest.java
@@ -6,6 +6,7 @@ package org.geoserver.wps.ogr;
 
 import static junit.framework.Assert.assertEquals;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -13,18 +14,14 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.custommonkey.xmlunit.SimpleNamespaceContext;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.ogr.core.Format;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.util.XmlTestUtil;
 import org.geoserver.wfs.response.Ogr2OgrConfigurator;
 import org.geoserver.wfs.response.Ogr2OgrTestUtil;
 import org.geoserver.wfs.response.OgrConfiguration;
@@ -39,9 +36,15 @@ import com.mockrunner.mock.web.MockHttpServletResponse;
 import com.thoughtworks.xstream.XStream;
 
 public class WPSOgrTest extends WPSTestSupport {
-
+    
+    private XmlTestUtil xml;
+    
     @Before
     public void setUp() throws Exception {
+        xml = new XmlTestUtil();
+        xml.addNamespace("kml", "http://www.opengis.net/kml/2.2");
+        //xml.setShowXML(System.out); // Uncomment to print XML to stdout on failure
+        
         Assume.assumeTrue(Ogr2OgrTestUtil.isOgrAvailable());
     }
 
@@ -139,13 +142,7 @@ public class WPSOgrTest extends WPSTestSupport {
             configurator.loadConfiguration();
             Document d = postAsDOM("wps",
                     getWpsDocumentXML("application/vnd.google-earth.kml; subtype=OGR-KML"));
-            Map<String, String> m = new HashMap<String, String>();
-            m.put("kml", "http://www.opengis.net/kml/2.2");
-            org.custommonkey.xmlunit.NamespaceContext ctx = new SimpleNamespaceContext(m);
-            XpathEngine engine = XMLUnit.newXpathEngine();
-            engine.setNamespaceContext(ctx);
-            assertEquals(1, engine.getMatchingNodes("//kml:kml/kml:Document/kml:Schema", d)
-                    .getLength());
+            assertThat(d, xml.hasOneNode("//kml:kml/kml:Document/kml:Schema | //kml:kml/kml:Document/kml:Folder/kml:Schema"));
         } catch (IOException e) {
             System.err.println(e.getStackTrace());
         } finally {

--- a/src/platform/pom.xml
+++ b/src/platform/pom.xml
@@ -70,6 +70,11 @@
    <scope>test</scope>
   </dependency>
   <dependency>
+   <groupId>xmlunit</groupId>
+   <artifactId>xmlunit</artifactId>
+   <scope>test</scope>
+  </dependency>
+  <dependency>
    <groupId>org.hamcrest</groupId>
    <artifactId>hamcrest-library</artifactId>
    <scope>test</scope>

--- a/src/platform/src/test/java/org/geoserver/util/XmlTestUtil.java
+++ b/src/platform/src/test/java/org/geoserver/util/XmlTestUtil.java
@@ -1,0 +1,200 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.util;
+
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.AbstractList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XpathEngine;
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * An aid for XML related testing.
+ * 
+ * @author Kevin Smith, Boundless
+ *
+ */
+public class XmlTestUtil {
+    private OutputStream showXML = null;
+    private Map<String, String> namespaces = new HashMap<>();
+    private org.custommonkey.xmlunit.NamespaceContext namespaceContext;
+    
+    
+    private void regenerateContext() {
+        namespaceContext=new SimpleNamespaceContext(namespaces);
+    }
+    
+    public XmlTestUtil() {
+        regenerateContext();
+    }
+    
+    /**
+     * Set an output stream to print XML to when a matcher fails. Null to disable.
+     * @param showXML
+     */
+    public void setShowXML(OutputStream showXML) {
+        this.showXML = showXML;
+    }
+    
+    /**
+     * Add a namespace to be used when resolving XPath expressions.
+     * @param prefix
+     * @param uri
+     */
+    public void addNamespace(String prefix, String uri) {
+        namespaces.put(prefix, uri);
+        regenerateContext();
+    }
+    
+    /**
+     * Match a document where one node matched the XPath expression, and it also matches the given matcher.
+     * @param xPath
+     * @param matcher
+     * @return
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Matcher<Document> hasOneNode(final String xPath, final Matcher<? super Node> matcher) {
+        return hasNodes(xPath, (Matcher)contains(matcher));
+    }
+    /**
+     * Match a document where one node matches the XPath expression.
+     * @param xPath
+     * @param matcher
+     * @return
+     */
+    public Matcher<Document> hasOneNode(final String xPath) {
+        return hasOneNode(xPath, any(Node.class));
+    }    
+    /**
+     * Match a document at least one of the nodes matched by the given XPath expression matches the given matcher.
+     * @param xPath
+     * @param matcher
+     * @return
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Matcher<Document> hasNode(final String xPath, final Matcher<Node> matcher) {
+        return hasNodes(xPath, (Matcher) hasItem(matcher));
+    }
+    
+    /**
+     * Match a document at least one node matches the given XPath.
+     * @param xPath
+     * @param matcher
+     * @return
+     */
+    public Matcher<Document> hasNode(final String xPath) {
+        return hasNode(xPath, any(Node.class));
+    }
+    
+    /**
+     * Match a document where the list of nodes selected by the given XPath expression also matches the given matcher.
+     * @param xPath
+     * @param matcher
+     * @return
+     */
+    public Matcher<Document> hasNodes(final String xPath, final Matcher<? extends Iterable<Node>> matcher) {
+        return new BaseMatcher<Document>() {
+            
+            @Override
+            public boolean matches(Object item) {
+                XpathEngine engine = XMLUnit.newXpathEngine();
+                engine.setNamespaceContext(namespaceContext);
+                try {
+                    List<Node> nodes = nodeCollection(engine.getMatchingNodes(xPath, (Document) item));
+                    return matcher.matches(nodes);
+                } catch (XpathException e) {
+                    return false;
+                }
+            }
+            
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Document where the list of nodes matching ")
+                    .appendValue(xPath).appendText(" is ").appendDescriptionOf(matcher);
+            }
+            
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                XpathEngine engine = XMLUnit.newXpathEngine();
+                engine.setNamespaceContext(namespaceContext);
+                try {
+                    List<Node> nodes = nodeCollection(engine.getMatchingNodes(xPath, (Document) item));
+                    
+                    matcher.describeMismatch(nodes, description);
+                    
+                    if(showXML != null) {
+                        printDom((Document) item, showXML);
+                    }
+                } catch (XpathException e) {
+                    description.appendText("exception occured: ").appendText(e.getMessage());
+                }
+            }
+        };
+    }
+
+    /**
+     * Make a Java List out of a DOM NodeList.
+     * @param nl
+     * @return
+     */
+    public static List<Node> nodeCollection(final NodeList nl) {
+        return new AbstractList<Node>() {
+            
+            @Override
+            public Node get(int index) {
+                return nl.item(index);
+            }
+            
+            @Override
+            public int size() {
+                return nl.getLength();
+            }
+            
+        };
+    }
+    
+    /**
+     * Print a DOM tree to an output stream or if there is an exception while doing so, print the stack trace.
+     * @param dom
+     * @param os
+     */
+    public static void printDom(Node dom, OutputStream os) {
+        Transformer trans;
+        PrintWriter w = new PrintWriter(os);
+        try {
+            TransformerFactory fact = TransformerFactory.newInstance();
+            trans = fact.newTransformer();
+            trans.transform(new DOMSource(dom), new StreamResult(new OutputStreamWriter(os)));
+        } catch (TransformerException e) {
+            w.println("An error ocurred while transforming the given DOM:");
+            e.printStackTrace(w);
+        }
+    }
+    
+}


### PR DESCRIPTION
Fixes unit test failures that seem to be local to my machine in the WFS and OGR-WPS modules.

It's not clear why the WFS tests only fail on my machine.  The OGR-WPS ones are ignored if ogr2ogr is not present.  Adding it to ares so the tests run may be a good idea.