### PR TITLE
[GEOS-7671] Params-Extractor module should rely on GeoServerDatadir instead of ResourceStore interface

### DIFF
--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/EchoParametersDao.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/EchoParametersDao.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.params.extractor;
 
+import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.ResourceStore;
@@ -33,7 +34,7 @@ public final class EchoParametersDao {
     private static final Logger LOGGER = Logging.getLogger(EchoParametersDao.class);
     private static final String NEW_LINE = System.getProperty("line.separator");
 
-    private static final ResourceStore DATA_DIRECTORY = (ResourceStore) GeoServerExtensions.bean("dataDirectory");
+    private static final GeoServerDataDirectory DATA_DIRECTORY = (GeoServerDataDirectory) GeoServerExtensions.bean("dataDirectory");
 
     public static String getEchoParametersPath() {
         return "params-extractor/echo-parameters.xml";

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.params.extractor;
 
+import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.filters.GeoServerFilter;
 import org.geoserver.platform.ExtensionPriority;
 import org.geoserver.platform.resource.Resource;
@@ -22,7 +23,7 @@ public final class Filter implements GeoServerFilter, ExtensionPriority {
 
     private List<Rule> rules;
 
-    public Filter(ResourceStore dataDirectory) {
+    public Filter(GeoServerDataDirectory dataDirectory) {
         Resource resource = dataDirectory.get(RulesDao.getRulesPath());
         rules = RulesDao.getRules(resource.in());
         resource.addListener(notify -> rules = RulesDao.getRules(resource.in()));

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.params.extractor;
 
+import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.ResourceStore;
@@ -33,7 +34,7 @@ public final class RulesDao {
     private static final Logger LOGGER = Logging.getLogger(RulesDao.class);
     private static final String NEW_LINE = System.getProperty("line.separator");
 
-    private static final ResourceStore DATA_DIRECTORY = (ResourceStore) GeoServerExtensions.bean("dataDirectory");
+    private static final GeoServerDataDirectory DATA_DIRECTORY = (GeoServerDataDirectory) GeoServerExtensions.bean("dataDirectory");
 
     public static String getRulesPath() {
         return "params-extractor/extraction-rules.xml";

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.params.extractor;
 
+import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.ows.URLMangler;
@@ -23,7 +24,7 @@ public class UrlMangler implements URLMangler {
 
     private List<EchoParameter> echoParameters;
 
-    public UrlMangler(ResourceStore dataDirectory) {
+    public UrlMangler(GeoServerDataDirectory dataDirectory) {
         Resource resource = dataDirectory.get(EchoParametersDao.getEchoParametersPath());
         echoParameters = EchoParametersDao.getEchoParameters(resource.in());
         resource.addListener(notify -> echoParameters = EchoParametersDao.getEchoParameters(resource.in()));

--- a/src/community/params-extractor/src/test/resources/testApplicationContext.xml
+++ b/src/community/params-extractor/src/test/resources/testApplicationContext.xml
@@ -6,8 +6,14 @@ application directory.
 -->
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
 <beans>
-    <bean id="dataDirectory" class="org.geoserver.platform.resource.FileSystemResourceStore">
+    <bean id="fileSystemResourceStore" class="org.geoserver.platform.resource.FileSystemResourceStore">
         <constructor-arg value="#{ systemProperties['java.io.tmpdir'] }/params-extractor-data-directory"/>
+    </bean>
+    <bean id="geoServerResourceLoader" class="org.geoserver.platform.GeoServerResourceLoader">
+        <constructor-arg ref="fileSystemResourceStore"/>
+    </bean>
+    <bean id="dataDirectory" class="org.geoserver.config.GeoServerDataDirectory">
+        <constructor-arg ref="geoServerResourceLoader"/>
     </bean>
     <bean id="geoServerExtensions" class="org.geoserver.platform.GeoServerExtensions"/>
 </beans>


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7671

The params-extractor community module was relying on GeoServerDataDirectory implementing the ResourceStore interface.

This was a consequence of the ResourceStore interface use clean:
https://github.com/nmco/geoserver/commit/8039744f129957dec49ce585c110a0e19868922a