### PR TITLE
Upgrade to commons-collections 3.2.2 to address CVE-2015-8103

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -738,7 +738,7 @@
    <dependency>
     <groupId>commons-collections</groupId>
     <artifactId>commons-collections</artifactId>
-    <version>3.1</version>
+    <version>3.2.2</version>
    </dependency>
    <dependency>
     <groupId>commons-dbcp</groupId>


### PR DESCRIPTION
* Prevent Java Serialization vulnerability of having cc 3.2.1 and earlier on the classpath
* https://commons.apache.org/proper/commons-collections/security-reports.html

Related PRs:
https://github.com/locationtech/geomesa/pull/827
https://github.com/geotools/geotools/pull/1128
https://github.com/GeoWebCache/geowebcache/pull/376

Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>