### PR TITLE
GEOS-7172, Fix checkbox/radio inputs in UI so they can be toggled by their labels.

### DIFF
--- a/src/community/geofence/src/main/java/org/geoserver/geofence/web/GeofencePage.html
+++ b/src/community/geofence/src/main/java/org/geoserver/geofence/web/GeofencePage.html
@@ -27,21 +27,21 @@
                 <span><wicket:message key="options"></wicket:message></span>
               </legend>
                 <ul>
-	            <li>
-	              <input id="allowRemoteAndInlineLayers" wicket:id="allowRemoteAndInlineLayers" type="checkbox" class="field checkbox"></input>
-	              <label for="allowRemoteAndInlineLayers" class="choice"><wicket:message key="allowRemoteAndInlineLayers"></wicket:message></label>
+	            <li class="choiceItem">
+	              <input id="allowRemoteAndInlineLayers" wicket:id="allowRemoteAndInlineLayers" type="checkbox"></input>
+	              <label for="allowRemoteAndInlineLayers"><wicket:message key="allowRemoteAndInlineLayers"></wicket:message></label>
 	            </li>
-	            <li>
-                  <input id="allowDynamicStyles" wicket:id="allowDynamicStyles" type="checkbox" class="field checkbox"></input>
-                  <label for="allowDynamicStyles" class="choice"><wicket:message key="allowDynamicStyles"></wicket:message></label>
+	            <li class="choiceItem">
+                  <input id="allowDynamicStyles" wicket:id="allowDynamicStyles" type="checkbox"></input>
+                  <label for="allowDynamicStyles"><wicket:message key="allowDynamicStyles"></wicket:message></label>
                 </li>
-                <li>
-                  <input id="grantWriteToWorkspacesToAuthenticatedUsers" wicket:id="grantWriteToWorkspacesToAuthenticatedUsers" type="checkbox" class="field checkbox"></input>
-                  <label for="grantWriteToWorkspacesToAuthenticatedUsers" class="choice"><wicket:message key="grantWriteToWorkspacesToAuthenticatedUsers"></wicket:message></label>
+                <li class="choiceItem">
+                  <input id="grantWriteToWorkspacesToAuthenticatedUsers" wicket:id="grantWriteToWorkspacesToAuthenticatedUsers" type="checkbox"></input>
+                  <label for="grantWriteToWorkspacesToAuthenticatedUsers"><wicket:message key="grantWriteToWorkspacesToAuthenticatedUsers"></wicket:message></label>
                 </li>
-                <li>
-                  <input id="useRolesToFilter" wicket:id="useRolesToFilter" type="checkbox" class="field checkbox"></input>
-                  <label for="useRolesToFilter" class="choice"><wicket:message key="useRolesToFilter"></wicket:message></label>
+                <li class="choiceItem">
+                  <input id="useRolesToFilter" wicket:id="useRolesToFilter" type="checkbox"></input>
+                  <label for="useRolesToFilter"><wicket:message key="useRolesToFilter"></wicket:message></label>
                 </li>
                 <li>
                   <label for="acceptedRoles"><wicket:message key="acceptedRoles"></wicket:message></label>

--- a/src/extension/geosearch/src/main/java/org/geoserver/geosearch/web/GeoSearchLayerConfigPanel.html
+++ b/src/extension/geosearch/src/main/java/org/geoserver/geosearch/web/GeoSearchLayerConfigPanel.html
@@ -7,10 +7,10 @@
     <li>  
       <fieldset>
         <legend><span><wicket:message key="geosearch">Geosearch</wicket:message></span></legend>
-        <ul>
+        <ul class="choiceList">
           <li>
-            <input id="geosearchEnable" class="field checkbox" wicket:id="geosearch.enable" type="checkbox"></input>
-            <label for="geosearchEnable" class="choice"><wicket:message key="enableGeosearchIndexing">Enable geosearch indexing</wicket:message></label>
+            <input id="geosearchEnable" wicket:id="geosearch.enable" type="checkbox"></input>
+            <label for="geosearchEnable"><wicket:message key="enableGeosearchIndexing">Enable geosearch indexing</wicket:message></label>
           </li>
         </ul>
       </fieldset>

--- a/src/extension/geosearch/src/main/java/org/geoserver/geosearch/web/GeoSearchLayerGroupConfigPanel.html
+++ b/src/extension/geosearch/src/main/java/org/geoserver/geosearch/web/GeoSearchLayerGroupConfigPanel.html
@@ -6,10 +6,10 @@
   <li>  
     <fieldset>
       <legend><span><wicket:message key="geosearch">Geosearch</wicket:message></span></legend>
-      <ul>
+      <ul class="choiceList">
         <li>
-          <input id="geosearchEnable" class="field checkbox" wicket:id="geosearch.enable" type="checkbox"></input>
-          <label for="geosearchEnable" class="choice"><wicket:message key="enableGeosearchIndexing">Enable geosearch indexing</wicket:message></label>
+          <input id="geosearchEnable" wicket:id="geosearch.enable" type="checkbox"></input>
+          <label for="geosearchEnable"><wicket:message key="enableGeosearchIndexing">Enable geosearch indexing</wicket:message></label>
         </li>
       </ul>
     </fieldset>

--- a/src/extension/importer/web/src/main/java/org/geoserver/importer/web/AdvancedDbParamPanel.html
+++ b/src/extension/importer/web/src/main/java/org/geoserver/importer/web/AdvancedDbParamPanel.html
@@ -13,15 +13,15 @@
   <a href="#" wicket:id="advancedLink"><wicket:message key="advanced">advanced</wicket:message></a>
   <div wicket:id="advancedContainer">
     <ul wicket:id="advanced">
-      <li wicket:id="excludeGeometrylessContainer">
-        <input type="checkbox" wicket:id="excludeGeometryless" size="6" class="field checkbox" /> 
-        <label class="choice" for="looseBBox">
+      <li class="choiceItem" wicket:id="excludeGeometrylessContainer">
+        <input type="checkbox" wicket:id="excludeGeometryless" size="6" /> 
+        <label for="excludeGeometrylessContainer">
           <wicket:message key="excludeGeometryless">excludeGeometryless</wicket:message>
         </label>
       </li>
-      <li wicket:id="looseBBoxContainer">
-        <input type="checkbox" wicket:id="looseBBox" size="6" class="field checkbox" /> 
-        <label class="choice" for="looseBBox">
+      <li class="choiceItem" wicket:id="looseBBoxContainer">
+        <input type="checkbox" wicket:id="looseBBox" size="6" /> 
+        <label for="looseBBoxContainer">
           <wicket:message key="looseBBox">looseBBox</wicket:message>
         </label>
       </li>

--- a/src/extension/importer/web/src/main/java/org/geoserver/importer/web/ConnectionPoolParamPanel.html
+++ b/src/extension/importer/web/src/main/java/org/geoserver/importer/web/ConnectionPoolParamPanel.html
@@ -21,18 +21,14 @@
       type="text" class="text"
       wicket:id="timeout"
       size="6" /></li>
-    <li><input
-      class="field checkbox"
+    <li class="choiceItem"><input
       type="checkbox"
       wicket:id="validate" /> <label
-      for="validate"
-      class="choice"><wicket:message key="validate">validate</wicket:message></label></li>
-    <li wicket:id="psContainer"><input
-      class="field checkbox"
+      for="validate"><wicket:message key="validate">validate</wicket:message></label></li>
+    <li class="choiceItem" wicket:id="psContainer"><input
       type="checkbox"
       wicket:id="preparedStatements" /> <label
-      for="preparedStatements"
-      class="choice"><wicket:message key="preparedStatements">preparedStatements</wicket:message></label></li>
+      for="preparedStatements"><wicket:message key="preparedStatements">preparedStatements</wicket:message></label></li>
   </wicket:panel>
 </ul>
 </body>

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/web/InspireAdminPanel.html
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/web/InspireAdminPanel.html
@@ -7,9 +7,9 @@
       <fieldset>
         <legend><span><wicket:message key="inspire">INSPIRE</wicket:message></span></legend>
         <ul>
-        <li>
-          <input id="createExtendedCapabilities" class="field checkbox" type="checkbox" wicket:id="createExtendedCapabilities" />
-          <label class="choice">
+        <li class="choiceItem">
+          <input id="createExtendedCapabilities" type="checkbox" wicket:id="createExtendedCapabilities" />
+          <label for="createExtendedCapabilities">
             <wicket:message key="createExtendedCapabilities">Create INSPIRE ExtendedCapabilities element</wicket:message>
           </label>
         </li>

--- a/src/extension/security/web/web-cas/src/main/java/org/geoserver/security/web/cas/CasAuthFilterPanel.html
+++ b/src/extension/security/web/web-cas/src/main/java/org/geoserver/security/web/cas/CasAuthFilterPanel.html
@@ -38,10 +38,10 @@
 		          <span><wicket:message key="singleSignOnParameters"></wicket:message></span>
 		          <a href="#" wicket:id="singleSignOnParametersHelp" class="help-link"></a>
 		 </legend>
-		  <ul>	  
+		  <ul class="choiceList">	  
 		  <li>                    	  	      	
-	    	<input id="sendRenew" wicket:id="sendRenew" type="checkbox" class="field checkbox"></input>
-	    	<label for="sendRenew" class="choice"><wicket:message key="sendRenew"></wicket:message></label>	    	
+	    	<input id="sendRenew" wicket:id="sendRenew" type="checkbox"></input>
+	    	<label for="sendRenew"><wicket:message key="sendRenew"></wicket:message></label>	    	
           </li>  				  
 		  </ul>	  	  
 	  </fieldset>	    	
