### PR TITLE
Use github raw urls to reference eclipse configuration files

### DIFF
--- a/doc/en/developer/source/eclipse-guide/index.rst
+++ b/doc/en/developer/source/eclipse-guide/index.rst
@@ -135,7 +135,7 @@ Eclipse preferences
 Code formatting
 ^^^^^^^^^^^^^^^
 
-#. Download https://github.com/geotools/geotools/blob/master/build/eclipse/formatter.xml
+#. Download https://raw.githubusercontent.com/geotools/geotools/master/build/eclipse/formatter.xml
 #. Navigate to ``Java``, ``Code Style``, ``Formatter`` and click ``Import...``
 
    .. image:: code_formatting1.jpg
@@ -156,7 +156,7 @@ Code formatting
 Code templates
 ^^^^^^^^^^^^^^
 
-#. Download https://github.com/geotools/geotools/blob/master/build/eclipse/codetemplates.xml
+#. Download https://raw.githubusercontent.com/geotools/geotools/master/build/eclipse/codetemplates.xml
 #. Navigate to ``Java``, ``Code Style``, ``Code Templates`` and click ``Import...``
 
    .. image:: code_templates.jpg


### PR DESCRIPTION
Downloading the links to the eclipse formatter configuration and the code templates resulted in downloading a HTML version of these files. This PR changes the links to point directly to the raw files.