### PR TITLE
[GEOS-7296] Fix read the features twice in WFS v1.1/2.0 GetFeature requests

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/CachedFeatureCollection.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/CachedFeatureCollection.java
@@ -1,0 +1,58 @@
+package org.geoserver.wfs;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.feature.collection.AbstractFeatureCollection;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+
+import org.opengis.feature.simple.SimpleFeature;
+
+/**
+ * A feature collection wrapping a base collection to cache the features managed.
+ * It avoids read from data source each an iterator is called.
+ * 
+ * @author Alvaro Huarte
+ */
+class CachedFeatureCollection extends AbstractFeatureCollection {
+    private List<SimpleFeature> cache = new ArrayList<SimpleFeature>();
+    
+    public CachedFeatureCollection(final SimpleFeatureCollection featureCollection) {
+        super(featureCollection.getSchema());
+        
+        SimpleFeatureIterator featureIterator = featureCollection.features();
+        if (featureIterator!=null) {
+            try {
+                while (featureIterator.hasNext()) cache.add(featureIterator.next());
+            }
+            finally {
+                featureIterator.close();
+            }
+        }
+        id = featureCollection.getID();
+    }
+    
+    @Override
+    public String getID() {
+        return id;
+    }
+    
+    @Override
+    protected Iterator<SimpleFeature> openIterator() {
+        return cache.iterator();
+    }
+
+    @Override
+    public int size() {
+        return cache.size();
+    }
+    
+    @Override
+    public ReferencedEnvelope getBounds() {
+        return DataUtilities.bounds(this);
+    }
+}

--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -528,6 +528,9 @@ public class GetFeature {
 
                 int size = 0;
                 if (calculateSize) {
+                    if (features.getSchema() instanceof SimpleFeatureType && queries.size() == 1)
+                        features = new CachedFeatureCollection((SimpleFeatureCollection)features);
+                    
                     size = features.size();
                 }
                 


### PR DESCRIPTION
It fixes the issue https://osgeo-org.atlassian.net/browse/GEOS-7296

The original FeatureCollection is cached to avoid that features are readed from data source (shapefiles...) each iterator from the original class in called.

Sorry, this fix haven't test. The issue is generated from mixed use of GeoServer and GeoTools.
