### PR TITLE
Fixing GeoGig plugin assembly descriptor

### DIFF
--- a/src/community/release/ext-geogig.xml
+++ b/src/community/release/ext-geogig.xml
@@ -11,7 +11,7 @@
       <directory>geogig/target</directory>
       <outputDirectory></outputDirectory>
       <includes>
-        <include>gs-web-geogig*.jar</include>
+        <include>gs-geogig-*.jar</include>
       </includes>
       <excludes>
           <exclude>*test*</exclude>


### PR DESCRIPTION
  The includes pattern doesn't match the plugin artifact JAR file name.