### PR TITLE
PR: (GEOS-7619) Allow the Wicket UI to show a Server Busy page when updating the configuration instead of locking the server

### DIFF
--- a/src/main/src/main/java/org/geoserver/GeoServerConfigurationLock.java
+++ b/src/main/src/main/java/org/geoserver/GeoServerConfigurationLock.java
@@ -5,11 +5,13 @@
  */
 package org.geoserver;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.geoserver.platform.GeoServerExtensions;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -25,6 +27,12 @@ import org.geotools.util.logging.Logging;
  * 
  */
 public class GeoServerConfigurationLock {
+    
+    /** DEFAULT_TRY_LOCK_TIMEOUT_MS */
+    private static final long DEFAULT_TRY_LOCK_TIMEOUT_MS =
+            (GeoServerExtensions.getProperty("CONFIGURATION_TRYLOCK_TIMEOUT") != null ? 
+                Long.valueOf(GeoServerExtensions.getProperty("CONFIGURATION_TRYLOCK_TIMEOUT")) : 5000);
+
     private static final Level LEVEL = Level.FINE;
 
     private static final Logger LOGGER = Logging.getLogger(GeoServerConfigurationLock.class);
@@ -59,21 +67,66 @@ public class GeoServerConfigurationLock {
             return;
         }
 
-        Lock lock;
-        if (type == LockType.WRITE) {
-            lock = readWriteLock.writeLock();
-        } else {
-            lock = readWriteLock.readLock();
-        }
-        if (LOGGER.isLoggable(LEVEL)) {
-            LOGGER.log(LEVEL, "Thread " + Thread.currentThread().getId() + " locking in mode "
-                    + type);
-        }
+        Lock lock = getLock(type);
+        
         lock.lock();
+        
         if (LOGGER.isLoggable(LEVEL)) {
             LOGGER.log(LEVEL, "Thread " + Thread.currentThread().getId() + " got the lock in mode "
                     + type);
         }
+    }
+    
+    /**
+     * Tries to open a lock in the specified mode. Acquires the lock if it is available and returns immediately with the value true. 
+     * If the lock is not available then this method will return immediately with the value false.
+     * 
+     * A typical usage idiom for this method would be:
+     * 
+     * <pre>
+     *  Lock lock = ...;
+     *  if (lock.tryLock()) {
+     *    try {
+     *      // manipulate protected state
+     *    } finally {
+     *      lock.unlock();
+     *    }
+     *  } else {
+     *    // perform alternative actions
+     *  }}
+     * </pre>
+     * 
+     * This usage ensures that the lock is unlocked if it was acquired, and doesn't try to unlock if the lock was not acquired.
+     *  
+     * @param type
+     * @return true if the lock was acquired and false otherwise
+     */
+    public boolean tryLock(LockType type) {
+        if (!enabled) {
+            return true;
+        }
+
+        Lock lock = getLock(type);
+        
+        boolean res = false;
+        try {
+            res = lock.tryLock(DEFAULT_TRY_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.WARNING, "Thread " + Thread.currentThread().getId() + " thrown an InterruptedException on GeoServerConfigurationLock TryLock.", e);
+            res = false;
+        }
+        
+        if (LOGGER.isLoggable(LEVEL)) {
+            if (res) {
+                LOGGER.log(LEVEL, "Thread " + Thread.currentThread().getId() + " got the lock in mode "
+                        + type);
+            } else {
+                LOGGER.log(LEVEL, "Thread " + Thread.currentThread().getId() + " could not get the lock in mode "
+                        + type);
+            }
+        }
+        
+        return res;
     }
 
     /**
@@ -87,12 +140,8 @@ public class GeoServerConfigurationLock {
             return;
         }
 
-        Lock lock;
-        if (type == LockType.WRITE) {
-            lock = readWriteLock.writeLock();
-        } else {
-            lock = readWriteLock.readLock();
-        }
+        Lock lock  = getLock(type);
+        
         if (LOGGER.isLoggable(LEVEL)) {
             LOGGER.log(LEVEL, "Thread " + Thread.currentThread().getId()
                     + " releasing the lock in mode " + type);
@@ -106,6 +155,24 @@ public class GeoServerConfigurationLock {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    /**
+     * @param type
+     * @return
+     */
+    private Lock getLock(LockType type) {
+        Lock lock;
+        if (type == LockType.WRITE) {
+            lock = readWriteLock.writeLock();
+        } else {
+            lock = readWriteLock.readLock();
+        }
+        if (LOGGER.isLoggable(LEVEL)) {
+            LOGGER.log(LEVEL, "Thread " + Thread.currentThread().getId() + " locking in mode "
+                    + type);
+        }
+        return lock;
     }
 
 }

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
@@ -340,19 +340,19 @@ public class GeoServerApplication extends WebApplication implements ApplicationC
         
         @Override
         public void onRequestHandlerScheduled(RequestCycle cycle, IRequestHandler handler) {
-            processHandler(handler);
+            processHandler(cycle, handler);
         }
 
