### PR TITLE
[GEOS-7256] Maven Cobertura plugin does not work

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1069,6 +1069,11 @@
       <artifactId>pngj</artifactId>
       <version>2.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <version>1.4.01</version>
+    </dependency>
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>


### PR DESCRIPTION
Manage `xml-apis` version in parent POM to avoid version conflicts when Maven Cobertura plugin is run.