### PR TITLE
GEOS-7305 - Make KML module code compilable with Java 1.8 source

### DIFF
--- a/src/kml/src/main/java/org/geoserver/kml/icons/IconService.java
+++ b/src/kml/src/main/java/org/geoserver/kml/icons/IconService.java
@@ -8,6 +8,7 @@ package org.geoserver.kml.icons;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -76,10 +77,20 @@ public class IconService extends AbstractController {
         String q = request.getQueryString();
         try {
             Style style = styleInfo.getStyle();
-            Map<String,String> properties = 
+            Map<String,Object> properties = 
                 q != null ? KvpUtils.parseQueryString("?"+q) : Collections.EMPTY_MAP;
+            Map<String, String> kvp = new HashMap<String, String>();
+            for (String key : properties.keySet()) {
+                Object value = properties.get(key);
+                if (value instanceof String) {
+                    kvp.put(key, (String) value);
+                } else {
+                    String[] values = (String[]) value;
+                    kvp.put(key, values[0]);
+                }
+            }
 
-            Style adjustedStyle = IconPropertyInjector.injectProperties(style, properties);
+            Style adjustedStyle = IconPropertyInjector.injectProperties(style, kvp);
 
             BufferedImage image = IconRenderer.renderIcon(adjustedStyle);
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1249,8 +1249,8 @@
      <artifactId>maven-compiler-plugin</artifactId>
      <version>2.3.2</version>
      <configuration>
-       <source>1.8</source>
-       <target>1.8</target>
+       <source>1.7</source>
+       <target>1.7</target>
        <debug>true</debug>
        <encoding>UTF-8</encoding>
        <!-- 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1249,8 +1249,8 @@
      <artifactId>maven-compiler-plugin</artifactId>
      <version>2.3.2</version>
      <configuration>
-       <source>1.7</source>
-       <target>1.7</target>
+       <source>1.8</source>
+       <target>1.8</target>
        <debug>true</debug>
        <encoding>UTF-8</encoding>
        <!-- 


### PR DESCRIPTION
Switched source and target Java versions to 1.8 from 1.7 and fixed a compilation error that occurs in KML module when this change is made. I may have gone a bit beyond scope of original bug report by switching versions, maybe this should be a separate task?