@@ -53,9 +53,9 @@
 		  		<a href="#" wicket:id="singleSignOutParametersHelp" class="help-link"></a>
 		  </legend>			  
 		     <ul>	  	  
-			  <li>					
-					<input id="singleSignOut" wicket:id="singleSignOut" type="checkbox" class="field checkbox"></input>
-					<label for="singleSignOut" class="choice"><wicket:message key="singleSignOut"></wicket:message></label>
+			  <li class="choiceItem">					
+					<input id="singleSignOut" wicket:id="singleSignOut" type="checkbox"></input>
+					<label for="singleSignOut"><wicket:message key="singleSignOut"></wicket:message></label>
 					
 			  </li>
 			  <li>

--- a/src/extension/wcs2_0-eo/web/src/main/java/org/geoserver/wcs2_0/eo/web/WCSEOAdminPanel.html
+++ b/src/extension/wcs2_0-eo/web/src/main/java/org/geoserver/wcs2_0/eo/web/WCSEOAdminPanel.html
@@ -10,8 +10,8 @@
 						<span><wicket:message key="wcseo">wcseo</wicket:message></span>
 					</legend>
 					<ul>
-						<li><input type="checkbox" wicket:id="enabled"></input> <label
-							for="enabled" class="choice"><wicket:message
+						<li class="choiceItem"><input type="checkbox" wicket:id="enabled"></input> <label
+							for="enabled"><wicket:message
 									key="enabled">enable</wicket:message></label></li>
 						<li>
 						<li><label><wicket:message key="defaultCount">defaultCount</wicket:message></label>

--- a/src/extension/wcs2_0-eo/web/src/main/java/org/geoserver/wcs2_0/eo/web/WCSEOLayerConfig.html
+++ b/src/extension/wcs2_0-eo/web/src/main/java/org/geoserver/wcs2_0/eo/web/WCSEOLayerConfig.html
@@ -9,9 +9,9 @@
 						<legend>
 							<span><wicket:message key="wcseo">wcseo</wicket:message></span>
 						</legend>
-						<ul>
-							<li><input type="checkbox" class="field checkbox" wicket:id="dataset"></input> <label
-								for="dataset" class="choice"><wicket:message
+						<ul class="choiceList">
+							<li><input type="checkbox" wicket:id="dataset"></input> <label
+								for="dataset"><wicket:message
 										key="dataset">expose as dataset</wicket:message></label></li>
 						</ul>
 					</fieldset>

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSRequestBuilderPanel.html
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSRequestBuilderPanel.html
@@ -43,9 +43,9 @@
         <fieldset>
           <legend><span><wicket:message key="authentication">authentication</wicket:message></span></legend>
           <ul>
-            <li>
-              <input class="field checkbox" style="display:inline" type="checkbox" wicket:id="authenticate"/>
-              <label class="choice"><wicket:message key="authenticate">authenticate</wicket:message></label>
+            <li class="choiceItem">
+              <input type="checkbox" wicket:id="authenticate"/>
+              <label for="authenticate"><wicket:message key="authenticate">authenticate</wicket:message></label>
             </li>
             <li wicket:id="userpwdContainer">
 	            <ul>

--- a/src/web/core/src/main/java/org/geoserver/web/admin/GlobalSettingsPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/admin/GlobalSettingsPage.html
@@ -4,17 +4,17 @@
 <wicket:extend>
 <form wicket:id="form">
   <ul>
-    <li>
-      <input id="verbose" class="field checkbox" type="checkbox" wicket:id="verbose" />
-      <label class="choice"><wicket:message key="verboseMessaging">Enable Verbose Messaging</wicket:message></label>
+    <li class="choiceItem">
+      <input id="verbose" type="checkbox" wicket:id="verbose" />
+      <label for="verbose"><wicket:message key="verboseMessaging">Enable Verbose Messaging</wicket:message></label>
     </li>
-    <li>
-      <input id="verboseExceptions" class="field checkbox" type="checkbox" wicket:id="verboseExceptions" />
-      <label class="choice"><wicket:message key="verboseExceptions">Enable Verbose Exceptions</wicket:message></label>
+    <li class="choiceItem">
+      <input id="verboseExceptions" type="checkbox" wicket:id="verboseExceptions" />
+      <label for="verboseExceptions"><wicket:message key="verboseExceptions">Enable Verbose Exceptions</wicket:message></label>
     </li>
-    <li>
-      <input id="globalServices" class="field checkbox" type="checkbox" wicket:id="globalServices" />
-      <label class="choice"><wicket:message key="globalServices">Enable Global Services</wicket:message></label>
+    <li class="choiceItem">
+      <input id="globalServices" type="checkbox" wicket:id="globalServices" />
+      <label for="globalServices"><wicket:message key="globalServices">Enable Global Services</wicket:message></label>
     </li>
     <li>
       <label for="charset"><wicket:message key="resourceErrorHandling">Resource Error Handling</wicket:message></label>
@@ -36,9 +36,9 @@
       <label for="log4jConfigFile"><wicket:message key="log4jConfigFile">Logging Profile</wicket:message></label>
       <select id="log4jConfigFile" class="field select" wicket:id="log4jConfigFile" />
     </li>
-    <li>
-      <input id="stdOutLogging" class="field checkbox" type="checkbox" wicket:id="stdOutLogging" />
-      <label class="choice"><wicket:message key="stdOutLogging">Enable logging to STDOUT</wicket:message></label>
+    <li class="choiceItem">
+      <input id="stdOutLogging" type="checkbox" wicket:id="stdOutLogging" />
+      <label for="stdOutLogging"><wicket:message key="stdOutLogging">Enable logging to STDOUT</wicket:message></label>
     </li>
     <li>
       <label for="loggingLocation"><wicket:message key="loggingLocation">Logfile</wicket:message></label>
@@ -48,10 +48,10 @@
       <label for="xmlPostRequestLogBufferSize"><wicket:message key="xmlPostRequestLogBufferSize">log buffer size for incoming XML POST requests</wicket:message></label>
       <input id="xmlPostRequestLogBufferSize"class="field text" type="text" wicket:id="xmlPostRequestLogBufferSize" />
     </li>
-    <li>
-      <label for="xmlExternalEntitiesEnabled"><wicket:message key="xmlExternalEntities">XML Entities</wicket:message></label>
-      <input id="xmlExternalEntitiesEnabled" class="field checkbox" type="checkbox" wicket:id="xmlExternalEntitiesEnabled" />
-      <label class="choice"><wicket:message key="xmlExternalEntitiesEnabled">Evaluate XML Entities</wicket:message></label>
+    <li class="choiceItem">
+      <span class="fieldname"><wicket:message key="xmlExternalEntities">XML Entities</wicket:message></span>
+      <input id="xmlExternalEntitiesEnabled" type="checkbox" wicket:id="xmlExternalEntitiesEnabled" />
+      <label for="xmlExternalEntitiesEnabled"><wicket:message key="xmlExternalEntitiesEnabled">Evaluate XML Entities</wicket:message></label>
     </li>
     <li>
       <label for="featureTypeCacheSize"><wicket:message key="featureTypeCacheSize">Feature Type Cache Size</wicket:message></label>

--- a/src/web/core/src/main/java/org/geoserver/web/admin/JAIPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/admin/JAIPage.html
@@ -20,25 +20,25 @@
       <label for="tilePriority"><wicket:message key="tilePriority">tilePriority</wicket:message></label>
       <input id="tilePriority" class="field text" type="text" wicket:id="tilePriority" />
     </li>
-    <li>
-      <input id="recycling" class="field checkbox" type="checkbox" wicket:id="recycling" />
-      <label class="choice"><wicket:message key="recycling">recycling</wicket:message></label>
+    <li class="choiceItem">
+      <input id="recycling" type="checkbox" wicket:id="recycling" />
+      <label for="recycling"><wicket:message key="recycling">recycling</wicket:message></label>
     </li>
-    <li>
-      <input id="jpegAcceleration" class="field checkbox" type="checkbox" wicket:id="jpegAcceleration" />
-      <label class="choice"><wicket:message key="jpegAcceleration">jpegAcceleration</wicket:message></label>
+    <li class="choiceItem">
+      <input id="jpegAcceleration" type="checkbox" wicket:id="jpegAcceleration" />
+      <label for="jpegAcceleration"><wicket:message key="jpegAcceleration">jpegAcceleration</wicket:message></label>
     </li>
     <li>
       <label for="pngEncoderType"><wicket:message key="pngEncoderType">pngEncoderType</wicket:message></label>
       <select id="pngEncoderType" class="field checkbox" wicket:id="pngEncoderType" ></select>
     </li>
-    <li>
-      <input id="allowNativeMosaic" class="field checkbox" type="checkbox" wicket:id="allowNativeMosaic" />
-      <label class="choice"><wicket:message key="allowNativeMosaic">allowNativeMosaic</wicket:message></label>
+    <li class="choiceItem">
+      <input id="allowNativeMosaic" type="checkbox" wicket:id="allowNativeMosaic" />
+      <label for="allowNativeMosaic"><wicket:message key="allowNativeMosaic">allowNativeMosaic</wicket:message></label>
     </li>
