### PR TITLE
Unit tests and docs for GEOT-5526: SQL Encoding of Nested Filters

### DIFF
--- a/doc/en/user/source/data/app-schema/joining.rst
+++ b/doc/en/user/source/data/app-schema/joining.rst
@@ -62,3 +62,24 @@ Using joining is strongly recommended when a large number of features need to be
 when producing maps with WMS (see :ref:`app-schema.wms-support`).
 
 Optimising the performance of the database will maximise the benefit of using joining, including for small queries.
+
+Native Encoding of Filters on Nested Attributes
+-----------------------------------------------
+
+When App-Schema Joining is active, filters operating on nested attributes (i.e. attributes of features that are joined to the queried type via :ref:`app-schema.feature-chaining`) are translated to SQL and executed directly in the database backend, rather than being evaluated in memory after all features have been loaded (which was standard behavior in earlier versions of GeoServer). Native encoding can yield significant performance improvements, especially when the total number of features in the database is high (several thousands or more), but only a few of them would satisfy the filter.
+
+There are, however, a few limitations in the current implementation:
+
+1. Joining support must not have been explicitly disabled and all its pre-conditions must be met (see above)
+2. only binary comparison operators (e.g. ``PropertyIsEqualTo``, ``PropertyIsGreaterThan``, etc...), ``PropertyIsLike`` and ``PropertyIsNull`` filters are translated to SQL
+3. filters involving conditional polymorphic mappings are evaluated in memory
+4. filters comparing two or more different nested attributes are evaluated in memory
+5. filters matching multiple nested attribute mappings are evaluated in memory
+
+Much like Joining support, native encoding of nested filters is turned on by default, and it is disabled by adding to your app-schema.properties file the line ::
+
+     app-schema.encodeNestedFilters = false
+
+Or, alternatively, by setting the value of the Java System Property "app-schema.encodeNestedFilters" to "false", for example ::
+
+     java -DGEOSERVER_DATA_DIR=... -Dapp-schema.encodeNestedFilters=false Start

--- a/doc/en/user/source/data/app-schema/joining.rst
+++ b/doc/en/user/source/data/app-schema/joining.rst
@@ -71,12 +71,12 @@ When App-Schema Joining is active, filters operating on nested attributes (i.e. 
 There are, however, a few limitations in the current implementation:
 
 1. Joining support must not have been explicitly disabled and all its pre-conditions must be met (see above)
-2. only binary comparison operators (e.g. ``PropertyIsEqualTo``, ``PropertyIsGreaterThan``, etc...), ``PropertyIsLike`` and ``PropertyIsNull`` filters are translated to SQL
-3. filters involving conditional polymorphic mappings are evaluated in memory
-4. filters comparing two or more different nested attributes are evaluated in memory
-5. filters matching multiple nested attribute mappings are evaluated in memory
+2. Only binary comparison operators (e.g. ``PropertyIsEqualTo``, ``PropertyIsGreaterThan``, etc...), ``PropertyIsLike`` and ``PropertyIsNull`` filters are translated to SQL
+3. Filters involving conditional polymorphic mappings are evaluated in memory
+4. Filters comparing two or more different nested attributes are evaluated in memory
+5. Filters matching multiple nested attribute mappings are evaluated in memory
 
-Much like Joining support, native encoding of nested filters is turned on by default, and it is disabled by adding to your app-schema.properties file the line ::
+Much like joining support, native encoding of nested filters is turned on by default, and it is disabled by adding to your app-schema.properties file the line ::
 
      app-schema.encodeNestedFilters = false
 

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
@@ -9,6 +9,7 @@ package org.geoserver.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -37,14 +38,27 @@ import org.custommonkey.xmlunit.XpathEngine;
 import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.WFSInfo;
+import org.geotools.data.DataAccess;
 import org.geotools.data.complex.AppSchemaDataAccess;
 import org.geotools.data.complex.AppSchemaDataAccessRegistry;
 import org.geotools.data.complex.DataAccessRegistry;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.jdbc.FilterToSQL;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.jdbc.BasicSQLDialect;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.jdbc.PreparedStatementSQLDialect;
+import org.geotools.jdbc.SQLDialect;
 import org.geotools.xml.AppSchemaValidator;
 import org.geotools.xml.AppSchemaXSDRegistry;
 import org.geotools.xml.resolver.SchemaCache;
 import org.geotools.xml.resolver.SchemaCatalog;
 import org.geotools.xml.resolver.SchemaResolver;
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
@@ -609,4 +623,91 @@ public abstract class AbstractAppSchemaTestSupport extends GeoServerSystemTestSu
         return actual;
     }
 
