### PR TITLE
[GEOS-6226] Make maintainer and onlineResource elements consistent

### DIFF
--- a/data/citewcs-1.0/services.xml
+++ b/data/citewcs-1.0/services.xml
@@ -79,7 +79,7 @@ NONE
 <keyword>WMS</keyword>
 <keyword>GEOSERVER</keyword>
 </keywords>
-<onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+<onlineResource>http://geoserver.org</onlineResource>
 <fees>NONE</fees>
 <accessConstraints>NONE</accessConstraints>
 <srsXmlStyle value = "false" />
@@ -100,13 +100,13 @@ from New York City.</abstract>
 <keyword>NY</keyword>
 <keyword>New York</keyword>
 </keywords>
-<onlineResource>http://www.openplans.org/</onlineResource>
+<onlineResource>http://geoserver.org</onlineResource>
 <fees>NONE</fees>
 <accessConstraints>NONE</accessConstraints>
 <srsXmlStyle value = "true" />
 <serviceLevel value = "31" />
 <citeConformanceHacks>true</citeConformanceHacks>
-<maintainer>The Open Planning Project</maintainer>
+<maintainer>http://geoserver.org/comm</maintainer>
 </service>
 <service type = "WMS" enabled = "true" >
 <!--
@@ -123,11 +123,11 @@ from New York City.</abstract>
 <keyword>NY</keyword>
 <keyword>New York</keyword>
 </keywords>
-<onlineResource>http://www.openplans.org/</onlineResource>
+<onlineResource>http://geoserver.org</onlineResource>
 <fees>NONE</fees>
 <accessConstraints>NONE</accessConstraints>
 <srsXmlStyle value = "false" />
-<maintainer>The Open Planning Project</maintainer>
+<maintainer>http://geoserver.org/comm</maintainer>
 <svgAntiAlias>true</svgAntiAlias>
 </service>
 </services>

--- a/data/citewfs-1.0/wcs.xml
+++ b/data/citewfs-1.0/wcs.xml
@@ -31,7 +31,7 @@ This is a description of your Web Coverage Server.
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/data/citewfs-1.0/wfs.xml
+++ b/data/citewfs-1.0/wfs.xml
@@ -3,7 +3,7 @@
   <enabled>true</enabled>
   <name>TOPP GeoServer</name>
   <title>The Open Planning Project Basemap Server</title>
-  <maintainer>The Open Planning Project</maintainer>
+  <maintainer>http://geoserver.org/comm</maintainer>
   <abstrct>This is a test server.  It contains some basemap data 
 from New York City.</abstrct>
   <accessConstraints>NONE</accessConstraints>
@@ -27,7 +27,7 @@ from New York City.</abstrct>
   </keywords>
   <metadataLink/>
   <citeCompliant>true</citeCompliant>
-  <onlineResource>http://www.openplans.org/</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gml>

--- a/data/citewfs-1.0/wms.xml
+++ b/data/citewfs-1.0/wms.xml
@@ -3,7 +3,7 @@
   <enabled>true</enabled>
   <name>FreeWMS</name>
   <title>The Open Planning Project Basemap Server</title>
-  <maintainer>The Open Planning Project</maintainer>
+  <maintainer>http://geoserver.org/comm</maintainer>
   <abstrct>This is a test server.  It contains some basemap data 
 from New York City.</abstrct>
   <accessConstraints>NONE</accessConstraints>
@@ -24,7 +24,7 @@ from New York City.</abstrct>
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://www.openplans.org/</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>

--- a/data/citewfs-1.1-h2/wcs.xml
+++ b/data/citewfs-1.1-h2/wcs.xml
@@ -28,7 +28,7 @@ This is a description of your Web Coverage Server.
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/data/citewfs-1.1-h2/wfs.xml
+++ b/data/citewfs-1.1-h2/wfs.xml
@@ -3,7 +3,7 @@
   <enabled>true</enabled>
   <name>TOPP GeoServer</name>
   <title>The Open Planning Project Basemap Server</title>
-  <maintainer>The Open Planning Project</maintainer>
+  <maintainer>http://geoserver.org/comm</maintainer>
   <abstrct>This is a test server.  It contains some basemap data 
 from New York City.</abstrct>
   <accessConstraints>NONE</accessConstraints>
@@ -24,7 +24,7 @@ from New York City.</abstrct>
   </keywords>
   <metadataLink/>
   <citeCompliant>true</citeCompliant>
