### PR TITLE
[GEOS-7692] Add error checking to Style Editor Layer Attributes tab

### DIFF
--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -24,6 +24,12 @@ import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.util.tester.FormTester;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.TestData;
@@ -32,8 +38,12 @@ import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.wicket.GeoServerTablePanel;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.junit.Before;
 import org.junit.Test;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.w3c.dom.Document;
 
 public class StyleEditPageTest extends GeoServerWicketTestSupport {
@@ -54,6 +64,37 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
             }
             buildingsStyle = getCatalog().getStyleByName(MockData.BUILDINGS.getLocalPart());
         }
+        
+        //Create a layer with inaccesible
+        Catalog catalog = getCatalog();
+        
+        DataStoreInfo  ds = catalog.getStoreByName("sf", "unstore", DataStoreInfo.class);
+        if (ds == null) {
+            CatalogBuilder cb = new CatalogBuilder(catalog);
+            cb.setWorkspace(catalog.getWorkspaceByName("sf"));
+            ds = cb.buildDataStore("unstore");
+            catalog.add(ds);
+            
+            FeatureTypeInfo ft = catalog.getFactory().createFeatureType();
+            ft.setName("unres");
+            ft.setStore(catalog.getStoreByName("unstore", DataStoreInfo.class));
+            ft.setCatalog(catalog);
+            ft.setNamespace(catalog.getNamespaceByPrefix("sf"));
+            ft.setSRS("EPSG:4326");
+            CoordinateReferenceSystem wgs84 = CRS.decode("EPSG:4326");
+            ft.setNativeCRS(wgs84);
+            ft.setLatLonBoundingBox(new ReferencedEnvelope(-110, 0, -60, 50, wgs84));
+            ft.setProjectionPolicy(ProjectionPolicy.FORCE_DECLARED);
+            
+            catalog.add(ft);
+            
+            LayerInfo ftl = catalog.getFactory().createLayer();
+            ftl.setResource(ft);
+            ftl.setName("unlayer");
+            ftl.setDefaultStyle(getCatalog().getStyleByName("Default"));
+            
+            catalog.add(ftl);
+}
         edit = new StyleEditPage(buildingsStyle);
         tester.startPage(edit);
     }
@@ -101,6 +142,18 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
     @Test
     public void testLoadLegend() {
         
+    }
+    
+    @Test
+    public void testLayerAttributesUnreachableLayer() throws Exception {
+        tester.executeAjaxEvent("styleForm:context:tabs-container:tabs:3:link", "click");
+        tester.executeAjaxEvent("styleForm:context:panel:changeLayer:link", "click");
+        tester.assertComponent("styleForm:popup:content:layer.table", GeoServerTablePanel.class);
+        
+        tester.executeAjaxEvent("styleForm:popup:content:layer.table:navigatorBottom:navigator:last", "click");
+        tester.assertLabel("styleForm:popup:content:layer.table:listContainer:items:30:itemProperties:2:component:link:layer.name", "unlayer");
+        tester.executeAjaxEvent("styleForm:popup:content:layer.table:listContainer:items:30:itemProperties:2:component:link", "click");
+        tester.assertContains("Failed to load attribute list, internal error is:");
     }
     
     @Test


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7692

If the layer is invalid, an error message will be displayed at the top of the page, similar to the one that gets displayed on the Layer Edit page under similar circumstances.
