### PR TITLE
[GEOS-7782] Add INSPIRE grid set when INSPIRE extensions is loaded (backport 2.9.x)

### DIFF
--- a/doc/en/user/source/extensions/inspire/using.rst
+++ b/doc/en/user/source/extensions/inspire/using.rst
@@ -10,17 +10,17 @@ When the INSPIRE extension has been properly installed, the :ref:`services_webad
 
 .. note:: If you do not see this content in the service configuration pages, the INSPIRE extension may not be installed properly.  Reread the section on :ref:`inspire_installing` and verify that the correct file was saved to the correct directory.
 
-Extended WMS configuration
---------------------------
+Extended WMS and WMTS configuration
+-----------------------------------
 
-INSPIRE-specific configuration is accessed on the main :ref:`services_webadmin_wms` page in the :ref:`web_admin`. This is accessed by clicking on the :guilabel:`WMS` link on the sidebar.
+INSPIRE-specific configuration is accessed on the main :ref:`services_webadmin_wms` or WMTS settings page in the :ref:`web_admin`. This is accessed by clicking on the :guilabel:`WMS` or :guilabel:`WMTS` link on the sidebar.
 
-.. note:: You must be logged in as an administrator to edit WMS configuration.
+.. note:: You must be logged in as an administrator to edit WMS or WMTS configuration.
 
-Once on the WMS configuration page, there will be a block titled :guilabel:`INSPIRE`. If you enable the checkbox shown above this section will have three additional settings:
+Once on the service configuration page, there will be a block titled :guilabel:`INSPIRE`. If you enable the checkbox shown above this section will have three additional settings:
 
 * :guilabel:`Language` combo box, for setting the Supported, Default, and Response languages
-* :guilabel:`Service Metadata URL` field, a URL containing the location of the metadata associated with the WMS
+* :guilabel:`Service Metadata URL` field, a URL containing the location of the metadata associated with the service
 * :guilabel:`Service Metadata Type` combo box, for detailing whether the metadata came from a CSW (Catalog Service) or a standalone metadata file
 
 .. figure:: images/inspire.png
@@ -28,7 +28,7 @@ Once on the WMS configuration page, there will be a block titled :guilabel:`INSP
 
    *INSPIRE-related options*
 
-After clicking :guilabel:`Submit` on this page, any changes will be immediately reflected in the WMS 1.3.0 capabilities document.
+After clicking :guilabel:`Submit` on this page, any changes will be immediately reflected in the services (WMS 1.3.0 or WMTS 1.0.0) capabilities document.
 
 .. note:: At the time of writing the `INSPIRE Schemas <http://inspire.ec.europa.eu/schemas/common/1.0/common.xsd>`_ only allow 23 choices for :guilabel:`Language`. The GeoServer INSPIRE extension allows some other languages to be chosen. If you choose one of these your capabilities document won't be Schema valid but, as discussed in :geos:`issue 7388 <7388>`, the INSPIRE Schemas seem to be at fault. If you have some other language you want adding to the list then please :ref:`raise the issue <getting_involved>`.
 
@@ -38,12 +38,12 @@ After clicking :guilabel:`Submit` on this page, any changes will be immediately 
 
 .. note:: Currently GeoServer does not offer the ability to configure alternate languages, as there is no way for an administrator to configure multiple responses.  There is an :geos:`open issue <4502>` on the GeoServer issue tracker that we are hoping to secure funding for.  If you are interested in implementing or funding this improvement, please raise the issue on the :ref:`GeoServer mailing list <getting_involved>`.
 
-Extended WMS Capabilities
--------------------------
+Extended WMS and WMTS Capabilities
+----------------------------------
 
 .. note:: The INSPIRE extension only modifies the WMS 1.3.0 response, so please make sure that you are viewing the correct capabilities document.
 
-The WMS 1.3.0 capabilities document will contain two additional entries in the ``xsi:schemaLocation`` of the root ``<WMS_Capabilities>`` tag once the INSPIRE extension is installed:
+The WMS 1.3.0 and WMTS 1.0.0 capabilities document will contain two additional entries in the ``xsi:schemaLocation`` of the root ``<WMS_Capabilities>`` tag once the INSPIRE extension is installed:
 
 * ``http://inspire.ec.europa.eu/schemas/inspire_vs/1.0``
 * ``http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd``
