### PR TITLE
WMTS multi dimensional fixes

### DIFF
--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/Domains.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/Domains.java
@@ -88,7 +88,7 @@ public class Domains {
             // accessing the features of a raster
             return getFeatureCollection((CoverageInfo) resourceInfo);
         } catch (IOException exception) {
-            throw new RuntimeException(String.format("Error get features of layer '%s'.", layerInfo.getName()));
+            throw new RuntimeException(String.format("Error getting features of layer '%s'.", layerInfo.getName()), exception);
         }
     }
 
@@ -98,7 +98,7 @@ public class Domains {
     private FeatureCollection getFeatureCollection(CoverageInfo typeInfo) throws IOException {
         GridCoverage2DReader reader = (GridCoverage2DReader) typeInfo.getGridCoverageReader(null, null);
         if (!(reader instanceof StructuredGridCoverage2DReader)) {
-            throw new RuntimeException("Non structured grid coverages cannot be filtered.");
+            throw new RuntimeException("Is not possible to obtain a feature collection from a non structured reader.");
         }
         StructuredGridCoverage2DReader structuredReader = (StructuredGridCoverage2DReader) reader;
         String coverageName = structuredReader.getGridCoverageNames()[0];

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
@@ -15,7 +15,6 @@ import org.geoserver.gwc.wmts.dimensions.DimensionsUtils;
 import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.ows.util.KvpMap;
 import org.geoserver.ows.util.KvpUtils;
-import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.WMS;
 import org.geotools.factory.CommonFactoryFinder;

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
@@ -226,7 +226,7 @@ public final class MultiDimensionalExtension extends WMTSExtensionImpl {
         xml.simpleElement("ows:Identifier", dimension.getDimensionName(), true);
         // default value is mandatory
         xml.simpleElement("Default", dimension.getDefaultValueAsString(), true);
-        for (String value : dimension.getDomainValuesAsStrings(Filter.INCLUDE).second) {
+        for (String value : dimension.getDomainValuesAsStrings(Filter.INCLUDE).second.second) {
             xml.simpleElement("Value", value, true);
         }
         xml.endElement("Dimension");

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/CoverageDimensionsReader.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/CoverageDimensionsReader.java
@@ -1,0 +1,289 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.wmts.dimensions;
+
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.gwc.wmts.Tuple;
+import org.geotools.coverage.grid.io.DimensionDescriptor;
+import org.geotools.coverage.grid.io.GranuleSource;
+import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
+import org.geotools.data.Query;
+import org.geotools.data.memory.MemoryFeatureCollection;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.util.DateRange;
+import org.geotools.util.NumberRange;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.function.Function;
+
+/**
+ * This class allow us to abstract from the type of different raster readers (structured and non structured ones).
+ */
+abstract class CoverageDimensionsReader {
+
+    public enum DataType {
+        TEMPORAL, NUMERIC, CUSTOM
+    }
+
+    abstract Tuple<String, String> getDimensionAttributesNames(String dimensionName);
+
+    abstract String getGeometryAttributeName();
+
+    abstract Tuple<String, FeatureCollection> getValues(String dimensionName, Filter filter, DataType dataType);
+
+    List<Object> readWithDuplicates(String dimensionName, Filter filter, DataType dataType, Comparator<Object> comparator) {
+        // getting the feature collection with the values and the attribute name
+        Tuple<String, FeatureCollection> values = getValues(dimensionName, filter, dataType);
+        if (values == null) {
+            return Collections.emptyList();
+        }
+        // extracting the values removing the duplicates
+        return DimensionsUtils.getValuesWithDuplicates(values.first, values.second, comparator);
+    }
+
+    Set<Object> readWithoutDuplicates(String dimensionName, Filter filter, DataType dataType, Comparator<Object> comparator) {
+        // getting the feature collection with the values and the attribute name
+        Tuple<String, FeatureCollection> values = getValues(dimensionName, filter, dataType);
+        if (values == null) {
+            return new TreeSet<>();
+        }
+        // extracting the values keeping the duplicates
+        return DimensionsUtils.getValuesWithoutDuplicates(values.first, values.second, comparator);
+    }
+
+    /**
+     * Instantiate a coverage reader from the provided read. If the reader is a structured one good we can use some
+     * optimizations otherwise we will have to really on the layer metadata.
+     */
+    static CoverageDimensionsReader instantiateFrom(CoverageInfo typeInfo) {
+        // let's get this coverage reader
+        GridCoverage2DReader reader;
+        try {
+            reader = (GridCoverage2DReader) typeInfo.getGridCoverageReader(null, null);
+        } catch (Exception exception) {
+            throw new RuntimeException("Error getting coverage reader.", exception);
+        }
+        if (reader instanceof StructuredGridCoverage2DReader) {
+            // good we have a structured coverage reader
+            return new WrapStructuredGridCoverageDimensions2DReader(typeInfo, (StructuredGridCoverage2DReader) reader);
+        }
+        // non structured reader let's do our best
+        return new WrapNonStructuredReader(typeInfo, reader);
+    }
+
+    private static final class WrapStructuredGridCoverageDimensions2DReader extends CoverageDimensionsReader {
+
+        private final CoverageInfo typeInfo;
+        private final StructuredGridCoverage2DReader reader;
+
+        private WrapStructuredGridCoverageDimensions2DReader(CoverageInfo typeInfo, StructuredGridCoverage2DReader reader) {
+            this.typeInfo = typeInfo;
+            this.reader = reader;
+        }
+
+        @Override
+        public Tuple<String, String> getDimensionAttributesNames(String dimensionName) {
+            try {
+                // raster dimensions don't provide start and end attributes so we need the ask the dimension descriptors
+                List<DimensionDescriptor> descriptors = reader.getDimensionDescriptors(reader.getGridCoverageNames()[0]);
+                // we have this raster dimension descriptors let's find the descriptor for our dimension
+                String startAttributeName = null;
+                String endAttributeName = null;
+                // let's find the descriptor for our dimension
+                for (DimensionDescriptor descriptor : descriptors) {
+                    if (dimensionName.equalsIgnoreCase(descriptor.getName())) {
+                        // descriptor found
+                        startAttributeName = descriptor.getStartAttribute();
+                        endAttributeName = descriptor.getEndAttribute();
+                    }
+                }
+                return Tuple.tuple(startAttributeName, endAttributeName);
+            } catch (IOException exception) {
+                throw new RuntimeException("Error extracting dimensions descriptors from raster.", exception);
+            }
+        }
+
+        @Override
+        public String getGeometryAttributeName() {
+            try {
+                // getting the source of our coverage
+                GranuleSource source = reader.getGranules(reader.getGridCoverageNames()[0], true);
+                // well returning the geometry attribute
+                return source.getSchema().getGeometryDescriptor().getLocalName();
+            } catch (Exception exception) {
+                throw new RuntimeException("Error getting coverage geometry attribute.");
+            }
+
+        }
+
+        /**
+         * Helper method that can be used to read the domain values of a dimension from a raster.
+         * The provided filter will be used to filter the domain values that should be returned,
+         * if the provided filter is NULL nothing will be filtered.
+         */
+        @Override
+        public Tuple<String, FeatureCollection> getValues(String dimensionName, Filter filter, DataType dataType) {
+            try {
+                // opening the source and descriptors for our raster
+                GranuleSource source = reader.getGranules(reader.getGridCoverageNames()[0], true);
+                List<DimensionDescriptor> descriptors = reader.getDimensionDescriptors(reader.getGridCoverageNames()[0]);
+                // let's find our dimension and query the data
+                for (DimensionDescriptor descriptor : descriptors) {
+                    if (dimensionName.equalsIgnoreCase(descriptor.getName())) {
+                        // we found our dimension descriptor, creating a query
+                        Query query = new Query(source.getSchema().getName().getLocalPart());
+                        if (filter != null) {
+                            query.setFilter(filter);
+                        }
+                        // reading the features using the build query
+                        FeatureCollection featureCollection = source.getGranules(query);
+                        // get the features attribute that contain our dimension values
+                        String attributeName = descriptor.getStartAttribute();
+                        return Tuple.tuple(attributeName, featureCollection);
+                    }
+                }
+                // well our dimension was not found
+                return null;
+            } catch (Exception exception) {
+                throw new RuntimeException("Error reading domain values.", exception);
+            }
+        }
+    }
+
+    private static final class WrapNonStructuredReader extends CoverageDimensionsReader {
+
+        private final CoverageInfo typeInfo;
+        private final GridCoverage2DReader reader;
+
+        private WrapNonStructuredReader(CoverageInfo typeInfo, GridCoverage2DReader reader) {
+            this.typeInfo = typeInfo;
+            this.reader = reader;
+        }
+
+        private static final ThreadLocal<DateFormat> DATE_FORMATTER = new ThreadLocal<DateFormat>() {
+
+            @Override
+            protected DateFormat initialValue() {
+                SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+                dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+                return dateFormatter;
+            }
+        };
+
+        private static Date formatDate(String rawValue) {
+            try {
+                return DATE_FORMATTER.get().parse(rawValue);
+            } catch (Exception exception) {
+                throw new RuntimeException(String.format("Error parsing date '%s'.", rawValue), exception);
+            }
+        }
+
+        private static final Function<String, Object> TEMPORAL_CONVERTER = (rawValue) -> {
+            if (rawValue.contains("/")) {
+                String[] parts = rawValue.split("/");
+                return new DateRange(formatDate(parts[0]), formatDate(parts[1]));
+            } else {
+                return formatDate(rawValue);
+            }
+        };
+
+        private static final Function<String, Object> NUMERICAL_CONVERTER = (rawValue) -> {
+            if (rawValue.contains("/")) {
+                String[] parts = rawValue.split("/");
+                return new NumberRange<>(Double.class, Double.parseDouble(parts[0]), Double.parseDouble(parts[1]));
+            } else {
+                return Double.parseDouble(rawValue);
+            }
+        };
+
+        private static final Function<String, Object> STRING_CONVERTER = (rawValue) -> rawValue;
+
+        @Override
+        public Tuple<String, String> getDimensionAttributesNames(String dimensionName) {
+            // by convention the metadata entry that contains a dimension information follows the pattern
+            // [DIMENSION_NAME]_DOMAIN, i.e. TIME_DOMAIN, ELEVATION_DOMAIN or HAS_CUSTOM_DOMAIN
+            String attributeName = dimensionName.toUpperCase() + "_DOMAIN";
+            // we only have one value no start and end values
+            return Tuple.tuple(attributeName, null);
+        }
+
+        @Override
+        public String getGeometryAttributeName() {
+            // spatial filtering is not supported for non structured readers
+            return null;
+        }
+
+        @Override
+        public Tuple<String, FeatureCollection> getValues(String dimensionName, Filter filter, DataType dataType) {
+            String metaDataValue;
+            try {
+                metaDataValue = reader.getMetadataValue(dimensionName.toUpperCase() + "_DOMAIN");
+            } catch (Exception exception) {
+                throw new RuntimeException(String.format(
+                        "Error extract dimension '%s' values from raster '%s'.",
+                        dimensionName, typeInfo.getName()), exception);
+            }
+            if (metaDataValue == null || metaDataValue.isEmpty()) {
+                return Tuple.tuple(getDimensionAttributesNames(dimensionName).first, null);
+            }
+            String[] rawValues = metaDataValue.split(",");
+            dataType = normalizeDataType(rawValues[0], dataType);
+            Tuple<SimpleFeatureType, Function<String, Object>> featureTypeAndConverter =
+                    getFeatureTypeAndConverter(dimensionName, rawValues[0], dataType);
+            MemoryFeatureCollection featureCollection = new MemoryFeatureCollection(featureTypeAndConverter.first);
+            for (int i = 0; i < rawValues.length; i++) {
+                SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureTypeAndConverter.first);
+                featureBuilder.add(featureTypeAndConverter.second.apply(rawValues[i]));
+                SimpleFeature feature = featureBuilder.buildFeature(String.valueOf(i));
+                if (filter == null || filter.evaluate(feature)) {
+                    featureCollection.add(feature);
+                }
+            }
+            return Tuple.tuple(getDimensionAttributesNames(dimensionName).first, featureCollection);
+        }
+
+        private DataType normalizeDataType(String rawValue, DataType dataType) {
+            if (dataType.equals(DataType.CUSTOM)) {
+                try {
+                    TEMPORAL_CONVERTER.apply(rawValue);
+                    return DataType.TEMPORAL;
+                } catch (Exception exception) {
+                    // not a temporal value
+                }
+                try {
+                    NUMERICAL_CONVERTER.apply(rawValue);
+                    return DataType.NUMERIC;
+                } catch (Exception exception) {
+                    // not a numerical value
+                }
+            }
+            return dataType;
+        }
+
+        private Tuple<SimpleFeatureType, Function<String, Object>> getFeatureTypeAndConverter(String dimensionName, String rawValue, DataType dataType) {
+            SimpleFeatureTypeBuilder featureTypeBuilder = new SimpleFeatureTypeBuilder();
+            featureTypeBuilder.setName(typeInfo.getName());
+            switch (dataType) {
+                case TEMPORAL:
+                    featureTypeBuilder.add(getDimensionAttributesNames(dimensionName).first, TEMPORAL_CONVERTER.apply(rawValue).getClass());
+                    return Tuple.tuple(featureTypeBuilder.buildFeatureType(), TEMPORAL_CONVERTER);
+                case NUMERIC:
+                    featureTypeBuilder.add(getDimensionAttributesNames(dimensionName).first, NUMERICAL_CONVERTER.apply(rawValue).getClass());
+                    return Tuple.tuple(featureTypeBuilder.buildFeatureType(), NUMERICAL_CONVERTER);
+            }
+            featureTypeBuilder.add(getDimensionAttributesNames(dimensionName).first, String.class);
+            return Tuple.tuple(featureTypeBuilder.buildFeatureType(), STRING_CONVERTER);
+        }
+    }
+}

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/CoverageDimensionsReader.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/CoverageDimensionsReader.java
@@ -15,6 +15,7 @@ import org.geotools.data.memory.MemoryFeatureCollection;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.DateRange;
 import org.geotools.util.NumberRange;
 import org.opengis.feature.simple.SimpleFeature;
@@ -42,24 +43,26 @@ abstract class CoverageDimensionsReader {
 
     abstract Tuple<String, FeatureCollection> getValues(String dimensionName, Filter filter, DataType dataType);
 
-    List<Object> readWithDuplicates(String dimensionName, Filter filter, DataType dataType, Comparator<Object> comparator) {
+    Tuple<ReferencedEnvelope, List<Object>> readWithDuplicates(String dimensionName, Filter filter, DataType dataType, Comparator<Object> comparator) {
         // getting the feature collection with the values and the attribute name
         Tuple<String, FeatureCollection> values = getValues(dimensionName, filter, dataType);
         if (values == null) {
-            return Collections.emptyList();
+            return Tuple.tuple(new ReferencedEnvelope(), Collections.emptyList());
         }
         // extracting the values removing the duplicates
-        return DimensionsUtils.getValuesWithDuplicates(values.first, values.second, comparator);
+        return Tuple.tuple(values.second.getBounds(),
+                DimensionsUtils.getValuesWithDuplicates(values.first, values.second, comparator));
     }
 
-    Set<Object> readWithoutDuplicates(String dimensionName, Filter filter, DataType dataType, Comparator<Object> comparator) {
+    Tuple<ReferencedEnvelope, Set<Object>> readWithoutDuplicates(String dimensionName, Filter filter, DataType dataType, Comparator<Object> comparator) {
         // getting the feature collection with the values and the attribute name
         Tuple<String, FeatureCollection> values = getValues(dimensionName, filter, dataType);
         if (values == null) {
-            return new TreeSet<>();
+            return Tuple.tuple(new ReferencedEnvelope(), new TreeSet<>());
         }
         // extracting the values keeping the duplicates
-        return DimensionsUtils.getValuesWithoutDuplicates(values.first, values.second, comparator);
+        return Tuple.tuple(values.second.getBounds(),
+                DimensionsUtils.getValuesWithoutDuplicates(values.first, values.second, comparator));
     }
 
     /**

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/Dimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/Dimension.java
@@ -9,14 +9,11 @@ import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.dimension.DimensionDefaultValueSelectionStrategy;
 import org.geoserver.wms.dimension.DimensionFilterBuilder;
-import org.geotools.coverage.grid.io.DimensionDescriptor;
-import org.geotools.coverage.grid.io.GranuleSource;
-import org.geotools.coverage.grid.io.GridCoverage2DReader;
-import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
+import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.factory.GeoTools;
 import org.geotools.feature.FeatureCollection;
-import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.gml2.bindings.GML2EncodingUtils;
 import org.opengis.filter.Filter;
@@ -24,10 +21,7 @@ import org.opengis.filter.FilterFactory;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.TreeSet;
+import java.util.*;
 
 /**
  * <p>
@@ -62,9 +56,11 @@ public abstract class Dimension {
 
     /**
      * Returns this dimension domain values filtered with the provided filter.
-     * The provided filter can be NULL.
+     * The provided filter can be NULL. Duplicate values may be included if
+     * noDuplicates parameter is set to FALSE.
      */
-    public abstract TreeSet<?> getDomainValues(Filter filter);
+    public abstract List<Object> getDomainValues(Filter filter, boolean noDuplicates);
+
 
     /**
      * Returns a filter that will contain all the restrictions applied to this dimension.
@@ -89,7 +85,7 @@ public abstract class Dimension {
      * </p>
      */
     public Tuple<String, List<Integer>> getHistogram(Filter filter, String resolution) {
-        return HistogramUtils.buildHistogram(getDomainValues(filter), resolution);
+        return HistogramUtils.buildHistogram(getDomainValues(filter, false), resolution);
     }
 
     protected abstract String getDefaultValueFallbackAsString();
@@ -110,18 +106,6 @@ public abstract class Dimension {
         return dimensionInfo;
     }
 
-    ReferencedEnvelope getBoundingBox() {
-        return boundingBox;
-    }
-
-    List<Object> getDomainRestrictions() {
-        return domainRestrictions;
-    }
-
-    FilterFactory getFilterFactory() {
-        return filterFactory;
-    }
-
     public void setBoundingBox(ReferencedEnvelope boundingBox) {
         this.boundingBox = boundingBox;
     }
@@ -134,42 +118,6 @@ public abstract class Dimension {
         }
     }
 
-    public Tuple<String, String> getAttributes() {
-        ResourceInfo resourceInfo = layerInfo.getResource();
-        if (resourceInfo instanceof FeatureTypeInfo) {
-            // for vectors this information easily available
-            return Tuple.tuple(dimensionInfo.getAttribute(), dimensionInfo.getEndAttribute());
-        }
-        if (resourceInfo instanceof CoverageInfo) {
-            // raster dimensions don't provide start and end attributes so we need the ask the dimension descriptor
-            Tuple<String, StructuredGridCoverage2DReader> rasterReader;
-            try {
-                rasterReader = getRasterReader();
-            } catch (IOException exception) {
-                throw new RuntimeException(String.format(
-                        "Error opening structured reader for raster '%s'.", layerInfo.getName(), exception));
-            }
-            List<DimensionDescriptor> descriptors;
-            try {
-                descriptors = rasterReader.second.getDimensionDescriptors(rasterReader.first);
-            } catch (IOException exception) {
-                throw new RuntimeException(String.format(
-                        "Error extracting dimensions descriptors from raster '%s'.", layerInfo.getName(), exception));
-            }
-            // we have this raster dimension descriptors let's find the descriptor for our dimension
-            String startAttributeName = null;
-            String endAttributeName = null;
-            for (DimensionDescriptor descriptor : descriptors) {
-                if (getDimensionName().equalsIgnoreCase(descriptor.getName())) {
-                    startAttributeName = descriptor.getStartAttribute();
-                    endAttributeName = descriptor.getEndAttribute();
-                }
-            }
-            return Tuple.tuple(startAttributeName, endAttributeName);
-        }
-        return Tuple.tuple(null, null);
-    }
-
     /**
      * Returns this dimension values represented as strings taking in account this
      * dimension representation strategy. The returned values will be sorted. The
@@ -177,7 +125,7 @@ public abstract class Dimension {
      * can be NULL.
      */
     public Tuple<Integer, List<String>> getDomainValuesAsStrings(Filter filter) {
-        TreeSet<?> domainValues = getDomainValues(filter);
+        List<Object> domainValues = getDomainValues(filter, true);
         return Tuple.tuple(domainValues.size(), DimensionsUtils.getDomainValuesAsStrings(dimensionInfo, domainValues));
     }
 
@@ -197,7 +145,7 @@ public abstract class Dimension {
     Filter buildVectorFilter() {
         FeatureTypeInfo typeInfo = (FeatureTypeInfo) getResourceInfo();
         Filter filter = Filter.INCLUDE;
-        if (getBoundingBox() != null) {
+        if (boundingBox != null) {
             // we have a bounding box so lets build a filter for it
             String geometryAttributeName;
             try {
@@ -210,7 +158,7 @@ public abstract class Dimension {
             // creating the bounding box filter and append it to our filter
             filter = appendBoundingBoxFilter(filter, geometryAttributeName);
         }
-        if (getDomainRestrictions() != null) {
+        if (domainRestrictions != null) {
             // we have a domain filter
             filter = appendDomainRestrictionsFilter(filter, dimensionInfo.getAttribute(), dimensionInfo.getEndAttribute());
         }
@@ -223,7 +171,7 @@ public abstract class Dimension {
     Filter buildRasterFilter() {
         CoverageInfo typeInfo = (CoverageInfo) getResourceInfo();
         Filter filter = Filter.INCLUDE;
-        if (getBoundingBox() != null) {
+        if (boundingBox != null) {
             // we have a bounding box so lets build a filter for it
             try {
                 filter = appendBoundingBoxFilter(filter, typeInfo);
@@ -232,8 +180,9 @@ public abstract class Dimension {
                         typeInfo.getName()), exception);
             }
         }
-        if (getDomainRestrictions() != null) {
-            Tuple<String, String> attributes = getAttributes();
+        if (domainRestrictions != null) {
+            CoverageDimensionsReader reader = CoverageDimensionsReader.instantiateFrom(typeInfo);
+            Tuple<String, String> attributes = reader.getDimensionAttributesNames(getDimensionName());
             if (attributes.first == null) {
                 throw new RuntimeException(String.format(
                         "Could not found start attribute name for dimension '%s' in raster '%s'.", getDimensionName(), typeInfo.getName()));
@@ -245,19 +194,19 @@ public abstract class Dimension {
     }
 
     /**
-     * Helper method
+     * Helper method that extract the geomtry attribute name from the current type info and invoke
+     * the method that will actually build the spatial filter.
      */
     private Filter appendBoundingBoxFilter(Filter filter, CoverageInfo typeInfo) throws IOException {
-        // let's find the geometry attribute name
-        GridCoverage2DReader reader = (GridCoverage2DReader) typeInfo.getGridCoverageReader(null, null);
-        if (!(reader instanceof StructuredGridCoverage2DReader)) {
+        // getting the geometry attribute name
+        CoverageDimensionsReader reader = CoverageDimensionsReader.instantiateFrom(typeInfo);
+        String geometryAttributeName = reader.getGeometryAttributeName();
+        // checking if we have a valid geometry attribute
+        if (geometryAttributeName == null) {
+            // this raster doesn't supports spatial filtering
             return filter;
         }
-        StructuredGridCoverage2DReader structuredReader = (StructuredGridCoverage2DReader) reader;
-        String coverageName = structuredReader.getGridCoverageNames()[0];
-        GranuleSource source = structuredReader.getGranules(coverageName, true);
-        String geometryAttributeName = source.getSchema().getGeometryDescriptor().getLocalName();
-        // creating
+        // creating the filter
         return appendBoundingBoxFilter(filter, geometryAttributeName);
     }
 
@@ -266,11 +215,11 @@ public abstract class Dimension {
      * the current bounding box restriction. The bounding box filter will be merged with the provided filter.
      */
     private Filter appendBoundingBoxFilter(Filter filter, String geometryAttributeName) {
-        CoordinateReferenceSystem coordinateReferenceSystem = getBoundingBox().getCoordinateReferenceSystem();
+        CoordinateReferenceSystem coordinateReferenceSystem = boundingBox.getCoordinateReferenceSystem();
         String epsgCode = coordinateReferenceSystem == null ? null : GML2EncodingUtils.toURI(coordinateReferenceSystem);
-        Filter spatialFilter = getFilterFactory().bbox(geometryAttributeName, getBoundingBox().getMinX(), getBoundingBox().getMinY(),
-                getBoundingBox().getMaxX(), getBoundingBox().getMaxY(), epsgCode);
-        return getFilterFactory().and(filter, spatialFilter);
+        Filter spatialFilter = filterFactory.bbox(geometryAttributeName, boundingBox.getMinX(), boundingBox.getMinY(),
+                boundingBox.getMaxX(), boundingBox.getMaxY(), epsgCode);
+        return filterFactory.and(filter, spatialFilter);
     }
 
     /**
@@ -278,53 +227,81 @@ public abstract class Dimension {
      * attributes. The created filter will be merged with the provided filter.
      */
     private Filter appendDomainRestrictionsFilter(Filter filter, String startAttributeName, String endAttributeName) {
-        DimensionFilterBuilder dimensionFilterBuilder = new DimensionFilterBuilder(getFilterFactory());
-        dimensionFilterBuilder.appendFilters(startAttributeName, endAttributeName, getDomainRestrictions());
-        return getFilterFactory().and(filter, dimensionFilterBuilder.getFilter());
+        DimensionFilterBuilder dimensionFilterBuilder = new DimensionFilterBuilder(filterFactory);
+        dimensionFilterBuilder.appendFilters(startAttributeName, endAttributeName, domainRestrictions);
+        return filterFactory.and(filter, dimensionFilterBuilder.getFilter());
     }
 
     /**
-     * Helper method that can be used to read the domain values of a dimension from a raster.
-     * The provided filter will be used to filter the domain values that should be returned,
-     * if the provided filter is NULL nothing will ve filtered.
+     * Helper method used to get domain values from a raster type.
      */
-    TreeSet<?> getRasterDomainValues(Filter filter) throws IOException {
-        // preparing to read the dimension domain values
-        Tuple<String, StructuredGridCoverage2DReader> rasterReader = getRasterReader();
-        GranuleSource source = rasterReader.second.getGranules(rasterReader.first, true);
-        List<DimensionDescriptor> descriptors = rasterReader.second.getDimensionDescriptors(rasterReader.first);
-        // let's find our dimension
-        for (DimensionDescriptor descriptor : descriptors) {
-            if (getDimensionName().equalsIgnoreCase(descriptor.getName())) {
-                // we found our dimension descriptor, creating a query
-                Query query = new Query(source.getSchema().getName().getLocalPart());
-                if (filter != null) {
-                    query.setFilter(filter);
-                }
-                // reading the features removing duplicates
-                FeatureCollection featureCollection = source.getGranules(query);
-                UniqueVisitor uniqueVisitor = new UniqueVisitor(descriptor.getStartAttribute());
-                featureCollection.accepts(uniqueVisitor, null);
-                return new TreeSet(uniqueVisitor.getUnique());
-            }
+    List<Object> getRasterDomainValues(Filter filter, boolean noDuplicates,
+                                       CoverageDimensionsReader.DataType dataType, Comparator<Object> comparator) {
+        CoverageDimensionsReader reader = CoverageDimensionsReader.instantiateFrom((CoverageInfo) resourceInfo);
+        if (noDuplicates) {
+            // no duplicate values should be included
+            Set<Object> values = reader.readWithoutDuplicates(getDimensionName(), filter, dataType, comparator);
+            List<Object> list = new ArrayList<>(values.size());
+            list.addAll(values);
+            return list;
         }
-        // well our dimension was not found
-        return new TreeSet();
+        // we need the duplicate values (this is useful for some operations like get histogram operation)
+        return reader.readWithDuplicates(getDimensionName(), filter, dataType, comparator);
     }
 
     /**
-     * Helper method that will open a structured grid coverage for the current dimension resource.
-     * Returns a tuple that will contain the coverage name and the reader.
+     * Helper method used to get domain values from a vector type.
      */
-    private Tuple<String, StructuredGridCoverage2DReader> getRasterReader() throws IOException {
-        CoverageInfo typeInfo = (CoverageInfo) getResourceInfo();
-        GridCoverage2DReader reader = (GridCoverage2DReader) typeInfo.getGridCoverageReader(null, null);
-        if (!(reader instanceof StructuredGridCoverage2DReader)) {
-            throw new RuntimeException("Non structured grid coverages cannot be filtered.");
+    List<Object> getVectorDomainValues(Filter filter, boolean noDuplicates, Comparator<Object> comparator) {
+        FeatureCollection featureCollection = getVectorDomainValues(filter);
+        if (noDuplicates) {
+            // no duplicate values should be included
+            Set<Object> values = DimensionsUtils.
+                    getValuesWithoutDuplicates(dimensionInfo.getAttribute(), featureCollection, comparator);
+            List<Object> list = new ArrayList<>(values.size());
+            list.addAll(values);
+            return list;
         }
-        StructuredGridCoverage2DReader structuredReader = (StructuredGridCoverage2DReader) reader;
-        String coverageName = structuredReader.getGridCoverageNames()[0];
-        return Tuple.tuple(coverageName, structuredReader);
+        // we need the duplicate values (this is useful for some operations like get histogram operation)
+        return DimensionsUtils.getValuesWithDuplicates(dimensionInfo.getAttribute(), featureCollection, comparator);
+    }
+
+    /**
+     * Helper method used to get domain values from a vector type in the form of a feature collection.
+     */
+    FeatureCollection getVectorDomainValues(Filter filter) {
+        FeatureTypeInfo typeInfo = (FeatureTypeInfo) getResourceInfo();
+        FeatureSource source;
+        try {
+            source = typeInfo.getFeatureSource(null, GeoTools.getDefaultHints());
+        } catch (Exception exception) {
+            throw new RuntimeException(String.format(
+                    "Error getting feature source of vector '%s'.", resourceInfo.getName()), exception);
+        }
+        Query query = new Query(source.getSchema().getName().getLocalPart(), filter == null ? Filter.INCLUDE : filter);
+        query.setPropertyNames(new String[]{dimensionInfo.getAttribute()});
+        try {
+            return source.getFeatures(query);
+        } catch (Exception exception) {
+            throw new RuntimeException(String.format(
+                    "Error reading feature from layer '%s' for dimension '%s'.",
+                    resourceInfo.getName(), getDimensionName()), exception);
+        }
+    }
+
+    /**
+     * Return dimension start and end attributes, values may be NULL.
+     */
+    public Tuple<String, String> getAttributes() {
+        ResourceInfo resourceInfo = layerInfo.getResource();
+        if (resourceInfo instanceof FeatureTypeInfo) {
+            // for vectors this information easily available
+            return Tuple.tuple(dimensionInfo.getAttribute(), dimensionInfo.getEndAttribute());
+        }
+        if (resourceInfo instanceof CoverageInfo) {
+            return CoverageDimensionsReader.instantiateFrom((CoverageInfo) resourceInfo).getDimensionAttributesNames(getDimensionName());
+        }
+        return Tuple.tuple(null, null);
     }
 
     @Override

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterCustomDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterCustomDimension.java
@@ -6,8 +6,10 @@ package org.geoserver.gwc.wmts.dimensions;
 
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.gwc.wmts.dimensions.CoverageDimensionsReader.DataType;
 import org.geoserver.wms.WMS;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.Filter;
 
 import java.util.List;
@@ -32,7 +34,7 @@ public class RasterCustomDimension extends Dimension {
     }
 
     @Override
-    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
         return getRasterDomainValues(filter, noDuplicates, DataType.CUSTOM, DimensionsUtils.CUSTOM_COMPARATOR);
     }
 

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterCustomDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterCustomDimension.java
@@ -4,16 +4,13 @@
  */
 package org.geoserver.gwc.wmts.dimensions;
 
-import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
-import org.geoserver.catalog.util.ReaderDimensionsAccessor;
+import org.geoserver.gwc.wmts.dimensions.CoverageDimensionsReader.DataType;
 import org.geoserver.wms.WMS;
-import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.opengis.filter.Filter;
 
-import java.io.IOException;
-import java.util.TreeSet;
+import java.util.List;
 
 /**
  * Represents a custom dimension of a raster.
@@ -35,19 +32,8 @@ public class RasterCustomDimension extends Dimension {
     }
 
     @Override
-    public TreeSet<?> getDomainValues(Filter filter) {
-        try {
-            CoverageInfo typeInfo = (CoverageInfo) getResourceInfo();
-            GridCoverage2DReader reader = (GridCoverage2DReader) typeInfo.getGridCoverageReader(null, null);
-            ReaderDimensionsAccessor dimensions = new ReaderDimensionsAccessor(reader);
-            if (filter == null || filter.equals(Filter.INCLUDE)) {
-                return new TreeSet<>(dimensions.getDomain(getDimensionName()));
-            }
-            return getRasterDomainValues(filter);
-        } catch (IOException exception) {
-            throw new RuntimeException(String.format("Error getting domain values for dimension '%s' of coverage '%s'.",
-                    getDimensionName(), getResourceInfo().getName()), exception);
-        }
+    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+        return getRasterDomainValues(filter, noDuplicates, DataType.CUSTOM, DimensionsUtils.CUSTOM_COMPARATOR);
     }
 
     @Override

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterElevationDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterElevationDimension.java
@@ -4,14 +4,14 @@
  */
 package org.geoserver.gwc.wmts.dimensions;
 
-import org.geoserver.catalog.*;
-import org.geoserver.catalog.util.ReaderDimensionsAccessor;
+import org.geoserver.catalog.DimensionDefaultValueSetting;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.wms.WMS;
-import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.opengis.filter.Filter;
 
-import java.io.IOException;
-import java.util.TreeSet;
+import java.util.List;
 
 /**
  * Represents an elevation dimension of a raster.
@@ -28,19 +28,8 @@ public class RasterElevationDimension extends Dimension {
     }
 
     @Override
-    public TreeSet<?> getDomainValues(Filter filter) {
-        try {
-            CoverageInfo typeInfo = (CoverageInfo) getResourceInfo();
-            GridCoverage2DReader reader = (GridCoverage2DReader) typeInfo.getGridCoverageReader(null, null);
-            ReaderDimensionsAccessor dimensions = new ReaderDimensionsAccessor(reader);
-            if (filter == null || filter.equals(Filter.INCLUDE)) {
-                return dimensions.getElevationDomain();
-            }
-            return getRasterDomainValues(filter);
-        } catch (IOException exception) {
-            throw new RuntimeException(String.format("Error getting domain values for dimension '%s' of coverage '%s'.",
-                    getDimensionName(), getResourceInfo().getName()), exception);
-        }
+    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+        return getRasterDomainValues(filter, noDuplicates, CoverageDimensionsReader.DataType.NUMERIC, DimensionsUtils.NUMERICAL_COMPARATOR);
     }
 
     @Override

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterElevationDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterElevationDimension.java
@@ -8,7 +8,9 @@ import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.Filter;
 
 import java.util.List;
@@ -28,7 +30,7 @@ public class RasterElevationDimension extends Dimension {
     }
 
     @Override
-    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
         return getRasterDomainValues(filter, noDuplicates, CoverageDimensionsReader.DataType.NUMERIC, DimensionsUtils.NUMERICAL_COMPARATOR);
     }
 

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterTimeDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterTimeDimension.java
@@ -4,14 +4,14 @@
  */
 package org.geoserver.gwc.wmts.dimensions;
 
-import org.geoserver.catalog.*;
-import org.geoserver.catalog.util.ReaderDimensionsAccessor;
+import org.geoserver.catalog.DimensionDefaultValueSetting;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.wms.WMS;
-import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.opengis.filter.Filter;
 
-import java.io.IOException;
-import java.util.TreeSet;
+import java.util.List;
 
 /**
  * Represents a time dimension of a raster.
@@ -28,19 +28,8 @@ public class RasterTimeDimension extends Dimension {
     }
 
     @Override
-    public TreeSet<?> getDomainValues(Filter filter) {
-        try {
-            CoverageInfo typeInfo = (CoverageInfo) getResourceInfo();
-            GridCoverage2DReader reader = (GridCoverage2DReader) typeInfo.getGridCoverageReader(null, null);
-            ReaderDimensionsAccessor dimensions = new ReaderDimensionsAccessor(reader);
-            if (filter == null || filter.equals(Filter.INCLUDE)) {
-                return dimensions.getTimeDomain();
-            }
-            return getRasterDomainValues(filter);
-        } catch (IOException exception) {
-            throw new RuntimeException(String.format("Error getting domain values for dimension '%s' of coverage '%s'.",
-                    getDimensionName(), getResourceInfo().getName()), exception);
-        }
+    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+        return getRasterDomainValues(filter, noDuplicates, CoverageDimensionsReader.DataType.TEMPORAL, DimensionsUtils.TEMPORAL_COMPARATOR);
     }
 
     @Override

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterTimeDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterTimeDimension.java
@@ -8,7 +8,9 @@ import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.Filter;
 
 import java.util.List;
@@ -28,7 +30,7 @@ public class RasterTimeDimension extends Dimension {
     }
 
     @Override
-    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
         return getRasterDomainValues(filter, noDuplicates, CoverageDimensionsReader.DataType.TEMPORAL, DimensionsUtils.TEMPORAL_COMPARATOR);
     }
 

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorElevationDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorElevationDimension.java
@@ -7,7 +7,9 @@ package org.geoserver.gwc.wmts.dimensions;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.Filter;
 
 import java.util.List;
@@ -27,7 +29,7 @@ public class VectorElevationDimension extends Dimension {
     }
 
     @Override
-    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
         return getVectorDomainValues(filter, noDuplicates, DimensionsUtils.NUMERICAL_COMPARATOR);
     }
 

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorElevationDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorElevationDimension.java
@@ -5,14 +5,12 @@
 package org.geoserver.gwc.wmts.dimensions;
 
 import org.geoserver.catalog.DimensionInfo;
-import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.gwc.wmts.FilteredFeatureType;
 import org.geoserver.wms.WMS;
 import org.opengis.filter.Filter;
 
-import java.util.TreeSet;
+import java.util.List;
 
 /**
  * Represents an elevation dimension of a vector (feature type).
@@ -29,24 +27,8 @@ public class VectorElevationDimension extends Dimension {
     }
 
     @Override
-    public TreeSet<?> getDomainValues(Filter filter) {
-        try {
-            FeatureTypeInfo typeInfo = (FeatureTypeInfo) getResourceInfo();
-            TreeSet<?> fullDomainValues = getWms().getFeatureTypeElevations(typeInfo);
-            fullDomainValues = fullDomainValues == null ? new TreeSet<>() : fullDomainValues;
-            if (filter == null || filter.equals(Filter.INCLUDE)) {
-                return fullDomainValues;
-            }
-            TreeSet<?> restrictedValues = getWms().getFeatureTypeElevations(new FilteredFeatureType(typeInfo, filter));
-            if (restrictedValues == null) {
-                restrictedValues = new TreeSet<>();
-            }
-            return restrictedValues;
-        } catch (Exception exception) {
-            throw new RuntimeException(String.format(
-                    "Error getting domain values for dimension '%s' of vector '%s'.",
-                    getDimensionName(), getResourceInfo().getName()), exception);
-        }
+    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+        return getVectorDomainValues(filter, noDuplicates, DimensionsUtils.NUMERICAL_COMPARATOR);
     }
 
     @Override

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorTimeDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorTimeDimension.java
@@ -4,12 +4,14 @@
  */
 package org.geoserver.gwc.wmts.dimensions;
 
-import org.geoserver.catalog.*;
-import org.geoserver.gwc.wmts.FilteredFeatureType;
+import org.geoserver.catalog.DimensionDefaultValueSetting;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.wms.WMS;
 import org.opengis.filter.Filter;
 
-import java.util.TreeSet;
+import java.util.List;
 
 /**
  * Represents a time dimension of a vector (feature type).
@@ -26,24 +28,8 @@ public class VectorTimeDimension extends Dimension {
     }
 
     @Override
-    public TreeSet<?> getDomainValues(Filter filter) {
-        try {
-            FeatureTypeInfo typeInfo = (FeatureTypeInfo) getResourceInfo();
-            TreeSet<?> fullDomainValues = getWms().getFeatureTypeTimes(typeInfo);
-            fullDomainValues = fullDomainValues == null ? new TreeSet<>() : fullDomainValues;
-            if (filter == null || filter.equals(Filter.INCLUDE)) {
-                return fullDomainValues;
-            }
-            TreeSet<?> restrictedValues = getWms().getFeatureTypeTimes(new FilteredFeatureType(typeInfo, filter));
-            if (restrictedValues == null) {
-                restrictedValues = new TreeSet<>();
-            }
-            return restrictedValues;
-        } catch (Exception exception) {
-            throw new RuntimeException(String.format(
-                    "Error getting domain values for dimension '%s' of vector '%s'.",
-                    getDimensionName(), getResourceInfo().getName()), exception);
-        }
+    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+        return getVectorDomainValues(filter, noDuplicates, DimensionsUtils.TEMPORAL_COMPARATOR);
     }
 
     @Override

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorTimeDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorTimeDimension.java
@@ -8,7 +8,9 @@ import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.Filter;
 
 import java.util.List;
@@ -28,7 +30,7 @@ public class VectorTimeDimension extends Dimension {
     }
 
     @Override
-    public List<Object> getDomainValues(Filter filter, boolean noDuplicates) {
+    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
         return getVectorDomainValues(filter, noDuplicates, DimensionsUtils.TEMPORAL_COMPARATOR);
     }
 

--- a/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
+++ b/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
@@ -67,8 +67,8 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[ows:Identifier='time']", "2");
         // check raster elevation dimension
         checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[wmts:Default='0.0']", "1");
-        checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[wmts:Value='0.0']", "1");
-        checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[wmts:Value='100.0']", "1");
+        checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[wmts:Value='0']", "1");
+        checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[wmts:Value='100']", "1");
         // check raster time dimension
         checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[wmts:Default='0.0']", "1");
         checkXpathCount(result, "/wmts:Contents/wmts:Layer/wmts:Dimension[wmts:Value='2008-10-31T00:00:00.000Z--2008-11-01T00:00:00.000Z']", "1");
@@ -94,7 +94,7 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Size='2']", "2");
         // check the elevation domain
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[ows:Identifier='elevation']", "1");
-        checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Domain='0.0,100.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Domain='0,100']", "1");
         // check the time domain
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[ows:Identifier='time']", "1");
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Domain='2008-10-31T00:00:00.000Z--2008-11-01T00:00:00.000Z']", "1");
@@ -205,7 +205,7 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         // check the returned histogram
         checkXpathCount(result, "/md:Histogram[ows:Identifier='elevation']", "1");
         checkXpathCount(result, "/md:Histogram[md:Domain='0.0/100.0/25.0']", "1");
-        checkXpathCount(result, "/md:Histogram[md:Values='1,0,0,1']", "1");
+        checkXpathCount(result, "/md:Histogram[md:Values='2,0,0,2']", "1");
     }
 
     @Test
@@ -218,7 +218,7 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         // check the returned histogram
         checkXpathCount(result, "/md:Histogram[ows:Identifier='time']", "1");
         checkXpathCount(result, "/md:Histogram[md:Domain='2012-02-11T00:00:00.000Z/2012-02-12T00:00:00.000Z/P1M']", "1");
-        checkXpathCount(result, "/md:Histogram[md:Values='2']", "1");
+        checkXpathCount(result, "/md:Histogram[md:Values='3']", "1");
     }
 
     @Test

--- a/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
+++ b/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
@@ -98,6 +98,12 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         // check the time domain
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[ows:Identifier='time']", "1");
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Domain='2008-10-31T00:00:00.000Z--2008-11-01T00:00:00.000Z']", "1");
+        // check the space domain
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@CRS='EPSG:4326']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@minx='0.23722068851276978']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@miny='40.562080748421806']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxx='14.592757149389236']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxy='44.55808294568743']", "1");
     }
 
     @Test
@@ -117,6 +123,12 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         // check the time domain
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[ows:Identifier='time']", "1");
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Domain='2012-02-11T00:00:00.000Z,2012-02-12T00:00:00.000Z']", "1");
+        // check the space domain
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@CRS='EPSG:4326']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@minx='-180.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@miny='-90.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxx='180.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxy='90.0']", "1");
     }
 
     @Test
@@ -136,6 +148,12 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[ows:Identifier='time']", "1");
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Domain='2008-10-31T00:00:00.000Z--2008-11-01T00:00:00.000Z']", "1");
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Size='2']", "1");
+        // check the space domain
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@CRS='EPSG:4326']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@minx='0.23722068851276978']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@miny='40.562080748421806']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxx='14.592757149389236']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxy='44.55808294568743']", "1");
     }
 
     @Test
@@ -149,6 +167,12 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         checkXpathCount(result, "/md:Domains/md:DimensionDomain", "2");
         // the domain should not contain any values
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Size='0']", "2");
+        // check the space domain
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@CRS='EPSG:4326']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@minx='0.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@miny='0.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxx='-1.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxy='-1.0']", "1");
     }
 
     @Test
@@ -162,10 +186,10 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         checkXpathCount(result, "/md:Domains/md:DimensionDomain", "2");
         // check the space domain
         checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@CRS='EPSG:4326']", "1");
-        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@minx='5.0']", "1");
-        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@miny='5.0']", "1");
-        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxx='6.0']", "1");
-        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxy='6.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@minx='0.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@miny='0.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxx='-1.0']", "1");
+        checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@maxy='-1.0']", "1");
         // the domain should not contain any values
         checkXpathCount(result, "/md:Domains/md:DimensionDomain[md:Size='0']", "2");
     }

--- a/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/RasterElevationDimensionTest.java
+++ b/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/RasterElevationDimensionTest.java
@@ -52,9 +52,9 @@ public class RasterElevationDimensionTest extends TestsSupport {
 
     @Test
     public void testGetDomainsValues() throws Exception {
-        testDomainsValuesRepresentation(DimensionPresentation.LIST, "0.0", "100.0");
-        testDomainsValuesRepresentation(DimensionPresentation.CONTINUOUS_INTERVAL, "0.0--100.0");
-        testDomainsValuesRepresentation(DimensionPresentation.DISCRETE_INTERVAL, "0.0--100.0");
+        testDomainsValuesRepresentation(DimensionPresentation.LIST, "0", "100");
+        testDomainsValuesRepresentation(DimensionPresentation.CONTINUOUS_INTERVAL, "0--100");
+        testDomainsValuesRepresentation(DimensionPresentation.DISCRETE_INTERVAL, "0--100");
     }
 
     @Override
@@ -68,7 +68,7 @@ public class RasterElevationDimensionTest extends TestsSupport {
         Dimension dimension = buildDimension(dimensionInfo);
         Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "50");
         assertThat(histogram.first, is("0.0/100.0/50.0"));
-        assertThat(histogram.second, containsInAnyOrder(1, 1));
+        assertThat(histogram.second, containsInAnyOrder(2, 2));
     }
 
     /**

--- a/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/RasterTimeDimensionTest.java
+++ b/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/RasterTimeDimensionTest.java
@@ -55,7 +55,7 @@ public class RasterTimeDimensionTest extends TestsSupport {
             formatDate(DATE_VALUES[4])
     };
 
-    //@Test
+    @Test
     public void testDisabledDimension() throws Exception {
         // enable a time dimension
         DimensionInfo dimensionInfo = new DimensionInfoImpl();
@@ -149,7 +149,7 @@ public class RasterTimeDimensionTest extends TestsSupport {
         Dimension dimension = buildDimension(dimensionInfo);
         Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "P1Y");
         assertThat(histogram.first, is("2008-10-31T00:00:00.000Z/" + STRING_VALUES[4] + "/P1Y"));
-        assertThat(histogram.second.stream().reduce(0, (total, value) -> total + value), is(4));
+        assertThat(histogram.second.stream().reduce(0, (total, value) -> total + value), is(6));
     }
 
     /**

--- a/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/TestsSupport.java
+++ b/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/TestsSupport.java
@@ -87,7 +87,7 @@ public abstract class TestsSupport extends WMSTestSupport {
     protected void testDomainsValuesRepresentation(DimensionPresentation dimensionPresentation, String... expectedDomainValues) throws IOException {
         DimensionInfo dimensionInfo = createDimension(true, dimensionPresentation, null);
         Dimension dimension = buildDimension(dimensionInfo);
-        List<String> valuesAsStrings = dimension.getDomainValuesAsStrings(Filter.INCLUDE).second;
+        List<String> valuesAsStrings = dimension.getDomainValuesAsStrings(Filter.INCLUDE).second.second;
         assertThat(valuesAsStrings.size(), is(expectedDomainValues.length));
         assertThat(valuesAsStrings, containsInAnyOrder(expectedDomainValues));
     }

--- a/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorElevationDimensionTest.java
+++ b/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorElevationDimensionTest.java
@@ -70,7 +70,7 @@ public class VectorElevationDimensionTest extends TestsSupport {
         Dimension dimension = buildDimension(dimensionInfo);
         Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "0.1");
         assertThat(histogram.first, is("1.0/2.0/0.1"));
-        assertThat(histogram.second, containsInAnyOrder(1, 0, 0, 0, 0, 0, 0, 0, 0, 1));
+        assertThat(histogram.second, containsInAnyOrder(2, 0, 0, 0, 0, 0, 0, 0, 0, 1));
     }
 
     /**

--- a/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorTimeDimensionTest.java
+++ b/src/community/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorTimeDimensionTest.java
@@ -70,7 +70,7 @@ public class VectorTimeDimensionTest extends TestsSupport {
         Dimension dimension = buildDimension(dimensionInfo);
         Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "P1D");
         assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-12T00:00:00.000Z/P1D"));
-        assertThat(histogram.second, containsInAnyOrder(2));
+        assertThat(histogram.second, containsInAnyOrder(3));
     }
 
     /**


### PR DESCRIPTION
This pull request provide two commits that fix this issues (one commit for each issue):
- https://osgeo-org.atlassian.net/browse/GEOS-7722
- https://osgeo-org.atlassian.net/browse/GEOS-7721

All the changes were made in the WMTS multi dimensional community module.

The existing dimensions retrieval machinery assumes that we always want the unique values (no duplicates) and hence returns the domain values in a TreeSet. The GetHistogram operation needs to access the full domain values (including the duplicates ones).

For every DescribeOperation a bounding box of the used features will be used as spatial domain and properly encoded in the response. When is not possible to compute a bounding  box for the selected features (no geometry, non structured reader, etc ...) a default referenced envelope is returned.

Testes have been updated to reflect the new changes.