-    <li>
-      <input id="allowNativeWarp" class="field checkbox" type="checkbox" wicket:id="allowNativeWarp" />
-      <label for="allowNativeWarp" class="choice"><wicket:message key="allowNativeWarp">allowNativeWarp</wicket:message></label>
+    <li class="choiceItem">
+      <input id="allowNativeWarp"type="checkbox" wicket:id="allowNativeWarp" />
+      <label for="allowNativeWarp"><wicket:message key="allowNativeWarp">allowNativeWarp</wicket:message></label>
     </li>
     <li>
 	   <div wicket:id="jaiext"></div>

--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -389,31 +389,39 @@ width: 90%;
 line-height: 1.5em;
 }
 
-label.choice,ul.choiceList>li>label {
+label.choice,ul.choiceList>li label, *.choiceItem label {
 color: #222; 
 font-weight: normal;
 font-size: 100%;
 }
 
+ul.choiceList>li span.fieldname, *.choiceItem span.fieldname {
+margin-left: -2em;
+}
+ul.choiceList>li span.fieldname:dir(rtl), *.choiceItem span.fieldname:dir(rtl) {
+margin-left: 0;
+margin-right: -2em;
+}
+
 
 /* For a "choiceList" create padding down leading side to act as a "hanging indent" then move the checkbox/radio into that padding. This allows the label to remain inline so it doesn't produce clickable whitespace. */
-ul.choiceList>li {
+ul.choiceList>li,*.choiceItem {
 position: relative;
 padding-left: 2em; 
 }
-ul.choiceList>li:dir(rtl){
+ul.choiceList>li:dir(rtl),*.choiceItem:dir(rtl){
 padding-left: 0;
 padding-right: 2em;
 }
-ul.choiceList>li>label {
+ul.choiceList>li label,*.choiceItem label{
 display: inline;
 }
-ul.choiceList>li>input[type=checkbox],ul.choiceList>li>input[type=radio] {
+ul.choiceList>li input[type=checkbox],ul.choiceList>li input[type=radio],*.choiceItem input[type=checkbox],*.choiceItem input[type=radio] {
 display: block;
 position: absolute;
 left: 0;
 }
-ul.choiceList>li:dir(rtl)>input[type=checkbox],ul.choiceList>li:dir(rtl)>input[type=radio] {
+ul.choiceList>li:dir(rtl) input[type=checkbox],ul.choiceList>li:dir(rtl) input[type=radio],*.choiceItem:dir(rtl) input[type=checkbox],*.choiceItem:dir(rtl) input[type=radio] {
 left: auto;
 right: 0;
 }

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/AttributeEditPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/AttributeEditPage.html
@@ -12,7 +12,10 @@
             id="name" class="text" type="text" wicket:id="name"/></li>
         <li><label for="binding"><wicket:message key="type">type</wicket:message></label> <select
             id="binding" wicket:id="binding"></select></li>
-        <li><input type="checkbox" id="nullable" wicket:id="nullable"/> <label class="choice"><wicket:message key="nullable">nullable</wicket:message></label></li>
+        <li class="choiceItem">
+	  <input type="checkbox" id="nullable" wicket:id="nullable"/>
+	  <label for="nullable"><wicket:message key="nullable">nullable</wicket:message></label>
+	</li>
         <li wicket:id="sizeContainer"><label for="size"><wicket:message key="size">size</wicket:message></label>
         <input id="size" class="text" type="text" wicket:id="size"/></li>
         <li wicket:id="crsContainer"><label for="crs"><wicket:message key="crs">cRS</wicket:message></label>

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/BasicResourceConfig.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/BasicResourceConfig.html
@@ -15,13 +15,13 @@
               <label for="name"><wicket:message key="name">Name</wicket:message></label>
               <input id="name" class="text" type="text" wicket:id="name"/>
             </li>
-            <li>
-              <input id="basic-enabled" class="field checkbox" wicket:id="enabled" type="checkbox"/>
-              <label class="choice"><wicket:message key="enabled">Enabled</wicket:message></label>
+            <li class="choiceItem">
+              <input id="basic-enabled" wicket:id="enabled" type="checkbox"/>
+              <label for="basic-enabled"><wicket:message key="enabled">Enabled</wicket:message></label>
             </li>
-	        <li>
-	          <input id="basic-advertised" class="field checkbox" wicket:id="advertised" type="checkbox"/>
-	          <label class="choice"><wicket:message key="advertised">Advertised</wicket:message></label>
+	        <li class="choiceItem">
+	          <input id="basic-advertised" wicket:id="advertised" type="checkbox"/>
+	          <label for="basic-advertised"><wicket:message key="advertised">Advertised</wicket:message></label>
 	        </li>
             <li>
               <label for="title"><wicket:message key="titleMsg">Title</wicket:message></label>

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanel.html
@@ -5,9 +5,9 @@
     <div>
       <fieldset><legend><span><wicket:message key="curves">curves</wicket:message></span></legend>
         <ul>
-           <li>
-              <input id="linestrings-are-curves" class="field checkbox" wicket:id="circularArcPresent" type="checkbox"/>
-              <label for="linestrings-are-curves" class="choice"><wicket:message key="linestrings-are-curves">Enabled</wicket:message></label>
+           <li class="choiceItem">
+              <input id="linestrings-are-curves" wicket:id="circularArcPresent" type="checkbox"/>
+              <label for="linestrings-are-curves"><wicket:message key="linestrings-are-curves">Enabled</wicket:message></label>
             </li>
             <li>
               <label for="tolerance"><wicket:message key="tolerance">tolerance</wicket:message></label>

--- a/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage$SettingsPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage$SettingsPanel.html
@@ -11,17 +11,17 @@
            <div wicket:id="contact"></div>
          </li>
          <div wicket:id="otherSettings">
-             <li>
-              <input id="verbose" class="field checkbox" type="checkbox" wicket:id="verbose" />
-              <label class="choice"><wicket:message key="verboseMessaging">Enable Verbose Messaging</wicket:message></label>
+             <li class="choiceItem">
+              <input id="verbose" type="checkbox" wicket:id="verbose" />
+              <label for="verbose"><wicket:message key="verboseMessaging">Enable Verbose Messaging</wicket:message></label>
             </li>
-            <li>
-              <input id="verboseExceptions" class="field checkbox" type="checkbox" wicket:id="verboseExceptions" />
-              <label class="choice"><wicket:message key="verboseExceptions">Enable Verbose Exceptions</wicket:message></label>
+            <li class="choiceItem">
+              <input id="verboseExceptions" type="checkbox" wicket:id="verboseExceptions" />
+              <label for="verboseExceptions"><wicket:message key="verboseExceptions">Enable Verbose Exceptions</wicket:message></label>
             </li>
-		    <li>
-		      <input id="localWorkspaceIncludesPrefix" class="field checkbox" type="checkbox" wicket:id="localWorkspaceIncludesPrefix" />
-		      <label class="choice"><wicket:message key="localWorkspaceIncludesPrefix">Remove Layer Prefix from Local Workspace Capabilities</wicket:message></label>
+		    <li class="choiceItem">
+		      <input id="localWorkspaceIncludesPrefix" type="checkbox" wicket:id="localWorkspaceIncludesPrefix" />
+		      <label for="localWorkspaceIncludesPrefix"><wicket:message key="localWorkspaceIncludesPrefix">Remove Layer Prefix from Local Workspace Capabilities</wicket:message></label>
 		    </li>
             <li>
               <label for="numDecimals"><wicket:message key="numDecimals">Number of Decimals</wicket:message></label>

--- a/src/web/core/src/main/java/org/geoserver/web/publish/HTTPLayerConfig.html
+++ b/src/web/core/src/main/java/org/geoserver/web/publish/HTTPLayerConfig.html
@@ -8,9 +8,9 @@
       <fieldset>
         <legend><span><wicket:message key="httpSettings">HTTP Settings</wicket:message></span></legend>
         <ul>
-          <li>
-            <input id="cachingEnabled" class="field checkbox" wicket:id="cachingEnabled" type="checkbox">
-            <label for="cachingEnabled" class="choice"><wicket:message key="cacheResponses">Cache Responses</wicket:message></label>
+          <li class="choiceItem">
+            <input id="cachingEnabled" wicket:id="cachingEnabled" type="checkbox">
+            <label for="cachingEnabled"><wicket:message key="cacheResponses">Cache Responses</wicket:message></label>
           </li>
           <li>
             <label for="cacheAgeMax"><wicket:message key="cacheTime">Cache Time (seconds)</wicket:message></label>

--- a/src/web/core/src/main/java/org/geoserver/web/services/BaseServiceAdminPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/services/BaseServiceAdminPage.html
@@ -20,13 +20,13 @@
       <fieldset>
         <legend><span><wicket:message key="serviceMetadata">Service Metadata</wicket:message></span></legend>
         <ul>
-          <li>
-            <input wicket:id="enabled" type="checkbox" class="field checkbox">
-            <label class="choice"><span wicket:id="service.enabled">enable</span></label>
+          <li class="choiceItem">
+            <input wicket:id="enabled" type="checkbox">
+            <label for="enabled"><span wicket:id="service.enabled">enable</span></label>
           </li>
-          <li>
-            <input wicket:id="citeCompliant" type="checkbox" class="field checkbox">
-            <label class="choice"><wicket:message key="strictCITECompliance">Strict CITE compliance</wicket:message></label>
+          <li class="choiceItem">
+            <input wicket:id="citeCompliant" type="checkbox">
+            <label for="citeCompliant"><wicket:message key="strictCITECompliance">Strict CITE compliance</wicket:message></label>
           </li>
           <li>
             <label><wicket:message key="maintainer">Maintainer</wicket:message></label>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.html
@@ -4,9 +4,9 @@
 <fieldset>
   <legend><span><wicket:message key="GWCSettingsPage.defaultCacheOptions">Default Caching Options</wicket:message></span></legend>
   <ul>
-    <li>
-      <input id="cacheLayersByDefault" class="field checkbox" type="checkbox" wicket:id="cacheLayersByDefault" />
-      <label class="choice">
+    <li class="choiceItem">
+      <input id="cacheLayersByDefault" type="checkbox" wicket:id="cacheLayersByDefault" />
+      <label for="cacheLayersByDefault">
         <wicket:message key="GWCSettingsPage.cacheLayersByDefault">Automatically cache newly added layers</wicket:message>
       </label>
     </li>
@@ -22,9 +22,9 @@
             </div>
             <br>
           </li>
-          <li>
-            <input id="cacheNonDefaultStyles" class="field checkbox" type="checkbox" wicket:id="cacheNonDefaultStyles" />
-            <label class="choice">
+          <li class="choiceItem">
+            <input id="cacheNonDefaultStyles" type="checkbox" wicket:id="cacheNonDefaultStyles" />
+            <label for="cacheNonDefaultStyles">
               <wicket:message key="GWCSettingsPage.cacheNonDefaultStyles">Automatically cache non default styles</wicket:message>
             </label>
           </li>
@@ -53,30 +53,30 @@
             <table>
               <tr>
               <td>
-              <div wicket:id="vectorFormatsGroup">
-                <label><wicket:message key="GWCSettingsPage.defaultCacheFormatsVector">Vector Layers</wicket:message></label>
-                <span wicket:id="vectorFromats" style="padding: 2px;">
-                  <input wicket:id="vectorFormatsOption" type="checkbox" style="margin: 1px;"/>
-                  <label wicket:id="name" class="choice" style="padding: 1px;">[this is where name will be]</label>
-                </span>
+              <div wicket:id="vectorFormatsGroup" class="choiceItem">
+                <span class="fieldname"><wicket:message key="GWCSettingsPage.defaultCacheFormatsVector">Vector Layers</wicket:message></span>
+                <div wicket:id="vectorFromats" style="padding: 2px;">
+                  <input wicket:id="vectorFormatsOption" type="checkbox"/>
+                  <label wicket:id="name" for="vectorFormatsOption">[this is where name will be]</label>
+                </div>
               </div>
               </td>
               <td>
-              <div wicket:id="rasterFormatsGroup">
-                <label><wicket:message key="GWCSettingsPage.defaultCacheFormatsRaster">Raster Layers</wicket:message></label>
-                <span wicket:id="rasterFromats" style="padding: 2px;">
-                  <input wicket:id="rasterFormatsOption" type="checkbox" style="margin: 1px;"/>
-                  <label wicket:id="name" class="choice" style="padding: 1px;">[this is where name will be]</label>
-                </span>
+              <div wicket:id="rasterFormatsGroup" class="choiceItem">
+                <span class="fieldname"><wicket:message key="GWCSettingsPage.defaultCacheFormatsRaster">Raster Layers</wicket:message></span>
+                <div wicket:id="rasterFromats" style="padding: 2px;">
+                  <input wicket:id="rasterFormatsOption" type="checkbox"/>
+                  <label wicket:id="name" for="rasterFormatsOption">[this is where name will be]</label>
+                </div>
               </div>
               </td>
               <td>
-              <div wicket:id="otherFormatsGroup">
-                <label><wicket:message key="GWCSettingsPage.defaultCacheFormatsOther">Other Layers</wicket:message></label>
-                <span wicket:id="otherFromats" style="padding: 2px;">
-                  <input wicket:id="otherFormatsOption" type="checkbox" style="margin: 1px;"/>
-                  <label wicket:id="name" class="choice" style="padding: 1px;">[this is where name will be]</label>
-                </span>
+              <div wicket:id="otherFormatsGroup" class="choiceItem">
+                <span class="fieldname"><wicket:message key="GWCSettingsPage.defaultCacheFormatsOther">Other Layers</wicket:message></span>
+                <div wicket:id="otherFromats" style="padding: 2px;">
+                  <input wicket:id="otherFormatsOption" type="checkbox"/>
+                  <label wicket:id="name" for="otherFormatsOption">[this is where name will be]</label>
+                </div>
               </div>
               </td>
               </tr>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/GWCServicesPanel.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/GWCServicesPanel.html
@@ -3,26 +3,26 @@
 <wicket:panel>
   <fieldset>
     <legend><span><wicket:message key="gwcProvidedServices">GWC Provided Services</wicket:message></span></legend>
-    <ul>
+    <ul class="choiceList">
       <li>
-        <input id="enableWMSIntegration" class="field checkbox" type="checkbox" wicket:id="enableWMSIntegration" />
-        <label class="choice"><wicket:message key="GWCSettingsPage.enableWMSIntegration">Enable GWC</wicket:message></label>
+        <input id="enableWMSIntegration" type="checkbox" wicket:id="enableWMSIntegration" />
+        <label for="enableWMSIntegration"><wicket:message key="GWCSettingsPage.enableWMSIntegration">Enable GWC</wicket:message></label>
       </li>
       <li>
-        <input id="enableWMSC" class="field checkbox" type="checkbox" wicket:id="enableWMSC" />
-        <label class="choice"><wicket:message key="GWCSettingsPage.enableWMSC">Enable WMS-C</wicket:message></label>
+        <input id="enableWMSC" type="checkbox" wicket:id="enableWMSC" />
+        <label for="enableWMSC"><wicket:message key="GWCSettingsPage.enableWMSC">Enable WMS-C</wicket:message></label>
       </li>
       <li>
-        <input id="enableTMS" class="field checkbox" type="checkbox" wicket:id="enableTMS" />
-        <label class="choice"><wicket:message key="GWCSettingsPage.enableTMS">Enable TMS</wicket:message></label>
+        <input id="enableTMS" type="checkbox" wicket:id="enableTMS" />
+        <label for="enableTMS"><wicket:message key="GWCSettingsPage.enableTMS">Enable TMS</wicket:message></label>
       </li>
       <li>
-        <input id="enableWMTS" class="field checkbox" type="checkbox" wicket:id="enableWMTS" />
-        <label class="choice"><wicket:message key="GWCSettingsPage.enableWMTS">Enable WMTS</wicket:message></label>
+        <input id="enableWMTS" type="checkbox" wicket:id="enableWMTS" />
+        <label for="enableWMTS"><wicket:message key="GWCSettingsPage.enableWMTS">Enable WMTS</wicket:message></label>
       </li>
       <li>
-        <input id="enableSecurity" class="field checkbox" type="checkbox" wicket:id="enableSecurity" />
-        <label class="choice"><wicket:message key="GWCSettingsPage.enableSecurity">Enable Security</wicket:message></label>
+        <input id="enableSecurity" type="checkbox" wicket:id="enableSecurity" />
+        <label for="enableSecurity"><wicket:message key="GWCSettingsPage.enableSecurity">Enable Security</wicket:message></label>
       </li>
     </ul>
   </fieldset>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaConfigPanel.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaConfigPanel.html
@@ -4,9 +4,9 @@
     <fieldset>
       <legend><span><wicket:message key="diskQuota">Disk Quota</wicket:message></span></legend>
       <ul>
-        <li>
-          <input id="enableDiskQuota" class="field checkbox" type="checkbox" wicket:id="enableDiskQuota" />
-          <label class="choice"><wicket:message key="enableDiskQuota">Enable Disk Quota</wicket:message></label>
+        <li class="choiceItem">
+          <input id="enableDiskQuota" type="checkbox" wicket:id="enableDiskQuota" />
+          <label for="enableDiskQuota"><wicket:message key="enableDiskQuota">Enable Disk Quota</wicket:message></label>
         </li>
         <li>
           <label for="cleanUpFreq"><wicket:message key="cleanUpFreq">Force cache disk quota is exceeded every:</wicket:message></label>
@@ -23,14 +23,14 @@
         <li>
           <label><wicket:message key="globalQuotaTitle">When forcing quota limits, remove tiles that are:</wicket:message></label>
           <div wicket:id="globalQuotaExpirationPolicy">
-          <ul>
+          <ul class="choiceList">
             <li>
-              <input id="globalQuotaPolicyLFU" class="field radio" type="radio" wicket:id="globalQuotaPolicyLFU" />
-              <label class="choice"><wicket:message key="LFU">Least frequently used</wicket:message></label>
+              <input id="globalQuotaPolicyLFU" type="radio" wicket:id="globalQuotaPolicyLFU" />
+              <label for="globalQuotaPolicyLFU"><wicket:message key="LFU">Least frequently used</wicket:message></label>
             </li>
             <li>
-              <input id="globalQuotaPolicyLRU" class="field radio" type="radio" wicket:id="globalQuotaPolicyLRU" value="LRU"/>
-              <label class="choice"><wicket:message key="LRU">Least recently used</wicket:message></label>
+              <input id="globalQuotaPolicyLRU" type="radio" wicket:id="globalQuotaPolicyLRU" value="LRU"/>
+              <label for="globalQuotaPolicyLRU"><wicket:message key="LRU">Least recently used</wicket:message></label>
             </li>
           </ul>
           </div>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.html
@@ -7,20 +7,20 @@
         <span><wicket:message key="GeoServerTileLayerEditor.title">Tile caching configuration</wicket:message></span>
       </legend>
       <ul>
-        <li>
-          <input id="createTileLayer" wicket:id="createTileLayer" class="field checkbox" type="checkbox"/>
-          <label wicket:id="createTileLayerLabel" class="choice">Create a cached Layer for this Layer/Group</label>
+        <li class="choiceItem">
+          <input id="createTileLayer" wicket:id="createTileLayer" type="checkbox"/>
+          <label for="createTileLayer" wicket:id="createTileLayerLabel">Create a cached Layer for this Layer/Group</label>
         </li>
         <li wicket:id="container">
           <div wicket:id="configs">
             <ul>
-              <li>
-                <input id="tileCacheEnabled" wicket:id="enabled" class="field checkbox" type="checkbox"/>
-                <label class="choice"><wicket:message key="enabled">Enable tile caching</wicket:message></label>
+              <li class="choiceItem">
+                <input id="tileCacheEnabled" wicket:id="enabled" type="checkbox"/>
+                <label for="enabled"><wicket:message key="enabled">Enable tile caching</wicket:message></label>
               </li>
-              <li>
-                <input id="inMemoryCached" wicket:id="inMemoryCached" class="field checkbox" type="checkbox"/>
-                <label for="inMemoryCached" class="choice"><wicket:message key="inMemoryCached">Disable in memory caching for this Layer</wicket:message></label>
+              <li class="choiceItem">
+                <input id="inMemoryCached" wicket:id="inMemoryCached" type="checkbox"/>
+                <label for="inMemoryCached"><wicket:message key="inMemoryCached">Disable in memory caching for this Layer</wicket:message></label>
               </li>                    
               <li>
 	            <label for="blobStoreId"><wicket:message key="blobStoreId"></wicket:message></label>
@@ -38,13 +38,13 @@
                 <select class="select" id="gutter" wicket:id="gutter"></select>
                 <br>
               </li>
-              <li>
-                <label for="cacheFormatsGroup"><wicket:message key="cacheFormats">Cache formats:</wicket:message></label>
-                <span wicket:id="cacheFormatsGroup">
-                  <span wicket:id="cacheFormats" style="padding: 2px;">
-                    <input wicket:id="cacheFormatsOption" type="checkbox" style="margin: 1px;"/>
-                    <label wicket:id="name" class="choice" style="padding: 1px;">[this is where name will be]</label>
-                  </span></span>
+              <li class="choiceItem">
+                <span class="fieldname"><wicket:message key="cacheFormats">Cache formats:</wicket:message></span>
+                <div wicket:id="cacheFormatsGroup">
+                  <div wicket:id="cacheFormats" style="padding: 2px;">
+                    <input wicket:id="cacheFormatsOption" type="checkbox"/>
+                    <label for="cacheFormatsOption" wicket:id="name">[this is where name will be]</label>
+                  </div></div>
               </li>
               <li>
                 <label for="expireCache" class="text"><wicket:message key="expireCache">Expire server cache after n seconds (set to 0 to use source setting)</wicket:message></label>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/SecuritySettingsPage$EncryptionPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/SecuritySettingsPage$EncryptionPanel.html
@@ -8,9 +8,9 @@
   </ul>
   <ul>
     
-    <li>
-      <input id="encryptingUrlParams" wicket:id="encryptingUrlParams" type="checkbox" class="field checkbox"/>
-      <label class="choice">
+    <li class="choiceItem">
+      <input id="encryptingUrlParams" wicket:id="encryptingUrlParams" type="checkbox"/>
+      <label for="encryptingUrlParams">
         <wicket:message key="encryptingUrlParams"></wicket:message>
       </label>
     </li>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/auth/BasicAuthFilterPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/auth/BasicAuthFilterPanel.html
@@ -4,10 +4,10 @@
     xmlns:wicket="http://wicket.apache.org/">
 <body>
 <wicket:extend>
-    <ul>
+    <ul class="choiceList">
       <li>
-        <input id="useRememberMe" type="checkbox" wicket:id="useRememberMe" class="field checkbox"/>
-        <label class="choice"><wicket:message key="useRememberMe"></wicket:message></label>
+        <input id="useRememberMe" type="checkbox" wicket:id="useRememberMe"/>
+        <label for="useRememberMe"><wicket:message key="useRememberMe"></wicket:message></label>
       </li>
     </ul>
 </wicket:extend>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/auth/SecurityFilterChainPage.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/auth/SecurityFilterChainPage.html
@@ -27,17 +27,17 @@
             <input type="text" wicket:id="patternString" class="text"/>
           </li>
 
-          <li>
-            <input id="disabled" wicket:id="disabled" type="checkbox" class="field checkbox"/>
-            <label class="choice"><wicket:message key="disabled"></wicket:message></label>
+          <li class="choiceItem">
+            <input id="disabled" wicket:id="disabled" type="checkbox"/>
+            <label for="disabled"><wicket:message key="disabled"></wicket:message></label>
           </li>
-          <li>
-            <input id="allowSessionCreation" wicket:id="allowSessionCreation" type="checkbox" class="field checkbox"/>
-            <label class="choice"><wicket:message key="allowSessionCreation"></wicket:message></label>
+          <li class="choiceItem">
+            <input id="allowSessionCreation" wicket:id="allowSessionCreation" type="checkbox"/>
+            <label for="allowSessionCreation"><wicket:message key="allowSessionCreation"></wicket:message></label>
           </li>
-          <li>
-            <input id="requireSSL" wicket:id="requireSSL" type="checkbox" class="field checkbox"/>
-            <label for="requireSSL" class="choice"><wicket:message key="requireSSL"></wicket:message></label>
+          <li class="choiceItem">
+            <input id="requireSSL" wicket:id="requireSSL" type="checkbox"/>
+            <label for="requireSSL"><wicket:message key="requireSSL"></wicket:message></label>
           </li>
           <li>
              <label for="roleFilterName"><wicket:message key="roleFilterName"></wicket:message></label>
@@ -50,40 +50,38 @@
           <span><wicket:message key="chainConfigMethod"></wicket:message></span>
           <a href="#" wicket:id="chainConfigMethodHelp" class="help-link"></a>
          </legend>
-         <ul>
-          <li>
-            <p>
-            <input id="matchHTTPMethod" wicket:id="matchHTTPMethod" type="checkbox" class="field checkbox"/>
-            <label for="matchHTTPMethod" class="choice"><wicket:message key="matchHTTPMethod"></wicket:message></label>
-            </p>
+         <ul class="choiceList">
+          <li style="margin-bottom: 0.5em;">
+            <input id="matchHTTPMethod" wicket:id="matchHTTPMethod" type="checkbox"/>
+            <label for="matchHTTPMethod"><wicket:message key="matchHTTPMethod"></wicket:message></label>
           </li>
           <li>
-	         <input id="GET" wicket:id="GET" type="checkbox" class="field checkbox"/>
-	         <label class="choice">GET</label>
+	         <input id="GET" wicket:id="GET" type="checkbox"/>
+	         <label for="GET">GET</label>
          </li>
          <li>
-	         <input id="POST" wicket:id="POST" type="checkbox" class="field checkbox"/>
-	         <label class="choice">POST</label>
+	         <input id="POST" wicket:id="POST" type="checkbox"/>
+	         <label for="POST">POST</label>
          </li>
          <li>
-             <input id="PUT" wicket:id="PUT" type="checkbox" class="field checkbox"/>
-             <label class="choice">PUT</label>
+             <input id="PUT" wicket:id="PUT" type="checkbox"/>
+             <label for="PUT">PUT</label>
          </li>
          <li>
-             <input id="DELETE" wicket:id="DELETE" type="checkbox" class="field checkbox"/>
-             <label class="choice">DELETE</label>
+             <input id="DELETE" wicket:id="DELETE" type="checkbox"/>
+             <label for="DELETE">DELETE</label>
          </li>
          <li>
-             <input id="OPTIONS" wicket:id="OPTIONS" type="checkbox" class="field checkbox"/>
-             <label class="choice">OPTIONS</label>
+             <input id="OPTIONS" wicket:id="OPTIONS" type="checkbox"/>
+             <label for="OPTIONS">OPTIONS</label>
          </li>
          <li>
-            <input id="HEAD" wicket:id="HEAD" type="checkbox" class="field checkbox"/>
-            <label class="choice">HEAD</label>
+            <input id="HEAD" wicket:id="HEAD" type="checkbox"/>
+            <label for="HEAD">HEAD</label>
          </li>
          <li>
-            <input id="TRACE" wicket:id="TRACE" type="checkbox" class="field checkbox"/>
-            <label class="choice">TRACE</label>
+            <input id="TRACE" wicket:id="TRACE" type="checkbox"/>
+            <label for="TRACE">TRACE</label>
          </li>
          </ul>
       </fieldset>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/group/AbstractGroupPage.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/group/AbstractGroupPage.html
@@ -13,9 +13,9 @@
             <label for="groupname"><wicket:message key="groupname">groupname</wicket:message></label>
             <input type="text" wicket:id="groupname" id="groupname" class="text"/>
           </li>
-          <li>
-            <input type="checkbox" wicket:id="enabled" id="enabled" class="field checkbox"/>
-            <label class="choice"><wicket:message key="enabled">enabled</wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="enabled" id="enabled"/>
+            <label for="enabled"><wicket:message key="enabled">enabled</wicket:message></label>
           </li>
         </ul>
        </fieldset>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/passwd/MasterPasswordProviderPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/passwd/MasterPasswordProviderPanel.html
@@ -12,9 +12,9 @@
             <a href="#" wicket:id="settingsHelp" class="help-link"></a>
           </legend>
           <ul>
-           <li>
-             <input type="checkbox" wicket:id="readOnly" class="field checkbox"/>
-             <label for="readOnly" class="choice"><wicket:message key="readOnly"></wicket:message></label>
+           <li class="choiceItem">
+             <input type="checkbox" wicket:id="readOnly"/>
+             <label for="readOnly"><wicket:message key="readOnly"></wicket:message></label>
            </li>
            <li>
              <wicket:child></wicket:child>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/passwd/PasswordPolicyPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/passwd/PasswordPolicyPanel.html
@@ -11,25 +11,25 @@
           <span><wicket:message key="settings"></wicket:message></span>
         </legend>
         <ul>
-          <li>
-            <input type="checkbox" wicket:id="digitRequired" class="field checkbox"/>
-            <label for="digitRequired" class="choice"><wicket:message key="digitRequired"></wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="digitRequired"/>
+            <label for="digitRequired"><wicket:message key="digitRequired"></wicket:message></label>
           </li>
-          <li>
-            <input type="checkbox" wicket:id="uppercaseRequired" class="field checkbox"/>
-            <label for="uppercaseRequired" class="choice"><wicket:message key="uppercaseRequired"></wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="uppercaseRequired"/>
+            <label for="uppercaseRequired"><wicket:message key="uppercaseRequired"></wicket:message></label>
           </li>
-          <li>
-            <input type="checkbox" wicket:id="lowercaseRequired" class="field checkbox"/>
-            <label for="lowercaseRequired" class="choice"><wicket:message key="lowercaseRequired"></wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="lowercaseRequired"/>
+            <label for="lowercaseRequired"><wicket:message key="lowercaseRequired"></wicket:message></label>
           </li>
           <li>
             <label for="minLength"><wicket:message key="minLength"></wicket:message></label>
             <input type="text" wicket:id="minLength" class="text" /> 
           </li>
-          <li>
-            <input type="checkbox" wicket:id="unlimitedMaxLength" class="field checkbox"/>
-            <label for="unlimited" class="choice">
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="unlimitedMaxLength"/>
+            <label for="unlimitedMaxLength">
               <wicket:message key="unlimitedLength"></wicket:message>
             </label>
           </li>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/passwd/URLMasterPasswordProviderPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/passwd/URLMasterPasswordProviderPanel.html
@@ -11,9 +11,9 @@
           <a href="#" wicket:id="urlHelp" class="help-link"></a>
         </legend>
         <ul>
-          <li>
-            <input type="checkbox" wicket:id="encrypting" class="field checkbox"/>
-            <label for="encrypting" class="choice"><wicket:message key="encrypting"></wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="encrypting"/>
+            <label for="encrypting"><wicket:message key="encrypting"></wicket:message></label>
           </li>
           <li>
             <label for="url"><wicket:message key="url"></wicket:message></label>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/XMLRoleServicePanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/XMLRoleServicePanel.html
@@ -15,9 +15,9 @@
               <label for="fileName"><wicket:message key="fileName"></wicket:message></label>
               <input wicket:id="fileName" type="text" class="field text"></input>
             </li>
-            <li>
-              <input wicket:id="validating" type="checkbox" class="field checkbox" ></input>
-              <label for="validating" class="choice"><wicket:message key="validating"></wicket:message></label>
+            <li class="choiceItem">
+              <input wicket:id="validating" type="checkbox"></input>
+              <label for="validating"><wicket:message key="validating"></wicket:message></label>
             </li>
             <li>
               <label for="checkInterval"><wicket:message key="checkInterval"></wicket:message></label>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/user/AbstractUserPage.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/user/AbstractUserPage.html
@@ -13,19 +13,19 @@
                    <label for="username"><wicket:message key="username">username</wicket:message></label>
                    <input type="text" wicket:id="username" id="username" class="text" />
                 </li>
-                <li>
-                   <input type="checkbox"  wicket:id="enabled" id="enabled" class="field checkbox"/>
-                   <label class="choice"><wicket:message key="enabled">enabled</wicket:message></label>
+                <li class="choiceItem">
+                   <input type="checkbox"  wicket:id="enabled" id="enabled"/>
+                   <label for="enabled"><wicket:message key="enabled">enabled</wicket:message></label>
                 </li>
                 <li>
                   <label for="password"><wicket:message key="password">password</wicket:message></label>
-                  <input type="password" " wicket:id="password" id="password" class="text"/>
+                  <input type="password" wicket:id="password" id="password" class="text"/>
                 </li>
                 <li>
                   <label for="confirmPassword">
                     <wicket:message key="confirmPassword">confirmPassword</wicket:message>
                   </label> 
-                  <input type="password" " wicket:id="confirmPassword" id="confirmPassword" class="text"/>
+                  <input type="password" wicket:id="confirmPassword" id="confirmPassword" class="text"/>
                 </li>
             </ul>
           </fieldset>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/usergroup/UserGroupServicePanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/usergroup/UserGroupServicePanel.html
@@ -15,9 +15,9 @@
              <label for="passwordEncoderName"><wicket:message key="passwordEncryption"></wicket:message></label>
              <select wicket:id="passwordEncoderName"/>
            </li>
-           <li>
-            <input wicket:id="recodeExistingPasswords" type="checkbox" class="field checkbox" />
-            <label for="recodeExistingPasswords" class="choice"><wicket:message key="recodeExistingPasswords"></wicket:message></label>
+           <li class="choiceItem">
+            <input wicket:id="recodeExistingPasswords" type="checkbox" />
+            <label for="recodeExistingPasswords"><wicket:message key="recodeExistingPasswords"></wicket:message></label>
            </li>
            <li>
              <label for="passwordPolicyName"><wicket:message key="passwordPolicy"></wicket:message></label>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/usergroup/XMLUserGroupServicePanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/usergroup/XMLUserGroupServicePanel.html
@@ -15,9 +15,9 @@
             <label for="fileName"><wicket:message key="fileName"></wicket:message></label>
             <input wicket:id="fileName" type="text" class="field text">
           </li>
-          <li>
-            <input wicket:id="validating" type="checkbox" class="field checkbox" >
-            <label for="validating" class="choice"><wicket:message key="validating"></wicket:message></label>
+          <li class="choiceItem">
+            <input wicket:id="validating" type="checkbox">
+            <label for="validating"><wicket:message key="validating"></wicket:message></label>
           </li>
           <li>
             <label for="checkInterval"><wicket:message key="checkInterval"></wicket:message></label>

--- a/src/web/security/jdbc/src/main/java/org/geoserver/security/web/jdbc/JDBCConnectionPanel.html
+++ b/src/web/security/jdbc/src/main/java/org/geoserver/security/web/jdbc/JDBCConnectionPanel.html
@@ -8,9 +8,9 @@
     <li>
       <div wicket:id="feedback"></div>
     </li>
-    <li>
-      <input id="jndi" wicket:id="jndi" type="checkbox" class="field checkbox"></input>
-      <label for="jndi" class="choice">
+    <li class="choiceList">
+      <input id="jndi" wicket:id="jndi" type="checkbox"></input>
+      <label for="jndi">
         <wicket:message key="jndi"></wicket:message>
       </label>
     </li>

--- a/src/web/security/jdbc/src/main/java/org/geoserver/security/web/jdbc/JDBCRoleServicePanel.html
+++ b/src/web/security/jdbc/src/main/java/org/geoserver/security/web/jdbc/JDBCRoleServicePanel.html
@@ -19,9 +19,9 @@
             <span><wicket:message key="databaseInit"></wicket:message></span>
           </legend>
           <ul>
-          <li>
-            <input id="createTables" wicket:id="creatingTables" type="checkbox" class="field checkbox"></input>
-            <label for="createTables" class="choice">
+          <li class="choiceItem">
+            <input id="createTables" wicket:id="creatingTables" type="checkbox"></input>
+            <label for="creatingTables">
               <wicket:message key="createTables"></wicket:message>
             </label>
           </li>

--- a/src/web/security/jdbc/src/main/java/org/geoserver/security/web/jdbc/JDBCUserGroupServicePanel.html
+++ b/src/web/security/jdbc/src/main/java/org/geoserver/security/web/jdbc/JDBCUserGroupServicePanel.html
@@ -21,9 +21,9 @@
             <span><wicket:message key="databaseInit"></wicket:message></span>
           </legend>
           <ul>
-              <li>
-                <input id="createTables" wicket:id="creatingTables" type="checkbox" class="field checkbox"></input>
-                <label for="createTables" class="choice">
+              <li class="choiceItem">
+                <input id="createTables" wicket:id="creatingTables" type="checkbox"></input>
+                <label for="creatingTables">
                   <wicket:message key="createTables"></wicket:message>
                 </label>
               </li>

--- a/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel$LDAPAuthorizationPanel.html
+++ b/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel$LDAPAuthorizationPanel.html
@@ -7,8 +7,8 @@
  <ul>
   <li>
   
-  	<input id="bindBeforeGroupSearch" wicket:id="bindBeforeGroupSearch" type="checkbox" class="field checkbox"></input>
-    <label for="bindBeforeGroupSearch" class="choice">
+  	<input class="choiceItem" id="bindBeforeGroupSearch" wicket:id="bindBeforeGroupSearch" type="checkbox"></input>
+    <label for="bindBeforeGroupSearch">
       <wicket:message key="bindBeforeGroupSearch"></wicket:message>
     </label>    
   </li>

--- a/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.html
+++ b/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.html
@@ -16,9 +16,9 @@
               <input id="serverURL" wicket:id="serverURL" type="text" class="text"></input>
             </li>
             
-            <li>
-              <input id="useTLS" wicket:id="useTLS" type="checkbox" class="field checkbox"></input>
-              <label for="useTLS" class="choice"><wicket:message key="useTLS"></wicket:message></label>
+            <li class="choiceItem">
+              <input id="useTLS" wicket:id="useTLS" type="checkbox"></input>
+              <label for="useTLS"><wicket:message key="useTLS"></wicket:message></label>
             </li>
             <li>
               <label for="userDnPattern"><wicket:message key="userDnPattern"></wicket:message></label>
@@ -41,9 +41,9 @@
             <span><wicket:message key="authorization"></wicket:message></span>
           </legend>
           <ul>
-           <li>
-            <input id="useLdapAuthorization" wicket:id="useLdapAuthorization" type="checkbox" class="field checkbox"></input>
-            <label for="useLdapAuthorization" class="choice">
+           <li class="choiceItem">
+            <input id="useLdapAuthorization" wicket:id="useLdapAuthorization" type="checkbox"></input>
+            <label for="useLdapAuthorization">
               <wicket:message key="useLdapAuthorization"></wicket:message>
             </label>
            </li>

--- a/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPRoleServicePanel.html
+++ b/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPRoleServicePanel.html
@@ -16,9 +16,9 @@
               <input id="serverURL" wicket:id="serverURL" type="text" class="text"></input>
             </li>
             
-            <li>
-              <input id="useTLS" wicket:id="useTLS" type="checkbox" class="field checkbox"></input>
-              <label for="useTLS" class="choice"><wicket:message key="useTLS"></wicket:message></label>
+            <li class="choiceItem">
+              <input id="useTLS" wicket:id="useTLS" type="checkbox"></input>
+              <label for="useTLS"><wicket:message key="useTLS"></wicket:message></label>
             </li>
             <li>
 			    <label for="groupSearchBase"><wicket:message key="groupSearchBase"></wicket:message></label>
@@ -45,9 +45,9 @@
             <span><wicket:message key="authentication"></wicket:message></span>
           </legend>
           <ul>
-           <li>
-            <input id="bindBeforeGroupSearch" wicket:id="bindBeforeGroupSearch" type="checkbox" class="field checkbox"></input>
-            <label for="bindBeforeGroupSearch" class="choice">
+           <li class="choiceItem">
+            <input id="bindBeforeGroupSearch" wicket:id="bindBeforeGroupSearch" type="checkbox"></input>
+            <label for="bindBeforeGroupSearch">
               <wicket:message key="bindBeforeGroupSearch"></wicket:message>
             </label>
            </li>

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/WCSAdminPage.html
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/WCSAdminPage.html
@@ -5,12 +5,12 @@
 	<fieldset><legend><span><wicket:message
 		key="processing">processing</wicket:message></span></legend>
 	<ul>
-		<li><input class="field checkbox" type="checkbox"
-			wicket:id="subsamplingEnabled"></input> <label class="choice"><wicket:message
+		<li class="choiceItem"><input class="field checkbox" type="checkbox"
+			wicket:id="subsamplingEnabled"></input> <label for="subsamplingEnabled"><wicket:message
 			key="subsampling">subsampling</wicket:message></label></li>
 		<li><label><wicket:message key="overviewPolicy">overview</wicket:message></label>
 		<select wicket:id="overviewPolicy" class="field"></select></li>
-		<li><input wicket:id="latLon" type="checkbox"></input> <label class="choice"><wicket:message
+		<li class="choiceItem"><input wicket:id="latLon" type="checkbox"></input> <label for="latLon"><wicket:message
 			key="latLonOrder">subsampling</wicket:message></label></li>		
 	</ul>
 	</fieldset>

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/WCSRequestBuilderPanel.html
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/WCSRequestBuilderPanel.html
@@ -20,9 +20,9 @@
             <li wicket:id="sourceGridContainer">
               <label for="grid"><wicket:message key="grid">grid</wicket:message></label>
               <ul>
-                 <li>
-                   <input id="manualGrid" class="field checkbox" type="checkbox" wicket:id="manualGrid" />
-                   <label for="manualGrid" class="choice"><wicket:message key="manualGrid">manualGrid</wicket:message></label>
+                 <li class="choiceItem">
+                   <input id="manualGrid" type="checkbox" wicket:id="manualGrid" />
+                   <label for="manualGrid"><wicket:message key="manualGrid">manualGrid</wicket:message></label>
                  </li>
                  <li>
 		              <div wicket:id="sourceGrid"></div> 

--- a/src/web/wfs/src/main/java/org/geoserver/wfs/web/WFSAdminPage.html
+++ b/src/web/wfs/src/main/java/org/geoserver/wfs/web/WFSAdminPage.html
@@ -13,13 +13,13 @@
           <label for="maxNumberOfFeaturesForPreview"><wicket:message key="maxNumberOfFeaturesForPreview">Maximum number of features for preview (Values &lt= 0 use the maximum number of features)</wicket:message></label>
           <input class="field text" wicket:id="maxNumberOfFeaturesForPreview" type="text"></input>
         </li>
-        <li>
-          <input class="field checkbox" wicket:id="featureBounding" type="checkbox"></input>
-          <label class="choice" for="featureBounding"><wicket:message key="featureBounding">Return bounding box with every feature</wicket:message></label>
+        <li class="choiceItem">
+          <input wicket:id="featureBounding" type="checkbox"></input>
+          <label for="featureBounding"><wicket:message key="featureBounding">Return bounding box with every feature</wicket:message></label>
         </li>
-        <li>
-          <input class="field checkbox" wicket:id="hitsIgnoreMaxFeatures" type="checkbox"></input>
-          <label class="choice" for="hitsIgnoreMaxFeatures"><wicket:message key="hitsIgnoreMaxFeatures">Ignore maximum number of features when calculating hits</wicket:message></label>
+        <li class="choiceItem">
+          <input wicket:id="hitsIgnoreMaxFeatures" type="checkbox"></input>
+          <label for="hitsIgnoreMaxFeatures"><wicket:message key="hitsIgnoreMaxFeatures">Ignore maximum number of features when calculating hits</wicket:message></label>
         </li>
       </ul>
     </fieldset>
@@ -41,18 +41,18 @@
     <fieldset>
       <legend><span><wicket:message key="serviceLevel">Service Level</wicket:message></span></legend>
       <div wicket:id="serviceLevel">
-        <ul>
+        <ul class="choiceList">
           <li>
-            <input id="basic" wicket:id="basic" class="field radio" type="radio"></input>
-            <label for="basic" class="choice"><wicket:message key="basic">basic</wicket:message></label>
+            <input id="basic" wicket:id="basic" type="radio"></input>
+            <label for="basic"><wicket:message key="basic">basic</wicket:message></label>
           </li>
           <li>
-            <input id="transactional" wicket:id="transactional" class="field radio" type="radio"></input>
-            <label for="transactional" class="choice"><wicket:message key="transactional">Transactional</wicket:message></label>
+            <input id="transactional" wicket:id="transactional" type="radio"></input>
+            <label for="transactional"><wicket:message key="transactional">Transactional</wicket:message></label>
           </li>
           <li>
-     	    <input id="complete" wicket:id="complete" class="field radio" type="radio"></input>
-            <label for="complete" class="choice"><wicket:message key="complete">Complete</wicket:message></label>
+     	    <input id="complete" wicket:id="complete" type="radio"></input>
+            <label for="complete"><wicket:message key="complete">Complete</wicket:message></label>
           </li>
         </ul>
       </div>
@@ -79,10 +79,10 @@
   <li>
     <fieldset>
       <legend><span><wicket:message key="conformance">Conformance</wicket:message></span></legend>
-      <ul>
+      <ul class="choiceList">
        <li>
-          <input class="field checkbox" wicket:id="canonicalSchemaLocation" type="checkbox"></input>
-          <label class="choice" for="canonicalSchemaLocation"><wicket:message key="canonicalSchemaLocation">Encode canonical WFS schema location</wicket:message></label>
+          <input wicket:id="canonicalSchemaLocation" type="checkbox"></input>
+          <label for="canonicalSchemaLocation"><wicket:message key="canonicalSchemaLocation">Encode canonical WFS schema location</wicket:message></label>
         </li>
       </ul>
     </fieldset>
@@ -91,14 +91,14 @@
     <fieldset>
       <legend><span><wicket:message key="encodeFeatureMember">Encode response with </wicket:message></span></legend>
       <div wicket:id="encodeFeatureMember">
-        <ul>
+        <ul class="choiceList">
           <li>
-            <input id="featureMembers" wicket:id="featureMembers" class="field radio" type="radio"></input>
-            <label for="featureMembers" class="choice"><wicket:message key="featureMembers">One "featureMembers" element</wicket:message></label>
+            <input id="featureMembers" wicket:id="featureMembers" type="radio"></input>
+            <label for="featureMembers"><wicket:message key="featureMembers">One "featureMembers" element</wicket:message></label>
           </li>
           <li>
-            <input id="featureMember" wicket:id="featureMember" class="field radio" type="radio"></input>
-            <label for="featureMember" class="choice"><wicket:message key="featureMember">Multiple "featureMember" elements</wicket:message></label>
+            <input id="featureMember" wicket:id="featureMember" type="radio"></input>
+            <label for="featureMember"><wicket:message key="featureMember">Multiple "featureMember" elements</wicket:message></label>
           </li>         
         </ul>
       </div>
@@ -107,10 +107,10 @@
   <li>
     <fieldset>
       <legend><span><wicket:message key="shapeOutputFormat">SHAPE-ZIP output format</wicket:message></span></legend>
-      <ul>
+      <ul class="choiceList">
        <li>
-          <input class="field checkbox" wicket:id="shapeZipPrjFormat" type="checkbox"></input>
-          <label class="choice" for="shapeZipPrjFormat"><wicket:message key="shapeZipPrjFormat">SHAPE-ZIP default prj is ESRI</wicket:message></label>
+          <input wicket:id="shapeZipPrjFormat" type="checkbox"></input>
+          <label for="shapeZipPrjFormat"><wicket:message key="shapeZipPrjFormat">SHAPE-ZIP default prj is ESRI</wicket:message></label>
         </li>
       </ul>
     </fieldset>

--- a/src/web/wfs/src/main/java/org/geoserver/wfs/web/publish/WFSLayerConfig.html
+++ b/src/web/wfs/src/main/java/org/geoserver/wfs/web/publish/WFSLayerConfig.html
@@ -27,10 +27,10 @@
                     <span><wicket:message key="skipNumberMatchedTitle">otherSRS</wicket:message></span>
                     <a href="#" wicket:id="skipNumberMatchedHelp" class="help-link"></a>
                 </legend>
-                <ul>
+                <ul class="choiceList">
                     <li>
-                        <input id="skipNumberMatched" class="field checkbox" wicket:id="skipNumberMatched" type="checkbox"></input>
-                        <label for="skipNumberMatched" class="choice"><wicket:message key="skipNumberMatched">skipNumberMatched</wicket:message></label>
+                        <input id="skipNumberMatched" wicket:id="skipNumberMatched" type="checkbox"></input>
+                        <label for="skipNumberMatched"><wicket:message key="skipNumberMatched">skipNumberMatched</wicket:message></label>
                     </li>
                 </ul>
             </fieldset>
@@ -42,9 +42,9 @@
           <a href="#" wicket:id="otherSRSHelp" class="help-link"></a>
         </legend>
         <ul>
-            <li>
-              <input id="basic-enabled" class="field checkbox" wicket:id="overridingServiceSRS" type="checkbox"></input>
-              <label for="basic-enabled" class="choice"><wicket:message key="overridingServiceSRS">overridingServiceSRS</wicket:message></label>
+            <li class="choiceItem">
+              <input id="basic-enabled" wicket:id="overridingServiceSRS" type="checkbox"></input>
+              <label for="basic-enabled"><wicket:message key="overridingServiceSRS">overridingServiceSRS</wicket:message></label>
             </li>
             <ul>
               <li wicket:id="otherSRSContainer">

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/MimeTypesFormComponent.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/MimeTypesFormComponent.html
@@ -6,10 +6,9 @@
 	<wicket:panel>
 		<ul>
 			<li>
-				<div>
-					<input wicket:id="mimeTypeCheckingEnabled" type="checkbox"
-						class="field checkbox" /> 
-					<label class="choice"><wicket:message
+				<div class="choiceItem">
+					<input wicket:id="mimeTypeCheckingEnabled" type="checkbox"/> 
+					<label for="mimeTypeCheckingEnabled"><wicket:message
 							key="mimeTypeCheckingEnabled"></wicket:message>
 					</label>
 				</div>

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.html
@@ -14,9 +14,9 @@
           <li>
             <textarea class="input textarea" rows="10" cols="30" wicket:id="srs"></textarea>
           </li>
-          <li>
-            <input class="field checkbox" type="checkbox" wicket:id="bBOXForEachCRS"></input>
-            <label class="choice"><wicket:message key="bboxForEachCRS">Output bounding box for each supported CRS</wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="bBOXForEachCRS"></input>
+            <label for="bBOXForEachCRS"><wicket:message key="bboxForEachCRS">Output bounding box for each supported CRS</wicket:message></label>
           </li>
         </ul>
       </fieldset>
@@ -24,14 +24,14 @@
     <li>
       <fieldset>
         <legend><span><wicket:message key="projectionHandlingOptions">Raster Rendering Options</wicket:message></span></legend>
-        <ul>
+        <ul class="choiceList">
           <li>
-            <input class="field checkbox" type="checkbox" wicket:id="aph.enabled"></input>
-            <label class="choice"><wicket:message key="aph.enabled">Enabled advanced projection handling</wicket:message></label>
+            <input type="checkbox" wicket:id="aph.enabled"></input>
+            <label for="aph.enabled"><wicket:message key="aph.enabled">Enabled advanced projection handling</wicket:message></label>
           </li>
           <li>
-            <input class="field checkbox" type="checkbox" wicket:id="aph.wrap"></input>
-            <label class="choice"><wicket:message key="aph.wrap">Enable continous map wrapping</wicket:message></label>
+            <input type="checkbox" wicket:id="aph.wrap"></input>
+            <label for="aph.wrap"><wicket:message key="aph.wrap">Enable continous map wrapping</wicket:message></label>
           </li>
         </ul>
       </fieldset>
@@ -59,13 +59,13 @@
             <label><wicket:message key="superoverlayMode">superoverlay Mode</wicket:message></label>
             <select wicket:id="kml.superoverlayMode"></select>
          </li>
-         <li>
-            <input class="field checkbox" type="checkbox" wicket:id="kml.kmattr"></input>
-            <label class="choice"><wicket:message key="kmattr">Show vector placemarks</wicket:message></label>
+         <li class="choiceItem">
+            <input type="checkbox" wicket:id="kml.kmattr"></input>
+            <label for="kml.kmattr"><wicket:message key="kmattr">Show vector placemarks</wicket:message></label>
          </li>
-         <li>
-            <input class="field checkbox" type="checkbox" wicket:id="kml.kmlplacemark"></input>
-            <label class="choice"><wicket:message key="kmlplacemark">Show raster placemarks</wicket:message></label>
+         <li class="choiceItem">
+            <input type="checkbox" wicket:id="kml.kmlplacemark"></input>
+            <label for="kml.kmlplacemark"><wicket:message key="kmlplacemark">Show raster placemarks</wicket:message></label>
          </li>
          <li>
             <label><wicket:message key="kmScore">Raster/vector threshold (0-100, default 40)</wicket:message></label>
@@ -97,9 +97,9 @@
       <fieldset>
         <legend><span><wicket:message key="watermarkSettings">Watermark Settings</wicket:message></span></legend>
         <ul>
-          <li>
-            <input class="field checkbox" type="checkbox" wicket:id="watermark.enabled"></input>
-            <label class="choice"><wicket:message key="enableWatermark">Enable Watermark</wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="watermark.enabled"></input>
+            <label for="watermark.enabled"><wicket:message key="enableWatermark">Enable Watermark</wicket:message></label>
           </li>
           <li>
             <label><wicket:message key="watermarkUrl">Watermark URL</wicket:message></label>
@@ -159,9 +159,9 @@
             <label><wicket:message key="framesDelay">Frames Delay (ms, default 1s)</wicket:message></label>
             <input class="text" type="text" wicket:id="anim.framesdelay"></input>
           </li>
-          <li>
-            <input class="field checkbox" type="checkbox" wicket:id="anim.loopcontinuously"></input>
-            <label class="choice"><wicket:message key="loopContinuously">Loop Continuously</wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="anim.loopcontinuously"></input>
+            <label for="anim.loopcontinuously"><wicket:message key="loopContinuously">Loop Continuously</wicket:message></label>
           </li>
         </ul>
       </fieldset>
@@ -174,9 +174,9 @@
             <label><wicket:message key="svgProducer">SVG producer</wicket:message></label>
             <select wicket:id="svg.producer"></select>
           </li>
-          <li>
-            <input class="field checkbox" type="checkbox" wicket:id="svg.antialias"></input>
-            <label class="choice"><wicket:message key="enableAntialiasing">Enable antialiasing</wicket:message></label>
+          <li class="choiceItem">
+            <input type="checkbox" wicket:id="svg.antialias"></input>
+            <label for="svg.antialias"><wicket:message key="enableAntialiasing">Enable antialiasing</wicket:message></label>
           </li>
         </ul>
       </fieldset>
@@ -184,10 +184,10 @@
     <li>
       <fieldset>
         <legend><span><wicket:message key="scalehintOptions">Scalehint Options</wicket:message></span></legend>
-        <ul>
+        <ul class="choiceList">
           <li>
-            <input class="field checkbox" type="checkbox" wicket:id="scalehint.mapunitsPixel"></input>
-            <label class="choice"><wicket:message key="scalehintUnitsPixel">Show the Scalehint as units per diagonal pixel in the GetCapability response</wicket:message></label>
+            <input type="checkbox" wicket:id="scalehint.mapunitsPixel"></input>
+            <label for="scalehint.mapunitsPixel"><wicket:message key="scalehintUnitsPixel">Show the Scalehint as units per diagonal pixel in the GetCapability response</wicket:message></label>
           </li>
         </ul>
       </fieldset>      


### PR DESCRIPTION
Changes to geoserver.css and to most of the checkboxes in the geoserver UI.  Allows the checkboxes to be toggled by their labels while not toggling then when clicking on whitespace near the label and also gives a hanging indent of the label if it is multiline.  Also fixes/restores missing `for` attributes.

I tried to use `wicket:for` but that doesn't seem to work, possibly because of the ancient wicket we're using.  I couldn't find a clear indication of when that feature was added to wicket.