### PR TITLE
Fixes to mixed mode catalog behavior

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/InMemorySecurityFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/InMemorySecurityFilter.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -9,6 +9,7 @@ import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.Predicates;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.SecureCatalogImpl.MixedModeBehavior;
 import org.geotools.filter.expression.InternalVolatileFunction;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
@@ -66,7 +67,7 @@ public class InMemorySecurityFilter extends InternalVolatileFunction {
             info = getCatalog().getWorkspaceByName(((NamespaceInfo) info).getPrefix());
         }
         WrapperPolicy policy = getSecurityWrapper().buildWrapperPolicy(resourceAccesssManager,
-                user, info);
+                user, info, MixedModeBehavior.HIDE);
         AccessLevel accessLevel = policy.getAccessLevel();
         boolean visible = !AccessLevel.HIDDEN.equals(accessLevel);
         return Boolean.valueOf(visible);

--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -5,7 +5,8 @@
  */
 package org.geoserver.security;
 
-import static org.geoserver.catalog.Predicates.*;
+import static org.geoserver.catalog.Predicates.acceptAll;
+import static org.geoserver.catalog.Predicates.or;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,6 +14,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import org.bouncycastle.asn1.cmp.Challenge;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogFactory;
@@ -40,8 +42,6 @@ import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.impl.AbstractDecorator;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
-import org.geoserver.ows.Dispatcher;
-import org.geoserver.ows.Request;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.security.decorators.DecoratingCatalogFactory;
@@ -73,6 +73,14 @@ import com.google.common.collect.ImmutableList;
  * @author Andrea Aime - GeoSolutions
  */
 public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Catalog {
+    
+    /**
+     * How to behave in case of mixed mode catalog access, hide the resource or challenge
+     * the user to authenticate. For any direct access (by name, id) do challenge, for any
+     * "catch all" or "catch group" access, where the single resource was not explicitly requested,
+     * hide.
+     */
+    public enum MixedModeBehavior { HIDE, CHALLENGE };
 
     protected ResourceAccessManager accessManager;
     
@@ -126,23 +134,23 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     // -------------------------------------------------------------------
 
     public CoverageInfo getCoverage(String id) {
-        return checkAccess(user(), delegate.getCoverage(id));
+        return checkAccess(user(), delegate.getCoverage(id), MixedModeBehavior.CHALLENGE);
     }
 
     public CoverageInfo getCoverageByName(String ns, String name) {
-        return checkAccess(user(), delegate.getCoverageByName(ns, name));
+        return checkAccess(user(), delegate.getCoverageByName(ns, name), MixedModeBehavior.CHALLENGE);
     }
 
     public CoverageInfo getCoverageByName(NamespaceInfo ns, String name) {
-        return checkAccess(user(), delegate.getCoverageByName(ns, name));
+        return checkAccess(user(), delegate.getCoverageByName(ns, name), MixedModeBehavior.CHALLENGE);
     }
     
     public CoverageInfo getCoverageByName(Name name) {
-        return checkAccess(user(), delegate.getCoverageByName(name));
+        return checkAccess(user(), delegate.getCoverageByName(name), MixedModeBehavior.CHALLENGE);
     }
     
     public CoverageInfo getCoverageByName(String name) {
-        return checkAccess(user(), delegate.getCoverageByName(name));
+        return checkAccess(user(), delegate.getCoverageByName(name), MixedModeBehavior.CHALLENGE);
     }
 
     public List<CoverageInfo> getCoverages() {
@@ -160,7 +168,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     
     public CoverageInfo getCoverageByCoverageStore(
             CoverageStoreInfo coverageStore, String name) {
-        return checkAccess(user(), delegate.getCoverageByCoverageStore(coverageStore, name));
+        return checkAccess(user(), delegate.getCoverageByCoverageStore(coverageStore, name), MixedModeBehavior.CHALLENGE);
     }
 
     public List<CoverageInfo> getCoveragesByStore(CoverageStoreInfo store) {
@@ -168,21 +176,21 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
     
     public CoverageStoreInfo getCoverageStore(String id) {
-        return checkAccess(user(), delegate.getCoverageStore(id));
+        return checkAccess(user(), delegate.getCoverageStore(id), MixedModeBehavior.CHALLENGE);
     }
 
     public CoverageStoreInfo getCoverageStoreByName(String name) {
-        return checkAccess(user(), delegate.getCoverageStoreByName(name));
+        return checkAccess(user(), delegate.getCoverageStoreByName(name), MixedModeBehavior.CHALLENGE);
     }
     
     public CoverageStoreInfo getCoverageStoreByName(String workspaceName,
             String name) {
-        return checkAccess(user(), delegate.getCoverageStoreByName(workspaceName,name));
+        return checkAccess(user(), delegate.getCoverageStoreByName(workspaceName,name), MixedModeBehavior.CHALLENGE);
     }
     
     public CoverageStoreInfo getCoverageStoreByName(WorkspaceInfo workspace,
             String name) {
-        return checkAccess(user(), delegate.getCoverageStoreByName(workspace,name));
+        return checkAccess(user(), delegate.getCoverageStoreByName(workspace,name), MixedModeBehavior.CHALLENGE);
     }
     
     public List<CoverageStoreInfo> getCoverageStoresByWorkspace(
@@ -200,19 +208,19 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public DataStoreInfo getDataStore(String id) {
-        return checkAccess(user(), delegate.getDataStore(id));
+        return checkAccess(user(), delegate.getDataStore(id), MixedModeBehavior.CHALLENGE);
     }
 
     public DataStoreInfo getDataStoreByName(String name) {
-        return checkAccess(user(), delegate.getDataStoreByName(name));
+        return checkAccess(user(), delegate.getDataStoreByName(name), MixedModeBehavior.CHALLENGE);
     }
     
     public DataStoreInfo getDataStoreByName(String workspaceName, String name) {
-        return checkAccess(user(), delegate.getDataStoreByName(workspaceName,name));
+        return checkAccess(user(), delegate.getDataStoreByName(workspaceName,name), MixedModeBehavior.CHALLENGE);
     }
     
     public DataStoreInfo getDataStoreByName(WorkspaceInfo workspace, String name) {
-        return checkAccess(user(), delegate.getDataStoreByName(workspace,name)) ;
+        return checkAccess(user(), delegate.getDataStoreByName(workspace,name), MixedModeBehavior.CHALLENGE) ;
     }
     
     public List<DataStoreInfo> getDataStoresByWorkspace(String workspaceName) {
@@ -236,23 +244,23 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public FeatureTypeInfo getFeatureType(String id) {
-        return checkAccess(user(), delegate.getFeatureType(id));
+        return checkAccess(user(), delegate.getFeatureType(id), MixedModeBehavior.CHALLENGE);
     }
 
     public FeatureTypeInfo getFeatureTypeByName(String ns, String name) {
-        return checkAccess(user(), delegate.getFeatureTypeByName(ns, name));
+        return checkAccess(user(), delegate.getFeatureTypeByName(ns, name), MixedModeBehavior.CHALLENGE);
     }
     
     public FeatureTypeInfo getFeatureTypeByName(NamespaceInfo ns, String name) {
-        return checkAccess(user(), delegate.getFeatureTypeByName(ns,name));
+        return checkAccess(user(), delegate.getFeatureTypeByName(ns,name), MixedModeBehavior.CHALLENGE);
     }
 
     public FeatureTypeInfo getFeatureTypeByName(Name name) {
-        return checkAccess(user(), delegate.getFeatureTypeByName(name));
+        return checkAccess(user(), delegate.getFeatureTypeByName(name), MixedModeBehavior.CHALLENGE);
     }
     
     public FeatureTypeInfo getFeatureTypeByName(String name) {
-        return checkAccess(user(), delegate.getFeatureTypeByName(name));
+        return checkAccess(user(), delegate.getFeatureTypeByName(name), MixedModeBehavior.CHALLENGE);
     }
 
     public List<FeatureTypeInfo> getFeatureTypes() {
@@ -265,11 +273,11 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
 
     public FeatureTypeInfo getFeatureTypeByStore(DataStoreInfo dataStore,
             String name) {
-        return checkAccess(user(), delegate.getFeatureTypeByStore(dataStore , name));
+        return checkAccess(user(), delegate.getFeatureTypeByStore(dataStore , name), MixedModeBehavior.CHALLENGE);
     }
     public FeatureTypeInfo getFeatureTypeByDataStore(DataStoreInfo dataStore,
             String name) {
-        return checkAccess(user(), delegate.getFeatureTypeByDataStore(dataStore , name));
+        return checkAccess(user(), delegate.getFeatureTypeByDataStore(dataStore , name), MixedModeBehavior.CHALLENGE);
     }
     
     public List<FeatureTypeInfo> getFeatureTypesByStore(DataStoreInfo store) {
@@ -280,32 +288,32 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public LayerInfo getLayer(String id) {
-        return checkAccess(user(), delegate.getLayer(id));
+        return checkAccess(user(), delegate.getLayer(id), MixedModeBehavior.CHALLENGE);
     }
 
     public LayerInfo getLayerByName(String name) {
-        return checkAccess(user(), delegate.getLayerByName(name));
+        return checkAccess(user(), delegate.getLayerByName(name), MixedModeBehavior.CHALLENGE);
     }
     
     public LayerInfo getLayerByName(Name name) {
-        return checkAccess(user(), delegate.getLayerByName(name));
+        return checkAccess(user(), delegate.getLayerByName(name), MixedModeBehavior.CHALLENGE);
     }
 
     public LayerGroupInfo getLayerGroup(String id) {
-        return checkAccess(user(), delegate.getLayerGroup(id));
+        return checkAccess(user(), delegate.getLayerGroup(id), MixedModeBehavior.CHALLENGE);
     }
 
     public LayerGroupInfo getLayerGroupByName(String name) {
-        return checkAccess(user(), delegate.getLayerGroupByName(name));
+        return checkAccess(user(), delegate.getLayerGroupByName(name), MixedModeBehavior.CHALLENGE);
     }
 
     public LayerGroupInfo getLayerGroupByName(String workspaceName, String name) {
-        return checkAccess(user(), delegate.getLayerGroupByName(workspaceName, name));
+        return checkAccess(user(), delegate.getLayerGroupByName(workspaceName, name), MixedModeBehavior.CHALLENGE);
     }
 
     public LayerGroupInfo getLayerGroupByName(WorkspaceInfo workspace,
             String name) {
-        return checkAccess(user(), delegate.getLayerGroupByName(workspace, name));
+        return checkAccess(user(), delegate.getLayerGroupByName(workspace, name), MixedModeBehavior.CHALLENGE);
     }
 
     public List<LayerGroupInfo> getLayerGroups() {
@@ -350,15 +358,15 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public NamespaceInfo getNamespace(String id) {
-        return checkAccess(user(), delegate.getNamespace(id));
+        return checkAccess(user(), delegate.getNamespace(id), MixedModeBehavior.CHALLENGE);
     }
 
     public NamespaceInfo getNamespaceByPrefix(String prefix) {
-        return checkAccess(user(), delegate.getNamespaceByPrefix(prefix));
+        return checkAccess(user(), delegate.getNamespaceByPrefix(prefix), MixedModeBehavior.CHALLENGE);
     }
 
     public NamespaceInfo getNamespaceByURI(String uri) {
-        return checkAccess(user(), delegate.getNamespaceByURI(uri));
+        return checkAccess(user(), delegate.getNamespaceByURI(uri), MixedModeBehavior.CHALLENGE);
     }
 
     public List<NamespaceInfo> getNamespaces() {
@@ -366,24 +374,24 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public <T extends ResourceInfo> T getResource(String id, Class<T> clazz) {
-        return checkAccess(user(), delegate.getResource(id, clazz));
+        return checkAccess(user(), delegate.getResource(id, clazz), MixedModeBehavior.CHALLENGE);
     }
 
     public <T extends ResourceInfo> T getResourceByName(Name name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getResourceByName(name, clazz));
+        return checkAccess(user(), delegate.getResourceByName(name, clazz), MixedModeBehavior.CHALLENGE);
     }
     
     public <T extends ResourceInfo> T getResourceByName(String name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getResourceByName(name, clazz));
+        return checkAccess(user(), delegate.getResourceByName(name, clazz), MixedModeBehavior.CHALLENGE);
     }
 
     public <T extends ResourceInfo> T getResourceByName(NamespaceInfo ns,
             String name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getResourceByName(ns, name, clazz)) ;
+        return checkAccess(user(), delegate.getResourceByName(ns, name, clazz), MixedModeBehavior.CHALLENGE) ;
     }
 
     public <T extends ResourceInfo> T getResourceByName(String ns, String name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getResourceByName(ns, name, clazz));
+        return checkAccess(user(), delegate.getResourceByName(ns, name, clazz), MixedModeBehavior.CHALLENGE);
     }
 
     public <T extends ResourceInfo> List<T> getResources(Class<T> clazz) {
@@ -402,7 +410,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     
     public <T extends ResourceInfo> T getResourceByStore(StoreInfo store,
             String name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getResourceByStore(store, name, clazz));
+        return checkAccess(user(), delegate.getResourceByStore(store, name, clazz), MixedModeBehavior.CHALLENGE);
     }
     
     public <T extends ResourceInfo> List<T> getResourcesByStore(
@@ -411,21 +419,21 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public <T extends StoreInfo> T getStore(String id, Class<T> clazz) {
-        return checkAccess(user(), delegate.getStore(id, clazz));
+        return checkAccess(user(), delegate.getStore(id, clazz), MixedModeBehavior.CHALLENGE);
     }
 
     public <T extends StoreInfo> T getStoreByName(String name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getStoreByName(name, clazz));
+        return checkAccess(user(), delegate.getStoreByName(name, clazz), MixedModeBehavior.CHALLENGE);
     }
 
     public <T extends StoreInfo> T getStoreByName(String workspaceName,
             String name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getStoreByName(workspaceName, name, clazz));
+        return checkAccess(user(), delegate.getStoreByName(workspaceName, name, clazz), MixedModeBehavior.CHALLENGE);
     }
     
     public <T extends StoreInfo> T getStoreByName(WorkspaceInfo workspace,
             String name, Class<T> clazz) {
-        return checkAccess(user(), delegate.getStoreByName(workspace, name, clazz));
+        return checkAccess(user(), delegate.getStoreByName(workspace, name, clazz), MixedModeBehavior.CHALLENGE);
     }
 
     public <T extends StoreInfo> List<T> getStores(Class<T> clazz) {
@@ -443,11 +451,11 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public WorkspaceInfo getWorkspace(String id) {
-        return checkAccess(user(), delegate.getWorkspace(id));
+        return checkAccess(user(), delegate.getWorkspace(id), MixedModeBehavior.CHALLENGE);
     }
 
     public WorkspaceInfo getWorkspaceByName(String name) {
-        return checkAccess(user(), delegate.getWorkspaceByName(name));
+        return checkAccess(user(), delegate.getWorkspaceByName(name), MixedModeBehavior.CHALLENGE);
     }
 
     public List<WorkspaceInfo> getWorkspaces() {
@@ -463,24 +471,24 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     @SuppressWarnings("unchecked")
-    protected <T extends CatalogInfo> T checkAccess(Authentication user, T info) {
+    protected <T extends CatalogInfo> T checkAccess(Authentication user, T info, MixedModeBehavior mixedModeBehavior) {
         if (info instanceof WorkspaceInfo) {
-            return (T) checkAccess(user, (WorkspaceInfo) info);
+            return (T) checkAccess(user, (WorkspaceInfo) info, mixedModeBehavior);
         }
         if (info instanceof NamespaceInfo) {
-            return (T) checkAccess(user, (NamespaceInfo) info);
+            return (T) checkAccess(user, (NamespaceInfo) info, mixedModeBehavior);
         }
         if (info instanceof StoreInfo) {
-            return (T) checkAccess(user, (StoreInfo) info);
+            return (T) checkAccess(user, (StoreInfo) info, mixedModeBehavior);
         }
         if (info instanceof ResourceInfo) {
-            return (T) checkAccess(user, (ResourceInfo) info);
+            return (T) checkAccess(user, (ResourceInfo) info, mixedModeBehavior);
         }
         if (info instanceof LayerInfo) {
-            return (T) checkAccess(user, (LayerInfo) info);
+            return (T) checkAccess(user, (LayerInfo) info, mixedModeBehavior);
         }
         if (info instanceof LayerGroupInfo) {
-            return (T) checkAccess(user, (LayerGroupInfo) info);
+            return (T) checkAccess(user, (LayerGroupInfo) info, mixedModeBehavior);
         }
 
         return info;
@@ -493,13 +501,13 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * @return
      */
     protected <T extends ResourceInfo> T checkAccess(Authentication user,
-            T info) {
+            T info, MixedModeBehavior mixedModeBehavior) {
         // handle null case
         if (info == null)
             return null;
         
         // first off, handle the case where the user cannot even read the data
-        WrapperPolicy policy = buildWrapperPolicy(user, info, info.getName());
+        WrapperPolicy policy = buildWrapperPolicy(user, info, info.getName(), mixedModeBehavior);
         
         // handle the modes that do not require wrapping
         if(policy.level == AccessLevel.HIDDEN)
@@ -525,11 +533,11 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * 
      * @return <code>null</code> if the user can't acess the style, otherwise the original style.
      */
-    protected StyleInfo checkAccess(Authentication user, StyleInfo style) {
+    protected StyleInfo checkAccess(Authentication user, StyleInfo style, MixedModeBehavior mixedModeBehavior) {
         if (style == null)
             return null;
         
-        WrapperPolicy policy = buildWrapperPolicy(user, style, style.getName());
+        WrapperPolicy policy = buildWrapperPolicy(user, style, style.getName(), mixedModeBehavior);
         
         // if we don't need to hide it, then we can return it as is since it
         // can only provide metadata.
@@ -544,11 +552,11 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * workspace in read mode, null otherwise
      * @return
      */
-    protected <T extends StoreInfo> T checkAccess(Authentication user, T store) {
+    protected <T extends StoreInfo> T checkAccess(Authentication user, T store, MixedModeBehavior mixedModeBehavior) {
         if (store == null)
             return null;
         
-        WrapperPolicy policy = buildWrapperPolicy(user, store.getWorkspace(), store.getName());
+        WrapperPolicy policy = buildWrapperPolicy(user, store.getWorkspace(), store.getName(), mixedModeBehavior);
         
         // handle the modes that do not require wrapping
         if(policy.level == AccessLevel.HIDDEN)
@@ -578,12 +586,12 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * otherwise
      * @return
      */
-    protected LayerInfo checkAccess(Authentication user, LayerInfo layer) {
+    protected LayerInfo checkAccess(Authentication user, LayerInfo layer, MixedModeBehavior mixedModeBehavior) {
         if (layer == null)
             return null;
         
         // first off, handle the case where the user cannot even read the data
-        WrapperPolicy policy = buildWrapperPolicy(user, layer, layer.getName());
+        WrapperPolicy policy = buildWrapperPolicy(user, layer, layer.getName(), mixedModeBehavior);
         
         // handle the modes that do not require wrapping
         if(policy.level == AccessLevel.HIDDEN)
@@ -601,19 +609,20 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * it, null otherwise
      * @return
      */
-    protected LayerGroupInfo checkAccess(Authentication user, LayerGroupInfo group) {
+    protected LayerGroupInfo checkAccess(Authentication user, LayerGroupInfo group, MixedModeBehavior mixedModeBehavior) {
         if (group == null)
             return null;
 
         //first check the layer group itself
-        WrapperPolicy policy = buildWrapperPolicy(user, group, group.getName());
+        WrapperPolicy policy = buildWrapperPolicy(user, group, group.getName(), mixedModeBehavior);
         if(policy.level == AccessLevel.HIDDEN) {
             return null;
         }
         
         LayerInfo rootLayer = group.getRootLayer();
         if (LayerGroupInfo.Mode.EO.equals(group.getMode())) {
-            rootLayer = checkAccess(user, rootLayer);
+            // if the root cannot be used, blow up with an error in mixed mode
+            rootLayer = checkAccess(user, rootLayer, MixedModeBehavior.CHALLENGE);
             if (rootLayer == null) {
                 return null;
             }
@@ -622,7 +631,8 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         final List<PublishedInfo> layers = group.getLayers();
         ArrayList<PublishedInfo> wrapped = new ArrayList<PublishedInfo>(layers.size());        
         for (PublishedInfo layer : layers) {
-            PublishedInfo checked = checkAccess(user, layer);
+            // for nested layers, hide in mixed mode, the inner layers were not explicitly requested
+            PublishedInfo checked = checkAccess(user, layer, MixedModeBehavior.HIDE);
             if (checked != null) {
                 wrapped.add(checked);
             }
@@ -637,7 +647,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * null otherwise
      * @return
      */
-    protected <T extends NamespaceInfo> T checkAccess(Authentication user, T ns) {
+    protected <T extends NamespaceInfo> T checkAccess(Authentication user, T ns, MixedModeBehavior mixedModeBehavior) {
         if(ns == null)
             return null;
         
@@ -649,7 +659,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
             ws = delegate.getFactory().createWorkspace();
             ws.setName(ns.getPrefix());
         }
-        WorkspaceInfo info = checkAccess(user, ws);
+        WorkspaceInfo info = checkAccess(user, ws, mixedModeBehavior);
         if (info == null)
             return null;
         else
@@ -661,11 +671,11 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * null otherwise
      * @return
      */
-    protected <T extends WorkspaceInfo> T checkAccess(Authentication user, T ws) {
+    protected <T extends WorkspaceInfo> T checkAccess(Authentication user, T ws, MixedModeBehavior mixedModeBehavior) {
         if (ws == null)
             return null;
         
-        WrapperPolicy policy = buildWrapperPolicy(user, ws, ws.getName());
+        WrapperPolicy policy = buildWrapperPolicy(user, ws, ws.getName(), mixedModeBehavior);
         
         // if we don't need to hide it, then we can return it as is since it
         // can only provide metadata.
@@ -682,7 +692,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * @param info the catalog object being accessed
      * @return the combination of access level and response policy to apply to the request
      */
-    WrapperPolicy buildWrapperPolicy(@Nonnull ResourceAccessManager accessManager, Authentication user, @Nonnull CatalogInfo info) {
+    WrapperPolicy buildWrapperPolicy(@Nonnull ResourceAccessManager accessManager, Authentication user, @Nonnull CatalogInfo info, MixedModeBehavior mixedModeBehavior) {
         Assert.notNull(info);
 
         if (info instanceof NamespaceInfo) {
@@ -695,25 +705,25 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
                 ws = delegate.getFactory().createWorkspace();
                 ws.setName(((NamespaceInfo) info).getPrefix());
             }
-            return buildWrapperPolicy(accessManager, user, ws, ws.getName());
+            return buildWrapperPolicy(accessManager, user, ws, ws.getName(), mixedModeBehavior);
 
         }
 
         if (info instanceof WorkspaceInfo) {
-            return buildWrapperPolicy(accessManager, user, info, ((WorkspaceInfo) info).getName());
+            return buildWrapperPolicy(accessManager, user, info, ((WorkspaceInfo) info).getName(), mixedModeBehavior);
         }
 
         if (info instanceof StoreInfo) {
             return buildWrapperPolicy(accessManager, user, ((StoreInfo) info).getWorkspace(),
-                    ((StoreInfo) info).getName());
+                    ((StoreInfo) info).getName(), mixedModeBehavior);
         }
 
         if (info instanceof ResourceInfo) {
-            return buildWrapperPolicy(accessManager, user, info, ((ResourceInfo) info).getName());
+            return buildWrapperPolicy(accessManager, user, info, ((ResourceInfo) info).getName(), mixedModeBehavior);
         }
 
         if (info instanceof LayerInfo) {
-            return buildWrapperPolicy(accessManager, user, info, ((LayerInfo) info).getName());
+            return buildWrapperPolicy(accessManager, user, info, ((LayerInfo) info).getName(), mixedModeBehavior);
         }
 
         if (info instanceof LayerGroupInfo) {
@@ -722,7 +732,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
             WrapperPolicy mostRestrictive = WrapperPolicy.readWrite(null);
 
             for (PublishedInfo layer : ((LayerGroupInfo) info).getLayers()) {
-                WrapperPolicy policy = buildWrapperPolicy(accessManager, user, layer, layer.getName());
+                WrapperPolicy policy = buildWrapperPolicy(accessManager, user, layer, layer.getName(), mixedModeBehavior);
                 if (AccessLevel.HIDDEN.equals(policy.getAccessLevel())) {
                     return policy;
                 }
@@ -735,15 +745,15 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
 
             return mostRestrictive;
         } else if(info instanceof StyleInfo){
-            return buildWrapperPolicy(accessManager, user, info, ((StyleInfo) info).getName());
+            return buildWrapperPolicy(accessManager, user, info, ((StyleInfo) info).getName(), mixedModeBehavior);
         }
 
         throw new IllegalArgumentException("Can't build wrapper policy for objects of type "
                 + info.getClass().getName());
     }
     
-    protected WrapperPolicy buildWrapperPolicy(Authentication user, @Nonnull CatalogInfo info) {
-        return buildWrapperPolicy(accessManager, user, info);
+    protected WrapperPolicy buildWrapperPolicy(Authentication user, @Nonnull CatalogInfo info, MixedModeBehavior mixedModeBehavior) {
+        return buildWrapperPolicy(accessManager, user, info, mixedModeBehavior);
     }
 
     /**
@@ -757,12 +767,12 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      * @return
      */
     public WrapperPolicy buildWrapperPolicy(Authentication user,
-            CatalogInfo info, String resourceName) {
-        return SecureCatalogImpl.buildWrapperPolicy(accessManager, user, info, resourceName);
+            CatalogInfo info, String resourceName, MixedModeBehavior mixedModeBehavior) {
+        return SecureCatalogImpl.buildWrapperPolicy(accessManager, user, info, resourceName, mixedModeBehavior);
     }
     
     static WrapperPolicy buildWrapperPolicy(ResourceAccessManager accessManager, 
-            Authentication user, CatalogInfo info, String resourceName) {
+            Authentication user, CatalogInfo info, String resourceName, MixedModeBehavior mixedModeBehavior) {
         boolean canRead = true;
         boolean canWrite = true;
 
@@ -852,12 +862,12 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
                 return WrapperPolicy.hide(limits);
             } else if (mode == CatalogMode.MIXED) {
                 // if request is a get capabilities and mixed, we hide again
-                Request request = Dispatcher.REQUEST.get();
-                if(request != null && "GetCapabilities".equalsIgnoreCase(request.getRequest()))
+                if(mixedModeBehavior == MixedModeBehavior.HIDE) {
                     return WrapperPolicy.hide(limits);
-                // otherwise challenge the user for credentials
-                else
+                } else {
+                    // otherwise challenge the user for credentials
                     throw unauthorizedAccess(resourceName);
+                }
             } else {
                 // for challenge mode we agree to show freely only the metadata, every
                 // other access will trigger a security exception
@@ -909,7 +919,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
             List<T> resources) {
         List<T> result = new ArrayList<T>();
         for (T original : resources) {
-            T secured = checkAccess(user, original);
+            T secured = checkAccess(user, original, MixedModeBehavior.HIDE);
             if (secured != null)
                 result.add(secured);
         }
@@ -928,7 +938,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     protected <T extends StoreInfo> List<T> filterStores(Authentication user, List<T> resources) {
         List<T> result = new ArrayList<T>();
         for (T original : resources) {
-            T secured = checkAccess(user, original);
+            T secured = checkAccess(user, original, MixedModeBehavior.HIDE);
             if (secured != null)
                 result.add(secured);
         }
@@ -947,7 +957,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     protected List<LayerGroupInfo> filterGroups(Authentication user, List<LayerGroupInfo> groups) {
         List<LayerGroupInfo> result = new ArrayList<LayerGroupInfo>();
         for (LayerGroupInfo original : groups) {
-            LayerGroupInfo secured = checkAccess(user, original);
+            LayerGroupInfo secured = checkAccess(user, original, MixedModeBehavior.HIDE);
             if (secured != null)
                 result.add(secured);
         }
@@ -966,7 +976,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     protected List<LayerInfo> filterLayers(Authentication user, List<LayerInfo> layers) {
         List<LayerInfo> result = new ArrayList<LayerInfo>();
         for (LayerInfo original : layers) {
-            LayerInfo secured = checkAccess(user, original);
+            LayerInfo secured = checkAccess(user, original, MixedModeBehavior.HIDE);
             if (secured != null)
                 result.add(secured);
         }
@@ -980,7 +990,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     protected List<StyleInfo> filterStyles(Authentication user, List<StyleInfo> styles) {
         List<StyleInfo> result = new ArrayList<StyleInfo>();
         for (StyleInfo original : styles) {
-            StyleInfo secured = checkAccess(user, original);
+            StyleInfo secured = checkAccess(user, original, MixedModeBehavior.HIDE);
             if (secured != null)
                 result.add(secured);
         }
@@ -1000,7 +1010,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
             List<T> namespaces) {
         List<T> result = new ArrayList<T>();
         for (T original : namespaces) {
-            T secured = checkAccess(user, original);
+            T secured = checkAccess(user, original, MixedModeBehavior.HIDE);
             if (secured != null)
                 result.add(secured);
         }
@@ -1020,7 +1030,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
             List<T> workspaces) {
         List<T> result = new ArrayList<T>();
         for (T original : workspaces) {
-            T secured = checkAccess(user, original);
+            T secured = checkAccess(user, original, MixedModeBehavior.HIDE);
             if (secured != null)
                 result.add(secured);
         }
@@ -1242,15 +1252,15 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public StyleInfo getStyleByName(String name) {
-        return checkAccess(user(), delegate.getStyleByName(name));
+        return checkAccess(user(), delegate.getStyleByName(name), MixedModeBehavior.CHALLENGE);
     }
 
     public StyleInfo getStyleByName(String workspaceName, String name) {
-        return checkAccess(user(), delegate.getStyleByName(workspaceName, name)); 
+        return checkAccess(user(), delegate.getStyleByName(workspaceName, name), MixedModeBehavior.CHALLENGE); 
     }
 
     public StyleInfo getStyleByName(WorkspaceInfo workspace, String name) {
-        return checkAccess(user(), delegate.getStyleByName(workspace, name));
+        return checkAccess(user(), delegate.getStyleByName(workspace, name), MixedModeBehavior.CHALLENGE);
     }
 
     public List<StyleInfo> getStyles() {
@@ -1358,7 +1368,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     public DataStoreInfo getDefaultDataStore(WorkspaceInfo workspace) {
-        return checkAccess(user(), delegate.getDefaultDataStore(workspace));
+        return checkAccess(user(), delegate.getDefaultDataStore(workspace), MixedModeBehavior.CHALLENGE);
     }
 
     public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo defaultStore) {
@@ -1395,8 +1405,9 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         CloseableIterator<T> filtered;
         filtered = delegate.list(of, securityFilter, offset, count, sortBy);
 
-        // create secured decorators on-demand
-        final Function<T, T> securityWrapper = securityWrapper(of);
+        // create secured decorators on-demand. Assume this method is used only for listing, not
+        // for accessing a single resource by name/id, thus use hide policy for mixed mode
+        final Function<T, T> securityWrapper = securityWrapper(of, MixedModeBehavior.HIDE);
         final CloseableIterator<T> filteredWrapped;
         filteredWrapped = CloseableIteratorAdapter.transform(filtered, securityWrapper);
 
@@ -1414,14 +1425,14 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
      *         input
      * @see #checkAccess(Authentication, CatalogInfo)
      */
-    private <T extends CatalogInfo> Function<T, T> securityWrapper(final Class<T> forClass) {
+    private <T extends CatalogInfo> Function<T, T> securityWrapper(final Class<T> forClass, MixedModeBehavior mixedModeBehavior) {
 
         final Authentication user = user();
         return new Function<T, T>() {
 
             @Override
             public T apply(T input) {
-                T checked = checkAccess(user, input);
+                T checked = checkAccess(user, input, mixedModeBehavior);
                 return checked;
             }
         };

--- a/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplFilterTest.java
@@ -1,3 +1,8 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.security.impl;
 
 import static org.hamcrest.Matchers.*;
@@ -135,7 +140,7 @@ public class SecureCatalogImplFilterTest {
             // Not relevant to the test ad complicates things due to static calls
             @Override
             protected <T extends CatalogInfo> T checkAccess(
-                    Authentication user, T info) {
+                    Authentication user, T info, MixedModeBehavior mixedModeBehavior) {
                 return info;
             }
         };

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderMixedModeTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderMixedModeTest.java
@@ -1,0 +1,100 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */package org.geoserver.web.demo;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.TestResourceAccessManager;
+import org.geoserver.security.VectorAccessLimits;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+
+import com.google.common.collect.Lists;
+
+public class PreviewLayerProviderMixedModeTest extends GeoServerWicketTestSupport {
+
+    /**
+     * Add the test resource access manager in the spring context
+     */
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:/org/geoserver/web/demo/ResourceAccessManagerContext.xml");
+    }
+        
+    /**
+     * Enable the Spring Security auth filters
+     */
+    @Override
+    protected List<javax.servlet.Filter> getFilters() {
+        return Collections.singletonList((javax.servlet.Filter) GeoServerExtensions
+                .bean("filterChainProxy"));
+    }
+
+    /**
+     * Add the users
+     */
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        
+        addUser("cite", "cite", null, Collections.singletonList("ROLE_DUMMY"));
+        addUser("cite_mixed", "cite", null, Collections.singletonList("ROLE_DUMMY"));
+        
+        // populate the access manager
+        TestResourceAccessManager tam = (TestResourceAccessManager) applicationContext
+                .getBean("testResourceAccessManager");
+        Catalog catalog = getCatalog();
+        FeatureTypeInfo buildings = catalog.getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
+
+        // user in mixed mode
+        tam.putLimits("cite_mixed", buildings, new VectorAccessLimits(CatalogMode.MIXED, null, Filter.EXCLUDE, null, Filter.EXCLUDE));
+        
+    }
+    
+    @Test
+    public void testMixedMode() throws Exception {
+        PreviewLayerProvider provider = new PreviewLayerProvider();
+        
+        // full access
+        login("cite", "cite");
+        assertTrue(previewHasBuildings(provider));
+        
+        // no access, but no exception either, since this is not a direct access
+        login("cite_mixed", "cite");
+        assertFalse(previewHasBuildings(provider));
+    }
+
+    private boolean previewHasBuildings(PreviewLayerProvider provider) {
+        Iterator<PreviewLayer> it = provider.iterator(0, provider.size());
+        String buildingsPrefixedName = getLayerId(SystemTestData.BUILDINGS);
+        while(it.hasNext()) {
+            PreviewLayer pl = it.next();
+            if(buildingsPrefixedName.equals(pl.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private PreviewLayer getPreviewLayer(PreviewLayerProvider provider, String prefixedName) {
+        for (PreviewLayer pl : Lists.newArrayList(provider.iterator(0, Integer.MAX_VALUE))) {
+            if(pl.getName().equals(prefixedName)) {
+                return pl; 
+            }
+        }
+        return null;
+    }
+}

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderTest.java
@@ -136,7 +136,7 @@ public class PreviewLayerProviderTest extends GeoServerWicketTestSupport {
         PreviewLayerProvider provider = new PreviewLayerProvider();
         provider.getItems();
     }
-
+    
     private PreviewLayer getPreviewLayer(PreviewLayerProvider provider, String prefixedName) {
         for (PreviewLayer pl : Lists.newArrayList(provider.iterator(0, Integer.MAX_VALUE))) {
             if(pl.getName().equals(prefixedName)) {

--- a/src/web/demo/src/test/resources/org/geoserver/web/demo/ResourceAccessManagerContext.xml
+++ b/src/web/demo/src/test/resources/org/geoserver/web/demo/ResourceAccessManagerContext.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+  <bean id="testResourceAccessManager" class="org.geoserver.security.TestResourceAccessManager"/>
+</beans>

--- a/src/wfs/src/test/java/org/geoserver/wfs/ResourceAccessManagerWFSTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/ResourceAccessManagerWFSTest.java
@@ -1,16 +1,19 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.wfs;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static junit.framework.Assert.assertTrue;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.Catalog;
@@ -19,6 +22,7 @@ import org.geoserver.data.test.CiteTestData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.CatalogMode;
+import org.geoserver.security.DataAccessLimits;
 import org.geoserver.security.ResourceAccessManager;
 import org.geoserver.security.TestResourceAccessManager;
 import org.geoserver.security.VectorAccessLimits;
@@ -29,6 +33,8 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.PropertyName;
 import org.w3c.dom.Document;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
 
 /**
  * Performs integration tests using a mock {@link ResourceAccessManager}
@@ -130,6 +136,7 @@ public class ResourceAccessManagerWFSTest extends WFSTestSupport {
         addUser("cite_insertfilter", "cite", null, Collections.singletonList("ROLE_DUMMY"));
         addUser("cite_writefilter", "cite", null, Collections.singletonList("ROLE_DUMMY"));
         addUser("cite_writeatts", "cite", null, Collections.singletonList("ROLE_DUMMY"));
+        addUser("cite_mixed", "cite", null, Collections.singletonList("ROLE_DUMMY"));
         
         //------
         
@@ -169,6 +176,9 @@ public class ResourceAccessManagerWFSTest extends WFSTestSupport {
         List<PropertyName> writeAtts = Arrays.asList(ff.property("the_geom"), ff.property("FID"));
         tam.putLimits("cite_writeatts", buildings, new VectorAccessLimits(CatalogMode.HIDE, null,
                 null, writeAtts, null));
+        
+        // user with mixed mode access
+        tam.putLimits("cite_mixed", buildings, new VectorAccessLimits(CatalogMode.MIXED, null, Filter.EXCLUDE, null, Filter.EXCLUDE));
     }
 
     @Test
@@ -248,6 +258,41 @@ public class ResourceAccessManagerWFSTest extends WFSTestSupport {
         assertXpathEvaluatesTo("1", "count(//xsd:element[@name='FID'])", doc);
         assertXpathEvaluatesTo("1", "count(//xsd:element[@name='ADDRESS'])", doc);
 
+    }
+    
+    @Test
+    public void testCapabilitiesMixed() throws Exception {
+        setRequestAuth("admin", "geoserver");
+        Document doc = getAsDOM("cite/wfs?request=GetCapabilities&version=1.1.0&service=wfs");
+        print(doc);
+        assertXpathEvaluatesTo("1", "count(//wfs:FeatureType[wfs:Name='cite:Buildings'])", doc);
+        
+        // this one not
+        setRequestAuth("cite_mixed", "cite");
+        doc = getAsDOM("cite/wfs?request=GetCapabilities&version=1.1.0&service=wfs");
+        print(doc);
+        assertXpathEvaluatesTo("0", "count(//wfs:FeatureType[wfs:Name='cite:Buildings'])", doc);
+    }
+
+    
+    @Test
+    public void testDescribeMixed() throws Exception {
+        // this one should see all types
+        setRequestAuth("admin", "geoserver");
+        Document doc = getAsDOM("cite/wfs?request=DescribeFeatureType&version=1.1.0&service=wfs");
+        // print(doc);
+        assertXpathEvaluatesTo("1", "count(//xsd:complexType[@name='BuildingsType'])", doc);
+        
+        // this one not
+        setRequestAuth("cite_mixed", "cite");
+        doc = getAsDOM("cite/wfs?request=DescribeFeatureType&version=1.1.0&service=wfs");
+        // print(doc);
+        assertXpathEvaluatesTo("0", "count(//xsd:complexType[@name='BuildingsType'])", doc);
+        
+        // and a direct access will fail with an auth challenge
+        setRequestAuth("cite_mixed", "cite");
+        MockHttpServletResponse response = getAsServletResponse("cite/wfs?request=DescribeFeatureType&version=1.1.0&service=wfs&typeName=" + getLayerId(SystemTestData.BUILDINGS));
+        assertEquals(403, response.getErrorCode());
     }
     
     @Test


### PR DESCRIPTION
Mixed mode is quite more popular that I'd thought.
Make sure we only throw in mixed mode when there is a direct single resource access, evaluating what "single" means at the Catalog API access level (if one uses an access by id or by name, then that's direct access, some external information was provided by a user to get there), and hide the layers when just listing or filtering based on workspace and the like. 
Solves GEOS-5714, GEOS-4695, GEOS-3903, GEOS-5290