### PR TITLE
[GEOS-7459] Securing an app-schema data store may result in ClassCastException being thrown

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SecuredFeatureChainingTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SecuredFeatureChainingTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,17 +6,15 @@
 
 package org.geoserver.test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Map.Entry;
 
 import org.geoserver.catalog.Catalog;
@@ -26,11 +24,19 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.CatalogMode;
 import org.geoserver.security.TestResourceAccessManager;
 import org.geoserver.security.VectorAccessLimits;
+import org.geoserver.security.decorators.ReadOnlyDataAccess;
+import org.geoserver.security.decorators.SecuredDataStoreInfo;
+import org.geotools.data.DataAccess;
+import org.geotools.data.complex.AppSchemaDataAccess;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.factory.Hints;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.expression.FeaturePropertyAccessorFactory;
+import org.geotools.util.NullProgressListener;
+import org.junit.Assert;
 import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.PropertyName;
@@ -137,4 +143,22 @@ public class SecuredFeatureChainingTest extends AbstractAppSchemaTestSupport {
 
     }
 
+    /**
+     * Tests that {@link SecuredDataStoreInfo#getDataStore(org.opengis.util.ProgressListener)} correctly
+     * returns a {@link DataAccess} instance.
+     * 
+     * @throws IOException
+     */
+    @Test
+    public void testSecuredDataStoreInfo() throws IOException {
+        login("cite_readatts", "cite", "ROLE_DUMMY");
+
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml:GeologicUnit");
+        assertNotNull(ftInfo);
+
+        DataAccess<? extends FeatureType, ? extends Feature> dataAccess = ftInfo.getStore()
+                .getDataStore(new NullProgressListener());
+        assertNotNull(dataAccess);
+        assertTrue(dataAccess instanceof ReadOnlyDataAccess);
+    }
 }

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredDataStoreInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredDataStoreInfo.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -12,7 +12,6 @@ import org.geoserver.security.AccessLevel;
 import org.geoserver.security.SecureCatalogImpl;
 import org.geoserver.security.WrapperPolicy;
 import org.geotools.data.DataAccess;
-import org.geotools.data.DataStore;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.util.ProgressListener;
@@ -37,7 +36,7 @@ public class SecuredDataStoreInfo extends DecoratingDataStoreInfo {
     }
 
     @Override
-    public DataStore getDataStore(ProgressListener listener) throws IOException {
+    public DataAccess<? extends FeatureType, ? extends Feature> getDataStore(ProgressListener listener) throws IOException {
         final DataAccess<? extends FeatureType, ? extends Feature> ds = super
                 .getDataStore(listener);
         if (ds == null)
@@ -45,7 +44,7 @@ public class SecuredDataStoreInfo extends DecoratingDataStoreInfo {
         else if(policy.level == AccessLevel.METADATA)
             throw SecureCatalogImpl.unauthorizedAccess(this.getName());
         else
-            return (DataStore) SecuredObjects.secure(ds, policy);
+            return (DataAccess<? extends FeatureType, ? extends Feature>) SecuredObjects.secure(ds, policy);
     }
 
 }


### PR DESCRIPTION
Takes the simplest path and changes the signature of `SecuredDataStoreInfo.getDataStore` to return a generic `DataAccess<FeatureType, Feature>` instance.

Formally, this is a public API change, but shouldn't present a real problem, as the `getDataStore` method in `DataStoreInfo` (the interface decorated by `SecuredDataStoreInfo`) already returns `DataAccess<FeatureType, Feature>`.