### PR TITLE
[Backport from 2.9] Fix GeoGig plugin to align with GeoGig core changes

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerGeoGigRepositoryResolver.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerGeoGigRepositoryResolver.java
@@ -4,17 +4,18 @@
  */
 package org.geogig.geoserver.config;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
 import java.io.IOException;
 import java.net.URI;
 
 import org.locationtech.geogig.repository.Context;
-import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.repository.RepositoryResolver;
 import org.locationtech.geogig.storage.ConfigDatabase;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 /**
@@ -23,6 +24,7 @@ import com.google.common.base.Strings;
 public class GeoServerGeoGigRepositoryResolver extends RepositoryResolver {
 
     public static final String GEOSERVER_URI_SCHEME = "geoserver";
+
     public static final int SCHEME_LENGTH = GEOSERVER_URI_SCHEME.length() + "://".length();
 
     public static String getURI(String repoName) {
@@ -52,14 +54,12 @@ public class GeoServerGeoGigRepositoryResolver extends RepositoryResolver {
 
     @Override
     public String getName(URI repoURI) {
-        Preconditions.checkArgument(canHandle(repoURI), "Not a GeoServer GeoGig repository URI: %s",
-                repoURI);
+        checkArgument(canHandle(repoURI), "Not a GeoServer GeoGig repository URI: %s", repoURI);
         // valid looking URI, strip the name part out and get everything after the scheme
         // "geoserver" and the "://"
         String name = repoURI.toString().substring(SCHEME_LENGTH);
         // if it's empty, they didn't provide a name or Id
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name),
-                "No GeoGig repository Name or ID specified");
+        checkArgument(!Strings.isNullOrEmpty(name), "No GeoGig repository Name or ID specified");
         return name;
     }
 
@@ -82,11 +82,9 @@ public class GeoServerGeoGigRepositoryResolver extends RepositoryResolver {
         try {
             RepositoryInfo info = repoMgr.getByRepoName(name);
             String repositoryId = info.getId();
-            GeoGIG gig = repoMgr.getRepository(repositoryId);
-            Repository repo = gig.getRepository();
-            if (!repo.isOpen()) {
-                repo.open();
-            }
+            Repository repo = repoMgr.getRepository(repositoryId);
+            checkState(repo.isOpen(), "RepositoryManager returned a closed repository for %s",
+                    name);
             return repo;
         } catch (IOException ioe) {
             // didn't find a repo

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
@@ -4,6 +4,7 @@
  */
 package org.geogig.geoserver.config;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 
 import java.io.IOException;
