### PR TITLE
Align plugin for GeoGig REST implementation with GeoGig Web API

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
@@ -10,28 +10,17 @@ import static org.locationtech.geogig.porcelain.ConfigOp.ConfigAction.CONFIG_SET
 import static org.locationtech.geogig.porcelain.ConfigOp.ConfigScope.LOCAL;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
-import org.geogig.geoserver.config.GeoGigInitializer;
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geogig.geoserver.config.RepositoryManager;
-import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.DataStoreInfo;
-import org.geoserver.catalog.NamespaceInfo;
-import org.geoserver.catalog.WorkspaceInfo;
-import org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory;
-import org.locationtech.geogig.plumbing.ResolveRepositoryName;
 import org.locationtech.geogig.porcelain.ConfigOp;
 import org.locationtech.geogig.rest.repository.CommandResource;
 import org.restlet.data.Request;
 import org.restlet.data.Status;
 import org.restlet.resource.Representation;
 import org.restlet.resource.Variant;
-
-import com.google.common.base.Throwables;
 
 public class InitCommandResource extends CommandResource {
 
@@ -47,12 +36,8 @@ public class InitCommandResource extends CommandResource {
         if (getResponse().getStatus() == Status.SUCCESS_CREATED) {
             // set the Author name and email from the Init request
             setAuthor(request);
-            // get the repository name
-            String repositoryName = geogig.get().command(ResolveRepositoryName.class).call();
             // save the repo in the Manager
             RepositoryInfo repoInfo = saveRepository();
-            Catalog catalog = RepositoryManager.get().getCatalog();
-            setUpDataStore(catalog, repositoryName, repoInfo);
         }
         return representation;
     }
@@ -88,33 +73,5 @@ public class InitCommandResource extends CommandResource {
         repoInfo.setLocation(location);
         // save the repo, this will set a UUID
         return RepositoryManager.get().save(repoInfo);
-    }
-
-    public DataStoreInfo setUpDataStore(Catalog catalog, String storeName, RepositoryInfo repoInfo) {
-        NamespaceInfo ns = catalog.getDefaultNamespace();
-        WorkspaceInfo ws = catalog.getDefaultWorkspace();
-        DataStoreInfo ds = catalog.getFactory().createDataStore();
-        ds.setEnabled(true);
-        ds.setDescription("GeoGIG repository");
-        ds.setName(storeName);
-        ds.setType(GeoGigDataStoreFactory.DISPLAY_NAME);
-        ds.setWorkspace(ws);
-        Map<String, Serializable> connParams = ds.getConnectionParameters();
-
-        connParams.put(GeoGigDataStoreFactory.REPOSITORY.key, repoInfo.getId());
-        connParams.put(GeoGigDataStoreFactory.DEFAULT_NAMESPACE.key, ns.getURI());
-        connParams.put(GeoGigDataStoreFactory.RESOLVER_CLASS_NAME.key,
-                GeoGigInitializer.REPO_RESOLVER_CLASSNAME);
-        catalog.add(ds);
-
-        try {
-            DataStoreInfo dsInfo = catalog.getDataStoreByName(ws, storeName);
-            String repoId = (String) dsInfo.getConnectionParameters()
-                    .get(GeoGigDataStoreFactory.REPOSITORY.key);
-            RepositoryManager.get().get(repoId);
-        } catch (IOException e) {
-            Throwables.propagate(e);
-        }
-        return ds;
     }
 }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitRequestHandler.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitRequestHandler.java
@@ -5,6 +5,7 @@
 package org.geogig.geoserver.rest;
 
 import static org.locationtech.geogig.rest.repository.RESTUtils.getStringAttribute;
+import static org.restlet.data.Status.CLIENT_ERROR_BAD_REQUEST;
 
 import java.io.File;
 import java.io.IOException;
