### PR TITLE
GSIP-143 add status page for system properties and environment

### DIFF
--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -12,6 +12,8 @@
         <constructor-arg index="1" value="GeoServer Main"/>
     </bean>
     <bean class="org.geoserver.platform.RenderingEngineStatus"/>
+    <bean class="org.geoserver.platform.SystemPropertyStatus"/>
+    <bean class="org.geoserver.platform.SystemEnvironmentStatus"/>
     
     <!--  lock providers -->
     <bean id="nullLockProvider" class="org.geoserver.platform.resource.NullLockProvider"/>

--- a/src/platform/src/main/java/org/geoserver/platform/SystemEnvironmentStatus.java
+++ b/src/platform/src/main/java/org/geoserver/platform/SystemEnvironmentStatus.java
@@ -1,0 +1,60 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.platform;
+
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Map.Entry;
+
+public class SystemEnvironmentStatus implements ModuleStatus {
+
+    @Override
+    public String getModule() {
+        return "system-environment";
+    }
+
+    @Override
+    public Optional<String> getComponent() {
+        return Optional.ofNullable("system-environment");
+    }
+
+    @Override
+    public String getName() {
+        return "system-environment";
+    }
+
+    @Override
+    public Optional<String> getVersion() {
+        return Optional.ofNullable(null);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getMessage() {
+        StringBuffer result = new StringBuffer();
+        for (Iterator<Entry<String, String>> it = System.getenv().entrySet().iterator(); it
+                .hasNext();) {
+            Entry<String, String> entry = it.next();
+            result.append(entry.getKey().toString() + "=" + entry.getValue().toString() + "\n");
+        }
+        return Optional.ofNullable(result.toString());
+    }
+
+    @Override
+    public Optional<String> getDocumentation() {
+        return Optional.empty();
+    }
+
+}

--- a/src/platform/src/main/java/org/geoserver/platform/SystemPropertyStatus.java
+++ b/src/platform/src/main/java/org/geoserver/platform/SystemPropertyStatus.java
@@ -1,0 +1,60 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.platform;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+public class SystemPropertyStatus implements ModuleStatus {
+
+    @Override
+    public String getModule() {
+        return "system-properties";
+    }
+
+    @Override
+    public Optional<String> getComponent() {
+        return Optional.ofNullable("system-properties");
+    }
+
+    @Override
+    public String getName() {
+        return "system-properties";
+    }
+
+    @Override
+    public Optional<String> getVersion() {
+        return Optional.ofNullable(null);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getMessage() {
+        StringBuffer result = new StringBuffer();
+        for (Iterator<Entry<Object, Object>> it = System.getProperties().entrySet().iterator(); it
+                .hasNext();) {
+            Entry<Object, Object> entry = it.next();
+            result.append(entry.getKey().toString() + "=" + entry.getValue().toString() + "\n");
+        }
+        return Optional.ofNullable(result.toString());
+    }
+
+    @Override
+    public Optional<String> getDocumentation() {
+        return Optional.empty();
+    }
+
+}

--- a/src/platform/src/test/java/org/geoserver/platform/SystemEnvironmentTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/SystemEnvironmentTest.java
@@ -1,0 +1,25 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.platform;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SystemEnvironmentTest {
+
+    @Test
+    public void testSystemPropertiesStatus() {
+        String key =  System.getenv().keySet().iterator().next();
+        String value = System.getenv(key);
+        
+        SystemEnvironmentStatus status = new SystemEnvironmentStatus();
+        assertTrue(status.getMessage().isPresent());
+        assertTrue(status.getMessage().get().contains(key));
+        assertTrue(status.getMessage().get().contains(value));
+    }
+
+}

--- a/src/platform/src/test/java/org/geoserver/platform/SystemPropertiesStatusTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/SystemPropertiesStatusTest.java
@@ -1,0 +1,27 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.platform;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SystemPropertiesStatusTest {
+
+    String KEY = "TESTTESTTEST";
+
+    String VALUE = "ABCDEF_TEST_TEST_TEST";
+
+    @Test
+    public void testSystemPropertiesStatus() {
+        System.setProperty(KEY, VALUE);
+        SystemPropertyStatus status = new SystemPropertyStatus();
+        assertTrue(status.getMessage().isPresent());
+        assertTrue(status.getMessage().get().contains(KEY));
+        assertTrue(status.getMessage().get().contains(VALUE));
+    }
+
+}


### PR DESCRIPTION
Added status page for System.getenv and System.getProperties.

Also, noticed that RenderingEngineStatusTest.java didn't have (c) header and had incorrect formating - fixed.