### PR TITLE
[GEOS-7782] Add INSPIRE grid set when INSPIRE extensions is loaded

### DIFF
--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wmts/InspireGridSetLoader.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wmts/InspireGridSetLoader.java
@@ -1,0 +1,55 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.inspire.wmts;
+
+import org.geoserver.gwc.GWC;
+import org.geoserver.platform.ContextLoadedEvent;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSet;
+import org.geowebcache.grid.GridSetFactory;
+import org.geowebcache.grid.SRS;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * Loads the inspire grid set and mark it as non editable by the user.
+ */
+public class InspireGridSetLoader implements ApplicationListener<ContextLoadedEvent> {
+
+    public static final String INSPIRE_GRID_SET_NAME = "InspireCRS84Quad";
+
+    @Override
+    public synchronized void onApplicationEvent(ContextLoadedEvent event) {
+        GWC gwc = GWC.get();
+        // this grid set should not be editable by the user
+        gwc.addEmbeddedGridSet(INSPIRE_GRID_SET_NAME);
+        GridSet gridSet = gwc.getGridSetBroker().get(INSPIRE_GRID_SET_NAME);
+        if (gridSet != null) {
+            // this grid set already exists
+            return;
+        }
+        // the grid set resolutions
+        double[] resolutions = new double[]{
+                0.703125, 0.3515625, 0.17578125, 0.087890625, 0.0439453125, 0.02197265625, 0.010986328125, 0.0054931640625,
+                0.00274658203125, 0.001373291015625, 6.866455078125E-4, 3.433227539062E-4, 1.716613769531E-4, 8.58306884766E-5,
+                4.29153442383E-5, 2.14576721191E-5, 1.07288360596E-5, 5.3644180298E-6};
+        // the grid sets scale names
+        String[] scaleNames = new String[]{
+                "InspireCRS84Quad:0", "InspireCRS84Quad:1", "InspireCRS84Quad:2", "InspireCRS84Quad:3", "InspireCRS84Quad:4",
+                "InspireCRS84Quad:5", "InspireCRS84Quad:6", "InspireCRS84Quad:7", "InspireCRS84Quad:8", "InspireCRS84Quad:9",
+                "InspireCRS84Quad:10", "InspireCRS84Quad:11", "InspireCRS84Quad:12", "InspireCRS84Quad:13", "InspireCRS84Quad:14",
+                "InspireCRS84Quad:15", "InspireCRS84Quad:16", "InspireCRS84Quad:17"};
+        // creating thee grid set
+        gridSet = GridSetFactory.createGridSet(INSPIRE_GRID_SET_NAME, SRS.getEPSG4326(), BoundingBox.WORLD4326, false,
+                resolutions, null, 111319.49079327358, GridSetFactory.DEFAULT_PIXEL_SIZE_METER, scaleNames, 256, 256, false);
+        // set a proper description
+        gridSet.setDescription("Every layer offered by a INSPIRE WMTS should use the InspireCRS84Quad Matrix Set");
+        try {
+            // add the grid set
+            gwc.addGridSet(gridSet);
+        } catch (Exception exception) {
+            throw new RuntimeException("Error adding grid set InspireCRS84Quad.", exception);
+        }
+    }
+}

--- a/src/extension/inspire/src/main/resources/applicationContext.xml
+++ b/src/extension/inspire/src/main/resources/applicationContext.xml
@@ -48,4 +48,7 @@
     <property name="componentClass" value="org.geoserver.inspire.web.InspireAdminPanel"/>
     <property name="serviceClass" value="org.geoserver.gwc.wmts.WMTSInfo"/>
   </bean>
+
+  <bean id="inspireGridSetLoader" class="org.geoserver.inspire.wmts.InspireGridSetLoader">
+  </bean>
 </beans>

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/InspireGridSetLoaderTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/InspireGridSetLoaderTest.java
@@ -1,0 +1,28 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.inspire.wmts;
+
+import org.geoserver.gwc.GWC;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+
+import static org.geoserver.inspire.wmts.InspireGridSetLoader.INSPIRE_GRID_SET_NAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Testing that INSPIRE grid set is correctly loaded and configured.
+ */
+public class InspireGridSetLoaderTest extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testGridSetLoading() throws Exception {
+        GWC gwc = GWC.get();
+        // let's see if the inspire grid set has been correctly registered
+        assertThat(gwc.getGridSetBroker().get(INSPIRE_GRID_SET_NAME), notNullValue());
+        assertThat(gwc.isInternalGridSet(INSPIRE_GRID_SET_NAME), is(true));
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -223,6 +223,9 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     private GeoWebCacheEnvironment gwcEnvironment;
     
     final GeoServerEnvironment gsEnvironment = GeoServerExtensions.bean(GeoServerEnvironment.class);
+
+    // list of GeoServer contributed grid sets that should not be editable by the user
+    private final Set<String> geoserverEmbeddedGridSets = new HashSet<>();
     
     public GWC(final GWCConfigPersister gwcConfigPersister, final StorageBroker sb,
             final TileLayerDispatcher tld, final GridSetBroker gridSetBroker,
@@ -1883,12 +1886,18 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     }
 
     /**
+     * Add the provided grid set id to the list of GeoServer grid sets that cannot be edited by the user.
+     */
+    public void addEmbeddedGridSet(String gridSetId) {
+        geoserverEmbeddedGridSets.add(gridSetId);
+    }
+
+    /**
      * @return {@code true} if the GridSet named {@code gridSetId} is a GWC internally defined one,
      *         {@code false} otherwise
      */
     public boolean isInternalGridSet(final String gridSetId) {
-        boolean internal = gridSetBroker.getEmbeddedNames().contains(gridSetId);
-        return internal;
+        return gridSetBroker.getEmbeddedNames().contains(gridSetId) || geoserverEmbeddedGridSets.contains(gridSetId);
     }
 
     /**


### PR DESCRIPTION
This pull request added a new method on GWC singleton to allow GeoServer extensions to register non editable grid sets.

Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-7782

