### PR TITLE
Remove server name and port from ResponseUtils.baseURL

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/util/ResponseUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/ResponseUtils.java
@@ -424,9 +424,8 @@ public class ResponseUtils {
      * @return A String of the form "&lt;scheme&gt;://&lt;server&gt;:&lt;port&gt;/&lt;context&gt;/"
      */
     public static String baseURL(HttpServletRequest req) {
-        StringBuffer sb = new StringBuffer(req.getScheme());
-        sb.append("://").append(req.getServerName()).append(":").append(req.getServerPort())
-                .append(req.getContextPath()).append("/");
+        StringBuffer sb = new StringBuffer();
+        sb.append(req.getContextPath()).append("/");
         return sb.toString();
     }
     


### PR DESCRIPTION
Behind a proxy, the server name and server port do not
match the request. By example, through apache, you proxy
/geoserver -> 127.0.0.1:8080/geoserver
It gives :
server name = 127.0.0.1
server port = 8080
And then, links in the web interface are "http://127.0.0.1:8080/..."
which is not what we want
If we remove server name and server port, the browser will correctly
interpret the the links