### PR TITLE
[GEOS-7212] Missing links in "JMS based Clustering" documentation

### DIFF
--- a/doc/en/user/source/community/jms-cluster/index.rst
+++ b/doc/en/user/source/community/jms-cluster/index.rst
@@ -89,7 +89,7 @@ The instance.name is used to distinguish from which GeoServer instance the messa
 
 Broker URL
 ----------
-The broker.url field is used to instruct the internal JMS machinery where to publish messages to (master GeoServer installation) or where to consume messages from (slave GeoServer installation). Many options are available for configuring the connection between the GeoServer instance and the JMS broker, for a complete list, please, check this link. In case when (recommended) failover set up  is put in place multiple broker URLs can be used: please, check this link for more information about how to configure that.
+The broker.url field is used to instruct the internal JMS machinery where to publish messages to (master GeoServer installation) or where to consume messages from (slave GeoServer installation). Many options are available for configuring the connection between the GeoServer instance and the JMS broker, for a complete list, please, check http://activemq.apache.org/configuring-transports.html. In case when (recommended) failover set up  is put in place multiple broker URLs can be used. See http://activemq.apache.org/failover-transport-reference.html for more information about how to configure that.
 Note
 GeoServer will not complete the start-up phase until the target broker is correctly activated and reachable.
 


### PR DESCRIPTION
This is a proposed fix for: https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-7212