### PR TITLE
improvments

### DIFF
--- a/src/community/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/community/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -52,6 +52,7 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
     private final VectorTileBuilderFactory tileBuilderFactory;
 
     private boolean clipToMapBounds;
+    private double  overSamplingFactor = 2.0; //1=no oversampling, 4=four time oversample (generialization will be 1/4 pixel)
 
     private boolean transformToScreenCoordinates;
 
@@ -61,6 +62,10 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
         this.tileBuilderFactory = tileBuilderFactory;
     }
 
+    public void setOverSamplingFactor(double  factor) {
+        this.overSamplingFactor = factor;
+    }
+    
     public void setClipToMapBounds(boolean clip) {
         this.clipToMapBounds = clip;
     }
@@ -100,17 +105,17 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
 
             PipelineBuilder builder;
             try {
-                builder = PipelineBuilder.newBuilder(renderingArea, paintArea, sourceCrs);
+                builder = PipelineBuilder.newBuilder(renderingArea, paintArea, sourceCrs,overSamplingFactor);
             } catch (FactoryException e) {
                 throw new ServiceException(e);
             }
 
-            Pipeline pipeline = builder//
-                    .preprocess()//
-                    .transform(transformToScreenCoordinates)//
-                    .simplify(transformToScreenCoordinates)//
-                    .clip(clipToMapBounds, transformToScreenCoordinates)//
-                    .collapseCollections()//
+            Pipeline pipeline = builder
+                    .preprocess()
+                    .transform(transformToScreenCoordinates)
+                    .simplify(transformToScreenCoordinates)
+                    .clip(clipToMapBounds, transformToScreenCoordinates)
+                    .collapseCollections()
                     .build();
 
             Query query = getStyleQuery(layer, mapContent);

--- a/src/community/vectortiles/src/main/resources/applicationContext.xml
+++ b/src/community/vectortiles/src/main/resources/applicationContext.xml
@@ -21,7 +21,7 @@
   <bean id="wmsTopoJSONMapOutputFormat" class="org.geoserver.wms.vector.VectorTileMapOutputFormat">
     <constructor-arg ref="wms"/>
     <constructor-arg ref="wmsTopoJSONBuilderFactory"/>
-    <property name="clipToMapBounds" value="false">
+    <property name="clipToMapBounds" value="true">
       <description>Use geometries clipped to tile bounds
       Clipping is set to false since OL3 does not yet have a way to deal with clipped geometries.
       It should be set to true once OL3 knows what to do with clipped geometries.
@@ -29,6 +29,9 @@
     </property>
     <property name="transformToScreenCoordinates" value="true">
       <description>The topoJSON map builder expects geometries in screen coordinates</description>
+    </property>
+    <property name="overSamplingFactor" value="2.0">
+      <description>Sub-pixel accuracy - higher value means less generalization (higher resolution results)</description>
     </property>
   </bean>
 
@@ -38,9 +41,12 @@
   <bean id="wmsGeoJsonMapOutputFormat" class="org.geoserver.wms.vector.VectorTileMapOutputFormat">
     <constructor-arg ref="wms" />
     <constructor-arg ref="wmsGeoJsonBuilderFactory" />
-    <property name="clipToMapBounds" value="false"/>
+    <property name="clipToMapBounds" value="true"/>
     <property name="transformToScreenCoordinates" value="false">
       <description>The geoJson map builder expects geometries in map coordinates</description>
+    </property>
+     <property name="overSamplingFactor" value="2.0">
+      <description>Sub-pixel accuracy - higher value means less generalization (higher resolution results)</description>
     </property>
   </bean>
     
@@ -52,6 +58,9 @@
     <constructor-arg ref="wmsMapBoxBuilderFactory"/>
     <property name="clipToMapBounds" value="true" />
     <property name="transformToScreenCoordinates" value="true" />
+     <property name="overSamplingFactor" value="2.0">
+      <description>Sub-pixel accuracy - higher value means less generalization (higher resolution results)</description>
+    </property>
   </bean>
   
 


### PR DESCRIPTION
I have made some changes to the module;

a) turned on clipping for all formats (applicationContext.xml)
     * OpenLayers handles this properly now
b) add new option (applicationContext.xml) for oversampling 
     * Results looked "blocky", setting this to "2" makes it more detailed
     * please verify that I didn't miss anything!!
c) Changed from DouglasPeuckerSimplifier to TopologyPreservingSimplifier
      * DP was not properly simplifying polygons with "thin" parts