### PR TITLE
[GEOS-7792] WFS ignores disabling of stores (master)

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/DisabledResourceFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/DisabledResourceFilter.java
@@ -20,8 +20,6 @@ import org.opengis.filter.Filter;
  */
 public class DisabledResourceFilter extends AbstractCatalogFilter {
 
-    static final Filter ENABLED_FILTER = Predicates.equal("enabled", true);
-
     private boolean shouldApplyFilter() {
         Request request = Dispatcher.REQUEST.get();
         // for the moment, match any recognized OGC request
@@ -30,18 +28,23 @@ public class DisabledResourceFilter extends AbstractCatalogFilter {
 
     @Override
     public Filter getSecurityFilter(Class<? extends CatalogInfo> clazz) {
-        if (shouldApplyFilter() && LayerInfo.class.isAssignableFrom(clazz)
-                || ResourceInfo.class.isAssignableFrom(clazz)) {
-            return ENABLED_FILTER;
-        } else {
-            return Filter.INCLUDE;
+        if (shouldApplyFilter()) {
+            if (LayerInfo.class.isAssignableFrom(clazz)) {
+                return Predicates.and(Predicates.equal("enabled", true),
+                        Predicates.equal("resource.enabled", true),
+                        Predicates.equal("resource.store.enabled", true));
+            } else if (ResourceInfo.class.isAssignableFrom(clazz)) {
+                return Predicates.and(Predicates.equal("enabled", true),
+                        Predicates.equal("store.enabled", true));
+            }
         }
+        return Filter.INCLUDE;
     }
 
     @Override
     public boolean hideLayer(LayerInfo layer) {
         if (shouldApplyFilter()) {
-            return !layer.isEnabled();
+            return !layer.enabled();
         }
         return false;
     }
@@ -49,8 +52,9 @@ public class DisabledResourceFilter extends AbstractCatalogFilter {
     @Override
     public boolean hideResource(ResourceInfo resource) {
         if (shouldApplyFilter()) {
-            return !resource.isEnabled();
+            return !resource.enabled();
         }
         return false;
     }
+
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
@@ -21,8 +21,10 @@ import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
@@ -375,7 +377,30 @@ public class GetFeatureTest extends WFSTestSupport {
                 doc);
         XMLAssert.assertXpathEvaluatesTo("typeName", "//ogc:ServiceException/@locator", doc);
     }
-    
+
+    /**
+     * Test that a request for a resource from a disabled store fails.
+     */
+    @Test
+    public void testRequestDisabledStore() throws Exception {
+        Catalog catalog = getCatalog();
+        StoreInfo store = catalog.getStoreByName("cdf", DataStoreInfo.class);
+        try {
+            store.setEnabled(false);
+            catalog.save(store);
+            Document doc = getAsDOM(
+                    "wfs?service=WFS&version=1.0.0&request=GetFeature&typename=cdf:Fifteen");
+            // print(doc);
+            XMLAssert.assertXpathEvaluatesTo("1", "count(//ogc:ServiceException)", doc);
+            XMLAssert.assertXpathEvaluatesTo("InvalidParameterValue",
+                    "//ogc:ServiceException/@code", doc);
+            XMLAssert.assertXpathEvaluatesTo("typeName", "//ogc:ServiceException/@locator", doc);
+        } finally {
+            store.setEnabled(true);
+            catalog.save(store);
+        }
+    }
+
     /**
      * Tests CQL filter
      * 

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureJoinTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureJoinTest.java
@@ -54,6 +54,7 @@ public class GetFeatureJoinTest extends WFS20TestSupport {
         DataStoreInfo ds = cat.getFactory().createDataStore();
         ds.setName("foo");
         ds.setWorkspace(cat.getDefaultWorkspace());
+        ds.setEnabled(true);
         
         Map params = ds.getConnectionParameters(); 
         params.put("dbtype", "h2");

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
@@ -52,6 +52,7 @@ public class GetFeaturePagingTest extends WFS20TestSupport {
         DataStoreInfo ds = cat.getFactory().createDataStore();
         ds.setName("foo");
         ds.setWorkspace(cat.getDefaultWorkspace());
+        ds.setEnabled(true);
         
         Map params = ds.getConnectionParameters(); 
         params.put("dbtype", "h2");


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7792

This PR implements both the simple and ```getSecurityFilter``` changes proposed by @aaime. Note that the ```getSecurityFilter``` change does not fix the bug by itself. I would also like some feedback on the ```shouldApplyFilter``` logic; see the [Jira comment](https://osgeo-org.atlassian.net/browse/GEOS-7792?focusedCommentId=60278&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-60278) for details. This PR leaves the ```shouldApplyFilter``` logic as-is. I am happy to change it based on feedback.

This PR also fixes WFS 2.0 ```GetFeatureJoinTest``` and ```GetFeaturePagingTest```, which were running with disabled stores.