### PR TITLE
Fixed gdal-wcs usage example

### DIFF
--- a/doc/en/user/source/community/gdal/usage_example.rst
+++ b/doc/en/user/source/community/gdal/usage_example.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 For example, the above produces the following output using gdal 1.11.2 compiled with libgeotiff 1.4.0, libpng 1.6,  libjpeg-turbo 1.3.1, libjasper 1.900.1 and libecwj2 3.3::
 
    Usage: gdal_translate [--help-general] [--long-usage]

--- a/doc/en/user/source/conf.py
+++ b/doc/en/user/source/conf.py
@@ -63,7 +63,13 @@ today_fmt = '%B %d, %Y'
 
 # List of directories, relative to source directories, that shouldn't be searched
 # for source files.
-exclude_trees = []
+#exclude_trees = []
+
+# A list of glob-style patterns that should be excluded when looking for source files.
+# They are matched against the source file names relative to the source directory,
+# using slashes as directory separators on all platforms.
+# New in Sphinx 1.0, makes unused_docs, exclude_trees and exclude_dirnames obsolete.
+exclude_patterns = ['community/gdal/usage_example.rst']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None


### PR DESCRIPTION
Added `community/gdal/usage_example.rst` to `exclude_patterns` configuration variable to avoid warning on page not being included in any toctree.