@@ -72,6 +72,8 @@ With the example values shown in the above configuration panel, this block would
     <inspire_common:Language>eng</inspire_common:Language>
    </inspire_common:ResponseLanguage>
   </inspire_vs:ExtendedCapabilities>
+
+ISNPIRE recommends that every layer offered by a INSPIRE WMTS should use the InspireCRS84Quad grid set which is already configured in GeoServer, but is up to the user to select it when publishing a INSPIRE WMTS layer. 
 
 Extended WFS and WCS configuration
 ----------------------------------

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wmts/InspireGridSetLoader.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wmts/InspireGridSetLoader.java
@@ -1,0 +1,55 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.inspire.wmts;
+
+import org.geoserver.gwc.GWC;
+import org.geoserver.platform.ContextLoadedEvent;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSet;
+import org.geowebcache.grid.GridSetFactory;
+import org.geowebcache.grid.SRS;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * Loads the inspire grid set and mark it as non editable by the user.
+ */
+public class InspireGridSetLoader implements ApplicationListener<ContextLoadedEvent> {
+
+    public static final String INSPIRE_GRID_SET_NAME = "InspireCRS84Quad";
+
+    @Override
+    public synchronized void onApplicationEvent(ContextLoadedEvent event) {
+        GWC gwc = GWC.get();
+        // this grid set should not be editable by the user
+        gwc.addEmbeddedGridSet(INSPIRE_GRID_SET_NAME);
+        GridSet gridSet = gwc.getGridSetBroker().get(INSPIRE_GRID_SET_NAME);
+        if (gridSet != null) {
+            // this grid set already exists
+            return;
+        }
+        // the grid set resolutions
+        double[] resolutions = new double[]{
+                0.703125, 0.3515625, 0.17578125, 0.087890625, 0.0439453125, 0.02197265625, 0.010986328125, 0.0054931640625,
+                0.00274658203125, 0.001373291015625, 6.866455078125E-4, 3.433227539062E-4, 1.716613769531E-4, 8.58306884766E-5,
+                4.29153442383E-5, 2.14576721191E-5, 1.07288360596E-5, 5.3644180298E-6};
+        // the grid sets scale names
+        String[] scaleNames = new String[]{
+                "InspireCRS84Quad:0", "InspireCRS84Quad:1", "InspireCRS84Quad:2", "InspireCRS84Quad:3", "InspireCRS84Quad:4",
+                "InspireCRS84Quad:5", "InspireCRS84Quad:6", "InspireCRS84Quad:7", "InspireCRS84Quad:8", "InspireCRS84Quad:9",
+                "InspireCRS84Quad:10", "InspireCRS84Quad:11", "InspireCRS84Quad:12", "InspireCRS84Quad:13", "InspireCRS84Quad:14",
+                "InspireCRS84Quad:15", "InspireCRS84Quad:16", "InspireCRS84Quad:17"};
+        // creating thee grid set
+        gridSet = GridSetFactory.createGridSet(INSPIRE_GRID_SET_NAME, SRS.getEPSG4326(), BoundingBox.WORLD4326, false,
+                resolutions, null, 111319.49079327358, GridSetFactory.DEFAULT_PIXEL_SIZE_METER, scaleNames, 256, 256, false);
+        // set a proper description
+        gridSet.setDescription("Every layer offered by a INSPIRE WMTS should use the InspireCRS84Quad Matrix Set");
+        try {
+            // add the grid set
+            gwc.addGridSet(gridSet);
+        } catch (Exception exception) {
+            throw new RuntimeException("Error adding grid set InspireCRS84Quad.", exception);
+        }
+    }
+}

--- a/src/extension/inspire/src/main/resources/applicationContext.xml
+++ b/src/extension/inspire/src/main/resources/applicationContext.xml
@@ -48,4 +48,7 @@
     <property name="componentClass" value="org.geoserver.inspire.web.InspireAdminPanel"/>
     <property name="serviceClass" value="org.geoserver.gwc.wmts.WMTSInfo"/>
   </bean>
