### PR TITLE
[GEOS-7358] Fix: use ResourceAccessManager pluggable authorization in UI.

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -87,7 +87,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         return accessManager;
     }
 
-    static ResourceAccessManager lookupResourceAccessManager() throws Exception {
+    public static ResourceAccessManager lookupResourceAccessManager() throws Exception {
         ResourceAccessManager manager = GeoServerExtensions.bean(ResourceAccessManager.class);
         if (manager == null) {
             DataAccessManager daManager = lookupDataAccessManager();


### PR DESCRIPTION
Authorization architecture allows ResourceAccessManager to be pluggable,
but the WorkspaceAdminComponentAuthorizer class forces the use of the default access manager.