### PR TITLE
[GEOS-7467] Make JMS cluster plugin only serialize the necessary data

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/pom.xml
+++ b/src/community/jms-cluster/jms-geoserver/pom.xml
@@ -260,6 +260,11 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -23,16 +23,10 @@ import org.jdom.JDOMException;
  */
 public class DocumentFile {
 
-    private final Resource path;
+    private final String resourceName;
+    private final String resourcePath;
 
     private final String body;
-
-    /**
-     * @return the path
-     */
-    public final Resource getPath() {
-        return path;
-    }
 
     /**
      * @return the body containing the parsed file
@@ -53,7 +47,8 @@ public class DocumentFile {
         if (!Resources.exists(path)) {
             throw new IllegalArgumentException("Unable to locate the file path: \'" + path + "\'");
         }
-        this.path = path;
+        this.resourceName = path.name();
+        this.resourcePath = path.path();
         this.body = document;
     }
 
@@ -61,10 +56,19 @@ public class DocumentFile {
         if (!Resources.exists(path)) {
             throw new IllegalArgumentException("Unable to locate the file path: \'" + path + "\'");
         }
-        this.path = path;
+        this.resourceName = path.name();
+        this.resourcePath = path.path();
         try (InputStream in = path.in()) {
             this.body = IOUtils.toString(in);
         }
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public String getResourcePath() {
+        return resourcePath;
     }
 
     /**
@@ -75,7 +79,7 @@ public class DocumentFile {
      * @throws IOException
      */
     public void writeTo(Resource file) throws JDOMException, IOException {
-        try (OutputStream out = path.out()) {
+        try (OutputStream out = file.out()) {
             IOUtils.write(body, out);
         }
     }

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFileHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFileHandler.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -11,6 +11,7 @@ import org.apache.commons.io.IOUtils;
 import org.geoserver.cluster.JMSEventHandler;
 
 import com.thoughtworks.xstream.XStream;
+import org.geoserver.platform.resource.Resources;
 
 /**
  * XML file handler:<br>
@@ -27,7 +28,7 @@ public class DocumentFileHandler extends
 
 	@Override
 	public boolean synchronize(DocumentFile event) throws Exception {
-		try (OutputStream fout = event.getPath().out()) {			
+		try (OutputStream fout = Resources.fromPath(event.getResourcePath()).out()) {
 			xstream.toXML(event.getBody(), fout);
 			return true;
 		} catch (IllegalStateException e) {

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogStylesFileHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogStylesFileHandler.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -51,10 +51,10 @@ public class JMSCatalogStylesFileHandler extends DocumentFileHandler {
 		} else if (!ReadOnlyConfiguration.isReadOnly(config)) {
 			try {
 				GeoServerResourceLoader loader = GeoServerExtensions.bean(GeoServerResourceLoader.class);
-				Resource file = loader.get("styles").get(event.getPath().name());
+				Resource file = loader.get("styles").get(event.getResourceName());
 				
 				if ( !Resources.exists(file) ) {
-					final String styleAbsolutePath = event.getPath().path();
+					final String styleAbsolutePath = event.getResourcePath();
 					if ( styleAbsolutePath.indexOf("workspaces") > 0 ) {
 						file = loader.get(styleAbsolutePath.substring(styleAbsolutePath.indexOf("workspaces")));
 					}

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/DocumentFileTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/DocumentFileTest.java
@@ -1,0 +1,77 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers;
+
+import com.thoughtworks.xstream.XStream;
+import org.apache.commons.io.FileUtils;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.Resource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class DocumentFileTest {
+
+    private File rootDirectory;
+    private FileSystemResourceStore resourceStore;
+
+    @Before
+    public void before() throws Exception {
+        rootDirectory = Files.createTempDirectory("jsm-test-").toFile();
+        resourceStore = new FileSystemResourceStore(rootDirectory);
+    }
+
+    @After
+    public void after() throws Exception {
+        FileUtils.deleteDirectory(rootDirectory);
+    }
+
+    @Test
+    public void testSerializeDocumentFile() throws Exception {
+        // creating a style in data directory
+        Resource resource = addResourceToDataDir("styles/style.sld", "some style definition");
+        // instantiating a document file representing the style file
+        DocumentFile documentFile = new DocumentFile(resource);
+        // serialising the file document
+        DocumentFileHandlerSPI handler = new DocumentFileHandlerSPI(0, new XStream());
+        String result = handler.createHandler().serialize(documentFile);
+        // checking the serialization result
+        assertThat(result, notNullValue());
+        assertThat(XMLUnit.compareXML(readResourceFileContent("document_file_1.xml"), result).similar(), is(true));
+    }
+
+    /**
+     * Creates a resource path in the data directory and write the provided content in it.
+     */
+    private Resource addResourceToDataDir(String resourcePath, String resourceContent) throws Exception {
+        XMLUnit.setIgnoreWhitespace(true);
+        File resourceFile = new File(rootDirectory, resourcePath);
+        resourceFile.getParentFile().mkdirs();
+        Files.write(resourceFile.toPath(), resourceContent.getBytes());
+        return resourceStore.get("styles/style.sld");
+    }
+
+    /**
+     * Helper method that will read the content of a resource file and return it as a String.
+     */
+    private String readResourceFileContent(String resourceFileName) throws Exception {
+        try (InputStream input = DocumentFileTest.class.getClassLoader().getResourceAsStream(resourceFileName);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        }
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/resources/document_file_1.xml
+++ b/src/community/jms-cluster/jms-geoserver/src/test/resources/document_file_1.xml
@@ -1,0 +1,5 @@
+<org.geoserver.cluster.impl.handlers.DocumentFile>
+    <resourceName>style.sld</resourceName>
+    <resourcePath>styles/style.sld</resourcePath>
+    <body>some style definition</body>
+</org.geoserver.cluster.impl.handlers.DocumentFile>


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7467

JMD plugin doesn't serialize and send the whole store anymore. A test case was added for this.