### PR TITLE
[GEOS-7597] Add JNA to netcdf-out release configuration

### DIFF
--- a/src/release/ext-netcdf-out.xml
+++ b/src/release/ext-netcdf-out.xml
@@ -19,6 +19,7 @@
         <include>joda-time*.jar</include>
         <include>jcip-annotations*.jar</include>
         <include>ehcache-core*.jar</include>
+        <include>jna*.jar</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Fairly basic configuration change based on testing the netcdf-out extension. It turns out it was missing the jar required for native linking (required for NetCDF 4 support).