### PR TITLE
[GEOS-7227] Improve null handling for Import bounds calculation

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
@@ -918,27 +918,11 @@ public class Importer implements DisposableBean, ApplicationListener {
 
             addToCatalog(task);
             
-            //Calculate bounds, if applicable
             if (task.getLayer().getResource() instanceof FeatureTypeInfo) {
                 FeatureTypeInfo featureType = (FeatureTypeInfo) task.getLayer().getResource();
                 FeatureTypeInfo resource = getCatalog().getResourceByName(
                         featureType.getName(), FeatureTypeInfo.class);
-                if (resource.getNativeBoundingBox().isEmpty()
-                        || resource.getMetadata().get("recalculate-bounds").equals(Boolean.TRUE)) {
-                    
-                    // force computation
-                    CatalogBuilder cb = new CatalogBuilder(getCatalog());
-                    ReferencedEnvelope nativeBounds = cb.getNativeBounds(resource);
-                    resource.setNativeBoundingBox(nativeBounds);
-                    resource.setLatLonBoundingBox(cb.getLatLonBounds(nativeBounds,
-                            resource.getCRS()));
-                    getCatalog().save(resource);
-                    
-                    //Do not re-calculate on subsequent imports
-                    if (resource.getMetadata().get("recalculate-bounds") != null) {
-                        resource.getMetadata().remove("recalculate-bounds");
-                    }
-                }
+                calculateBounds(resource);
             }
 
             // apply post transform
@@ -994,28 +978,9 @@ public class Importer implements DisposableBean, ApplicationListener {
                     if (task.getUpdateMode() == UpdateMode.CREATE) {
                         addToCatalog(task);
                     }
-    
-                    // verify that the newly created featuretype's resource
-                    // has bounding boxes computed - this might be required
-                    // for csv or other uploads that have a geometry that is
-                    // the result of a transform. there may be another way...
                     FeatureTypeInfo resource = getCatalog().getResourceByName(
                             featureType.getQualifiedName(), FeatureTypeInfo.class);
-                    if (resource.getNativeBoundingBox().isEmpty()
-                            || resource.getMetadata().get("recalculate-bounds").equals(Boolean.TRUE)) {
-                        // force computation
-                        CatalogBuilder cb = new CatalogBuilder(getCatalog());
-                        ReferencedEnvelope nativeBounds = cb.getNativeBounds(resource);
-                        resource.setNativeBoundingBox(nativeBounds);
-                        resource.setLatLonBoundingBox(cb.getLatLonBounds(nativeBounds,
-                                resource.getCRS()));
-                        getCatalog().save(resource);
-                        
-                        //Do not re-calculate on subsequent imports
-                        if (resource.getMetadata().get("recalculate-bounds") != null) {
-                            resource.getMetadata().remove("recalculate-bounds");
-                        }
-                    }
+                    calculateBounds(resource);
                 }
             }
             catch(Exception e) {
@@ -1065,6 +1030,42 @@ public class Importer implements DisposableBean, ApplicationListener {
 
         task.setState(canceled ? ImportTask.State.CANCELED : ImportTask.State.COMPLETE);
 
+    }
+    
+    /**
+     * (Re)calculates the bounds for a FeatureTypeInfo.
+     * Bounds will be calculated if:
+     * <li> The native bounds of the resource are null or empty
+     * <li> The resource has a metadata entry "recalculate-bounds"="true"<br><br>
+     * 
+     * Otherwise, this method has no effect.<br><br>
+     * 
+     * If the metadata entry "recalculate-bounds"="true" exists, 
+     * it will be removed after bounds are calculated.<br><br>
+     * 
+     * This is currently used by csv / kml uploads that have a geometry that may be the result of a 
+     * transform, and by JDBC imports which wait to calculate bounds until after the layers that 
+     * will be imported have been chosen.
+     * 
+     * @param resource The resource to calculate the bounds for
+     */
+    protected void calculateBounds(FeatureTypeInfo resource) throws IOException {
+        if (resource.getNativeBoundingBox() == null || resource.getNativeBoundingBox().isEmpty()
+                || Boolean.TRUE.equals(resource.getMetadata().get("recalculate-bounds"))
+                || "true".equals(resource.getMetadata().get("recalculate-bounds"))) {
+            // force computation
+            CatalogBuilder cb = new CatalogBuilder(getCatalog());
+            ReferencedEnvelope nativeBounds = cb.getNativeBounds(resource);
+            resource.setNativeBoundingBox(nativeBounds);
+            resource.setLatLonBoundingBox(cb.getLatLonBounds(nativeBounds,
+                    resource.getCRS()));
+            getCatalog().save(resource);
+            
+            //Do not re-calculate on subsequent imports
+            if (resource.getMetadata().get("recalculate-bounds") != null) {
+                resource.getMetadata().remove("recalculate-bounds");
+            }
+        }
     }
 
     private void checkSingleHarvest(List<HarvestedSource> harvests) throws IOException {

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTest.java
@@ -8,11 +8,27 @@ package org.geoserver.importer;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 
 import org.apache.commons.io.FileUtils;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ImporterTest extends ImporterTestSupport {
+
+
+    @Before
+    public void addPrimitiveGeoFeature() throws IOException {
+        revertLayer(SystemTestData.PRIMITIVEGEOFEATURE);
+    }
 
     public void testCreateContextSingleFile() throws Exception {
         File dir = unpack("shape/archsites_epsg_prj.zip");
@@ -73,4 +89,67 @@ public class ImporterTest extends ImporterTestSupport {
         ImportContext context = importer.createContext(new Directory(dir));
         assertEquals(1, context.getTasks().size());
     }
+    
+    @Test
+    public void testCalculateBounds() throws Exception {
+        
+        FeatureTypeInfo resource = getCatalog().getFeatureTypeByName("sf", "PrimitiveGeoFeature");
+        CatalogBuilder cb = new CatalogBuilder(getCatalog());
+        ReferencedEnvelope nativeBounds = cb.getNativeBounds(resource);
+        resource.setNativeBoundingBox(nativeBounds);
+        resource.setLatLonBoundingBox(cb.getLatLonBounds(nativeBounds,
+                resource.getCRS()));
+        getCatalog().save(resource);
+        
+        assertNotNull(resource.getNativeBoundingBox());
+        assertFalse(resource.getNativeBoundingBox().isEmpty());
+        
+        ReferencedEnvelope bbox = resource.getNativeBoundingBox();
+        
+        //Test null bbox
+        resource.setNativeBoundingBox(null);
+        importer.calculateBounds(resource);
+        assertFalse(resource.getNativeBoundingBox().isEmpty());
+        assertEquals(bbox, resource.getNativeBoundingBox());
+        
+        //Test empty bbox
+        resource.setNativeBoundingBox(new ReferencedEnvelope());
+        assertTrue(resource.getNativeBoundingBox().isEmpty());
+        importer.calculateBounds(resource);
+        assertFalse(resource.getNativeBoundingBox().isEmpty());
+        assertEquals(bbox, resource.getNativeBoundingBox());
+        
+        //Test nonempty bbox - should not be changed
+        ReferencedEnvelope customBbox = new ReferencedEnvelope(30, 60, -10, 30, bbox.getCoordinateReferenceSystem());
+        resource.setNativeBoundingBox(customBbox);
+        assertFalse(bbox.equals(resource.getNativeBoundingBox()));
+        importer.calculateBounds(resource);
+        assertFalse(resource.getNativeBoundingBox().isEmpty());
+        assertFalse(bbox.equals(resource.getNativeBoundingBox()));
+        
+        //Test with "recalculate-bounds"=false
+        resource.setNativeBoundingBox(customBbox);
+        resource.getMetadata().put("recalculate-bounds", false);
+        assertFalse(bbox.equals(resource.getNativeBoundingBox()));
+        importer.calculateBounds(resource);
+        assertFalse(resource.getNativeBoundingBox().isEmpty());
+        assertFalse(bbox.equals(resource.getNativeBoundingBox()));
+        
+        //Test with "recalculate-bounds"=true
+        resource.setNativeBoundingBox(customBbox);
+        resource.getMetadata().put("recalculate-bounds", true);
+        assertFalse(bbox.equals(resource.getNativeBoundingBox()));
+        importer.calculateBounds(resource);
+        assertFalse(resource.getNativeBoundingBox().isEmpty());
+        assertTrue(bbox.equals(resource.getNativeBoundingBox()));
+        
+        //Test with "recalculate-bounds"="true"
+        resource.setNativeBoundingBox(customBbox);
+        resource.getMetadata().put("recalculate-bounds", "true");
+        assertFalse(bbox.equals(resource.getNativeBoundingBox()));
+        importer.calculateBounds(resource);
+        assertFalse(resource.getNativeBoundingBox().isEmpty());
+        assertTrue(bbox.equals(resource.getNativeBoundingBox()));
+    }
+    
 }


### PR DESCRIPTION
Continuation/improvement of https://github.com/geoserver/geoserver/pull/1247

When doing some downstream testing, I ran into a NPE in the vicinity of Importe.java:927. However, I was unable to reproduce this failure in a debugger.
Changes: 
* Updated the bounds status check to be more null-safe.
* Also updated the check to match string values of "true" (which can ocurr if the metadata has been saved to disk).