@@ -14,10 +15,28 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.geotools.util.logging.Logging;
-import org.locationtech.geogig.repository.GeoGIG;
+import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.Ref;
+import org.locationtech.geogig.model.RevCommit;
+import org.locationtech.geogig.model.RevFeature;
+import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.repository.AbstractGeoGigOp;
+import org.locationtech.geogig.repository.Context;
+import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.repository.RepositoryResolver;
+import org.locationtech.geogig.repository.StagingArea;
+import org.locationtech.geogig.repository.WorkingTree;
+import org.locationtech.geogig.storage.BlobStore;
+import org.locationtech.geogig.storage.ConfigDatabase;
+import org.locationtech.geogig.storage.ConflictsDatabase;
+import org.locationtech.geogig.storage.GraphDatabase;
+import org.locationtech.geogig.storage.ObjectDatabase;
+import org.locationtech.geogig.storage.RefDatabase;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -29,24 +48,21 @@ class RepositoryCache {
 
     private static final Logger LOGGER = Logging.getLogger(RepositoryCache.class);
 
-    private final LoadingCache<String, GeoGIG> repoCache;
+    private final LoadingCache<String, Repository> repoCache;
 
     public RepositoryCache(final RepositoryManager repoManager) {
 
-        RemovalListener<String, GeoGIG> listener = new RemovalListener<String, GeoGIG>() {
+        RemovalListener<String, Repository> disposingListener = new RemovalListener<String, Repository>() {
             @Override
-            public void onRemoval(RemovalNotification<String, GeoGIG> notification) {
+            public void onRemoval(RemovalNotification<String, Repository> notification) {
                 String repoId = notification.getKey();
-                GeoGIG geogig = notification.getValue();
-                if (geogig != null) {
-                    URI location = null;
+                Repository repository = notification.getValue();
+                if (repository != null) {
                     try {
-                        if (geogig.getContext() != null) {
-                            location = geogig.getRepository().getLocation();
-                        }
+                        URI location = repository.getLocation();
                         LOGGER.fine(format("Closing cached GeoGig repository instance %s",
                                 location != null ? location : repoId));
-                        geogig.close();
+                        repository.close();
                         LOGGER.finer(format("Closed cached GeoGig repository instance %s",
                                 location != null ? location : repoId));
                     } catch (RuntimeException e) {
@@ -57,18 +73,19 @@ class RepositoryCache {
             }
         };
 
-        final CacheLoader<String, GeoGIG> loader = new CacheLoader<String, GeoGIG>() {
+        final CacheLoader<String, Repository> loader = new CacheLoader<String, Repository>() {
             private final RepositoryManager manager = repoManager;
 
             @Override
-            public GeoGIG load(final String repoId) throws Exception {
+            public Repository load(final String repoId) throws Exception {
                 try {
                     RepositoryInfo repoInfo = manager.get(repoId);
                     URI repoLocation = repoInfo.getLocation();
+                    // RepositoryResolver.load returns an open repository or fails
                     Repository repo = RepositoryResolver.load(repoLocation);
-                    GeoGIG geogig = new GeoGIG(repo);
-                    geogig.getRepository();
-                    return geogig;
+                    checkState(repo.isOpen());
+
+                    return repo;
                 } catch (Exception e) {
                     LOGGER.log(Level.WARNING,
                             format("Error loading GeoGig repository instance for id %s", repoId),
@@ -81,13 +98,21 @@ class RepositoryCache {
         repoCache = CacheBuilder.newBuilder()//
                 .softValues()//
                 .expireAfterAccess(5, TimeUnit.MINUTES)//
-                .removalListener(listener)//
+                .removalListener(disposingListener)//
                 .build(loader);
     }
 
-    public GeoGIG get(String repositoryId) throws IOException {
+    /**
+     * @implNote: the returned repository's close() method does nothing. Closing the repository
+     *            happens when it's evicted from the cache or is removed. This avoids several errors
+     *            as GeoSever can aggressively create and dispose DataStores, whose dispose() method
+     *            would otherwise close the repository and produce unexpected exceptions for any
+     *            other code using it.
+     */
+    public Repository get(final String repositoryId) throws IOException {
         try {
-            return repoCache.get(repositoryId);
+            Repository repo = repoCache.get(repositoryId);
+            return new UnclosableRepository(repo);
         } catch (ExecutionException e) {
             Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
             throw new IOException("Error obtaining cached geogig instance for repo " + repositoryId,
@@ -101,5 +126,170 @@ class RepositoryCache {
 
     public void invalidateAll() {
         repoCache.invalidateAll();
+    }
+
+    private static class UnclosableRepository implements Repository {
+
+        private final Repository subject;
+
+        UnclosableRepository(Repository subject) {
+            this.subject = subject;
+        }
+
+        @Override
+        public void close() {
+            // ignored
+        }
+
+        @Override
+        public void addListener(RepositoryListener listener) {
+            subject.addListener(listener);
+        }
+
+        @Override
+        public void configure() throws RepositoryConnectionException {
+            subject.configure();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return subject.isOpen();
+        }
+
+        @Override
+        public void open() throws RepositoryConnectionException {
+            subject.open();
+        }
+
+        @Override
+        public URI getLocation() {
+            return subject.getLocation();
+        }
+
+        @Override
+        public <T extends AbstractGeoGigOp<?>> T command(Class<T> commandClass) {
+            return subject.command(commandClass);
+        }
+
+        @Override
+        public boolean blobExists(ObjectId id) {
+            return subject.blobExists(id);
+        }
+
+        @Override
+        public Optional<Ref> getRef(String revStr) {
+            return subject.getRef(revStr);
+        }
+
+        @Override
+        public Optional<Ref> getHead() {
+            return subject.getHead();
+        }
+
+        @Override
+        public boolean commitExists(ObjectId id) {
+            return subject.commitExists(id);
+        }
+
+        @Override
+        public RevCommit getCommit(ObjectId commitId) {
+            return subject.getCommit(commitId);
+        }
+
+        @Override
+        public boolean treeExists(ObjectId id) {
+            return subject.treeExists(id);
+        }
+
+        @Override
+        public ObjectId getRootTreeId() {
+            return subject.getRootTreeId();
+        }
+
+        @Override
+        public RevFeature getFeature(ObjectId contentId) {
+            return subject.getFeature(contentId);
+        }
+
+        @Override
+        public RevTree getOrCreateHeadTree() {
+            return subject.getOrCreateHeadTree();
+        }
+
+        @Override
+        public RevTree getTree(ObjectId treeId) {
+            return subject.getTree(treeId);
+        }
+
+        @Override
+        public Optional<Node> getRootTreeChild(String path) {
+            return subject.getRootTreeChild(path);
+        }
+
+        @Override
+        public Optional<Node> getTreeChild(RevTree tree, String childPath) {
+            return subject.getTreeChild(tree, childPath);
+        }
+
+        @Override
+        public Optional<Integer> getDepth() {
+            return subject.getDepth();
+        }
+
+        @Override
+        public boolean isSparse() {
+            return subject.isSparse();
+        }
+
+        @Override
+        public Context context() {
+            return subject.context();
+        }
+
+        @Override
+        public WorkingTree workingTree() {
+            return subject.workingTree();
+        }
+
+        @Override
+        public StagingArea index() {
+            return subject.index();
+        }
+
+        @Override
+        public RefDatabase refDatabase() {
+            return subject.refDatabase();
+        }
+
+        @Override
+        public Platform platform() {
+            return subject.platform();
+        }
+
+        @Override
+        public ObjectDatabase objectDatabase() {
+            return subject.objectDatabase();
+        }
+
+        @Override
+        public ConflictsDatabase conflictsDatabase() {
+            return subject.conflictsDatabase();
+        }
+
+        @Override
+        public ConfigDatabase configDatabase() {
+            return subject.configDatabase();
+        }
+
+        @Override
+        public GraphDatabase graphDatabase() {
+            return subject.graphDatabase();
+        }
+
+        @Override
+        public BlobStore blobStore() {
+            return subject.blobStore();
+        }
+
     }
 }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
@@ -10,14 +10,10 @@ import java.io.File;
 import java.io.Serializable;
 import java.net.URI;
 
-import org.locationtech.geogig.plumbing.ResolveRepositoryName;
-import org.locationtech.geogig.repository.Repository;
-import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.repository.RepositoryResolver;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
 
 public class RepositoryInfo implements Serializable {
 
@@ -97,31 +93,14 @@ public class RepositoryInfo implements Serializable {
     }
 
     public String getRepoName() {
-        if (this.repoName != null) {
-            return repoName;
-        }
         if (this.location != null) {
-            Repository repo = null;
-            try {
+            if (this.repoName == null) {
                 // lookup the resolver
                 RepositoryResolver resolver = RepositoryResolver.lookup(this.location);
-                // if the repo exists, get the name from it
-                if (resolver.repoExists(this.location)) {
-                    // it exists, load it and fetch the name
-                    repo = RepositoryResolver.load(this.location);
-                    return repo.command(ResolveRepositoryName.class).call();
-                }
-                // the repo doesn't exist, derive the name from the location
-                return resolver.getName(this.location);
-            } catch (RepositoryConnectionException e) {
-                Throwables.propagate(e);
-            } finally {
-                if (repo != null) {
-                    repo.close();
-                }
+                this.repoName = resolver.getName(this.location);
             }
         }
-        return null;
+        return this.repoName;
     }
 
     @Override

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
@@ -18,6 +18,7 @@ import org.geogig.geoserver.config.RepositoryManager;
 import org.locationtech.geogig.plumbing.ResolveGeogigURI;
 import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.Hints;
+import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.rest.RestletException;
 import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.restlet.data.Method;
@@ -84,12 +85,12 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
 
     @Override
     public void delete(Request request) {
-        Optional<GeoGIG> geogig = getGeogig(request);
+        Optional<Repository> geogig = getGeogig(request);
         Preconditions.checkState(geogig.isPresent(), "No repository to delete.");
 
         final String repositoryName = getStringAttribute(request, "repository");
         final String repoId = getRepoIdForName(repositoryName);
-        GeoGIG ggig = geogig.get();
+        Repository ggig = geogig.get();
         Optional<URI> repoUri = ggig.command(ResolveGeogigURI.class).call();
         Preconditions.checkState(repoUri.isPresent(), "No repository to delete.");
 
@@ -139,13 +140,13 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
     }
 
     @Override
-    public Optional<GeoGIG> getGeogig(Request request) {
+    public Optional<Repository> getGeogig(Request request) {
         Optional<String> repositoryName = getRepositoryName(request);
         if (!repositoryName.isPresent()) {
             return Optional.absent();
         }
         // look for one with the provided name first
-        Optional<GeoGIG> geogig = getGeogig(repositoryName.get());
+        Optional<Repository> geogig = getGeogig(repositoryName.get());
         if (!geogig.isPresent() && isInitRequest(request)) {
             // special handling of INIT requests
             geogig = InitRequestHandler.createGeoGIG(request);
@@ -159,12 +160,12 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
         return geogig;
     }
 
-    public Optional<GeoGIG> getGeogig(String repositoryName) {
-        GeoGIG geogig = findRepository(repositoryName);
+    public Optional<Repository> getGeogig(String repositoryName) {
+        Repository geogig = findRepository(repositoryName);
         return Optional.fromNullable(geogig);
     }
 
-    private GeoGIG findRepository(String repositoryName) {
+    private Repository findRepository(String repositoryName) {
 
         RepositoryManager manager = RepositoryManager.get();
         String repoId = getRepoIdForName(repositoryName);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
@@ -48,14 +48,12 @@ public class InitCommandResource extends CommandResource {
         if (attributes.containsKey(AUTHOR_NAME)) {
             // set the author name
             geogig.get().command(ConfigOp.class).setAction(CONFIG_SET).setScope(LOCAL)
-                    .setName("user.name")
-                    .setValue(attributes.get(AUTHOR_NAME).toString()).call();
+                    .setName("user.name").setValue(attributes.get(AUTHOR_NAME).toString()).call();
         }
         if (attributes.containsKey(AUTHOR_EMAIL)) {
             // set the author email
             geogig.get().command(ConfigOp.class).setAction(CONFIG_SET).setScope(LOCAL)
-                    .setName("user.email")
-                    .setValue(attributes.get(AUTHOR_EMAIL).toString()).call();
+                    .setName("user.email").setValue(attributes.get(AUTHOR_EMAIL).toString()).call();
         }
     }
 
@@ -63,7 +61,7 @@ public class InitCommandResource extends CommandResource {
         // repo was just created, need to register it with an ID in the manager
         // cretae a RepositoryInfo object
         RepositoryInfo repoInfo = new RepositoryInfo();
-        URI location = geogig.get().getRepository().getLocation();
+        URI location = geogig.get().getLocation();
         if ("file".equals(location.getScheme())) {
             // need the parent
             File parentDir = new File(location).getParentFile();

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitRequestHandler.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitRequestHandler.java
@@ -19,6 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.Hints;
+import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.rest.RestletException;
 import org.restlet.data.Form;
 import org.restlet.data.MediaType;
@@ -213,7 +214,8 @@ class InitRequestHandler {
                     // use the defaukt in PostgresConfigBean
                 }
             }
-            final String uri = bean.buildUriForRepo(UUID.randomUUID().toString()).toString();
+            final String uri = bean.buildUriForRepo(
+                    hints.get(Hints.REPOSITORY_NAME).get().toString()).toString();
             hints.set(Hints.REPOSITORY_URL, uri);
         }
     }
@@ -237,7 +239,7 @@ class InitRequestHandler {
         return hints;
     }
 
-    static Optional<GeoGIG> createGeoGIG(Request request) {
+    static Optional<Repository> createGeoGIG(Request request) {
         final Hints hints = INSTANCE.createHintsFromRequest(request);
         // now build the repo with the Hints
         return Optional.fromNullable(RepositoryManager.get().createRepo(hints));

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditFormPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditFormPanel.java
@@ -30,9 +30,9 @@ import org.locationtech.geogig.porcelain.RemoteAddOp;
 import org.locationtech.geogig.porcelain.RemoteListOp;
 import org.locationtech.geogig.porcelain.RemoteRemoveOp;
 import org.locationtech.geogig.repository.Context;
-import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.GeogigTransaction;
 import org.locationtech.geogig.repository.Remote;
+import org.locationtech.geogig.repository.Repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +120,7 @@ public abstract class RepositoryEditFormPanel extends Panel {
         }
 
         ArrayList<RemoteInfo> list = new ArrayList<>();
-        GeoGIG geogig;
+        Repository geogig;
         try {
             geogig = RepositoryManager.get().getRepository(repoId);
             if (geogig != null) {
@@ -157,13 +157,13 @@ public abstract class RepositoryEditFormPanel extends Panel {
     private void onSave(RepositoryInfo repoInfo, AjaxRequestTarget target) {
         RepositoryManager manager = RepositoryManager.get();
         // update remotes
-        GeoGIG geogig;
+        Repository geogig;
         try {
             repoInfo = manager.save(repoInfo);
             geogig = manager.getRepository(repoInfo.getId());
         } catch (Exception e) {
-            form.error("Unable to connect to repository " + repoInfo.getLocation() +
-                    "\n" + e.getMessage());
+            form.error("Unable to connect to repository " + repoInfo.getLocation() + "\n"
+                    + e.getMessage());
             target.addComponent(form);
             return;
         }
@@ -175,8 +175,8 @@ public abstract class RepositoryEditFormPanel extends Panel {
             }
         };
 
-        Map<Integer, RemoteInfo> currentRemotes = new HashMap<>(Maps.uniqueIndex(
-                loadRemoteInfos(repoInfo), keyFunction));
+        Map<Integer, RemoteInfo> currentRemotes = new HashMap<>(
+                Maps.uniqueIndex(loadRemoteInfos(repoInfo), keyFunction));
 
         Set<RemoteInfo> newRemotes = Sets.newHashSet(remotes.getRemotes());
         if (!currentRemotes.isEmpty() || !newRemotes.isEmpty()) {
@@ -232,8 +232,8 @@ public abstract class RepositoryEditFormPanel extends Panel {
                 try {
                     cmd.call();
                 } catch (RuntimeException e) {
-                    throw new RuntimeException("Error adding remote " + ri.getName() + ": "
-                            + e.getMessage(), e);
+                    throw new RuntimeException(
+                            "Error adding remote " + ri.getName() + ": " + e.getMessage(), e);
                 }
             } else {
                 // handle upadtes
@@ -249,8 +249,8 @@ public abstract class RepositoryEditFormPanel extends Panel {
                             .setPassword(ri.getPassword());
                     addop.call();
                 } catch (RuntimeException e) {
-                    throw new RuntimeException("Error updating remote " + ri.getName() + ": "
-                            + e.getMessage(), e);
+                    throw new RuntimeException(
+                            "Error updating remote " + ri.getName() + ": " + e.getMessage(), e);
                 }
 
             }

--- a/src/community/geogig/src/main/resources/applicationContext.xml
+++ b/src/community/geogig/src/main/resources/applicationContext.xml
@@ -8,6 +8,7 @@
   
   <bean id="geogigRepoManager" class="org.geogig.geoserver.config.RepositoryManager">
     <constructor-arg ref="geogigConfigStore"/>
+    <constructor-arg ref="catalog" />
   </bean>
 
   <bean id="geoGigGeoServerLifeCycleListener" class="org.geogig.geoserver.config.GeoGigGeoServerLifeCycleListener">

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/config/ConfigStoreTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/config/ConfigStoreTest.java
@@ -128,14 +128,14 @@ public class ConfigStoreTest {
     public void loadNull() throws Exception {
         thrown.expect(NullPointerException.class);
         thrown.expectMessage("null id");
-        store.load(null);
+        store.get(null);
     }
 
     @Test
     public void loadNonExistent() throws Exception {
         final String dummyId = "94bcb762-9ee9-4b43-a912-063509966989";
         try {
-            store.load(dummyId);
+            store.get(dummyId);
             fail("Expected FileNotFoundException");
         } catch (FileNotFoundException e) {
             assertTrue(e.getMessage().startsWith("File not found: "));
@@ -159,14 +159,14 @@ public class ConfigStoreTest {
         Resource resource = dataDir.get(path);
         Files.write(expected, resource.file(), Charsets.UTF_8);
 
-        RepositoryInfo info = store.load(dummyId);
+        RepositoryInfo info = store.get(dummyId);
         assertNotNull(info);
         assertEquals(dummyId, info.getId());
         assertEquals(new URI("file:/home/test/repo"), info.getLocation());
     }
 
     @Test
-    public void load() throws Exception {
+    public void get() throws Exception {
         final String dummyId = "94bcb762-9ee9-4b43-a912-063509966988";
         String expected = "<RepositoryInfo>"//
                 + "<id>" + dummyId + "</id>"//
@@ -177,7 +177,7 @@ public class ConfigStoreTest {
         Resource resource = dataDir.get(path);
         Files.write(expected, resource.file(), Charsets.UTF_8);
 
-        RepositoryInfo info = store.load(dummyId);
+        RepositoryInfo info = store.get(dummyId);
         assertNotNull(info);
         assertEquals(dummyId, info.getId());
         assertEquals(new URI("file:/home/test/repo"), info.getLocation());
@@ -198,7 +198,7 @@ public class ConfigStoreTest {
         Files.write(expected, resource.file(), Charsets.UTF_8);
         thrown.expect(IOException.class);
         thrown.expectMessage("Unable to load");
-        store.load(dummyId);
+        store.get(dummyId);
     }
 
     @Test
@@ -254,10 +254,10 @@ public class ConfigStoreTest {
         Resource resource = dataDir.get(path);
         Files.write(expected, resource.file(), Charsets.UTF_8);
 
-        assertNotNull(store.load(dummyId));
+        assertNotNull(store.get(dummyId));
         assertTrue(store.delete(dummyId));
         thrown.expect(FileNotFoundException.class);
-        assertNull(store.load(dummyId));
+        assertNull(store.get(dummyId));
     }
 
     @Test

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
@@ -37,6 +37,7 @@ import org.json.JSONObject;
 import org.locationtech.geogig.geotools.data.GeoGigDataStore;
 import org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory;
 import org.locationtech.geogig.repository.GeoGIG;
+import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.repository.RepositoryResolver;
 import org.locationtech.geogig.web.api.TestData;
 import org.opengis.feature.Feature;
@@ -214,7 +215,7 @@ public class GeoServerFunctionalTestContext extends FunctionalTestContext {
      * @return the repository
      */
     @Override
-    public GeoGIG getRepo(String name) {
+    public Repository getRepo(String name) {
         return repoProvider.getGeogig(name).orNull();
     }
 

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/PluginWebAPICucumberHooks.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/PluginWebAPICucumberHooks.java
@@ -21,12 +21,13 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.locationtech.geogig.plumbing.ResolveGeogigURI;
 import org.locationtech.geogig.porcelain.ConfigOp;
-import org.locationtech.geogig.repository.GeoGIG;
+import org.locationtech.geogig.repository.Repository;
 import org.restlet.data.Form;
 import org.restlet.data.Method;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.StepDefAnnotation;
@@ -197,7 +198,7 @@ public class PluginWebAPICucumberHooks {
 
     @Then("^the parent directory of repository \"([^\"]*)\" equals System Temp directory$")
     public void checkRepositoryParent(final String repo) throws Exception {
-        GeoGIG geogig = context.getRepo(repo);
+        Repository geogig = context.getRepo(repo);
         final Optional<URI> repoLocation = geogig.command(ResolveGeogigURI.class).call();
         assertTrue("Expected Repository location to be present", repoLocation.isPresent());
         URI repoURI = repoLocation.get();
@@ -211,7 +212,7 @@ public class PluginWebAPICucumberHooks {
 
     @Then("^the Author config of repository \"([^\"]*)\" is set$")
     public void checkAuthorConfig(final String repo) throws Exception {
-        GeoGIG geogig = context.getRepo(repo);
+        Repository geogig = context.getRepo(repo);
         final Optional<URI> repoLocation = geogig.command(ResolveGeogigURI.class).call();
         assertTrue("Expected Repository location to be present", repoLocation.isPresent());
         // get the config
@@ -265,7 +266,7 @@ public class PluginWebAPICucumberHooks {
 
     @Then("^the parent directory of repository \"([^\"]*)\" is NOT the System Temp directory$")
     public void checkRepositoryParent2(final String repo) throws Exception {
-        GeoGIG geogig = context.getRepo(repo);
+        Repository geogig = context.getRepo(repo);
         final Optional<URI> repoLocation = geogig.command(ResolveGeogigURI.class).call();
         assertTrue("Expected Repository location to be present", repoLocation.isPresent());
         URI repoURI = repoLocation.get();
@@ -295,7 +296,7 @@ public class PluginWebAPICucumberHooks {
 
     @Then("^there should be no \"([^\"]*)\" created$")
     public void checkRepoNotInitialized(final String repo) throws Exception {
-        GeoGIG geogig = context.getRepo(repo);
+        Repository geogig = context.getRepo(repo);
         assertTrue("Expected repository to NOT EXIST", null == geogig);
     }
 }

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/rest/GeoGigWebAPIIntegrationTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/rest/GeoGigWebAPIIntegrationTest.java
@@ -88,7 +88,6 @@ public class GeoGigWebAPIIntegrationTest extends GeoServerSystemTestSupport {
     public void before() throws Exception {
         // protected void onSetUp(SystemTestData testData) throws Exception {
         Catalog catalog = getCatalog();
-        RepositoryManager.get().setCatalog(catalog);
         geogigData.init()//
                 .config("user.name", "gabriel")//
                 .config("user.email", "gabriel@test.com")//


### PR DESCRIPTION
 - Fix GeoGig repository name on Init with PG backend
 - Add geogig profile to web/app/pom.xml
 - Let RepositoryManager cache RepositoryInfo instances
 - Simplified RepositoryInfo.getRepoName()
 - It simply delegates to RepositoryResolver.getName(URI),
   the logic to resolve the name has been moved to geogig.
 - Make sure RepositoryCache returns an open repository if it exists
 - Follow up from upstream: upgrade web api to use Repository instead of GeoGIG
 - Don't let DataStore.dispose() close the geogig repository.
 - Repository instances are cached as it can be resource
   intensive to continuously create and destroy them.