### PR TITLE
VectorTiles: Applies the buffer used for clipping when querying for features.

### DIFF
--- a/src/community/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
+++ b/src/community/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
@@ -243,13 +243,17 @@ class PipelineBuilder {
                 clippingEnvelope = paintArea;
             } else {
                 ReferencedEnvelope renderingArea = context.renderingArea;
-                renderingArea.expandBy( clipBBOXSizeIncreasePixels * context.pixelSizeInTargetCRS);
+                renderingArea.expandBy(getClipDistance());
                 clippingEnvelope = renderingArea;
             }
 
             addLast(new Clip(clippingEnvelope));
         }
         return this;
+    }
+
+    public double getClipDistance() {
+        return clipBBOXSizeIncreasePixels * context.pixelSizeInTargetCRS;
     }
 
     private static final class Transform extends Pipeline {

--- a/src/community/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/community/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -118,7 +118,7 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
                     .collapseCollections()
                     .build();
 
-            Query query = getStyleQuery(layer, mapContent);
+            Query query = getStyleQuery(layer, mapContent, builder.getClipDistance());
             query.getHints().remove(Hints.SCREENMAP);
 
             FeatureCollection<?, ?> features = featureSource.getFeatures(query);

--- a/src/community/vectortiles/src/main/java/org/geotools/renderer/lite/VectorMapRenderUtils.java
+++ b/src/community/vectortiles/src/main/java/org/geotools/renderer/lite/VectorMapRenderUtils.java
@@ -53,7 +53,7 @@ public class VectorMapRenderUtils {
 
     private static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
 
-    public static Query getStyleQuery(Layer layer, WMSMapContent mapContent) throws IOException {
+    public static Query getStyleQuery(Layer layer, WMSMapContent mapContent, double bufferDistance) throws IOException {
 
         final ReferencedEnvelope renderingArea = mapContent.getRenderingArea();
         final Rectangle screenSize = new Rectangle(mapContent.getMapWidth(),
@@ -77,7 +77,7 @@ public class VectorMapRenderUtils {
         Query styleQuery;
         try {
             styleQuery = VectorMapRenderUtils.getStyleQuery(featureSource, styleList,
-                    renderingArea, screenSize, geometryDescriptor);
+                    renderingArea, bufferDistance, screenSize, geometryDescriptor);
         } catch (IllegalFilterException | FactoryException e1) {
             throw Throwables.propagate(e1);
         }
@@ -95,6 +95,7 @@ public class VectorMapRenderUtils {
             FeatureSource<?, ?> source, //
             List<LiteFeatureTypeStyle> styleList, //
             ReferencedEnvelope mapArea,//
+            double bufferDistance,
             Rectangle screenSize, //
             GeometryDescriptor geometryAttribute//
     ) throws IllegalFilterException, IOException, FactoryException {
@@ -103,8 +104,11 @@ public class VectorMapRenderUtils {
         Query query = new Query(schema.getName().getLocalPart());
         query.setProperties(Query.ALL_PROPERTIES);
 
+        ReferencedEnvelope bufferArea = ReferencedEnvelope.create(mapArea);
+        bufferArea.expandBy(bufferDistance);
+
         String geomName = geometryAttribute.getLocalName();
-        Filter filter = FF.bbox(FF.property(geomName), mapArea);
+        Filter filter = FF.bbox(FF.property(geomName), bufferArea);
         query.setFilter(filter);
 
         LiteFeatureTypeStyle[] styles = styleList


### PR DESCRIPTION
Existing code use a bbox filter that is the same as the tile border. Surrounding features that are located near the tile border are not included. When rendering vector tiles using a thick line style (especially road), some thick lines will get cropped near the tile border.

![mvt-before-fix-marked](https://cloud.githubusercontent.com/assets/14147841/15005481/c5525d26-11f7-11e6-8d7f-9ddaa07e9e86.png)
Those lines are NOT in the neighbor tile. So the neighbor tile does not render it at all.

I have updated the code to expand the bbox filter by the clip buffer.

![mvt-after-fix-marked](https://cloud.githubusercontent.com/assets/14147841/15005569/f08670da-11f8-11e6-86ed-ebfd89e1af3c.png)
Those lines are now included in the neighbor tile.