### PR TITLE
[GEOS-7306] Stored Queries don't work on App-Schema layers backed by DB

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/StoredQuery.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/StoredQuery.java
@@ -207,6 +207,10 @@ public class StoredQuery {
             
             //parse
             Parser p = new Parser(new WFSConfiguration());
+            //"inject" namespace mappings
+            if (catalog != null) {
+                p.getNamespaces().add(new CatalogNamespaceSupport(catalog));
+            }
             try {
                 QueryType compiled = 
                     (QueryType) p.parse(new ByteArrayInputStream(sb.toString().getBytes()));


### PR DESCRIPTION
To actually reproduce the issue, the provided unit test must be run on a test database, which is explained in the [GeoServer programming guide](http://docs.geoserver.org/latest/en/developer/programming-guide/app-schema/index.html#running-tests-from-junit).