### PR TITLE
[GEOS-7746] Use the computed width and height instead of the default values (backport 2.9.x)

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -1313,8 +1313,8 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
                 String layerName = layerInfo.prefixedName();
                 Map<String, String> params = params("service", "WMS", "request",
                         "GetLegendGraphic", "format", gwcLegendInfo.format, "width",
-                        String.valueOf(GetLegendGraphicRequest.DEFAULT_WIDTH), "height",
-                        String.valueOf(GetLegendGraphicRequest.DEFAULT_HEIGHT), "layer", layerName);
+                        String.valueOf(gwcLegendInfo.width), "height",
+                        String.valueOf(gwcLegendInfo.height), "layer", layerName);
                 if (!styleInfo.getName().equals(layerInfo.getDefaultStyle().getName())) {
                     params.put("style", styleInfo.getName());
                 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -779,14 +779,14 @@ public class GeoServerTileLayerTest {
         assertThat(legendsInfo.get("default_style").height, is(150));
         assertThat(legendsInfo.get("default_style").format, is("image/png"));
         assertThat(legendsInfo.get("default_style").legendUrl, is("http://localhost:8080/geoserver/ows?service=" +
-                "WMS&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=workspace%3AMockLayerInfoName"));
+                "WMS&request=GetLegendGraphic&format=image%2Fpng&width=120&height=150&layer=workspace%3AMockLayerInfoName"));
         // alternateStyle-1
         assertThat(legendsInfo.get("alternateStyle-1"), notNullValue());
         assertThat(legendsInfo.get("alternateStyle-1").width, is(120));
         assertThat(legendsInfo.get("alternateStyle-1").height, is(150));
         assertThat(legendsInfo.get("alternateStyle-1").format, is("image/png"));
         assertThat(legendsInfo.get("alternateStyle-1").legendUrl, is("http://localhost:8080/geoserver/ows?service" +
-                "=WMS&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=workspace%3AMockLayerInfoName&style=alternateStyle-1"));
+                "=WMS&request=GetLegendGraphic&format=image%2Fpng&width=120&height=150&layer=workspace%3AMockLayerInfoName&style=alternateStyle-1"));
         // alternateStyle-2
         assertThat(legendsInfo.get("alternateStyle-2"), notNullValue());
         assertThat(legendsInfo.get("alternateStyle-2").width, is(150));


### PR DESCRIPTION
GeoServerTileLayer was always using the default width and height for the GetLegendeGraphics URL instead of of the computed values.

This pull request also updates the tests.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7746

Backport of pull request: https://github.com/geoserver/geoserver/pull/1836