### PR TITLE
GEOS-7493 Path.names not removing root slash

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -1,4 +1,4 @@
-/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -44,7 +44,7 @@ public final class Files {
         final File file;
 
         private ResourceAdaptor(File file) {
-            this.file = file;
+            this.file = file.getAbsoluteFile();
         }
 
         @Override

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -233,7 +233,7 @@ public class Paths {
         String item;
         do {
             item = path.substring(index, split);
-            if (item != "/") {
+            if (item.length() != 0 && item != "/") {
                 names.add(item);
             }
             index = split + 1;

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
@@ -1,3 +1,7 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.platform.resource;
 
 import static org.junit.Assert.fail;
@@ -26,7 +30,13 @@ public class FileWrapperResourceTheoryTest extends ResourceTheoryTest {
     protected Resource getResource(String path) throws Exception {
         File file = Paths.toFile(null, path);
         if (!file.isAbsolute()) {
-            file = Paths.toFile(folder.getRoot(), path);
+            //in linux, an absolute path might appear relative if the root slash has been removed.
+            if (folder.getRoot().getPath().startsWith("/") &&
+                    path.startsWith(folder.getRoot().getPath().substring(1))) {
+                file = Paths.toFile(new File("/"), path);
+            } else {
+                file = Paths.toFile(folder.getRoot(), path);
+            }
         }
         return Files.asResource(file);
     }

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2014 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -487,4 +487,13 @@ public abstract class ResourceTheoryTest {
         assertTrue(res.delete());
         
     }
+
+    @Theory
+    public void theoryRootSlashIsIgnored(String path) throws Exception {
+        final Resource res = getResource(path);
+        final Resource res2 = getResource("/" + path);
+        assertTrue(res.equals(res2));
+        assertTrue(res.path().equals(res2.path()));
+    }
+
 }

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceFinder.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceFinder.java
@@ -5,6 +5,7 @@
 package org.geoserver.rest.resources;
 
 import org.geoserver.ows.util.ResponseUtils;
+import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.rest.util.RESTUtils;
 import org.restlet.Finder;
@@ -32,7 +33,7 @@ public class ResourceFinder extends Finder {
     public Resource findTarget(Request request, Response response) {        
         String path = ResponseUtils.urlDecode(request.getResourceRef().getRelativeRef().getPath());
         if (".".equals(path)) { //root
-            path = "/";
+            path = Paths.BASE;
         }
         //format
         request.getAttributes().put("format", RESTUtils.getQueryStringValue(request, "format"));

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceResource.java
@@ -265,14 +265,11 @@ public class ResourceResource extends AbstractResource {
                         protected void wrapInternal(Map<String, Object> properties, SimpleHash model, 
                                 ResourceMetadata object) {
                             super.wrapInternal(properties, model, object);
-                            properties.put(
-                                    "path", 
-                                    object.getParent() == null ? "/" :  
-                                        Paths.path(object.getParent().getPath(),
-                                    object.getName()));
+                            properties.put("path", 
+                                    object.getParent() == null ? "/" :
+                                        "/" + Paths.path(object.getParent().getPath(), object.getName()));
                             properties.put("parent_path", 
-                                    object.getParent() == null ? "" : 
-                                        object.getParent().getPath());
+                                    object.getParent() == null ? "" : object.getParent().getPath());
                             properties.put("parent_href", 
                                     object.getParent() == null ? "" : 
                                         formatHtmlLink(object.getParent().getLink().getHref()));


### PR DESCRIPTION
See:

Paths.names (method used by multiple ResourceStores) not removing root slash
https://osgeo-org.atlassian.net/browse/GEOS-7493