### PR TITLE
Make javadoc aggregation work with java 8

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1475,6 +1475,67 @@
      </configuration>
    </plugin>
 
+<!-- ======================================================= -->
+   <!--     Javadoc generation.                                 -->
+   <!-- ======================================================= -->
+   <plugin>
+    <artifactId>maven-javadoc-plugin</artifactId>
+    <version>2.10.3</version>
+    <configuration>
+     <source>1.8</source>
+     <version>false</version>
+     <noqualifier>all</noqualifier>
+     <quiet>true</quiet>
+     <maxmemory>256M</maxmemory>
+     <encoding>UTF-8</encoding>
+     <!-- <additionalparam>-keywords</additionalparam> -->
+     <additionalparam>-Xdoclint:none</additionalparam>
+     <breakiterator>true</breakiterator>
+     <tags>
+      <tag>
+       <name>todo</name>
+       <placement>tfmc</placement>
+       <head>TODO:</head>
+      </tag>
+      <tag>
+       <name>task</name>
+       <placement>tfmc</placement>
+       <head>TODO:</head>
+      </tag>
+      <tag>
+       <name>revisit</name>
+       <placement>tfmc</placement>
+       <head>TODO:</head>
+      </tag>
+      <tag>
+       <name>source</name>
+       <placement>Xt</placement>
+       <head>Source:</head>
+      </tag>
+      <tag>
+       <name>tutorial</name>
+       <placement>Xt</placement>
+       <head>Tutorial:</head>
+      </tag>
+     </tags>
+
+     <links>
+      <link>http://docs.oracle.com/javase/7/docs/api/</link>
+      <link>http://docs.oracle.com/javaee/7/api/</link>
+      <link>http://download.java.net/media/jai/javadoc/1.1.3/jai-apidocs</link>
+      <link>http://download.java.net/media/jai-imageio/javadoc/1.0_01</link>
+      <link>http://download.java.net/media/java3d/javadoc/1.5.1</link>
+      <link>http://jscience.org/api/</link>
+      <link>http://tsusiatsoftware.net/jts/javadoc</link>
+      <link>http://docs.geotools.org/latest/javadocs/</link>
+      <link>http://xmlgraphics.apache.org/batik/javadoc</link>
+      <link>http://www.1t3xt.info/api/</link>
+      <link>http://freemarker.sourceforge.net/docs/api/</link>
+      <link>http://wicket.apache.org/docs/wicket-1.3.2/wicket/apidocs</link>
+     </links>
+    </configuration>
+   </plugin>
+
   </plugins>
 
   <extensions>
@@ -1501,7 +1562,7 @@
    <!-- ======================================================= -->
    <plugin>
     <artifactId>maven-javadoc-plugin</artifactId>
-    <version>2.9</version>
+    <version>2.10.3</version>
     <configuration>
      <source>1.8</source>
      <version>false</version>
@@ -1509,7 +1570,8 @@
      <quiet>true</quiet>
      <maxmemory>256M</maxmemory>
      <encoding>UTF-8</encoding>
-     <additionalparam>-keywords</additionalparam>
+     <!-- <additionalparam>-keywords</additionalparam> -->
+     <additionalparam>-Xdoclint:none</additionalparam>
      <breakiterator>true</breakiterator>
      <tags>
       <tag>


### PR DESCRIPTION
The upgrade to the 2.10 version turned out not to be necessary, but does not hurt either...