### PR TITLE
Duplicated isGmlPrefixing and setGmlPrefixing?

### DIFF
--- a/src/wcs/src/main/java/org/geoserver/wcs/WCSInfoImpl.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/WCSInfoImpl.java
@@ -62,14 +62,6 @@ public class WCSInfoImpl extends ServiceInfoImpl implements WCSInfo {
         this.maxOutputMemory = maxOutputSize;
     }
 
-    public boolean isGmlPrefixing() {
-        return gmlPrefixing;
-    }
-
-    public void setGmlPrefixing(boolean gmlPrefixing) {
-        this.gmlPrefixing = gmlPrefixing;
-    }
-
     public boolean isSubsamplingEnabled() {
         return subsamplingEnabled == null ? true : subsamplingEnabled; 
     }


### PR DESCRIPTION
These appear to be unintentionally duplicated identically, removing the second copy.