### PR TITLE
[GEOS-7595] Fix JDBCConfig import

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/JDBCGeoServerLoader.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/JDBCGeoServerLoader.java
@@ -87,8 +87,6 @@ public class JDBCGeoServerLoader extends DefaultGeoServerLoader {
         if (config.isImport()) {
             readCatalog(catalog, xp);
             decImportStep();
-            config.setImport(false);
-            config.save();
         }
     }
 


### PR DESCRIPTION
See issue here: https://osgeo-org.atlassian.net/browse/GEOS-7595

Looking at the existing test case, it only test the empty config / no import case, hence why it didn't catch this issue. I would have liked to add a proper test case, but was not quite sure how to implement it properly, given that: (a) jdbcconfig relies upon an existing configuration, and a database and (b) I am not especially familiar with jdbcconfig.

While this is a community module and therefore strictly speaking does not require a test case, I would be much happier if it had one. I would appreciiate it if someone more familiar with the jdbcconfig module would either be able to add a proper test case, or give me a few pointers.

Also: @NielsCharlier - this change reverts some of the changes you made for https://github.com/geoserver/geoserver/commit/17dfdf29e71be9bcfd4eef47596681732aaad6f3. Could you comment on whether my changes seem resonable. Full explanation of changes is in the attached ticket.