### PR TITLE
[GEOS-7474] Speed up usage of git-commit-it

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1469,7 +1469,7 @@
    <plugin>
      <groupId>pl.project13.maven</groupId>
      <artifactId>git-commit-id-plugin</artifactId>
-     <version>2.1.13</version>
+     <version>2.1.15</version>
      <executions>
        <execution>
          <goals>
@@ -1482,6 +1482,23 @@
        <failOnNoGitDirectory>false</failOnNoGitDirectory>
        <skipPoms>false</skipPoms>
        <verbose>false</verbose>
+       <injectAllReactorProjects>true</injectAllReactorProjects>
+       <runOnlyOnce>true</runOnlyOnce>
+       <!--
+       In order to use native git (3+ times faster) add the following in ~/.m2/settings.xml
+       <profiles>
+         <profile>
+           <id>gitNative</id>
+           <properties>
+             <git.commit.useNative>true</git.commit.useNative>
+           </properties>
+         </profile>
+       <profiles>
+       <activeProfiles>
+         <activeProfile>gitNative</activeProfile>
+       </activeProfiles>
+       -->
+       <useNativeGit>${git.commit.useNative}</useNativeGit>
      </configuration>
    </plugin>
 
@@ -1759,6 +1776,7 @@
   <!-- NOTE: be careful if upgrading slf4j, check the netcdf and netcdf-out build correcly -->
   <slf4j.version>1.6.4</slf4j.version>
   <joda-time.version>2.8.1</joda-time.version>
+  <git.commit.useNative>false</git.commit.useNative>
  </properties>
 
  <profiles>


### PR DESCRIPTION
On my computer this single change cuts the release build time from 20:43 down to 19:13, or a minute and a half speedup.
