### PR TITLE
[GEOS-7744] Makes layers data by default only editable by admin users (backport 2.8.x)

### DIFF
--- a/doc/en/user/source/security/layer.rst
+++ b/doc/en/user/source/security/layer.rst
@@ -9,6 +9,8 @@ GeoServer allows access to be determined on a per-layer basis.
 
 Providing access to layers is linked to :ref:`roles <sec_rolesystem_roles>`. Layers and roles are linked in a file called ``layers.properties``, which is located in the ``security`` directory in your GeoServer data directory. The file contains the rules that control access to workspaces and layers.
 
+.. note:: The default layers security configuration in GeoServer allows any anonymous user to read data from any layer but only allows admin users to edit data.
+
 Rules
 -----
 

--- a/src/main/src/main/java/org/geoserver/security/impl/layers.properties.template
+++ b/src/main/src/main/java/org/geoserver/security/impl/layers.properties.template
@@ -6,4 +6,4 @@
 # The operation will be allowed if the current user has at least one of the
 # roles in the rule
 *.*.r=*
-*.*.w=ADMIN,GROUP_ADMI
+*.*.w=ADMIN,GROUP_ADMIN

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CascadeVisitorAbstractTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CascadeVisitorAbstractTest.java
@@ -23,8 +23,9 @@ public class CascadeVisitorAbstractTest extends GeoServerSystemTestSupport {
     protected static final String WS_STYLE = "wsStyle";
 
     protected void setUpTestData(org.geoserver.data.test.SystemTestData testData) throws Exception {
-        // add nothing here
-    };
+        // use the default tests security
+        testData.setUpSecurity();
+    }
 
     protected void onSetUp(org.geoserver.data.test.SystemTestData testData) throws Exception {
         Catalog catalog = getCatalog();
@@ -34,7 +35,6 @@ public class CascadeVisitorAbstractTest extends GeoServerSystemTestSupport {
         testData.addVectorLayer(BRIDGES, catalog);
         testData.addVectorLayer(FORESTS, catalog);
         testData.addVectorLayer(BUILDINGS, catalog);
-
         setupExtras(testData, catalog);
     }
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/WFSCurvesTestSupport.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/WFSCurvesTestSupport.java
@@ -65,5 +65,6 @@ public class WFSCurvesTestSupport extends WFSTestSupport {
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
         // do not call super, we only need the curved data sets
+        testData.setUpSecurity();
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/WFSXStreamLoaderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/WFSXStreamLoaderTest.java
@@ -21,6 +21,7 @@ public class WFSXStreamLoaderTest extends WFSTestSupport {
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
         // no test data needed
+        testData.setUpSecurity();
     }
 
     @Test

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/Transaction3DTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/Transaction3DTest.java
@@ -46,7 +46,8 @@ public class Transaction3DTest extends WFSTestSupport {
     
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
-        // only need the 3d test data, not the rest 
+        // only need the 3d test data, not the rest
+        testData.setUpSecurity();
     }
     
     @Before


### PR DESCRIPTION
This pull request changes the default configuration so that by default  layers data can only be edited by admin users. Documentation was also updated.

Mailing list discussion: http://osgeo-org.1560.x6.nabble.com/Who-changed-my-data-or-is-it-sane-to-have-WFS-T-open-to-all-by-default-td5286288.html

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7744

Backport of pull request: https://github.com/geoserver/geoserver/pull/1835