### PR TITLE
GEOS-7521: fix external module so it doesn't clip

### DIFF
--- a/src/community/vectortiles/pom.xml
+++ b/src/community/vectortiles/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>no.ecc.vectortile</groupId>
       <artifactId>java-vector-tile</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.9</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -67,6 +67,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
 
 </project>

--- a/src/community/vectortiles/src/main/java/no/ecc/vectortile/VectorTileEncoderNoClip.java
+++ b/src/community/vectortiles/src/main/java/no/ecc/vectortile/VectorTileEncoderNoClip.java
@@ -1,0 +1,25 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package no.ecc.vectortile;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+/*
+ * provides VectorTileEncoder that doesn't do any clipping.
+ * Our clipping system is "better" (more robust, faster, and maintainable here). 
+ */
+public class VectorTileEncoderNoClip extends VectorTileEncoder {
+
+    public VectorTileEncoderNoClip(int extent, int polygonClipBuffer, boolean autoScale) {
+        super(extent,polygonClipBuffer,autoScale);
+    }
+    
+    /*
+     *    returns original geometry - no clipping.  Assume upstream has already clipped!
+     */
+    protected Geometry clipGeometry(Geometry geometry) {
+        return geometry;
+    }
+}

--- a/src/community/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilder.java
+++ b/src/community/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilder.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import no.ecc.vectortile.VectorTileEncoder;
+import no.ecc.vectortile.VectorTileEncoderNoClip;
 
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.map.RawMap;
@@ -33,7 +34,7 @@ public class MapBoxTileBuilder implements VectorTileBuilder {
         final int extent = Math.max(mapSize.width, mapSize.height);
         final int polygonClipBuffer = extent / 32;
         final boolean autoScale = false;
-        this.encoder = new VectorTileEncoder(extent, polygonClipBuffer, autoScale);
+        this.encoder = new VectorTileEncoderNoClip(extent, polygonClipBuffer, autoScale);
     }
 
     @Override


### PR DESCRIPTION
See details in ticket.

a) moved to 1.0.9
b) created subclass that doesn't do any clipping
c) use the sub-class