### PR TITLE
GeoServerResourceLoader: use resourcestore rather than basedirectory …

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
@@ -215,7 +215,7 @@ public class GeoServerResourceLoader extends DefaultResourceLoader implements Re
      */
     @Deprecated 
     public File url(String url) {
-        return Files.url(baseDirectory, url);
+        return Files.url(get(Paths.BASE).dir(), url);
     }
     
     /**


### PR DESCRIPTION
…for url to file conversion

Motivation: We are running geoserver without a data directory at all, with an in-memory resource store.
Note that this change has no effect when using the default resource store (DataDirectoryResourceStore)

Testing: This method is already being tested extensively in two places: GeoServerDataDirectoryTest and PropertyDataStoreRelativeUrlTest. 