### PR TITLE
wmsMapBoxMapOutputFormat.clipToMapBounds should be false

### DIFF
--- a/src/community/vectortiles/src/main/resources/applicationContext.xml
+++ b/src/community/vectortiles/src/main/resources/applicationContext.xml
@@ -56,7 +56,7 @@
   <bean id="wmsMapBoxMapOutputFormat" class="org.geoserver.wms.vector.VectorTileMapOutputFormat">
     <constructor-arg ref="wms"/>
     <constructor-arg ref="wmsMapBoxBuilderFactory"/>
-    <property name="clipToMapBounds" value="true" />
+    <property name="clipToMapBounds" value="false" />
     <property name="transformToScreenCoordinates" value="true" />
      <property name="overSamplingFactor" value="2.0">
       <description>Sub-pixel accuracy - higher value means less generalization (higher resolution results)</description>


### PR DESCRIPTION
clipToMapBounds doesn't allow for a buffer around the tiles, whereas the VectorTileEncoder.addFeature function has a nice default buffer to clip features just beyond the tile size to prevent tile edges being rendered in the client.
Setting the clipToMapBounds to false sends over the unclipped geometries to the VectorTileEncoder which will clip them accordingly. If kept to true the geometries are already clipped to the tile-edge and the tile-edge will show up in the client