### PR TITLE
[GEOS-7676] Makes the importer share the request context when starting a job asynchronously (backport 2.9.x)

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
@@ -93,6 +93,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.thoughtworks.xstream.XStream;
 import com.vividsolutions.jts.geom.Geometry;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * Primary controller/facade of the import subsystem.
@@ -872,14 +874,29 @@ public class Importer implements DisposableBean, ApplicationListener {
     }
 
     public Long runAsync(final ImportContext context, final ImportFilter filter, final boolean init) {
+        // we store the current request spring context
+        RequestAttributes parentRequestAttributes = RequestContextHolder.getRequestAttributes();
+        Thread parentThread = Thread.currentThread();
+        // creating an asynchronous importer job
         return jobs.submit(new Job<ImportContext>() {
+
             @Override
             protected ImportContext call(ProgressMonitor monitor) throws Exception {
-                if (init) {
-                    init(context, true);
+                try {
+                    // set the parent request spring context, some interceptors like the security ones
+                    // for example may need to have access to the original request attributes
+                    RequestContextHolder.setRequestAttributes(parentRequestAttributes);
+                    if (init) {
+                        init(context, true);
+                    }
+                    run(context, filter, monitor);
+                    return context;
+                } finally {
+                    if (Thread.currentThread() != parentThread) {
+                        // cleaning request spring context for the current thread
+                        RequestContextHolder.resetRequestAttributes();
+                    }
                 }
-                run(context, filter, monitor);
-                return context;
             }
 
             @Override

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RequestContextListener.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RequestContextListener.java
@@ -1,0 +1,45 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.importer.rest;
+
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.security.AbstractResourceAccessManager;
+import org.geoserver.security.DataAccessLimits;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * The purpose of this class is to test that requests spring context are correctly shared
+ * between multiple threads. This happens for example when we perform a job asynchronously.
+ */
+public final class RequestContextListener extends AbstractResourceAccessManager {
+
+    private CallBack callBack;
+
+    public interface CallBack {
+        void invoked(HttpServletRequest request, Authentication user, ResourceInfo resource);
+    }
+
+    public void setCallBack(CallBack callBack) {
+        this.callBack = callBack;
+    }
+
+    @Override
+    public DataAccessLimits getAccessLimits(Authentication user, ResourceInfo resource) {
+        if (callBack != null) {
+            // let's see if we can access this request context
+            try {
+                HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+                callBack.invoked(request, user, resource);
+            } catch (Exception exception) {
+                // the call back should have test if the request context was properly obtained
+            }
+        }
+        return super.getAccessLimits(user, resource);
+    }
+}

--- a/src/extension/importer/rest/src/test/resources/applicationContext.xml
+++ b/src/extension/importer/rest/src/test/resources/applicationContext.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean id="securityCatalog" class="org.geoserver.importer.rest.RequestContextListener"/>
+</beans>


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7676
This pull request also provides a test case for this.

This is a backport to 2.9.x of pull request https://github.com/geoserver/geoserver/pull/1762