### PR TITLE
Fix Responses for GeoGig Repository list and info

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
@@ -97,7 +97,7 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
         try {
             GeoGIG.delete(repoUri.get());
             RepositoryManager manager = RepositoryManager.get();
-            manager.invalidate(repoId);
+            manager.delete(repoId);
         } catch (Exception e) {
             Throwables.propagate(e);
         }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeogigDispatcher.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeogigDispatcher.java
@@ -100,7 +100,9 @@ public class GeogigDispatcher extends AbstractController {
         Router router = createRoot();
 
         router.attach("/repos", RepositoryListResource.class);
+        router.attach("/repos.{extension}", RepositoryListResource.class);
         router.attach("/repos/", RepositoryListResource.class);
+        router.attach("/repos.{extension}/", RepositoryListResource.class);
 
         router.attach("/tasks.{extension}", TaskStatusResource.class);
         router.attach("/tasks", TaskStatusResource.class);
@@ -109,12 +111,12 @@ public class GeogigDispatcher extends AbstractController {
         router.attach("/tasks/{taskId}/download", TaskResultDownloadResource.class);
 
         Router osm = new OSMRouter();
-        router.attach("/repos/{repository}", DeleteRepository.class);
         router.attach("/repos/{repository}/osm", osm);
 
         Router postgis = new PGRouter();
         router.attach("/repos/{repository}/postgis", postgis);
 
+        // GET and DELETE requests are handled in the same resource
         router.attach("/repos/{repository}.{extension}", RepositoryResource.class);
         router.attach("/repos/{repository}", RepositoryResource.class);
         router.attach("/repos/{repository}/repo", makeRepoRouter());

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryResource.java
@@ -21,6 +21,7 @@ import org.locationtech.geogig.repository.RepositoryResolver;
 import org.locationtech.geogig.rest.JettisonRepresentation;
 import org.locationtech.geogig.rest.RestletException;
 import org.locationtech.geogig.rest.Variants;
+import org.locationtech.geogig.rest.repository.DeleteRepository;
 import org.restlet.Context;
 import org.restlet.data.MediaType;
 import org.restlet.data.Preference;
@@ -28,7 +29,6 @@ import org.restlet.data.Request;
 import org.restlet.data.Response;
 import org.restlet.data.Status;
 import org.restlet.resource.Representation;
-import org.restlet.resource.Resource;
 import org.restlet.resource.Variant;
 
 import com.google.common.base.Function;
@@ -37,14 +37,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 /**
- * Access point to a single repository.
- * <p>
- * Defines the following repository ends points:
- * <ul>
- * <li>{@code /manifest}
- * </ul>
+ * Access point to a single repository. Provides a Repository information response for <b>GET</b>
+ * requests. Performs a Repository delete operation for <b>DELETE</b> requests.
  */
-public class RepositoryResource extends Resource {
+public class RepositoryResource extends DeleteRepository {
 
     private static final Variant HTML = new Variant(MediaType.TEXT_HTML);
 
@@ -124,7 +120,7 @@ public class RepositoryResource extends Resource {
 
     private static class RepositorytRepresentation extends JettisonRepresentation {
 
-        private RepositoryInfo repo;
+        private final RepositoryInfo repo;
 
         public RepositorytRepresentation(MediaType mediaType, String baseURL, RepositoryInfo repo) {
             super(mediaType, baseURL);
@@ -135,9 +131,7 @@ public class RepositoryResource extends Resource {
         protected void write(XMLStreamWriter w) throws XMLStreamException {
             w.writeStartElement("repository");
             element(w, "id", repo.getId());
-            RepositoryResolver uriResolver = RepositoryResolver.lookup(repo.getLocation());
-            String name = uriResolver.getName(repo.getLocation());
-            element(w, "name", name);
+            element(w, "name", repo.getRepoName());
             element(w, "location", repo.getLocation());
             w.writeEndElement();
         }

--- a/src/community/geogig/src/main/resources/org/geogig/geoserver/functional/PluginListRepositories.feature
+++ b/src/community/geogig/src/main/resources/org/geogig/geoserver/functional/PluginListRepositories.feature
@@ -1,0 +1,41 @@
+# (c) 2016 Open Source Geospatial Foundation - all rights reserved
+# This code is licensed under the GPL 2.0 license, available at the root
+# application directory.
+
+@PluginRepositoryManagement
+Feature: Plugin list repositories
+  Listing all repositories on the server is done by issuing a GET request to "/repos".
+  The response should be a 200 OK and contain a list of repositories configured. For each repository
+  in the returned list, the NAME, ID a a link to the repository's info should be included.
+
+  Scenario: Get list of Repositories in JSON format
+    Given There is a default multirepo server
+     When I call "GET /repos.json"
+     Then the response status should be '200'
+      And the response ContentType should be "application/json"
+      And the json response "repos.repo" should contain "id" 2 times
+      And the json response "repos.repo" should contain "name" 2 times
+      And the json response "repos.repo" should contain "href" 2 times
+      And the json response "repos.repo" attribute "href" should each contain "/geoserver/geogig/repos/"
+
+  Scenario: Get Repository info in JSON format
+    Given There is a default multirepo server
+     When I call "GET /repos.json"
+     Then the response status should be '200'
+      And the response ContentType should be "application/json"
+      And the json response "repos.repo" should contain "href" 2 times
+     Then I save the first href link from "repos.repo" as "@href"
+     When I call "GET {@href}"
+     Then the response status should be '200'
+      And the response ContentType should be "application/json"
+      And the json response "repository" should contain "id"
+      And the json response "repository" should contain "name"
+      And the json response "repository" should contain "location"
+     
+  Scenario: Get Repository info in XML format
+    Given There is a default multirepo server
+     When I call "GET /repos"
+     Then the response status should be '200'
+      And the response ContentType should be "application/xml"
+      And the xml response should contain "/repos/repo/atom:link" 2 times
+     


### PR DESCRIPTION
  - Fix the returned repository URLs when making a GET request to geogig/repos
  - Combine DELETE and GET repository resources into a single Restlet Resource
    to address Router contention
  - Fix issue with DELETE not correctly deleting a repository and leaving a
    broken repo hanging around.
  - Add functional tests to verify list and info