### PR TITLE
Changed JAI Download links to data.opengeo.org

### DIFF
--- a/doc/en/user/source/production/java.rst
+++ b/doc/en/user/source/production/java.rst
@@ -45,7 +45,7 @@ Installing native JAI on Windows
 Installing native JAI on Linux
 ``````````````````````````````
 
-#. Go to the `JAI download page <http://download.java.net/media/jai/builds/release/1_1_3/>`_ and download the Linux installer for version 1.1.3, choosing the appropriate architecture:
+#. Go to the `OpenGeo JAI download page <http://data.opengeo.org/suite/jai/>`_ and download the Linux installer for version 1.1.3, choosing the appropriate architecture:
 
    * `i586` for the 32 bit systems
    * `amd64` for the 64 bit ones (even if using Intel processors)
@@ -58,7 +58,7 @@ Installing native JAI on Linux
     # accept license 
     $ sudo rm jai-1_1_3-lib-linux-i586-jdk.bin
   
-#. Go to the `JAI Image I/O download page <http://download.java.net/media/jai-imageio/builds/release/1.1/>`_ and download the Linux installer for version 1.1, choosing the appropriate architecture:
+#. Go to the `OpenGeo JAI Image I/O Download page <http://data.opengeo.org/suite/jai/>`_ and download the Linux installer for version 1.1, choosing the appropriate architecture:
 
    * `i586` for the 32 bit systems
    * `amd64` for the 64 bit ones (even if using Intel processors)


### PR DESCRIPTION
OpenGeo provides native installer resources for JAI and JAI Image I/O. User may have problems to find bin packages via Oracle pages since there are only Versions 1.1.2 / 1.0 available (http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-java-client-419417.html)