### PR TITLE
[GEOS-7272] OL3 Preview wraps tiled layers, using OL3 internal srs

### DIFF
--- a/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
+++ b/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
@@ -275,11 +275,7 @@
           }
         })
       });
-      var projection = new ol.proj.Projection({
-          code: '${request.SRS?js_string}',
-          units: '${units?js_string}',
-          axisOrientation: 'neu'
-      });
+      var projection = ol.proj.get('${request.SRS?js_string}');
       var map = new ol.Map({
         controls: ol.control.defaults({
           attribution: false


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7272

Either of this or https://github.com/geoserver/geoserver/pull/1701 is a viable fix
This is the more correct approach, but carries a higher risk of causing problems with odd projections not supported by default in OL3.

I have tested with EPSG:4326 and EPSG:3031 (Antarctic Polar) with no issues.