### PR TITLE
Use parseDouble instead of convert function in sldService community module

### DIFF
--- a/src/community/sldService/src/main/java/org/geoserver/sldservice/utils/classifier/RulesBuilder.java
+++ b/src/community/sldService/src/main/java/org/geoserver/sldservice/utils/classifier/RulesBuilder.java
@@ -349,8 +349,8 @@ public class RulesBuilder {
 
 	private Expression normalizeProperty(PropertyName property,
 			Class<?> propertyType, boolean normalize) {
-		if(normalize && Integer.class.isAssignableFrom(propertyType) || Long.class.isAssignableFrom(propertyType)) {
-			return ff.function("convert", property, ff.literal("java.lang.Double"));
+		if(normalize && (Integer.class.isAssignableFrom(propertyType) || Long.class.isAssignableFrom(propertyType))) {
+			return ff.function("parseDouble", property);
 		}
 		return property;
 	}

--- a/src/community/sldService/src/test/java/org/geoserver/sldservice/utils/classifier/ClassifierTestSupport.java
+++ b/src/community/sldService/src/test/java/org/geoserver/sldservice/utils/classifier/ClassifierTestSupport.java
@@ -19,7 +19,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.factory.GeoTools;
 import org.geotools.factory.Hints;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
-import org.geotools.filter.function.FilterFunction_Convert;
+import org.geotools.filter.function.FilterFunction_parseDouble;
 import org.geotools.styling.PolygonSymbolizer;
 import org.geotools.styling.Rule;
 import org.mockito.Mockito;
@@ -299,7 +299,7 @@ public class ClassifierTestSupport extends SLDServiceBaseTest {
         
         checkRule(rules[0], "#550000", org.opengis.filter.PropertyIsLessThanOrEqualTo.class);
         org.opengis.filter.PropertyIsLessThanOrEqualTo filter = (org.opengis.filter.PropertyIsLessThanOrEqualTo) rules[0].getFilter();
-        assertTrue(filter.getExpression1() instanceof FilterFunction_Convert);
+        assertTrue(filter.getExpression1() instanceof FilterFunction_parseDouble);
     }
     
     public void testCustomRamp() throws IOException {


### PR DESCRIPTION
Potential fix for https://osgeo-org.atlassian.net/browse/GEOS-7501

Use parseDouble instead of convert function to create renderable sld rules, and only if 'normalize' boolean is true.

The 'convert' function creates SLD rules that are not renderable (exception included at bottom):

```
        <PropertyIsGreaterThanOrEqualTo>
          <Function name="convert">
            <PropertyName>value</PropertyName>
            <Literal>java.lang.Double</Literal>
          </Function>
          <Literal>220.0</Literal>
        </PropertyIsGreaterThanOrEqualTo>
```

Switching to 'parseDouble' produces renderable SLD:

```
        <PropertyIsGreaterThanOrEqualTo>
          <Function name="parseDouble">
            <PropertyName>value</PropertyName>
          </Function>
          <Literal>220.0</Literal>
        </PropertyIsGreaterThanOrEqualTo>
```

The exception caused by the convert function is:

```
Caused by: java.lang.IllegalArgumentException: Filter Function problem for function convert argument #1 - expected type Class
    at org.geotools.filter.function.FilterFunction_Convert.evaluate(FilterFunction_Convert.java:51)
    at org.geotools.filter.FilterAbstract.eval(FilterAbstract.java:95)
    at org.geotools.filter.MultiCompareFilterImpl.evaluate(MultiCompareFilterImpl.java:64)
    at org.geotools.filter.AndImpl.evaluate(AndImpl.java:44)
    at org.geotools.filter.OrImpl.evaluate(OrImpl.java:41)
    at org.geotools.data.FilteringFeatureReader.hasNext(FilteringFeatureReader.java:133)
    at org.geotools.data.store.ContentFeatureCollection$WrappingFeatureIterator.hasNext(ContentFeatureCollection.java:143)
    at org.geotools.renderer.lite.StreamingRenderer.drawPlain(StreamingRenderer.java:2294)
    at org.geotools.renderer.lite.StreamingRenderer.processStylers(StreamingRenderer.java:1917)
    at org.geotools.renderer.lite.StreamingRenderer.paint(StreamingRenderer.java:833)
    at org.geoserver.wms.map.RenderedImageMapOutputFormat.produceMap(RenderedImageMapOutputFormat.java:548)
    ... 112 more
```
