### PR TITLE
Improvement of download estimator calculations and limit checking for…

### DIFF
--- a/doc/en/user/source/community/wps-download/index.rst
+++ b/doc/en/user/source/community/wps-download/index.rst
@@ -35,8 +35,8 @@ GeoServer will automatically create a new one with the default properties:
   maxFeatures=100000
   #8000 px X 8000 px
   rasterSizeLimits=64000000
-  #8000 px X 8000 px (USELESS RIGHT NOW)
-  writeLimits=64000000
+  #8000 px X 8000 px X 3 bands X 1 byte per band = 192MB
+  writeLimits=192000000
   # 50 MB
   hardOutputLimit=52428800
   # STORE =0, BEST =8
@@ -46,7 +46,7 @@ Where the available limits are:
 
  * ``maxFeatures`` : maximum number of features to download
  * ``rasterSizeLimits`` : maximum pixel size of the Raster to read
- * ``writeLimits`` : maximum pixel size of the Raster to write (currently not used)
+ * ``writeLimits`` : maximum raw raster size in bytes (a limit of how much space can a raster take in memory). For a given raster, its raw size in bytes is calculated by multiplying pixel number (raster_width x raster_height) with the accumated sum of each band's pixel sample_type size in bytes, for all bands
  * ``hardOutputLimit`` : maximum file size to download
  * ``compressionLevel`` : compression level for the output zip file
 

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadEstimatorProcess.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadEstimatorProcess.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -68,6 +68,7 @@ public class DownloadEstimatorProcess implements GSProcess {
      * @param clip the crop to geometry
      * @param targetSizeX the size of the target image along the X axis
      * @param targetSizeY the size of the target image along the Y axis
+     * @param bandIndices the band indices selected for output, in case of raster input
      * @param progressListener the progress listener
      * @return the boolean
      * @throws Exception
@@ -82,6 +83,7 @@ public class DownloadEstimatorProcess implements GSProcess {
             @DescribeParameter(name = "cropToROI", min = 0, description = "Crop to ROI") Boolean clip,
             @DescribeParameter(name = "targetSizeX", min = 0, minValue = 1, description = "X Size of the Target Image (applies to raster data only)") Integer targetSizeX,
             @DescribeParameter(name = "targetSizeY", min = 0, minValue = 1, description = "Y Size of the Target Image (applies to raster data only)") Integer targetSizeY,
+            @DescribeParameter(name = "selectedBands", description = "Band Selection Indices", min = 0) int[] bandIndices,
             ProgressListener progressListener) throws Exception {
 
         //
@@ -157,7 +159,7 @@ public class DownloadEstimatorProcess implements GSProcess {
             }
             final CoverageInfo coverage = (CoverageInfo) resourceInfo;
             return new RasterEstimator(limits).execute(progressListener, coverage, roi, targetCRS,
-                    clip, filter, targetSizeX, targetSizeY);
+                    clip, filter, targetSizeX, targetSizeY, bandIndices);
         }
 
         if (LOGGER.isLoggable(Level.FINE)) {

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadProcess.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadProcess.java
@@ -99,6 +99,7 @@ public class DownloadProcess implements GSProcess, ApplicationContextAware {
      * @param interpolation interpolation method to use when reprojecting / scaling
      * @param targetSizeX the size of the target image along the X axis
      * @param targetSizeY the size of the target image along the Y axis
+     * @param bandIndices the band indices selected for output, in case of raster input
      * @param progressListener the progress listener
      * @return the file
      * @throws ProcessException the process exception
@@ -166,7 +167,7 @@ public class DownloadProcess implements GSProcess, ApplicationContextAware {
                 LOGGER.log(Level.FINE, "Running the estimator");
             }
             if (!estimator.execute(layerName, filter, targetCRS, roiCRS, roi, clip, targetSizeX,
-                    targetSizeY, progressListener)) {
+                    targetSizeY, bandIndices, progressListener)) {
                 throw new IllegalArgumentException("Download Limits Exceeded. Unable to proceed!");
             }
 

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadServiceConfiguration.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadServiceConfiguration.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -42,11 +42,11 @@ public class DownloadServiceConfiguration {
     /** 8000 px X 8000 px */
     private long rasterSizeLimits = DEFAULT_RASTER_SIZE_LIMITS;
 
-    /** 8000 px X 8000 px (USELESS RIGHT NOW) */
-    private long writeLimits = DEFAULT_RASTER_SIZE_LIMITS;
+    /** Max size in bytes of raw raster output */
+    private long writeLimits = DEFAULT_WRITE_LIMITS;
 
     /** 50 MB */
-    private long hardOutputLimit = DEFAULT_WRITE_LIMITS;
+    private long hardOutputLimit = DEFAULT_HARD_OUTPUT_LIMITS;
 
     /** STORE =0, BEST =8 */
     private int compressionLevel = DEFAULT_COMPRESSION_LEVEL;

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterEstimator.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterEstimator.java
@@ -1,14 +1,17 @@
-/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.wps.gs.download;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageInfo;
+import org.geotools.coverage.TypeMap;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.geometry.jts.JTS;
@@ -59,22 +62,15 @@ class RasterEstimator {
      * @param filter the {@link Filter} to load the data
      * @param targetSizeX the size of the target image along the X axis
      * @param targetSizeY the size of the target image along the Y axis
-     * @return
+     * @param selectedBands the band indices selected for output, in case of raster input
+     *
      */
     public boolean execute(final ProgressListener progressListener, CoverageInfo coverageInfo,
             Geometry roi, CoordinateReferenceSystem targetCRS, boolean clip, Filter filter,
-            Integer targetSizeX, Integer targetSizeY) throws Exception {
+            Integer targetSizeX, Integer targetSizeY, int[] bandIndices) throws Exception {
 
-        //
-        // Do we need to do anything?
-        //
         final long rasterSizeLimits = downloadServiceConfiguration.getRasterSizeLimits();
-        if (rasterSizeLimits <= 0) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine("No raster size limits, moving on....");
-            }
-            return true;
-        }
+
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("Raster size limits: " + rasterSizeLimits);
         }
@@ -161,21 +157,62 @@ class RasterEstimator {
         }
         if (areaRead >= Integer.MAX_VALUE || targetArea >= Integer.MAX_VALUE) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, "Area to read or target image size exceed maximum integer value: " + Integer.MAX_VALUE);
