### PR TITLE
GeoServerResourceLoader: allow setting data directory without changin…

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
@@ -157,7 +157,9 @@ public class GeoServerResourceLoader extends DefaultResourceLoader implements Re
      */
     public void setBaseDirectory(File baseDirectory) {
         this.baseDirectory = baseDirectory;
-        this.resources = new FileSystemResourceStore( baseDirectory );
+        if (resources == ResourceStore.EMPTY) {
+            resources = new FileSystemResourceStore(baseDirectory);
+        }
     }
 
     @Override


### PR DESCRIPTION
…g resource store

Motivation: we are running a geoserver without a web context (so the data directory is never set in the setServletContext method as it is supposed to) and with its own resource store. We need to programmatically set the data directory without changing the resource store a filesystembased one. (Without a data directory set, the url() method fails).

Testing: this method is actually nowhere used in geoserver, there isn't really anything to test.