### PR TITLE
GEOS-4972 Allow the link attribute in a GeoRSS feed to be templated like the title and description attributes

### DIFF
--- a/doc/en/user/source/tutorials/georss/georss.rst
+++ b/doc/en/user/source/tutorials/georss/georss.rst
@@ -13,6 +13,18 @@ If you are using a web browser which can render rss feeds simply visit the url `
 
    *topp:states rss feed*
 
+Templating
+----------
+Geoserver uses freemarker templates to customize the returned GeoRSS feed. If you are not familiar with freemarker templates you may wish to read the :ref:`tutorial_freemarkertemplate` tutorial, and the :ref:`getutorial_kmlplacemark` page, which has simple examples.
+
+Three template files are currently supported:
+
+* ``title.ftl``
+* ``description.ftl``
+* ``link.ftl``
+
+Each of these files may be used to customize the assocated field in the GeoRSS feed.
+
 Ajax Map Mashups
 ----------------
 .. note::

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureTemplate.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureTemplate.java
@@ -140,6 +140,26 @@ public class FeatureTemplate {
     }
 
     /**
+     * Executes the link template for a feature writing the results to an
+     * output stream.
+     * <p>
+     * This method is convenience for:
+     * <code>
+     * link( feature, new OutputStreamWriter( output ) );
+     * </code>
+     * </p>
+     *
+     * @param feature The feature to execute the template against.
+     * @param output The output to write the result of the template to.
+     *
+     * @throws IOException Any errors that occur during execution of the template.
+     */
+    public void link(SimpleFeature feature, OutputStream output)
+        throws IOException {
+        link(feature, new OutputStreamWriter(output, Charset.forName("UTF-8")));
+    }
+
+    /**
      * Executes the description template for a feature writing the results to an
      * output stream.
      * <p>
@@ -173,6 +193,19 @@ public class FeatureTemplate {
     }
 
     /**
+     * Executes the link template for a feature writing the results to a
+     * writer.
+     *
+     * @param feature The feature to execute the template against.
+     * @param writer The writer to write the template output to.
+     *
+     * @throws IOException Any errors that occur during execution of the template.
+     */
+    public void link(SimpleFeature feature, Writer writer) throws IOException {
+        execute(feature, feature.getFeatureType(), writer, "link.ftl",null);
+    }
+
+    /**
      * Executes the description template for a feature writing the results to a
      * writer.
      *
@@ -197,6 +230,21 @@ public class FeatureTemplate {
     public String title(SimpleFeature feature) throws IOException {
         caw.reset();
         title(feature, caw);
+
+        return caw.toString();
+    }
+
+    /**
+     * Executes the link template for a feature returning the result as a
+     * string.
+     *
+     * @param feature The feature to execute the template against.
+     *
+     * @throws IOException Any errors that occur during execution of the template.
+     */
+    public String link(SimpleFeature feature) throws IOException {
+        caw.reset();
+        link(feature, caw);
 
         return caw.toString();
     }

--- a/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
@@ -86,22 +86,22 @@ public final class AtomUtils {
 
     //TODO: use an html based output format
     public static String getEntryURL(WMS wms, SimpleFeature feature, WMSMapContent context){
-		try {
-			return featureTemplate.link(feature);
-		} catch (IOException ioe){
-			String nsUri = feature.getType().getName().getNamespaceURI();
-			String nsPrefix = wms.getNameSpacePrefix(nsUri);
- 
-			HashMap<String,String> params = new HashMap<String,String>();
-			params.put("format", "application/atom+xml");
-			params.put("layers",  nsPrefix + ":" + feature.getType().getTypeName());
-			params.put("featureid", feature.getID());
+        try {
+            return featureTemplate.link(feature);
+        } catch (IOException ioe){
+            String nsUri = feature.getType().getName().getNamespaceURI();
+            String nsPrefix = wms.getNameSpacePrefix(nsUri);
+
+            HashMap<String,String> params = new HashMap<String,String>();
+            params.put("format", "application/atom+xml");
+            params.put("layers",  nsPrefix + ":" + feature.getType().getTypeName());
+            params.put("featureid", feature.getID());
          
-			return ResponseUtils.buildURL(context.getRequest().getBaseUrl(),
-				"wms/reflect",
-				params,
-				URLType.SERVICE);
-        }			
+            return ResponseUtils.buildURL(context.getRequest().getBaseUrl(),
+                    "wms/reflect",
+                    params,
+                    URLType.SERVICE);
+        }
     }
 
     public static String getEntryURI(WMS wms, SimpleFeature feature, WMSMapContent context){

--- a/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
@@ -86,18 +86,22 @@ public final class AtomUtils {
 
     //TODO: use an html based output format
     public static String getEntryURL(WMS wms, SimpleFeature feature, WMSMapContent context){
-        String nsUri = feature.getType().getName().getNamespaceURI();
-        String nsPrefix = wms.getNameSpacePrefix(nsUri);
-
-        HashMap<String,String> params = new HashMap<String,String>();
-        params.put("format", "application/atom+xml");
-        params.put("layers",  nsPrefix + ":" + feature.getType().getTypeName());
-        params.put("featureid", feature.getID());
-        
-        return ResponseUtils.buildURL(context.getRequest().getBaseUrl(),
-             "wms/reflect",
-             params,
-             URLType.SERVICE);
+		try {
+			return featureTemplate.link(feature);
+		} catch (IOException ioe){
+			String nsUri = feature.getType().getName().getNamespaceURI();
+			String nsPrefix = wms.getNameSpacePrefix(nsUri);
+ 
+			HashMap<String,String> params = new HashMap<String,String>();
+			params.put("format", "application/atom+xml");
+			params.put("layers",  nsPrefix + ":" + feature.getType().getTypeName());
+			params.put("featureid", feature.getID());
+         
+			return ResponseUtils.buildURL(context.getRequest().getBaseUrl(),
+				"wms/reflect",
+				params,
+				URLType.SERVICE);
+        }			
     }
 
     public static String getEntryURI(WMS wms, SimpleFeature feature, WMSMapContent context){

--- a/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
@@ -65,14 +65,14 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.BASIC_POLYGONS));
         map.addLayer(createMapLayer(MockData.BASIC_POLYGONS));
 
-		try {
-			File linkFile = new File(testData.getDataDirectoryRoot().getAbsolutePath() + "/workspaces/cite/cite/BasicPolygons/link.ftl");
-			FileOutputStream out = new FileOutputStream(linkFile);
-			out.write("http://dummp.com".getBytes());
-			out.close();
-		} catch (Exception e) {
-			System.out.println("Error writing link.ftl: " + e);
-		}
+        try {
+            File linkFile = new File(testData.getDataDirectoryRoot().getAbsolutePath() + "/workspaces/cite/cite/BasicPolygons/link.ftl");
+            FileOutputStream out = new FileOutputStream(linkFile);
+            out.write("http://dummp.com".getBytes());
+            out.close();
+        } catch (Exception e) {
+            System.out.println("Error writing link.ftl: " + e);
+        }
 
         Document document;
         try {

--- a/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
@@ -60,12 +60,13 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         assertEquals("Test Abstract", description.item(0).getChildNodes().item(0).getNodeValue());
     }
 	
+    @Test
     public void testLinkTemplate() throws Exception {
         WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.BASIC_POLYGONS));
         map.addLayer(createMapLayer(MockData.BASIC_POLYGONS));
 
 		try {
-			File linkFile = new File(testData.getDataDirectoryRoot().getPath() + "/featureTypes/cite_BasicPolygons/link.ftl");
+			File linkFile = new File(testData.getDataDirectoryRoot().getAbsolutePath() + "/workspaces/cite/cite/BasicPolygons/link.ftl");
 			FileOutputStream out = new FileOutputStream(linkFile);
 			out.write("http://dummp.com".getBytes());
 			out.close();
@@ -93,6 +94,7 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         }
     }
 
+    @Test
     public void testLatLongInternal() throws Exception {
         WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.BASIC_POLYGONS));
         map.addLayer(createMapLayer(MockData.BASIC_POLYGONS));

--- a/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.File;
+import java.io.FileOutputStream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -56,6 +58,39 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         Element channel = (Element) element.getElementsByTagName("channel").item(0);
         NodeList description = channel.getElementsByTagName("description");
         assertEquals("Test Abstract", description.item(0).getChildNodes().item(0).getNodeValue());
+    }
+	
+    public void testLinkTemplate() throws Exception {
+        WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.BASIC_POLYGONS));
+        map.addLayer(createMapLayer(MockData.BASIC_POLYGONS));
+
+		try {
+			File linkFile = new File(testData.getDataDirectoryRoot().getPath() + "/featureTypes/cite_BasicPolygons/link.ftl");
+			FileOutputStream out = new FileOutputStream(linkFile);
+			out.write("http://dummp.com".getBytes());
+			out.close();
+		} catch (Exception e) {
+			System.out.println("Error writing link.ftl: " + e);
+		}
+
+        Document document;
+        try {
+            document = getRSSResponse(map, AtomGeoRSSTransformer.GeometryEncoding.LATLONG);
+        } finally {
+            map.dispose();
+        }
+        Element element = document.getDocumentElement();
+        assertEquals("rss", element.getNodeName());
+
+        NodeList items = element.getElementsByTagName("item");
+
+        int n = getFeatureSource(MockData.BASIC_POLYGONS).getCount(Query.ALL);
+
+        assertEquals(n, items.getLength());
+        for (int i = 0; i < items.getLength(); i++) {
+            Element item = (Element) items.item(i);
+			assertEquals("http://dummp.com", item.getElementsByTagName("link").item(0).getChildNodes().item(0).getNodeValue());
+        }
     }
 
     public void testLatLongInternal() throws Exception {


### PR DESCRIPTION
This allows the link to be templated in GeoRSS feeds