### PR TITLE
Match geotools commons-pool version

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -726,7 +726,7 @@
    <dependency>
     <groupId>commons-pool</groupId>
     <artifactId>commons-pool</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
    </dependency>
    <dependency>
     <groupId>commons-collections</groupId>


### PR DESCRIPTION
GeoTools uses commons-pool 1.5.4 via gt-referencing
GeoServer explicitly requires commons-pool 1.5.3 in the top level pom. However, the only dependancies that use this are gt-referencing (via gs-wcs) and commons-dbcp (via gs-jdbcconfig), both of which actually depend upon 1.5.4.
The GeoServer dependancy appears necessary in order for the release module to actually pick up the jar during packaging.
This PR fixes the patch version so that we are actually consistent with the dependancies that are pulling this jar.