### PR TITLE
[GEOS-7385] Do not re-encode Filter in default charset when parsing WFS KVP Filter

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/kvp/FilterKvpParser.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/kvp/FilterKvpParser.java
@@ -1,13 +1,11 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.wfs.kvp;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -23,10 +21,10 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.ows.KvpParser;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.platform.ServiceException;
+import org.geoserver.util.EntityResolverProvider;
 import org.geotools.filter.FilterFilter;
 import org.geotools.gml.GMLFilterDocument;
 import org.geotools.gml.GMLFilterGeometry;
-import org.geoserver.util.EntityResolverProvider;
 import org.geotools.xml.Configuration;
 import org.geotools.xml.Parser;
 import org.opengis.filter.Filter;
@@ -78,10 +76,8 @@ public abstract class FilterKvpParser extends KvpParser {
             if ("".equals(string.trim())) {
                 filters.add(Filter.INCLUDE);
             } else {
-                InputStream input = new ByteArrayInputStream(string.getBytes());
-
                 try {
-                    Filter filter = (Filter) parser.parse(input);
+                    Filter filter = (Filter) parser.parse(new StringReader(string));
 
                     if (filter == null) {
                         throw new NullPointerException();

--- a/src/wfs/src/test/java/org/geoserver/wfs/kvp/Filter_2_0_0_KvpParserTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/kvp/Filter_2_0_0_KvpParserTest.java
@@ -1,0 +1,78 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.wfs.kvp;
+
+import java.net.URLDecoder;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.expression.PropertyName;
+
+/**
+ * Tests for {@link Filter_2_0_0_KvpParser}, the parser for Filter 2.0 in KVP requests.
+ * 
+ * @author Ben Caradoc-Davies (Transient Software Limited)
+ */
+public class Filter_2_0_0_KvpParserTest {
+
+    /**
+     * Test that Filter 2.0 {@code fes:PropertyIsLike} can be parsed from percent-encoded form into a {@link PropertyIsLike} object.
+     * 
+     * @param expectedLiteral expected decoded filter literal
+     * @param encodedLiteral percent-encoded filter literal
+     */
+    private static void parsePropertyIsLike(String expectedLiteral, String encodedLiteral)
+            throws Exception {
+        String encodedXml = "%3Cfes:Filter" //
+                + "%20xmlns:fes=%22http://www.opengis.net/fes/2.0%22%3E" //
+                + "%3Cfes:PropertyIsLike" //
+                + "%20wildCard=%22*%22" //
+                + "%20singleChar=%22%25%22" //
+                + "%20escapeChar=%22!%22%3E" //
+                + "%3Cfes:ValueReference%3E" //
+                + "topp:STATE_NAME" //
+                + "%3C/fes:ValueReference%3E" //
+                + "%3Cfes:Literal%3E" //
+                + encodedLiteral //
+                + "%3C/fes:Literal%3E%" //
+                + "3C/fes:PropertyIsLike%3E" //
+                + "%3C/fes:Filter%3E";
+        String xml = URLDecoder.decode(encodedXml, "UTF-8");
+        @SuppressWarnings("unchecked")
+        List<Filter> filters = (List<Filter>) new Filter_2_0_0_KvpParser(null).parse(xml);
+        Assert.assertEquals(1, filters.size());
+        PropertyIsLike propertyIsLike = (PropertyIsLike) filters.get(0);
+        Assert.assertEquals("*", propertyIsLike.getWildCard());
+        Assert.assertEquals("%", propertyIsLike.getSingleChar());
+        Assert.assertEquals("!", propertyIsLike.getEscape());
+        Assert.assertEquals(true, propertyIsLike.isMatchingCase());
+        Assert.assertEquals("topp:STATE_NAME",
+                ((PropertyName) propertyIsLike.getExpression()).getPropertyName());
+        Assert.assertEquals(expectedLiteral, propertyIsLike.getLiteral());
+    }
+
+    /**
+     * Test that Filter 2.0 {@code fes:PropertyIsLike} with an ASCII literal can be parsed from percent-encoded form into a {@link PropertyIsLike}
+     * object.
+     */
+    @Test
+    public void testPropertyIsLikeAsciiLiteral() throws Exception {
+        parsePropertyIsLike("Illino*", "Illino*");
+    }
+
+    /**
+     * Test that Filter 2.0 {@code fes:PropertyIsLike} with a non-ASCII literal can be parsed from percent-encoded form into a {@link PropertyIsLike}
+     * object.
+     */
+    @Test
+    public void testPropertyIsLikeNonAsciiLiteral() throws Exception {
+        parsePropertyIsLike("ü*", "%C3%BC*");
+    }
+
+}


### PR DESCRIPTION
See: https://osgeo-org.atlassian.net/browse/GEOS-7385
Supersedes: https://github.com/geoserver/geoserver/pull/1446
