### PR TITLE
[GEOS-7373] WFS2: fix next/previous URLs when skipNumberMatched is true

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -618,7 +618,6 @@ public class GetFeature {
             // where the client has limited the result set size, so we compute it lazily
             if (isNumberMatchedSkipped) {
                 totalCount = BigInteger.valueOf(-1);
-                totalOffset = 0;
             } else if(count < maxFeatures && calculateSize) {
                  // optimization: if count < max features then total count == count
                  totalCount = BigInteger.valueOf(count);
@@ -767,11 +766,10 @@ public class GetFeature {
             if (count > 0 && offset > -1) {
                 //next
 
-                //calculate the count of the next result set 
-                int nextCount = total.intValue() - (offset + count);
-                if (nextCount > 0) {
+                // don't return a next if we are at the end.
+                // (ie. are returning less results than requested)
+                if (maxFeatures <= count) {
                     kvp.put("startIndex", String.valueOf(offset > 0 ? offset + count : count));
-                    //kvp.put("count", String.valueOf(nextCount));
                     kvp.put("count", String.valueOf(maxFeatures));
                     result.setNext(buildURL(request.getBaseUrl(), "wfs", kvp, URLType.SERVICE));
                 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,6 +6,7 @@
 package org.geoserver.wfs.v2_0;
 
 import static org.junit.Assert.*;
+
 import java.io.ByteArrayInputStream;
 import java.net.URLDecoder;
 import java.util.Arrays;
@@ -311,6 +312,22 @@ public class GetFeaturePagingTest extends WFS20TestSupport {
         doTestNextPreviousGET("cdf:Fifteen");
     }
 
+    @Test
+    public void testNextPreviousSkipNumberMatchedGET() throws Exception {
+        FeatureTypeInfo fti = this.getCatalog().getFeatureTypeByName("Fifteen");
+        fti.setSkipNumberMatched(true);
+        this.getCatalog().save(fti);
+        try {
+            assertEquals(true, fti.getSkipNumberMatched());
+            doTestNextPreviousGET("gs:Fifteen");
+            doTestNextPreviousGET("cdf:Fifteen");
+        }
+        finally {
+            fti.setSkipNumberMatched(false);
+            this.getCatalog().save(fti);
+        }
+    }
+
     public void doTestNextPreviousGET(String typeName) throws Exception {
         Document doc = getAsDOM("/wfs?request=GetFeature&version=2.0.0&service=wfs&" +
                 "typename=" + typeName + "&count=5");
@@ -392,6 +409,7 @@ public class GetFeaturePagingTest extends WFS20TestSupport {
     }
 
     void assertStartIndexCount(Document doc, String att, int startIndex, int count) {
+        assertTrue(doc.getDocumentElement().hasAttribute(att));
         String s = doc.getDocumentElement().getAttribute(att);
         String[] kvp = s.split("\\?")[1].split("&");
         int actualStartIndex = -1;


### PR DESCRIPTION
For paged WFS2.0 requests, fixes missing `next=` & `previous=` URLs in the response when `skipNumberMatched=true`.

[GEOS-7373](https://osgeo-org.atlassian.net/browse/GEOS-7373)