### PR TITLE
GEOS-7646: Applying default conversion to feature type for PostGIS.

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/FeatureDataConverter.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/FeatureDataConverter.java
@@ -201,7 +201,7 @@ public class FeatureDataConverter {
         @Override
         public SimpleFeatureType convertType(SimpleFeatureType featureType, VectorFormat format,
                 ImportData data, ImportTask item) {
-            SimpleFeatureType converted = featureType;
+            SimpleFeatureType converted = DEFAULT.convertType(featureType, format, data, item );
             String featureTypeName = convertTypeName(featureType.getTypeName());
             // trim the length of the name
             // by default, postgis table/index names need to fit in 64 characters

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/FeatureDataConverterTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/FeatureDataConverterTest.java
@@ -25,6 +25,21 @@ public class FeatureDataConverterTest {
 
     @Test
     public void testXMLUnsafeAttributeRenaming() {
+        SimpleFeatureType badatts = buildFeatureTypeWithXMLUnsafeAtts();
+        badatts = FeatureDataConverter.DEFAULT.convertType(badatts, null, null, null);
+
+        assertEquals("_123_number_first", badatts.getAttributeDescriptors().get(0).getLocalName());
+        assertEquals("i_has_spaces", badatts.getAttributeDescriptors().get(1).getLocalName());
+    }
+    
+    @Test
+    public void testPostgisConversion() {
+        SimpleFeatureType t = FeatureDataConverter.TO_POSTGIS.convertType(buildFeatureTypeWithXMLUnsafeAtts(), null, null, null);
+        assertEquals("_123_number_first", t.getAttributeDescriptors().get(0).getLocalName());
+        assertEquals("i_has_spaces", t.getAttributeDescriptors().get(1).getLocalName());
+    }
+
+    SimpleFeatureType buildFeatureTypeWithXMLUnsafeAtts() {
         SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();
         typeBuilder.setName("badatts");
 
@@ -34,11 +49,7 @@ public class FeatureDataConverterTest {
         attBuilder.setBinding(String.class);
         typeBuilder.add(attBuilder.buildDescriptor("i has spaces"));
 
-        SimpleFeatureType badatts = typeBuilder.buildFeatureType();
-        badatts = FeatureDataConverter.DEFAULT.convertType(badatts, null, null, null);
-
-        assertEquals("_123_number_first", badatts.getAttributeDescriptors().get(0).getLocalName());
-        assertEquals("i_has_spaces", badatts.getAttributeDescriptors().get(1).getLocalName());
+        return typeBuilder.buildFeatureType();
     }
     
     @Test


### PR DESCRIPTION
The default conversion applies logic to rename attributes with spaces or other
cases where the name is not a valid XML element name. This matches the behaviour
of the conversion that is done on the feature by feature level.