### PR TITLE
[GEOS-7731] CoverageViewReader supporting AbstractGridFormat.BANDS parameter

### DIFF
--- a/src/extension/grib/src/test/java/org/geoserver/catalog/CoverageViewReaderTest.java
+++ b/src/extension/grib/src/test/java/org/geoserver/catalog/CoverageViewReaderTest.java
@@ -8,8 +8,10 @@ package org.geoserver.catalog;
 import static org.junit.Assert.assertEquals;
 
 import java.awt.image.ColorModel;
+import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,18 +24,25 @@ import org.geoserver.catalog.CoverageView.InputCoverageBand;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geoserver.wms.map.GetMapIntegrationTest;
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.GranuleStore;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.gce.imagemosaic.catalog.index.Indexer.Coverages.Coverage;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.parameter.DefaultParameterDescriptor;
+import org.geotools.parameter.Parameter;
+import org.junit.Assert;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.coverage.grid.GridCoverageReader;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.parameter.GeneralParameterValue;
 
 /**
  * Base support class for CoverageViews based on multiple coverages from the same store.
@@ -49,19 +58,18 @@ public class CoverageViewReaderTest extends GeoServerSystemTestSupport {
             MockData.SF_PREFIX);
 
     private CoverageView coverageView = null;
+    private CoverageView multiBandCoverageView = null;
 
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
         super.setUpTestData(testData);
+        testData.setUpDefaultRasterLayers();
         testData.setUpRasterLayer(CURRENT, "currents.zip", null, null, CoverageViewReaderTest.class);
-
-        createCoverageView();
     }
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         super.onSetUp(testData);
-        addViewToCatalog();
     }
 
     private void addViewToCatalog() throws Exception {
@@ -77,6 +85,22 @@ public class CoverageViewReaderTest extends GeoServerSystemTestSupport {
         final LayerInfo layerInfo = builder.buildLayer(coverageInfo);
         cat.add(layerInfo);
     }
+    
+    private void addMultiBandViewToCatalog() throws Exception {
+        final Catalog cat = getCatalog();
+        CoverageStoreInfo storeInfo = cat.getCoverageStoreByName("multiband");
+        
+        CatalogBuilder builder = new CatalogBuilder(cat);
+        builder.setStore(storeInfo);
+        
+        // Reordered bands coverage
+        CoverageInfo coverageInfo = multiBandCoverageView.createCoverageInfo("multiband_select",
+                storeInfo, builder);
+        coverageInfo.getParameters().put("USE_JAI_IMAGEREAD", "false");
+        cat.add(coverageInfo);
+        final LayerInfo layerInfoView = builder.buildLayer(coverageInfo);
+        cat.add(layerInfoView);    
+    }
 
     private void createCoverageView() throws Exception {
         final InputCoverageBand band_u = new InputCoverageBand("u-component_of_current_surface", "0");
@@ -91,11 +115,46 @@ public class CoverageViewReaderTest extends GeoServerSystemTestSupport {
         coverageBands.add(outputBand_v);
         coverageView = new CoverageView("regional_currents", coverageBands);
     }
+    
+    private void createMultiBandCoverageView() throws Exception {
+        final InputCoverageBand ib0 = new InputCoverageBand("multiband", "2");
+        final CoverageBand b0 = new CoverageBand(Collections.singletonList(ib0), "multiband@2",
+                0, CompositionType.BAND_SELECT);
+
+        final InputCoverageBand ib1 = new InputCoverageBand("multiband", "1");
+        final CoverageBand b1 = new CoverageBand(Collections.singletonList(ib1), "multiband@1",
+                1, CompositionType.BAND_SELECT);
+
+        final InputCoverageBand ib2 = new InputCoverageBand("multiband", "0");
+        final CoverageBand b2 = new CoverageBand(Collections.singletonList(ib2), "multiband@0",
+                2, CompositionType.BAND_SELECT);
+        
+        final InputCoverageBand ib3 = new InputCoverageBand("multiband", "0");
+        final CoverageBand b3 = new CoverageBand(Collections.singletonList(ib3), "multiband@0",
+                0, CompositionType.BAND_SELECT);
+
+        final InputCoverageBand ib4 = new InputCoverageBand("multiband", "1");
+        final CoverageBand b4 = new CoverageBand(Collections.singletonList(ib4), "multiband@1",
+                1, CompositionType.BAND_SELECT);
+
+        final List<CoverageBand> coverageBands = new ArrayList<CoverageBand>(1);
+        coverageBands.add(b0);
+        coverageBands.add(b1);
+        coverageBands.add(b2);
+        
+        coverageBands.add(b3);
+        coverageBands.add(b4);
+           
+        multiBandCoverageView = new CoverageView("multiband_select", coverageBands);
+    }
 
     /**
      */
     @Test
     public void testCoverageView() throws Exception {
+        createCoverageView();
+        addViewToCatalog();
+
         final Catalog cat = getCatalog();
         final CoverageInfo coverageInfo = cat.getCoverageByName("regional_currents");
         final MetadataMap metadata = coverageInfo.getMetadata();
@@ -126,6 +185,80 @@ public class CoverageViewReaderTest extends GeoServerSystemTestSupport {
         ColorModel colorModel = layout.getColorModel(null);
         assertEquals (2, colorModel.getNumComponents());
         reader.dispose();
+    }
+    
+    /**
+     * Test creation of a Coverage from a multi band CoverageView using an 
+     * {@link org.geotools.coverage.grid.io.AbstractGridFormat#BANDS} reading parameter
+     */
+    @Test
+    public void testBandSelectionOnCoverageView() throws Exception {
+        createMultiBandCoverageView();
+        addMultiBandViewToCatalog();
+    	
+        final Catalog cat = getCatalog();
+        final CoverageInfo coverageInfo = cat.getCoverageByName("multiband_select");
+        final MetadataMap metadata = coverageInfo.getMetadata();
+
+        final ResourcePool resPool = cat.getResourcePool();
+        final ReferencedEnvelope bbox = coverageInfo.getLatLonBoundingBox();
+        final GridCoverage coverage = resPool.getGridCoverage(coverageInfo, "multiband_select", bbox, null);
+        RenderedImage srcImage = coverage.getRenderedImage();
+        
+        assertEquals(coverage.getNumSampleDimensions(), 5);
+        ((GridCoverage2D) coverage).dispose(true);
+        final GridCoverageReader reader = resPool.getGridCoverageReader(coverageInfo, "multiband_select", null);
+        int[] bandIndices = new int[]{2,0,1,0,2,2,2,3};
+        Parameter<int[]> bandIndicesParam = null;
+        
+        if (bandIndices != null) {
+            bandIndicesParam = (Parameter<int[]>) AbstractGridFormat.BANDS.createValue();
+            bandIndicesParam.setValue(bandIndices);
+        }
+        
+        GridCoverage2DReader myReader = (GridCoverage2DReader) reader;
+        ImageLayout layout = myReader.getImageLayout();
+        SampleModel sampleModel = layout.getSampleModel(null);
+        assertEquals (5, sampleModel.getNumBands());
+        reader.dispose();
+        
+        List<GeneralParameterValue> paramList = new ArrayList<GeneralParameterValue>();
+        paramList.addAll(Arrays.asList(bandIndicesParam));
+        GeneralParameterValue[] readParams = paramList.toArray(new GeneralParameterValue[paramList
+                .size()]);
+        GridCoverage result = reader.read(readParams);
+        assertEquals (8, result.getNumSampleDimensions());
+        RenderedImage destImage = result.getRenderedImage();
+            
+        int dWidth = destImage.getWidth();
+        int dHeight = destImage.getHeight();
+        
+        int[] destImageRowBand0 = new int[dWidth*dHeight];
+        int[] destImageRowBand1 = new int[destImageRowBand0.length];
+        int[] destImageRowBand2 = new int[destImageRowBand0.length];
+        int[] destImageRowBand3 = new int[destImageRowBand0.length];
+        destImage.getData().getSamples(0, 0, dWidth, dHeight, 0, destImageRowBand0);
+        destImage.getData().getSamples(0, 0, dWidth, dHeight, 1, destImageRowBand1);
+        destImage.getData().getSamples(0, 0, dWidth, dHeight, 2, destImageRowBand2);
+        destImage.getData().getSamples(0, 0, dWidth, dHeight, 3, destImageRowBand3);
+        
+        int sWidth = srcImage.getWidth();
+        int sHeight = srcImage.getHeight();
+        
+        int[] srcImageRowBand0 = new int[sWidth*sHeight];
+        int[] srcImageRowBand1 = new int[srcImageRowBand0.length];
+        int[] srcImageRowBand2 = new int[srcImageRowBand0.length];
+        int[] srcImageRowBand3 = new int[srcImageRowBand0.length];
+
+        srcImage.getData().getSamples(0, 0, sWidth, sHeight, 0, srcImageRowBand0);
+        srcImage.getData().getSamples(0, 0, sWidth, sHeight, 1, srcImageRowBand1);
+        srcImage.getData().getSamples(0, 0, sWidth, sHeight, 2, srcImageRowBand2);
+        
+        Assert.assertTrue(Arrays.equals(destImageRowBand0,srcImageRowBand2));
+        Assert.assertTrue(Arrays.equals(destImageRowBand1,srcImageRowBand0));
+        Assert.assertTrue(Arrays.equals(destImageRowBand2,srcImageRowBand1));
+        Assert.assertTrue(Arrays.equals(destImageRowBand3,srcImageRowBand0));
+        Assert.assertFalse(Arrays.equals(destImageRowBand0,srcImageRowBand0));
     }
 
 }

