### PR TITLE
[GEOS-7294] Allow make a Layer Group not queryable

### DIFF
--- a/doc/en/user/source/webadmin/data/layergroups.rst
+++ b/doc/en/user/source/webadmin/data/layergroups.rst
@@ -71,6 +71,8 @@ You can view layer groups in the :ref:`layerpreview` section of the web admin.
 
    *Openlayers preview of the layer group "tasmania"*
 
+.. note:: By default, a layer group is queryable when at least a child layer is queryable. Uncheck "Queryable" box if you want to explicitly indicate that it is not queryable independently of how the child layers are configured.
+
 Add a Layer Group
 -----------------
 

--- a/src/main/src/main/java/org/geoserver/catalog/LayerGroupInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerGroupInfo.java
@@ -88,6 +88,24 @@ public interface LayerGroupInfo extends PublishedInfo {
     void setMode( Mode mode );    
 
     /**
+     * Get whether the layer group is forced to be not queryable and hence can not be subject of a GetFeatureInfo request.
+     * <p>
+     * In order to preserve current default behavior (A LayerGroup is queryable when at least a
+     * child layer is queryable), this flag allows explicitly indicate that it is not queryable 
+     * independently how the child layers are configured.
+     * </p>
+     * <p>
+     * Default is {@code false}
+     * </p>
+     */
+    boolean isQueryDisabled();
+    
+    /**
+     * Set the layer group to be not queryable and hence can not be subject of a GetFeatureInfo request.
+     */
+    void setQueryDisabled(boolean queryDisabled);
+    
+    /**
      * Returns a workspace or <code>null</code> if global.
      */
     WorkspaceInfo getWorkspace();    

--- a/src/main/src/main/java/org/geoserver/catalog/impl/LayerGroupInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LayerGroupInfoImpl.java
@@ -29,6 +29,7 @@ public class LayerGroupInfoImpl implements LayerGroupInfo {
     protected String id;
     protected String name;
     protected Mode mode = Mode.SINGLE;
+    protected Boolean queryDisabled;
     
     /**
      * This property in 2.2.x series is stored under the metadata map with key 'title'.
@@ -114,6 +115,16 @@ public class LayerGroupInfoImpl implements LayerGroupInfo {
         this.mode = mode;
     }
        
+    @Override
+    public boolean isQueryDisabled() {
+        return queryDisabled != null ? queryDisabled.booleanValue() : false;
+    }
+    
+    @Override
+    public void setQueryDisabled(boolean queryDisabled) {
+        this.queryDisabled = queryDisabled ? Boolean.TRUE : null;
+    }
+    
     @Override
     public String getTitle() {
         if(title == null && metadata != null) {
@@ -272,6 +283,7 @@ public class LayerGroupInfoImpl implements LayerGroupInfo {
         result = prime * result + ((identifiers == null) ? 0 : identifiers.hashCode());
         result = prime * result + ((attribution == null) ? 0 : attribution.hashCode());
         result = prime * result + ((metadataLinks == null) ? 0 : metadataLinks.hashCode());
+        result = prime * result + ((queryDisabled == null) ? 0 : queryDisabled.hashCode());
         return result;
     }
 
@@ -370,6 +382,12 @@ public class LayerGroupInfoImpl implements LayerGroupInfo {
             if (other.getMetadataLinks() != null)
                 return false;
         } else if (!metadataLinks.equals(other.getMetadataLinks()))
+            return false;
+        
+        if (queryDisabled == null) {
+            if (other.isQueryDisabled())
+                return false;
+        } else if (!queryDisabled.equals(other.isQueryDisabled()))
             return false;
         
         return true;

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingLayerGroupInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingLayerGroupInfo.java
@@ -83,6 +83,16 @@ public class DecoratingLayerGroupInfo extends AbstractDecorator<LayerGroupInfo> 
     }
     
     @Override
+    public boolean isQueryDisabled() {
+        return delegate.isQueryDisabled();
+    }
+    
+    @Override
+    public void setQueryDisabled(boolean queryDisabled) {
+        delegate.setQueryDisabled(queryDisabled);
+    }
+    
+    @Override
     public WorkspaceInfo getWorkspace() {
         return delegate.getWorkspace();
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.html
@@ -31,6 +31,10 @@
          <label for="mode"><wicket:message key="mode">Mode</wicket:message></label>
          <select wicket:id="mode"></select>
        </li>
+       <li class="choiceItem">
+         <input id="queryable" type="checkbox" wicket:id="queryable" />
+         <label for="queryable"><wicket:message key="queryable">Queryable</wicket:message></label>
+       </li>
 	   <li wicket:id="rootLayerContainer">
 	   	 <div wicket:id="rootLayer"></div>
 	   </li>

--- a/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layergroup/AbstractLayerGroupPage.java
@@ -16,6 +16,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.SubmitLink;
@@ -25,6 +26,7 @@ import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.util.convert.IConverter;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.validator.AbstractValidator;
@@ -59,6 +61,7 @@ public abstract class AbstractLayerGroupPage extends GeoServerSecuredPage {
     String layerGroupId;
     protected RootLayerEntryPanel rootLayerPanel;    
     private ListView<LayerGroupConfigurationPanelInfo> extensionPanels;
+    private CheckBox queryableCheckBox;
     
     /**
      * Subclasses must call this method to initialize the UI for this page 
@@ -112,6 +115,9 @@ public abstract class AbstractLayerGroupPage extends GeoServerSecuredPage {
         });
         
         form.add(modeChoice);
+        
+        queryableCheckBox = new CheckBox("queryable", new Model<Boolean>(!layerGroup.isQueryDisabled()));
+        form.add(queryableCheckBox);
         
         form.add(new TextField("title"));
         form.add(new TextArea("abstract"));
@@ -262,6 +268,10 @@ public abstract class AbstractLayerGroupPage extends GeoServerSecuredPage {
                     lg.getStyles().add(entry.getStyle());
                 }
 
+                // update not queryable flag
+                Boolean queryable = queryableCheckBox.getModelObject();
+                lg.setQueryDisabled(!queryable);
+                
                 try {
                     AbstractLayerGroupPage.this.save();
                 }

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -348,6 +348,7 @@ AbstractLayerGroupPage.up              = Move layer up
 AbstractLayerGroupPage.notFound        = Could not find layer group "{0}"
 AbstractLayerGroupPage.duplicateGroupNameError = A layer group named ${name} already exists
 AbstractLayerGroupPage.workspace = Workspace
+AbstractLayerGroupPage.queryable       = Queryable
 
 RootLayerEntryPanel.rootLayer  	   = Root Layer
 RootLayerEntryPanel.setRootLayer   = Set Root Layer...

--- a/src/web/core/src/main/resources/GeoServerApplication_es.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication_es.properties
@@ -323,6 +323,7 @@ AbstractLayerGroupPage.up              = Mover capa hacia arriba
 AbstractLayerGroupPage.notFound        = No se ha encontrado el grupo de capas "{0}"
 AbstractLayerGroupPage.duplicateGroupNameError = Ya existe un grupo de capas llamado ${name}
 AbstractLayerGroupPage.workspace = Espacio de trabajo
+AbstractLayerGroupPage.queryable       = Interrogable
 
 RootLayerEntryPanel.rootLayer  	   = Capa raíz
 RootLayerEntryPanel.setRootLayer   = Definir capa raíz...

--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -970,6 +970,10 @@ public class WMS implements ApplicationContextAware {
     }
 
     public boolean isQueryable(LayerGroupInfo layerGroup) {
+        
+        if (layerGroup.isQueryDisabled())
+            return false;
+        
         boolean queryable = false;
         
         for (PublishedInfo published : layerGroup.getLayers()) {

--- a/src/wms/src/main/java/org/geoserver/wms/kvp/MapLayerInfoKvpParser.java
+++ b/src/wms/src/main/java/org/geoserver/wms/kvp/MapLayerInfoKvpParser.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -33,6 +33,13 @@ public class MapLayerInfoKvpParser extends KvpParser {
         rawNamesParser = new FlatKvpParser(key, String.class);
     }
 
+    /**
+     * Returns whether the specified resource must be skipped in the context of the current request.
+     */
+    protected boolean skipResource(Object theResource) {
+        return false;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public List<MapLayerInfo> parse(final String paramValue) throws Exception {
@@ -52,12 +59,23 @@ public class MapLayerInfoKvpParser extends KvpParser {
                     throw new ServiceException(layerName + ": no such layer on this server",
                             "LayerNotDefined", getClass().getSimpleName());
                 } else {
+                    if (skipResource(groupInfo))
+                        continue;
+
                     for (LayerInfo li : groupInfo.layers()) {
+                        
+                        if (skipResource(li))
+                            continue;
+
                         layer = new MapLayerInfo(li);
                         layers.add(layer);
                     }
                 }
             } else {
+                
+                if (skipResource(layerInfo))
+                    continue;
+                
                 layer = new MapLayerInfo(layerInfo);
                 layers.add(layer);
             }

--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -179,6 +179,13 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements HttpServ
         return request;
     }
 
+    /**
+     * Returns whether the specified resource must be skipped in the context of the current request.
+     */
+    protected boolean skipResource(Object theResource) {
+        return false;
+    }
+    
     @SuppressWarnings("rawtypes")
     @Override
     public GetMapRequest read(Object request, Map kvp, Map rawKvp) throws Exception {
@@ -228,10 +235,19 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements HttpServ
         String layerParam = (String) rawKvp.get("LAYERS");
         if (layerParam != null) {
             List<String> layerNames = KvpUtils.readFlat(layerParam);
-            requestedLayerInfos.addAll(parseLayers(layerNames, remoteOwsUrl, remoteOwsType));
+            
+            for (Object o : parseLayers(layerNames, remoteOwsUrl, remoteOwsType)) {
+                if (!skipResource(o)) {
+                    requestedLayerInfos.add(o);
+                }
+            }
 
             List<MapLayerInfo> layers = new ArrayList<MapLayerInfo>();
             for (Object o : requestedLayerInfos) {
+                
+                if (skipResource(o))
+                    continue;
+                
                 if (o instanceof LayerInfo) {
                     layers.add(new MapLayerInfo((LayerInfo) o));
                 } else if (o instanceof LayerGroupInfo) {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -922,4 +922,41 @@ public class GetFeatureInfoTest extends WMSTestSupport {
        
        catalog.remove(layerGroup);
    }
+   
+   /**
+    * Test GetFeatureInfo on a group layer with no-queryable flag activated
+    * @throws Exception
+    */
+   @Test
+   public void testNotQueryableGroupLayer() throws Exception {
+       Catalog catalog = getCatalog();
+       CatalogFactory factory = catalog.getFactory();
+       WorkspaceInfo workspace = catalog.getWorkspaceByName(MockData.CITE_PREFIX);
+       String groupLayer = "glnotqueryable";
+       
+       LayerGroupInfo layerGroup = factory.createLayerGroup();
+       layerGroup.setName(groupLayer);
+       layerGroup.setWorkspace(workspace);
+       layerGroup.getLayers().add( catalog.getLayerByName(getLayerId(MockData.FORESTS)) );
+       new CatalogBuilder(catalog).calculateLayerGroupBounds(layerGroup);
+       catalog.add(layerGroup);
+       
+       String name = MockData.CITE_PREFIX+":"+groupLayer;
+       String request = "wms?bbox=-0.002,-0.002,0.002,0.002&styles=&format=jpeg" +
+               "&info_format=text/plain&request=GetFeatureInfo&layers="
+               + name + "&query_layers=" + name + "&width=20&height=20&x=10&y=10";
+       
+       String result = getAsString(request);
+       assertNotNull(result);
+       assertTrue(result.indexOf("Green Forest") > 0);
+       
+       // Test no-queryable flag activated
+       layerGroup.setQueryDisabled(true);
+       
+       result = getAsString(request);
+       assertNotNull(result);
+       assertTrue(result.indexOf("no layer was queryable") > 0);
+       
+       catalog.remove(layerGroup);
+   }
 }


### PR DESCRIPTION
This pull allows make a Layer Group explicitly not queryable. Currently, a layer Group is queryable if it contains at least a queryable layer, and the user can not override it.

See issues:
https://osgeo-org.atlassian.net/browse/GEOS-7294

This feature was funded by: Tracasa (http://www.tracasa.es/en)
