### PR TITLE
[GEOS-7523] Make GWC settings UI only show the accepted eviction policies (backport 2.8.x)

### DIFF
--- a/doc/en/user/source/webadmin/tilecache/defaults.rst
+++ b/doc/en/user/source/webadmin/tilecache/defaults.rst
@@ -148,7 +148,11 @@ Parameter for configuring in memory cache size in MB.
 
 Cache Eviction Policy
 ```````````````````````````````````````
-Paramter for configuring in memory cache eviction policy, it may be: LRU, LFU, EXPIRE_AFTER_WRITE, EXPIRE_AFTER_ACCESS, NULL
+Parameter for configuring in memory cache eviction policy, it may be: LRU, LFU, EXPIRE_AFTER_WRITE, EXPIRE_AFTER_ACCESS, NULL
+
+This eviction policies may not be supported by all caches implementations. For example, Guava Caching only supports the eviction policies: EXPIRE_AFTER_WRITE, EXPIRE_AFTER_ACCESS and NULL.
+
+Note, only the eviction policies accepted by the selected cache will be shown on the UI.
 
 Cache Eviction Time (in Seconds)
 ```````````````````````````````````````

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/InMemoryBlobStorePanel.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/InMemoryBlobStorePanel.java
@@ -380,35 +380,18 @@ public class InMemoryBlobStorePanel extends Panel {
                     evictionTimeValue);
             evictionTime.setType(Long.class).setOutputMarkupId(true).setEnabled(true);
 
+            // by the default all available eviction policies are available
+            List<EvictionPolicy> evictionPolicies = Arrays.asList(EvictionPolicy.values());
+            ConfigurableBlobStore store = GeoServerExtensions.bean(ConfigurableBlobStore.class);
+            if (store != null) {
+                // we use the current cache accepted eviction policies
+                CacheProvider cache = store.getCacheProviders().get(key);
+                evictionPolicies = cache.getSupportedPolicies();
+            }
+
             final DropDownChoice<EvictionPolicy> policyDropDown = new DropDownChoice<EvictionPolicy>(
-                    "policy", policy, Arrays.asList(EvictionPolicy.values()));
+                    "policy", policy, evictionPolicies);
             policyDropDown.setOutputMarkupId(true).setEnabled(true);
-            // Validation for Eviction Policy
-            policyDropDown.add(new IValidator<EvictionPolicy>() {
-
-                @Override
-                public void validate(IValidatable<EvictionPolicy> validatable) {
-
-                    EvictionPolicy value = validatable.getValue();
-                    if (value != EvictionPolicy.NULL) {
-                        final ConfigurableBlobStore store = GeoServerExtensions
-                                .bean(ConfigurableBlobStore.class);
-                        // Ensure that the defined Eviction policy can be accepted by the cache used
-                        if (store != null) {
-                            CacheProvider cache = store.getCacheProviders().get(key);
-                            if (cache != null) {
-                                List<EvictionPolicy> policies = cache.getSupportedPolicies();
-                                if (policies != null && !policies.contains(value)) {
-                                    ValidationError error = new ValidationError();
-                                    error.setMessage(new ParamResourceModel(
-                                            "BlobStorePanel.invalidPolicy", null, "").getObject());
-                                    validatable.error(error);
-                                }
-                            }
-                        }
-                    }
-                }
-            });
 
             final TextField<Integer> textConcurrency = new TextField<Integer>("concurrencyLevel",
                     concurrencyLevel);


### PR DESCRIPTION
The issue associated with this pull request: https://osgeo-org.atlassian.net/browse/GEOS-7523

This pull request fixes the issue, updates the documentation and add a test case.
