### PR TITLE
[GEOS-7539]Geoserver  2.9beta2 and 2.9rc1 does not start when using the extension imagemap: Update applicationContext.xml

### DIFF
--- a/src/extension/imagemap/src/main/java/applicationContext.xml
+++ b/src/extension/imagemap/src/main/java/applicationContext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 -<!-- 
- - Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ - Copyright (C) 2014 - 2016 - Open Source Geospatial Foundation. All rights reserved.
  - This code is licensed under the GPL 2.0 license, available at the root
  - application directory.
  - -->

--- a/src/extension/imagemap/src/main/java/applicationContext.xml
+++ b/src/extension/imagemap/src/main/java/applicationContext.xml
@@ -1,16 +1,17 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<!-- 
- Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
- This code is licensed under the GPL 2.0 license, available at the root
- application directory.
- -->
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:aop="http://www.springframework.org/schema/aop"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/aop
+        http://www.springframework.org/schema/aop/spring-aop.xsd">
 
-<beans>		
-	<bean id="HTMLImageMapMapProducer" 	singleton="true" 
+
+	<bean id="HTMLImageMapMapProducer" 	scope="singleton" 
 		class="org.vfny.geoserver.wms.responses.map.htmlimagemap.HTMLImageMapMapProducer">
 	</bean>
-    <bean id="HTMLImageMapResponse"  singleton="true" 
+    <bean id="HTMLImageMapResponse"  scope="singleton" 
       class="org.vfny.geoserver.wms.responses.map.htmlimagemap.HTMLImageMapResponse">
     </bean>
 </beans>

--- a/src/extension/imagemap/src/main/java/applicationContext.xml
+++ b/src/extension/imagemap/src/main/java/applicationContext.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
+-<!-- 
+ - Copyright (C) 2014 - Open Source Geospatial Foundation. All rights reserved.
+ - This code is licensed under the GPL 2.0 license, available at the root
+ - application directory.
+ - -->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:aop="http://www.springframework.org/schema/aop"


### PR DESCRIPTION
Geoserver does not start when using the extension imagemap (geoserver-2.9-RC1-imagemap-plugin.zip). Works fine in 2.9beta1, does not work in 2.9beta2 and 2.9rc1. Tested in Linux and Windows.

An error occurred in the file applicationContext.xml :

Attribute "singleton" must be declared for element type "bean"

See https://osgeo-org.atlassian.net/browse/GEOS-7539