### PR TITLE
[GEOS-7256] Maven Cobertura plugin does not work

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1040,6 +1040,11 @@
       <artifactId>pngj</artifactId>
       <version>2.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <version>1.4.01</version>
+    </dependency>
 	<dependency>
 	  <groupId>javax.jms</groupId>
 	  <artifactId>jms-api</artifactId>


### PR DESCRIPTION
This is the backport to the 2.7.x branch.