### PR TITLE
Fix GeoGig DB closed issue

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerGeoGigRepositoryResolver.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerGeoGigRepositoryResolver.java
@@ -7,7 +7,6 @@ package org.geogig.geoserver.config;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
@@ -82,16 +81,19 @@ public class GeoServerGeoGigRepositoryResolver extends RepositoryResolver {
         // get the repo by name
         try {
             RepositoryInfo info = repoMgr.getByRepoName(name);
-            String repositoryId = info.getId();
-            Repository repo = repoMgr.getRepository(repositoryId);
+            // get the native RepositoryResolver for the location and open it directly
+            // Using the RepositryManager to get the repo would cause the repo to be managed by the RepositoryManager,
+            // when this repo should be managed by the DataStore. The DataStore will close this repo instance when
+            // GeoServer decides to dispose the DataStore.
+            Repository repo = RepositoryResolver.load(info.getLocation());
             checkState(repo.isOpen(), "RepositoryManager returned a closed repository for %s",
                     name);
             return repo;
-        } catch (IOException ioe) {
+        } catch (Exception ex) {
             // didn't find a repo
             RepositoryConnectionException rce = new RepositoryConnectionException(
                     "No GeoGig repository found with NAME or ID: " + name);
-            rce.initCause(ioe);
+            rce.initCause(ex);
             throw rce;
         }
     }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
@@ -15,28 +15,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.geotools.util.logging.Logging;
-import org.locationtech.geogig.model.Node;
-import org.locationtech.geogig.model.ObjectId;
-import org.locationtech.geogig.model.Ref;
-import org.locationtech.geogig.model.RevCommit;
-import org.locationtech.geogig.model.RevFeature;
-import org.locationtech.geogig.model.RevTree;
-import org.locationtech.geogig.repository.AbstractGeoGigOp;
-import org.locationtech.geogig.repository.Context;
-import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.repository.Repository;
-import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.repository.RepositoryResolver;
-import org.locationtech.geogig.repository.StagingArea;
-import org.locationtech.geogig.repository.WorkingTree;
-import org.locationtech.geogig.storage.BlobStore;
-import org.locationtech.geogig.storage.ConfigDatabase;
-import org.locationtech.geogig.storage.ConflictsDatabase;
-import org.locationtech.geogig.storage.GraphDatabase;
-import org.locationtech.geogig.storage.ObjectDatabase;
-import org.locationtech.geogig.storage.RefDatabase;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -111,8 +92,7 @@ class RepositoryCache {
      */
     public Repository get(final String repositoryId) throws IOException {
         try {
-            Repository repo = repoCache.get(repositoryId);
-            return new UnclosableRepository(repo);
+            return repoCache.get(repositoryId);
         } catch (ExecutionException e) {
             Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
             throw new IOException("Error obtaining cached geogig instance for repo " + repositoryId,
@@ -126,170 +106,5 @@ class RepositoryCache {
 
     public void invalidateAll() {
         repoCache.invalidateAll();
-    }
-
-    private static class UnclosableRepository implements Repository {
-
-        private final Repository subject;
-
-        UnclosableRepository(Repository subject) {
-            this.subject = subject;
-        }
-
-        @Override
-        public void close() {
-            // ignored
-        }
-
-        @Override
-        public void addListener(RepositoryListener listener) {
-            subject.addListener(listener);
-        }
-
-        @Override
-        public void configure() throws RepositoryConnectionException {
-            subject.configure();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return subject.isOpen();
-        }
-
-        @Override
-        public void open() throws RepositoryConnectionException {
-            subject.open();
-        }
-
-        @Override
-        public URI getLocation() {
-            return subject.getLocation();
-        }
-
-        @Override
-        public <T extends AbstractGeoGigOp<?>> T command(Class<T> commandClass) {
-            return subject.command(commandClass);
-        }
-
-        @Override
-        public boolean blobExists(ObjectId id) {
-            return subject.blobExists(id);
-        }
-
-        @Override
-        public Optional<Ref> getRef(String revStr) {
-            return subject.getRef(revStr);
-        }
-
-        @Override
-        public Optional<Ref> getHead() {
-            return subject.getHead();
-        }
-
-        @Override
-        public boolean commitExists(ObjectId id) {
-            return subject.commitExists(id);
-        }
-
-        @Override
-        public RevCommit getCommit(ObjectId commitId) {
-            return subject.getCommit(commitId);
-        }
-
-        @Override
-        public boolean treeExists(ObjectId id) {
-            return subject.treeExists(id);
-        }
-
-        @Override
-        public ObjectId getRootTreeId() {
-            return subject.getRootTreeId();
-        }
-
-        @Override
-        public RevFeature getFeature(ObjectId contentId) {
-            return subject.getFeature(contentId);
-        }
-
-        @Override
-        public RevTree getOrCreateHeadTree() {
-            return subject.getOrCreateHeadTree();
-        }
-
-        @Override
-        public RevTree getTree(ObjectId treeId) {
-            return subject.getTree(treeId);
-        }
-
-        @Override
-        public Optional<Node> getRootTreeChild(String path) {
-            return subject.getRootTreeChild(path);
-        }
-
-        @Override
-        public Optional<Node> getTreeChild(RevTree tree, String childPath) {
-            return subject.getTreeChild(tree, childPath);
-        }
-
-        @Override
-        public Optional<Integer> getDepth() {
-            return subject.getDepth();
-        }
-
-        @Override
-        public boolean isSparse() {
-            return subject.isSparse();
-        }
-
-        @Override
-        public Context context() {
-            return subject.context();
-        }
-
-        @Override
-        public WorkingTree workingTree() {
-            return subject.workingTree();
-        }
-
-        @Override
-        public StagingArea index() {
-            return subject.index();
-        }
-
-        @Override
-        public RefDatabase refDatabase() {
-            return subject.refDatabase();
-        }
-
-        @Override
-        public Platform platform() {
-            return subject.platform();
-        }
-
-        @Override
-        public ObjectDatabase objectDatabase() {
-            return subject.objectDatabase();
-        }
-
-        @Override
-        public ConflictsDatabase conflictsDatabase() {
-            return subject.conflictsDatabase();
-        }
-
-        @Override
-        public ConfigDatabase configDatabase() {
-            return subject.configDatabase();
-        }
-
-        @Override
-        public GraphDatabase graphDatabase() {
-            return subject.graphDatabase();
-        }
-
-        @Override
-        public BlobStore blobStore() {
-            return subject.blobStore();
-        }
-
     }
 }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditPanel.java
@@ -77,15 +77,7 @@ public class RepositoryEditPanel extends FormComponentPanel<RepositoryInfo> {
                             }
                         } else {
                             // try to connect
-                            Repository repository = null;
-                            try {
-                                repository = resolver.open(location);
-                            } finally {
-                                if (repository != null) {
-                                    repository.close();
-                                }
-                            }
-
+                            resolver.open(location);
                         }
                     } catch (Exception ex) {
                         // likely failed to connect


### PR DESCRIPTION
  - Separate Geogig DataStore repository references from cached
    references so repos don't get closed on DataStore instances