--- a/src/main/src/main/java/org/geoserver/catalog/SingleGridCoverage2DReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/SingleGridCoverage2DReader.java
@@ -62,7 +62,7 @@ public class SingleGridCoverage2DReader implements GridCoverage2DReader {
      */
     protected void checkCoverageName(String coverageName) {
         if (!this.coverageName.equals(coverageName)) {
-            throw new IllegalArgumentException("Unkonwn coverage named " + coverageName
+            throw new IllegalArgumentException("Unknown coverage named " + coverageName
                     + ", the only valid value is: " + this.coverageName);
         }
     }

--- a/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
@@ -82,9 +82,12 @@ import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.geotools.renderer.lite.RendererUtilities;
 import org.geotools.renderer.lite.RenderingTransformationHelper;
 import org.geotools.renderer.lite.StreamingRenderer;
+import org.geotools.renderer.lite.gridcoverage2d.ChannelSelectionUpdateStyleVisitor;
 import org.geotools.renderer.lite.gridcoverage2d.GridCoverageRenderer;
 import org.geotools.resources.image.ColorUtilities;
+import org.geotools.styling.ChannelSelection;
 import org.geotools.styling.RasterSymbolizer;
+import org.geotools.styling.SelectedChannelType;
 import org.geotools.styling.Style;
 import org.geotools.util.logging.Logging;
 import org.opengis.feature.Feature;
@@ -919,6 +922,12 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
             tileSizeY = mapContent.getMapHeight();
         }
         
+        // 
+        // Band selection
+        //
+        final int[] bandIndices = 
+                ChannelSelectionUpdateStyleVisitor.getBandIndicesFromSelectionChannels(symbolizer);
+        
         // actual read
         RenderedImage image = null;
         GridCoverage2D coverage=null; 
@@ -938,7 +947,7 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                 // handling
                 final Object params = feature.getProperty("params").getValue();
                 GeneralParameterValue[] readParameters = getReadParameters(params, null, null,
-                        interpolation, readerBgColor);
+                        interpolation, readerBgColor, bandIndices);
                 final GridCoverageRenderer gcr = new GridCoverageRenderer(mapEnvelope.getCoordinateReferenceSystem(), mapEnvelope,
                         mapRasterArea, worldToScreen, interpolationHints);
                 gcr.setAdvancedProjectionHandlingEnabled(true);
