### PR TITLE
test feature by grid code at row / col location

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/utfgrid/UTFGridIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/utfgrid/UTFGridIntegrationTest.java
@@ -335,27 +335,26 @@ public class UTFGridIntegrationTest extends WMSTestSupport {
         assertEquals("Route 75", f.getString("NAME"));
         assertEquals(0, f.getInt("NUM_LANES"));
         
-        tester.assertGridPixel('#', 6, 27);
-        f = tester.getFeature('#');
+        char code = tester.charAt( 6, 27);
+        f = tester.getFeature(code);
         assertEquals("111", f.getString("FID"));
         assertEquals("Cam Stream", f.getString("NAME"));
         
-        tester.assertGridPixel('%', 10, 12);
-        f = tester.getFeature('%');
+        code = tester.charAt( 10, 12);
+        f = tester.getFeature(code);
         assertEquals("120", f.getString("FID"));
         assertEquals(" ", f.getString("NAME"));
         assertEquals("Stock Pond", f.getString("TYPE"));
         
-        tester.assertGridPixel('$', 10, 62);
-        f = tester.getFeature('$');
+        code = tester.charAt(10, 62);
+        f = tester.getFeature(code);
         assertEquals("103", f.getString("FID"));
         assertEquals("Route 5", f.getString("NAME"));
         
-        tester.assertGridPixel('\'', 23, 33);
-        f = tester.getFeature('\'');
+        code = tester.charAt(23, 33);
+        f = tester.getFeature(code);
         assertEquals("110", f.getString("FID"));
         assertEquals("Cam Bridge", f.getString("NAME"));
-
         
         tester.assertGridPixel('&', 22, 56);
         tester.assertGridPixel('&', 24, 35);
@@ -367,8 +366,8 @@ public class UTFGridIntegrationTest extends WMSTestSupport {
         assertEquals("109", f.getString("FID"));
         assertEquals("Green Forest", f.getString("NAME"));
         
-        tester.assertGridPixel('(', 32, 9);
-        f = tester.getFeature('(');
+        code = tester.charAt( 32, 9);
+        f = tester.getFeature(code);
         assertEquals("102", f.getString("FID"));
         assertEquals("Route 5", f.getString("NAME"));
     }

--- a/src/wms/src/test/java/org/geoserver/wms/utfgrid/UTFGridTester.java
+++ b/src/wms/src/test/java/org/geoserver/wms/utfgrid/UTFGridTester.java
@@ -89,7 +89,18 @@ class UTFGridTester {
         String key = "" + (int) gridToKey(code);
         return data.getJSONObject(key);
     }
-
+    
+    /**
+     * Look up code at row and col provided.
+     * @param row
+     * @param col
+     * @return grid code
+     */
+    char charAt( int row, int col){
+        String gridRow = grid.getString(row);
+        return gridRow.charAt(col);
+    }
+    
     /**
      * Check the specified code can be found in the grid at row/col
      * @param code


### PR DESCRIPTION
Adjust UTFGridIntegrationTest to test features using grid code at a location (rather than assuming grid code).

This is a follow up to GEOT-5322 which changed the number of featuers returned due to clipping.