### PR TITLE
Remove unnecessary repositories from main pom file

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -72,6 +72,18 @@
     <url>http://download.osgeo.org/webdav/geotools/</url>
     <!-- release repository used by geotools (and third-party dependencies) -->
   </repository>
+   
+   <repository>
+      <id>geosolutions</id>
+      <name>geosolutions repository</name>
+      <url>http://maven.geo-solutions.it/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+     <releases>
+       <enabled>true</enabled>
+     </releases>
+    </repository>
  </repositories>
 
  <dependencyManagement>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!-- 
- Copyright (C) 2015 - Open Source Geospatial Foundation. All rights reserved.
+<!--
+ Copyright (C) 2016 - Open Source Geospatial Foundation. All rights reserved.
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -72,27 +72,6 @@
     <url>http://download.osgeo.org/webdav/geotools/</url>
     <!-- release repository used by geotools (and third-party dependencies) -->
   </repository>
-   
-  <repository>
-    <id>maven-restlet</id>
-    <name>Restlet Maven Repository</name>
-    <url>http://maven.restlet.org</url>
-    <snapshots>
-      <enabled>false</enabled>
-    </snapshots>
-  </repository>
-
-   <repository>
-      <id>geosolutions</id>
-      <name>geosolutions repository</name>
-      <url>http://maven.geo-solutions.it/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-     <releases>
-       <enabled>true</enabled>
-     </releases>
-    </repository>
  </repositories>
 
  <dependencyManagement>


### PR DESCRIPTION
A 3rd party repo went down and was causing the build to take > 10 hours due to very long timeouts.

Given the way that Maven handles repo failures, I think that we should do our best to minimize the number of repos included. All of the necessary jars seem to be pulling correctly when only the Boundless and OSGeo repositories are used.

I was having a problem pulling a jar when building the community extensions, but the project (geoscript-py) is currently semi abandoned and was relying on unsupported snapshots.

[I submitted this previously, but had accidentally done it off of a branch under active development]