### PR TITLE
[GEOS-7499] Fix unwrapping of SecuredWMSLayerInfo in SecuredLayerInfo and SecureCatalogImpl

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -1058,7 +1058,8 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
             return ((SecuredFeatureTypeInfo) info).unwrap(ResourceInfo.class);
         if (info instanceof SecuredCoverageInfo)
             return ((SecuredCoverageInfo) info).unwrap(ResourceInfo.class);
-
+        if (info instanceof SecuredWMSLayerInfo)
+            return ((SecuredWMSLayerInfo) info).unwrap(ResourceInfo.class);
         return info;
     }
     

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredLayerInfo.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -44,7 +44,9 @@ public class SecuredLayerInfo extends DecoratingLayerInfo {
 
     @Override
     public void setResource(ResourceInfo resource) {
-        if (resource instanceof SecuredFeatureTypeInfo || resource instanceof SecuredCoverageInfo) {
+        if (resource instanceof SecuredFeatureTypeInfo
+                || resource instanceof SecuredCoverageInfo
+                || resource instanceof SecuredWMSLayerInfo) {
             resource = (ResourceInfo) SecureCatalogImpl.unwrap(resource);
         }
 


### PR DESCRIPTION
Issue: https://osgeo-org.atlassian.net/browse/GEOS-7499

The cause of this issue was SecureCatalogImpl and SecuredLayerInfo not properly handling the SecuredWMSLayerInfo wrapper.
The SecureCatalogImpl was not unwrapping resources info of type SecuredWMSLayerInfo, this was provoking the "Not a proxy error" exception.
The SecuredWMSLayerInfo was not unwrapping resources info of type SecuredWMSLayerInfo in the setResource method, so it was overriding the existing layer WMSLayerInfo resource with the secure wrapper. So the first request will go well and the next ones will fail (tricky to found this error).

This pull request add proper handling for the SecuredWMSLayerInfo wrapper and also add tests cases for this.
