### PR TITLE
Get back some vertical space in the style editor

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
@@ -109,7 +109,13 @@ public class GeoServerBasePage extends WebPage implements IAjaxIndicatorAware {
         add(new ExternalLink("faviconLink", faviconUrl, null));
 	    
 	    // page title
-	    add(new Label("pageTitle", getPageTitle()));
+	    add(new Label("pageTitle", new LoadableDetachableModel<String>() {
+
+            @Override
+            protected String load() {
+                return getPageTitle();
+            }
+        }));
 
         // login form
         WebMarkupContainer loginForm = new WebMarkupContainer("loginform") {
@@ -301,8 +307,7 @@ public class GeoServerBasePage extends WebPage implements IAjaxIndicatorAware {
 	 */
 	String getPageTitle() {
 	    try {
-	        ParamResourceModel model = new ParamResourceModel("title", this);
-	        return "GeoServer: " + model.getString();
+	        return "GeoServer: " + getTitle();
 	    } catch(Exception e) {
 	        LOGGER.warning(getClass().getSimpleName() + " does not have a title set");
 	    }

--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -1070,6 +1070,11 @@ height: 2.1em;
 margin: 1.5em 0 2.5em;
 }
 
+.tab-row-compact {
+margin: 1.5em 0 1em;
+}
+
+
 .tab-row ul {
 list-style-type: none;
 margin: 0;

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.html
@@ -1,7 +1,6 @@
 <html xmlns:wicket="http://wicket.apache.org/">
 <body>
 <wicket:extend>
-    <h1><span wicket:id="stylename"></span></h1>
     <form wicket:id="styleForm" id="styleForm">
         <div wicket:id="context" style="margin-bottom: 3em"> </div>
         <fieldset>

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -120,11 +120,7 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
             styleModel = new CompoundPropertyModel<StyleInfo>(getCatalog().getFactory().createStyle());
             styleModel.getObject().setName("");
             styleModel.getObject().setLegend(getCatalog().getFactory().createLegend());
-            add(new Label("stylename",""));
         } else {
-            add(new Label("stylename", 
-                    (style.getWorkspace() == null ? "" : style.getWorkspace().getName() + ":")
-                    + style.getName()));
             styleModel = new CompoundPropertyModel<StyleInfo>(new StyleDetachableModel(style));
         }
         
@@ -230,7 +226,12 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
             }
         }
         
-        tabbedPanel = new AjaxTabbedPanel<ITab>("context", tabs);
+        tabbedPanel = new AjaxTabbedPanel<ITab>("context", tabs) {
+            protected String getTabContainerCssClass()
+            {
+                return "tab-row tab-row-compact";
+            }
+        };
         
         styleForm.add(tabbedPanel);
         
@@ -275,7 +276,7 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
         add(cancelLink);
         
     }
-
+    
     StyleHandler styleHandler() {
         String format = styleModel.getObject().getFormat();
         return Styles.handler(format);

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
@@ -76,6 +76,18 @@ public class StyleEditPage extends AbstractStylePage {
     public StyleEditPage(StyleInfo style) {
         super(style);
     }
+    
+    @Override
+    protected String getTitle() {
+        StyleInfo style = styleModel.getObject();
+        String styleName = "";
+        if(style != null) {
+            styleName = (style.getWorkspace() == null ? "" : style.getWorkspace().getName() + ":")
+            + style.getName();
+        }
+
+        return new ParamResourceModel("title", this, styleName).getString();
+    }
 
     @Override
     protected void onStyleFormSubmit() {

--- a/src/web/wms/src/main/resources/GeoServerApplication.properties
+++ b/src/web/wms/src/main/resources/GeoServerApplication.properties
@@ -46,7 +46,7 @@ KMLLayerConfigPanel.kmlFormatSettings           = KML Format Settings
 
 StyleEditPage.description = Edit the current style. The editor can provide syntax highlighting and automatic formatting. Click on the "validate" button to verify the style is a valid SLD document.
 StyleEditPage.name        = Name
-StyleEditPage.title       = Style Editor
+StyleEditPage.title       = Style Editor - {0}
 StyleEditPage.notFound    = Could not find style "{0}"
 StyleEditPage.globalStyleReadOnly = This page is read-ony, global styles can only be modified by full administrator
 StyleNewPage.description = Type a new style definition, or use an existing one as a template, or upload a ready made \


### PR DESCRIPTION
Removes the style name inside the page "contents" and puts it in the title instead