+    /**
+     * Checks that the identifiers of the features in the provided collection match the specified ids.
+     * 
+     * <p>
+     * Note that:
+     * <ul>
+     * <li>The method considers that feature identifiers follow the convention <code>[type name].[ID]</code> and only matches the ID part.</li>
+     * <li>If the feature collection contains a feature whose identifier does not match any of the passed ids, the check will fail</li>
+     * </ul>
+     * </p>
+     * 
+     * @param featureSet the feature collection to check
+     * @param fids the feature identifiers that must be present in the collection
+     */
+    protected void assertContainsFeatures(FeatureCollection featureSet, String... fids) {
+        List<String> fidList = Arrays.asList(fids);
+
+        try (FeatureIterator it = featureSet.features()) {
+            int count = 0;
+            while (it.hasNext()) {
+                Feature f = it.next();
+                String[] parts = f.getIdentifier().getID().split("\\.");
+                String fid = parts[parts.length - 1];
+                assertTrue(fidList.contains(fid));
+                count++;
+            }
+            assertEquals(fidList.size(), count);
+        }
+    }
+
+    /**
+     * Checks that all the pre-conditions for SQL encoding filters on nested attributes are met:
+     * 
+     * <ol>
+     * <li>Source datastore is backed by a RDBMS</li>
+     * <li>Joining support is enabled</li>
+     * <li>Nested filters encoding is enabled</li>
+     * </ol>
+     * 
+     * <p>
+     * If the method returns <code>false</code> the test should be skipped.
+     * </p>
+     * 
+     * @param rootMapping the feature type being queried
+     * @return <code>true</code> if nested filters encoding can be tested, <code>false</code> otherwise.
+     */
+    protected boolean shouldTestNestedFiltersEncoding(FeatureTypeMapping rootMapping) {
+        if (!(rootMapping.getSource().getDataStore() instanceof JDBCDataStore))
+            return false;
+        if (!AppSchemaDataAccessConfigurator.isJoining())
+            return false;
+        if (!AppSchemaDataAccessConfigurator.shouldEncodeNestedFilters())
+            return false;
+        return true;
+    }
+
+    /**
+     * Creates a properly configured {@link NestedFilterToSQL} instance to enable testing the SQL encoding of filters on nested attributes.
+     * 
+     * <p>
+     * Note: before calling this method, clients should verify that nested filters encoding is enabled by calling
+     * {@link #shouldTestNestedFiltersEncoding(FeatureTypeMapping)}.
+     * </p>
+     * 
+     * @param mapping the feature type being queried
+     * @return nested filter encoder
+     */
+    protected NestedFilterToSQL createNestedFilterEncoder(FeatureTypeMapping mapping) {
+        DataAccess<?, ?> source = mapping.getSource().getDataStore();
+        if (!(source instanceof JDBCDataStore)) {
+            throw new IllegalArgumentException(
+                    "nested filters encoding requires the source datastore be a JDBCDataStore");
+        }
+        JDBCDataStore store = (JDBCDataStore) source;
+        SQLDialect dialect = store.getSQLDialect();
+        FilterToSQL original = null;
+        if (dialect instanceof BasicSQLDialect) {
+            original = ((BasicSQLDialect) dialect).createFilterToSQL();
+        } else if (dialect instanceof PreparedStatementSQLDialect) {
+            original = ((PreparedStatementSQLDialect) dialect).createPreparedFilterToSQL();
+        }
+        original.setFeatureType((SimpleFeatureType) mapping.getSource().getSchema());
+
+        NestedFilterToSQL nestedFilterToSQL = new NestedFilterToSQL(mapping, original);
+        nestedFilterToSQL.setInline(true);
+        return nestedFilterToSQL;
+    }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
@@ -9,7 +9,6 @@ package org.geoserver.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -50,6 +49,7 @@ import org.geotools.feature.FeatureIterator;
 import org.geotools.jdbc.BasicSQLDialect;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.jdbc.PreparedFilterToSQL;
 import org.geotools.jdbc.PreparedStatementSQLDialect;
 import org.geotools.jdbc.SQLDialect;
 import org.geotools.xml.AppSchemaValidator;
@@ -703,6 +703,8 @@ public abstract class AbstractAppSchemaTestSupport extends GeoServerSystemTestSu
             original = ((BasicSQLDialect) dialect).createFilterToSQL();
         } else if (dialect instanceof PreparedStatementSQLDialect) {
             original = ((PreparedStatementSQLDialect) dialect).createPreparedFilterToSQL();
+            // disable prepared statements to have literals actually encoded in the SQL
+            ((PreparedFilterToSQL)original).setPrepareEnabled(false);
         }
         original.setFeatureType((SimpleFeatureType) mapping.getSource().getSchema());
 

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -7,18 +7,45 @@
 package org.geoserver.test;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import org.junit.Assume;
 import org.junit.Test;
-
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.And;
+import org.opengis.filter.Filter;
+import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsLike;
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.xml.v1_1_0.WFS;
 import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureSource;
 import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.AppSchemaDataAccessRegistry;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.complex.filter.ComplexFilterSplitter;
+import org.geotools.data.jdbc.FilterToSQL;
+import org.geotools.data.jdbc.FilterToSQLException;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.filter.FilterFactoryImplNamespaceAware;
+import org.geotools.jdbc.BasicSQLDialect;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.jdbc.PreparedStatementSQLDialect;
+import org.geotools.jdbc.SQLDialect;
+import org.geotools.util.NullProgressListener;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -1372,6 +1399,135 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         wfs.setEncodeFeatureMember(encodeFeatureMember);
         getGeoServer().save(wfs);
     }