-        private void processHandler(IRequestHandler handler) {
+        private void processHandler(RequestCycle cycle, IRequestHandler handler) {
             if(handler instanceof IPageRequestHandler) {
                 IPageRequestHandler pageHandler = (IPageRequestHandler) handler;
                 Class<? extends IRequestablePage> pageClass = pageHandler.getPageClass();
                 for (WicketCallback callback : callbacks) {
-                    callback.onRequestTargetSet(pageClass);
+                    callback.onRequestTargetSet(cycle, pageClass);
                 }
             } else if(handler instanceof IRequestHandlerDelegate) {
                 IRequestHandlerDelegate delegator = (IRequestHandlerDelegate) handler;
-                processHandler(delegator.getDelegateHandler());
+                processHandler(cycle, delegator.getDelegateHandler());
             }
             
         }
@@ -360,7 +360,7 @@ public class GeoServerApplication extends WebApplication implements ApplicationC
         @Override
         public void onRequestHandlerResolved(org.apache.wicket.request.cycle.RequestCycle cycle,
                 IRequestHandler handler) {
-            processHandler(handler);
+            processHandler(cycle, handler);
         }
 
         @Override

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -57,7 +57,7 @@ import com.google.common.base.Stopwatch;
  * @author Andrea Aime - TOPP
  * 
  */
-public class GeoServerHomePage extends GeoServerBasePage {
+public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnlockablePage {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public GeoServerHomePage() {

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerUnlockablePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerUnlockablePage.java
@@ -1,0 +1,17 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web;
+
+/**
+ * Interface for GeoServer Pages which can simply ignore ConfigurationLock since they are safe.
+ * 
+ * The developer *MUST* know what he is doing and manage the configuration read/write safely!
+ * 
+ * @author Alessio Fabiani, GeoSolutions S.A.S.
+ *
+ */
+public interface GeoServerUnlockablePage {
+
+}

--- a/src/web/core/src/main/java/org/geoserver/web/ServerBusyPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/ServerBusyPage.html
@@ -1,0 +1,7 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+<body>
+<wicket:extend>
+<p wicket:id="serverBusyMessage">Server is currently busy. Please wait...</p>
+</wicket:extend>
+</body>
+</html>

--- a/src/web/core/src/main/java/org/geoserver/web/ServerBusyPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/ServerBusyPage.java
@@ -1,0 +1,20 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.ResourceModel;
+
+/**
+ * Displays a message suggesting the user to login or to elevate his privileges
+ */
+public class ServerBusyPage extends GeoServerBasePage implements GeoServerUnlockablePage {
+
+    public ServerBusyPage() {
+        IModel model = new ResourceModel( "ServerBusyPage.serverBusyMessage" );
+        add(new Label("serverBusyMessage", model));
+    }
+}

--- a/src/web/core/src/main/java/org/geoserver/web/WicketCallback.java
+++ b/src/web/core/src/main/java/org/geoserver/web/WicketCallback.java
@@ -34,10 +34,24 @@ public interface WicketCallback {
     /**
      * Called when a request target is set on the request cycle
      * 
+     * This method is taken for retro-compatibility with old GeoServer verisons
+     * 
      * @param requestTarget
+     * @deprecated replaced by {@link #onRequestTargetSet(cycle, requestTarget)}
      */
     void onRequestTargetSet(Class<? extends IRequestablePage> requestTarget);
 
+    /**
+     * Called when a request target is set on the request cycle
+     * 
+     * @param cycle
+     * @param requestTarget
+     */
+    default void onRequestTargetSet(RequestCycle cycle, 
+            Class<? extends IRequestablePage> requestTarget) {
+        onRequestTargetSet(requestTarget);
+    }
+    
     /**
      * Called when a runtime exception is thrown, just before the actual handling of the runtime
      * exception.

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -672,6 +672,10 @@ UnauthorizedPage.insufficientPrivileges = The current user does not have suffici
 UnauthorizedPage.unauthorizedMessage = The current user does not have sufficient privileges to access the page or \
         perform the requested operation
 
+ServerBusyPage.title               = Server busy
+ServerBusyPage.description         =
+ServerBusyPage.serverBusyMessage   = Server is currently busy. Please wait...
+
 WFSDataStoreFactory\:BUFFER_SIZE = Feature buffer size
 
 WFSDataStoreFactory\:ENCODING = Character encoding for XML messages

--- a/src/web/core/src/test/java/org/geoserver/web/admin/AbstractAdminPrivilegeTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/admin/AbstractAdminPrivilegeTest.java
@@ -14,13 +14,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import org.apache.wicket.core.request.handler.PageProvider;
 import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.DataView;
-import org.apache.wicket.request.IRequestHandler;
-import org.apache.wicket.request.Response;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.geoserver.catalog.Catalog;

--- a/src/web/core/src/test/java/org/geoserver/web/admin/ServerBusyPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/admin/ServerBusyPageTest.java
@@ -1,0 +1,82 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.admin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.GeoServerConfigurationLock.LockType;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.ServerBusyPage;
+import org.geoserver.web.data.store.DataAccessEditPage;
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+/**
+ * @author Alessio Fabiani, GeoSolutions
+ *
+ */
+public class ServerBusyPageTest extends GeoServerWicketTestSupport {
+
+    @Test
+    public void testStoreEditServerBusyPage() throws Exception {
+        System.setProperty("CONFIGURATION_TRYLOCK_TIMEOUT", "0");
+        
+        login();
+
+        List<GrantedAuthority> l= new ArrayList<GrantedAuthority>();
+        l.add(new SimpleGrantedAuthority("ROLE_ANONYMOUS"));
+        
+        final LockType type = LockType.WRITE;
+        final GeoServerConfigurationLock locker = (GeoServerConfigurationLock) GeoServerExtensions.bean("configurationLock");
+
+        if (locker != null) {
+            Thread configWriter = new Thread(){
+
+                public void run() {
+                    // Acquiring Configuration Lock as another user
+                    locker.setEnabled(true);
+                    locker.lock(type);
+
+                    try {
+                        // Consider the TIMEOUT time spent when checking for the lock...
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+                    } finally {
+                        try {
+                            locker.unlock(type);
+                        } catch(Exception e) {
+                            
+                        }
+                    }
+                }
+
+                
+            };
+            configWriter.start();
+
+            Thread.sleep(300);
+            
+            tester.startPage(DataAccessEditPage.class, new PageParameters().add("wsName", "cite").add("storeName", "cite"));
+            if (!locker.tryLock(type)) {
+                tester.assertRenderedPage(ServerBusyPage.class);
+            } else {
+                tester.assertRenderedPage(DataAccessEditPage.class);
+            }
+            tester.assertNoErrorMessage();
+
+            try {
+                locker.unlock(type);
+            } catch(Exception e) {
+                
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
The idea behind this proposal is the following one:

Currently GeoServer tries to acquire an exclusive lock when accessing pages which can read/write the configuration through the WicketConfigurationCallback, thus causing the UI to hang until the configuration has been released by the catalog.
The problem is that in some cases, if the configuration change requires too much, the UI is not accessible at all.

With this PR I would like to address to goals:

1. Avoid completely freeze the UI when the configuration is locked

2. Allow a developer (who knows what he is doing) to create pages which can be accessed also when the configuration is locked by some process (thing for instance to an extension which needs to safely cancel/stop a long write operation)

The proposed solution is the following one:

- Implement a "tryLock" method on the global GeoServerLock, which returns true/false if the configuration can be taken or not.

- Test the lock before rendering the page: if the lock can be taken, the page will be rendered as usual, otherwise the server will redirect the user to a "ServerBusy" page.

- A new interface "GeoServerUnlockablePage" allows us to recognize the pages which can be always rendered, skipping the locking checks.
