### PR TITLE
[GEOS-7960] Ensure edits are not lost when switching tabs

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -24,6 +24,7 @@ import org.apache.wicket.extensions.ajax.markup.html.tabs.AjaxTabbedPanel;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
 import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.extensions.markup.html.tabs.PanelCachingTab;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.link.Link;
@@ -45,7 +46,6 @@ import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.web.ComponentAuthorizer;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.GeoServerSecuredPage;
-import org.geoserver.web.data.style.StyleDetachableModel;
 import org.geoserver.web.wicket.CodeMirrorEditor;
 import org.geoserver.web.wicket.GeoServerAjaxFormLink;
 import org.geoserver.web.wicket.ParamResourceModel;
@@ -53,6 +53,11 @@ import org.xml.sax.SAXParseException;
 
 /**
  * Base page for creating/editing styles
+ * <p>
+ * WARNING: one crucial aspect of this page is its ability to not loose edits when one switches from
+ * one tab to the other. I did not find any effective way to unit test this, so _please_, if you do
+ * modify anything in this class (especially the models), manually retest that the edits are not
+ * lost on tab switch.
  */
 @SuppressWarnings("serial")
 public abstract class AbstractStylePage extends GeoServerSecuredPage {
@@ -121,7 +126,7 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
             styleModel.getObject().setName("");
             styleModel.getObject().setLegend(getCatalog().getFactory().createLegend());
         } else {
-            styleModel = new CompoundPropertyModel<StyleInfo>(new StyleDetachableModel(style));
+            styleModel = new CompoundPropertyModel<StyleInfo>(style);
         }
         
         /* init main form */
@@ -230,6 +235,25 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
             protected String getTabContainerCssClass()
             {
                 return "tab-row tab-row-compact";
+            }
+            @Override
+            protected WebMarkupContainer newLink(String linkId, final int index) {
+                /*
+                 * Use a submit link here in order to save the state of the current tab to the model
+                 * setDefaultFormProcessing(false) is used so that we do not do a full submit 
+                 * (with validation + saving to the catalog)
+                 */
+                AjaxSubmitLink link =  new AjaxSubmitLink(linkId) {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public void onSubmit(AjaxRequestTarget target, Form<?> form) {
+                        setSelectedTab(index);
+                        target.add(AbstractStylePage.this);
+                    }
+                };
+                link.setDefaultFormProcessing(false);
+                return link;
             }
         };
         

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
@@ -93,7 +93,7 @@ public class StyleEditPage extends AbstractStylePage {
     protected void onStyleFormSubmit() {
         // write out the file and save name modifications
         try {
-            StyleInfo style = (StyleInfo) styleForm.getModelObject();
+            StyleInfo style = getStyleInfo();
             String format = style.getFormat();
             style.setFormat(format);
             Version version = Styles.handler(format).version(rawStyle);


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7690

Uses a submit link to save the model status when switching tabs.

As with the [PublishedConfigurationPage](https://github.com/geoserver/geoserver/blob/master/src/web/core/src/main/java/org/geoserver/web/publish/PublishedConfigurationPage.java#L44) upon which this fix is modeled, there is no easy way of testing this behavior with the wicket tester.