### PR TITLE
[GEOS-7352] Error rendering coverage with transformation when out of bounding box

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
@@ -1058,11 +1058,11 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                     coverage = readBestCoverage(reader, params,
                             ReferencedEnvelope.reference(readGG.getEnvelope()),
                             readGG.getGridRange2D(), interpolation, readerBgColor);
-                    // Nothing found, we return a constant image with background value
-                    if (coverage == null) {
-                        // we're outside of the coverage definition area, return an empty space
-                        image = createBkgImage(mapWidth, mapHeight, bgColor, null);
-                    }
+                }
+                // Nothing found, we return a constant image with background value
+                if (coverage == null) {
+                    // we're outside of the coverage definition area, return an empty space
+                    image = createBkgImage(mapWidth, mapHeight, bgColor, null);
                 }
                 // If the image has not already been prepared, we render the image using the
                 // GridCoverageRenderer

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -250,6 +250,18 @@ public class GetMapIntegrationTest extends WMSTestSupport {
                 + "&srs=epsg:4326&BBOX=-130,49,-125,54";
         image = getAsImage(url, "image/png");
         color = getPixelColor(image, 25, 25);
+        // the color is white, or white-ish
+        assertTrue(color.getRed() + color.getGreen() + color.getBlue() > (250 * 3));
+    }
+
+    @Test
+    public void testRasterRenderingTxOutOfBbox() throws Exception {
+        String layer = getLayerId(MockData.USA_WORLDIMG);
+        String url = "wms?service=WMS&VERSION=1.1.1&request=GetMap&styles=crop_raster"
+                + "&format=image/png&layers="  + layer + "&WIDTH=100&HEIGHT=100"
+                + "&srs=epsg:4326&BBOX=-120,40,-115,45";
+        BufferedImage image = getAsImage(url, "image/png");
+        Color color = getPixelColor(image, 25, 25);
         // the color is white, or white-ish
         assertTrue(color.getRed() + color.getGreen() + color.getBlue() > (250 * 3));
     }


### PR DESCRIPTION
Fix for:
[GEOS-7352] Error rendering coverage with transformation when out of bounding box

This can be backported to 2.8.x and 2.7.x.