### PR TITLE
[GEOS-7311]: Fix extraction of nullValues of a coverage

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -1099,7 +1099,7 @@ public class CatalogBuilder {
             if (categories != null) {
                 for (Category cat : categories) {
 
-                    if ((cat != null) && cat.getName().toString().equalsIgnoreCase("no data")) {
+                    if ((cat != null) && cat.getName().toString(Locale.ENGLISH).equalsIgnoreCase("no data")) {
                         double min = cat.getRange().getMinimum();
                         double max = cat.getRange().getMaximum();
 

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
@@ -218,6 +219,16 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
         assertNull(dimension.getUnit());
     }
     
+    @Test
+    public void testSingleBandedCoverage_GEOS7311() throws Exception {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("es", "ES"));
+        testSingleBandedCoverage();
+        Locale.setDefault(new Locale("fr", "FR"));
+        testSingleBandedCoverage();
+        Locale.setDefault(defaultLocale);
+    }
+ 
     @Test
     public void testMultiBandCoverage() throws Exception {
         Catalog cat = getCatalog();


### PR DESCRIPTION
This pull fix the issue https://osgeo-org.atlassian.net/browse/GEOS-7311.

The testSingleBandedCoverage test function (https://github.com/geoserver/geoserver/blob/master/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java#L192) now works in non-english environments.

Alvaro