+                LOGGER.log(Level.FINE, "Area to read or target image size exceeds maximum integer value: " + Integer.MAX_VALUE);
             }
             return false;
         }
 
         // If the area exceeds the limits, false is returned
-        if (areaRead > rasterSizeLimits) {
+        if (rasterSizeLimits > DownloadServiceConfiguration.NO_LIMIT 
+                && (areaRead > rasterSizeLimits || targetArea > rasterSizeLimits)) {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Area exceeds the limits");
             }
             return false;
         }
         if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.log(Level.FINE, "Area does not exceeds the limits");
+            LOGGER.log(Level.FINE, "Area does not exceed the limits");
         }
+        // Try to check write limits, using input's coverageinfo 
+        int bandsCount =  coverageInfo.getDimensions().size();
+        
+        // Use sample info type for each output band to estimate size
+        List<CoverageDimensionInfo> coverageDimensionInfoList = coverageInfo.getDimensions();
+        int accumulatedPixelSizeInBits = 0;
+        
+        // Use only selected bands for output, if specified
+        if (bandIndices!=null && bandIndices.length>0){
+            for (int i=0;i<bandIndices.length;i++){
+                //Use valid indices
+                if (bandIndices[i]>=0 && bandIndices[i]<bandsCount)
+                    accumulatedPixelSizeInBits +=
+                        TypeMap.getSize(coverageDimensionInfoList.get(bandIndices[i]).getDimensionType());
+            }
+        }else{
+            for (int i=0;i<bandsCount;i++){
+                accumulatedPixelSizeInBits +=
+                        TypeMap.getSize(coverageDimensionInfoList.get(i).getDimensionType());
+            
+            }
+        }
+        
+        /// Total size in bytes
+        long rasterSizeInBytes = (long) targetArea*accumulatedPixelSizeInBits/8;
+        
+        final long writeLimits = downloadServiceConfiguration.getWriteLimits();
+        
+        // If size exceeds the write limits, false is returned
+        if (writeLimits > DownloadServiceConfiguration.NO_LIMIT && rasterSizeInBytes > writeLimits) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Output raw raster size ("+rasterSizeInBytes+") exceeds"
+                        + " the specified write limits ("+writeLimits+")");
+            }
+            return false;
+        }
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "Output raw raster size ("+rasterSizeInBytes+") does not exceed"
+                    + " the specified write limits ("+writeLimits+")");
+        }    
         return true;
 
     }


### PR DESCRIPTION
… raster datasets with WPS. With this improvement, calculation of the  _writeLimit_ for raster datasets takes into account the bands and the sample types of the raster dataset.

Fore more details, see JIRA issue [GEOS-7678](https://osgeo-org.atlassian.net/browse/GEOS-7678) 

This is a backport PR for branch 2.8.x