### PR TITLE
Consolidate dependencies on proprietary JDBC drivers in profiles separate from building their data store extensions

### DIFF
--- a/src/community/jdbcconfig/pom.xml
+++ b/src/community/jdbcconfig/pom.xml
@@ -93,7 +93,7 @@
   </dependencies>
   <profiles>
       <profile>
-          <id>oracle</id>
+          <id>oracleDriver</id>
           <dependencies>
             <dependency>
                 <groupId>com.oracle</groupId>

--- a/src/extension/importer/core/pom.xml
+++ b/src/extension/importer/core/pom.xml
@@ -65,7 +65,7 @@
  
   <profiles>
     <profile>
-      <id>oracle</id>
+      <id>oracleDriver</id>
       <dependencies>
         <dependency>
           <groupId>com.oracle</groupId>
@@ -74,7 +74,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>sqlserver</id>
+      <id>sqlserverDriver</id>
       <dependencies>
         <dependency>
           <groupId>com.microsoft</groupId>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -418,6 +418,16 @@
           <artifactId>gs-oracle</artifactId>
           <version>2.9-SNAPSHOT</version>
         </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>oracleDriver</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.extension</groupId>
+          <artifactId>gs-oracle</artifactId>
+          <version>2.9-SNAPSHOT</version>
+        </dependency>
         <dependency>
             <groupId>com.oracle</groupId>
             <artifactId>ojdbc7</artifactId>


### PR DESCRIPTION
Was causing build issues when the `oracle` or `sqlserver` profiles were enabled to build the data store extensions along with the `jdbcconfig` or `importer` extensions.  The latter modules should have been using the `sqlserverDriver` and `oracleDriver` profiles instead.