### PR TITLE
[GEOS-6432] Include all supported WMS exception formats in GetCapabilities

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -88,6 +88,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Envelope;
+import org.geoserver.wfs.json.JSONType;
 
 /**
  * Geotools xml framework based encoder for a Capabilities WMS 1.3.0 document.
@@ -106,7 +107,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
     public static final String WMS_CAPS_MIME = "text/xml";
 
     /** the WMS supported exception formats */
-    static final String[] EXCEPTION_FORMATS = { "XML", "INIMAGE", "BLANK" };
+    static final String[] EXCEPTION_FORMATS = { "XML", "INIMAGE", "BLANK", "JSON" };
 
     /**
      * The geoserver base URL to append it the schemas/wms/1.3.0/exceptions_1_3_0.xsd schema
@@ -590,7 +591,9 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             for (String exceptionFormat : EXCEPTION_FORMATS) {
                 element("Format", exceptionFormat);
             }
-
+            if (JSONType.isJsonpEnabled()) {
+                element("Format", "JSONP");
+            }
             end("Exception");
         }
 

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -86,6 +86,7 @@ import sun.security.action.GetBooleanAction;
 
 import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Envelope;
+import org.geoserver.wfs.json.JSONType;
 
 /**
  * Geotools xml framework based encoder for a Capabilities WMS 1.1.1 document.
@@ -102,7 +103,8 @@ public class GetCapabilitiesTransformer extends TransformerBase {
 
     /** the WMS supported exception formats */
     static final String[] EXCEPTION_FORMATS = { "application/vnd.ogc.se_xml",
-            "application/vnd.ogc.se_inimage", "application/vnd.ogc.se_blank" };
+            "application/vnd.ogc.se_inimage", "application/vnd.ogc.se_blank",
+            "application/json"};
 
     /**
      * Set of supported metadta link types. Links of any other type will be ignored to honor the DTD
@@ -566,7 +568,9 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             for (String exceptionFormat : GetCapabilitiesTransformer.EXCEPTION_FORMATS) {
                 element("Format", exceptionFormat);
             }
-
+            if (JSONType.isJsonpEnabled()) {
+                element("Format", JSONType.jsonp);
+            }
             end("Exception");
         }
 

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
@@ -33,6 +33,7 @@ import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSTestSupport;
 import org.junit.Test;
@@ -411,7 +412,21 @@ public class CapabilitiesTest extends WMSTestSupport {
         assertTrue(xpath.evaluate("//Exception/Format[1]", doc).equals("application/vnd.ogc.se_xml"));
         assertTrue(xpath.evaluate("//Exception/Format[2]", doc).equals("application/vnd.ogc.se_inimage"));
         assertTrue(xpath.evaluate("//Exception/Format[3]", doc).equals("application/vnd.ogc.se_blank"));
-        assertTrue(xpath.getMatchingNodes("//Exception/Format", doc).getLength() == 3);
+        assertTrue(xpath.evaluate("//Exception/Format[4]", doc).equals("application/json"));
+        assertTrue(xpath.getMatchingNodes("//Exception/Format", doc).getLength() >= 4);
+
+        boolean jsonpOriginal = JSONType.isJsonpEnabled();
+        try {
+            JSONType.setJsonpEnabled(true);
+            doc = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.1.1", true);
+            assertTrue(xpath.evaluate("//Exception/Format[5]", doc).equals("text/javascript"));
+            assertTrue(xpath.getMatchingNodes("//Exception/Format", doc).getLength() == 5);
+            JSONType.setJsonpEnabled(false);
+            doc = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.1.1", true);
+            assertTrue(xpath.getMatchingNodes("//Exception/Format", doc).getLength() == 4);
+        } finally {
+            JSONType.setJsonpEnabled(jsonpOriginal);
+        }
     }
 
     @org.junit.Test 


### PR DESCRIPTION
This is a pretty old bug: https://osgeo-org.atlassian.net/browse/GEOS-6432.

The PR extends current test for 1.1.1, and adds a new for 1.3.0. If there is an existing 1.3.0 test, would appreciate someone pointing it out to me.