### PR TITLE
[GEOS-7606] Use consistent version of httpclient/httpcore for release artifacts

### DIFF
--- a/src/release/pom.xml
+++ b/src/release/pom.xml
@@ -89,6 +89,16 @@
    <artifactId>commons-logging</artifactId>
   </dependency>
   <dependency>
+    <groupId>org.apache.httpcomponents</groupId>
+    <artifactId>httpclient</artifactId>
+    <version>4.3.3</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.httpcomponents</groupId>
+    <artifactId>httpcore</artifactId>
+    <version>4.3.3</version>
+  </dependency>
+  <dependency>
    <groupId>org.geotools</groupId>
    <artifactId>gt-arcsde-common</artifactId>
    <version>${gt.version}</version>


### PR DESCRIPTION
The geoserver release process collects all jars for all extensions in a single maven process when building extensions. This means that when there are conflicting jar versions, it will choose some arbitrary version from among the valid ones. In this instance, various extension debend on numerous httpclient and httpcore versions:

```
[INFO] org.geoserver.script:gs-script-groovy:jar:2.9-SNAPSHOT
[INFO] \- org.geoscript:geoscript-groovy:jar:1.7-SNAPSHOT:compile
[INFO]    \- org.geotools:gt-netcdf:jar:15-SNAPSHOT:compile
[INFO]       \- edu.ucar:cdm:jar:4.6.2:compile
[INFO]          +- edu.ucar:httpservices:jar:4.6.2:runtime
[INFO]          |  \- org.apache.httpcomponents:httpclient:jar:4.3.6:runtime
[INFO]          \- org.apache.httpcomponents:httpcore:jar:4.3.3:runtime

[INFO] org.geoserver.community:gs-web-solr:jar:2.9-SNAPSHOT
[INFO] \- org.apache.solr:solr-solrj:jar:4.9.0:compile
[INFO]    +- org.apache.httpcomponents:httpclient:jar:4.3.1:compile
[INFO]    +- org.apache.httpcomponents:httpcore:jar:4.3:compile
[INFO]    \- org.apache.httpcomponents:httpmime:jar:4.3.1:compile

[INFO] org.geoserver.community:gs-wps-remote:jar:2.9-SNAPSHOT
[INFO] \- org.igniterealtime.smack:smack-bosh:jar:4.0.3:compile
[INFO]    \- org.igniterealtime.jbosh:jbosh:jar:0.8.0:compile
[INFO]       \- org.apache.httpcomponents:httpclient:jar:4.3.3:compile
[INFO]          \- org.apache.httpcomponents:httpcore:jar:4.3.2:compile

[INFO] org.geoserver.community:gs-gwc-s3:jar:2.9-SNAPSHOT
[INFO] \- org.geowebcache:gwc-aws-s3:jar:1.9-SNAPSHOT:compile
[INFO]    \- com.amazonaws:aws-java-sdk-s3:jar:1.9.30:compile
[INFO]       \- com.amazonaws:aws-java-sdk-kms:jar:1.9.30:compile
[INFO]          \- com.amazonaws:aws-java-sdk-core:jar:1.9.30:compile
[INFO]             \- org.apache.httpcomponents:httpclient:jar:4.3.4:compile
[INFO]                \- org.apache.httpcomponents:httpcore:jar:4.3.2:compile

[INFO] org.geoserver.community:gs-release:jar:2.9-SNAPSHOT
[INFO] +- org.geoserver.script:gs-script-groovy:jar:2.9-SNAPSHOT:compile
[INFO] |  \- org.geoscript:geoscript-groovy:jar:1.7-SNAPSHOT:compile
[INFO] |     \- org.geotools:gt-netcdf:jar:15-SNAPSHOT:compile
[INFO] |        \- edu.ucar:cdm:jar:4.6.2:compile
[INFO] |           \- edu.ucar:httpservices:jar:4.6.2:runtime
[INFO] \- org.geoserver.community:gs-web-solr:jar:2.9-SNAPSHOT:compile
[INFO]    \- org.apache.solr:solr-solrj:jar:4.9.0:compile
[INFO]       +- org.apache.httpcomponents:httpclient:jar:4.3.1:compile
[INFO]       +- org.apache.httpcomponents:httpcore:jar:4.3:compile
[INFO]       \- org.apache.httpcomponents:httpmime:jar:4.3.1:compile

[INFO] org.geoserver.extension:gs-printing:jar:2.9-SNAPSHOT
[INFO] \- org.mapfish.print:print-lib:jar:2.1.2:compile
[INFO]    \- com.codahale.metrics:metrics-httpclient:jar:3.0.2:compile
[INFO]       \- org.apache.httpcomponents:httpclient:jar:4.2.5:compile
[INFO]          \- org.apache.httpcomponents:httpcore:jar:4.2.4:compile

[INFO] org.geoserver.extension:gs-grib:jar:2.9-SNAPSHOT
[INFO] \- org.geotools:gt-grib:jar:15-SNAPSHOT:compile
[INFO]    \- edu.ucar:cdm:jar:4.6.2:compile
[INFO]       +- edu.ucar:httpservices:jar:4.6.2:runtime
[INFO]       |  \- org.apache.httpcomponents:httpclient:jar:4.3.6:runtime
[INFO]       \- org.apache.httpcomponents:httpcore:jar:4.3.3:runtime

[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ gs-netcdf ---
[INFO] org.geoserver.extension:gs-netcdf:jar:2.9-SNAPSHOT
[INFO] \- org.geotools:gt-netcdf:jar:15-SNAPSHOT:compile
[INFO]    \- edu.ucar:cdm:jar:4.6.2:compile
[INFO]       +- edu.ucar:httpservices:jar:4.6.2:runtime
[INFO]       |  \- org.apache.httpcomponents:httpclient:jar:4.3.6:runtime
[INFO]       \- org.apache.httpcomponents:httpcore:jar:4.3.3:runtime

[INFO] org.geoserver:gs-release:jar:2.9-SNAPSHOT
[INFO] +- org.geoserver.extension:gs-printing:jar:2.9-SNAPSHOT:compile
[INFO] |  \- org.mapfish.print:print-lib:jar:2.1.2:compile
[INFO] |     \- com.codahale.metrics:metrics-httpclient:jar:3.0.2:compile
[INFO] |        \- org.apache.httpcomponents:httpclient:jar:4.2.5:compile
[INFO] \- org.geoserver.extension:gs-grib:jar:2.9-SNAPSHOT:compile
[INFO]    \- org.geotools:gt-grib:jar:15-SNAPSHOT:compile
[INFO]       \- edu.ucar:cdm:jar:4.6.2:compile
[INFO]          +- edu.ucar:httpservices:jar:4.6.2:runtime
[INFO]          \- org.apache.httpcomponents:httpcore:jar:4.3.3:compile
```

When running `mvn -Prelease assembly:attached`, we wind up with httpcore 4.3.3 and httpclient 4.2.5.
Note that httpcore is a dependency of httpclient and they should match versions.

This commit explicitly declares versions of these jars (based on the most common / safe jar among all dependencies) in the release pom, so that we ship sensible jar versions.