### PR TITLE
Add ability to create PostgreSQL backed GeoGIG repositories via REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ target
 # Intellij
 .idea/
 *.iml
+
+# Cucumber Testing artifacts
+cucumber-report

--- a/src/community/geogig/pom.xml
+++ b/src/community/geogig/pom.xml
@@ -19,6 +19,7 @@
     <jline.version>2.12</jline.version>
     <mockito.version>1.8.5</mockito.version>
     <logback.version>1.1.2</logback.version>
+    <cucumber-java.version>1.2.4</cucumber-java.version>
   </properties>
 
   <repositories>
@@ -205,8 +206,40 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>info.cukes</groupId>
+      <artifactId>cucumber-java</artifactId>
+      <version>${cucumber-java.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>info.cukes</groupId>
+      <artifactId>cucumber-junit</artifactId>
+      <version>${cucumber-java.version}</version>
+      <scope>test</scope>
+    </dependency>    
+    <dependency>
+      <groupId>info.cukes</groupId>
+      <artifactId>cucumber-guice</artifactId>
+      <version>${cucumber-java.version}</version>
+      <scope>test</scope>
+    </dependency>  
+    <dependency>
       <groupId>org.locationtech.geogig</groupId>
       <artifactId>geogig-core</artifactId>
+      <version>${geogig.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-web-api</artifactId>
+      <version>${geogig.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-web-api-functional-tests</artifactId>
       <version>${geogig.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -248,12 +281,19 @@
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
+    </dependency>  
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <version>2.1.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>xmlunit</groupId>
-      <artifactId>xmlunit</artifactId>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-matchers</artifactId>
+      <version>2.1.0</version>
       <scope>test</scope>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>com.mockrunner</groupId>
       <artifactId>mockrunner</artifactId>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/ConfigStore.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/ConfigStore.java
@@ -137,7 +137,7 @@ public class ConfigStore {
         return resource;
     }
 
-    private Resource getConfigRoot() {
+    public Resource getConfigRoot() {
         return resourceLoader.get(CONFIG_DIR_NAME);
     }
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoGigInitializer.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoGigInitializer.java
@@ -33,7 +33,7 @@ public class GeoGigInitializer implements GeoServerInitializer {
 
     private static final Logger LOGGER = Logging.getLogger(GeoGigInitializer.class);
 
-    private ConfigStore store;
+    private final ConfigStore store;
 
     public static final String REPO_RESOLVER_CLASSNAME = GeoServerStoreRepositoryResolver.class
             .getName();
@@ -47,6 +47,7 @@ public class GeoGigInitializer implements GeoServerInitializer {
         // create RepositoryInfos for each datastore that doesn't have it to preserve backwards
         // compatibility
         Catalog catalog = geoServer.getCatalog();
+        RepositoryManager.get().setCatalog(catalog);
         Map<URI, RepositoryInfo> allByLocation = getAllByLocation();
 
         Multimap<URI, DataStoreInfo> byRepo = storesByRepository(catalog);
@@ -57,14 +58,14 @@ public class GeoGigInitializer implements GeoServerInitializer {
 
                 final RepositoryInfo info = create(repoURI);
 
-                for (DataStoreInfo store : byRepo.get(repoURI)) {
+                for (DataStoreInfo dataStore : byRepo.get(repoURI)) {
                     LOGGER.info(
                             format("Upgrading config for GeoGig store %s to refer to GeoServer's RepositoryInfo %s",
-                                    store.getName(), info.getId()));
-                    Map<String, Serializable> params = store.getConnectionParameters();
+                                    dataStore.getName(), info.getId()));
+                    Map<String, Serializable> params = dataStore.getConnectionParameters();
                     params.put(REPOSITORY.key, info.getId());
                     params.put(RESOLVER_CLASS_NAME.key, REPO_RESOLVER_CLASSNAME);
-                    catalog.save(store);
+                    catalog.save(dataStore);
                 }
             }
         }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
@@ -10,10 +10,14 @@ import java.io.File;
 import java.io.Serializable;
 import java.net.URI;
 
+import org.locationtech.geogig.api.plumbing.ResolveRepositoryName;
+import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.repository.RepositoryResolver;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
 
 public class RepositoryInfo implements Serializable {
 
@@ -82,9 +86,12 @@ public class RepositoryInfo implements Serializable {
 
     public String getRepoName() {
         if (this.location != null)  {
-            // Name is deprecated, use the RepositoryResolver
-            RepositoryResolver uriResolver = RepositoryResolver.lookup(this.location);
-            return uriResolver.getName(this.location);
+        	try {
+        		Repository repo = RepositoryResolver.load(this.location);
+        		return repo.command(ResolveRepositoryName.class).call();
+        	} catch (RepositoryConnectionException e) {
+        		Throwables.propagate(e);
+        	}
         }
         return null;
     }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
@@ -85,13 +85,21 @@ public class RepositoryInfo implements Serializable {
     }
 
     public String getRepoName() {
-        if (this.location != null)  {
-        	try {
-        		Repository repo = RepositoryResolver.load(this.location);
-        		return repo.command(ResolveRepositoryName.class).call();
-        	} catch (RepositoryConnectionException e) {
-        		Throwables.propagate(e);
-        	}
+        if (this.location != null) {
+            try {
+                // lookup the resolver
+                RepositoryResolver resolver = RepositoryResolver.lookup(this.location);
+                // if the repo exists, get the name from it
+                if (resolver.repoExists(this.location)) {
+                    // it exists, load it and fetch the name
+                    Repository repo = RepositoryResolver.load(this.location);
+                    return repo.command(ResolveRepositoryName.class).call();
+                }
+                // the repo doesn't exist, derive the name from the location
+                return resolver.getName(this.location);
+            } catch (RepositoryConnectionException e) {
+                Throwables.propagate(e);
+            }
         }
         return null;
     }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -112,12 +113,21 @@ public class RepositoryManager {
     	this.repoCache.invalidate(repoId);
     }
     
-    public GeoGIG createRepo(final Hints hints, final String repoId) {
-        Resource root = store.getConfigRoot();
-        File parent = root.parent().dir();
-        File f = new File(parent, repoId);
-        final URI repoURI = f.toURI();
-        hints.set(Hints.REPOSITORY_URL, repoURI);
+    public GeoGIG createRepo(final Hints hints) {
+        // get the Config store location
+        // only generate a location if no URI is set in the hints
+        if (!hints.get(Hints.REPOSITORY_URL).isPresent()) {
+            Optional<Serializable> repositoryName = hints.get(Hints.REPOSITORY_NAME);
+            // use the name from the Hints. It should never be null, but in case it is, generate one
+            String repoName = repositoryName.isPresent() ? repositoryName.get().toString() :
+                    UUID.randomUUID().toString();
+            // no location set yet, generate one
+            Resource root = store.getConfigRoot();
+            File parent = root.parent().dir().getAbsoluteFile();
+            File f = new File(parent, repoName);
+            final URI repoURI = f.toURI().normalize();
+            hints.set(Hints.REPOSITORY_URL, repoURI);
+        }
 
         Context context = GlobalContextBuilder.builder().build(hints);
 
@@ -135,16 +145,13 @@ public class RepositoryManager {
     }
 
     public List<DataStoreInfo> findGeogigStores() {
-        return findGeogigStores(getCatalog());
+        return findGeogigStores(this.catalog);
     }
 
     public Catalog getCatalog() {
-    	if (catalog == null) {
-    		catalog = GeoServerApplication.get().getCatalog();
-    	}
-        return catalog;
+        return this.catalog;
     }
-    
+
     public void setCatalog(Catalog catalog) {
     	this.catalog = catalog;
     }
@@ -179,7 +186,7 @@ public class RepositoryManager {
         String locationKey = "connectionParameters." + GeoGigDataStoreFactory.REPOSITORY.key;
         filter = and(filter, equal(locationKey, repoId));
         List<DataStoreInfo> dependent;
-        try (CloseableIterator<DataStoreInfo> stores = getCatalog().list(DataStoreInfo.class,
+        try (CloseableIterator<DataStoreInfo> stores = this.catalog.list(DataStoreInfo.class,
                 filter)) {
             dependent = Lists.newArrayList(stores);
         }
@@ -193,12 +200,11 @@ public class RepositoryManager {
         filter = and(filter, equal(locationKey, repoId));
         List<DataStoreInfo> stores = findDataStores(repoId);
         List<CatalogInfo> dependent = new ArrayList<CatalogInfo>(stores);
-        Catalog catalog = getCatalog();
         for (DataStoreInfo store : stores) {
-            List<FeatureTypeInfo> ftypes = catalog.getFeatureTypesByDataStore(store);
+            List<FeatureTypeInfo> ftypes = this.catalog.getFeatureTypesByDataStore(store);
             dependent.addAll(ftypes);
             for (FeatureTypeInfo ftype : ftypes) {
-                dependent.addAll(catalog.getLayers(ftype));
+                dependent.addAll(this.catalog.getLayers(ftype));
             }
         }
 
@@ -207,14 +213,14 @@ public class RepositoryManager {
 
     public List<LayerInfo> findLayers(DataStoreInfo store) {
         Filter filter = equal("resource.store.id", store.getId());
-        try (CloseableIterator<LayerInfo> it = getCatalog().list(LayerInfo.class, filter)) {
+        try (CloseableIterator<LayerInfo> it = this.catalog.list(LayerInfo.class, filter)) {
             return Lists.newArrayList(it);
         }
     }
 
     public List<FeatureTypeInfo> findFeatureTypes(DataStoreInfo store) {
         Filter filter = equal("store.id", store.getId());
-        try (CloseableIterator<FeatureTypeInfo> it = getCatalog().list(FeatureTypeInfo.class,
+        try (CloseableIterator<FeatureTypeInfo> it = this.catalog.list(FeatureTypeInfo.class,
                 filter)) {
             return Lists.newArrayList(it);
         }
@@ -271,7 +277,7 @@ public class RepositoryManager {
 
     public void delete(final String repoId) {
         List<DataStoreInfo> repoStores = findDataStores(repoId);
-        CascadeDeleteVisitor deleteVisitor = new CascadeDeleteVisitor(getCatalog());
+        CascadeDeleteVisitor deleteVisitor = new CascadeDeleteVisitor(this.catalog);
         for (DataStoreInfo storeInfo : repoStores) {
             storeInfo.accept(deleteVisitor);
         }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
@@ -6,21 +6,33 @@ package org.geogig.geoserver.rest;
 
 import static org.locationtech.geogig.rest.repository.RESTUtils.getStringAttribute;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 
+import org.geogig.geoserver.config.ConfigStore;
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geogig.geoserver.config.RepositoryManager;
+import org.geoserver.platform.resource.Resource;
 import org.geoserver.rest.RestletException;
 import org.locationtech.geogig.api.GeoGIG;
+import org.locationtech.geogig.api.plumbing.ResolveGeogigURI;
+import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.restlet.data.Request;
 import org.restlet.data.Status;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
 
 /**
@@ -29,40 +41,86 @@ import com.google.common.collect.Iterators;
  */
 public class GeoServerRepositoryProvider implements RepositoryProvider {
 
-    private Optional<String> getRepositoryId(Request request) {
+    private Optional<String> getRepositoryName(Request request) {
         final String repo = getStringAttribute(request, "repository");
         return Optional.fromNullable(repo);
     }
 
     public Optional<RepositoryInfo> findRepository(Request request) {
-        Optional<String> repositoryId = getRepositoryId(request);
-        if (!repositoryId.isPresent()) {
+        Optional<String> repositoryName = getRepositoryName(request);
+        if (!repositoryName.isPresent()) {
             return Optional.absent();
         }
         try {
-            String repoId = repositoryId.get();
-            RepositoryManager repositoryManager = RepositoryManager.get();
-            RepositoryInfo repositoryInfo;
-            repositoryInfo = repositoryManager.get(repoId);
-            return Optional.of(repositoryInfo);
+            String repoName = repositoryName.get();
+            String repoId = getRepoIdForName(repoName);
+            if (repoId != null) {
+                RepositoryManager repositoryManager = RepositoryManager.get();
+	            RepositoryInfo repositoryInfo;
+	            repositoryInfo = repositoryManager.get(repoId);
+	            return Optional.of(repositoryInfo);
+            } else {
+            	return Optional.absent();
+            }
         } catch (NoSuchElementException | IOException e) {
             return Optional.absent();
         }
     }
+    
+    private Map<String, String> repoNameToId = new HashMap<String, String>();
 
     public List<RepositoryInfo> getRepositoryInfos() {
         return RepositoryManager.get().getAll();
     }
+    
+    private void updateMappings() {
+    	List<RepositoryInfo> infos = getRepositoryInfos();
+    	repoNameToId.clear();
+    	for (RepositoryInfo info : infos) {
+    		repoNameToId.put(info.getRepoName(), info.getId());
+    	}
+    }
+    
+    private String getRepoIdForName(String repoName) {
+        String repoId = repoNameToId.get(repoName);
+        if (repoId == null) {
+        	updateMappings();
+        	repoId = repoNameToId.get(repoName);
+        }
+        return repoId;
+    }
 
     @Override
     public void delete(Request request) {
-        // TODO Auto-generated method stub
+        Optional<GeoGIG> geogig = getGeogig(request);
+        Preconditions.checkState(geogig.isPresent(), "No repository to delete.");
+
+        final String repositoryName = getStringAttribute(request, "repository");
+        final String repoId = repoNameToId.get(repositoryName);
+        GeoGIG ggig = geogig.get();
+        Optional<URI> repoUri = ggig.command(ResolveGeogigURI.class).call();
+        Preconditions.checkState(repoUri.isPresent(), "No repository to delete.");
+
+        ggig.close();
+        try {
+            GeoGIG.delete(repoUri.get());
+            RepositoryManager manager = RepositoryManager.get();
+            manager.invalidate(repoId);
+            repoNameToId.remove(repositoryName);
+        } catch (Exception e) {
+            Throwables.propagate(e);
+        }
 
     }
 
     @Override
     public void invalidate(String repoName) {
-        // TODO Auto-generated method stub
+        if (repoNameToId.containsKey(repoName)) {
+            final String repoId = repoNameToId.get(repoName);
+            RepositoryManager manager = RepositoryManager.get();
+            manager.invalidate(repoId);
+            repoNameToId.remove(repoName);
+        }
     }
 
     @Override
@@ -71,32 +129,41 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
         return Iterators.transform(infos.iterator(), new Function<RepositoryInfo, String>() {
             @Override
             public String apply(RepositoryInfo input) {
-                return input.getId();
+                return input.getRepoName();
             }
         });
     }
 
     @Override
     public Optional<GeoGIG> getGeogig(Request request) {
-        Optional<String> repositoryId = getRepositoryId(request);
-        if (!repositoryId.isPresent()) {
+        Optional<String> repositoryName = getRepositoryName(request);
+        if (!repositoryName.isPresent()) {
             return Optional.absent();
         }
-        GeoGIG geogig = findRepository(request, repositoryId.get());
+        return getGeogig(repositoryName.get());
+    }
+    
+    public Optional<GeoGIG> getGeogig(String repositoryName) {
+        GeoGIG geogig = findRepository(repositoryName);
         return Optional.of(geogig);
     }
 
-    private GeoGIG findRepository(Request request, String repositoryId) {
+    private GeoGIG findRepository(String repositoryName) {
 
         RepositoryManager manager = RepositoryManager.get();
+        String repoId = getRepoIdForName(repositoryName);
+        if (repoId == null) {
+        	repoId = UUID.randomUUID().toString();
+        }
         try {
-            manager.get(repositoryId);
-            return manager.getRepository(repositoryId);
+            RepositoryInfo info = manager.get(repoId);
+            return manager.getRepository(repoId);
         } catch (NoSuchElementException e) {
-            throw new RestletException("No such repository: " + repositoryId,
-                    Status.CLIENT_ERROR_NOT_FOUND);
+            Hints hints = new Hints();
+            hints.set(Hints.REPOSITORY_NAME, repositoryName);
+            return manager.createRepo(hints, repoId);
         } catch (IOException e) {
-            throw new RestletException("Error accessing datastore " + repositoryId,
+            throw new RestletException("Error accessing datastore " + repositoryName,
                     Status.SERVER_ERROR_INTERNAL, e);
         }
     }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeogigDispatcher.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeogigDispatcher.java
@@ -20,6 +20,7 @@ import org.locationtech.geogig.rest.TaskStatusResource;
 import org.locationtech.geogig.rest.osm.OSMRouter;
 import org.locationtech.geogig.rest.postgis.PGRouter;
 import org.locationtech.geogig.rest.repository.CommandResource;
+import org.locationtech.geogig.rest.repository.DeleteRepository;
 import org.locationtech.geogig.rest.repository.FixedEncoder;
 import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.locationtech.geogig.rest.repository.RepositoryRouter;
@@ -108,6 +109,7 @@ public class GeogigDispatcher extends AbstractController {
         router.attach("/tasks/{taskId}/download", TaskResultDownloadResource.class);
 
         Router osm = new OSMRouter();
+        router.attach("/repos/{repository}", DeleteRepository.class);
         router.attach("/repos/{repository}/osm", osm);
 
         Router postgis = new PGRouter();
@@ -117,6 +119,7 @@ public class GeogigDispatcher extends AbstractController {
         router.attach("/repos/{repository}", RepositoryResource.class);
         router.attach("/repos/{repository}/repo", makeRepoRouter());
         router.attach("/repos/{repository}/import", UploadCommandResource.class);
+        router.attach("/repos/{repository}/init", InitCommandResource.class);
         router.attach("/repos/{repository}/import.{extension}", UploadCommandResource.class);
         router.attach("/repos/{repository}/{command}.{extension}", CommandResource.class);
         router.attach("/repos/{repository}/{command}", CommandResource.class);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
@@ -1,0 +1,76 @@
+package org.geogig.geoserver.rest;
+
+import static org.locationtech.geogig.rest.repository.RESTUtils.getGeogig;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Map;
+
+import org.geogig.geoserver.config.RepositoryInfo;
+import org.geogig.geoserver.config.RepositoryManager;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.locationtech.geogig.api.GeoGIG;
+import org.locationtech.geogig.api.plumbing.ResolveGeogigURI;
+import org.locationtech.geogig.api.plumbing.ResolveRepositoryName;
+import org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory;
+import org.locationtech.geogig.rest.repository.CommandResource;
+import org.restlet.data.Request;
+import org.restlet.data.Status;
+import org.restlet.resource.Representation;
+import org.restlet.resource.Variant;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+
+public class InitCommandResource extends CommandResource {
+	
+	@Override
+	protected String getCommandName() {
+        return "init";
+    }
+	
+	@Override
+	protected Representation runCommand(Variant variant, Request request) {
+		Representation representation = super.runCommand(variant, request);
+
+		if (getResponse().getStatus() == Status.SUCCESS_CREATED) {
+			Catalog catalog = RepositoryManager.get().getCatalog();
+			setUpDataStore(catalog, geogig.get().command(ResolveRepositoryName.class).call());
+		}
+		return representation;
+	}
+	
+    public DataStoreInfo setUpDataStore(Catalog catalog, String storeName) {
+    	NamespaceInfo ns = catalog.getDefaultNamespace();
+    	WorkspaceInfo ws = catalog.getDefaultWorkspace();
+        DataStoreInfo ds = catalog.getFactory().createDataStore();
+        ds.setEnabled(true);
+        ds.setDescription("GeoGIG repository");
+        ds.setName(storeName);
+        ds.setType(GeoGigDataStoreFactory.DISPLAY_NAME);
+        ds.setWorkspace(ws);
+        Map<String, Serializable> connParams = ds.getConnectionParameters();
+
+        Optional<URI> GeogigDir = geogig.get().command(ResolveGeogigURI.class).call();
+        File repositoryUrl = new File(GeogigDir.get()).getParentFile();
+
+        connParams.put(GeoGigDataStoreFactory.REPOSITORY.key, repositoryUrl.getAbsolutePath());
+        connParams.put(GeoGigDataStoreFactory.DEFAULT_NAMESPACE.key, ns.getURI());
+        catalog.add(ds);
+
+        try {
+            DataStoreInfo dsInfo = catalog.getDataStoreByName(ws, storeName);
+            String repoId = (String) dsInfo.getConnectionParameters()
+                    .get(GeoGigDataStoreFactory.REPOSITORY.key);
+        	RepositoryInfo info = RepositoryManager.get().get(repoId);
+        } catch (IOException e) {
+        	Throwables.propagate(e);
+        }
+        return ds;
+    }
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryListResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryListResource.java
@@ -121,7 +121,7 @@ public class RepositoryListResource extends Resource {
 
         @Override
         protected void write(XMLStreamWriter w) throws XMLStreamException {
-            w.writeStartElement("repositories");
+            w.writeStartElement("repos");
             for (RepositoryInfo repo : repos) {
                 write(w, repo);
             }
@@ -129,12 +129,12 @@ public class RepositoryListResource extends Resource {
         }
 
         private void write(XMLStreamWriter w, RepositoryInfo repo) throws XMLStreamException {
-            w.writeStartElement("repository");
+            w.writeStartElement("repo");
             element(w, "id", repo.getId());
             RepositoryResolver uriResolver = RepositoryResolver.lookup(repo.getLocation());
             String name = uriResolver.getName(repo.getLocation());
             element(w, "name", name);
-            encodeAlternateAtomLink(w, repo.getId());
+            encodeAlternateAtomLink(w, repo.getRepoName());
             w.writeEndElement();
         }
 

--- a/src/community/geogig/src/main/resources/org/geogig/geoserver/rest/RepositoryListResource.ftl
+++ b/src/community/geogig/src/main/resources/org/geogig/geoserver/rest/RepositoryListResource.ftl
@@ -14,7 +14,7 @@
 <#if repositories?size != 0>
 <ul>
 <#foreach repo in repositories>
-<li><a href="${page.pageURI(repo.id)}">${repo.id}</a> (${repo.repoName})</li>
+<li><a href="${page.pageURI(repo.repoName)}">${repo.repoName}</a> (${repo.id})</li>
 </#foreach>
 </ul>
 <#else>

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/GeoGigTestData.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/GeoGigTestData.java
@@ -94,13 +94,21 @@ public class GeoGigTestData extends ExternalResource {
 
     @Override
     protected void before() throws Throwable {
+    	setUp("testrepo");
+    }
+    
+    public void setUp(String repoName) throws Exception {
         tmpFolder = new TemporaryFolder();
         tmpFolder.create();
-        this.geogig = createGeogig();
+        this.geogig = createRepository(repoName);
     }
 
     @Override
     protected void after() {
+    	tearDown();
+    }
+    
+    public void tearDown() {
         try {
             if (geogig != null) {
                 geogig.close();
@@ -112,10 +120,10 @@ public class GeoGigTestData extends ExternalResource {
     }
 
     protected GeoGIG createGeogig() throws IOException {
-        return createRpository("testrepo");
+        return createRepository("testrepo");
     }
 
-    public GeoGIG createRpository(String name) {
+    public GeoGIG createRepository(String name) {
         File dataDirectory = tmpFolder.getRoot();
         repoDir = new File(dataDirectory, name);
         Assert.assertTrue(repoDir.mkdir());

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
@@ -1,3 +1,7 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geogig.geoserver.functional;
 
 import static org.junit.Assert.assertEquals;
@@ -47,143 +51,153 @@ import com.mockrunner.mock.web.MockServletOutputStream;
  * Context for running GeoGIG web API functional tests from the plugin endpoints.
  */
 public class GeoServerFunctionalTestContext extends FunctionalTestContext {
-	
+
     private static final Random rnd = new Random();
-    
+
     private MockHttpServletResponse lastResponse = null;
-    
+
     private GeoServerRepositoryProvider repoProvider = null;
-	
+
     /**
      * Helper class for running mock http requests.
      */
-	private class TestHelper extends GeoServerSystemTestSupport {
-		
-		public TestHelper() {
-			super();
-	    	testSetupFrequency = TestSetupFrequency.REPEAT;
-		}
+    private class TestHelper extends GeoServerSystemTestSupport {
 
-	    /**
-	     * Override to avoid creating default geoserver test data
-	     */
-	    @Override
-	    protected void setUpTestData(SystemTestData testData) throws Exception {
-	    }
-	    
-	    /**
-	     * @return the catalog used by the test helper
-	     */
-	    public Catalog getCatalog() {
-	    	return super.getCatalog();
-	    }
-	    
-	    /**
-	     * Issue a POST request to the provided URL with the given file passed as form data.
-	     * 
-	     * @param resourceUri the url to issue the request to
-	     * @param formFieldName the form field name for the file to be posted
-	     * @param file the file to post
-	     * @return the response to the request
-	     */
-	    public MockHttpServletResponse postFile(String resourceUri, String formFieldName, File file) throws Exception {
-	    	Part[] parts = new Part[1];
-	    	parts[0] = new FilePart(formFieldName, file);
+        public TestHelper() {
+            super();
+            testSetupFrequency = TestSetupFrequency.REPEAT;
+        }
 
-	        MultipartRequestEntity multipart = new MultipartRequestEntity(parts, new PostMethod().getParams());
+        /**
+         * Override to avoid creating default geoserver test data
+         */
+        @Override
+        protected void setUpTestData(SystemTestData testData) throws Exception {
+        }
 
-	        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-	        multipart.writeRequest(bout);
+        /**
+         * @return the catalog used by the test helper
+         */
+        public Catalog getCatalog() {
+            return super.getCatalog();
+        }
 
-	        MockHttpServletRequest req = createRequest(resourceUri);
-	        req.setContentType(multipart.getContentType());
-	        req.addHeader("Content-Type", multipart.getContentType());
-	        req.setMethod("POST");
-	        req.setBodyContent(bout.toByteArray());
+        /**
+         * Issue a POST request to the provided URL with the given file passed as form data.
+         *
+         * @param resourceUri   the url to issue the request to
+         * @param formFieldName the form field name for the file to be posted
+         * @param file          the file to post
+         *
+         * @return the response to the request
+         */
+        public MockHttpServletResponse postFile(String resourceUri, String formFieldName, File file)
+                throws Exception {
+            Part[] parts = new Part[1];
+            parts[0] = new FilePart(formFieldName, file);
 
-	        return dispatch(req);
-	    }
-	    
-	    /**
-	     * Issue a request with the given {@link Method} to the provided resource URI.
-	     * 
-	     * @param method the http method to use
-	     * @param resourceUri the uri to issue the request to
-	     * @return the response to the request
-	     */
-	    public MockHttpServletResponse callInternal(Method method, String resourceUri) throws Exception {
-	    	MockHttpServletRequest request = super.createRequest(resourceUri);
-	    	request.setMethod(method.getName());
-	    	
-	    	return dispatch(request, null);
-	    	
-	    }
-	    
-	    /**
-	     * Provide access to the helper function that turns the response into a {@link Document}.
-	     * 
-	     * @param stream the stream to read as a document
-	     * @return the {@link Document}
-	     * @throws Exception
-	     */
-	    public Document getDom(InputStream stream) throws Exception {
-	    	return dom(stream);
-	    }
-	}
-	
-	private TestHelper helper = null;
+            MultipartRequestEntity multipart = new MultipartRequestEntity(parts,
+                    new PostMethod().getParams());
+
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            multipart.writeRequest(bout);
+
+            MockHttpServletRequest req = createRequest(resourceUri);
+            req.setContentType(multipart.getContentType());
+            req.addHeader("Content-Type", multipart.getContentType());
+            req.setMethod("POST");
+            req.setBodyContent(bout.toByteArray());
+
+            return dispatch(req);
+        }
+
+        /**
+         * Issue a request with the given {@link Method} to the provided resource URI.
+         *
+         * @param method      the http method to use
+         * @param resourceUri the uri to issue the request to
+         *
+         * @return the response to the request
+         */
+        public MockHttpServletResponse callInternal(Method method, String resourceUri)
+                throws Exception {
+            MockHttpServletRequest request = super.createRequest(resourceUri);
+            request.setMethod(method.getName());
+
+            return dispatch(request, null);
+
+        }
+
+        /**
+         * Provide access to the helper function that turns the response into a {@link Document}.
+         *
+         * @param stream the stream to read as a document
+         *
+         * @return the {@link Document}
+         *
+         * @throws Exception
+         */
+        public Document getDom(InputStream stream) throws Exception {
+            return dom(stream);
+        }
+    }
+
+    private TestHelper helper = null;
 
     /**
      * Set up the context for a scenario.
      */
-	@Override
-	protected void setUp() throws Exception {
-		if (helper == null) {
-			helper = new TestHelper();
-			helper.doSetup();
-			
-			repoProvider = new GeoServerRepositoryProvider();
-			
-			RepositoryManager.get().setCatalog(helper.getCatalog());
-		}
-		
-	}
+    @Override
+    protected void setUp() throws Exception {
+        if (helper == null) {
+            helper = new TestHelper();
+            helper.doSetup();
+
+            repoProvider = new GeoServerRepositoryProvider();
+
+            RepositoryManager.get().setCatalog(helper.getCatalog());
+        }
+
+    }
 
     /**
      * Clean up resources used in the scenario.
      */
-	@Override
-	protected void tearDown() throws Exception {
-		try {
-			if (helper != null) {
-				RepositoryManager.close();
-				helper.doTearDown();
-			}
-		} finally {
-			helper = null;
-		}
-	}
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            if (helper != null) {
+                RepositoryManager.close();
+                helper.doTearDown();
+            }
+        } finally {
+            helper = null;
+        }
+    }
 
     /**
      * Return the {@link GeoGIG} that corresponds to the given repository name.
-     * 
+     *
      * @param name the repository to get
+     *
      * @return the repository
      */
-	@Override
-	public GeoGIG getRepo(String name) {
-		return repoProvider.getGeogig(name).orNull();
-	}
+    @Override
+    public GeoGIG getRepo(String name) {
+        return repoProvider.getGeogig(name).orNull();
+    }
 
     /**
      * Create a repository with the given name for testing.
-     * 
+     *
      * @param name the repository name
+     *
      * @return a newly created {@link TestData} for the repository.
+     *
      * @throws Exception
      */
-	@Override
-	protected TestData createRepo(String name) throws Exception {
+    @Override
+    protected TestData createRepo(String name) throws Exception {
         GeoGigTestData testData = new GeoGigTestData();
         testData.setUp(name);
         testData.init();
@@ -210,111 +224,112 @@ public class GeoServerFunctionalTestContext extends FunctionalTestContext {
         RepositoryInfo repositoryInfo = RepositoryManager.get().get(repoId);
         assertNotNull(repositoryInfo);
         return new TestData(geogig);
-	}
-	
-	/**
-	 * Helper function that asserts that there is a last response and returns it.
-	 * 
-	 * @return the last response
-	 */
-	private MockHttpServletResponse getLastResponse() {
-		assertNotNull(lastResponse);
-		return lastResponse;
-	}
+    }
+
+    /**
+     * Helper function that asserts that there is a last response and returns it.
+     *
+     * @return the last response
+     */
+    private MockHttpServletResponse getLastResponse() {
+        assertNotNull(lastResponse);
+        return lastResponse;
+    }
 
     /**
      * Issue a POST request to the provided URL with the given file passed as form data.
-     * 
-     * @param resourceUri the url to issue the request to
+     *
+     * @param resourceUri   the url to issue the request to
      * @param formFieldName the form field name for the file to be posted
-     * @param file the file to post
+     * @param file          the file to post
      */
-	@Override
-	protected void postFileInternal(String resourceUri, String formFieldName, File file) {
-		resourceUri = replaceVariables(resourceUri);
-		try {
-			lastResponse = helper.postFile("/geogig" + resourceUri, formFieldName, file);
-		} catch (Exception e) {
-			Throwables.propagate(e);
-		}
-	}
+    @Override
+    protected void postFileInternal(String resourceUri, String formFieldName, File file) {
+        resourceUri = replaceVariables(resourceUri);
+        try {
+            lastResponse = helper.postFile("/geogig" + resourceUri, formFieldName, file);
+        } catch (Exception e) {
+            Throwables.propagate(e);
+        }
+    }
 
     /**
      * Issue a request with the given {@link Method} to the provided resource URI.
-     * 
-     * @param method the http method to use
+     *
+     * @param method      the http method to use
      * @param resourceUri the uri to issue the request to
      */
-	@Override
-	protected void callInternal(Method method, String resourceUri) {
-		try {
-			resourceUri = replaceVariables(resourceUri);
-			this.lastResponse = helper.callInternal(method, "/geogig" + resourceUri);
-		} catch (Exception e) {
-			Throwables.propagate(e);
-		}
-	}
+    @Override
+    protected void callInternal(Method method, String resourceUri) {
+        try {
+            resourceUri = replaceVariables(resourceUri);
+            this.lastResponse = helper.callInternal(method, "/geogig" + resourceUri);
+        } catch (Exception e) {
+            Throwables.propagate(e);
+        }
+    }
 
     /**
      * @return the content of the last response as text
      */
-	@Override
-	public String getLastResponseText() {
-		return getLastResponse().getOutputStreamContent();
-	}
+    @Override
+    public String getLastResponseText() {
+        return getLastResponse().getOutputStreamContent();
+    }
 
     /**
      * @return the content type of the last response
      */
-	@Override
-	public String getLastResponseContentType() {
-		return getLastResponse().getContentType();
-	}
+    @Override
+    public String getLastResponseContentType() {
+        return getLastResponse().getContentType();
+    }
 
-	/**
+    /**
      * @return the content of the last response as a {@link Document}
      */
-	@Override
-	public Document getLastResponseAsDom() {
-		Document result = null;
-		try {
-			result = helper.getDom(getLastResponseInputStream());
-		} catch (Exception e) {
-			Throwables.propagate(e);
-		}
-		return result;
-	}
+    @Override
+    public Document getLastResponseAsDom() {
+        Document result = null;
+        try {
+            result = helper.getDom(getLastResponseInputStream());
+        } catch (Exception e) {
+            Throwables.propagate(e);
+        }
+        return result;
+    }
 
     /**
      * @return the status code of the last response
      */
-	@Override
-	public int getLastResponseStatus() {
-		MockHttpServletResponse response = getLastResponse();
-		int code = response.getStatusCode();
-		if (response.getStatusCode() == 200) {
-			code = response.getErrorCode();
-		}
-		return code;
-	}
+    @Override
+    public int getLastResponseStatus() {
+        MockHttpServletResponse response = getLastResponse();
+        int code = response.getStatusCode();
+        if (response.getStatusCode() == 200) {
+            code = response.getErrorCode();
+        }
+        return code;
+    }
 
     /**
      * @return the content of the last response as an {@link InputStream}
+     *
      * @throws Exception
      */
-	@Override
-	public InputStream getLastResponseInputStream() throws Exception {
-		return new ByteArrayInputStream(getBinary(getLastResponse()));
-	}
+    @Override
+    public InputStream getLastResponseInputStream() throws Exception {
+        return new ByteArrayInputStream(getBinary(getLastResponse()));
+    }
 
     /**
      * @return the allowed http methods of the last response
      */
-	@Override
-	public Set<String> getLastResponseAllowedMethods() {
-		return Sets.newHashSet(getLastResponse().getHeader("ALLOW").split(","));
-	}
-	
+    @Override
+    public Set<String> getLastResponseAllowedMethods() {
+        return Sets.newHashSet(getLastResponse().getHeader("ALLOW").split(","));
+    }
+
     protected byte[] getBinary(MockHttpServletResponse response) {
         try {
             MockServletOutputStream os = (MockServletOutputStream) response.getOutputStream();
@@ -323,9 +338,9 @@ public class GeoServerFunctionalTestContext extends FunctionalTestContext {
             ByteArrayOutputStream bos = (ByteArrayOutputStream) field.get(os);
             return bos.toByteArray();
         } catch (Exception e) {
-            throw new RuntimeException("Whoops, did you change the MockRunner version? "
-                    + "If so, you might want to change this method too");
+            throw new RuntimeException("Whoops, did you change the MockRunner version? " +
+                     "If so, you might want to change this method too");
         }
     }
-	
+
 }

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
@@ -1,0 +1,331 @@
+package org.geogig.geoserver.functional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.Set;
+
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.multipart.FilePart;
+import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
+import org.apache.commons.httpclient.methods.multipart.Part;
+import org.geogig.geoserver.GeoGigTestData;
+import org.geogig.geoserver.GeoGigTestData.CatalogBuilder;
+import org.geogig.geoserver.config.RepositoryInfo;
+import org.geogig.geoserver.config.RepositoryManager;
+import org.geogig.geoserver.rest.GeoServerRepositoryProvider;
+import org.geogig.web.functional.FunctionalTestContext;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geoserver.test.TestSetupFrequency;
+import org.geotools.data.DataAccess;
+import org.locationtech.geogig.api.GeoGIG;
+import org.locationtech.geogig.geotools.data.GeoGigDataStore;
+import org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory;
+import org.locationtech.geogig.web.api.TestData;
+import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
+import org.restlet.data.Method;
+import org.w3c.dom.Document;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Sets;
+import com.mockrunner.mock.web.MockHttpServletRequest;
+import com.mockrunner.mock.web.MockHttpServletResponse;
+import com.mockrunner.mock.web.MockServletOutputStream;
+
+/**
+ * Context for running GeoGIG web API functional tests from the plugin endpoints.
+ */
+public class GeoServerFunctionalTestContext extends FunctionalTestContext {
+	
+    private static final Random rnd = new Random();
+    
+    private MockHttpServletResponse lastResponse = null;
+    
+    private GeoServerRepositoryProvider repoProvider = null;
+	
+    /**
+     * Helper class for running mock http requests.
+     */
+	private class TestHelper extends GeoServerSystemTestSupport {
+		
+		public TestHelper() {
+			super();
+	    	testSetupFrequency = TestSetupFrequency.REPEAT;
+		}
+
+	    /**
+	     * Override to avoid creating default geoserver test data
+	     */
+	    @Override
+	    protected void setUpTestData(SystemTestData testData) throws Exception {
+	    }
+	    
+	    /**
+	     * @return the catalog used by the test helper
+	     */
+	    public Catalog getCatalog() {
+	    	return super.getCatalog();
+	    }
+	    
+	    /**
+	     * Issue a POST request to the provided URL with the given file passed as form data.
+	     * 
+	     * @param resourceUri the url to issue the request to
+	     * @param formFieldName the form field name for the file to be posted
+	     * @param file the file to post
+	     * @return the response to the request
+	     */
+	    public MockHttpServletResponse postFile(String resourceUri, String formFieldName, File file) throws Exception {
+	    	Part[] parts = new Part[1];
+	    	parts[0] = new FilePart(formFieldName, file);
+
+	        MultipartRequestEntity multipart = new MultipartRequestEntity(parts, new PostMethod().getParams());
+
+	        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+	        multipart.writeRequest(bout);
+
+	        MockHttpServletRequest req = createRequest(resourceUri);
+	        req.setContentType(multipart.getContentType());
+	        req.addHeader("Content-Type", multipart.getContentType());
+	        req.setMethod("POST");
+	        req.setBodyContent(bout.toByteArray());
+
+	        return dispatch(req);
+	    }
+	    
+	    /**
+	     * Issue a request with the given {@link Method} to the provided resource URI.
+	     * 
+	     * @param method the http method to use
+	     * @param resourceUri the uri to issue the request to
+	     * @return the response to the request
+	     */
+	    public MockHttpServletResponse callInternal(Method method, String resourceUri) throws Exception {
+	    	MockHttpServletRequest request = super.createRequest(resourceUri);
+	    	request.setMethod(method.getName());
+	    	
+	    	return dispatch(request, null);
+	    	
+	    }
+	    
+	    /**
+	     * Provide access to the helper function that turns the response into a {@link Document}.
+	     * 
+	     * @param stream the stream to read as a document
+	     * @return the {@link Document}
+	     * @throws Exception
+	     */
+	    public Document getDom(InputStream stream) throws Exception {
+	    	return dom(stream);
+	    }
+	}
+	
+	private TestHelper helper = null;
+
+    /**
+     * Set up the context for a scenario.
+     */
+	@Override
+	protected void setUp() throws Exception {
+		if (helper == null) {
+			helper = new TestHelper();
+			helper.doSetup();
+			
+			repoProvider = new GeoServerRepositoryProvider();
+			
+			RepositoryManager.get().setCatalog(helper.getCatalog());
+		}
+		
+	}
+
+    /**
+     * Clean up resources used in the scenario.
+     */
+	@Override
+	protected void tearDown() throws Exception {
+		try {
+			if (helper != null) {
+				RepositoryManager.close();
+				helper.doTearDown();
+			}
+		} finally {
+			helper = null;
+		}
+	}
+
+    /**
+     * Return the {@link GeoGIG} that corresponds to the given repository name.
+     * 
+     * @param name the repository to get
+     * @return the repository
+     */
+	@Override
+	public GeoGIG getRepo(String name) {
+		return repoProvider.getGeogig(name).orNull();
+	}
+
+    /**
+     * Create a repository with the given name for testing.
+     * 
+     * @param name the repository name
+     * @return a newly created {@link TestData} for the repository.
+     * @throws Exception
+     */
+	@Override
+	protected TestData createRepo(String name) throws Exception {
+        GeoGigTestData testData = new GeoGigTestData();
+        testData.setUp(name);
+        testData.init();
+        GeoGIG geogig = testData.getGeogig();
+
+        Catalog catalog = helper.getCatalog();
+        CatalogBuilder catalogBuilder = testData.newCatalogBuilder(catalog);
+        int i = rnd.nextInt();
+        catalogBuilder.namespace("geogig.org/" + i).workspace("geogigws" + i)
+                .store("geogigstore" + i);
+        catalogBuilder.addAllRepoLayers().build();
+
+        String workspaceName = catalogBuilder.workspaceName();
+        String storeName = catalogBuilder.storeName();
+        DataStoreInfo dsInfo = catalog.getDataStoreByName(workspaceName, storeName);
+        assertNotNull(dsInfo);
+        assertEquals(GeoGigDataStoreFactory.DISPLAY_NAME, dsInfo.getType());
+        DataAccess<? extends FeatureType, ? extends Feature> dataStore = dsInfo.getDataStore(null);
+        assertNotNull(dataStore);
+        assertTrue(dataStore instanceof GeoGigDataStore);
+
+        String repoId = (String) dsInfo.getConnectionParameters()
+                .get(GeoGigDataStoreFactory.REPOSITORY.key);
+        RepositoryInfo repositoryInfo = RepositoryManager.get().get(repoId);
+        assertNotNull(repositoryInfo);
+        return new TestData(geogig);
+	}
+	
+	/**
+	 * Helper function that asserts that there is a last response and returns it.
+	 * 
+	 * @return the last response
+	 */
+	private MockHttpServletResponse getLastResponse() {
+		assertNotNull(lastResponse);
+		return lastResponse;
+	}
+
+    /**
+     * Issue a POST request to the provided URL with the given file passed as form data.
+     * 
+     * @param resourceUri the url to issue the request to
+     * @param formFieldName the form field name for the file to be posted
+     * @param file the file to post
+     */
+	@Override
+	protected void postFileInternal(String resourceUri, String formFieldName, File file) {
+		resourceUri = replaceVariables(resourceUri);
+		try {
+			lastResponse = helper.postFile("/geogig" + resourceUri, formFieldName, file);
+		} catch (Exception e) {
+			Throwables.propagate(e);
+		}
+	}
+
+    /**
+     * Issue a request with the given {@link Method} to the provided resource URI.
+     * 
+     * @param method the http method to use
+     * @param resourceUri the uri to issue the request to
+     */
+	@Override
+	protected void callInternal(Method method, String resourceUri) {
+		try {
+			resourceUri = replaceVariables(resourceUri);
+			this.lastResponse = helper.callInternal(method, "/geogig" + resourceUri);
+		} catch (Exception e) {
+			Throwables.propagate(e);
+		}
+	}
+
+    /**
+     * @return the content of the last response as text
+     */
+	@Override
+	public String getLastResponseText() {
+		return getLastResponse().getOutputStreamContent();
+	}
+
+    /**
+     * @return the content type of the last response
+     */
+	@Override
+	public String getLastResponseContentType() {
+		return getLastResponse().getContentType();
+	}
+
+	/**
+     * @return the content of the last response as a {@link Document}
+     */
+	@Override
+	public Document getLastResponseAsDom() {
+		Document result = null;
+		try {
+			result = helper.getDom(getLastResponseInputStream());
+		} catch (Exception e) {
+			Throwables.propagate(e);
+		}
+		return result;
+	}
+
+    /**
+     * @return the status code of the last response
+     */
+	@Override
+	public int getLastResponseStatus() {
+		MockHttpServletResponse response = getLastResponse();
+		int code = response.getStatusCode();
+		if (response.getStatusCode() == 200) {
+			code = response.getErrorCode();
+		}
+		return code;
+	}
+
+    /**
+     * @return the content of the last response as an {@link InputStream}
+     * @throws Exception
+     */
+	@Override
+	public InputStream getLastResponseInputStream() throws Exception {
+		return new ByteArrayInputStream(getBinary(getLastResponse()));
+	}
+
+    /**
+     * @return the allowed http methods of the last response
+     */
+	@Override
+	public Set<String> getLastResponseAllowedMethods() {
+		return Sets.newHashSet(getLastResponse().getHeader("ALLOW").split(","));
+	}
+	
+    protected byte[] getBinary(MockHttpServletResponse response) {
+        try {
+            MockServletOutputStream os = (MockServletOutputStream) response.getOutputStream();
+            final Field field = os.getClass().getDeclaredField("buffer");
+            field.setAccessible(true);
+            ByteArrayOutputStream bos = (ByteArrayOutputStream) field.get(os);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("Whoops, did you change the MockRunner version? "
+                    + "If so, you might want to change this method too");
+        }
+    }
+	
+}

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestInjectorSource.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestInjectorSource.java
@@ -1,9 +1,12 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geogig.geoserver.functional;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
-
 import cucumber.api.guice.CucumberModules;
 import cucumber.runtime.java.guice.InjectorSource;
 
@@ -11,6 +14,7 @@ import cucumber.runtime.java.guice.InjectorSource;
  * Creates the injector for cucumber functional tests.
  */
 public class GeoServerFunctionalTestInjectorSource implements InjectorSource {
+
     @Override
     public Injector getInjector() {
         return Guice.createInjector(Stage.PRODUCTION, CucumberModules.SCENARIO,

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestInjectorSource.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestInjectorSource.java
@@ -1,0 +1,19 @@
+package org.geogig.geoserver.functional;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Stage;
+
+import cucumber.api.guice.CucumberModules;
+import cucumber.runtime.java.guice.InjectorSource;
+
+/**
+ * Creates the injector for cucumber functional tests.
+ */
+public class GeoServerFunctionalTestInjectorSource implements InjectorSource {
+    @Override
+    public Injector getInjector() {
+        return Guice.createInjector(Stage.PRODUCTION, CucumberModules.SCENARIO,
+                new GeoServerFunctionalTestModule());
+    }
+}

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestModule.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestModule.java
@@ -1,0 +1,15 @@
+package org.geogig.geoserver.functional;
+
+import org.geogig.web.functional.FunctionalTestContext;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * Binds the {@link GeoServerFunctionalTestContext} for use in web API functional tests.
+ */
+public class GeoServerFunctionalTestModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(FunctionalTestContext.class).to(GeoServerFunctionalTestContext.class);
+    }
+}

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestModule.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestModule.java
@@ -1,3 +1,7 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geogig.geoserver.functional;
 
 import org.geogig.web.functional.FunctionalTestContext;
@@ -8,6 +12,7 @@ import com.google.inject.AbstractModule;
  * Binds the {@link GeoServerFunctionalTestContext} for use in web API functional tests.
  */
 public class GeoServerFunctionalTestModule extends AbstractModule {
+
     @Override
     protected void configure() {
         bind(FunctionalTestContext.class).to(GeoServerFunctionalTestContext.class);

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/RunWebAPIFunctionalTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/RunWebAPIFunctionalTest.java
@@ -1,3 +1,7 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geogig.geoserver.functional;
 
 import org.junit.runner.RunWith;
@@ -8,10 +12,11 @@ import cucumber.api.junit.Cucumber;
 /**
  * Single cucumber test runner. Its sole purpose is to serve as an entry point for junit. Step
  * definitions and hooks are defined in their own classes so they can be reused across features.
- * 
+ * <p>
  */
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:org/geogig/web/functional/"}, glue = { "org.geogig.web.functional" }, plugin = { "pretty", "html:cucumber-report",
-        "json:cucumber-report/cucumber.json" })
+@CucumberOptions(strict = true, features = {"classpath:org/geogig/web/functional/"},
+        glue = {"org.geogig.web.functional"}, plugin = {"pretty", "html:cucumber-report",
+                "json:cucumber-report/cucumber.json"})
 public class RunWebAPIFunctionalTest {
 }

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/RunWebAPIFunctionalTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/RunWebAPIFunctionalTest.java
@@ -1,0 +1,17 @@
+package org.geogig.geoserver.functional;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+/**
+ * Single cucumber test runner. Its sole purpose is to serve as an entry point for junit. Step
+ * definitions and hooks are defined in their own classes so they can be reused across features.
+ * 
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(strict = true, features = {"classpath:org/geogig/web/functional/"}, glue = { "org.geogig.web.functional" }, plugin = { "pretty", "html:cucumber-report",
+        "json:cucumber-report/cucumber.json" })
+public class RunWebAPIFunctionalTest {
+}

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/rest/GeoGigGeoServerRESTntegrationTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/rest/GeoGigGeoServerRESTntegrationTest.java
@@ -27,6 +27,7 @@ import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.rest.CatalogRESTTestSupport;
 import org.geoserver.data.test.SystemTestData;
 import org.geotools.data.DataStore;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.locationtech.geogig.api.GeoGIG;
@@ -84,6 +85,11 @@ public class GeoGigGeoServerRESTntegrationTest extends CatalogRESTTestSupport {
         // LayerInfo lineLayerInfo = catalog.getLayerByName(layerName);
         // assertNotNull(lineLayerInfo);
     }
+   
+    @After
+    public void after() {
+		RepositoryManager.close();
+    }
 
     /**
      * Override so that default layers are not added
@@ -108,7 +114,7 @@ public class GeoGigGeoServerRESTntegrationTest extends CatalogRESTTestSupport {
     @Test
     public void createDataStoreOldConfigNewRepo() throws Exception {
 
-        GeoGIG geogig = geogigData.createRpository("new_repo_old_config");
+        GeoGIG geogig = geogigData.createRepository("new_repo_old_config");
         try {
             geogig.command(InitOp.class).call();
             final File repo = geogig.command(ResolveGeogigDir.class).getFile().get()
@@ -251,7 +257,7 @@ public class GeoGigGeoServerRESTntegrationTest extends CatalogRESTTestSupport {
                 + " </connectionParameters>\n"//
                 + "</dataStore>\n";
 
-        GeoGIG geogig = geogigData.createRpository("new_repo");
+        GeoGIG geogig = geogigData.createRepository("new_repo");
         try {
             geogig.command(InitOp.class).call();
             File repo = geogig.command(ResolveGeogigDir.class).getFile().get();

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/rest/GeoGigWebAPIIntegrationTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/rest/GeoGigWebAPIIntegrationTest.java
@@ -30,6 +30,7 @@ import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.test.TestSetup;
 import org.geoserver.test.TestSetupFrequency;
 import org.geotools.data.DataAccess;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +58,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.mockrunner.mock.web.MockHttpServletResponse;
 
-@TestSetup(run = TestSetupFrequency.ONCE)
+@TestSetup(run = TestSetupFrequency.REPEAT)
 public class GeoGigWebAPIIntegrationTest extends GeoServerSystemTestSupport {
 
     /**
@@ -81,7 +82,8 @@ public class GeoGigWebAPIIntegrationTest extends GeoServerSystemTestSupport {
     @Before
     public void before() throws Exception {
         // protected void onSetUp(SystemTestData testData) throws Exception {
-
+        Catalog catalog = getCatalog();
+        RepositoryManager.get().setCatalog(catalog);
         geogigData.init()//
                 .config("user.name", "gabriel")//
                 .config("user.email", "gabriel@test.com")//
@@ -102,7 +104,7 @@ public class GeoGigWebAPIIntegrationTest extends GeoServerSystemTestSupport {
 
         geogigData.add().commit("Added test features");
 
-        Catalog catalog = getCatalog();
+
         CatalogBuilder catalogBuilder = geogigData.newCatalogBuilder(catalog);
         int i = rnd.nextInt();
         catalogBuilder.namespace("geogig.org/" + i).workspace("geogigws" + i)
@@ -131,7 +133,12 @@ public class GeoGigWebAPIIntegrationTest extends GeoServerSystemTestSupport {
                 .get(GeoGigDataStoreFactory.REPOSITORY.key);
         RepositoryInfo repositoryInfo = RepositoryManager.get().get(repoId);
         assertNotNull(repositoryInfo);
-        BASE_URL = "/geogig/repos/" + repositoryInfo.getId();
+        BASE_URL = "/geogig/repos/testrepo";
+    }
+   
+    @After
+    public void after() {
+		RepositoryManager.close();
     }
 
     /**

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/security/SecurityLoggerTestIntegrationTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/security/SecurityLoggerTestIntegrationTest.java
@@ -24,9 +24,11 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.test.TestSetup;
 import org.geoserver.test.TestSetupFrequency;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.locationtech.geogig.api.plumbing.ResolveRepositoryName;
 import org.w3c.dom.Document;
 
 @TestSetup(run = TestSetupFrequency.REPEAT)
@@ -72,13 +74,18 @@ public class SecurityLoggerTestIntegrationTest extends GeoServerSystemTestSuppor
         info.setLocation(repoURL);
         info = repositoryManager.save(info);
 
-        BASE_URL = "/geogig/repos/" + info.getId();
+        BASE_URL = "/geogig/repos/testrepo";
 
         logStore = GeoServerExtensions.bean(LogStore.class);
         assertNotNull(logStore);
 
         SecurityLogger logger = GeoServerExtensions.bean(SecurityLogger.class);
         assertNotNull(logger);
+    }
+    
+    @After
+    public void after() {
+		RepositoryManager.close();
     }
 
     private void login() throws Exception {
@@ -90,7 +97,6 @@ public class SecurityLoggerTestIntegrationTest extends GeoServerSystemTestSuppor
         String remoteURL = "http://example.com/geogig/upstream";
         final String url = BASE_URL + "/remote?remoteName=upstream&remoteURL=" + remoteURL;
         Document dom = getAsDOM(url);
-        System.out.println(dom.toString());
         // <response><success>true</success><name>upstream</name></response>
         assertXpathEvaluatesTo("true", "/response/success", dom);
 

--- a/src/community/geogig/src/test/resources/cucumber.properties
+++ b/src/community/geogig/src/test/resources/cucumber.properties
@@ -1,1 +1,4 @@
+# (c) 2016 Open Source Geospatial Foundation - all rights reserved
+# This code is licensed under the GPL 2.0 license, available at the root
+# application directory.
 guice.injector-source=org.geogig.geoserver.functional.GeoServerFunctionalTestInjectorSource

--- a/src/community/geogig/src/test/resources/cucumber.properties
+++ b/src/community/geogig/src/test/resources/cucumber.properties
@@ -1,0 +1,1 @@
+guice.injector-source=org.geogig.geoserver.functional.GeoServerFunctionalTestInjectorSource


### PR DESCRIPTION
 - Update plugin to support repsoitory management changes in GeoGig and run functional web API tests
 - Allow for specifying a 'repositoryURI' form element continaing the desired repo location
 - Update .gitignore to ignore generated Cucumber test reports