### PR TITLE
[GEOS-7754] GeoServer Environment Allow Parametrization should set to FALSE by Default

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerEnvironment.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerEnvironment.java
@@ -50,7 +50,7 @@ public class GeoServerEnvironment {
      * Default to FALSE
      */
     public final static boolean ALLOW_ENV_PARAMETRIZATION = Boolean
-            .valueOf(System.getProperty("ALLOW_ENV_PARAMETRIZATION", "true"));
+            .valueOf(System.getProperty("ALLOW_ENV_PARAMETRIZATION", "false"));
 
     private static final String PROPERTYFILENAME = "geoserver-environment.properties";
 

--- a/src/platform/src/test/java/org/geoserver/platform/GeoServerEnvironmentTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/GeoServerEnvironmentTest.java
@@ -6,11 +6,14 @@ package org.geoserver.platform;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import javax.servlet.ServletContext;
 
 import org.easymock.EasyMock;
+import org.geotools.util.logging.Logging;
 import org.junit.Assert;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 
 import junit.framework.TestCase;
@@ -22,10 +25,16 @@ import junit.framework.TestCase;
  */
 public class GeoServerEnvironmentTest extends TestCase {
 
+    /**
+     * logger
+     */
+    protected static final Logger LOGGER = Logging.getLogger("org.geoserver.platform");
+    
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
         System.setProperty("TEST_SYS_PROPERTY", "ABC");
-        System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
+        System.setProperty("ALLOW_ENV_PARAMETRIZATION", "false");
 
         ServletContext context = EasyMock.createMock(ServletContext.class);
         EasyMock.expect(context.getInitParameter("GEOSERVER_REQUIRE_FILE")).andReturn(null);
@@ -63,16 +72,18 @@ public class GeoServerEnvironmentTest extends TestCase {
         gsext.setApplicationContext(appContext);
     }
 
+    @Override
     protected void tearDown() throws Exception {
         super.tearDown();
         System.clearProperty("TEST_SYS_PROPERTY");
         System.clearProperty("ALLOW_ENV_PARAMETRIZATION");
     }
 
+    @Test
     public void testSystemProperty() {
         // check for a property we did set up in the setUp
         GeoServerEnvironment genv = new GeoServerEnvironment();
-        assertEquals("ABC", genv.resolveValue("${TEST_SYS_PROPERTY}"));
+        LOGGER.info("GeoServerEnvironment = " + GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION);
 
         assertEquals("ABC", genv.resolveValue("${TEST_SYS_PROPERTY}"));
         assertEquals("${TEST_PROPERTY}", genv.resolveValue("${TEST_PROPERTY}"));

--- a/src/platform/src/test/java/org/geoserver/platform/SystemEnvironmentTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/SystemEnvironmentTest.java
@@ -7,9 +7,21 @@ package org.geoserver.platform;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.easymock.EasyMock;
+import org.geotools.util.logging.Logging;
 import org.junit.Test;
+import org.springframework.context.ApplicationContext;
 
 public class SystemEnvironmentTest {
+    
+    /**
+     * logger
+     */
+    protected static final Logger LOGGER = Logging.getLogger("org.geoserver.platform");
 
     @Test
     public void testSystemPropertiesStatus() {
@@ -22,4 +34,38 @@ public class SystemEnvironmentTest {
         assertTrue(status.getMessage().get().contains(value));
     }
 
+    @Test
+    public void testGeoServerEnvironmentDefaultValue() {
+        System.clearProperty("ALLOW_ENV_PARAMETRIZATION");
+        String sysProperty = System.getProperty("ALLOW_ENV_PARAMETRIZATION");
+        
+        GeoServerResourceLoader loader = EasyMock.createMockBuilder(GeoServerResourceLoader.class)
+                .withConstructor().createMock();
+
+        ApplicationContext appContext = EasyMock.createMock(ApplicationContext.class);
+        EasyMock.expect(appContext.getBeanNamesForType(ExtensionFilter.class))
+                .andReturn(new String[] {}).anyTimes();
+        EasyMock.expect(appContext.getBeanNamesForType(ExtensionProvider.class))
+                .andReturn(new String[] {}).anyTimes();
+        EasyMock.expect(appContext.getBeanNamesForType(GeoServerResourceLoader.class))
+                .andReturn(new String[] { "geoServerLoader" }).anyTimes();
+        Map<String, GeoServerResourceLoader> genvMap = new HashMap<>();
+        genvMap.put("geoServerLoader", loader);
+        EasyMock.expect(appContext.getBeansOfType(GeoServerResourceLoader.class)).andReturn(genvMap)
+                .anyTimes();
+        EasyMock.expect(appContext.getBean("geoServerLoader")).andReturn(loader).anyTimes();
+        EasyMock.expect(appContext.isSingleton("geoServerLoader")).andReturn(true).anyTimes();
+
+        EasyMock.replay(appContext);
+        GeoServerExtensions gsext = new GeoServerExtensions();
+        gsext.setApplicationContext(appContext);
+        
+        // By default ALLOW_ENV_PARAMETRIZATION flag is set to FALSE
+        LOGGER.info("ALLOW_ENV_PARAMETRIZATION = " + sysProperty);
+        if (sysProperty == null || !Boolean.valueOf(sysProperty)) {
+            GeoServerEnvironment genv = new GeoServerEnvironment();
+            LOGGER.info("GeoServerEnvironment = " + GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION);
+            assertTrue(!GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION);
+        }
+    }
 }


### PR DESCRIPTION
It is just a change of the default value of a flag. There's no need to add specific tests for this since there are already tests for GeoServerEnvironment functionality.