### PR TITLE
Bump log4j dependency to 1.2.17, to allow configuring rollingPolicy v…

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -913,7 +913,7 @@
    <dependency>
     <groupId>log4j</groupId>
     <artifactId>log4j</artifactId>
-    <version>1.2.14</version>
+    <version>1.2.17</version>
    </dependency>
    <dependency>
     <groupId>com.lowagie</groupId>


### PR DESCRIPTION
…ia properties

https://issues.apache.org/bugzilla/show_bug.cgi?id=36384

(the default to 1.2.14 fails.. - this was merged and works fine in our georchestra fork)