### PR TITLE
[GEOS-7661] Support NaN in DecimalConverter

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/wicket/DecimalConverter.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/DecimalConverter.java
@@ -5,6 +5,7 @@
 package org.geoserver.web.wicket;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
 
@@ -37,11 +38,14 @@ public class DecimalConverter extends DoubleConverter {
         if (value == null || value.trim().length() == 0) {
             return null;
         }
-
-        if (value.equals("-\u221E")) {
-            return new Double(Double.NEGATIVE_INFINITY);
-        } else if (value.equals("\u221E")) {
+        final NumberFormat format = getNumberFormat(locale);
+        final DecimalFormatSymbols symbols = ((DecimalFormat)format).getDecimalFormatSymbols();
+        if (value.equals(symbols.getNaN())) {
+            return new Double(Double.NaN);
+        } else if (value.equals(symbols.getInfinity())) {
             return new Double(Double.POSITIVE_INFINITY);
+        } else if (value.equals("-"+symbols.getInfinity())) {
+            return new Double(Double.NEGATIVE_INFINITY);
         } else {
             return super.convertToObject(value, locale);
         }

--- a/src/web/core/src/test/java/org/geoserver/web/wicket/DecimalTextFieldTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/wicket/DecimalTextFieldTest.java
@@ -60,6 +60,15 @@ public class DecimalTextFieldTest {
     }
     
     @Test
+    public void testNaN() throws Exception {
+        theValue = Double.NaN;
+        setUp();
+        FormTester ft = tester.newFormTester("form");
+        ft.submit();
+        assertEquals((Double)Double.NaN, theValue);
+    }
+    
+    @Test
     public void testLocale() throws Exception {
         FormTester ft = tester.newFormTester("form");
         ft.setValue("input", "12,15");


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7661

@aaime - this bug was introduced by #1667, could you take a quick look at my fix here?

Also note that after your change, NaN is getting output as `\ufffd` (literally �, the unicode replacement character) in the UI, in accordance with http://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html (See the section on **Special Values**).

This is technically correct programatically, but may be a bit confusing from a user perspective.