### PR TITLE
[GEOS-7272] OL3 Preview wraps tiled layers

### DIFF
--- a/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
+++ b/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
@@ -278,7 +278,8 @@
       var projection = new ol.proj.Projection({
           code: '${request.SRS?js_string}',
           units: '${units?js_string}',
-          axisOrientation: 'neu'
+          axisOrientation: 'neu',
+          global: ${global}
       });
       var map = new ol.Map({
         controls: ol.control.defaults({


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7272

Either of this or https://github.com/geoserver/geoserver/pull/1702 is a viable fix
This is a hackier fix, but carries less risk of introducing problems with new projections, since it is not changing how we handle them.