### PR TITLE
Convert Component visitor usage over

### DIFF
--- a/src/community/dyndimension/pom.xml
+++ b/src/community/dyndimension/pom.xml
@@ -25,7 +25,12 @@
       <artifactId>gs-web-core</artifactId>
       <version>${project.version}</version>
     </dependency>    
-          
+    <dependency>
+        <groupId>org.apache.wicket</groupId>
+        <artifactId>wicket</artifactId>
+        <type>pom</type>
+    </dependency>
+
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>

--- a/src/community/dyndimension/src/main/java/org/geoserver/web/data/resource/DynamicDimensionsTabPanel.java
+++ b/src/community/dyndimension/src/main/java/org/geoserver/web/data/resource/DynamicDimensionsTabPanel.java
@@ -29,7 +29,6 @@ import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.markup.repeater.ReuseIfModelsEqualStrategy;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.geoserver.catalog.DimensionInfo;
@@ -273,7 +272,7 @@ public class DynamicDimensionsTabPanel extends PublishedEditTabPanel<LayerInfo> 
 
         @Override
         public void convertInput() {
-            visitChildren(TextArea.class, (Component component, final IVisit<Void> visit) -> {
+            visitChildren(TextArea.class, (component, visit) -> {
                 if (component instanceof TextArea) {
                     TextArea textArea = (TextArea) component;
                     textArea.updateModel();

--- a/src/community/dyndimension/src/main/java/org/geoserver/web/data/resource/DynamicDimensionsTabPanel.java
+++ b/src/community/dyndimension/src/main/java/org/geoserver/web/data/resource/DynamicDimensionsTabPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -29,6 +29,7 @@ import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.markup.repeater.ReuseIfModelsEqualStrategy;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.geoserver.catalog.DimensionInfo;
@@ -272,12 +273,10 @@ public class DynamicDimensionsTabPanel extends PublishedEditTabPanel<LayerInfo> 
 
         @Override
         public void convertInput() {
-            visitChildren(TextArea.class, new org.apache.wicket.Component.IVisitor<TextArea<?>>() {
-
-                @Override
-                public Object component(TextArea<?> component) {
-                    component.updateModel();
-                    return null;
+            visitChildren(TextArea.class, (Component component, final IVisit<Void> visit) -> {
+                if (component instanceof TextArea) {
+                    TextArea textArea = (TextArea) component;
+                    textArea.updateModel();
                 }
             });
             setConvertedInput(new DefaultValueConfigurations(configurations));

--- a/src/community/wms-eo/pom.xml
+++ b/src/community/wms-eo/pom.xml
@@ -30,7 +30,12 @@
       <artifactId>gs-web-core</artifactId>
       <version>${project.version}</version>
     </dependency>    
-          
+    <dependency>
+        <groupId>org.apache.wicket</groupId>
+        <artifactId>wicket</artifactId>
+        <type>pom</type>
+    </dependency>
+
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>

--- a/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupAbstractPage.java
+++ b/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupAbstractPage.java
@@ -5,7 +5,6 @@
  */
 package org.geoserver.wms.eo.web;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -25,7 +24,8 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.util.convert.IConverter;
 import org.apache.wicket.validation.IValidatable;
-import org.apache.wicket.validation.validator.AbstractValidator;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
@@ -501,14 +501,14 @@ public abstract class EoLayerGroupAbstractPage extends GeoServerSecuredPage {
      */
     protected abstract void onSubmit(LayerGroupInfo lg);
     
-    class GroupNameValidator extends AbstractValidator {
+    class GroupNameValidator implements IValidator<String> {
 
         @Override
-        protected void onValidate(IValidatable validatable) {
-            String name = (String) validatable.getValue();
+        public void validate(IValidatable<String> iv) {
+            String name = (String) iv.getValue();
             LayerGroupInfo other = getCatalog().getLayerGroupByName(name);
             if(other != null && (layerGroupId == null || !other.getId().equals(layerGroupId))) {
-                error(validatable, "duplicateGroupNameError", Collections.singletonMap("name", name));
+                iv.error(new ValidationError("duplicateGroupNameError"));
             }
         }
         

--- a/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupAbstractPage.java
+++ b/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupAbstractPage.java
@@ -508,7 +508,7 @@ public abstract class EoLayerGroupAbstractPage extends GeoServerSecuredPage {
             String name = (String) iv.getValue();
             LayerGroupInfo other = getCatalog().getLayerGroupByName(name);
             if(other != null && (layerGroupId == null || !other.getId().equals(layerGroupId))) {
-                iv.error(new ValidationError("duplicateGroupNameError"));
+                iv.error(new ValidationError("duplicateGroupNameError").setVariable("name", name));
             }
         }
         

--- a/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupEditPage.java
+++ b/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupEditPage.java
@@ -10,7 +10,6 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.web.data.layergroup.LayerGroupPage;
 import org.geoserver.web.wicket.ParamResourceModel;
@@ -41,7 +40,7 @@ public class EoLayerGroupEditPage extends EoLayerGroupAbstractPage {
             //global layer groups only editable by full admin
             if (lg.getWorkspace() == null) {
                 //disable all form components but cancel
-                f.visitChildren((Component component, final IVisit<Void> visit) -> {
+                f.visitChildren((component, visit) -> {
                     if (!(component instanceof AbstractLink && "cancel".equals(component.getId()))) {
                         component.setEnabled(false);
                     }

--- a/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupEditPage.java
+++ b/src/community/wms-eo/src/main/java/org/geoserver/wms/eo/web/EoLayerGroupEditPage.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -10,7 +10,7 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.apache.wicket.util.visit.IVisitor;
+import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.web.data.layergroup.LayerGroupPage;
 import org.geoserver.web.wicket.ParamResourceModel;
@@ -41,14 +41,11 @@ public class EoLayerGroupEditPage extends EoLayerGroupAbstractPage {
             //global layer groups only editable by full admin
             if (lg.getWorkspace() == null) {
                 //disable all form components but cancel
-                f.visitChildren(new IVisitor<Component>() {
-                    @Override
-                    public Object component(Component c) {
-                        if (!(c instanceof AbstractLink && "cancel".equals(c.getId()))) {
-                            c.setEnabled(false);
-                        }
-                        return CONTINUE_TRAVERSAL_BUT_DONT_GO_DEEPER;
+                f.visitChildren((Component component, final IVisit<Void> visit) -> {
+                    if (!(component instanceof AbstractLink && "cancel".equals(component.getId()))) {
+                        component.setEnabled(false);
                     }
+                    visit.dontGoDeeper();
                 });
                 f.get("save").setVisible(false);
                 

--- a/src/extension/importer/web/pom.xml
+++ b/src/extension/importer/web/pom.xml
@@ -48,6 +48,11 @@
       <classifier>tests</classifier>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+        <groupId>org.apache.wicket</groupId>
+        <artifactId>wicket</artifactId>
+        <type>pom</type>
+    </dependency>
   </dependencies>
   
 </project>

--- a/src/extension/importer/web/src/main/java/org/geoserver/importer/web/NewWorkspacePanel.java
+++ b/src/extension/importer/web/src/main/java/org/geoserver/importer/web/NewWorkspacePanel.java
@@ -42,7 +42,8 @@ class NewWorkspacePanel extends Panel {
         public void validate(IValidatable<String> iv) {
             String value = iv.getValue();
             if (GeoServerApplication.get().getCatalog().getWorkspaceByName(value) != null) {
-                iv.error(new ValidationError("NewWorkspacePanel.duplicateWorkspace"));
+                iv.error(new ValidationError("NewWorkspacePanel.duplicateWorkspace")
+                .setVariable("workspace", value));
             }
         }
     }

--- a/src/extension/importer/web/src/main/java/org/geoserver/importer/web/NewWorkspacePanel.java
+++ b/src/extension/importer/web/src/main/java/org/geoserver/importer/web/NewWorkspacePanel.java
@@ -1,18 +1,18 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014, 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.importer.web;
 
-import java.util.Collections;
 
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.validation.IValidatable;
-import org.apache.wicket.validation.validator.AbstractValidator;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.XMLNameValidator;
 
@@ -29,21 +29,22 @@ class NewWorkspacePanel extends Panel {
         TextField wst = new TextField("workspace", new PropertyModel(this, "workspace"));
         wst.setRequired(true);
 
-        wst.add(new AbstractValidator() {
+        wst.add(new WorkspaceDoesNotExistValidator());
 
-            @Override
-            protected void onValidate(IValidatable validatable) {
-                String value = (String) validatable.getValue();
-                if (GeoServerApplication.get().getCatalog().getWorkspaceByName(value) != null) {
-                    error(validatable, "NewWorkspacePanel.duplicateWorkspace", Collections
-                            .singletonMap("workspace", value));
-                }
-
-            }
-        });
         wst.add(new XMLNameValidator());
 
         this.add(wst);
+    }
+
+    static class WorkspaceDoesNotExistValidator implements IValidator<String> {
+
+        @Override
+        public void validate(IValidatable<String> iv) {
+            String value = iv.getValue();
+            if (GeoServerApplication.get().getCatalog().getWorkspaceByName(value) != null) {
+                iv.error(new ValidationError("NewWorkspacePanel.duplicateWorkspace"));
+            }
+        }
     }
 
 }

--- a/src/extension/netcdf-out/pom.xml
+++ b/src/extension/netcdf-out/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- 
- Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ Copyright (C) 2014 - 2016 - Open Source Geospatial Foundation. All rights reserved.
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->
@@ -132,6 +132,11 @@
         <artifactId>jcl-over-slf4j</artifactId>
       </exclusion>
     </exclusions>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.wicket</groupId>
+    <artifactId>wicket</artifactId>
+    <type>pom</type>
   </dependency>
   <dependency>
    <groupId>com.mockrunner</groupId>

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFPanel.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFPanel.java
@@ -25,9 +25,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.util.visit.IVisit;
-import org.apache.wicket.validation.IValidatable;
-import org.apache.wicket.validation.ValidationError;
-import org.apache.wicket.validation.validator.AbstractValidator;
+import org.apache.wicket.validation.validator.RangeValidator;
 import org.geoserver.web.GeoServerBasePage;
 import org.geoserver.web.netcdf.NetCDFSettingsContainer.GlobalAttribute;
 import org.geoserver.web.wicket.GeoServerAjaxFormLink;
@@ -78,31 +76,7 @@ public class NetCDFPanel<T extends NetCDFSettingsContainer> extends FormComponen
         dataPacking.setOutputMarkupId(true);
         container.add(dataPacking);        
 
-        compressionLevel.add(new AbstractValidator<Integer>() {
-
-            @Override
-            public boolean validateOnNullValue() {
-                return true;
-            }
-
-            @Override
-            protected void onValidate(IValidatable<Integer> validatable) {
-                if (validatable != null && validatable.getValue() != null) {
-                    Integer value = validatable.getValue();
-                    if (value < 0) {
-                        ValidationError error = new ValidationError();
-                        error.setMessage(new ParamResourceModel(
-                                "NetCDFOutSettingsPanel.lowCompression", null, "").getObject());
-                        validatable.error(error);
-                    } else if (value > 9) {
-                        ValidationError error = new ValidationError();
-                        error.setMessage(new ParamResourceModel(
-                                "NetCDFOutSettingsPanel.highCompression", null, "").getObject());
-                        validatable.error(error);
-                    }
-                }
-            }
-        });
+        compressionLevel.add(new RangeValidator(0, 9));
         container.add(compressionLevel);
 
         IModel<List<GlobalAttribute>> attributeModel = new PropertyModel(netcdfModel,

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFPanel.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFPanel.java
@@ -168,7 +168,7 @@ public class NetCDFPanel<T extends NetCDFSettingsContainer> extends FormComponen
 
     @Override
     public void convertInput() {
-        globalAttributes.visitChildren((Component component, final IVisit<Void> visit) -> {
+        globalAttributes.visitChildren((component, visit) -> {
             if (component instanceof FormComponent) {
                 FormComponent<?> formComponent = (FormComponent<?>) component;
                 formComponent.processInput();

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFPanel.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2015-2016 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -24,6 +24,7 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.ValidationError;
 import org.apache.wicket.validation.validator.AbstractValidator;
@@ -192,16 +193,11 @@ public class NetCDFPanel<T extends NetCDFSettingsContainer> extends FormComponen
     }
 
     @Override
-    protected void convertInput() {
-        globalAttributes.visitChildren(new Component.IVisitor<Component>() {
-
-            @Override
-            public Object component(Component component) {
-                if (component instanceof FormComponent) {
-                    FormComponent<?> formComponent = (FormComponent<?>) component;
-                    formComponent.processInput();
-                }
-                return Component.IVisitor.CONTINUE_TRAVERSAL;
+    public void convertInput() {
+        globalAttributes.visitChildren((Component component, final IVisit<Void> visit) -> {
+            if (component instanceof FormComponent) {
+                FormComponent<?> formComponent = (FormComponent<?>) component;
+                formComponent.processInput();
             }
         });
         compressionLevel.processInput();

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/layer/NetCDFOutSettingsEditor.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/layer/NetCDFOutSettingsEditor.java
@@ -1,4 +1,4 @@
-/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2015-2016 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -28,6 +28,7 @@ import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.util.string.Strings;
+import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.platform.GeoServerExtensions;
@@ -149,16 +150,11 @@ public class NetCDFOutSettingsEditor extends NetCDFPanel<NetCDFLayerSettingsCont
     }
 
     @Override
-    protected void convertInput() {
-        globalAttributes.visitChildren(new Component.IVisitor<Component>() {
-
-            @Override
-            public Object component(Component component) {
-                if (component instanceof FormComponent) {
-                    FormComponent<?> formComponent = (FormComponent<?>) component;
-                    formComponent.processInput();
-                }
-                return Component.IVisitor.CONTINUE_TRAVERSAL;
+    public void convertInput() {
+        globalAttributes.visitChildren((Component component, final IVisit<Void> visit) -> {
+            if (component instanceof FormComponent) {
+                FormComponent<?> formComponent = (FormComponent<?>) component;
+                formComponent.processInput();
             }
         });
         compressionLevel.processInput();

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/layer/NetCDFOutSettingsEditor.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/layer/NetCDFOutSettingsEditor.java
@@ -151,7 +151,7 @@ public class NetCDFOutSettingsEditor extends NetCDFPanel<NetCDFLayerSettingsCont
 
     @Override
     public void convertInput() {
-        globalAttributes.visitChildren((Component component, final IVisit<Void> visit) -> {
+        globalAttributes.visitChildren((component, visit) -> {
             if (component instanceof FormComponent) {
                 FormComponent<?> formComponent = (FormComponent<?>) component;
                 formComponent.processInput();

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/RangePanel.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/RangePanel.java
@@ -1,4 +1,4 @@
-/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2015-2016 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -12,6 +12,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.web.wicket.DecimalTextField;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.NumberRange;
@@ -71,23 +72,16 @@ public class RangePanel extends FormComponentPanel<NumberRange> {
     }
 
     public RangePanel setReadOnly(final boolean readOnly) {
-        visitChildren(TextField.class, new org.apache.wicket.Component.IVisitor() {
-            public Object component(Component component) {
-                component.setEnabled(!readOnly);
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            component.setEnabled(!readOnly);
         });
         return this;
     }
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, new org.apache.wicket.Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).processInput();
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).processInput();
         });
 
         // update the envelope model
@@ -103,12 +97,8 @@ public class RangePanel extends FormComponentPanel<NumberRange> {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, new Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).clearInput();
-                return CONTINUE_TRAVERSAL;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).clearInput();
         });
     }
 

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/RangePanel.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/RangePanel.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.wps.web;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.TextField;
@@ -12,7 +11,6 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.web.wicket.DecimalTextField;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.NumberRange;
@@ -72,7 +70,7 @@ public class RangePanel extends FormComponentPanel<NumberRange> {
     }
 
     public RangePanel setReadOnly(final boolean readOnly) {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             component.setEnabled(!readOnly);
         });
         return this;
@@ -80,7 +78,7 @@ public class RangePanel extends FormComponentPanel<NumberRange> {
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).processInput();
         });
 
@@ -97,7 +95,7 @@ public class RangePanel extends FormComponentPanel<NumberRange> {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).clearInput();
         });
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
@@ -550,7 +550,7 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
     }
 
     /**
-     * Checks the sql view name is unique
+     * Checks the SQL view name is unique
      */
     class ViewNameValidator implements IValidator<String> {
 
@@ -565,7 +565,9 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
                 if(currvt != null) {
                     if(typeInfoId == null || !typeInfoId.equals(curr.getId())) {
                         if(currvt.getName().equals(vtName)) {
-                            IValidationError err = new ValidationError("duplicateSqlViewName:" + vtName);
+                            IValidationError err = new ValidationError("duplicateSqlViewName")
+                                    .setVariable("name", vtName)
+                                    .setVariable("typeName", curr.getName());
                             validatable.error(err);
                             return;
                         }

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -11,9 +11,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
@@ -531,35 +529,34 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
     }
     
     /**
-     * Validaes the regular expression syntax
+     * Validates the regular expression syntax
      */
-    static class RegexpValidator extends AbstractValidator {
+    static class RegexpValidator implements IValidator<String> {
 
         @Override
-        protected void onValidate(IValidatable validatable) {
-            String value = (String) validatable.getValue();
+        public void validate(IValidatable<String> iv) {
+            String value = iv.getValue();
             if(value != null) {
                 try {
                     Pattern.compile(value);
                 } catch(PatternSyntaxException e) {
-                    Map<String, String> map = new HashMap<String, String>();
-                    map.put("regexp", value);
-                    map.put("error", e.getMessage().replaceAll("\\^?", ""));
-                    error(validatable, "invalidRegexp", map);
+                    ValidationError error = new ValidationError(this);
+                    error.setVariable("regexp", value);
+                    error.setVariable("error", e.getMessage().replaceAll("\\^?", ""));
+                    iv.error(error);
                 }
             }
         }
-        
     }
 
     /**
      * Checks the sql view name is unique
      */
-    class ViewNameValidator implements IValidator {
+    class ViewNameValidator implements IValidator<String> {
 
         @Override
-        public void validate(IValidatable validatable) {
-            String vtName = (String) validatable.getValue();
+        public void validate(IValidatable<String> validatable) {
+            String vtName = validatable.getValue();
             
             final DataStoreInfo store = getCatalog().getStore(storeId, DataStoreInfo.class);
             List<FeatureTypeInfo> ftis = getCatalog().getResourcesByStore(store, FeatureTypeInfo.class);
@@ -568,9 +565,6 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
                 if(currvt != null) {
                     if(typeInfoId == null || !typeInfoId.equals(curr.getId())) {
                         if(currvt.getName().equals(vtName)) {
-                            Map<String, String> map = new HashMap<String, String>();
-                            map.put("name", vtName);
-                            map.put("typeName", curr.getName());
                             IValidationError err = new ValidationError("duplicateSqlViewName:" + vtName);
                             validatable.error(err);
                             return;

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/PeriodEditor.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/PeriodEditor.java
@@ -7,12 +7,10 @@ package org.geoserver.web.data.resource;
 
 import java.math.BigDecimal;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.validator.RangeValidator;
 
 /**
@@ -106,7 +104,7 @@ public class PeriodEditor extends FormComponentPanel<BigDecimal> {
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).processInput();
         });
 
@@ -120,7 +118,7 @@ public class PeriodEditor extends FormComponentPanel<BigDecimal> {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).clearInput();
         });
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/PeriodEditor.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/PeriodEditor.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -12,11 +12,12 @@ import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.validator.RangeValidator;
 
 /**
- * Helps edit a time period 
- * 
+ * Helps edit a time period
+ *
  * @author Andrea Aime - GeoSolutions
  */
 @SuppressWarnings("serial")
@@ -105,12 +106,8 @@ public class PeriodEditor extends FormComponentPanel<BigDecimal> {
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, new org.apache.wicket.Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).processInput();
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).processInput();
         });
 
         long time = seconds * secondMS + minutes * minuteMS + hours * hourMS + days * dayMS + weeks
@@ -123,12 +120,8 @@ public class PeriodEditor extends FormComponentPanel<BigDecimal> {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, new Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).clearInput();
-                return CONTINUE_TRAVERSAL;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).clearInput();
         });
     }
 

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
@@ -19,7 +19,6 @@ import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -183,7 +182,7 @@ public class ResourceConfigurationPage extends PublishedConfigurationPage<LayerI
      */
     public void updateResource(ResourceInfo info, final AjaxRequestTarget target) {
         myResourceModel.setObject(info);
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             if (component instanceof ResourceConfigurationPanel) {
                 ResourceConfigurationPanel rcp = (ResourceConfigurationPanel) component;
                 rcp.resourceUpdated(target);

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceConfigurationPage.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -12,13 +12,14 @@ import java.util.List;
 import org.apache.wicket.Component;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.apache.wicket.util.visit.IVisitor;
+import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -51,13 +52,13 @@ import org.geoserver.web.data.layer.LayerPage;
 public class ResourceConfigurationPage extends PublishedConfigurationPage<LayerInfo> {
 
     private static final long serialVersionUID = 7870938096047218989L;
-    
+
     IModel<ResourceInfo> myResourceModel;
 
     public ResourceConfigurationPage(PageParameters parameters) {
         this(parameters.get(WORKSPACE).toOptionalString(), parameters.get(NAME).toString());
     }
-    
+
     public ResourceConfigurationPage(String workspaceName, String layerName) {
         super(false);
         this.returnPageClass = LayerPage.class;
@@ -98,7 +99,7 @@ public class ResourceConfigurationPage extends PublishedConfigurationPage<LayerI
         this.returnPageClass = LayerPage.class;
         setupResource(isNew ? info.getResource() : getCatalog().getResource(info.getResource().getId(), ResourceInfo.class));
     }
-    
+
     private void setupResource(ResourceInfo resource) {
         getPublishedInfo().setResource(resource);
         myResourceModel = new CompoundPropertyModel<ResourceInfo>(new ResourceModel(resource));
@@ -150,13 +151,13 @@ public class ResourceConfigurationPage extends PublishedConfigurationPage<LayerI
             };
             return dataPanelList;
         }
-        
+
     }
 
 
     /**
      * Returns the {@link ResourceInfo} contained in this page
-     * 
+     *
      * @return
      */
     public ResourceInfo getResourceInfo() {
@@ -166,7 +167,7 @@ public class ResourceConfigurationPage extends PublishedConfigurationPage<LayerI
 
     /**
      * Allows collaborating pages to update the resource info object
-     * 
+     *
      * @param info
      * @param target
      */
@@ -176,25 +177,19 @@ public class ResourceConfigurationPage extends PublishedConfigurationPage<LayerI
 
     /**
      * Allows collaborating pages to update the resource info object
-     * 
-     * @param info
+     *
+     * @param info the resource info to update
      * @param target
      */
     public void updateResource(ResourceInfo info, final AjaxRequestTarget target) {
         myResourceModel.setObject(info);
-        visitChildren(new IVisitor<Component>() {
-
-            @Override
-            public Object component(Component component) {
-                if (component instanceof ResourceConfigurationPanel) {
-                    ResourceConfigurationPanel rcp = (ResourceConfigurationPanel) component;
-                    rcp.resourceUpdated(target);
-                    return IVisitor.CONTINUE_TRAVERSAL_BUT_DONT_GO_DEEPER;
-                }
-                return IVisitor.CONTINUE_TRAVERSAL;
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            if (component instanceof ResourceConfigurationPanel) {
+                ResourceConfigurationPanel rcp = (ResourceConfigurationPanel) component;
+                rcp.resourceUpdated(target);
+                visit.dontGoDeeper();
             }
         });
-
     }
 
     @Override
@@ -239,7 +234,7 @@ public class ResourceConfigurationPage extends PublishedConfigurationPage<LayerI
         } else {
             ResourceInfo oldState = catalog.getResource(resourceInfo.getId(),
                     ResourceInfo.class);
-            
+
             catalog.validate(resourceInfo, true).throwIfInvalid();
             catalog.save(resourceInfo);
             try {

--- a/src/web/core/src/main/java/org/geoserver/web/publish/PublishedEditTabPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/publish/PublishedEditTabPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -10,6 +10,7 @@ import java.io.IOException;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.web.data.resource.ResourceConfigurationPage;
@@ -17,14 +18,14 @@ import org.geoserver.web.data.resource.ResourceConfigurationPage;
 /**
  * Extension point for panels which appear in separate tabs on the layer edit page.
  * <p>
- * Subclasses <b>must</b> override the {@link #LayerEditTabPanel(String, IModel)} constructor 
- * and <b>not</b> change its signature. 
+ * Subclasses <b>must</b> override the {@link #LayerEditTabPanel(String, IModel)} constructor
+ * and <b>not</b> change its signature.
  * </p>
  * <p>
  * Instances of this class are described in a spring context with a {@link PublishedEditTabPanelInfo}
- * bean. 
+ * bean.
  * </p>
- * 
+ *
  * @author Justin Deoliveira, OpenGeo
  * @author Niels Charlier
  *
@@ -32,7 +33,7 @@ import org.geoserver.web.data.resource.ResourceConfigurationPage;
 public class PublishedEditTabPanel<T extends PublishedInfo> extends Panel {
 
     private static final long serialVersionUID = 8044055895040826418L;
-    
+
     /**
      * @param id The id given to the panel.
      * @param model The model for the panel which wraps a {@link LayerInfo} instance.
@@ -40,7 +41,7 @@ public class PublishedEditTabPanel<T extends PublishedInfo> extends Panel {
     public PublishedEditTabPanel(String id, IModel<? extends T> model) {
         super(id, model);
     }
-    
+
     /**
      * Returns the layer currently being edited by the panel.
      */
@@ -56,15 +57,11 @@ public class PublishedEditTabPanel<T extends PublishedInfo> extends Panel {
     public void save() throws IOException {
         //do nothing by default
     }
-    
-    
+
+
     public PublishedEditTabPanel<T> setInputEnabled(final boolean enabled) {
-        visitChildren(new IVisitor<Component>() {
-            @Override
-            public Object component(Component c) {
-                c.setEnabled(enabled);
-                return CONTINUE_TRAVERSAL;
-            }
+        visitChildren((Component component, final IVisit<Void> visit) -> {
+            component.setEnabled(enabled);
         });
         return this;
     }

--- a/src/web/core/src/main/java/org/geoserver/web/publish/PublishedEditTabPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/publish/PublishedEditTabPanel.java
@@ -7,10 +7,8 @@ package org.geoserver.web.publish;
 
 import java.io.IOException;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.web.data.resource.ResourceConfigurationPage;
@@ -60,7 +58,7 @@ public class PublishedEditTabPanel<T extends PublishedInfo> extends Panel {
 
 
     public PublishedEditTabPanel<T> setInputEnabled(final boolean enabled) {
-        visitChildren((Component component, final IVisit<Void> visit) -> {
+        visitChildren((component, visit) -> {
             component.setEnabled(enabled);
         });
         return this;

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -19,10 +19,11 @@ import org.geotools.geometry.jts.ReferencedEnvelope3D;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
+import org.apache.wicket.util.visit.IVisit;
 
 /**
  * A form component for a {@link Envelope} object.
- * 
+ *
  * @author Justin Deoliveira, OpenGeo
  * @author Andrea Aime, OpenGeo
  */
@@ -38,48 +39,48 @@ public class EnvelopePanel extends FormComponentPanel {
     protected WebMarkupContainer crsContainer;
     protected  CRSPanel crsPanel;
     protected boolean crsRequired;
-    
+
     public EnvelopePanel(String id ) {
         super(id);
-        
+
         initComponents();
     }
-    
+
     public EnvelopePanel(String id, ReferencedEnvelope e) {
         this(id, new Model(e));
     }
-    
+
     public EnvelopePanel(String id, IModel model) {
         super(id, model);
-        
+
         initComponents();
     }
-    
+
     public void setCRSFieldVisible(boolean visible) {
         crsContainer.setVisible(visible);
     }
-    
+
     public boolean isCRSFieldVisible() {
         return crsContainer.isVisible();
     }
-    
+
     public boolean isCrsRequired() {
         return crsRequired;
     }
 
     /**
-     * Makes the CRS bounds a required component of the envelope. 
+     * Makes the CRS bounds a required component of the envelope.
      * It is warmly suggested that the crs field be made visible too
      * @param crsRequired
      */
     public void setCrsRequired(boolean crsRequired) {
         this.crsRequired = crsRequired;
     }
-    
+
     public boolean is3D(){
     	return crs != null && crs.getCoordinateSystem().getDimension() >= 3;
     }
-    
+
     public void setLabelsVisibility(boolean visible) {
         minXLabel.setVisible(visible);
         minYLabel.setVisible(visible);
@@ -91,7 +92,7 @@ public class EnvelopePanel extends FormComponentPanel {
 
     void initComponents() {
         updateFields();
-        
+
         add(minXLabel = new Label("minXL", new ResourceModel("minX")));
         add(minYLabel = new Label("minYL", new ResourceModel("minY")));
         add(minZLabel = new Label("minZL", new ResourceModel("minZ")));
@@ -99,32 +100,32 @@ public class EnvelopePanel extends FormComponentPanel {
         add(maxYLabel = new Label("maxYL", new ResourceModel("maxY")));
         add(maxZLabel = new Label("maxZL", new ResourceModel("maxZ")));
 
-        
+
         add( minXInput = new DecimalTextField( "minX", new PropertyModel(this, "minX")) );
         add( minYInput = new DecimalTextField( "minY", new PropertyModel(this, "minY")) );
         add( minZInput = new DecimalTextField( "minZ", new PropertyModel(this, "minZ")) );
         add( maxXInput = new DecimalTextField( "maxX", new PropertyModel(this, "maxX") ));
         add( maxYInput = new DecimalTextField( "maxY", new PropertyModel(this, "maxY")) );
         add( maxZInput = new DecimalTextField( "maxZ", new PropertyModel(this, "maxZ")) );
-        
+
         minZInput.setVisible(is3D());
         minZLabel.setVisible(is3D());
         maxZInput.setVisible(is3D());
         maxZLabel.setVisible(is3D());
-        
+
         crsContainer = new WebMarkupContainer("crsContainer");
         crsContainer.setVisible(false);
         crsPanel = new CRSPanel("crs", new PropertyModel(this, "crs"));
         crsContainer.add(crsPanel);
         add(crsContainer);
     }
-    
+
     @Override
     protected void onBeforeRender() {
         updateFields();
         super.onBeforeRender();
     }
-    
+
     private void updateFields() {
         ReferencedEnvelope e = (ReferencedEnvelope) getModelObject();
         if(e != null) {
@@ -149,32 +150,26 @@ public class EnvelopePanel extends FormComponentPanel {
             }
         }
     }
-   
+
     public EnvelopePanel setReadOnly( final boolean readOnly ) {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-            public Object component(Component component) {
-                component.setEnabled( !readOnly );
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            component.setEnabled(!readOnly);
         });
         crsPanel.setReadOnly(readOnly);
 
         return this;
     }
-    
+
     @Override
     public void convertInput() {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).processInput();
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).processInput();
         });
+
         if(isCRSFieldVisible()) {
             crsPanel.processInput();
         }
-        
+
         // update the envelope model
         if(minX != null && maxX != null && minY != null && maxY != null) {
             if(crsRequired && crs == null) {
@@ -193,21 +188,17 @@ public class EnvelopePanel extends FormComponentPanel {
             setConvertedInput(null);
         }
     }
-    
+
     @Override
     protected void onModelChanged() {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, new Component.IVisitor() {
-            
-            public Object component(Component component) {
-                ((TextField) component).clearInput();
-                return CONTINUE_TRAVERSAL;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).clearInput();
         });
     }
-    
+
     /**
      * Returns the coordinate reference system added by the user in the GUI, if any and valid
      * @return
@@ -215,5 +206,5 @@ public class EnvelopePanel extends FormComponentPanel {
     public CoordinateReferenceSystem getCoordinateReferenceSystem() {
         return crs;
     }
-    
+
 }

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/EnvelopePanel.java
@@ -5,7 +5,6 @@
  */
 package org.geoserver.web.wicket;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
@@ -19,7 +18,6 @@ import org.geotools.geometry.jts.ReferencedEnvelope3D;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
-import org.apache.wicket.util.visit.IVisit;
 
 /**
  * A form component for a {@link Envelope} object.
@@ -152,7 +150,7 @@ public class EnvelopePanel extends FormComponentPanel {
     }
 
     public EnvelopePanel setReadOnly( final boolean readOnly ) {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             component.setEnabled(!readOnly);
         });
         crsPanel.setReadOnly(readOnly);
@@ -162,7 +160,7 @@ public class EnvelopePanel extends FormComponentPanel {
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).processInput();
         });
 
@@ -194,7 +192,7 @@ public class EnvelopePanel extends FormComponentPanel {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).clearInput();
         });
     }

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerDialog.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerDialog.java
@@ -23,7 +23,6 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
-import org.apache.wicket.util.visit.IVisit;
 
 /**
  * An abstract OK/cancel dialog, subclasses will have to provide the actual contents and behavior
@@ -277,7 +276,7 @@ public class GeoServerDialog extends Panel {
          * @param form
          */
         public void onError(final AjaxRequestTarget target, Form form) {
-            form.getPage().visitChildren(IFeedback.class, (Component component, final IVisit<Void> visit) -> {
+            form.getPage().visitChildren(IFeedback.class, (component, visit) -> {
                 if (component.getOutputMarkupId()) {
                     target.add(component);
                 }

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerDialog.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerDialog.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -23,6 +23,7 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.util.visit.IVisit;
 
 /**
  * An abstract OK/cancel dialog, subclasses will have to provide the actual contents and behavior
@@ -42,7 +43,7 @@ public class GeoServerDialog extends Panel {
 
     /**
      * Sets the window title
-     * 
+     *
      * @param title
      */
     public void setTitle(IModel title) {
@@ -100,7 +101,7 @@ public class GeoServerDialog extends Panel {
     /**
      * Shows an OK/cancel dialog. The delegate will provide contents and behavior for the OK button
      * (and if needed, for the cancel one as well)
-     * 
+     *
      * @param target
      * @param delegate
      */
@@ -134,12 +135,12 @@ public class GeoServerDialog extends Panel {
 
     /**
      * Shows an information style dialog box.
-     * 
+     *
      * @param heading The heading of the information topic.
-     * @param messages A list of models, displayed each as a separate paragraphs, containing the 
+     * @param messages A list of models, displayed each as a separate paragraphs, containing the
      *   information dialog content.
      */
-    public void showInfo(AjaxRequestTarget target, final IModel<String> heading, 
+    public void showInfo(AjaxRequestTarget target, final IModel<String> heading,
             final IModel<String>... messages) {
         window.setPageCreator(new ModalWindow.PageCreator() {
             public Page createPage() {
@@ -177,7 +178,7 @@ public class GeoServerDialog extends Panel {
 
     /**
      * Submit link that will forward to the {@link DialogDelegate}
-     * 
+     *
      * @return
      */
     AjaxSubmitLink sumbitLink(Component contents) {
@@ -187,7 +188,7 @@ public class GeoServerDialog extends Panel {
             protected void onSubmit(AjaxRequestTarget target, Form form) {
                 submit(target, (Component) this.getDefaultModelObject());
             }
-            
+
             @Override
             protected void onError(AjaxRequestTarget target, Form form) {
                 delegate.onError(target, form);
@@ -200,7 +201,7 @@ public class GeoServerDialog extends Panel {
 
     /**
      * Link that will forward to the {@link DialogDelegate}
-     * 
+     *
      * @return
      */
     Component cancelLink() {
@@ -262,7 +263,7 @@ public class GeoServerDialog extends Panel {
 
         /**
          * Builds the contents for this dialog
-         * 
+         *
          * @param id
          * @return
          */
@@ -271,27 +272,22 @@ public class GeoServerDialog extends Panel {
         /**
          * Called when the form inside the dialog breaks. By default adds all feedback
          * panels to the target
-         * to the 
+         *
          * @param target
          * @param form
          */
         public void onError(final AjaxRequestTarget target, Form form) {
-            form.getPage().visitChildren(IFeedback.class, new IVisitor()
-            {
-                public Object component(Component component)
-                {
-                    if(component.getOutputMarkupId())
-                        target.add(component);
-                    return IVisitor.CONTINUE_TRAVERSAL;
+            form.getPage().visitChildren(IFeedback.class, (Component component, final IVisit<Void> visit) -> {
+                if (component.getOutputMarkupId()) {
+                    target.add(component);
                 }
-
             });
         }
 
         /**
          * Called when the dialog is closed, allows the delegate to perform ajax updates on the page
          * underlying the dialog
-         * 
+         *
          * @param target
          */
         public void onClose(AjaxRequestTarget target) {
@@ -300,15 +296,15 @@ public class GeoServerDialog extends Panel {
 
         /**
          * Called when the dialog is submitted
-         * 
+         *
          * @param target
          * @return true if the dialog is to be closed, false otherwise
          */
         protected abstract boolean onSubmit(AjaxRequestTarget target, Component contents);
 
         /**
-         * Called when the dialog is canceled.
-         * 
+         * Called when the dialog is cancelled.
+         *
          * @param target
          * @return true if the dialog is to be closed, false otherwise
          */

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerTablePanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerTablePanel.java
@@ -514,7 +514,7 @@ public abstract class GeoServerTablePanel<T> extends Panel {
     }
     
     public void processInputs() {
-        this.visitChildren(FormComponent.class, (Component component, final IVisit<Void> visit) -> {
+        this.visitChildren(FormComponent.class, (component, visit) -> {
             ((FormComponent) component).processInput();
             visit.dontGoDeeper();
         });

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerTablePanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerTablePanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -514,12 +514,9 @@ public abstract class GeoServerTablePanel<T> extends Panel {
     }
     
     public void processInputs() {
-        this.visitChildren(FormComponent.class, new IVisitor() {
-            
-            public Object component(Component component) {
-                ((FormComponent) component).processInput();
-                return IVisitor.CONTINUE_TRAVERSAL_BUT_DONT_GO_DEEPER;
-            }
+        this.visitChildren(FormComponent.class, (Component component, final IVisit<Void> visit) -> {
+            ((FormComponent) component).processInput();
+            visit.dontGoDeeper();
         });
     }
 

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/PointPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/PointPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -17,10 +17,11 @@ import org.apache.wicket.model.ResourceModel;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
+import org.apache.wicket.util.visit.IVisit;
 
 /**
  * A form component for a {@link Point} object.
- * 
+ *
  * @author Justin Deoliveira, OpenGeo
  * @author Andrea Aime, GeoSolutions
  */
@@ -34,23 +35,23 @@ public class PointPanel extends FormComponentPanel<Point> {
     protected Double x, y;
 
     protected DecimalTextField xInput, yInput;
-    
+
     public PointPanel(String id ) {
         super(id, new Model<Point>(null));
-        
+
         initComponents();
     }
-    
+
     public PointPanel(String id, Point p) {
         this(id, new Model(p));
     }
-    
+
     public PointPanel(String id, IModel<Point> model) {
         super(id, model);
-        
+
         initComponents();
     }
-    
+
     public void setLabelsVisibility(boolean visible) {
         xLabel.setVisible(visible);
         yLabel.setVisible(visible);
@@ -58,20 +59,20 @@ public class PointPanel extends FormComponentPanel<Point> {
 
     void initComponents() {
         updateFields();
-        
+
         add(xLabel = new Label("xL", new ResourceModel("x")));
         add(yLabel = new Label("yL", new ResourceModel("y")));
 
         add( xInput = new DecimalTextField( "x", new PropertyModel(this, "x")) );
         add( yInput = new DecimalTextField( "y", new PropertyModel(this, "y")) );
     }
-    
+
     @Override
     protected void onBeforeRender() {
         updateFields();
         super.onBeforeRender();
     }
-    
+
     private void updateFields() {
         Point p = (Point) getModelObject();
         if(p != null) {
@@ -79,28 +80,21 @@ public class PointPanel extends FormComponentPanel<Point> {
             this.y = p.getY();
         }
     }
-   
+
     public PointPanel setReadOnly( final boolean readOnly ) {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-            public Object component(Component component) {
-                component.setEnabled( !readOnly );
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            component.setEnabled(!readOnly);
         });
 
         return this;
     }
-    
+
     @Override
     public void convertInput() {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).processInput();
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).processInput();
         });
-        
+
         // update the point model
         if(x != null && y != null) {
             setConvertedInput(gf.createPoint(new Coordinate(x, y)));
@@ -108,29 +102,25 @@ public class PointPanel extends FormComponentPanel<Point> {
             setConvertedInput(null);
         }
     }
-    
+
     @Override
     protected void onModelChanged() {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, new Component.IVisitor() {
-            
-            public Object component(Component component) {
-                ((TextField) component).clearInput();
-                return CONTINUE_TRAVERSAL;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).clearInput();
         });
     }
-    
+
     /**
-     * Sets the max number of digits for the 
+     * Sets the max number of digits for the
      * @param maximumFractionDigits
      */
     public void setMaximumFractionDigits(int maximumFractionDigits) {
         xInput.setMaximumFractionDigits(maximumFractionDigits);
         yInput.setMaximumFractionDigits(maximumFractionDigits);
     }
-    
-    
+
+
 }

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/PointPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/PointPanel.java
@@ -5,7 +5,6 @@
  */
 package org.geoserver.web.wicket;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.TextField;
@@ -17,7 +16,6 @@ import org.apache.wicket.model.ResourceModel;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Point;
-import org.apache.wicket.util.visit.IVisit;
 
 /**
  * A form component for a {@link Point} object.
@@ -82,7 +80,7 @@ public class PointPanel extends FormComponentPanel<Point> {
     }
 
     public PointPanel setReadOnly( final boolean readOnly ) {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             component.setEnabled(!readOnly);
         });
 
@@ -91,7 +89,7 @@ public class PointPanel extends FormComponentPanel<Point> {
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).processInput();
         });
 
@@ -108,7 +106,7 @@ public class PointPanel extends FormComponentPanel<Point> {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).clearInput();
         });
     }

--- a/src/web/gwc/pom.xml
+++ b/src/web/gwc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- 
- Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ Copyright (C) 2014 - 2016 - Open Source Geospatial Foundation. All rights reserved.
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->
@@ -35,6 +35,11 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.wicket</groupId>
+        <artifactId>wicket</artifactId>
+        <type>pom</type>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/InMemoryBlobStorePanel.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/InMemoryBlobStorePanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -28,7 +28,6 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
-import org.apache.wicket.validation.validator.AbstractValidator;
 import org.geoserver.gwc.ConfigurableBlobStore;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.platform.GeoServerExtensions;
@@ -41,7 +40,7 @@ import org.geowebcache.storage.blobstore.memory.CacheStatistics;
 
 /**
  * This class is a new Panel for configuring In Memory Caching for GWC. The user can enable/disable In Memory caching, enable/disable file
- * persistence. Also fromt this panel the user can have information about cache statistics and also change the cache configuration.
+ * persistence. Also from this panel the user can have information about cache statistics and also change the cache configuration.
  * 
  * @author Nicola Lagomarsini Geosolutions
  */
@@ -256,11 +255,11 @@ public class InMemoryBlobStorePanel extends Panel {
     }
 
     /**
-     * {@link AbstractValidator} implementation for checking if the value is null or minor than 0
+     * {@link IValidator} implementation for checking if the value is null, or less or equal to 0
      * 
      * @author Nicola Lagomarsini Geosolutions
      */
-    static class MinimumLongValidator extends AbstractValidator<Long> {
+    static class MinimumLongValidator implements IValidator<Long> {
 
         private String errorKey;
 
@@ -269,39 +268,28 @@ public class InMemoryBlobStorePanel extends Panel {
         }
 
         @Override
-        public boolean validateOnNullValue() {
-            return true;
-        }
-
-        @Override
-        protected void onValidate(IValidatable<Long> validatable) {
-            if (validatable == null || validatable.getValue() <= 0) {
+        public void validate(IValidatable<Long> iv) {
+            if (iv == null || iv.getValue() <= 0) {
                 ValidationError error = new ValidationError();
                 error.setMessage(new ParamResourceModel(errorKey, null, "").getObject());
-                validatable.error(error);
+                iv.error(error);
             }
         }
     }
 
     /**
-     * {@link AbstractValidator} implementation for checking if the concurrency Level is null or minor than 0
+     * {@link IValidator} implementation for checking if the concurrency Level is null, or less than or equal to 0
      * 
      * @author Nicola Lagomarsini Geosolutions
      */
-    static class MinimumConcurrencyValidator extends AbstractValidator<Integer> {
+    static class MinimumConcurrencyValidator implements IValidator<Integer> {
 
         @Override
-        public boolean validateOnNullValue() {
-            return true;
-        }
-
-        @Override
-        protected void onValidate(IValidatable<Integer> validatable) {
-            if (validatable == null || validatable.getValue() <= 0) {
+        public void validate(IValidatable<Integer> iv) {
+            if (iv == null || iv.getValue() <= 0) {
                 ValidationError error = new ValidationError();
-                error.setMessage(new ParamResourceModel("BlobStorePanel.invalidConcurrency", null,
-                        "").getObject());
-                validatable.error(error);
+                error.setMessage(new ParamResourceModel("BlobStorePanel.invalidConcurrency", null, "").getObject());
+                iv.error(error);
             }
         }
     }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/AbstractGridSetPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/AbstractGridSetPage.java
@@ -1,11 +1,10 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.gwc.web.gridset;
 
-import java.util.Collections;
 import java.util.logging.Logger;
 
 import javax.measure.unit.Unit;
@@ -26,6 +25,8 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
 import org.apache.wicket.validation.validator.RangeValidator;
 import org.geoserver.gwc.GWC;
 import org.geoserver.web.GeoServerSecuredPage;
@@ -449,7 +450,7 @@ abstract class AbstractGridSetPage extends GeoServerSecuredPage {
 
     protected abstract void onSave(AjaxRequestTarget target, Form<?> form);
 
-    private static class UniqueNameValidator extends AbstractValidator<String> {
+    private static class UniqueNameValidator implements IValidator<String> {
         private static final long serialVersionUID = 1L;
 
         private final String previousName;
@@ -464,8 +465,8 @@ abstract class AbstractGridSetPage extends GeoServerSecuredPage {
         }
 
         @Override
-        protected void onValidate(IValidatable<String> validatable) {
-            final String name = validatable.getValue();
+        public void validate(IValidatable<String> iv) {
+            final String name = iv.getValue();
             if (name.equals(previousName)) {
                 return;
             }
@@ -475,8 +476,9 @@ abstract class AbstractGridSetPage extends GeoServerSecuredPage {
             }
             GridSet gridSet = gridSetBroker.get(name);
             if (gridSet != null) {
-                error(validatable, "gridSetAlreadyExists",
-                        Collections.singletonMap("name", (Object) name));
+                ValidationError error = new ValidationError("gridSetAlreadyExists");
+                error.setVariable("name", name);
+                iv.error(error);
             }
         }
     }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/AbstractParameterFilterSubform.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/AbstractParameterFilterSubform.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -10,6 +10,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.geowebcache.filter.parameters.ParameterFilter;
 
 /**
@@ -34,15 +35,10 @@ public abstract class AbstractParameterFilterSubform<T extends ParameterFilter> 
     
     @Override
     public void convertInput() {
-        visitChildren(new Component.IVisitor<Component>() {
-
-            @Override
-            public Object component(Component component) {
-                if (component instanceof FormComponent) {
-                    FormComponent<?> formComponent = (FormComponent<?>) component;
-                    formComponent.processInput();
-                }
-                return Component.IVisitor.CONTINUE_TRAVERSAL;
+        visitChildren((Component component, final IVisit<Void> visit) -> {
+            if (component instanceof FormComponent) {
+                FormComponent<?> formComponent = (FormComponent<?>) component;
+                formComponent.processInput();
             }
         });
         T filter = getModelObject();

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/AbstractParameterFilterSubform.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/AbstractParameterFilterSubform.java
@@ -6,11 +6,9 @@
 
 package org.geoserver.gwc.web.layer;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.geowebcache.filter.parameters.ParameterFilter;
 
 /**
@@ -35,7 +33,7 @@ public abstract class AbstractParameterFilterSubform<T extends ParameterFilter> 
     
     @Override
     public void convertInput() {
-        visitChildren((Component component, final IVisit<Void> visit) -> {
+        visitChildren((component, visit) -> {
             if (component instanceof FormComponent) {
                 FormComponent<?> formComponent = (FormComponent<?>) component;
                 formComponent.processInput();

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CaseNormalizerSubform.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CaseNormalizerSubform.java
@@ -1,4 +1,4 @@
-/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2015-2016 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -16,6 +16,7 @@ import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.CaseNormalizer.Case;
 
@@ -88,15 +89,10 @@ public class CaseNormalizerSubform extends FormComponentPanel<CaseNormalizer> {
     
     @Override
     public void convertInput() {
-        visitChildren(new Component.IVisitor<Component>() {
-            
-            @Override
-            public Object component(Component component) {
-                if (component instanceof FormComponent) {
-                    FormComponent<?> formComponent = (FormComponent<?>) component;
-                    formComponent.processInput();
-                }
-                return Component.IVisitor.CONTINUE_TRAVERSAL;
+        visitChildren((Component component, final IVisit<Void> visit) -> {
+            if (component instanceof FormComponent) {
+                FormComponent<?> formComponent = (FormComponent<?>) component;
+                formComponent.processInput();
             }
         });
         CaseNormalizer filter = getModelObject();

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CaseNormalizerSubform.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CaseNormalizerSubform.java
@@ -9,14 +9,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.CaseNormalizer.Case;
 
@@ -89,7 +87,7 @@ public class CaseNormalizerSubform extends FormComponentPanel<CaseNormalizer> {
     
     @Override
     public void convertInput() {
-        visitChildren((Component component, final IVisit<Void> visit) -> {
+        visitChildren((component, visit) -> {
             if (component instanceof FormComponent) {
                 FormComponent<?> formComponent = (FormComponent<?>) component;
                 formComponent.processInput();

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
@@ -29,6 +28,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
@@ -349,15 +349,10 @@ class GridSubsetsEditor extends FormComponentPanel<Set<XMLGridSubset>> {
 
     @Override
     public void convertInput() {
-        grids.visitChildren(new Component.IVisitor<Component>() {
-
-            @Override
-            public Object component(Component component) {
-                if (component instanceof FormComponent) {
-                    FormComponent<?> formComponent = (FormComponent<?>) component;
-                    formComponent.processInput();
-                }
-                return Component.IVisitor.CONTINUE_TRAVERSAL;
+        grids.visitChildren((Component component, final IVisit<Void> visit) -> {
+            if (component instanceof FormComponent) {
+                FormComponent<?> formComponent = (FormComponent<?>) component;
+                formComponent.processInput();
             }
         });
         List<XMLGridSubset> info = grids.getModelObject();

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
@@ -28,7 +28,6 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
@@ -349,7 +348,7 @@ class GridSubsetsEditor extends FormComponentPanel<Set<XMLGridSubset>> {
 
     @Override
     public void convertInput() {
-        grids.visitChildren((Component component, final IVisit<Void> visit) -> {
+        grids.visitChildren((component, visit) -> {
             if (component instanceof FormComponent) {
                 FormComponent<?> formComponent = (FormComponent<?>) component;
                 formComponent.processInput();

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/ParameterFilterEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/ParameterFilterEditor.java
@@ -37,7 +37,6 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
@@ -356,7 +355,7 @@ class ParameterFilterEditor extends FormComponentPanel<Set<ParameterFilter>> {
     
     @Override
     public void convertInput() {
-        filters.visitChildren((Component component, final IVisit<Void> visit) -> {
+        filters.visitChildren((component, visit) -> {
             if (component instanceof FormComponent) {
                 FormComponent<?> formComponent = (FormComponent<?>) component;
                 formComponent.processInput();

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/ParameterFilterEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/ParameterFilterEditor.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -18,7 +18,6 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
@@ -38,6 +37,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
@@ -356,15 +356,10 @@ class ParameterFilterEditor extends FormComponentPanel<Set<ParameterFilter>> {
     
     @Override
     public void convertInput() {
-        filters.visitChildren(new Component.IVisitor<Component>() {
-
-            @Override
-            public Object component(Component component) {
-                if (component instanceof FormComponent) {
-                    FormComponent<?> formComponent = (FormComponent<?>) component;
-                    formComponent.processInput();
-                }
-                return Component.IVisitor.CONTINUE_TRAVERSAL;
+        filters.visitChildren((Component component, final IVisit<Void> visit) -> {
+            if (component instanceof FormComponent) {
+                FormComponent<?> formComponent = (FormComponent<?>) component;
+                formComponent.processInput();
             }
         });
         List<ParameterFilter> info = filters.getModelObject();

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCServiceLinksTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCServiceLinksTest.java
@@ -5,10 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.link.ExternalLink;
-import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.web.GeoServerHomePage;
 import org.geoserver.web.GeoServerWicketTestSupport;
@@ -28,7 +26,7 @@ public class GWCServiceLinksTest extends GeoServerWicketTestSupport {
 
         Page lastPage = tester.getLastRenderedPage();
         final List<String> services = new ArrayList<String>();
-        lastPage.visitChildren(ExternalLink.class, (Component component, final IVisit<Void> visit) -> {
+        lastPage.visitChildren(ExternalLink.class, (component, visit) -> {
             String url = (String) component.getDefaultModelObject();
             if(url != null) {
                 if(url.startsWith("../gwc/service/")) {

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCServiceLinksTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCServiceLinksTest.java
@@ -1,17 +1,19 @@
 package org.geoserver.gwc.web;
 
-import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.wicket.Component.IVisitor;
+import org.apache.wicket.Component;
 import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.web.GeoServerHomePage;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class GWCServiceLinksTest extends GeoServerWicketTestSupport {
@@ -26,35 +28,28 @@ public class GWCServiceLinksTest extends GeoServerWicketTestSupport {
 
         Page lastPage = tester.getLastRenderedPage();
         final List<String> services = new ArrayList<String>();
-        lastPage.visitChildren(ExternalLink.class, new IVisitor<ExternalLink>() {
-
-            @Override
-            public Object component(ExternalLink component) {
-                String url = (String) component.getDefaultModelObject();
-                if(url != null) {
-                    if(url.startsWith("../gwc/service/")) {
-                        int idx = url.indexOf("?");
-                        String service;
-                        if(idx > 0) {
-                            service = url.substring("./gwc/service/".length() + 1, idx);
-                        } else {
-                            service = url.substring("./gwc/service/".length() + 1);
-                        }
-                        if(service != null) {
-                            services.add(service);
-                        }
-                    } else if(url.contains("GetCapabilities")){
-                        Map<String, Object> params = KvpUtils.parseQueryString(url);
-                        String service = (String) params.get("service");
-                        if(service != null) {
-                            services.add(service);
-                        }
+        lastPage.visitChildren(ExternalLink.class, (Component component, final IVisit<Void> visit) -> {
+            String url = (String) component.getDefaultModelObject();
+            if(url != null) {
+                if(url.startsWith("../gwc/service/")) {
+                    int idx = url.indexOf("?");
+                    String service;
+                    if(idx > 0) {
+                        service = url.substring("./gwc/service/".length() + 1, idx);
+                    } else {
+                        service = url.substring("./gwc/service/".length() + 1);
+                    }
+                    if(service != null) {
+                        services.add(service);
+                    }
+                } else if(url.contains("GetCapabilities")){
+                    Map<String, Object> params = KvpUtils.parseQueryString(url);
+                    String service = (String) params.get("service");
+                    if(service != null) {
+                        services.add(service);
                     }
                 }
-                
-                return IVisitor.CONTINUE_TRAVERSAL;
             }
-            
         });
         
         // GEOS-5886

--- a/src/web/security/core/pom.xml
+++ b/src/web/security/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- 
- Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ Copyright (C) 2014 - 2016 - Open Source Geospatial Foundation. All rights reserved.
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->
@@ -59,6 +59,11 @@
 			<artifactId>mockrunner</artifactId>
 			<scope>test</scope>
 		</dependency>
+            <dependency>
+                <groupId>org.apache.wicket</groupId>
+                <artifactId>wicket</artifactId>
+                <type>pom</type>
+            </dependency>
 	</dependencies>
 	<build>
 	  <plugins>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityNamedServiceNewPage.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityNamedServiceNewPage.java
@@ -7,7 +7,6 @@ package org.geoserver.security.web;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.wicket.Component;
 
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -22,7 +21,6 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
-import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.security.GeoServerSecurityService;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.web.GeoServerApplication;
@@ -159,7 +157,7 @@ public class SecurityNamedServiceNewPage
                 @Override
                 public void onClick(final AjaxRequestTarget target) {
                     //set all links enabled
-                    AjaxLinkGroup.this.visitChildren(AjaxLink.class, (Component component, final IVisit<Void> visit) -> {
+                    AjaxLinkGroup.this.visitChildren(AjaxLink.class, (component, visit) -> {
                         component.setEnabled(true);
                         target.add(component);
                         visit.dontGoDeeper();

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/data/DataSecurityPageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/data/DataSecurityPageTest.java
@@ -18,7 +18,6 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.form.RadioChoice;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.tester.FormTester;
-import org.apache.wicket.util.visit.IVisit;
 import org.geoserver.data.test.MockData;
 import org.geoserver.security.AccessMode;
 import org.geoserver.security.impl.DataAccessRule;
@@ -107,7 +106,7 @@ public class DataSecurityPageTest extends AbstractListPageTest<DataAccessRule> {
 
         form.select("catalogMode", 1);
 
-        form.getForm().visitChildren(RadioChoice.class, (Component component, final IVisit<Void> visit) -> {
+        form.getForm().visitChildren(RadioChoice.class, (component, visit) -> {
             if (component.getId().equals("catalogMode")) {
                 ((RadioChoice) component).onSelectionChanged();
             }

--- a/src/web/wcs/pom.xml
+++ b/src/web/wcs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- 
- Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ Copyright (C) 2014 - 2016 - Open Source Geospatial Foundation. All rights reserved.
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->
@@ -86,6 +86,11 @@
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.wicket</groupId>
+        <artifactId>wicket</artifactId>
+        <type>pom</type>
     </dependency>
  </dependencies>
 

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/AffineTransformPanel.java
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/AffineTransformPanel.java
@@ -7,14 +7,12 @@ package org.geoserver.wcs.web.demo;
 
 import java.awt.geom.AffineTransform;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
-import org.apache.wicket.util.visit.IVisit;
 
 /**
  * A form component for a {@link AffineTransform} object.
@@ -88,7 +86,7 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
     }
 
     public AffineTransformPanel setReadOnly( final boolean readOnly ) {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             component.setEnabled( !readOnly );
         });
 
@@ -97,7 +95,7 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).processInput();
         });
 
@@ -117,7 +115,7 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).clearInput();
         });
     }

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/AffineTransformPanel.java
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/AffineTransformPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -14,10 +14,11 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.util.visit.IVisit;
 
 /**
  * A form component for a {@link AffineTransform} object.
- * 
+ *
  * @author Justin Deoliveira, OpenGeo
  * @author Andrea Aime, GeoSolutions
  */
@@ -29,26 +30,26 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
     private WebMarkupContainer originYContainer;
     private WebMarkupContainer shearYContainer;
     private WebMarkupContainer newline;
-    
+
     public AffineTransformPanel(String id ) {
         super(id);
-        
+
         initComponents();
     }
-    
+
     public AffineTransformPanel(String id, AffineTransform e) {
         this(id, new Model(e));
     }
-    
+
     public AffineTransformPanel(String id, IModel model) {
         super(id, model);
-        
+
         initComponents();
     }
-    
+
     void initComponents() {
         updateFields();
-        
+
         originXContainer = new WebMarkupContainer("originXContainer");
         add(originXContainer);
         newline = new WebMarkupContainer("newline");
@@ -59,7 +60,7 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
         add(originYContainer);
         shearYContainer = new WebMarkupContainer("shearYContainer");
         add(shearYContainer);
-        
+
         add( new TextField( "scaleX", new PropertyModel(this, "scaleX")) );
         shearXContainer.add( new TextField( "shearX", new PropertyModel(this, "shearX")) );
         originXContainer.add( new TextField( "originX", new PropertyModel(this, "originX")) );
@@ -67,13 +68,13 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
         shearYContainer.add( new TextField( "shearY", new PropertyModel(this, "shearY")) );
         originYContainer.add( new TextField( "originY", new PropertyModel(this, "originY")) );
     }
-    
+
     @Override
     protected void onBeforeRender() {
         updateFields();
         super.onBeforeRender();
     }
-    
+
     private void updateFields() {
         AffineTransform at = getModelObject();
         if(at != null) {
@@ -85,55 +86,44 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
             this.originY = at.getTranslateY();
         }
     }
-   
+
     public AffineTransformPanel setReadOnly( final boolean readOnly ) {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-            public Object component(Component component) {
-                component.setEnabled( !readOnly );
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            component.setEnabled( !readOnly );
         });
 
         return this;
     }
-    
+
     @Override
     public void convertInput() {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).processInput();
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).processInput();
         });
-        
+
         // update the grid envelope
         if(isResolutionModeEnabled() && scaleX != null && scaleY != null) {
             setConvertedInput(AffineTransform.getScaleInstance(scaleX, scaleY));
-        } else if(scaleX != null && shearX != null && originX != null && 
+        } else if(scaleX != null && shearX != null && originX != null &&
            scaleY != null && shearY != null && originY != null) {
             setConvertedInput(new AffineTransform(scaleX, shearX, shearY, scaleY, originX, originY));
         } else {
             setConvertedInput(null);
         }
     }
-    
+
     @Override
     protected void onModelChanged() {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, new Component.IVisitor() {
-            
-            public Object component(Component component) {
-                ((TextField) component).clearInput();
-                return CONTINUE_TRAVERSAL;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).clearInput();
         });
     }
-    
+
     /**
-     * Turns the editor in a pure resolution editor 
+     * Turns the editor in a pure resolution editor
      * @param enabled
      */
     public void setResolutionModeEnabled(boolean enabled) {
@@ -143,7 +133,7 @@ public class AffineTransformPanel extends FormComponentPanel<AffineTransform> {
         originYContainer.setVisible(!enabled);
         newline.setVisible(!enabled);
     }
-    
+
     public boolean isResolutionModeEnabled() {
         return !shearXContainer.isVisible();
     }

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/GridPanel.java
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/GridPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -13,50 +13,50 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.util.visit.IVisit;
 import org.geotools.coverage.grid.GridEnvelope2D;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * A form component for a {@link GridEnvelope2D} object.
- * 
+ *
  * @author Justin Deoliveira, OpenGeo
  * @author Andrea Aime, OpenGeo
  */
 public class GridPanel extends FormComponentPanel {
 
     Integer minX,minY,maxX,maxY;
-    
+
     public GridPanel(String id ) {
         super(id);
-        
+
         initComponents();
     }
-    
+
     public GridPanel(String id, GridEnvelope2D e) {
         this(id, new Model(e));
     }
-    
+
     public GridPanel(String id, IModel model) {
         super(id, model);
-        
+
         initComponents();
     }
-    
+
     void initComponents() {
         updateFields();
-        
+
         add( new TextField( "minX", new PropertyModel(this, "minX")) );
         add( new TextField( "minY", new PropertyModel(this, "minY")) );
         add( new TextField( "maxX", new PropertyModel(this, "maxX") ));
         add( new TextField( "maxY", new PropertyModel(this, "maxY")) );
     }
-    
+
     @Override
     protected void onBeforeRender() {
         updateFields();
         super.onBeforeRender();
     }
-    
+
     private void updateFields() {
         GridEnvelope2D e = (GridEnvelope2D) getModelObject();
         if(e != null) {
@@ -66,28 +66,21 @@ public class GridPanel extends FormComponentPanel {
             this.maxY = (int) e.getMaxY();
         }
     }
-   
+
     public GridPanel setReadOnly( final boolean readOnly ) {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-            public Object component(Component component) {
-                component.setEnabled( !readOnly );
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            component.setEnabled( !readOnly );
         });
 
         return this;
     }
-    
+
     @Override
     public void convertInput() {
-        visitChildren( TextField.class, new org.apache.wicket.Component.IVisitor() {
-
-            public Object component(Component component) {
-                ((TextField) component).processInput();
-                return null;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).processInput();
         });
-        
+
         // update the grid envelope
         if(minX != null && maxX != null && minY != null && maxX != null) {
             final int width = maxX - minX;
@@ -97,19 +90,15 @@ public class GridPanel extends FormComponentPanel {
             setConvertedInput(null);
         }
     }
-    
+
     @Override
     protected void onModelChanged() {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, new Component.IVisitor() {
-            
-            public Object component(Component component) {
-                ((TextField) component).clearInput();
-                return CONTINUE_TRAVERSAL;
-            }
+        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+            ((TextField) component).clearInput();
         });
     }
-    
+
 }

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/GridPanel.java
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/demo/GridPanel.java
@@ -7,13 +7,11 @@ package org.geoserver.wcs.web.demo;
 
 import java.awt.Rectangle;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
-import org.apache.wicket.util.visit.IVisit;
 import org.geotools.coverage.grid.GridEnvelope2D;
 
 /**
@@ -68,7 +66,7 @@ public class GridPanel extends FormComponentPanel {
     }
 
     public GridPanel setReadOnly( final boolean readOnly ) {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             component.setEnabled( !readOnly );
         });
 
@@ -77,7 +75,7 @@ public class GridPanel extends FormComponentPanel {
 
     @Override
     public void convertInput() {
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).processInput();
         });
 
@@ -96,7 +94,7 @@ public class GridPanel extends FormComponentPanel {
         // when the client programmatically changed the model, update the fields
         // so that the textfields will change too
         updateFields();
-        visitChildren(TextField.class, (Component component, final IVisit<Void> visit) -> {
+        visitChildren(TextField.class, (component, visit) -> {
             ((TextField) component).clearInput();
         });
     }


### PR DESCRIPTION
This PR relates to the https://github.com/geoserver/geoserver/wiki/Wicket-migration-code-sprint#todos for `Component visit has changed, see this bit of the Wicket 1.5 migration guide for reference`.

There are a few whitespace cleanups (courtesy a bad IDE setting) in the early commits, hopefully not too hard to review.

Also added a little cleanup of the last of the AbstractVisitor usage.