### PR TITLE
[GEOS-7729] Display style page error messages on submit

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -259,11 +259,19 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
                 }
                 target.add(AbstractStylePage.this);
             }
+            @Override
+            protected void onError(AjaxRequestTarget target, Form<?> form) {
+                target.add(AbstractStylePage.this);
+            }
         });
         add(new AjaxSubmitLink("submit", styleForm) {
             @Override
             protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
                 doReturn(StylePage.class);
+            }
+            @Override
+            protected void onError(AjaxRequestTarget target, Form<?> form) {
+                target.add(AbstractStylePage.this);
             }
         });
         Link<StylePage> cancelLink = new Link<StylePage>("cancel") {


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7729

I tried adding a test case for this one, but it turns out we already test for the error message [here](https://github.com/geoserver/geoserver/blob/master/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java#L109).

It looks like the tester is getting the page that results from the form submission, however the cause of this bug (not seeing error messages) is that this page never actually gets returned to the user (by calling target.add(...)).

I can't see any way to test for this behavior within the wicket test framework.

However, some basic manual testing shows that the fix does work (I'm not happy about not having a unit test, but can't see any way around it here).