### PR TITLE
Updates GeoServerResourceStreamLocator to avoid resource lookups.

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
@@ -166,6 +166,7 @@ public class GeoServerApplication extends WebApplication implements ApplicationC
      */
     protected void init() {
         // enable GeoServer custom resource locators
+        getResourceSettings().setUseMinifiedResources(false);
         getResourceSettings().setResourceStreamLocator(new GeoServerResourceStreamLocator());
 
         /*

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerResourceStreamLocatorTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerResourceStreamLocatorTest.java
@@ -1,0 +1,56 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web;
+
+import com.google.common.collect.Iterators;
+import org.apache.wicket.core.util.resource.locator.IResourceNameIterator;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GeoServerResourceStreamLocatorTest {
+
+    @Test
+    /**
+     * Test that the resource locator only returns a name for certain file types.  
+     */
+    public void testNewResourceNameIterator() {
+        GeoServerResourceStreamLocator l = new GeoServerResourceStreamLocator();
+
+        IResourceNameIterator it = l.newResourceNameIterator("org/geoserver/Foo", Locale.US, null, null, "html", false);
+        assertEquals(1, Iterators.size(it));
+
+        it = l.newResourceNameIterator("org/geoserver/Foo", Locale.US, null, null, "css", false);
+        assertEquals(1, Iterators.size(it));
+
+        it = l.newResourceNameIterator("org/geoserver/Foo", Locale.US, null, null, "ico", false);
+        assertEquals(1, Iterators.size(it));
+
+        it = l.newResourceNameIterator("org/geoserver/Foo", Locale.US, null, null, "js", false);
+        assertEquals(1, Iterators.size(it));
+        
+        it = l.newResourceNameIterator("org/geoserver/Foo", Locale.US, null, null, "baz", false);
+        assertTrue(Iterators.size(it) > 1);
+
+        it = l.newResourceNameIterator("org/geoserver/Foo.html", Locale.US, null, null, (String) null, false);
+        assertEquals(1, Iterators.size(it));
+
+        it = l.newResourceNameIterator("org/geoserver/Foo.css", Locale.US, null, null, (String) null, false);
+        assertEquals(1, Iterators.size(it));
+
+        it = l.newResourceNameIterator("org/geoserver/Foo.ico", Locale.US, null, null, (String) null, false);
+        assertEquals(1, Iterators.size(it));
+
+        it = l.newResourceNameIterator("org/geoserver/Foo.js", Locale.US, null, null, (String) null, false);
+        assertEquals(1, Iterators.size(it));
+
+        it = l.newResourceNameIterator("org/geoserver/Foo.baz", Locale.US, null, null, (String) null, false);
+        assertTrue(Iterators.size(it) > 1);
+    }
+}


### PR DESCRIPTION
Updates the name iterator to avoid returning multiple locale specific
resource names for resources we don’t ship locale specific versions of.

Also turns off minified resources.