### PR TITLE
[GEOS-7712] Importer throws NullPointerException

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
@@ -1412,7 +1412,14 @@ public class Importer implements DisposableBean, ApplicationListener {
 
         //TODO: put an upper limit on how many times to try
         StoreInfo store = resource.getStore();
-        NamespaceInfo ns = catalog.getNamespaceByPrefix(store.getWorkspace().getName());
+        NamespaceInfo ns;
+        // try to get the Namespace from the StoreInfo Worksapce
+        if (store != null) {
+            ns = catalog.getNamespaceByPrefix(store.getWorkspace().getName());
+        } else {
+            // store is not set for some reason, just use the Namespace from the resource
+            ns = resource.getNamespace();
+        }
         
         String name = resource.getName();
 


### PR DESCRIPTION
  In some cases, importnig a raster causes a NullPointerException
  when trying to fetch the Namespace from the Catalog, using
  the Workspace name of the StoreInfo of the supplied ResourceInfo,
  because the StoreInfo is not set on the ResourceInfo.
  The ResourceInfo does seem to have a Namespace, so use that if
  we can't get it from the Store.