### PR TITLE
Update resource store to use alias to initialize the resourceStore

### DIFF
--- a/src/community/jdbcstore/src/main/resources/applicationContext.xml
+++ b/src/community/jdbcstore/src/main/resources/applicationContext.xml
@@ -34,8 +34,10 @@
     <property name="resourceNotificationDispatcher" ref="resourceNotificationDispatcher"/>
   </bean>
 
-   <bean id="resourceStore" class="org.geoserver.platform.resource.ResourceStoreProxy">
-      <property name="delegate" ref="jdbcResourceStore"/>
-   </bean>
+  <bean id="jdbcResourceStoreProxy" class="org.geoserver.platform.resource.ResourceStoreProxy">
+    <property name="delegate" ref="jdbcResourceStore"/>
+  </bean>
+
+  <alias name="jdbcResourceStoreProxy" alias="resourceStore" />
 
 </beans>


### PR DESCRIPTION
Changed the JDBC resourceStore bean to be initialized using alias, which causes it to take precedence over the default resourceStore definition.