@@ -1000,7 +1009,7 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                                 Object params, GridGeometry2D readGG) throws IOException {
                             return readBestCoverage(reader, params,
                                     ReferencedEnvelope.reference(readGG.getEnvelope()),
-                                    readGG.getGridRange2D(), interpolation, readerBgColor);
+                                    readGG.getGridRange2D(), interpolation, readerBgColor, bandIndices);
                         }
 
                     };
@@ -1029,7 +1038,18 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
 
                     coverage = readBestCoverage(reader, params,
                             ReferencedEnvelope.reference(readGG.getEnvelope()),
-                            readGG.getGridRange2D(), interpolation, readerBgColor);
+                            readGG.getGridRange2D(), interpolation, readerBgColor, bandIndices);
+
+                    // If reader supports band selection, symbolizer channels should be reordered.
+                    if (reader.getFormat().getReadParameters().getDescriptor().descriptors().
+                    		contains(AbstractGridFormat.BANDS) && params!=null){
+            	        // if bands are selected, alter the symbolizer to use bands in order 0,1,2,...
+                    	// since the channel order defined by it previously is taken care of the reader
+            	        if (bandIndices!=null){
+            	            GridCoverageRenderer.setupSymbolizerForBandsSelection(symbolizer);
+            	        }
+                    }
+
                 }
                 // Nothing found, we return a constant image with background value
                 if (coverage == null) {
@@ -1372,7 +1392,8 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
             final ReferencedEnvelope envelope,
             final Rectangle requestedRasterArea,
             final Interpolation interpolation,
-            final Color bgColor) throws IOException {
+            final Color bgColor,
+            final int[] bandIndices) throws IOException {
 
         ////
         //
@@ -1403,7 +1424,7 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
 
         GridCoverage2D coverage;
         GeneralParameterValue[] readParams = getReadParameters(params, envelope,
-                requestedRasterArea, interpolation, bgColor);
+                requestedRasterArea, interpolation, bgColor, bandIndices);
 
         coverage = reader.read(readParams);
 
