### PR TITLE
[GEOS-7570] Add test case for GetFeatureInfo with generic geometries (backport 2.9.x)

### DIFF
--- a/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/genericLines.properties
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/genericLines.properties
@@ -1,0 +1,5 @@
+_=geom:Geometry:4326,name:String
+line.1=LINESTRING(-1  1, -1 -1)|line1
+line.2=LINESTRING(-1 -1,  1 -1)|line2
+line.3=LINESTRING( 1 -1,  1  1)|line3
+line.4=LINESTRING( 1  1, -1  1)|line4

--- a/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/genericLines.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/genericLines.sld
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" 
+		xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+		xmlns="http://www.opengis.net/sld" 
+		xmlns:ogc="http://www.opengis.net/ogc" 
+		xmlns:xlink="http://www.w3.org/1999/xlink" 
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<NamedLayer>
+		<Name>LineWidth</Name>
+		<UserStyle>
+			<FeatureTypeStyle>
+				<Rule>
+					<LineSymbolizer>
+						<Stroke>
+							<CssParameter name="stroke">#0000FF</CssParameter>
+						</Stroke>
+					</LineSymbolizer>
+				</Rule>
+		    </FeatureTypeStyle>
+		</UserStyle>
+	</NamedLayer>
+</StyledLayerDescriptor>
+


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-7570

The actual fix for this is performed by this GeoTools pull request:
geotools/geotools#1329

This pull request only adds a new test case based on this issue.

Backport of pull request:
https://github.com/geoserver/geoserver/pull/1860