### PR TITLE
[GEOS-7499] Fix unwrapping of SecuredWMSLayerInfo in SecuredLayerInfo and SecureCatalogImpl (backport to 2.8.x)

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -1057,7 +1057,8 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
             return ((SecuredFeatureTypeInfo) info).unwrap(ResourceInfo.class);
         if (info instanceof SecuredCoverageInfo)
             return ((SecuredCoverageInfo) info).unwrap(ResourceInfo.class);
-
+        if (info instanceof SecuredWMSLayerInfo)
+            return ((SecuredWMSLayerInfo) info).unwrap(ResourceInfo.class);
         return info;
     }
     

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredLayerInfo.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -44,7 +44,9 @@ public class SecuredLayerInfo extends DecoratingLayerInfo {
 
     @Override
     public void setResource(ResourceInfo resource) {
-        if (resource instanceof SecuredFeatureTypeInfo || resource instanceof SecuredCoverageInfo) {
+        if (resource instanceof SecuredFeatureTypeInfo
+                || resource instanceof SecuredCoverageInfo
+                || resource instanceof SecuredWMSLayerInfo) {
             resource = (ResourceInfo) SecureCatalogImpl.unwrap(resource);
         }
 

--- a/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -10,11 +10,14 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.easymock.classextension.EasyMock.createMock;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -43,8 +46,10 @@ import org.geoserver.catalog.Predicates;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.AbstractCatalogDecorator;
+import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.catalog.util.CloseableIteratorAdapter;
 import org.geoserver.ows.Dispatcher;
@@ -54,12 +59,15 @@ import org.geoserver.security.AbstractCatalogFilter;
 import org.geoserver.security.CatalogFilterAccessManager;
 import org.geoserver.security.DataAccessManager;
 import org.geoserver.security.ResourceAccessManager;
+import org.geoserver.security.SecureCatalogImpl;
+import org.geoserver.security.WrapperPolicy;
 import org.geoserver.security.decorators.ReadOnlyDataStoreTest;
 import org.geoserver.security.decorators.SecuredCoverageInfo;
 import org.geoserver.security.decorators.SecuredDataStoreInfo;
 import org.geoserver.security.decorators.SecuredFeatureTypeInfo;
 import org.geoserver.security.decorators.SecuredLayerGroupInfo;
 import org.geoserver.security.decorators.SecuredLayerInfo;
+import org.geoserver.security.decorators.*;
 import org.geotools.util.logging.Logging;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -107,6 +115,7 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
         assertSame(arcGrid, sc.getCoverageByName("nurc:arcgrid"));
         assertSame(states, sc.getResourceByName("topp:states", FeatureTypeInfo.class));
         assertSame(arcGrid, sc.getResourceByName("nurc:arcgrid", CoverageInfo.class));
+        assertSame(cascaded, sc.getResourceByName("topp:cascaded", WMSLayerInfo.class));
         assertEquals(toppWs, sc.getWorkspaceByName("topp"));
         assertSame(statesStore, sc.getDataStoreByName("states"));
         assertSame(roadsStore, sc.getDataStoreByName("roads"));
@@ -1353,5 +1362,41 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
             }
             return false;
         }
+    }
+
+    @Test
+    public void testUnwrapping() {
+        // we create a mock a policy without defining any behavior since it will not be used
+        WrapperPolicy policy = createMock(WrapperPolicy.class);
+        // test that a secured coverage info info is correctly unwrapped to a coverage info
+        assertThat(SecureCatalogImpl.unwrap(new SecuredCoverageInfo(arcGrid, policy)), not(instanceOf(SecuredCoverageInfo.class)));
+        // test that a secured feature info info is correctly unwrapped to a feature info
+        assertThat(SecureCatalogImpl.unwrap(new SecuredFeatureTypeInfo(states, policy)), not(instanceOf(SecuredFeatureTypeInfo.class)));
+        // test that a secured WMS layer info info is correctly unwrapped to a WMS layer info
+        assertThat(SecureCatalogImpl.unwrap(new SecuredWMSLayerInfo(cascaded, policy)), not(instanceOf(SecuredWMSLayerInfo.class)));
+    }
+
+    @Test
+    public void testSettingResourceOnSecureLayerInfo() {
+        // we create a mock a policy without defining any behavior since it will not be used
+        WrapperPolicy policy = createMock(WrapperPolicy.class);
+        // testing for coverages
+        LayerInfo coverageLayerInfo = new LayerInfoImpl();
+        SecuredLayerInfo secureCoverageLayerInfo = new SecuredLayerInfo(coverageLayerInfo, policy);
+        secureCoverageLayerInfo.setResource(new SecuredCoverageInfo(arcGrid, policy));
+        assertThat(coverageLayerInfo.getResource(), not(instanceOf(SecuredCoverageInfo.class)));
+        assertThat(coverageLayerInfo.getResource(), instanceOf(CoverageInfo.class));
+        // testing for features
+        LayerInfo featureLayerInfo = new LayerInfoImpl();
+        SecuredLayerInfo secureFeatureLayerInfo = new SecuredLayerInfo(featureLayerInfo, policy);
+        secureFeatureLayerInfo.setResource(new SecuredFeatureTypeInfo(states, policy));
+        assertThat(featureLayerInfo.getResource(), not(instanceOf(SecuredFeatureTypeInfo.class)));
+        assertThat(featureLayerInfo.getResource(), instanceOf(FeatureTypeInfo.class));
+        // testing for WMS layers
+        LayerInfo wmsLayerInfo = new LayerInfoImpl();
+        SecuredLayerInfo secureWmsLayerInfo = new SecuredLayerInfo(wmsLayerInfo, policy);
+        secureWmsLayerInfo.setResource(new SecuredWMSLayerInfo(cascaded, policy));
+        assertThat(wmsLayerInfo.getResource(), not(instanceOf(SecuredWMSLayerInfo.class)));
+        assertThat(wmsLayerInfo.getResource(), instanceOf(WMSLayerInfo.class));
     }
 }


### PR DESCRIPTION


Issue: https://osgeo-org.atlassian.net/browse/GEOS-7499

The cause of this issue was SecureCatalogImpl and SecuredLayerInfo not properly handling the SecuredWMSLayerInfo wrapper.
The SecureCatalogImpl was not unwrapping resources info of type SecuredWMSLayerInfo, this was provoking the "Not a proxy error" exception.
The SecuredWMSLayerInfo was not unwrapping resources info of type SecuredWMSLayerInfo in the setResource method, so it was overriding the existing layer WMSLayerInfo resource with the secure wrapper. So the first request will go well and the next ones will fail (tricky to found this error).

This pull request add proper handling for the SecuredWMSLayerInfo wrapper and also add tests cases for this.
