### PR TITLE
preserve parameters for relative external urls of an external graphics

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
@@ -1235,8 +1235,16 @@ public class GeoServerDataDirectory implements ResourceStore {
                 URL url = super.locateResource(uri);
                 if(url.getProtocol().equalsIgnoreCase("resource")) {
                     //GEOS-7025: Just get the path; don't try to create the file
-                    return fileToUrlPreservingCqlTemplates(
+                    URL u = fileToUrlPreservingCqlTemplates(
                             Paths.toFile(root(), urlToResource(url).path()));
+                    if (url.getQuery() != null) {
+                        try {
+                            return new URL(u.toString() + "?" + url.getQuery());
+                        } catch (MalformedURLException ex) {
+                            return null;
+                        }
+                    }
+                    return u;
                 } else {
                     return url;
                 }
@@ -1431,7 +1439,7 @@ public class GeoServerDataDirectory implements ResourceStore {
 
     /**
      * Wrapper for {@link DataUtilities#fileToURL} that unescapes braces used to delimit CQL templates.
-     */
+     */ 
     public static URL fileToUrlPreservingCqlTemplates(File file) {
         URL url = DataUtilities.fileToURL(file);
         if (!file.getPath().contains("${")) {

--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
@@ -81,4 +81,37 @@ public class GeoServerDataDirectoryTest {
         //GEOS-7025: verify the icon file is not created if it doesn't already exist
         assertFalse(iconFile.exists());
     }
+    
+    @Test
+    public void testParsedStyleExternalWithParams() throws IOException {
+        File styleDir = new File(dataDir.root(), "styles");
+        styleDir.mkdir();
+        
+        //Copy the sld to the temp style dir
+        File styleFile = new File(styleDir, "external_with_params.sld");
+        Files.copy(this.getClass().getResourceAsStream("external_with_params.sld"), styleFile.toPath());
+        
+        File iconFile = new File(styleDir, "icon.png");
+        assertFalse(iconFile.exists());
+        
+        StyleInfoImpl si = new StyleInfoImpl(null);
+        si.setName("");
+        si.setId("");
+        si.setFormat("sld");
+        si.setFormatVersion(new Version("1.0.0"));
+        si.setFilename(styleFile.getName());
+        
+        Style s = dataDir.parsedStyle(si);
+        //Verify style is actually parsed correctly
+        Symbolizer symbolizer = s.featureTypeStyles().get(0).rules().get(0).symbolizers().get(0);
+        assertTrue(symbolizer instanceof PointSymbolizer);
+        GraphicalSymbol graphic = ((PointSymbolizer) symbolizer).getGraphic().graphicalSymbols().get(0);
+        assertTrue(graphic instanceof ExternalGraphic);
+        assertEquals(((ExternalGraphic) graphic).getLocation().getPath(), iconFile.toURI().toURL().getPath());
+        
+        assertEquals("param1=1", ((ExternalGraphic) graphic).getLocation().getQuery());
+        
+        //GEOS-7025: verify the icon file is not created if it doesn't already exist
+        assertFalse(iconFile.exists());
+    } 
 }

--- a/src/main/src/test/resources/org/geoserver/config/external_with_params.sld
+++ b/src/main/src/test/resources/org/geoserver/config/external_with_params.sld
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>external</Name>
+    <UserStyle>
+      <Name>external</Name> 
+      <Title>An external graphic</Title>
+      <Abstract>A sample point symbolizer with an external graphic</Abstract>
+
+      <FeatureTypeStyle>
+        <Rule>
+          <Title>Red flag</Title>
+          <PointSymbolizer>
+            <Graphic>
+              <ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="icon.png?param1=1" />
+                <Format>image/png</Format>
+              </ExternalGraphic>
+              <Size>
+                <ogc:Literal>20</ogc:Literal>
+              </Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor> 


### PR DESCRIPTION
At the moment geoserver strips additional parameters from an external graphics resource:

/test/mypic.gen?param1=1
is transformed to
/test/mypic.gen

Additional parameters are very useful in customizng dynamic symbol renderers.
This patch preserves these parameters.