+
+  <bean id="inspireGridSetLoader" class="org.geoserver.inspire.wmts.InspireGridSetLoader">
+  </bean>
 </beans>

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/InspireGridSetLoaderTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/InspireGridSetLoaderTest.java
@@ -1,0 +1,35 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.inspire.wmts;
+
+import org.geoserver.gwc.GWC;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+
+import static org.geoserver.inspire.wmts.InspireGridSetLoader.INSPIRE_GRID_SET_NAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Testing that INSPIRE grid set is correctly loaded and configured.
+ */
+public class InspireGridSetLoaderTest extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testGridSetLoading() throws Exception {
+        // let's wait a max of 30 seconds for the grid set registration
+        GWC gwc = GWC.get();
+        int waited = 0;
+        while(waited <= 30000 && GWC.get().getGridSetBroker().get(INSPIRE_GRID_SET_NAME) == null) {
+            // let' wait 100 milliseconds
+            Thread.sleep(100);
+            waited += 100;
+        }
+        // let's see if the inspire grid set has been correctly registered
+        assertThat(gwc.getGridSetBroker().get(INSPIRE_GRID_SET_NAME), notNullValue());
+        assertThat(gwc.isInternalGridSet(INSPIRE_GRID_SET_NAME), is(true));
+    }
+}

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/InspireGridSetLoaderTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/InspireGridSetLoaderTest.java
@@ -20,14 +20,7 @@ public class InspireGridSetLoaderTest extends GeoServerSystemTestSupport {
 
     @Test
     public void testGridSetLoading() throws Exception {
-        // let's wait a max of 30 seconds for the grid set registration
         GWC gwc = GWC.get();
-        int waited = 0;
-        while(waited <= 30000 && GWC.get().getGridSetBroker().get(INSPIRE_GRID_SET_NAME) == null) {
-            // let' wait 100 milliseconds
-            Thread.sleep(100);
-            waited += 100;
-        }
         // let's see if the inspire grid set has been correctly registered
         assertThat(gwc.getGridSetBroker().get(INSPIRE_GRID_SET_NAME), notNullValue());
         assertThat(gwc.isInternalGridSet(INSPIRE_GRID_SET_NAME), is(true));

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -225,7 +225,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     final GeoServerEnvironment gsEnvironment = GeoServerExtensions.bean(GeoServerEnvironment.class);
 
     // list of GeoServer contributed grid sets that should not be editable by the user
-    private final List<String> geoserverEmbeddedGridSets = new ArrayList<>();
+    private final Set<String> geoserverEmbeddedGridSets = new HashSet<>();
     
     public GWC(final GWCConfigPersister gwcConfigPersister, final StorageBroker sb,
             final TileLayerDispatcher tld, final GridSetBroker gridSetBroker,

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -223,6 +223,9 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     private GeoWebCacheEnvironment gwcEnvironment;
     
     final GeoServerEnvironment gsEnvironment = GeoServerExtensions.bean(GeoServerEnvironment.class);
+
+    // list of GeoServer contributed grid sets that should not be editable by the user
+    private final List<String> geoserverEmbeddedGridSets = new ArrayList<>();
     
     public GWC(final GWCConfigPersister gwcConfigPersister, final StorageBroker sb,
             final TileLayerDispatcher tld, final GridSetBroker gridSetBroker,
@@ -1883,12 +1886,18 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     }
 
     /**
+     * Add the provided grid set id to the list of GeoServer grid sets that cannot be edited by the user.
+     */
+    public void addEmbeddedGridSet(String gridSetId) {
+        geoserverEmbeddedGridSets.add(gridSetId);
+    }
+
+    /**
      * @return {@code true} if the GridSet named {@code gridSetId} is a GWC internally defined one,
      *         {@code false} otherwise
      */
     public boolean isInternalGridSet(final String gridSetId) {
-        boolean internal = gridSetBroker.getEmbeddedNames().contains(gridSetId);
-        return internal;
+        return gridSetBroker.getEmbeddedNames().contains(gridSetId) || geoserverEmbeddedGridSets.contains(gridSetId);
     }
 
     /**


### PR DESCRIPTION
This pull request added a new method on GWC singleton to allow GeoServer extensions to register non editable grid sets.

Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-7782