### PR TITLE
[GEOS-2613] GeoJSON support for setting decimal places.

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -8,9 +8,6 @@ package org.geoserver.wfs.json;
 import java.io.Writer;
 import java.util.Calendar;
 import java.util.logging.Logger;
-
-import net.sf.json.JSONException;
-import net.sf.json.util.JSONBuilder;
 
 import org.geotools.geometry.jts.coordinatesequence.CoordinateSequences;
 import org.geotools.referencing.CRS;
@@ -29,6 +26,9 @@ import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.geom.impl.CoordinateArraySequence;
 
+import net.sf.json.JSONException;
+import net.sf.json.util.JSONBuilder;
+
 
 /**
  * This class extends the JSONBuilder to be able to write out geometric types.  It is coded
@@ -39,10 +39,13 @@ import com.vividsolutions.jts.geom.impl.CoordinateArraySequence;
  *
  */
 public class GeoJSONBuilder extends JSONBuilder {
+
     private final Logger LOGGER = org.geotools.util.logging.Logging
     .getLogger(this.getClass());
     
     private CRS.AxisOrder axisOrder = CRS.AxisOrder.EAST_NORTH;
+
+    private int numDecimals = 6;
 
     public GeoJSONBuilder(Writer w) {
         super(w);
@@ -51,8 +54,8 @@ public class GeoJSONBuilder extends JSONBuilder {
     /**
      * Writes any geometry object.  This class figures out which geometry representation to write
      * and calls subclasses to actually write the object.
-     * @param geometry The geoemtry be encoded
-     * @return The JSONBuilder with the new geoemtry
+     * @param geometry The geometry to be encoded
+     * @return The JSONBuilder with the new geometry
      * @throws JSONException If anything goes wrong
      */
     public JSONBuilder writeGeom(Geometry geometry) throws JSONException {
@@ -159,20 +162,22 @@ public class GeoJSONBuilder extends JSONBuilder {
     private JSONBuilder writeCoordinate(double x, double y, double z) {
         this.array();
         if(axisOrder==CRS.AxisOrder.NORTH_EAST){
-            this.value(y);
-            this.value(x);
+            roundedValue(y);
+            roundedValue(x);
         } else {
-            this.value(x);
-            this.value(y);
+            roundedValue(x);
+            roundedValue(y);
         }
         if(!Double.isNaN(z)) {
-            this.value(z);
+            roundedValue(z);
         }
 
         return this.endArray();
     }
 
-    
+    private void roundedValue(double value) {
+        super.value(RoundingUtil.round(value, numDecimals));
+    }
     
     /**
      * Turns an envelope into an array [minX,minY,maxX,maxY]
@@ -183,15 +188,15 @@ public class GeoJSONBuilder extends JSONBuilder {
         this.key("bbox");
         this.array();
         if(axisOrder==CRS.AxisOrder.NORTH_EAST) {
-            this.value(env.getMinY());
-            this.value(env.getMinX());
-            this.value(env.getMaxY());
-            this.value(env.getMaxX());
+            roundedValue(env.getMinY());
+            roundedValue(env.getMinX());
+            roundedValue(env.getMaxY());
+            roundedValue(env.getMaxX());
         } else {
-            this.value(env.getMinX());
-            this.value(env.getMinY());
-            this.value(env.getMaxX());
-            this.value(env.getMaxY());
+            roundedValue(env.getMinX());
+            roundedValue(env.getMinY());
+            roundedValue(env.getMaxX());
+            roundedValue(env.getMaxY());
         }
         return this.endArray();
     }
@@ -289,7 +294,8 @@ public class GeoJSONBuilder extends JSONBuilder {
     
     /**
      * Overrides to handle the case of encoding {@code java.util.Date} and its date/time/timestamp
-     * descendants, as well as {@code java.util.Calendar} instances as ISO 8601 strings.
+     * descendants, as well as {@code java.util.Calendar} instances as ISO 8601 strings.  In addition
+     * handles rounding numbers to the specified number of decimal points.
      * 
      * @see net.sf.json.util.JSONBuilder#value(java.lang.Object)
      */
@@ -301,6 +307,7 @@ public class GeoJSONBuilder extends JSONBuilder {
         super.value(value);
         return this;
     }
+
     
     /**
      * Set the axis order to assume all input will be provided in. Has no effect on geometries 
@@ -309,5 +316,9 @@ public class GeoJSONBuilder extends JSONBuilder {
      */
     public void setAxisOrder(CRS.AxisOrder axisOrder) {
         this.axisOrder = axisOrder;
+    }
+
+    public void setNumberOfDecimals(int numberOfDecimals) {
+        this.numDecimals = numberOfDecimals;
     }
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -93,6 +93,8 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
     protected void write(FeatureCollectionResponse featureCollection, OutputStream output,
             Operation describeFeatureType) throws IOException {
 
+        int numDecimals = getNumDecimals(featureCollection.getFeature(), gs, gs.getCatalog());
+
         if (LOGGER.isLoggable(Level.INFO))
             LOGGER.info("about to encode JSON");
         // Generate bounds for every feature?
@@ -123,8 +125,9 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
             if (jsonp) {
                 outWriter.write(getCallbackFunction() + "(");
             }
-
+            
             final GeoJSONBuilder jsonWriter = new GeoJSONBuilder(outWriter);
+            jsonWriter.setNumberOfDecimals(numDecimals);
             jsonWriter.object().key("type").value("FeatureCollection");
             if(featureCount != null) {
                 jsonWriter.key("totalFeatures").value(featureCount);

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/RoundingUtil.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/RoundingUtil.java
@@ -1,0 +1,55 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+/**
+ * Utility class for rounding double values.
+ * 
+ * @author Dean Povey
+ *
+ */
+public class RoundingUtil {
+    // How to scale the double, indexed by the number of digits
+    private static double[] SCALE = {
+            1d,
+            10d,
+            100d,
+            1000d,
+            10000d,
+            100000d,
+            1000000d,
+            10000000d,
+            100000000d
+        };
+    
+    /**
+     * Round a value to the specified number of decimal places using the "Round Half Up" strategy.
+     * 
+     * <p>
+     * Special cases:
+     * <ul>
+     * <li>NaN is returned as NaN.<li>
+     * <li>+/-Infinity are returned as +/-Infinity.
+     * </ul>
+     * 
+     * @param value The value to round
+     * @param numDecimals The number of decimal places to round to.
+     * 
+     * @return The value rounded to the specified number of decimals
+     */
+    public static double round(double value, int numDecimals) {
+        // Technically this code will handle -numDecimals by rounding digits to the left of the decimal point, but that is
+        // probably a use case that is not really needed in practice.
+        
+        double scale = (numDecimals < 8) ? SCALE[numDecimals] : Math.pow(10, numDecimals);
+        
+        // Prevent us exceeding the maximum precision.  We make sure the minimum spacing between values is sufficient
+        // for the given scale otherwise just return the value.
+        if (Math.ulp(value) * scale > 1d) return value;
+        
+        return Math.floor(value * scale + 0.5) / scale;
+    }
+
+}

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -25,7 +25,7 @@ public class GeoJSONBuilderTest {
     StringWriter writer;
 
     GeoJSONBuilder builder;
-
+    
     @Before
     public void setUp() {
         writer = new StringWriter();
@@ -196,6 +196,30 @@ public class GeoJSONBuilderTest {
     @Test
     public void testWrite3DPolygon() throws Exception {
         Geometry g = new WKTReader().read("POLYGON((0 0 0, 0 10 1, 10 10 2, 10 0 3, 0 0 0),(1 1 4, 1 2 5, 2 2 6, 2 1 7, 1 1 4))");
+        builder.writeGeom(g);
+        assertEquals("{\"type\":\"Polygon\",\"coordinates\":[[[0,0,0],[0,10,1],[10,10,2],[10,0,3],[0,0,0]],[[1,1,4],[1,2,5],[2,2,6],[2,1,7],[1,1,4]]]}", writer.toString());
+    }
+    
+    @Test
+    public void testNumberOfDecimalsFor3dPoint() throws Exception {
+        builder.setNumberOfDecimals(2);
+        Geometry g = new WKTReader().read("POINT(2.1234 0.1234 20.9999)");
+        builder.writeGeom(g);
+        assertEquals("{\"type\":\"Point\",\"coordinates\":[2.12,0.12,21]}", writer.toString());        
+    }
+    
+    @Test
+    public void testNumberOfDecimalsFor3dLine() throws Exception {
+        builder.setNumberOfDecimals(3);
+        Geometry g = new WKTReader().read("LINESTRING(1E-3 1E-4 1E-5, 0 10.12312321 1.000002, 10.1 10.2 2.0, 10 0 3, 0 0 0)");
+        builder.writeGeom(g);
+        assertEquals("{\"type\":\"LineString\",\"coordinates\":[[0.001,0,0],[0,10.123,1],[10.1,10.2,2],[10,0,3],[0,0,0]]}", writer.toString());
+    }
+    
+    @Test
+    public void testNumberOfDecimalsFor3dPolygon() throws Exception {
+        builder.setNumberOfDecimals(0);
+        Geometry g = new WKTReader().read("POLYGON((0.1 0.2 0.3, 0.1 10.1 1.1, 10.2 10.3 2.4, 9.5 0.4 3, 0.1 0.2 0.3),(1 1 4, 1 2 5, 2 2 6, 2 1 7, 1 1 4))");
         builder.writeGeom(g);
         assertEquals("{\"type\":\"Polygon\",\"coordinates\":[[[0,0,0],[0,10,1],[10,10,2],[10,0,3],[0,0,0]],[[1,1,4],[1,2,5],[2,2,6],[2,1,7],[1,1,4]]]}", writer.toString());
     }

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
@@ -56,6 +56,7 @@ public class GeoJSONTest extends WFSTestSupport {
     public static QName POINT_LATLON = new QName(SystemTestData.CITE_URI, "PointLatLon", SystemTestData.CITE_PREFIX);
     public static QName POINT_LONLAT = new QName(SystemTestData.CITE_URI, "PointLonLat", SystemTestData.CITE_PREFIX);
     public static QName MULTI_GEOMETRIES_WITH_NULL = new QName(SystemTestData.CITE_URI, "MultiGeometriesWithNull", SystemTestData.CITE_PREFIX);
+    public static QName POINT_REDUCED = new QName(SystemTestData.CITE_URI, "PointReduced", SystemTestData.CITE_PREFIX);
     
     @Override
     @SuppressWarnings("unchecked")
@@ -87,6 +88,15 @@ public class GeoJSONTest extends WFSTestSupport {
         
         // A feature with a constant test setup for testing geometry/geometry_name consistency with null geometries
         data.addVectorLayer (MULTI_GEOMETRIES_WITH_NULL, Collections.EMPTY_MAP, getClass(), getCatalog());
+        
+        // A feature type with reduced precision
+        data.addVectorLayer (POINT_REDUCED, Collections.EMPTY_MAP, getClass(), getCatalog());
+        FeatureTypeInfo pointReduced = getCatalog().getFeatureTypeByName(POINT_REDUCED.getPrefix(), POINT_REDUCED.getLocalPart());
+        pointReduced.setNativeCRS(crsLatLon);
+        pointReduced.setSRS("EPSG:4326");
+        pointReduced.setProjectionPolicy(ProjectionPolicy.FORCE_DECLARED);
+        pointReduced.setNumDecimals(2);
+        getCatalog().save(pointReduced);
     }
 	
     @Test
@@ -465,6 +475,30 @@ public class GeoJSONTest extends WFSTestSupport {
         CoordinateReferenceSystem expectedCrs = CRS.decode("EPSG:4326");
         JSONObject aCRS = collection.getJSONObject("crs");
         assertThat(aCRS, encodesCRS(expectedCrs));
+    }
+    
+    @Test
+    public void testGetFeatureWhereLayerHasDecimalPointsSet() throws Exception {
+        JSONObject collection = (JSONObject) getAsJSON("wfs?request=GetFeature&version=1.0.0&typename=" + getLayerId(POINT_REDUCED)
+                + "&outputformat=" + JSONType.json);
+        assertThat(collection.getInt("totalFeatures"), is(3));
+
+        JSONArray features = collection.getJSONArray("features");
+        assertThat((Collection<?>)features, Matchers.hasSize(3));
+        JSONObject feature = features.getJSONObject(0);
+        
+        JSONObject geometry = feature.getJSONObject("geometry");
+        assertThat(geometry.getString("type"), is("Point"));
+        
+        JSONArray coords = geometry.getJSONArray("coordinates");
+        assertThat((Iterable<?>)coords, contains((Object)120.12, 0.56));
+        
+        JSONArray bbox = collection.getJSONArray("bbox");
+        assertThat((Iterable<?>)bbox, Matchers.contains((Object)(-170.19), -30.13, 120.12, 45.23));
+        
+        CoordinateReferenceSystem expectedCrs = CRS.decode("EPSG:4326");
+        JSONObject aCRS = collection.getJSONObject("crs");
+        assertThat(aCRS, encodesCRS(expectedCrs));        
     }
     
     @Test

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/PointReduced.properties
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/PointReduced.properties
@@ -1,0 +1,4 @@
+_=the_geom:Point:srid=4326,Name:String
+PointReduced.0=POINT(120.1234 0.556)| foo
+PointReduced.1=POINT(-170.1919192 45.2323)| bar
+PointReduced.2=POINT(60.128231 -30.13289123)| baz

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/RoundingUtilTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/RoundingUtilTest.java
@@ -1,0 +1,85 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Random;
+
+import org.junit.Test;
+
+/**
+ * 
+ * Test rounding
+ * 
+ * @author Dean Povey
+ *
+ */
+public class RoundingUtilTest {
+
+    @Test
+    public void testSpecialCases() {
+        for (int numDecimals = 0; numDecimals < 17; numDecimals++) {
+            assertThat(Double.isNaN(RoundingUtil.round(Double.NaN, numDecimals)), is(true));
+            assertThat(RoundingUtil.round(Double.NEGATIVE_INFINITY, numDecimals), is(equalTo(Double.NEGATIVE_INFINITY)));
+            assertThat(RoundingUtil.round(Double.POSITIVE_INFINITY, numDecimals), is(equalTo(Double.POSITIVE_INFINITY)));
+        }
+    }
+    
+    @Test
+    public void testSpecificCases() {
+        assertThat(RoundingUtil.round(0d, 0), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(0.1, 0), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(0.1, 1), is(equalTo(0.1)));
+        assertThat(RoundingUtil.round(0.1, 2), is(equalTo(0.1)));
+        assertThat(RoundingUtil.round(0.05, 1), is(equalTo(0.1)));
+        assertThat(RoundingUtil.round(-0.05, 1), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(0.0000001, 5), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(1.0000001, 7), is(equalTo(1.0000001)));
+        assertThat(RoundingUtil.round(1.00000015, 7), is(equalTo(1.0000002)));
+        assertThat(RoundingUtil.round(1E-3, 7), is(equalTo(0.001)));
+        assertThat(RoundingUtil.round(1E-4, 3), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(1E-10, 10), is(equalTo(1E-10)));
+        
+    }
+
+    @Test
+    public void testNoRoundingWhenPrecisionWouldBeExceeded() {
+        // Test cases where precision is exceeded.
+        assertThat(RoundingUtil.round(1.01234567890123456E12, 1), is(equalTo(1.0123456789012E12)));
+        assertThat(RoundingUtil.round(1.01234567890123456E12, 2), is(equalTo(1.01234567890123E12)));
+        assertThat(RoundingUtil.round(1.01234567890123456E13, 1), is(equalTo(1.01234567890123E13)));
+        assertThat(RoundingUtil.round(1.01234567890123456E13, 2), is(equalTo(1.012345678901235E13)));
+        assertThat(RoundingUtil.round(1.01234567890123456E14, 1), is(equalTo(1.012345678901235E14)));
+        assertThat(RoundingUtil.round(1.01234567890123456E14, 2), is(equalTo(1.0123456789012346E14)));
+        assertThat(RoundingUtil.round(1.01234567890123456E15, 1), is(equalTo(1.0123456789012345E15)));
+        assertThat(RoundingUtil.round(1.01234567890123456E15, 2), is(equalTo(1.0123456789012345E15)));
+        assertThat(RoundingUtil.round(1.01234567890123456E16, 1), is(equalTo(1.0123456789012346E16)));
+        assertThat(RoundingUtil.round(1.01234567890123456E16, 2), is(equalTo(1.0123456789012346E16)));
+        assertThat(RoundingUtil.round(1.0123456789012345E17, 1), is(equalTo(1.0123456789012345E17)));
+        assertThat(RoundingUtil.round(1.0123456789012345E18, 1), is(equalTo(1.0123456789012345E18)));
+        assertThat(RoundingUtil.round(1.01234567890123451E19, 1), is(equalTo(1.0123456789012345E19)));
+        assertThat(RoundingUtil.round(Double.MIN_VALUE, 15), is(equalTo(0d)));
+        assertThat(RoundingUtil.round(Double.MAX_VALUE, 1), is(equalTo(Double.MAX_VALUE)));
+    }
+    
+    @Test
+    public void testRandomRoundingVsBigDecimal() {
+        Random r = new Random();
+        for (int i = 0; i < 10000; i++) {
+            double value = r.nextDouble();
+            for (int numDecimals = 0; numDecimals <= 8; numDecimals++) {
+                double expected = new BigDecimal(Double.toString(value)).setScale(numDecimals, RoundingMode.HALF_UP).doubleValue();                
+                double actual = RoundingUtil.round(value, numDecimals);
+                assertThat(actual, is(equalTo(expected)));
+            }
+        }
+    
+    }
+}


### PR DESCRIPTION
This change adds support for limiting the number of decimal places used
for doubles when outputting GeoJSON responses to WFS queries.  Unit tests
are also added for this functionality.