### PR TITLE
fix svn links in developers guide

### DIFF
--- a/doc/en/developer/source/eclipse-guide/index.rst
+++ b/doc/en/developer/source/eclipse-guide/index.rst
@@ -135,7 +135,7 @@ Eclipse preferences
 Code formatting
 ^^^^^^^^^^^^^^^
 
-#. Download http://svn.osgeo.org/geotools/trunk/build/eclipse/formatter.xml
+#. Download https://github.com/geotools/geotools/blob/master/build/eclipse/formatter.xml
 #. Navigate to ``Java``, ``Code Style``, ``Formatter`` and click ``Import...``
 
    .. image:: code_formatting1.jpg
@@ -145,15 +145,32 @@ Code formatting
 
    .. image:: code_formatting2.jpg
 
+#. We follow "Sun Coding Conventions and a little bit more":
+  
+  * `Code Conventions for the Java Programming Language <http://www.oracle.com/technetwork/java/index-135089.html>`__
+  * but allow for 100 characters in width
+  * developers should use spaces for indentations, not tabulations. The tab width (4 or 8 spaces) is not the same on all editors.
+  
+  For more information see GeoTools `Coding Style <http://docs.geotools.org/latest/developer/conventions/code/style.html>`__ page.
+
 Code templates
 ^^^^^^^^^^^^^^
 
-#. Download http://svn.osgeo.org/geotools/trunk/build/eclipse/codetemplates.xml
+#. Download https://github.com/geotools/geotools/blob/master/build/eclipse/codetemplates.xml
 #. Navigate to ``Java``, ``Code Style``, ``Code Templates`` and click ``Import...``
 
    .. image:: code_templates.jpg
 
 #. Select the ``codetemplates.xml`` file downloaded in step 1
+#. Update the file header:
+   
+   .. code-block::
+   
+      /* (c) ${year} Open Source Geospatial Foundation - all rights reserved
+       * This code is licensed under the GPL 2.0 license, available at the root
+       * application directory.
+       */
+   
 #. Click ``Apply``
 
 Text editors


### PR DESCRIPTION
We should probably make our own code template for GeoServer rather then requiring a manual step