### PR TITLE
Improvement of download estimator calculations and limit checking for…

### DIFF
--- a/doc/en/user/source/community/wps-download/index.rst
+++ b/doc/en/user/source/community/wps-download/index.rst
@@ -35,8 +35,8 @@ GeoServer will automatically create a new one with the default properties:
   maxFeatures=100000
   #8000 px X 8000 px
   rasterSizeLimits=64000000
-  #8000 px X 8000 px (USELESS RIGHT NOW)
-  writeLimits=64000000
+  #8000 px X 8000 px X 3 bands X 1 byte per band = 192MB
+  writeLimits=192000000
   # 50 MB
   hardOutputLimit=52428800
   # STORE =0, BEST =8
@@ -46,7 +46,7 @@ Where the available limits are:
 
  * ``maxFeatures`` : maximum number of features to download
  * ``rasterSizeLimits`` : maximum pixel size of the Raster to read
- * ``writeLimits`` : maximum pixel size of the Raster to write (currently not used)
+ * ``writeLimits`` : maximum raw raster size in bytes (a limit of how much space can a raster take in memory). For a given raster, its raw size in bytes is calculated by multiplying pixel number (raster_width x raster_height) with the accumated sum of each band's pixel sample_type size in bytes, for all bands
  * ``hardOutputLimit`` : maximum file size to download
  * ``compressionLevel`` : compression level for the output zip file
 

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadEstimatorProcess.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadEstimatorProcess.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -68,6 +68,7 @@ public class DownloadEstimatorProcess implements GSProcess {
      * @param clip the crop to geometry
      * @param targetSizeX the size of the target image along the X axis
      * @param targetSizeY the size of the target image along the Y axis
+     * @param bandIndices the band indices selected for output, in case of raster input
      * @param progressListener the progress listener
      * @return the boolean
      */
@@ -81,6 +82,7 @@ public class DownloadEstimatorProcess implements GSProcess {
             @DescribeParameter(name = "cropToROI", min = 0, description = "Crop to ROI") Boolean clip,
             @DescribeParameter(name = "targetSizeX", min = 0, minValue = 1, description = "X Size of the Target Image (applies to raster data only)") Integer targetSizeX,
             @DescribeParameter(name = "targetSizeY", min = 0, minValue = 1, description = "Y Size of the Target Image (applies to raster data only)") Integer targetSizeY,
+            @DescribeParameter(name = "selectedBands", description = "Band Selection Indices", min = 0) int[] bandIndices,
             ProgressListener progressListener) throws Exception {
 
         //
@@ -156,7 +158,7 @@ public class DownloadEstimatorProcess implements GSProcess {
             }
             final CoverageInfo coverage = (CoverageInfo) resourceInfo;
             return new RasterEstimator(limits).execute(progressListener, coverage, roi, targetCRS,
-                    clip, filter, targetSizeX, targetSizeY);
+                    clip, filter, targetSizeX, targetSizeY, bandIndices);
         }
 
         if (LOGGER.isLoggable(Level.FINE)) {

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadProcess.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadProcess.java
@@ -100,6 +100,7 @@ public class DownloadProcess implements GSProcess, ApplicationContextAware {
      * @param interpolation interpolation method to use when reprojecting / scaling
      * @param targetSizeX the size of the target image along the X axis
      * @param targetSizeY the size of the target image along the Y axis
+     * @param bandIndices the band indices selected for output, in case of raster input
      * @param progressListener the progress listener
      * @return the file
      * @throws ProcessException the process exception
@@ -167,7 +168,7 @@ public class DownloadProcess implements GSProcess, ApplicationContextAware {
                 LOGGER.log(Level.FINE, "Running the estimator");
             }
             if (!estimator.execute(layerName, filter, targetCRS, roiCRS, roi, clip, targetSizeX,
-                    targetSizeY, progressListener)) {
+                    targetSizeY, bandIndices, progressListener)) {
                 throw new IllegalArgumentException("Download Limits Exceeded. Unable to proceed!");
             }
 

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadServiceConfiguration.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadServiceConfiguration.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -42,11 +42,11 @@ public class DownloadServiceConfiguration {
     /** 8000 px X 8000 px */
     private long rasterSizeLimits = DEFAULT_RASTER_SIZE_LIMITS;
 
-    /** 8000 px X 8000 px (USELESS RIGHT NOW) */
-    private long writeLimits = DEFAULT_RASTER_SIZE_LIMITS;
+    /** Max size in bytes of raw raster output */
+    private long writeLimits = DEFAULT_WRITE_LIMITS;
 
     /** 50 MB */
-    private long hardOutputLimit = DEFAULT_WRITE_LIMITS;
+    private long hardOutputLimit = DEFAULT_HARD_OUTPUT_LIMITS;
 
     /** STORE =0, BEST =8 */
     private int compressionLevel = DEFAULT_COMPRESSION_LEVEL;


### PR DESCRIPTION
… raster datasets with WPS. With this improvement, calculation of the  _writeLimit_ for raster datasets takes into account the bands and the sample types of the raster dataset.

Fore more details, see JIRA issue [GEOS-7678](https://osgeo-org.atlassian.net/browse/GEOS-7678) 