### PR TITLE
(2.8.x) Support for List and Map types in GeoJson

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -7,6 +7,8 @@ package org.geoserver.wfs.json;
 
 import java.io.Writer;
 import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import net.sf.json.JSONException;
@@ -286,19 +288,65 @@ public class GeoJSONBuilder extends JSONBuilder {
                 "Unable to determine geometry type " + geometry.getClass());
         }
     }
-    
+
     /**
-     * Overrides to handle the case of encoding {@code java.util.Date} and its date/time/timestamp
+     * Write a java.util.List out as a JSON Array. The values of the array will be converted
+     * using ike standard primitive conversions. If the list contains List or Map objects, they
+     * will be serialized as JSON Arrays and JSON Objects respectively.
+     *
+     * @param list a java.util.List to be serialized as JSON Array
+     */
+    public JSONBuilder writeList(final List list) {
+        this.array();
+        for (final Object o: list) {
+            this.value(o);
+        }
+        return this.endArray();
+    }
+
+    /**
+     * Write a java.util.Map out as a JSON Object. Keys are serialized using the toString method
+     * of the object and values are serialized using primitives conversions. If a value in the map
+     * is a List or Map object, it will be serialized as JSON Array or JSON Object respectively.
+     *
+     * @param map a java.util.Map object to be serialized as a JSON Object
+     */
+    public JSONBuilder writeMap(final Map map) {
+        this.object();
+        for (final Object k: map.keySet()) {
+            this.key(k.toString());
+            this.value(map.get(k));
+        }
+        return this.endObject();
+    }
+
+    /**
+     * Overrides handling of specialized types.
+     *
+     * Overrides the encoding {@code java.util.Date} and its date/time/timestamp
      * descendants, as well as {@code java.util.Calendar} instances as ISO 8601 strings.
-     * 
+     *
+     * Overrides the handling of java.util.Map, java.util.List, and Geometry objects
+     * as well.
+     *
      * @see net.sf.json.util.JSONBuilder#value(java.lang.Object)
      */
     @Override
     public GeoJSONBuilder value(Object value) {
-        if (value instanceof java.util.Date || value instanceof Calendar) {
-            value = Converters.convert(value, String.class);
+        if (value == null) {
+            super.value(value);
+        } else if (value instanceof Geometry) {
+            this.writeGeom((Geometry) value);
+        } else if (value instanceof List) {
+            this.writeList((List)value);
+        } else if (value instanceof Map) {
+            this.writeMap((Map)value);
+        } else {
+            if (value instanceof java.util.Date || value instanceof Calendar) {
+                value = Converters.convert(value, String.class);
+            }
+            super.value(value);
         }
-        super.value(value);
         return this;
     }
     

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -8,9 +8,10 @@ package org.geoserver.wfs.json;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringWriter;
-import java.util.Calendar;
-import java.util.TimeZone;
+import java.util.*;
 
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -199,4 +200,118 @@ public class GeoJSONBuilderTest {
         builder.writeGeom(g);
         assertEquals("{\"type\":\"Polygon\",\"coordinates\":[[[0,0,0],[0,10,1],[10,10,2],[10,0,3],[0,0,0]],[[1,1,4],[1,2,5],[2,2,6],[2,1,7],[1,1,4]]]}", writer.toString());
     }
+
+    @Test
+    public void testWriteStrList() throws Exception {
+        final List<String> list = Arrays.asList("a", "b", "c", "d");
+        builder.writeList(list);
+        assertEquals("[\"a\",\"b\",\"c\",\"d\"]", writer.toString());
+    }
+
+    @Test
+    public void testWriteIntList() throws Exception {
+        final List<Integer> list = Arrays.asList(Integer.MAX_VALUE, Integer.MIN_VALUE, 3 ,4);
+        builder.writeList(list);
+        assertEquals("[" + Integer.toString(Integer.MAX_VALUE) + "," +
+                Integer.toString(Integer.MIN_VALUE) + ",3,4]", writer.toString());
+    }
+
+    @Test
+    public void testWriteLongList() throws Exception {
+        final List<Long> list = Arrays.asList(Long.MAX_VALUE, Long.MIN_VALUE, 0L, -333L ,4L);
+        builder.writeList(list);
+        assertEquals("[" + Long.toString(Long.MAX_VALUE) + "," +
+                Long.toString(Long.MIN_VALUE) + ",0,-333,4]", writer.toString());
+    }
+
+    @Test
+    public void testWriteFloatList() throws Exception {
+        final List<Float> list = Arrays.asList(Float.MAX_VALUE, Float.MIN_VALUE, 0f, -333.2365f , 0.23235656f);
+        builder.writeList(list);
+        assertEquals("[" + Float.toString(Float.MAX_VALUE) + "," +
+                Float.toString(Float.MIN_VALUE) + ",0,-333.2365,0.23235656]", writer.toString());
+    }
+
+    @Test
+    public void testWriteDoubleList() throws Exception {
+        final List<Double> list = Arrays.asList(Double.MAX_VALUE, Double.MIN_VALUE, 0d, -333.2365d , 0.23235656d);
+        builder.writeList(list);
+        assertEquals("[" + Double.toString(Double.MAX_VALUE) + "," +
+                Double.toString(Double.MIN_VALUE) + ",0,-333.2365,0.23235656]", writer.toString());
+    }
+
+    @Test
+    public void testWriteUUIDList() throws Exception {
+        final UUID u1 = UUID.fromString("12345678-1234-1234-1234-123456781234");
+        final UUID u2 = UUID.fromString("00000000-0000-0000-0000-000000000000");
+        final List<UUID> list = Arrays.asList(u1, u2);
+        builder.writeList(list);
+        assertEquals("[" + "\"" +  u1.toString() + "\"" + "," + "\"" + u2.toString() + "\"" + "]", writer.toString());
+    }
+
+    @Test
+    public void testWriteStringStringMap() throws Exception {
+        final Map<String, String> map = new HashMap<String, String>() {{
+            put("a", "1");
+            put("b", "2");
+            put("c", "3");
+        }};
+        builder.writeMap(map);
+        final JSONObject root = JSONObject.fromObject(writer.toString());
+        assertEquals(3, root.size());
+        assertEquals("1", root.get("a"));
+        assertEquals("2", root.get("b"));
+        assertEquals("3", root.get("c"));
+    }
+
+    @Test
+    public void testWriteStringIntMap() throws Exception {
+        final Map<String, Integer> map = new HashMap<String, Integer>() {{
+            put("a", Integer.MAX_VALUE);
+            put("b", Integer.MIN_VALUE);
+            put("c", 3);
+        }};
+        builder.writeMap(map);
+        final JSONObject root = JSONObject.fromObject(writer.toString());
+        assertEquals(3, root.size());
+        assertEquals(Integer.MAX_VALUE, root.get("a"));
+        assertEquals(Integer.MIN_VALUE, root.get("b"));
+        assertEquals(3, root.get("c"));
+    }
+
+    @Test
+    public void testWriteListOfMaps() throws Exception {
+        final UUID u1 = UUID.fromString("12345678-1234-1234-1234-123456781234");
+        final Map<String, Object> tuple1 = new HashMap<String, Object>() {{
+            put("a", 1);
+            put("b", u1);
+            put("c", "object1");
+        }};
+
+        final UUID u2 = UUID.fromString("00000000-0000-0000-0000-000000000000");
+        final Map<String, Object> tuple2 = new HashMap<String, Object>() {{
+            put("a", 2);
+            put("b", u2);
+            put("c", "object2");
+        }};
+
+        final List<Map<String, Object>> tupleList = Arrays.asList(tuple1, tuple2);
+        builder.writeList(tupleList);
+
+        final JSONArray root = JSONArray.fromObject(writer.toString());
+        assertEquals(2, root.size());
+
+        final JSONObject o1 = root.getJSONObject(0);
+        assertEquals(3, o1.size());
+        assertEquals(1, o1.get("a"));
+        assertEquals(u1.toString(), o1.get("b"));
+        assertEquals("object1", o1.get("c"));
+
+        final JSONObject o2 = root.getJSONObject(1);
+        assertEquals(3, o2.size());
+        assertEquals(2, o2.get("a"));
+        assertEquals(u2.toString(), o2.get("b"));
+        assertEquals("object2", o2.get("c"));
+    }
 }
+


### PR DESCRIPTION
Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>

Previously lists/maps were toString()'d instead of using JSON Arrays and Objects as allowed in the geojson spec:

```
"someMapAttr": "{key=value, foo=bar}",
"someListAttr": "[Edward, Bill, Harry]",
```

New encoding is like this for properties who bindings are java.util.List or java.util.Map:
```
"someMapAttr": {
   "foo": "bar",
   "key": "value"
},
"someListAttr": [
    "Edward",
    "Bill",
    "Harry"
],
```

