### PR TITLE
[GEOS-4179] Importer and monitoring REST resources are not thread-safe

### DIFF
--- a/src/extension/importer/rest/src/main/resources/applicationContext.xml
+++ b/src/extension/importer/rest/src/main/resources/applicationContext.xml
@@ -6,49 +6,49 @@
   <!--
    rest bindings
     -->
-  <bean id="importResource" class="org.geoserver.importer.rest.ImportResource">
+  <bean id="importResource" class="org.geoserver.importer.rest.ImportResource" singleton="false">
     <constructor-arg ref="importer"/>
   </bean>
   <bean id="importContextFinder" class="org.geoserver.rest.BeanResourceFinder">
       <constructor-arg value="importResource"/>
   </bean>
 
-  <bean id="importTaskResource" class="org.geoserver.importer.rest.TaskResource">
+  <bean id="importTaskResource" class="org.geoserver.importer.rest.TaskResource" singleton="false">
     <constructor-arg ref="importer"/>
   </bean>
   <bean id="importTaskFinder" class="org.geoserver.rest.BeanResourceFinder">
       <constructor-arg value="importTaskResource"/>
   </bean>
 
-  <bean id="taskTargetResource" class="org.geoserver.importer.rest.TaskTargetResource">
+  <bean id="taskTargetResource" class="org.geoserver.importer.rest.TaskTargetResource" singleton="false">
     <constructor-arg ref="importer"/>
   </bean>
   <bean id="taskTargetFinder" class="org.geoserver.rest.BeanResourceFinder">
     <constructor-arg value="taskTargetResource"/>
   </bean>
 
-  <bean id="layerResource" class="org.geoserver.importer.rest.LayerResource">
+  <bean id="layerResource" class="org.geoserver.importer.rest.LayerResource" singleton="false">
     <constructor-arg ref="importer"/>
   </bean>
   <bean id="layerFinder" class="org.geoserver.rest.BeanResourceFinder">
       <constructor-arg value="layerResource"/>
   </bean>
 
-  <bean id="importDataResource" class="org.geoserver.importer.rest.DataResource">
+  <bean id="importDataResource" class="org.geoserver.importer.rest.DataResource" singleton="false">
     <constructor-arg ref="importer"/>
   </bean>
   <bean id="importDataFinder" class="org.geoserver.rest.BeanResourceFinder">
       <constructor-arg value="importDataResource"/>
   </bean>
 
-  <bean id="dirResource" class="org.geoserver.importer.rest.DirectoryResource">
+  <bean id="dirResource" class="org.geoserver.importer.rest.DirectoryResource" singleton="false">
     <constructor-arg ref="importer"/>
   </bean>
   <bean id="dirFinder" class="org.geoserver.rest.BeanResourceFinder">
       <constructor-arg value="dirResource"/>
   </bean>
 
-  <bean id="txResource" class="org.geoserver.importer.rest.TransformResource">
+  <bean id="txResource" class="org.geoserver.importer.rest.TransformResource" singleton="false">
     <constructor-arg ref="importer"/>
   </bean>
   <bean id="txFinder" class="org.geoserver.rest.BeanResourceFinder">

--- a/src/extension/monitor/core/src/main/java/applicationContext.xml
+++ b/src/extension/monitor/core/src/main/java/applicationContext.xml
@@ -34,14 +34,14 @@
     </bean>
     
     <!-- rest bindings -->
-    <bean id="requestResource" class="org.geoserver.monitor.rest.RequestResource">
+    <bean id="requestResource" class="org.geoserver.monitor.rest.RequestResource" scope="prototype">
       <constructor-arg ref="monitor"/>
     </bean>
     <bean id="requestResourceFinder" class="org.geoserver.rest.BeanResourceFinder">
       <constructor-arg value="requestResource"/>
     </bean>
     
-    <bean id="owsRequestResource" class="org.geoserver.monitor.rest.OwsRequestResource">
+    <bean id="owsRequestResource" class="org.geoserver.monitor.rest.OwsRequestResource" scope="prototype">
       <constructor-arg ref="monitor"/>
     </bean>
     <bean id="owsRequestResourceFinder" class="org.geoserver.rest.BeanResourceFinder">

--- a/src/rest/src/test/java/applicationContext.xml
+++ b/src/rest/src/test/java/applicationContext.xml
@@ -8,8 +8,8 @@
 
 <beans>
 
-    <bean id="exceptionThrowingResource" class="org.geoserver.rest.ExceptionThrowingResource"/>
-    <bean id="gsUserResource" class="org.geoserver.rest.GsUserResource"/>
+    <bean id="exceptionThrowingResource" class="org.geoserver.rest.ExceptionThrowingResource" singleton="false"/>
+    <bean id="gsUserResource" class="org.geoserver.rest.GsUserResource" singleton="false"/>
     <bean id="testMapping" class="org.geoserver.rest.RESTMapping">
       <property name="routes">
         <map>

--- a/src/restconfig/src/main/java/applicationContext.xml
+++ b/src/restconfig/src/main/java/applicationContext.xml
@@ -545,7 +545,7 @@
      <constructor-arg index="1" value="true"/> <!--  force reset instead of reload -->
   </bean>
 
-  <bean id="fontFinder" class="org.geoserver.rest.FontListResource"/>
+  <bean id="fontFinder" class="org.geoserver.rest.FontListResource"  singleton="false"/>
   
   <bean id="catalogLocker" class="org.geoserver.rest.RestConfigurationLockCallback">
     <constructor-arg index="0" ref="configurationLock"/>

--- a/src/restconfig/src/main/java/applicationSecurityContext.xml
+++ b/src/restconfig/src/main/java/applicationSecurityContext.xml
@@ -48,13 +48,13 @@
 </property>
 </bean>
 
-  <bean id="masterPasswordResource" class="org.geoserver.security.rest.MasterPasswordResource">
+  <bean id="masterPasswordResource" class="org.geoserver.security.rest.MasterPasswordResource" singleton="false">
   </bean>
 
-  <bean id="dataAccessControlResource" class="org.geoserver.security.rest.DataAccessControlResource"/>
-  <bean id="restAccessControlResource" class="org.geoserver.security.rest.RESTAccessControlResource"/>
-  <bean id="serviceAccessControlResource" class="org.geoserver.security.rest.ServiceAccessControlResource"/>
-  <bean id="catalogModeResource" class="org.geoserver.security.rest.CatalogModeResource"/>
+  <bean id="dataAccessControlResource" class="org.geoserver.security.rest.DataAccessControlResource" singleton="false"/>
+  <bean id="restAccessControlResource" class="org.geoserver.security.rest.RESTAccessControlResource" singleton="false"/>
+  <bean id="serviceAccessControlResource" class="org.geoserver.security.rest.ServiceAccessControlResource" singleton="false"/>
+  <bean id="catalogModeResource" class="org.geoserver.security.rest.CatalogModeResource" singleton="false"/>
   
   
 </beans>


### PR DESCRIPTION
Found this one while reviewing old tickets. Not affecting much the core REST api, but unfortunately the importer and monitoring REST API are fully non thread-safe (facepalm!).

I've made sure that the BeanResourceFinder rebels against non thread safe usage and then fixed the application contexts.

If someone used BeanResourceFinder in REST plugins this change will pose backwards compatibility issues but... do we really want to allow thread unsafe usage?