### PR TITLE
[GEOS-7492] Admin can temporarily lock themselves out of UI or REST

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/LockProviderInitializer.java
+++ b/src/main/src/main/java/org/geoserver/config/LockProviderInitializer.java
@@ -7,6 +7,7 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.GlobalLockProvider;
 import org.geoserver.platform.resource.LockProvider;
 import org.geoserver.platform.resource.MemoryLockProvider;
+import org.geoserver.platform.resource.NullLockProvider;
 
 /**
  * Initializes LockProvider based on configuration settings.
@@ -50,8 +51,9 @@ public class LockProviderInitializer implements GeoServerInitializer {
     
     public static void setLockProvider( String lockProviderName ){
         LockProvider delegate;
-        if( lockProviderName == null ){
-            delegate = new MemoryLockProvider();
+        if( lockProviderName == null ) {
+            // for backwards compatibility
+            delegate = new NullLockProvider();
         } else {
             Object provider = GeoServerExtensions.bean(lockProviderName);
             if( provider == null ){

--- a/src/main/src/main/java/org/geoserver/logging/LoggingUtils.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingUtils.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,7 +6,6 @@
 package org.geoserver.logging;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,7 +25,6 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
-import org.geoserver.platform.resource.Resources;
 import org.geoserver.platform.resource.Resource.Type;
 import org.vfny.geoserver.global.ConfigurationException;
 
@@ -177,7 +175,7 @@ public class LoggingUtils {
         }
         
         // reconfiguring log4j logger levels by resetting and loading a new set of configuration properties
-        try(InputStream loggingConfigStream = resource.in()){
+        try(InputStream loggingConfigStream = resource.in()) {
             if (loggingConfigStream == null) {
                 LoggingInitializer.LOGGER.warning("Couldn't open Log4J configuration file '" + resource);
                 return;
@@ -185,10 +183,8 @@ public class LoggingUtils {
                 LoggingInitializer.LOGGER.fine("GeoServer logging profile '" + resource.name() + "' enabled.");
             }
         
-            configureGeoServerLogging(resourceLoader, loggingConfigStream, suppressStdOutLogging, false, 
-                                    logFileName);
+            configureGeoServerLogging(resourceLoader, loggingConfigStream, suppressStdOutLogging, false, logFileName);
         }
-        
     }
 
     /**

--- a/src/main/src/test/java/org/geoserver/catalog/PropertyStyleHandler.java
+++ b/src/main/src/test/java/org/geoserver/catalog/PropertyStyleHandler.java
@@ -1,17 +1,31 @@
 package org.geoserver.catalog;
 
-import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.styling.*;
-import org.geotools.util.Version;
-import org.opengis.filter.FilterFactory;
-import org.xml.sax.EntityResolver;
-
-import java.awt.*;
+import java.awt.Color;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.styling.FeatureTypeStyle;
+import org.geotools.styling.LineSymbolizer;
+import org.geotools.styling.Mark;
+import org.geotools.styling.PointSymbolizer;
+import org.geotools.styling.PolygonSymbolizer;
+import org.geotools.styling.RasterSymbolizer;
+import org.geotools.styling.ResourceLocator;
+import org.geotools.styling.Rule;
+import org.geotools.styling.SLD;
+import org.geotools.styling.Style;
+import org.geotools.styling.StyleFactory;
+import org.geotools.styling.StyledLayerDescriptor;
+import org.geotools.styling.Symbolizer;
+import org.geotools.styling.UserLayer;
+import org.geotools.util.Version;
+import org.opengis.filter.FilterFactory;
+import org.xml.sax.EntityResolver;
 
 /**
  * Test style handler based on properties format.
@@ -44,7 +58,9 @@ public class PropertyStyleHandler extends StyleHandler {
     public StyledLayerDescriptor parse(Object input, Version version, ResourceLocator resourceLocator,
        EntityResolver enityResolver) throws IOException {
         Properties p = new Properties();
-        p.load(toReader(input));
+        try(Reader reader = toReader(input)) {
+            p.load(reader);
+        }
 
         Color color = color(p.getProperty("color"), Color.BLACK);
         Symbolizer sym = null;

--- a/src/main/src/test/java/org/geoserver/catalog/StylesTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/StylesTest.java
@@ -1,3 +1,7 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.catalog;
 
 import static org.junit.Assert.assertNotNull;
@@ -9,8 +13,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Properties;
 
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.MemoryLockProvider;
+import org.geoserver.platform.resource.Resource;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.styling.DefaultResourceLocator;
 import org.geotools.styling.PointSymbolizer;
 import org.geotools.styling.SLD;
 import org.geotools.styling.SLDParser;
@@ -62,6 +70,17 @@ public class StylesTest extends GeoServerSystemTestSupport {
         StyledLayerDescriptor sld = parser.parseSLD();
 
         assertNull(Styles.style(sld));
+    }
+    
+    @Test
+    public void testParseStyleTwiceLock() throws Exception {
+        StyleInfo style = getCatalog().getStyles().get(0);
+        FileSystemResourceStore store = (FileSystemResourceStore) getDataDirectory().getResourceStore();
+        store.setLockProvider(new MemoryLockProvider());
+        // parse twice to check we are not locking on it
+        Resource resource = getDataDirectory().style(style);
+        Styles.handler(style.getFormat()).parse(resource, style.getFormatVersion(), new DefaultResourceLocator(), null);
+        Styles.handler(style.getFormat()).parse(resource, style.getFormatVersion(), new DefaultResourceLocator(), null);
     }
 
 }

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
@@ -1,4 +1,4 @@
-/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -16,11 +16,23 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.geotools.util.logging.Logging;
 
 /**
  * Implementation of ResourceStore backed by the file system.
  */
 public class FileSystemResourceStore implements ResourceStore {
+    
+    static final Logger LOGGER = Logging.getLogger(FileSystemResource.class);
+    
+    /**
+     * When true, the stack trace that got an input stream that wasn't closed is recorded and then
+     * printed out when warning the user about this.
+     */
+    protected static final Boolean TRACE_ENABLED = "true".equalsIgnoreCase(System.getProperty("gs.lock.trace"));
     
     /** LockProvider used to secure resources for exclusive access */
     protected LockProvider lockProvider = new NullLockProvider();
@@ -178,12 +190,39 @@ public class FileSystemResourceStore implements ResourceStore {
                 throw new IllegalStateException("File not found " + actualFile);
             }
             final Lock lock = lock();
+            final Throwable tracer;
+            if(TRACE_ENABLED) {
+                tracer = new Exception();
+                tracer.fillInStackTrace();
+            } else {
+                tracer = null;
+            }
             try {
                 return new FileInputStream(file) {
+                    boolean closed = false;
+                    
+                    
                     @Override
                     public void close() throws IOException {
+                        closed = true;
                         super.close();
                         lock.release();
+                    }
+                    
+                    @Override
+                    protected void finalize() throws IOException {
+                        if(!closed) {
+                            String warn = "There is code leaving resource input streams open, locks around them might not be cleared! ";
+                            if(!TRACE_ENABLED) {
+                                warn += "Add -D" + TRACE_ENABLED + "=true to your JVM options to get a full stack trace of the code that acquired the input stream";
+                            }
+                            LOGGER.warning(warn);
+                            
+                            if(TRACE_ENABLED) {
+                                LOGGER.log(Level.WARNING, "The unclosed input stream originated on this stack trace", tracer);
+                            }
+                        }
+                        super.finalize();
                     }
                 };
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
…by changing logging level or styles. Lock held open when stream is not closed due to use of Resoruce.in() obtaining a lock on creation and releasing the lock on close().

See https://osgeo-org.atlassian.net/browse/GEOS-7492