### PR TITLE
[GEOS-6340]: Allow GetFeatureInfo on layer groups if at least one layer is queryable

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -970,18 +970,16 @@ public class WMS implements ApplicationContextAware {
     }
 
     public boolean isQueryable(LayerGroupInfo layerGroup) {
+        boolean queryable = false;
+        
         for (PublishedInfo published : layerGroup.getLayers()) {
             if (published instanceof LayerInfo) {
-                if (!isQueryable((LayerInfo) published)) {
-                    return false;
-                }
+                queryable |= isQueryable((LayerInfo) published);
             } else {
-                if (!isQueryable((LayerGroupInfo) published)) {
-                    return false;
-                }
+                queryable |= isQueryable((LayerGroupInfo) published);
             }
         }
-        return true;
+        return queryable;
     }
 
     /**


### PR DESCRIPTION
Allow GetFeatureInfo on layer groups if at least one layer is queryable. Currently, if one layer in a layerGroup has querying disabled, the entire layer group is unequeryable.

See issues:
https://osgeo-org.atlassian.net/browse/GEOS-6340
https://osgeo-org.atlassian.net/browse/GEOS-7293

This feature was funded by: Tracasa (http://www.tracasa.es/en)