### PR TITLE
[GEOS-7414] Fix LayerGroups styles handling in Geofence

### DIFF
--- a/src/community/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/community/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007 - 2015 GeoSolutions S.A.S.
+ *  Copyright (C) 2007 - 2016 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  *
  *  GPLv3 + Classpath exception
@@ -21,6 +21,7 @@ package org.geoserver.geofence;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +31,7 @@ import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.lowagie.text.Paragraph;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageInfo;
@@ -70,10 +72,8 @@ import org.geoserver.security.VectorAccessLimits;
 import org.geoserver.security.WMSAccessLimits;
 import org.geoserver.security.WorkspaceAccessLimits;
 import org.geoserver.security.impl.GeoServerRole;
-import org.geoserver.wms.GetFeatureInfoRequest;
-import org.geoserver.wms.GetLegendGraphicRequest;
-import org.geoserver.wms.GetMapRequest;
-import org.geoserver.wms.MapLayerInfo;
+import org.geoserver.wms.*;
+import org.geoserver.wms.map.GetMapKvpRequestReader;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
@@ -722,7 +722,7 @@ public class GeofenceAccessManager implements ResourceAccessManager, DispatcherC
         }
     }
 
-    private void overrideGetMapRequest(Request gsRequest, String service, String request, 
+    void overrideGetMapRequest(Request gsRequest, String service, String request,
     		Authentication user, GetMapRequest getMap)
     {
 		if (gsRequest.getKvp().get("layers") == null
@@ -741,12 +741,7 @@ public class GeofenceAccessManager implements ResourceAccessManager, DispatcherC
         // parse the styles param like the kvp parser would (since we have no way,
         // to know if a certain style was requested explicitly or defaulted, and
         // we need to tell apart the default case from the explicit request case
-        String stylesParam = (String) gsRequest.getRawKvp().get("STYLES");
-        List<String> styleNameList = new ArrayList<String>();
-        if (stylesParam != null)
-        {
-            styleNameList.addAll(KvpUtils.readFlat(stylesParam));
-        }
+        List<String> styleNameList = getRequestedStyles(gsRequest, getMap);
 
         // apply the override/security check for each layer in the request
         List<MapLayerInfo> layers = getMap.getLayers();
@@ -781,7 +776,7 @@ public class GeofenceAccessManager implements ResourceAccessManager, DispatcherC
             AccessInfo rule = rules.getAccessInfo(ruleFilter);
 
             // get the requested style name
-            String styleName = (styleNameList.size() > 0) ? styleNameList.get(i) : null;
+            String styleName = styleNameList.get(i);
 
             // if default use geofence default
             if (styleName != null) {
@@ -876,6 +871,67 @@ public class GeofenceAccessManager implements ResourceAccessManager, DispatcherC
         return service;
     }
 
-    
- 
+    /**
+     * Returns a list that contains the request styles that will correspond to the GetMap.getLayers().
+     * Layer groups are expanded in layers and the associated styles are set to null (layers
+     * groups can't use dynamic styles).
+     */
+    private List<String> getRequestedStyles(Request gsRequest, GetMapRequest getMap) {
+        List<String> requestedStyles = new ArrayList<>();
+        int styleIndex = 0;
+        List<String> parsedStyles = parseStylesParameter(gsRequest);
+        for(Object layer : parseLayersParameter(gsRequest, getMap)) {
+            if (layer  instanceof LayerGroupInfo) {
+                // a LayerGroup don't have styles so we just add null
+                for (int i = 0; i < ((LayerGroupInfo) layer).getLayers().size(); i++) {
+                    requestedStyles.add(null);
+                }
+            } else {
+                // the layer is a LayerInfo or MapLayerInfo (if it is a remote layer)
+                if(styleIndex >= parsedStyles.size()) {
+                    requestedStyles.add(null);
+                }
+                else {
+                    requestedStyles.add(parsedStyles.get(styleIndex));
+                }
+            }
+            styleIndex++;
+        }
+        return requestedStyles;
+    }
+
+    private List<Object> parseLayersParameter(Request gsRequest, GetMapRequest getMap) {
+        String rawLayersParameter = (String) gsRequest.getRawKvp().get("LAYERS");
+        if (rawLayersParameter != null) {
+            List<String> layersNames = KvpUtils.readFlat(rawLayersParameter);
+            return new LayersParser().parseLayers(layersNames, getMap.getRemoteOwsURL(), getMap.getRemoteOwsType());
+        }
+        return new ArrayList<>();
+    }
+
+    private List<String> parseStylesParameter(Request gsRequest) {
+        String rawStylesParameter = (String) gsRequest.getRawKvp().get("STYLES");
+        if (rawStylesParameter != null) {
+            return KvpUtils.readFlat(rawStylesParameter);
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * An helper that avoids duplicating the code to parse the layers parameter
+     */
+    static final class LayersParser extends GetMapKvpRequestReader {
+
+        public LayersParser() {
+            super(WMS.get());
+        }
+
+        public List parseLayers(List<String> requestedLayerNames, URL remoteOwsUrl, String remoteOwsType) {
+            try {
+                return super.parseLayers(requestedLayerNames, remoteOwsUrl, remoteOwsType);
+            } catch (Exception exception) {
+                throw new ServiceException("Error parsing requested layers.", exception);
+            }
+        }
+    }
 }

--- a/src/community/geofence/src/test/java/org/geoserver/geofence/AccessManagerTest.java
+++ b/src/community/geofence/src/test/java/org/geoserver/geofence/AccessManagerTest.java
@@ -1,24 +1,27 @@
+/* (c) 2013-2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.geofence;
 
-import java.util.Arrays;
+import java.util.*;
 
-import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.LayerInfo;
-import org.geoserver.catalog.StoreInfo;
-import org.geoserver.catalog.WorkspaceInfo;
-import org.geoserver.catalog.impl.DataStoreInfoImpl;
-import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
-import org.geoserver.catalog.impl.LayerInfoImpl;
-import org.geoserver.catalog.impl.WorkspaceInfoImpl;
+import com.mockrunner.mock.web.MockHttpServletRequest;
+import com.mockrunner.mock.web.MockRequestDispatcher;
+import org.geoserver.catalog.*;
+import org.geoserver.catalog.impl.*;
 import org.geoserver.data.test.MockData;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.security.VectorAccessLimits;
 import org.geoserver.security.WorkspaceAccessLimits;
+import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.MapLayerInfo;
 import org.geotools.factory.CommonFactoryFinder;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
@@ -26,6 +29,10 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.WKTReader;
 
 import org.junit.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.RequestContextListener;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 
 public class AccessManagerTest extends GeofenceBaseTest
@@ -255,5 +262,41 @@ public class AccessManagerTest extends GeofenceBaseTest
 
         assertEquals(filter, vl.getReadFilter());
         assertEquals(filter, vl.getWriteFilter());
+    }
+
+    @Test
+    public void testWmsGetMapRequestWithLayerGroupAndNormalLayerAndStyles() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        List<PublishedInfo> layers = new ArrayList<>();
+        layers.add(getCatalog().getLayerByName("Buildings"));
+        layers.add(getCatalog().getLayerByName("DividedRoutes"));
+        List<StyleInfo> styles = new ArrayList<>();
+        styles.add(getCatalog().getLayerByName("Buildings").getDefaultStyle());
+        styles.add(getCatalog().getLayerByName("DividedRoutes").getDefaultStyle());
+        LayerGroupInfoImpl layerGroup = new LayerGroupInfoImpl();
+        layerGroup.setName("layer_group");
+        layerGroup.setLayers(layers);
+        layerGroup.setStyles(styles);
+        getCatalog().add(layerGroup);
+        Map kvp = new HashMap<>();
+        kvp.put("LAYERS", "layer_group,Bridges");
+        kvp.put("layers", "layer_group,Bridges");
+        kvp.put("STYLES", ",lines");
+        Request gsRequest = new Request();
+        gsRequest.setKvp(kvp);
+        gsRequest.setRawKvp(kvp);
+        String service = "WMS";
+        String requestName = "GetMap";
+        Authentication user = new UsernamePasswordAuthenticationToken("admin", "geoserver", Arrays.asList(
+                new GrantedAuthority[] { new SimpleGrantedAuthority("ROLE_ADMINISTRATOR") } ));
+        SecurityContextHolder.getContext().setAuthentication(user);
+        List<MapLayerInfo> mapLayersInfos = new ArrayList<>();
+        mapLayersInfos.add(new MapLayerInfo(getCatalog().getLayerByName("Buildings")));
+        mapLayersInfos.add(new MapLayerInfo(getCatalog().getLayerByName("DividedRoutes")));
+        mapLayersInfos.add(new MapLayerInfo(getCatalog().getLayerByName("Bridges")));
+        GetMapRequest getMap = new GetMapRequest();
+        getMap.setLayers(mapLayersInfos);
+        accessManager.overrideGetMapRequest(gsRequest, service, requestName, user, getMap);
     }
 }


### PR DESCRIPTION
Currently if GeoFence is active a request like this:

`curl -X GET 'http://localhost:8080/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&STYLES=,line&LAYERS=tiger-ny,tiger_roads&SRS=EPSG%3A4326&WIDTH=531&HEIGHT=768&BBOX=-74.05900955200195%2C40.640830993652344%2C-73.87670516967773%2C40.9045028686523445' -o result.png`

will provoke an index out of bounds exception.

This patch allow GeoFence to properly handle requests that contains LayerGroups, normal Layers and dynamic styles.

This patch also adds a test case for this.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7414