### PR TITLE
Update psc list

### DIFF
--- a/doc/en/developer/source/policies/psc.rst
+++ b/doc/en/developer/source/policies/psc.rst
@@ -136,6 +136,7 @@ Current PSC
 * Christian Mueller
 * Jody Garnett
 * Jukka Rahkonen
+* Kevin Smith
 * Phil Scadden
 * Simone Giannecchini
 


### PR DESCRIPTION
As per nomination of @smithkm :

Alessio Fabiani
Andrea Aime +1
Ben Caradoc-Davies +1 (second)
Christian Mueller +1
Jody Garnett +1 (motion)
Jukka Rahkonen +1
Phil Scadden
Simone Giannecchini +1