### PR TITLE
Updating the appbundler jar link

### DIFF
--- a/src/release/installer/mac/build.xml
+++ b/src/release/installer/mac/build.xml
@@ -5,7 +5,7 @@
   <target name="bootstrap">
     <mkdir dir="lib"/>
     <get dest="lib" usetimestamp="true"
-       src="https://boundless.artifactoryonline.com/boundless/main/com/oracle/appbundler/1.0ea/appbundler-1.0ea.jar"/>
+       src="https://repo.boundlessgeo.com/artifactory/boundless-main/com/oracle/appbundler/1.0ea/appbundler-1.0ea.jar"/>
      <get dest="lib" usetimestamp="true"
        src="http://central.maven.org/maven2/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3.jar"/>
   </target>


### PR DESCRIPTION
Forgot this from the last release. The location of this jar changed.