### PR TITLE
Fixed typo in the Oracle Workspace Manager documentation title

### DIFF
--- a/doc/en/developer/source/programming-guide/versioning/wfsv/oracle.rst
+++ b/doc/en/developer/source/programming-guide/versioning/wfsv/oracle.rst
@@ -1,6 +1,6 @@
 .. _versioning_implementations_oracle:
 
-Oracle Worskspace Manager
+Oracle Workspace Manager
 ==========================================
 
 Workspace manager is an Oracle module that allows for version control like features while retaining the ability to work against the database as if the versioning system was not there.


### PR DESCRIPTION
Small typo in the documentation appears in the page title, so also shows in the parent page's TOC tree.