### PR TITLE
[GEOT-5308] Support predefined app-schema interpolation properties fo…

### DIFF
--- a/doc/en/user/source/data/app-schema/cql-functions.rst
+++ b/doc/en/user/source/data/app-schema/cql-functions.rst
@@ -93,10 +93,10 @@ The properties file serves as a lookup table to the function. It has no header, 
 
 **Syntax**::
 
-  Vocab(COLUMN_NAME, properties file URI)
+  Vocab(COLUMN_NAME, properties file)
 
 * **COLUMN_NAME**: column name to get values from
-* **properties file URI**: absolute path of the properties file or relative to the mapping file location
+* **properties file**: absolute path of the properties file
 
 **Example:**
 
@@ -111,11 +111,13 @@ Mapping file::
   <AttributeMapping>
     <targetAttribute>gml:name</targetAttribute>
     <sourceExpression>
-        <OCQL>Vocab(ABBREVIATION, '/test-data/mapping.properties')</OCQL>
+        <OCQL>Vocab(ABBREVIATION, strconcat('${config.parent}', '/mapping.properties'))</OCQL>
     </sourceExpression>
   </AttributeMapping>
 
 The above example will map **gml:name** to *urn:cgi:classifier:CGI:SimpleLithology:2008:gravel* if ABBREVIATION value is *1GRAV*.
+
+This example uses the ``config.parent`` predefined interpolation property to specify a vocabulary properties file in the same directory as the mapping file. See :ref:`app-schema.property-interpolation` for details.
 
 
 Geometry creation

--- a/doc/en/user/source/data/app-schema/property-interpolation.rst
+++ b/doc/en/user/source/data/app-schema/property-interpolation.rst
@@ -16,6 +16,14 @@ Defining properties
 * System properties override properties defined in a configuration file, so if you define ``-Dsome.property`` at the java command line, it will override a value specified in the ``app-schema.properties`` file. This is intended for debugging, so you can set a property file in an Eclipse launch configuration, but override some of the properties contained in the file by setting them explicitly as system properties.
 * All system properties are available for interpolation in mapping files.
 
+Predefined properties
+---------------------
+
+If not set elsewhere, the following properties are set for each mapping file:
+
+* ``config.file`` is set to the name of the mapping file
+* ``config.parent`` is set to the name of the directory containing the mapping file
+
 Using properties
 ----------------
 


### PR DESCRIPTION
…r mapping file and parent directory

https://osgeo-org.atlassian.net/browse/GEOT-5308

This updates the GeoServer documentation for the Vocab CQL function to note that an absolute file name is required and suggest using the ``${config.parent}`` interpolation property to construct one.