### PR TITLE
removed arbitrary setting of default data store

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -158,11 +158,6 @@ public class CatalogImpl implements Catalog {
         StoreInfo added;
         synchronized (facade) {
             added = facade.add(resolve(store));
-            
-            // if there is no default store use this one as the default
-            if(getDefaultDataStore(store.getWorkspace()) == null && store instanceof DataStoreInfo) {
-                setDefaultDataStore(store.getWorkspace(), (DataStoreInfo) store);
-            }
         }
         added(added);
     }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -158,6 +158,9 @@ public class CatalogImpl implements Catalog {
         StoreInfo added;
         synchronized (facade) {
             added = facade.add(resolve(store));
+             if(getDefaultDataStore(store.getWorkspace()) == null && store instanceof DataStoreInfo) {
+                setDefaultDataStore(store.getWorkspace(), (DataStoreInfo) store);
+            }
         }
         added(added);
     }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -158,6 +158,7 @@ public class CatalogImpl implements Catalog {
         StoreInfo added;
         synchronized (facade) {
             added = facade.add(resolve(store));
+            // if there is no default store use this one as the default
              if(getDefaultDataStore(store.getWorkspace()) == null && store instanceof DataStoreInfo) {
                 setDefaultDataStore(store.getWorkspace(), (DataStoreInfo) store);
             }


### PR DESCRIPTION
Removed the arbitrary setting of the default DataStore. The store selector will now default to "Create New" in the importer screen. This in preparation for a minor UI change to let users set and view the default Store.