### PR TITLE
Upgrading spring version to 3.2.15

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1617,7 +1617,7 @@
   <gs.version>2.9-SNAPSHOT</gs.version>
   <gt.version>15-SNAPSHOT</gt.version>
   <gwc.version>1.9-SNAPSHOT</gwc.version>
-  <spring.version>3.1.4.RELEASE</spring.version>
+  <spring.version>3.2.15.RELEASE</spring.version>
   <spring.security.version>3.1.0.RELEASE</spring.security.version> 
   <jetty.version>9.2.13.v20150730</jetty.version>
   <poi.version>3.8</poi.version>

--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -92,6 +92,11 @@
       <artifactId>servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context-support</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
 	<dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-ows</artifactId>


### PR DESCRIPTION
Pretty straight forward, no code changes. Only significant change is that some spring code that the wms module depeds on (some freemarker) stuff now lives in a new spring module, so there is a new dependency on spring-context-support required there.