### PR TITLE
[GEOS-7750] Get WMS and LegendSample beans only when needed

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -123,15 +123,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
 
     private WMS wms;
 
-    public GeoServerTileLayer(final PublishedInfo publishedInfo, final GWCConfig configDefaults,
-                              final GridSetBroker gridsets) {
-        this(publishedInfo, configDefaults, gridsets,
-                GeoServerExtensions.bean(LegendSample.class),
-                GeoServerExtensions.bean(WMS.class));
-    }
-
-    public GeoServerTileLayer(final PublishedInfo publishedInfo, final GWCConfig configDefaults,
-            final GridSetBroker gridsets, LegendSample legendSample, WMS wms) {
+    public GeoServerTileLayer(final PublishedInfo publishedInfo, final GWCConfig configDefaults, final GridSetBroker gridsets) {
         checkNotNull(publishedInfo, "publishedInfo");
         checkNotNull(gridsets, "gridsets");
         checkNotNull(configDefaults, "configDefaults");
@@ -139,9 +131,6 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         this.gridSetBroker = gridsets;
         this.publishedInfo = publishedInfo;
         this.info = TileLayerInfoUtil.loadOrCreate(getPublishedInfo(), configDefaults);
-
-        this.legendSample = legendSample;
-        this.wms = wms;
     }
 
     public GeoServerTileLayer(final PublishedInfo publishedInfo, final GridSetBroker gridsets,
@@ -1305,13 +1294,13 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
                 try {
                     gwcLegendInfo.width = GetLegendGraphicRequest.DEFAULT_WIDTH;
                     gwcLegendInfo.height = GetLegendGraphicRequest.DEFAULT_HEIGHT;
-                    Dimension dimension = legendSample.getLegendURLSize(styleInfo);
+                    Dimension dimension = getLegendSample().getLegendURLSize(styleInfo);
                     if (dimension != null) {
                         gwcLegendInfo.width = (int) dimension.getWidth();
                         gwcLegendInfo.height = (int) dimension.getHeight();
                     }
                     gwcLegendInfo.format = GetLegendGraphicRequest.DEFAULT_FORMAT;
-                    if (null == wms.getLegendGraphicOutputFormat(gwcLegendInfo.format)) {
+                    if (null == getWms().getLegendGraphicOutputFormat(gwcLegendInfo.format)) {
                         if (LOGGER.isLoggable(Level.WARNING)) {
                             LOGGER.warning("Default legend format (" + gwcLegendInfo.format +
                                     ")is not supported (jai not available?), can't add LegendURL element");
@@ -1335,5 +1324,35 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
             }
         }
         return legends;
+    }
+
+    /**
+     * Helper that gets the LegendSample bean from Spring context when needed.
+     */
+    private LegendSample getLegendSample() {
+        if (legendSample == null) {
+            // no need for synchronization the bean is always the same
+            legendSample = GeoServerExtensions.bean(LegendSample.class);
+        }
+        return legendSample;
+    }
+
+    /**
+     * Helper that gets the WMS bean from Spring context when needed.
+     */
+    private WMS getWms() {
+        if (wms == null) {
+            // no need for synchronization the bean is always the same
+            wms = GeoServerExtensions.bean(WMS.class);
+        }
+        return wms;
+    }
+
+    void setLegendSample(LegendSample legendSample) {
+        this.legendSample = legendSample;
+    }
+
+    void setWms(WMS wms) {
+        this.wms = wms;
     }
 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -767,7 +767,9 @@ public class GeoServerTileLayerTest {
         WMS wms = mock(WMS.class);
         GetLegendGraphicOutputFormat outputFormat = mock(GetLegendGraphicOutputFormat.class);
         when(wms.getLegendGraphicOutputFormat("image/png")).thenReturn(outputFormat);
-        GeoServerTileLayer tileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker, legendSample, wms);
+        GeoServerTileLayer tileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+        tileLayer.setLegendSample(legendSample);
+        tileLayer.setWms(wms);
         Map<String, TileLayer.LegendInfo> legendsInfo = tileLayer.getLegendsInfo();
         assertThat(legendsInfo.size(), is(3));
         // default_style


### PR DESCRIPTION
Requesting WMS and LegendSample beans provokes a Spring cyclic dependency error. This pull request fix this issue by requesting the beans only when needed.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7750