### PR TITLE
[GEOS-7255] Makes WMS GetFeatureInfo work with expressions dash-arrays (backport to 2.8.x)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -283,9 +283,9 @@ class FeatureInfoStylePreprocessor extends SymbolizerFilteringVisitor {
 
     private void addStrokeSymbolizerIfNecessary(Stroke stroke) {
         if (stroke != null) {
-            float[] dashArray = stroke.getDashArray();
+            List<Expression> dashArray = stroke.dashArray();
             Graphic graphicStroke = stroke.getGraphicStroke();
-            if (graphicStroke != null || dashArray != null && dashArray.length > 0) {
+            if (graphicStroke != null || dashArray != null && dashArray.size() > 0) {
                 addSolidLineSymbolier = true;
             }
         }

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/RenderingBasedFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/RenderingBasedFeatureInfoTest.java
@@ -1,3 +1,8 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.wms.featureinfo;
 
 import static org.junit.Assert.assertEquals;
@@ -78,6 +83,7 @@ public class RenderingBasedFeatureInfoTest extends WMSTestSupport {
         testData.addStyle("two-rules", "two-rules.sld", this.getClass(), getCatalog());
         testData.addStyle("two-fts", "two-fts.sld", this.getClass(), getCatalog());
         testData.addStyle("dashed", "dashed.sld",this.getClass(), getCatalog());
+        testData.addStyle("dashed-exp", "dashed-exp.sld",this.getClass(), getCatalog());
         testData.addStyle("polydash", "polydash.sld", this.getClass(), getCatalog());
         testData.addStyle("doublepoly", "doublepoly.sld", this.getClass(), getCatalog());
         testData.addStyle("pureLabel", "purelabel.sld", this.getClass(), getCatalog());
@@ -273,6 +279,16 @@ public class RenderingBasedFeatureInfoTest extends WMSTestSupport {
     			+ "&WIDTH=397&HEIGHT=512&format=image%2Fpng&styles=dashed&srs=EPSG%3A4326&version=1.1.1&x=182&y=241";
         JSONObject result = (JSONObject) getAsJSON(request);
         // we used to get no results 
+        assertEquals(1, result.getJSONArray("features").size());
+    }
+
+    @Test
+    public void testDashedWithExpressions() throws Exception {
+        String layer = getLayerId(MockData.GENERICENTITY);
+        String request = "wms?REQUEST=GetFeatureInfo&&BBOX=0.778809%2C45.421875%2C12.021973%2C59.921875&SERVICE=WMS"
+                + "&INFO_FORMAT=application/json&QUERY_LAYERS=" + layer + "&Layers=" + layer
+                + "&WIDTH=397&HEIGHT=512&format=image%2Fpng&styles=dashed-exp&srs=EPSG%3A4326&version=1.1.1&x=182&y=241";
+        JSONObject result = (JSONObject) getAsJSON(request);
         assertEquals(1, result.getJSONArray("features").size());
     }
 

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/dashed-exp.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/dashed-exp.sld
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" 
+ xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+ xmlns="http://www.opengis.net/sld" 
+ xmlns:ogc="http://www.opengis.net/ogc" 
+ xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- a Named Layer is the basic building block of an SLD document -->
+  <NamedLayer>
+    <Name>default_line</Name>
+    <UserStyle>
+    <!-- Styles can have names, titles and abstracts -->
+      <Title>Default Line</Title>
+      <Abstract>A sample style that draws a line</Abstract>
+      <!-- FeatureTypeStyles describe how to render different features -->
+      <!-- A FeatureTypeStyle for rendering lines -->
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>rule1</Name>
+          <Title>Blue Line</Title>
+          <Abstract>A solid blue line with a 1 pixel width</Abstract>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#0000FF</CssParameter>
+              <CssParameter name="stroke-dasharray">
+                <ogc:Mul>
+                    <ogc:Function name="strLength">
+                        <ogc:Literal>VWXYZ</ogc:Literal>
+                    </ogc:Function>
+                    <ogc:Literal>4</ogc:Literal>
+                </ogc:Mul>
+                <ogc:Literal>5</ogc:Literal>
+              </CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
This patch makes the WMS GetFeatureInfo operation work with styles that contains strokes with dash-arrays that contains expressions. Something like this for example:

```
(...)
<LineSymbolizer>
	<Stroke>
		<CssParameter name="stroke">#0000FF</CssParameter>
		<CssParameter name="stroke-dasharray">
			<ogc:Mul>
				<ogc:Function name="strLength">
					<ogc:Literal>VWXYZ</ogc:Literal>
				</ogc:Function>
				<ogc:Literal>4</ogc:Literal>
			</ogc:Mul>
			<ogc:Literal>5</ogc:Literal>
		</CssParameter>
	</Stroke>
</LineSymbolizer>
(...)
```

I also added a test for this use case.