-  <onlineResource>http://www.openplans.org/</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gml>

--- a/data/citewfs-1.1-h2/wms.xml
+++ b/data/citewfs-1.1-h2/wms.xml
@@ -3,7 +3,7 @@
   <enabled>true</enabled>
   <name>FreeWMS</name>
   <title>The Open Planning Project Basemap Server</title>
-  <maintainer>The Open Planning Project</maintainer>
+  <maintainer>http://geoserver.org/comm</maintainer>
   <abstrct>This is a test server.  It contains some basemap data 
 from New York City.</abstrct>
   <accessConstraints>NONE</accessConstraints>
@@ -21,7 +21,7 @@ from New York City.</abstrct>
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://www.openplans.org/</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>

--- a/data/citewfs-1.1/wcs.xml
+++ b/data/citewfs-1.1/wcs.xml
@@ -28,7 +28,7 @@ This is a description of your Web Coverage Server.
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/data/citewfs-1.1/wfs.xml
+++ b/data/citewfs-1.1/wfs.xml
@@ -3,7 +3,7 @@
   <enabled>true</enabled>
   <name>TOPP GeoServer</name>
   <title>The Open Planning Project Basemap Server</title>
-  <maintainer>The Open Planning Project</maintainer>
+  <maintainer>http://geoserver.org/comm</maintainer>
   <abstrct>This is a test server.  It contains some basemap data &#xd;
 from New York City.</abstrct>
   <accessConstraints>NONE</accessConstraints>
@@ -27,7 +27,7 @@ from New York City.</abstrct>
   </keywords>
   <metadataLink/>
   <citeCompliant>true</citeCompliant>
-  <onlineResource>http://www.openplans.org/</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>

--- a/data/citewfs-1.1/wms.xml
+++ b/data/citewfs-1.1/wms.xml
@@ -3,7 +3,7 @@
   <enabled>true</enabled>
   <name>FreeWMS</name>
   <title>The Open Planning Project Basemap Server</title>
-  <maintainer>The Open Planning Project</maintainer>
+  <maintainer>http://geoserver.org/comm</maintainer>
   <abstrct>This is a test server.  It contains some basemap data 
 from New York City.</abstrct>
   <accessConstraints>NONE</accessConstraints>
@@ -21,7 +21,7 @@ from New York City.</abstrct>
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://www.openplans.org/</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>

--- a/data/citewms-1.1/wcs.xml
+++ b/data/citewms-1.1/wcs.xml
@@ -28,7 +28,7 @@ This is a description of your Web Coverage Server.
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/data/citewms-1.1/wfs.xml
+++ b/data/citewms-1.1/wfs.xml
@@ -27,7 +27,7 @@ data.
     <string>GEOSERVER</string>
   </keywords>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gml>

--- a/data/citewms-1.1/wms.xml
+++ b/data/citewms-1.1/wms.xml
@@ -20,7 +20,7 @@ This is a description of your Web Map Server.
     <string>GEOSERVER</string>
   </keywords>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>

--- a/data/release/wcs.xml
+++ b/data/release/wcs.xml
@@ -30,7 +30,7 @@
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/data/release/wfs.xml
+++ b/data/release/wfs.xml
@@ -25,7 +25,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gml>

--- a/data/release/wms.xml
+++ b/data/release/wms.xml
@@ -22,7 +22,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>

--- a/src/community/gss/demo/central/wcs.xml
+++ b/src/community/gss/demo/central/wcs.xml
@@ -26,7 +26,7 @@
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/src/community/gss/demo/central/wfs.xml
+++ b/src/community/gss/demo/central/wfs.xml
@@ -21,7 +21,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <enabled>true</enabled>

--- a/src/community/gss/demo/central/wms.xml
+++ b/src/community/gss/demo/central/wms.xml
@@ -18,7 +18,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <enabled>true</enabled>

--- a/src/community/gss/demo/unit/wcs.xml
+++ b/src/community/gss/demo/unit/wcs.xml
@@ -26,7 +26,7 @@
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/src/community/gss/demo/unit/wfs.xml
+++ b/src/community/gss/demo/unit/wfs.xml
@@ -22,7 +22,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gml>

--- a/src/community/gss/demo/unit/wms.xml
+++ b/src/community/gss/demo/unit/wms.xml
@@ -19,7 +19,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>