-    
-    
+
+    @Test
+    public void testNestedFilterEncoding() throws FilterToSQLException, IOException {
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+        FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+        AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+        FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+
+        // make sure nested filters encoding is enabled, otherwise skip test
+        assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
+
+        JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+        NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
+
+        FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+        ff.setNamepaceContext(rootMapping.getNamespaces());
+
+        /*
+         * test combined filters on nested attributes
+         */
+        And and = ff
+                .and(ff.equals(ff.property("gsml:specification/gsml:GeologicUnit/gml:name"),
+                        ff.literal("New Group")),
+                        ff.equals(
+                                ff.property("gsml:specification/gsml:GeologicUnit/gsml:composition/gsml:CompositionPart/gsml:proportion/gsml:CGI_TermValue/gsml:value"),
+                                ff.literal("significant")));
+
+        // Each filter involves a single nested attribute --> can be encoded
+        ComplexFilterSplitter splitter = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitter.visit(and, null);
+        Filter preFilter = splitter.getFilterPre();
+        Filter postFilter = splitter.getFilterPost();
+
+        assertEquals(and, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        Filter unrolled = AppSchemaDataAccess.unrollFilter(and, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        String encodedFilter = nestedFilterToSQL.encodeToString(unrolled);
+
+        assertTrue(encodedFilter.matches("^\\(EXISTS.*AND EXISTS.*\\)$"));
+        assertContainsFeatures(fs.getFeatures(and), "mf4");
+
+        /*
+         * test like filter on nested attribute
+         */
+         PropertyIsLike like = ff.like(ff.property("gsml:specification/gsml:GeologicUnit/gml:description"), "*sedimentary*");
+
+        // Filter involving single nested attribute --> can be encoded
+        ComplexFilterSplitter splitterLike = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitterLike.visit(like, null);
+        preFilter = splitterLike.getFilterPre();
+        postFilter = splitterLike.getFilterPost();
+
+        assertEquals(like, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        unrolled = AppSchemaDataAccess.unrollFilter(like, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        encodedFilter = nestedFilterToSQL.encodeToString(unrolled);
+
+        // this is the generated query in PostGIS, but the test limits to check the presence of the
+        // EXISTS keyword, as the actual SQL is dependent on the underlying database
+//        String expected = "EXISTS (SELECT \"chain_link_1\".\"PKEY\" "
+//                + "FROM \"appschematest\".\"GEOLOGICUNIT\" \"chain_link_1\" "
+//                + "WHERE  UPPER(\"chain_link_1\".\"TEXTDESCRIPTION\") LIKE '%SEDIMENTARY%' "
+//                + "AND \"appschematest\".\"MAPPEDFEATUREPROPERTYFILE\".\"GEOLOGIC_UNIT_ID\" = \"chain_link_1\".\"GML_ID\")";
+//        assertEquals(expected, encodedFilter);
+        assertTrue(encodedFilter.contains("EXISTS"));
+        assertContainsFeatures(fs.getFeatures(like), "mf1", "mf2", "mf3");
+    }
+
+    @Test
+    public void testNestedFilterEncodingDisabled() throws IOException, FilterToSQLException {
+        // disable nested filters encoding during the test
+        AppSchemaDataAccessRegistry.getAppSchemaProperties().setProperty(
+                AppSchemaDataAccessConfigurator.PROPERTY_ENCODE_NESTED_FILTERS, "false");
+        try {
+            FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+            FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+            AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+            FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+
+            // make sure nested filters encoding is enabled, otherwise skip test
+            assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
+
+            JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+            NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
+
+            FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+            ff.setNamepaceContext(rootMapping.getNamespaces());
+
+            /*
+             * test the same like filter tested in method testNestedFilterEncoding
+             */
+            PropertyIsLike like = ff.like(ff.property("gsml:specification/gsml:GeologicUnit/gml:description"), "*sedimentary*");
+
+            // Encoding of filters involving nested attributes is disabled --> CANNOT be encoded
+            ComplexFilterSplitter splitterLike = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                    rootMapping);
+            splitterLike.visit(like, null);
+            Filter preFilter = splitterLike.getFilterPre();
+            Filter postFilter = splitterLike.getFilterPost();
+
+            assertEquals(Filter.INCLUDE, preFilter);
+            assertEquals(like, postFilter);
+
+            // filter must be "unrolled" (i.e. reverse mapped) first
+            Filter unrolled = AppSchemaDataAccess.unrollFilter(like, rootMapping);
+
+            // Filter is nested
+            assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+            assertContainsFeatures(fs.getFeatures(like), "mf1", "mf2", "mf3");
+        } finally {
+            // reset default
+            AppSchemaDataAccessRegistry.getAppSchemaProperties().setProperty(
+                    AppSchemaDataAccessConfigurator.PROPERTY_ENCODE_NESTED_FILTERS, "true");
+        }
+    }
+
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -1487,13 +1487,12 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         AppSchemaDataAccessRegistry.getAppSchemaProperties().setProperty(
                 AppSchemaDataAccessConfigurator.PROPERTY_ENCODE_NESTED_FILTERS, "false");
         try {
+            assertFalse(AppSchemaDataAccessConfigurator.shouldEncodeNestedFilters());
+
             FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
             FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
             AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
             FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
-
-            // make sure nested filters encoding is enabled, otherwise skip test
-            assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
 
             JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
             NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -6,25 +6,18 @@
 
 package org.geoserver.test;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Assume;
-import org.junit.Test;
-import org.opengis.feature.Feature;
-import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.filter.And;
-import org.opengis.filter.Filter;
-import org.opengis.filter.PropertyIsEqualTo;
-import org.opengis.filter.PropertyIsLike;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.xml.v1_1_0.WFS;
@@ -35,17 +28,15 @@ import org.geotools.data.complex.AppSchemaDataAccessRegistry;
 import org.geotools.data.complex.FeatureTypeMapping;
 import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
 import org.geotools.data.complex.filter.ComplexFilterSplitter;
-import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.jdbc.FilterToSQLException;
-import org.geotools.feature.FeatureCollection;
-import org.geotools.feature.FeatureIterator;
 import org.geotools.filter.FilterFactoryImplNamespaceAware;
-import org.geotools.jdbc.BasicSQLDialect;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.NestedFilterToSQL;
-import org.geotools.jdbc.PreparedStatementSQLDialect;
-import org.geotools.jdbc.SQLDialect;
 import org.geotools.util.NullProgressListener;
+import org.junit.Test;
+import org.opengis.filter.And;
+import org.opengis.filter.Filter;
+import org.opengis.filter.PropertyIsLike;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -1472,11 +1463,10 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
 
         // this is the generated query in PostGIS, but the test limits to check the presence of the
         // EXISTS keyword, as the actual SQL is dependent on the underlying database
-//        String expected = "EXISTS (SELECT \"chain_link_1\".\"PKEY\" "
-//                + "FROM \"appschematest\".\"GEOLOGICUNIT\" \"chain_link_1\" "
-//                + "WHERE  UPPER(\"chain_link_1\".\"TEXTDESCRIPTION\") LIKE '%SEDIMENTARY%' "
-//                + "AND \"appschematest\".\"MAPPEDFEATUREPROPERTYFILE\".\"GEOLOGIC_UNIT_ID\" = \"chain_link_1\".\"GML_ID\")";
-//        assertEquals(expected, encodedFilter);
+        // EXISTS (SELECT "chain_link_1"."PKEY" 
+        //      FROM "appschematest"."GEOLOGICUNIT" "chain_link_1" 
+        //      WHERE UPPER("chain_link_1"."TEXTDESCRIPTION") LIKE '%SEDIMENTARY%' AND 
+        //            "appschematest"."MAPPEDFEATUREPROPERTYFILE"."GEOLOGIC_UNIT_ID" = "chain_link_1"."GML_ID")
         assertTrue(encodedFilter.contains("EXISTS"));
         assertContainsFeatures(fs.getFeatures(like), "mf1", "mf2", "mf3");
     }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -1494,6 +1494,9 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
             AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
             FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
 
+            // skip test if it's not running against a database
+            assumeTrue(rootMapping.getSource().getDataStore() instanceof JDBCDataStore);
+
             JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
             NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
 

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NestedIdSupportTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NestedIdSupportTest.java
@@ -6,7 +6,25 @@
 
 package org.geoserver.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.IOException;
+
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.filter.ComplexFilterSplitter;
+import org.geotools.data.jdbc.FilterToSQLException;
+import org.geotools.filter.FilterFactoryImplNamespaceAware;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.util.NullProgressListener;
 import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.PropertyIsEqualTo;
 import org.w3c.dom.Document;
 
 /**
@@ -86,4 +104,56 @@ public class NestedIdSupportTest extends AbstractAppSchemaTestSupport {
                 "wfs:FeatureCollection/gml:featureMember/gsml:Borehole/@gml:id", doc);
     }
 
+    @Test
+    public void testNestedFiltersEncoding() throws IOException, FilterToSQLException {
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+        FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+        AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+        FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+
+        // make sure nested filters encoding is enabled, otherwise skip test
+        assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
+
+        JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+        NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
+
+        FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+        ff.setNamepaceContext(rootMapping.getNamespaces());
+        
+        /*
+         * test filter on nested ID
+         */
+        PropertyIsEqualTo nestedIdFilter = ff
+                .equals(ff
+                        .property("gsml:specification/gsml:GeologicUnit/gsml:composition/gsml:CompositionPart/gsml:lithology/gsml:ControlledConcept/@gml:id"),
+                        ff.literal("cc.1"));
+
+        // Filter involves a single nested attribute --> can be encoded
+        ComplexFilterSplitter splitter = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitter.visit(nestedIdFilter, null);
+        Filter preFilter = splitter.getFilterPre();
+        Filter postFilter = splitter.getFilterPost();
+
+        assertEquals(nestedIdFilter, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        Filter unrolled = AppSchemaDataAccess.unrollFilter(nestedIdFilter, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        String encodedFilter = nestedFilterToSQL.encodeToString(unrolled);
+
+        // this is the generated query in PostGIS, but the test limits to check the presence of the
+        // a few keywords, as the actual SQL is dependent on the underlying database
+//        EXISTS (SELECT "chain_link_3"."PKEY" 
+//            FROM "appschematest"."CONTROLLEDCONCEPT" "chain_link_3" 
+//                INNER JOIN "appschematest"."COMPOSITIONPART" "chain_link_2" ON "chain_link_2"."ROW_ID" = "chain_link_3"."COMPOSITION_ID" 
+//                INNER JOIN "appschematest"."GEOLOGICUNIT" "chain_link_1" ON "chain_link_1"."COMPONENTPART_ID" = "chain_link_2"."ROW_ID" 
+//            WHERE "chain_link_3"."GML_ID" = 'cc.1' AND "appschematest"."MAPPEDFEATUREPROPERTYFILE"."GEOLOGIC_UNIT_ID" = "chain_link_1"."GML_ID")
+        assertTrue(encodedFilter.matches("^EXISTS.*SELECT.*FROM.*INNER JOIN.*INNER JOIN.*WHERE.*$"));
+        assertContainsFeatures(fs.getFeatures(nestedIdFilter), "mf4");
+    }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NestedIdSupportTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NestedIdSupportTest.java
@@ -148,11 +148,11 @@ public class NestedIdSupportTest extends AbstractAppSchemaTestSupport {
 
         // this is the generated query in PostGIS, but the test limits to check the presence of the
         // a few keywords, as the actual SQL is dependent on the underlying database
-//        EXISTS (SELECT "chain_link_3"."PKEY" 
-//            FROM "appschematest"."CONTROLLEDCONCEPT" "chain_link_3" 
-//                INNER JOIN "appschematest"."COMPOSITIONPART" "chain_link_2" ON "chain_link_2"."ROW_ID" = "chain_link_3"."COMPOSITION_ID" 
-//                INNER JOIN "appschematest"."GEOLOGICUNIT" "chain_link_1" ON "chain_link_1"."COMPONENTPART_ID" = "chain_link_2"."ROW_ID" 
-//            WHERE "chain_link_3"."GML_ID" = 'cc.1' AND "appschematest"."MAPPEDFEATUREPROPERTYFILE"."GEOLOGIC_UNIT_ID" = "chain_link_1"."GML_ID")
+        // EXISTS (SELECT "chain_link_3"."PKEY" 
+        //      FROM "appschematest"."CONTROLLEDCONCEPT" "chain_link_3" 
+        //           INNER JOIN "appschematest"."COMPOSITIONPART" "chain_link_2" ON "chain_link_2"."ROW_ID" = "chain_link_3"."COMPOSITION_ID" 
+        //           INNER JOIN "appschematest"."GEOLOGICUNIT" "chain_link_1" ON "chain_link_1"."COMPONENTPART_ID" = "chain_link_2"."ROW_ID" 
+        //      WHERE "chain_link_3"."GML_ID" = 'cc.1' AND "appschematest"."MAPPEDFEATUREPROPERTYFILE"."GEOLOGIC_UNIT_ID" = "chain_link_1"."GML_ID")
         assertTrue(encodedFilter.matches("^EXISTS.*SELECT.*FROM.*INNER JOIN.*INNER JOIN.*WHERE.*$"));
         assertContainsFeatures(fs.getFeatures(nestedIdFilter), "mf4");
     }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/PolymorphismWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/PolymorphismWfsTest.java
@@ -6,8 +6,25 @@
 
 package org.geoserver.test;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
+import java.io.IOException;
+
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.filter.ComplexFilterSplitter;
+import org.geotools.data.jdbc.FilterToSQLException;
+import org.geotools.filter.FilterFactoryImplNamespaceAware;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.util.NullProgressListener;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.PropertyIsEqualTo;
 import org.w3c.dom.Document;
 
 /**
@@ -702,4 +719,107 @@ public class PolymorphismWfsTest extends AbstractAppSchemaTestSupport {
         // f6: make sure nothing is encoded
         assertXpathCount(0, "//ex:PolymorphicFeature[@gml:id='f6']/ex:anyValue", doc);
     }
+
+    @Test
+    public void testNestedFilterEncoding() throws FilterToSQLException, IOException {
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("ex", "PolymorphicFeature");
+        FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+        AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+        FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+
+        // make sure nested filters encoding is enabled, otherwise skip test
+        assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
+
+        JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+
+        FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+        ff.setNamepaceContext(rootMapping.getNamespaces());
+
+        /*
+         * test equals filter on first nested attribute
+         */
+        PropertyIsEqualTo equalsFirstValue = ff.equals(
+                ff.property("ex:firstValue/gsml:CGI_NumericValue/gsml:principalValue"),
+                ff.literal(1.0));
+
+        // Filter involving conditional polymorphism --> CANNOT be encoded
+        ComplexFilterSplitter splitterFirstValueFilter = new ComplexFilterSplitter(
+                store.getFilterCapabilities(), rootMapping);
+        splitterFirstValueFilter.visit(equalsFirstValue, null);
+        Filter preFilter = splitterFirstValueFilter.getFilterPre();
+        Filter postFilter = splitterFirstValueFilter.getFilterPost();
+
+        assertEquals(Filter.INCLUDE, preFilter);
+        assertEquals(equalsFirstValue, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        Filter unrolled = AppSchemaDataAccess.unrollFilter(equalsFirstValue, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        assertContainsFeatures(fs.getFeatures(equalsFirstValue), "f1");
+
+        /*
+         * test equals filter on second nested attribute
+         */
+        PropertyIsEqualTo equalsSecondValue = ff.equals(
+                ff.property("ex:secondValue/gsml:CGI_NumericValue/gsml:principalValue/@uom"),
+                ff.literal("m"));
+
+        // Filter involving conditional polymorphism --> CANNOT be encoded
+        ComplexFilterSplitter splitterSecondValue = new ComplexFilterSplitter(
+                store.getFilterCapabilities(), rootMapping);
+        splitterSecondValue.visit(equalsSecondValue, null);
+        preFilter = splitterSecondValue.getFilterPre();
+        postFilter = splitterSecondValue.getFilterPost();
+
+        assertEquals(Filter.INCLUDE, preFilter);
+        assertEquals(equalsSecondValue, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        unrolled = AppSchemaDataAccess.unrollFilter(equalsSecondValue, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        assertContainsFeatures(fs.getFeatures(equalsSecondValue), "f1", "f3");
+
+        /*
+         * test equals filter on third nested attribute
+         */
+        PropertyIsEqualTo equalsThirdValue = ff.equals(
+                ff.property("ex:thirdValue/gsml:CGI_NumericValue/gsml:principalValue"),
+                ff.literal(1.0));
+
+        // Filter involving non-conditional polymorphism --> can be encoded, because target attribute mapping can be unequivocally determined a-priori
+        ComplexFilterSplitter splitterThirdValueFilter = new ComplexFilterSplitter(
+                store.getFilterCapabilities(), rootMapping);
+        splitterThirdValueFilter.visit(equalsThirdValue, null);
+        preFilter = splitterThirdValueFilter.getFilterPre();
+        postFilter = splitterThirdValueFilter.getFilterPost();
+
+        assertEquals(equalsThirdValue, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        unrolled = AppSchemaDataAccess.unrollFilter(equalsThirdValue, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        NestedFilterToSQL nestedFilterEncoder = createNestedFilterEncoder(rootMapping);
+        String encodedFilter = nestedFilterEncoder.encodeToString(unrolled);
+
+        // this is the generated query in PostGIS, but the test limits to check the presence of the
+        // EXISTS keyword, as the actual SQL is dependent on the underlying database
+//        (EXISTS (SELECT "chain_link_1"."PKEY" 
+//            FROM "appschematest"."POLYMORPHICFEATURE" "chain_link_1" 
+//            WHERE "chain_link_1"."NUMERIC_VALUE" = 1.0 AND "appschematest"."POLYMORPHICFEATURE"."VALUE_ID" = "chain_link_1"."ID")
+//        assertEquals(expected, encodedFilter);
+        assertTrue(encodedFilter.contains("EXISTS"));
+
+        assertContainsFeatures(fs.getFeatures(equalsThirdValue), "f1", "f4");
+    }
+
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/PolymorphismWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/PolymorphismWfsTest.java
@@ -813,10 +813,10 @@ public class PolymorphismWfsTest extends AbstractAppSchemaTestSupport {
 
         // this is the generated query in PostGIS, but the test limits to check the presence of the
         // EXISTS keyword, as the actual SQL is dependent on the underlying database
-//        (EXISTS (SELECT "chain_link_1"."PKEY" 
-//            FROM "appschematest"."POLYMORPHICFEATURE" "chain_link_1" 
-//            WHERE "chain_link_1"."NUMERIC_VALUE" = 1.0 AND "appschematest"."POLYMORPHICFEATURE"."VALUE_ID" = "chain_link_1"."ID")
-//        assertEquals(expected, encodedFilter);
+        // EXISTS (SELECT "chain_link_1"."PKEY" 
+        //      FROM "appschematest"."POLYMORPHICFEATURE" "chain_link_1" 
+        //      WHERE "chain_link_1"."NUMERIC_VALUE" = 1.0 AND 
+        //            "appschematest"."POLYMORPHICFEATURE"."VALUE_ID" = "chain_link_1"."ID"
         assertTrue(encodedFilter.contains("EXISTS"));
 
         assertContainsFeatures(fs.getFeatures(equalsThirdValue), "f1", "f4");

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
@@ -12,37 +12,18 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.logging.Level;
 
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.complex.AppSchemaDataAccess;
-import org.geotools.data.complex.AttributeMapping;
 import org.geotools.data.complex.FeatureTypeMapping;
-import org.geotools.data.complex.NestedAttributeMapping;
-import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
 import org.geotools.data.complex.filter.ComplexFilterSplitter;
-import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.jdbc.FilterToSQLException;
-import org.geotools.data.joining.JoiningNestedAttributeMapping;
-import org.geotools.feature.FeatureCollection;
-import org.geotools.feature.FeatureIterator;
 import org.geotools.filter.FilterFactoryImplNamespaceAware;
-import org.geotools.jdbc.BasicSQLDialect;
 import org.geotools.jdbc.JDBCDataStore;
-import org.geotools.jdbc.JoiningJDBCFeatureSource;
 import org.geotools.jdbc.NestedFilterToSQL;
-import org.geotools.jdbc.PreparedStatementSQLDialect;
-import org.geotools.jdbc.SQLDialect;
 import org.geotools.util.NullProgressListener;
-import org.hsqldb.jdbc.JDBCDataSource;
-import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
-import org.opengis.feature.Feature;
-import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsEqualTo;
@@ -466,11 +447,10 @@ public class SimpleAttributeFeatureChainWfsTest extends AbstractAppSchemaTestSup
 
         // this is the generated query in PostGIS, but the test limits to check the presence of the
         // EXISTS keyword, as the actual SQL is dependent on the underlying database
-//        String expectedEncoded = "EXISTS (SELECT \"chain_link_1\".\"PKEY\" "
-//                + "FROM \"appschematest\".\"MAPPEDFEATURENAMEONE\" \"chain_link_1\" "
-//                + "WHERE \"chain_link_1\".\"NAME\" = 'nameone 4' "
-//                + "AND \"appschematest\".\"MAPPEDFEATUREWITHNESTEDNAME\".\"ID\" = \"chain_link_1\".\"MF_ID\")";
-//        assertEquals(expectedEncoded, encodedFilter);
+        // EXISTS (SELECT "chain_link_1"."PKEY" 
+        //      FROM "appschematest"."MAPPEDFEATURENAMEONE" "chain_link_1" 
+        //      WHERE "chain_link_1"."NAME" = 'nameone 4' AND
+        //            "appschematest"."MAPPEDFEATUREWITHNESTEDNAME"."ID" = "chain_link_1"."MF_ID")
         assertTrue(encodedFilter.contains("EXISTS"));
         assertContainsFeatures(fs.getFeatures(propertyIsEqualTo), "mf3");
 
@@ -554,12 +534,12 @@ public class SimpleAttributeFeatureChainWfsTest extends AbstractAppSchemaTestSup
 
         // this is the generated query in PostGIS, but the test limits to check the presence of the
         // EXISTS keyword, as the actual SQL is dependent on the underlying database
-//        String expected = "(LEX_D = 'GUNTHORPE FORMATION' OR EXISTS (SELECT \"chain_link_1\".\"PKEY\" "
-//                + "FROM \"appschematest\".\"MAPPEDFEATURENAMEONE\" \"chain_link_1\" "
-//                + "WHERE \"chain_link_1\".\"NAME\" = 'nameone 4' "
-//                + "AND \"appschematest\".\"MAPPEDFEATUREWITHNESTEDNAME\".\"ID\" = \"chain_link_1\".\"MF_ID\"))";
-//        assertEquals(expected, encodedCombined);
-        assertTrue(encodedCombined.contains("EXISTS"));
+        // (LEX_D = 'GUNTHORPE FORMATION' OR EXISTS 
+        //      (SELECT "chain_link_1"."PKEY" 
+        //      FROM "appschematest"."MAPPEDFEATURENAMEONE" "chain_link_1" 
+        //      WHERE "chain_link_1"."NAME" = 'nameone 4' AND 
+        //            "appschematest"."MAPPEDFEATUREWITHNESTEDNAME"."ID" = "chain_link_1"."MF_ID"))
+        assertTrue(encodedCombined.matches("^\\(.*GUNTHORPE FORMATION.*OR.*EXISTS.*\\)$"));
         assertContainsFeatures(fs.getFeatures(combined), "mf1", "mf3");
 
         /*

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
@@ -6,8 +6,47 @@
 
 package org.geoserver.test;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.AttributeMapping;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.NestedAttributeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.complex.filter.ComplexFilterSplitter;
+import org.geotools.data.jdbc.FilterToSQL;
+import org.geotools.data.jdbc.FilterToSQLException;
+import org.geotools.data.joining.JoiningNestedAttributeMapping;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.filter.FilterFactoryImplNamespaceAware;
+import org.geotools.jdbc.BasicSQLDialect;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.JoiningJDBCFeatureSource;
+import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.jdbc.PreparedStatementSQLDialect;
+import org.geotools.jdbc.SQLDialect;
+import org.geotools.util.NullProgressListener;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.Or;
+import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsNotEqualTo;
 import org.w3c.dom.Document;
 
 /**
@@ -383,6 +422,169 @@ public class SimpleAttributeFeatureChainWfsTest extends AbstractAppSchemaTestSup
                 "http://www.opengis.net/gml/srs/epsg.xml#4283",
                 "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf3']/gsml:shape/gml:Polygon/@srsName",
                 doc);
+    }
+
+    @Test
+    public void testNestedFilterEncoding() throws IOException, FilterToSQLException {
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+        FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+        AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+        FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+
+        // make sure nested filters encoding is enabled, otherwise skip test
+        assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
+
+        JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+        NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
+
+        FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+        ff.setNamepaceContext(rootMapping.getNamespaces());
+
+        /*
+         * test filter by name coming from child table
+         */
+        PropertyIsEqualTo propertyIsEqualTo = ff.equals(ff.property("gml:name[2]"),
+                ff.literal("nameone 4"));
+
+        // Filter involving single nested attribute --> can be encoded
+        ComplexFilterSplitter splitter = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitter.visit(propertyIsEqualTo, null);
+        Filter preFilter = splitter.getFilterPre();
+        Filter postFilter = splitter.getFilterPost();
+
+        assertEquals(propertyIsEqualTo, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        Filter unrolled = AppSchemaDataAccess.unrollFilter(propertyIsEqualTo, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        String encodedFilter = nestedFilterToSQL.encodeToString(unrolled);
+
+        // this is the generated query in PostGIS, but the test limits to check the presence of the
+        // EXISTS keyword, as the actual SQL is dependent on the underlying database
+//        String expectedEncoded = "EXISTS (SELECT \"chain_link_1\".\"PKEY\" "
+//                + "FROM \"appschematest\".\"MAPPEDFEATURENAMEONE\" \"chain_link_1\" "
+//                + "WHERE \"chain_link_1\".\"NAME\" = 'nameone 4' "
+//                + "AND \"appschematest\".\"MAPPEDFEATUREWITHNESTEDNAME\".\"ID\" = \"chain_link_1\".\"MF_ID\")";
+//        assertEquals(expectedEncoded, encodedFilter);
+        assertTrue(encodedFilter.contains("EXISTS"));
+        assertContainsFeatures(fs.getFeatures(propertyIsEqualTo), "mf3");
+
+        /*
+         * test filter on attribute of root feature type
+         */
+        PropertyIsEqualTo ordinaryFilter = ff.equals(ff.property("gml:name[1]"),
+                ff.literal("GUNTHORPE FORMATION"));
+
+        // Filter involving direct attribute of root feature type --> can be encoded
+        ComplexFilterSplitter splitter2 = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitter2.visit(ordinaryFilter, null);
+        preFilter = splitter2.getFilterPre();
+        postFilter = splitter2.getFilterPost();
+
+        assertEquals(ordinaryFilter, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // Filter must be "unrolled" (i.e. reverse mapped) prior to being encoded
+        unrolled = AppSchemaDataAccess.unrollFilter(ordinaryFilter, rootMapping);
+
+        // Filter is NOT nested
+        assertFalse(NestedFilterToSQL.isNestedFilter(unrolled));
+        // IS THIS A BUG?!?
+        String ordinaryEncoded = nestedFilterToSQL.encodeToString(unrolled);
+
+        assertFalse(ordinaryEncoded.contains("EXISTS"));
+        assertContainsFeatures(fs.getFeatures(ordinaryFilter), "mf1");
+
+        /*
+         * test filter matching multiple mappings
+         */
+        PropertyIsEqualTo multipleFilter = ff.equals(ff.property("gml:name"),
+                ff.literal("GUNTHORPE FORMATION"));
+
+        // Filter involves multiple nested attributes --> CANNOT be encoded
+        ComplexFilterSplitter splitter3 = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitter3.visit(multipleFilter, null);
+        preFilter = splitter3.getFilterPre();
+        postFilter = splitter3.getFilterPost();
+
+        assertEquals(Filter.INCLUDE, preFilter);
+        assertEquals(multipleFilter, postFilter);
+
+        // Filter must be "unrolled" (i.e. reverse mapped) first
+        unrolled = AppSchemaDataAccess.unrollFilter(multipleFilter, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        assertContainsFeatures(fs.getFeatures(multipleFilter), "mf1");
+
+        /*
+         * test combined filter, i.e. a filter composed of a "regular" filter, and a nested filter
+         */
+        PropertyIsEqualTo regularFilter = ff.equals(ff.property("gml:name[1]"),
+                ff.literal("GUNTHORPE FORMATION"));
+        PropertyIsEqualTo nestedFilter = ff.equals(ff.property("gml:name[2]"),
+                ff.literal("nameone 4"));
+        Or combined = ff.or(regularFilter, nestedFilter);
+
+        // Filter can be encoded!
+        ComplexFilterSplitter splitterCombined = new ComplexFilterSplitter(
+                store.getFilterCapabilities(), rootMapping);
+        splitterCombined.visit(combined, null);
+        preFilter = splitterCombined.getFilterPre();
+        postFilter = splitterCombined.getFilterPost();
+
+        assertEquals(combined, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // Filter must be "unrolled" (i.e. reverse mapped) first
+        unrolled = AppSchemaDataAccess.unrollFilter(combined, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        String encodedCombined = nestedFilterToSQL.encodeToString(unrolled);
+
+        // this is the generated query in PostGIS, but the test limits to check the presence of the
+        // EXISTS keyword, as the actual SQL is dependent on the underlying database
+//        String expected = "(LEX_D = 'GUNTHORPE FORMATION' OR EXISTS (SELECT \"chain_link_1\".\"PKEY\" "
+//                + "FROM \"appschematest\".\"MAPPEDFEATURENAMEONE\" \"chain_link_1\" "
+//                + "WHERE \"chain_link_1\".\"NAME\" = 'nameone 4' "
+//                + "AND \"appschematest\".\"MAPPEDFEATUREWITHNESTEDNAME\".\"ID\" = \"chain_link_1\".\"MF_ID\"))";
+//        assertEquals(expected, encodedCombined);
+        assertTrue(encodedCombined.contains("EXISTS"));
+        assertContainsFeatures(fs.getFeatures(combined), "mf1", "mf3");
+
+        /*
+         * test filter comparing multiple nested attributes
+         */
+        PropertyIsNotEqualTo notEquals = ff.notEqual(ff.property("gml:name[2]"),
+                ff.property("gml:name[3]"));
+
+        // Filter involves multiple nested attributes --> CANNOT be encoded
+        ComplexFilterSplitter splitterNotEquals = new ComplexFilterSplitter(
+                store.getFilterCapabilities(), rootMapping);
+        splitterNotEquals.visit(notEquals, null);
+        preFilter = splitterNotEquals.getFilterPre();
+        postFilter = splitterNotEquals.getFilterPost();
+
+        assertEquals(Filter.INCLUDE, preFilter);
+        assertEquals(notEquals, postFilter);
+
+        // Filter must be "unrolled" (i.e. reverse mapped) first
+        unrolled = AppSchemaDataAccess.unrollFilter(notEquals, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        assertContainsFeatures(fs.getFeatures(notEquals), "mf1", "mf2", "mf3", "mf4");
     }
 
     private void checkMf1(Document doc) {


### PR DESCRIPTION
This PR adds unit tests and docs for the GeoTools implementation described in [GEOT-5526](https://osgeo-org.atlassian.net/browse/GEOT-5526).

Tests have been added here rather than in the GeoTools app-schema module because they are necessarily online tests.

Related GeoTools PR:
https://github.com/geotools/geotools/pull/1319 