@@ -150,7 +151,7 @@ class InitRequestHandler {
                     addParameters(params, form);
                 } catch (Exception ex) {
                     throw new RestletException("Error parsing URL encoded form request",
-                            Status.CLIENT_ERROR_BAD_REQUEST, ex);
+                            CLIENT_ERROR_BAD_REQUEST, ex);
                 }
             } else if (MediaType.APPLICATION_JSON.equals(reqMediaType)) {
                 // JSON encoded parameters
@@ -159,9 +160,13 @@ class InitRequestHandler {
                     JSONObject jsonObj = jsonRep.toJsonObject();
                     addParameters(params, jsonObj);
                 } catch (IOException | JSONException ex) {
-                    throw new RestletException("Error parsing JSON request",
-                            Status.CLIENT_ERROR_BAD_REQUEST, ex);
+                    throw new RestletException("Error parsing JSON request",CLIENT_ERROR_BAD_REQUEST,
+                            ex);
                 }
+            } else if (null != reqMediaType) {
+                // unsupported MediaType
+                throw new RestletException("Unsupported Request MediaType: " + reqMediaType,
+                        CLIENT_ERROR_BAD_REQUEST);
             }
             // no parameters specified
         }

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
@@ -132,11 +132,16 @@ public class GeoServerFunctionalTestContext extends FunctionalTestContext {
 
         public MockHttpServletResponse callInternal(Method method, String resourceUri,
                 JSONObject payload) throws Exception {
+            return callWithContentTypeInternal(method, resourceUri, payload, "application/json");
+        }
+
+        public MockHttpServletResponse callWithContentTypeInternal(Method method, String resourceUri,
+                JSONObject payload, String contentType) throws Exception {
             MockHttpServletRequest request = super.createRequest(resourceUri);
             request.setMethod(method.getName());
             // set the JSON payload
             request.setContent(payload.toString().getBytes());
-            request.setContentType("application/json");
+            request.setContentType(contentType);
 
             return dispatch(request, null);
         }
@@ -373,6 +378,25 @@ public class GeoServerFunctionalTestContext extends FunctionalTestContext {
         try {
             resourceUri = replaceVariables(resourceUri);
             this.lastResponse = helper.callInternal(method, "/geogig" + resourceUri, payload);
+        } catch (Exception e) {
+            Throwables.propagate(e);
+        }
+    }
+
+    /**
+     * Invokes URI request with specified Content-Type. This is used for testing mismatches in request
+     * body content and the Content-Type header.
+     * @param method HTTP Method to invoke
+     * @param resourceUri URI address to which to send the request
+     * @param payload JSON object payload to encode into the request
+     * @param contentType Specific Content-Type header value to send
+     */
+    public void callWithContentType(Method method, String resourceUri, JSONObject payload,
+            String contentType) {
+        try {
+            resourceUri = replaceVariables(resourceUri);
+            this.lastResponse = helper.callWithContentTypeInternal(method, "/geogig" + resourceUri,
+                    payload, contentType);
         } catch (Exception e) {
             Throwables.propagate(e);
         }

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/PluginWebAPICucumberHooks.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/PluginWebAPICucumberHooks.java
@@ -27,7 +27,6 @@ import org.restlet.data.Method;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
-
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.StepDefAnnotation;
@@ -276,5 +275,27 @@ public class PluginWebAPICucumberHooks {
         // request.
         String parentDir = new File(repoURI).getParentFile().getParentFile().getAbsolutePath();
         assertNotEquals("Unexpected parent directory", SYSTEM_TEMP_PATH, parentDir);
+    }
+
+    @When("^I call \"([^\"]*)\" with an unsupported media type$")
+    public void callURLWithUnsupportedMediaType(final String methodAndURL) throws JSONException {
+        final int idx = methodAndURL.indexOf(' ');
+        checkArgument(idx > 0, "No METHOD given in URL definition: '%s'", methodAndURL);
+        final String httpMethod = methodAndURL.substring(0, idx);
+        String resourceUri = methodAndURL.substring(idx + 1).trim();
+        Method method = Method.valueOf(httpMethod);
+        // build the JSON payload
+        JSONObject payload = new JSONObject();
+        payload.put("parentDirectory", SYSTEM_TEMP_PATH);
+        // add in author details
+        payload.put("authorName", "GeoGig User");
+        payload.put("authorEmail", "geogig@geogig.org");
+        context.callWithContentType(method, resourceUri, payload, "application/xml");
+    }
+
+    @Then("^there should be no \"([^\"]*)\" created$")
+    public void checkRepoNotInitialized(final String repo) throws Exception {
+        GeoGIG geogig = context.getRepo(repo);
+        assertTrue("Expected repository to NOT EXIST", null == geogig);
     }
 }

--- a/src/community/geogig/src/test/resources/org/geogig/geoserver/functional/PluginInitRepository.feature
+++ b/src/community/geogig/src/test/resources/org/geogig/geoserver/functional/PluginInitRepository.feature
@@ -112,3 +112,9 @@ Feature: Plugin Initialize Repository
     And the xpath "/response/repo/atom:link/@href" contains "/repos/repo1.xml"
     And the parent directory of repository "repo1" equals System Temp directory
     And the Author config of repository "repo1" is set
+
+  Scenario: Verify Init with unsupported MediaType does not create a repository with defualt settings
+    Given There is an empty multirepo server
+    When I call "PUT /repos/repo1/init.json" with an unsupported media type
+    Then the response status should be '400'
+    And there should be no "repo1" created


### PR DESCRIPTION
 - Remove automatic DataStore creation during INIT via plugin
 - Return a 400 Bad Request if Content-Type is not supported,
   instead of creating a GeoGig repository with default config.