### PR TITLE
Avoid log about non existing memory leak

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/GetMap.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMap.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -120,6 +120,7 @@ public class GetMap {
             map = fireFinished(map);
             return map;
         } catch (Throwable t) {
+            mapContent.dispose();
             fireFailed(t);
             if(t instanceof RuntimeException) {
                 throw (RuntimeException) t;


### PR DESCRIPTION
It avoids a possible memory leak when the GetMap method throws an error.