### PR TITLE
[GEOS-7693] Do not allow WMS layers for Style Page Layer Preview / Attributes

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/LayerChooser.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/LayerChooser.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.wms.web.data;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,6 +17,8 @@ import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.web.wicket.GeoServerAjaxFormLink;
 import org.geoserver.web.wicket.GeoServerDataProvider;
@@ -68,7 +71,16 @@ public class LayerChooser extends Panel {
 
         @Override
         public List<LayerInfo> getItems() {
-            return parent.getCatalog().getLayers();
+            List<LayerInfo> items = new ArrayList<LayerInfo>();
+            for (LayerInfo l : parent.getCatalog().getLayers()) {
+                if (l.getResource() instanceof FeatureTypeInfo) {
+                    items.add(l);
+                }
+                if (l.getResource() instanceof CoverageInfo) {
+                    items.add(l);
+                }
+            }
+            return items;
         }
 
         @Override


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7693

Excludes all WMS layers from the layer chooser list.
WMS Layers cannot be styled, so there is no reason to show them in the Style Page Layer / Attribute preview.