@@ -1412,7 +1433,7 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
 
     private static GeneralParameterValue[] getReadParameters(final Object params,
             final ReferencedEnvelope envelope, final Rectangle requestedRasterArea,
-            final Interpolation interpolation, final Color bgColor) {
+            final Interpolation interpolation, final Color bgColor, int[] bandIndices) {
         Parameter<GridGeometry2D> readGG = null;
         if (envelope != null) {
             // //
@@ -1435,8 +1456,14 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
         } else {
             bgColorParam = null;
         }
-        
-        
+
+        //Inject bandIndices read param
+        Parameter<int[]> bandIndicesParam = null;
+        if (bandIndices != null) {
+            bandIndicesParam = (Parameter<int[]>) AbstractGridFormat.BANDS.createValue();
+            bandIndicesParam.setValue(bandIndices);
+        }
+
         // then I try to get read parameters associated with this
         // coverage if there are any.
         GeneralParameterValue[] readParams = (GeneralParameterValue[]) params;
@@ -1457,10 +1484,12 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
             final String readGGName = AbstractGridFormat.READ_GRIDGEOMETRY2D.getName().toString();
             final String readInterpolationName = ImageMosaicFormat.INTERPOLATION.getName().toString();
             final String bgColorName = AbstractGridFormat.BACKGROUND_COLOR.getName().toString();
+            final String bandsListName = AbstractGridFormat.BANDS.getName().toString();
             int i = 0;
             boolean foundInterpolation = false;
             boolean foundGG = false;
             boolean foundBgColor = false;
+            boolean foundBandIndices = false;
             for (; i < length; i++) {
                 final String paramName = readParams[i].getDescriptor().getName().toString();
                 if (paramName.equalsIgnoreCase(readGGName) && readGG != null) {
@@ -1473,10 +1502,14 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                     ((Parameter) readParams[i]).setValue(bgColor);
                     foundBgColor = true;
                 }
+                else if(paramName.equalsIgnoreCase(bandsListName) && bandIndices != null) {
+                    ((Parameter) readParams[i]).setValue(bandIndices);
+                    foundBandIndices = true;
+                }
             }
             
             // did we find anything?
-            if (!foundGG || !foundInterpolation || !(foundBgColor && bgColor != null)) {
+            if (!foundGG || !foundInterpolation || !(foundBgColor && bgColor != null) || !foundBandIndices) {
                 // add the correct read geometry to the supplied
                 // params since we did not find anything
                 List<GeneralParameterValue> paramList = new ArrayList<GeneralParameterValue>();
@@ -1490,6 +1523,9 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                 if(!foundBgColor && bgColor != null) {
                     paramList.add(bgColorParam);
                 }
+                if(!foundBandIndices && bandIndices != null) {
+                    paramList.add(bandIndicesParam);
+                }
                 readParams = paramList.toArray(new GeneralParameterValue[paramList
                         .size()]);
             }
@@ -1500,6 +1536,9 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
             }
             if (bgColor != null) {
                 paramList.add(bgColorParam);
+            }
+            if (bandIndices != null) {
+                paramList.add(bandIndicesParam);
             }
             paramList.add(readInterpolation);
             readParams = paramList.toArray(new GeneralParameterValue[paramList.size()]);


### PR DESCRIPTION
[GEOS-7731](https://osgeo-org.atlassian.net/browse/GEOS-7731)

This change allows CoverageViewReader to support the BANDS reading parameter for using selected bands from a CoverageView. Changes  have been done also to RenderedImageMapOutputFormat to support rendering of CoverageView rasters using a symbolizer with selection channels. In this case, selection channels determine the BANDS parameter used by the CoverageViewReader to read bands. This closely follows changes in GeoTools described at [GEOT-5513](https://osgeo-org.atlassian.net/browse/GEOT-5513)
