### PR TITLE
Updated the assertDateEquals to compare difference

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
@@ -5,8 +5,6 @@
  */
 package org.geoserver.wms;
 
-import static org.junit.Assert.assertEquals;
-
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
@@ -192,7 +190,8 @@ public abstract class WMSDimensionsTestSupport extends WMSTestSupport {
      * @param tolerance
      */
     protected static void assertDateEquals(java.util.Date d1, java.util.Date d2, long tolerance) {
-        assertEquals(d1.getTime(), d2.getTime(), tolerance);
+        long difference = Math.abs(d1.getTime() - d2.getTime());
+        assert(difference <= tolerance);
     }
 
 


### PR DESCRIPTION
@aaime I think you originally added the test, can you take a look at this replacement? I had some issues with it randomly on my machine (I think because the method used autocasts to float from long) and I think the replacement should accomplish the same thing. 

Update the assertDateEquals method to compare that the dates are within the tolerance of one another, rather than using the method from Assert.assertEquals. The assertEquals that it was using
was autocasting to float, which was then causing infrequent issues (at least for me). The updated method should accomplish the intended goal and the tests still pass