### PR TITLE
[GEOS-7366] Fixed a WPS file handle leak.

### DIFF
--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/resource/CoverageResourceListenerTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/resource/CoverageResourceListenerTest.java
@@ -1,0 +1,93 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps.resource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.easymock.classextension.EasyMock;
+import org.geoserver.wcs.CoverageCleanerCallback;
+import org.geoserver.wps.ProcessEvent;
+import org.geoserver.wps.ProcessListener;
+import org.geoserver.wps.executor.ExecutionStatus;
+import org.geoserver.wps.executor.ProcessState;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.feature.NameImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.classextension.EasyMock.createMock;
+import static org.easymock.classextension.EasyMock.replay;
+import static org.easymock.classextension.EasyMock.verify;
+
+public class CoverageResourceListenerTest {
+
+    private WPSResourceManager resourceManager;
+
+    private ProcessListener listener;
+
+    private ExecutionStatus status;
+
+    private Map<String, Object> inputs;
+
+    @Before
+    public void setUp() {
+        this.resourceManager = createMock(WPSResourceManager.class);
+        this.listener = new CoverageResourceListener(
+            this.resourceManager, new CoverageCleanerCallback());
+        this.status = new ExecutionStatus(
+            new NameImpl("gs", "TestProcess"), UUID.randomUUID().toString(), false);
+        this.status.setPhase(ProcessState.RUNNING);
+        this.inputs = new HashMap<>();
+        this.inputs.put("coverageA", null);
+        this.inputs.put("coverageB", null);
+        this.inputs.put("string", null);
+        this.inputs.put("integer", null);
+    }
+
+    @Test
+    public void testCheckInputWhenSucceeded() {
+        // expected addResource to be called twice
+        this.resourceManager.addResource(EasyMock.<GridCoverageResource> anyObject());
+        expectLastCall().times(2);
+        replay(this.resourceManager);
+
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.inputs.put("coverageA", createMock(GridCoverage2D.class));
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.inputs.put("coverageB", createMock(GridCoverage2D.class));
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.inputs.put("string", "testString");
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.inputs.put("integer", 1);
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.status.setPhase(ProcessState.SUCCEEDED);
+        this.listener.succeeded(new ProcessEvent(this.status, this.inputs));
+
+        // verify that addResource was called twice
+        verify(this.resourceManager);
+    }
+
+    @Test
+    public void testCheckInputWhenFailed() {
+        // expected addResource to be called once
+        this.resourceManager.addResource(EasyMock.<GridCoverageResource> anyObject());
+        expectLastCall().once();
+        replay(this.resourceManager);
+
+        // failure loading second coverage
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.inputs.put("coverageA", createMock(GridCoverage2D.class));
+        this.listener.progress(new ProcessEvent(this.status, this.inputs));
+        this.status.setPhase(ProcessState.FAILED);
+        this.listener.failed(new ProcessEvent(this.status, this.inputs));
+
+        // verify that addResource was called once
+        verify(this.resourceManager);
+    }
+}


### PR DESCRIPTION
LazyInputMap fires a ProcessEvent before it begins loading the inputs and another ProcessEvent after each input is loaded.  The current CoverageResourceListener will only check the inputs on the first event, where all of the inputs will be null.  This can result in leaking file handles.

This pull request updates CoverageResourceListener to check for non-null values.