### PR TITLE
App bundler jar URL fix

### DIFF
--- a/src/release/installer/mac/build.xml
+++ b/src/release/installer/mac/build.xml
@@ -5,7 +5,7 @@
   <target name="bootstrap">
     <mkdir dir="lib"/>
     <get dest="lib" usetimestamp="true"
-       src="https://boundless.artifactoryonline.com/boundless/main/com/oracle/appbundler/1.0ea/appbundler-1.0ea.jar"/>
+       src="https://repo.boundlessgeo.com/boundless/main/com/oracle/appbundler/1.0ea/appbundler-1.0ea.jar"/>
      <get dest="lib" usetimestamp="true"
        src="http://central.maven.org/maven2/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3.jar"/>
   </target>


### PR DESCRIPTION
Looks like this URL didn't get updated to the new repo location.