### PR TITLE
[GEOS-7771] Fix JSON encoding for a list of nulls

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.thoughtworks.xstream.io.json.JettisonStaxWriter;
 import org.apache.commons.collections.MultiHashMap;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.AttributionInfo;
@@ -1155,8 +1156,9 @@ public class XStreamPersister {
                     String typeName = cam.serializedClass( theClass );
                     writer.addAttribute("type", typeName);
                 }
-                
                 context.convertAnother( item, new ReferenceConverter( clazz ) );
+            } else if (writer instanceof JettisonStaxWriter) {
+                writer.setValue("null");
             }
             writer.endNode();
         }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7771

This particular solution causes a null value to be returned as "null" when encoded as JSON.

For example `{styles: {style: ["null", "null", "null", "null", "null"]}}`