### PR TITLE
GEOS-7507 windows installer service wrapper jetty update

### DIFF
--- a/src/release/installer/win/GeoServerEXE.nsi
+++ b/src/release/installer/win/GeoServerEXE.nsi
@@ -796,6 +796,8 @@ Section "Main" SectionMain
     SetOutPath "$INSTDIR\wrapper\lib"
     File /a wrapper.jar
     File /a wrapper.dll
+
+    CreateDirectory "$INSTDIR\work"
 	
     ; Install the service (and start it)
     nsExec::Exec "$INSTDIR\wrapper.exe -it ./wrapper/wrapper.conf wrapper.java.additional.4=-Djetty.port=$Port"

--- a/src/release/installer/win/wrapper.conf
+++ b/src/release/installer/win/wrapper.conf
@@ -20,8 +20,9 @@ wrapper.java.classpath.3=lib/*.jar
 wrapper.java.library.path.1=wrapper/lib
 
 # Java Additional Parameters
-wrapper.java.additional.1=-Djetty.home=.
+wrapper.java.additional.1=-Djetty.base=.
 wrapper.java.additional.2=-DGEOSERVER_DATA_DIR="%GEOSERVER_DATA_DIR%"
+wrapper.java.additional.3=-Djava.io.tmpdir=./work
 
 # Initial Java Heap Size (in MB)
 wrapper.java.initmemory=16
@@ -30,7 +31,7 @@ wrapper.java.initmemory=16
 wrapper.java.maxmemory=128
 
 # Application parameters.  Add parameters as needed starting from 1
-wrapper.app.parameter.1=org.mortbay.start.Main
+wrapper.app.parameter.1=org.eclipse.jetty.start.Main
 wrapper.app.parameter.2=etc/jetty.xml
 
 #********************************************************************


### PR DESCRIPTION
Jetty fails to start when running GeoServer as a Windows service.

The PR updates GeoServerEXE.nsi script to create a temporary files directory for Jetty and wrapper.conf according to comments on GEOS-7507.