### PR TITLE
Delete cached tiles when layer removed with REST DELETE via integrated GeoWebCache

### DIFF
--- a/src/gwc/src/main/resources/geowebcache-rest-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-rest-context.xml
@@ -26,6 +26,7 @@
     <property name="tileLayerDispatcher" ref="gwcTLDispatcher"/>
     <property name="urlMangler" ref="gwcURLMangler"/>
     <property name="controller" ref="geowebcacheDispatcher"/>
+    <property name="storageBroker" ref="gwcStorageBroker"/>
   </bean>
   <bean id="gwcBoundsRestlet" class="org.geowebcache.rest.bounds.BoundsRestlet">
     <property name="tileLayerDispatcher" ref="gwcTLDispatcher"/>


### PR DESCRIPTION
@smithkm this is the GeoServer counterpart to the GeoWebCache PR https://github.com/GeoWebCache/geowebcache/pull/374

Do not merge this PR until GeoWebCache PR https://github.com/GeoWebCache/geowebcache/pull/374 is merged. This PR must then be merged or the GeoServer build will break.

It is expected that Travis CI will fail for this PR as it does not know about the GeoWebCache changes.