### PR TITLE
Re-set entityResolverPrivider on configuration reload. Pass entityResolver to WMSStore

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePoolInitializer.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePoolInitializer.java
@@ -11,6 +11,7 @@ import org.geoserver.config.ConfigurationListenerAdapter;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.GeoServerInitializer;
+import org.geoserver.config.GeoServerReinitializer;
 import org.geoserver.util.EntityResolverProvider;
 
 /**
@@ -19,7 +20,7 @@ import org.geoserver.util.EntityResolverProvider;
  * @author Justin Deoliveira, OpenGeo
  *
  */
-public class ResourcePoolInitializer implements GeoServerInitializer {
+public class ResourcePoolInitializer implements GeoServerReinitializer {
 
     GeoServer gs;
     EntityResolverProvider resolverProvider;

--- a/src/main/src/main/java/org/geoserver/config/GeoServerInitializer.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerInitializer.java
@@ -14,5 +14,11 @@ package org.geoserver.config;
  */
 public interface GeoServerInitializer {
 
+    /**
+     * Performs initialization of GeoServer configuration.
+     * 
+     * @param geoServer
+     * @throws Exception
+     */
     void initialize( GeoServer geoServer ) throws Exception;
 }

--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -152,6 +152,19 @@ public abstract class GeoServerLoader {
         }
     }
     
+    protected void reloadInitializers(GeoServer geoServer) throws Exception {
+        //reload applicable initializer extensions
+        List<GeoServerReinitializer> initializers = GeoServerExtensions.extensions( GeoServerReinitializer.class );
+        for ( GeoServerReinitializer initer : initializers ) {
+            try {
+                initer.reinitialize( geoServer );
+            }
+            catch( Throwable t ) {
+                LOGGER.log(Level.SEVERE, "Failed to run initializer " + initer, t);
+            }
+        }
+    }
+    
     /**
      * Does some post processing on the catalog to ensure that the "well-known" styles
      * are always around.
@@ -206,6 +219,8 @@ public abstract class GeoServerLoader {
         
         loadCatalog( catalog, xp );
         loadGeoServer( geoserver, xp);
+        
+        reloadInitializers(geoserver);
     }
 
     protected void readCatalog(Catalog catalog, XStreamPersister xp) throws Exception {

--- a/src/main/src/main/java/org/geoserver/config/GeoServerReinitializer.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerReinitializer.java
@@ -1,0 +1,25 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config;
+
+
+/**
+ * Extension point interface for initializing based on configuration.
+ * Intended to be run both upon configuration initialization, and upon reload
+ *
+ */
+public interface GeoServerReinitializer extends GeoServerInitializer { 
+
+    /**
+     * Performs initialization  of GeoServer configuration, as well as any actions that should be
+     * performed only when reloading the configuration.
+     * 
+     * @param geoServer
+     * @throws Exception
+     */
+    default void reinitialize( GeoServer geoServer ) throws Exception {
+        initialize(geoServer);
+    };
+}

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.*;
 
 import java.awt.image.RenderedImage;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
@@ -62,6 +63,7 @@ import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.style.ExternalGraphic;
 import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
 
 /**
  * Tests for {@link ResourcePool}.
@@ -441,7 +443,11 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
     
     @Test
     public void testWmsCascadeEntityExpansion() throws Exception {
-        final ResourcePool rp = getCatalog().getResourcePool();
+        //Other tests mess with or reset the resourcePool, so lets make it is initialized properly
+        GeoServerExtensions.extensions(ResourcePoolInitializer.class).get(0).initialize(getGeoServer());
+        
+        ResourcePool rp = getCatalog().getResourcePool();
+        
         WMSStoreInfo info = getCatalog().getFactory().createWebMapServer();
         URL url = getClass().getResource("1.3.0Capabilities-xxe.xml");
         info.setCapabilitiesURL(url.toExternalForm());
@@ -450,10 +456,31 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
         info.setUseConnectionPooling(false);
         try {
             rp.getWebMapServer(info);
+            fail("WebMapServer instantiation should fail");
         } catch(IOException e) {
             assertThat(e.getCause(), instanceOf(ServiceException.class));
-            ServiceException cause = (ServiceException) e.getCause();
-            assertThat(cause.getMessage(), containsString("Error while parsing XML"));
+            ServiceException serviceException = (ServiceException) e.getCause();
+            assertThat(serviceException.getMessage(), containsString("Error while parsing XML"));
+            
+            SAXException saxException = (SAXException) serviceException.getCause();
+            Exception cause = saxException.getException();
+            assertFalse("Expect external entity cause", cause != null && cause instanceof FileNotFoundException);
+        }
+        //make sure clearing the catalog does not clear the EntityResolver
+        getGeoServer().reload();
+        rp = getCatalog().getResourcePool();
+        
+        try {
+            rp.getWebMapServer(info);
+            fail("WebMapServer instantiation should fail");
+        } catch(IOException e) {
+            assertThat(e.getCause(), instanceOf(ServiceException.class));
+            ServiceException serviceException = (ServiceException) e.getCause();
+            assertThat(serviceException.getMessage(), containsString("Error while parsing XML"));
+            
+            SAXException saxException = (SAXException) serviceException.getCause();
+            Exception cause = saxException.getException();
+            assertFalse("Expect external entity cause", cause != null && cause instanceof FileNotFoundException);
         }
         
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreNewPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreNewPage.java
@@ -129,7 +129,7 @@ public class WMSStoreNewPage extends AbstractWMSStorePage {
                     }
                 }
                 
-                WebMapServer server = new WebMapServer(new URL(url), client);
+                WebMapServer server = new WebMapServer(new URL(url), client, hints);
                 server.getCapabilities();
             } catch(IOException | ServiceException e) {
                 IValidationError err = new ValidationError("WMSCapabilitiesValidator.connectionFailure")

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/1.3.0Capabilities-xxe.xml
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/1.3.0Capabilities-xxe.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<!DOCTYPE Name [ 
+ <!ENTITY file SYSTEM "file:///file/not/there">]>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms capabilities_1_3_0.xsd">
+	<!-- Service Metadata -->
+	<Service>
+		<!-- The WMT-defined name for this type of service -->
+		<Name>WMS</Name>
+		<!-- Human-readable title for pick lists -->
+		<Title>World Map</Title>
+		<!-- Narrative description providing additional information -->
+		<Abstract>None</Abstract>
+		<!-- Top-level web address of service or service provider.  See also OnlineResource
+  elements under <DCPType>. -->
+		<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl"/>
+		<!-- Contact information -->
+		<ContactInformation>
+			<ContactPersonPrimary>
+				<ContactPerson></ContactPerson>
+				<ContactOrganization></ContactOrganization>
+			</ContactPersonPrimary>
+			<ContactPosition>None</ContactPosition>
+			<ContactAddress>
+				<AddressType>None</AddressType>
+				<Address>None</Address>
+				<City>None</City>
+				<StateOrProvince>None</StateOrProvince>
+				<PostCode>None</PostCode>
+				<Country>None</Country>
+			</ContactAddress>
+			<ContactVoiceTelephone>None</ContactVoiceTelephone>
+			<ContactElectronicMailAddress></ContactElectronicMailAddress>
+		</ContactInformation>
+		<!-- Fees or access constraints imposed. -->
+		<Fees>none</Fees>
+		<AccessConstraints>none</AccessConstraints>
+		<LayerLimit>40</LayerLimit>
+		<MaxWidth>2000</MaxWidth>
+		<MaxHeight>2000</MaxHeight>
+	</Service>
+	<Capability>
+		<Request>
+			<GetCapabilities>
+				<Format>text/xml</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+						<Post>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Post>
+					</HTTP>
+				</DCPType>
+			</GetCapabilities>
+			<GetMap>
+				<Format>image/gif</Format>
+				<Format>image/png</Format>
+				<Format>image/jpeg</Format>
+				<Format>image/bmp</Format>
+				<Format>image/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<!-- The URL here for invoking GetCapabilities using HTTP GET
+            is only a prefix to which a query string is appended. -->
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetMap>
+			<GetFeatureInfo>
+				<Format>text/xml</Format>
+				<Format>text/plain</Format>
+				<Format>text/html</Format>
+				<Format>text/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetFeatureInfo>
+		</Request>
+		<Exception>
+			<Format>XML</Format>
+			<Format>INIMAGE</Format>
+			<Format>BLANK</Format>
+		</Exception>
+		<Layer>
+			<Title>World Map</Title>
+			<CRS>CRS:84</CRS>
+			<!-- all layers are available in at least this CRS -->
+			<EX_GeographicBoundingBox>
+				<westBoundLongitude>-180</westBoundLongitude>
+				<eastBoundLongitude>180</eastBoundLongitude>
+				<southBoundLatitude>-90</southBoundLatitude>
+				<northBoundLatitude>90</northBoundLatitude>
+			</EX_GeographicBoundingBox>
+			<BoundingBox CRS="CRS:84" minx="-184" miny="-90.0000000017335" maxx="180" maxy="90"/>
+			<Layer queryable="1" opaque="1">
+				<Name>&file;</Name>
+				<Title>Bathymetry</Title>
+				<BoundingBox CRS="CRS:84" minx="-180" miny="-90" maxx="180" maxy="90"/>
+			</Layer>
+		</Layer>
+	</Capability>
+</WMS_Capabilities>
+

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/WMSStoreNewPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/WMSStoreNewPageTest.java
@@ -7,9 +7,12 @@ package org.geoserver.web.data.store;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.net.URL;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.ResourcePool;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.geoserver.web.data.store.panel.WorkspacePanel;
@@ -88,6 +91,48 @@ public class WMSStoreNewPageTest extends GeoServerWicketTestSupport {
 
         tester.clickLink("form:save", true);
         tester.assertErrorMessages("Connection test failed: foo");
+        catalog.save(info);
+
+        assertNotNull(info.getId());
+
+        WMSStoreInfo expandedStore = catalog.getResourcePool().clone(info, true);
+
+        assertNotNull(expandedStore.getId());
+        assertNotNull(expandedStore.getCatalog());
+
+        catalog.validate(expandedStore, false).throwIfInvalid();
+    }
+    
+    @Test
+    public void testSaveNewStoreEntityExpansion() throws Exception {
+
+        WMSStoreNewPage page = startPage();
+
+        assertNull(page.getDefaultModelObject());
+
+        final Catalog catalog = getCatalog();
+        WMSStoreInfo info = getCatalog().getFactory().createWebMapServer();
+        URL url = getClass().getResource("1.3.0Capabilities-xxe.xml");
+        info.setName("bar");
+
+        tester.assertNoErrorMessage();
+
+        FormTester form = tester.newFormTester("form");
+        form.select("workspacePanel:border:border_body:paramValue", 4);
+        Component wsDropDown = tester.getComponentFromLastRenderedPage(
+                "form:workspacePanel:border:border_body:paramValue");
+        tester.executeAjaxEvent(wsDropDown, "change");
+        form.setValue("namePanel:border:border_body:paramValue", "bar");
+        form.setValue("capabilitiesURL:border:border_body:paramValue", url.toExternalForm());
+
+        tester.clickLink("form:save", true);
+        tester.assertErrorMessages("Connection test failed: Error while parsing XML.");
+        
+        //make sure clearing the catalog does not clear the EntityResolver
+        getGeoServer().reload();
+        tester.clickLink("form:save", true);
+        tester.assertErrorMessages("Connection test failed: Error while parsing XML.");
+        
         catalog.save(info);
 
         assertNotNull(info.getId());


### PR DESCRIPTION
Add GeoServerReinitializer marker interface for GeoServerInitializers that should be run on both inital load and reload.
Updated test case, including improved cause verification based on GEOT-5533.