--- a/src/main/src/test/java/org/geoserver/config/services.xml
+++ b/src/main/src/test/java/org/geoserver/config/services.xml
@@ -69,7 +69,7 @@ This is a description of your Web Coverage Server.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "false" />
@@ -86,7 +86,7 @@ This is a description of your Web Coverage Server.
 This is a description of your Web Feature Server.
 
 The GeoServer is a full transactional Web Feature Server, you may wish to limit
-GeoServer to a Basic service level to prevent modificaiton of your geographic
+GeoServer to a Basic service level to prevent modification of your geographic
 data.
      </abstract>
       <metadataLink >null</metadataLink>
@@ -95,7 +95,7 @@ data.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "true" />
@@ -119,7 +119,7 @@ This is a description of your Web Map Server.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "false" />

--- a/src/main/src/test/java/org/geoserver/data/test/services.xml
+++ b/src/main/src/test/java/org/geoserver/data/test/services.xml
@@ -84,7 +84,7 @@ This is a description of your Web Coverage Server.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "false" />
@@ -101,7 +101,7 @@ This is a description of your Web Coverage Server.
 This is a description of your Web Feature Server.
 
 The GeoServer is a full transactional Web Feature Server, you may wish to limit
-GeoServer to a Basic service level to prevent modificaiton of your geographic
+GeoServer to a Basic service level to prevent modification of your geographic
 data.
      </abstract>
       <metadataLink >null</metadataLink>
@@ -110,7 +110,7 @@ data.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "true" />
@@ -134,7 +134,7 @@ This is a description of your Web Map Server.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "false" />

--- a/src/main/src/test/java/org/geoserver/logging/services.xml
+++ b/src/main/src/test/java/org/geoserver/logging/services.xml
@@ -69,7 +69,7 @@ This is a description of your Web Coverage Server.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "false" />
@@ -86,7 +86,7 @@ This is a description of your Web Coverage Server.
 This is a description of your Web Feature Server.
 
 The GeoServer is a full transactional Web Feature Server, you may wish to limit
-GeoServer to a Basic service level to prevent modificaiton of your geographic
+GeoServer to a Basic service level to prevent modification of your geographic
 data.
      </abstract>
       <metadataLink >null</metadataLink>
@@ -95,7 +95,7 @@ data.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "true" />
@@ -119,7 +119,7 @@ This is a description of your Web Map Server.
         <keyword>WMS</keyword>
         <keyword>GEOSERVER</keyword>
       </keywords>
-      <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+      <onlineResource>http://geoserver.org</onlineResource>
       <fees>NONE</fees>
       <accessConstraints>NONE</accessConstraints>
       <srsXmlStyle value = "false" />

--- a/src/wcs2_0/src/test/resources/wcs-test.xml
+++ b/src/wcs2_0/src/test/resources/wcs-test.xml
@@ -29,7 +29,7 @@
     <metadataType>other</metadataType>
   </metadataLink>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gmlPrefixing>false</gmlPrefixing>

--- a/src/wfs/src/test/java/org/geoserver/wfs/wfs-minimal.xml
+++ b/src/wfs/src/test/java/org/geoserver/wfs/wfs-minimal.xml
@@ -8,7 +8,7 @@
 This is a description of your Web Feature Server.
 
 The GeoServer is a full transactional Web Feature Server, you may wish to limit
-GeoServer to a Basic service level to prevent modificaiton of your geographic
+GeoServer to a Basic service level to prevent modification of your geographic
 data.
      </abstrct>
   <accessConstraints>NONE</accessConstraints>

--- a/src/wfs/src/test/java/org/geoserver/wfs/wfs-test.xml
+++ b/src/wfs/src/test/java/org/geoserver/wfs/wfs-test.xml
@@ -25,7 +25,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <gml>

--- a/src/wms/src/test/resources/org/geoserver/wms/wms-test.xml
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms-test.xml
@@ -22,7 +22,7 @@
   </keywords>
   <metadataLink/>
   <citeCompliant>false</citeCompliant>
-  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <onlineResource>http://geoserver.org</onlineResource>
   <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
   <verbose>false</verbose>
   <metadata>


### PR DESCRIPTION
This updates the various configuration files (mainly used in
GetCapabilities) to be consistent in what they specify for
<maintainer> and <onlineResource>.

The original bug report (https://osgeo-org.atlassian.net/browse/GEOS-6226) talked about invalid entries which is not the case any longer. However we still had some variation, which is made consistent in this change.

For extra value, there are a few spelling fixes too.