### PR TITLE
[GEOS-2613] GeoJSON support for setting decimal places.

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -93,6 +93,8 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
     protected void write(FeatureCollectionResponse featureCollection, OutputStream output,
             Operation describeFeatureType) throws IOException {
 
+        int numDecimals = getNumDecimals(featureCollection.getFeature(), gs, gs.getCatalog());
+
         if (LOGGER.isLoggable(Level.INFO))
             LOGGER.info("about to encode JSON");
         // Generate bounds for every feature?
@@ -123,8 +125,9 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
             if (jsonp) {
                 outWriter.write(getCallbackFunction() + "(");
             }
-
+            
             final GeoJSONBuilder jsonWriter = new GeoJSONBuilder(outWriter);
+            jsonWriter.setNumberOfDecimals(numDecimals);
             jsonWriter.object().key("type").value("FeatureCollection");
             if(featureCount != null) {
                 jsonWriter.key("totalFeatures").value(featureCount);

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/RoundingUtil.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/RoundingUtil.java
@@ -1,0 +1,56 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+/**
+ * Utility class for rounding double values.
+ * 
+ * @author Dean Povey
+ *
+ */
+public class RoundingUtil {
+    // How to scale the double, indexed by the number of digits
+    private static double[] SCALE = {
+            1d,
+            10d,
+            100d,
+            1000d,
+            10000d,
+            100000d,
+            1000000d,
+            10000000d,
+            100000000d
+        };
+    
+    /**
+     * Round a value to the specified number of decimal places using the "Round Half Up" strategy.
+     * 
+     * 
+     * <p>
+     * Special cases:
+     * <ul>
+     * <li>NaN is returned as NaN.<li>
+     * <li>+/-Infinity are returned as +/-Infinity.
+     * </ul>
+     * 
+     * @param value The value to round
+     * @param numDecimals The number of decimal places to round to.
+     * 
+     * @return The value rounded to the specified number of decimals
+     */
+    public static double round(double value, int numDecimals) {
+        // Technically this code will handle -numDecimals by rounding digits to the left of the decimal point, but that is
+        // probably a use case that is not really needed in practice.
+        
+        double scale = (numDecimals < 8) ? SCALE[numDecimals] : Math.pow(10, numDecimals);
+        
+        // Prevent us exceeding the maximum precision.  We make sure the minimum spacing between values is sufficient
+        // for the given scale otherwise just return the value.
+        if (Math.ulp(value) * scale > 1d) return value;
+        
+        return Math.floor(value * scale + 0.5) / scale;
+    }
+
+}

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -25,7 +25,7 @@ public class GeoJSONBuilderTest {
     StringWriter writer;
 
     GeoJSONBuilder builder;
-
+    
     @Before
     public void setUp() {
         writer = new StringWriter();
@@ -196,6 +196,30 @@ public class GeoJSONBuilderTest {
     @Test
     public void testWrite3DPolygon() throws Exception {
         Geometry g = new WKTReader().read("POLYGON((0 0 0, 0 10 1, 10 10 2, 10 0 3, 0 0 0),(1 1 4, 1 2 5, 2 2 6, 2 1 7, 1 1 4))");
+        builder.writeGeom(g);
+        assertEquals("{\"type\":\"Polygon\",\"coordinates\":[[[0,0,0],[0,10,1],[10,10,2],[10,0,3],[0,0,0]],[[1,1,4],[1,2,5],[2,2,6],[2,1,7],[1,1,4]]]}", writer.toString());
+    }
+    
+    @Test
+    public void testNumberOfDecimalsFor3dPoint() throws Exception {
+        builder.setNumberOfDecimals(2);
+        Geometry g = new WKTReader().read("POINT(2.1234 0.1234 20.9999)");
+        builder.writeGeom(g);
+        assertEquals("{\"type\":\"Point\",\"coordinates\":[2.12,0.12,21]}", writer.toString());        
+    }
+    
+    @Test
+    public void testNumberOfDecimalsFor3dLine() throws Exception {
+        builder.setNumberOfDecimals(3);
+        Geometry g = new WKTReader().read("LINESTRING(1E-3 1E-4 1E-5, 0 10.12312321 1.000002, 10.1 10.2 2.0, 10 0 3, 0 0 0)");
+        builder.writeGeom(g);
+        assertEquals("{\"type\":\"LineString\",\"coordinates\":[[0.001,0,0],[0,10.123,1],[10.1,10.2,2],[10,0,3],[0,0,0]]}", writer.toString());
+    }
+    
+    @Test
+    public void testNumberOfDecimalsFor3dPolygon() throws Exception {
+        builder.setNumberOfDecimals(0);
+        Geometry g = new WKTReader().read("POLYGON((0.1 0.2 0.3, 0.1 10.1 1.1, 10.2 10.3 2.4, 9.5 0.4 3, 0.1 0.2 0.3),(1 1 4, 1 2 5, 2 2 6, 2 1 7, 1 1 4))");
         builder.writeGeom(g);
         assertEquals("{\"type\":\"Polygon\",\"coordinates\":[[[0,0,0],[0,10,1],[10,10,2],[10,0,3],[0,0,0]],[[1,1,4],[1,2,5],[2,2,6],[2,1,7],[1,1,4]]]}", writer.toString());
     }

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/PointReduced.properties
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/PointReduced.properties
@@ -1,0 +1,4 @@
+_=the_geom:Point:srid=4326,Name:String
+PointReduced.0=POINT(120.1234 0.556)| foo
+PointReduced.1=POINT(-170.1919192 45.2323)| bar
+PointReduced.2=POINT(60.128231 -30.13289123)| baz

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/RoundingUtilTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/RoundingUtilTest.java
@@ -1,0 +1,85 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Random;
+
+import org.junit.Test;
+
+/**
+ * 
+ * Test rounding
+ * 
+ * @author Dean Povey
+ *
+ */
+public class RoundingUtilTest {
+
+    @Test
+    public void testSpecialCases() {
+        for (int numDecimals = 0; numDecimals < 17; numDecimals++) {
+            assertThat(Double.isNaN(RoundingUtil.round(Double.NaN, numDecimals)), is(true));
+            assertThat(RoundingUtil.round(Double.NEGATIVE_INFINITY, numDecimals), is(equalTo(Double.NEGATIVE_INFINITY)));
+            assertThat(RoundingUtil.round(Double.POSITIVE_INFINITY, numDecimals), is(equalTo(Double.POSITIVE_INFINITY)));
+        }
+    }
+    
+    @Test
+    public void testSpecificCases() {
+        assertThat(RoundingUtil.round(0d, 0), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(0.1, 0), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(0.1, 1), is(equalTo(0.1)));
+        assertThat(RoundingUtil.round(0.1, 2), is(equalTo(0.1)));
+        assertThat(RoundingUtil.round(0.05, 1), is(equalTo(0.1)));
+        assertThat(RoundingUtil.round(-0.05, 1), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(0.0000001, 5), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(1.0000001, 7), is(equalTo(1.0000001)));
+        assertThat(RoundingUtil.round(1.00000015, 7), is(equalTo(1.0000002)));
+        assertThat(RoundingUtil.round(1E-3, 7), is(equalTo(0.001)));
+        assertThat(RoundingUtil.round(1E-4, 3), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(1E-10, 10), is(equalTo(1E-10)));
+        
+    }
+
+    @Test
+    public void testNoRoundingWhenPrecisionWouldBeExceeded() {
+        // Test cases where precision is exceeded.
+        assertThat(RoundingUtil.round(1.01234567890123456E12, 1), is(equalTo(1.0123456789012E12)));
+        assertThat(RoundingUtil.round(1.01234567890123456E12, 2), is(equalTo(1.01234567890123E12)));
+        assertThat(RoundingUtil.round(1.01234567890123456E13, 1), is(equalTo(1.01234567890123E13)));
+        assertThat(RoundingUtil.round(1.01234567890123456E13, 2), is(equalTo(1.012345678901235E13)));
+        assertThat(RoundingUtil.round(1.01234567890123456E14, 1), is(equalTo(1.012345678901235E14)));
+        assertThat(RoundingUtil.round(1.01234567890123456E14, 2), is(equalTo(1.0123456789012346E14)));
+        assertThat(RoundingUtil.round(1.01234567890123456E15, 1), is(equalTo(1.0123456789012345E15)));
+        assertThat(RoundingUtil.round(1.01234567890123456E15, 2), is(equalTo(1.0123456789012345E15)));
+        assertThat(RoundingUtil.round(1.01234567890123456E16, 1), is(equalTo(1.0123456789012346E16)));
+        assertThat(RoundingUtil.round(1.01234567890123456E16, 2), is(equalTo(1.0123456789012346E16)));
+        assertThat(RoundingUtil.round(1.0123456789012345E17, 1), is(equalTo(1.0123456789012345E17)));
+        assertThat(RoundingUtil.round(1.0123456789012345E18, 1), is(equalTo(1.0123456789012345E18)));
+        assertThat(RoundingUtil.round(1.01234567890123451E19, 1), is(equalTo(1.0123456789012345E19)));
+        assertThat(RoundingUtil.round(Double.MIN_VALUE, 15), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(Double.MAX_VALUE, 1), is(equalTo(Double.MAX_VALUE)));
+    }
+    
+    @Test
+    public void testRandomRoundingVsBigDecimal() {
+        Random r = new Random();
+        for (int i = 0; i < 10000; i++) {
+            double value = r.nextDouble();
+            for (int numDecimals = 0; numDecimals <= 8; numDecimals++) {
+                double expected = new BigDecimal(Double.toString(value)).setScale(numDecimals, RoundingMode.HALF_UP).doubleValue();                
+                double actual = RoundingUtil.round(value, numDecimals);
+                assertThat(actual, is(equalTo(expected)));
+            }
+        }
+    
+    }
+}

--- a/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
@@ -1277,7 +1277,8 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
         //
         // If we need to add a collar use mosaic or if we need to blend/apply a bkg color
         if(!(imageBounds.contains(mapRasterArea) || imageBounds.equals(mapRasterArea))||transparencyType!=Transparency.OPAQUE) {
-            ROI[] rois = new ROI[] { new ROIShape(imageBounds) };
+            Rectangle roi = imageBounds.intersection(mapRasterArea);
+            ROI[] rois = new ROI[] { new ROIShape(!roi.isEmpty() ? roi : mapRasterArea) };
 
             // build the transparency thresholds
             double[][] thresholds = new double[][] { { ColorUtilities.getThreshold(image

--- a/src/wms/src/test/java/org/geoserver/wms/map/TinyRasterBoundingBoxTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/TinyRasterBoundingBoxTest.java
@@ -1,0 +1,157 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.map;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.awt.image.renderable.ParameterBlock;
+
+import javax.media.jai.ROI;
+import javax.media.jai.RenderedOp;
+import javax.xml.namespace.QName;
+
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.WMSMapContent;
+import org.geoserver.wms.WMSTestSupport;
+import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.map.GridReaderLayer;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.resources.image.ImageUtilities;
+import org.geotools.styling.Style;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengis.coverage.grid.GridEnvelope;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for very slow WMS GetMap response times when the requested 
+ * bounding box is much smaller than the resolution of the raster data 
+ * and advanced projection handling is disabled.
+ */
+public class TinyRasterBoundingBoxTest extends WMSTestSupport {
+
+    @BeforeClass
+    public static void disableAdvancedProjection() {
+        System.setProperty("ENABLE_ADVANCED_PROJECTION", "false");
+    }
+
+    private WMSMapContent map;
+
+    private BufferedImage image;
+
+    private RenderedOp op;
+
+    @Before
+    public void setUp() {
+        GetMapRequest request = new GetMapRequest();
+        request.setFormat("image/png");
+        this.map = new WMSMapContent();
+        this.map.setMapWidth(256);
+        this.map.setMapHeight(256);
+        this.map.setTransparent(true);
+        this.map.setRequest(request);
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        testData.addDefaultRasterLayer(MockData.TASMANIA_DEM, getCatalog());
+        testData.addStyle("rainfall", "rainfall.sld", MockData.class, getCatalog());
+    }
+
+    @After
+    public void tearDown() {
+        ImageUtilities.disposeImage(this.op);
+        this.map.dispose();
+        this.map = null;
+        this.image = null;
+        this.op = null;
+    }
+
+    @Test
+    public void testTinyRasterBboxContained() throws Exception {
+        CoverageInfo coverageInfo = addRasterToMap(MockData.TASMANIA_DEM);
+        Envelope env = coverageInfo.boundingBox();
+        Coordinate center = env.centre();
+        GridEnvelope range = coverageInfo.getGrid().getGridRange();
+        double offset = (env.getMaxX() - env.getMinX()) / range.getSpan(0) / 10.0;
+        Rectangle imageBounds = produceMap(center.x + offset, center.x + 2 * offset, 
+            center.y + offset, center.y + 2 * offset);
+        assertNotBlank("testTinyRasterBboxContained", this.image);
+        assertEquals("Mosaic", this.op.getOperationName());
+        Rectangle roiBounds = getRoiBounds();
+        assertTrue("Expected " + imageBounds + " to contain " + roiBounds, 
+            imageBounds.contains(roiBounds));
+    }
+
+    @Test
+    public void testTinyRasterBboxIntersection() throws Exception {
+        CoverageInfo coverageInfo = addRasterToMap(MockData.TASMANIA_DEM);
+        Envelope env = coverageInfo.boundingBox();
+        GridEnvelope range = coverageInfo.getGrid().getGridRange();
+        double offset = (env.getMaxX() - env.getMinX()) / range.getSpan(0) / 20.0;
+        Rectangle imageBounds = produceMap(env.getMinX() - offset, env.getMinX() + offset, 
+            env.getMaxY() - offset, env.getMaxY() + offset);
+        assertNotBlank("testTinyRasterBboxIntersection", this.image);
+        assertEquals("Mosaic", this.op.getOperationName());
+        Rectangle roiBounds = getRoiBounds();
+        assertTrue("Expected " + imageBounds + " to contain " + roiBounds, 
+            imageBounds.contains(roiBounds));
+    }
+
+    @Test
+    public void testTinyRasterBboxNoIntersection() throws Exception {
+        CoverageInfo coverageInfo = addRasterToMap(MockData.TASMANIA_DEM);
+        Envelope env = coverageInfo.boundingBox();
+        GridEnvelope range = coverageInfo.getGrid().getGridRange();
+        double offset = (env.getMaxX() - env.getMinX()) / range.getSpan(0) / 10.0;
+        Rectangle imageBounds = produceMap(env.getMaxX() + offset, env.getMaxX() + 2 * offset, 
+            env.getMinY() - 2 * offset, env.getMinY() - offset);
+        assertNotBlank("testTinyRasterBboxNoIntersection", this.image);
+        assertEquals("Mosaic", this.op.getOperationName());
+        Rectangle roiBounds = getRoiBounds();
+        assertTrue("Expected " + imageBounds + " to contain " + roiBounds, 
+            imageBounds.contains(roiBounds));
+    }
+
+    private CoverageInfo addRasterToMap(QName typeName) throws Exception {
+        CoverageInfo coverageInfo = getCatalog().getCoverageByName(
+            typeName.getNamespaceURI(), typeName.getLocalPart());
+        GridCoverage2DReader reader = (GridCoverage2DReader) 
+            coverageInfo.getGridCoverageReader(null, null);
+        Style style = getCatalog().getStyleByName("rainfall").getStyle();
+        this.map.addLayer(new GridReaderLayer(reader, style));
+        return coverageInfo;
+    }
+
+    private Rectangle getRoiBounds() {
+        ParameterBlock pb = this.op.getParameterBlock();
+        ROI[] rois = (ROI[]) pb.getObjectParameter(2);
+        return rois[0].getBounds();
+    }
+
+    private Rectangle produceMap(double minX, double maxX, double minY, double maxY) {
+        this.map.getViewport().setBounds(new ReferencedEnvelope(
+            minX, maxX, minY, maxY, DefaultGeographicCRS.WGS84));
+        RenderedImageMapOutputFormat rasterMapProducer = 
+            new RenderedImageMapOutputFormat(getWMS());
+        RenderedImageMap imageMap = rasterMapProducer.produceMap(this.map);
+        this.op = (RenderedOp) imageMap.getImage();
+        this.image = this.op.getAsBufferedImage();
+        imageMap.dispose();
+        return new Rectangle(0, 0, this.image.getWidth(), this.image.getHeight());
+    }
+}


### PR DESCRIPTION
This change adds support for limiting the number of decimal places used
for doubles when outputting GeoJSON responses to WFS queries.  Unit tests
are also added for this functionality.