### PR TITLE
Minor documentation fix

### DIFF
--- a/doc/en/user/source/extensions/css/directives.rst
+++ b/doc/en/user/source/extensions/css/directives.rst
@@ -28,7 +28,7 @@ For example:
 
   
 Supported directives
----------------
+--------------------
 
 .. list-table::
     :widths: 15 15 60 10


### PR DESCRIPTION
Avoid warning about title underline being too short.