### PR TITLE
Revert #1558

### DIFF
--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -235,26 +235,6 @@
       </modules>
     </profile>
     <profile>
-      <id>script-py</id>
-      <activation>
-        <property><name>script-py</name></property>
-      </activation> 
-      <modules>
-        <module>script/core</module>
-        <module>script/py</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>script-web</id>
-      <activation>
-        <property><name>script-web</name></property>
-      </activation> 
-      <modules>
-        <module>script/core</module>
-        <module>script/web</module>
-      </modules>
-    </profile>
-    <profile>
       <id>pgraster</id>
       <activation>
         <property><name>pgraster</name></property>


### PR DESCRIPTION
There was already a mechanism to do the same thing another way.

The script module defines default on profiles for its submodules which can be deactivated.

`-P script,-script-js,-script-bsh,-script-rb,-script-groovy`