### PR TITLE
[GEOT-5526] SQL Encoding of Filters on Nested Attributes

### DIFF
--- a/doc/en/user/source/data/app-schema/joining.rst
+++ b/doc/en/user/source/data/app-schema/joining.rst
@@ -62,3 +62,24 @@ Using joining is strongly recommended when a large number of features need to be
 when producing maps with WMS (see :ref:`app-schema.wms-support`).
 
 Optimising the performance of the database will maximise the benefit of using joining, including for small queries.
+
+Native Encoding of Filters on Nested Attributes
+-----------------------------------------------
+
+When App-Schema Joining is active, filters operating on nested attributes (i.e. attributes of features that are joined to the queried type via :ref:`app-schema.feature-chaining`) are translated to SQL and executed directly in the database backend, rather than being evaluated in memory after all features have been loaded (which was standard behavior in earlier versions of GeoServer). Native encoding can yield significant performance improvements, especially when the total number of features in the database is high (several thousands or more), but only a few of them would satisfy the filter.
+
+There are, however, a few limitations in the current implementation:
+
+1. Joining support must not have been explicitly disabled and all its pre-conditions must be met (see above)
+2. Only binary comparison operators (e.g. ``PropertyIsEqualTo``, ``PropertyIsGreaterThan``, etc...), ``PropertyIsLike`` and ``PropertyIsNull`` filters are translated to SQL
+3. Filters involving conditional polymorphic mappings are evaluated in memory
+4. Filters comparing two or more different nested attributes are evaluated in memory
+5. Filters matching multiple nested attribute mappings are evaluated in memory
+
+Much like joining support, native encoding of nested filters is turned on by default, and it is disabled by adding to your app-schema.properties file the line ::
+
+     app-schema.encodeNestedFilters = false
+
+Or, alternatively, by setting the value of the Java System Property "app-schema.encodeNestedFilters" to "false", for example ::
+
+     java -DGEOSERVER_DATA_DIR=... -Dapp-schema.encodeNestedFilters=false Start

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
@@ -37,14 +37,28 @@ import org.custommonkey.xmlunit.XpathEngine;
 import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.WFSInfo;
+import org.geotools.data.DataAccess;
 import org.geotools.data.complex.AppSchemaDataAccess;
 import org.geotools.data.complex.AppSchemaDataAccessRegistry;
 import org.geotools.data.complex.DataAccessRegistry;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.jdbc.FilterToSQL;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.jdbc.BasicSQLDialect;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.jdbc.PreparedFilterToSQL;
+import org.geotools.jdbc.PreparedStatementSQLDialect;
+import org.geotools.jdbc.SQLDialect;
 import org.geotools.xml.AppSchemaValidator;
 import org.geotools.xml.AppSchemaXSDRegistry;
 import org.geotools.xml.resolver.SchemaCache;
 import org.geotools.xml.resolver.SchemaCatalog;
 import org.geotools.xml.resolver.SchemaResolver;
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
@@ -611,4 +625,93 @@ public abstract class AbstractAppSchemaTestSupport extends GeoServerSystemTestSu
         return actual;
     }
 
+    /**
+     * Checks that the identifiers of the features in the provided collection match the specified ids.
+     * 
+     * <p>
+     * Note that:
+     * <ul>
+     * <li>The method considers that feature identifiers follow the convention <code>[type name].[ID]</code> and only matches the ID part.</li>
+     * <li>If the feature collection contains a feature whose identifier does not match any of the passed ids, the check will fail</li>
+     * </ul>
+     * </p>
+     * 
+     * @param featureSet the feature collection to check
+     * @param fids the feature identifiers that must be present in the collection
+     */
+    protected void assertContainsFeatures(FeatureCollection featureSet, String... fids) {
+        List<String> fidList = Arrays.asList(fids);
+
+        try (FeatureIterator it = featureSet.features()) {
+            int count = 0;
+            while (it.hasNext()) {
+                Feature f = it.next();
+                String[] parts = f.getIdentifier().getID().split("\\.");
+                String fid = parts[parts.length - 1];
+                assertTrue(fidList.contains(fid));
+                count++;
+            }
+            assertEquals(fidList.size(), count);
+        }
+    }
+
+    /**
+     * Checks that all the pre-conditions for SQL encoding filters on nested attributes are met:
+     * 
+     * <ol>
+     * <li>Source datastore is backed by a RDBMS</li>
+     * <li>Joining support is enabled</li>
+     * <li>Nested filters encoding is enabled</li>
+     * </ol>
+     * 
+     * <p>
+     * If the method returns <code>false</code> the test should be skipped.
+     * </p>
+     * 
+     * @param rootMapping the feature type being queried
+     * @return <code>true</code> if nested filters encoding can be tested, <code>false</code> otherwise.
+     */
+    protected boolean shouldTestNestedFiltersEncoding(FeatureTypeMapping rootMapping) {
+        if (!(rootMapping.getSource().getDataStore() instanceof JDBCDataStore))
+            return false;
+        if (!AppSchemaDataAccessConfigurator.isJoining())
+            return false;
+        if (!AppSchemaDataAccessConfigurator.shouldEncodeNestedFilters())
+            return false;
+        return true;
+    }
+
+    /**
+     * Creates a properly configured {@link NestedFilterToSQL} instance to enable testing the SQL encoding of filters on nested attributes.
+     * 
+     * <p>
+     * Note: before calling this method, clients should verify that nested filters encoding is enabled by calling
+     * {@link #shouldTestNestedFiltersEncoding(FeatureTypeMapping)}.
+     * </p>
+     * 
+     * @param mapping the feature type being queried
+     * @return nested filter encoder
+     */
+    protected NestedFilterToSQL createNestedFilterEncoder(FeatureTypeMapping mapping) {
+        DataAccess<?, ?> source = mapping.getSource().getDataStore();
+        if (!(source instanceof JDBCDataStore)) {
+            throw new IllegalArgumentException(
+                    "nested filters encoding requires the source datastore be a JDBCDataStore");
+        }
+        JDBCDataStore store = (JDBCDataStore) source;
+        SQLDialect dialect = store.getSQLDialect();
+        FilterToSQL original = null;
+        if (dialect instanceof BasicSQLDialect) {
+            original = ((BasicSQLDialect) dialect).createFilterToSQL();
+        } else if (dialect instanceof PreparedStatementSQLDialect) {
+            original = ((PreparedStatementSQLDialect) dialect).createPreparedFilterToSQL();
+            // disable prepared statements to have literals actually encoded in the SQL
+            ((PreparedFilterToSQL)original).setPrepareEnabled(false);
+        }
+        original.setFeatureType((SimpleFeatureType) mapping.getSource().getSchema());
+
+        NestedFilterToSQL nestedFilterToSQL = new NestedFilterToSQL(mapping, original);
+        nestedFilterToSQL.setInline(true);
+        return nestedFilterToSQL;
+    }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -6,19 +6,37 @@
 
 package org.geoserver.test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Test;
-
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.xml.v1_1_0.WFS;
 import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureSource;
 import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.AppSchemaDataAccessRegistry;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.complex.filter.ComplexFilterSplitter;
+import org.geotools.data.jdbc.FilterToSQLException;
+import org.geotools.filter.FilterFactoryImplNamespaceAware;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.NestedFilterToSQL;
+import org.geotools.util.NullProgressListener;
+import org.junit.Test;
+import org.opengis.filter.And;
+import org.opengis.filter.Filter;
+import org.opengis.filter.PropertyIsLike;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -1374,6 +1392,136 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         wfs.setEncodeFeatureMember(encodeFeatureMember);
         getGeoServer().save(wfs);
     }
-    
-    
+
+    @Test
+    public void testNestedFilterEncoding() throws FilterToSQLException, IOException {
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+        FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+        AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+        FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+
+        // make sure nested filters encoding is enabled, otherwise skip test
+        assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
+
+        JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+        NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
+
+        FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+        ff.setNamepaceContext(rootMapping.getNamespaces());
+
+        /*
+         * test combined filters on nested attributes
+         */
+        And and = ff
+                .and(ff.equals(ff.property("gsml:specification/gsml:GeologicUnit/gml:name"),
+                        ff.literal("New Group")),
+                        ff.equals(
+                                ff.property("gsml:specification/gsml:GeologicUnit/gsml:composition/gsml:CompositionPart/gsml:proportion/gsml:CGI_TermValue/gsml:value"),
+                                ff.literal("significant")));
+
+        // Each filter involves a single nested attribute --> can be encoded
+        ComplexFilterSplitter splitter = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitter.visit(and, null);
+        Filter preFilter = splitter.getFilterPre();
+        Filter postFilter = splitter.getFilterPost();
+
+        assertEquals(and, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        Filter unrolled = AppSchemaDataAccess.unrollFilter(and, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        String encodedFilter = nestedFilterToSQL.encodeToString(unrolled);
+
+        assertTrue(encodedFilter.matches("^\\(EXISTS.*AND EXISTS.*\\)$"));
+        assertContainsFeatures(fs.getFeatures(and), "mf4");
+
+        /*
+         * test like filter on nested attribute
+         */
+         PropertyIsLike like = ff.like(ff.property("gsml:specification/gsml:GeologicUnit/gml:description"), "*sedimentary*");
+
+        // Filter involving single nested attribute --> can be encoded
+        ComplexFilterSplitter splitterLike = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                rootMapping);
+        splitterLike.visit(like, null);
+        preFilter = splitterLike.getFilterPre();
+        postFilter = splitterLike.getFilterPost();
+
+        assertEquals(like, preFilter);
+        assertEquals(Filter.INCLUDE, postFilter);
+
+        // filter must be "unrolled" (i.e. reverse mapped) first
+        unrolled = AppSchemaDataAccess.unrollFilter(like, rootMapping);
+
+        // Filter is nested
+        assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+        encodedFilter = nestedFilterToSQL.encodeToString(unrolled);
+
+        // this is the generated query in PostGIS, but the test limits to check the presence of the
+        // EXISTS keyword, as the actual SQL is dependent on the underlying database
+        // EXISTS (SELECT "chain_link_1"."PKEY" 
+        //      FROM "appschematest"."GEOLOGICUNIT" "chain_link_1" 
+        //      WHERE UPPER("chain_link_1"."TEXTDESCRIPTION") LIKE '%SEDIMENTARY%' AND 
+        //            "appschematest"."MAPPEDFEATUREPROPERTYFILE"."GEOLOGIC_UNIT_ID" = "chain_link_1"."GML_ID")
+        assertTrue(encodedFilter.contains("EXISTS"));
+        assertContainsFeatures(fs.getFeatures(like), "mf1", "mf2", "mf3");
+    }
+
+    @Test
+    public void testNestedFilterEncodingDisabled() throws IOException, FilterToSQLException {
+        // disable nested filters encoding during the test
+        AppSchemaDataAccessRegistry.getAppSchemaProperties().setProperty(
+                AppSchemaDataAccessConfigurator.PROPERTY_ENCODE_NESTED_FILTERS, "false");
+        try {
+            assertFalse(AppSchemaDataAccessConfigurator.shouldEncodeNestedFilters());
+
+            FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+            FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+            AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+            FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+
+            // skip test if it's not running against a database
+            assumeTrue(rootMapping.getSource().getDataStore() instanceof JDBCDataStore);
+
+            JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+            NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
+
+            FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+            ff.setNamepaceContext(rootMapping.getNamespaces());
+
+            /*
+             * test the same like filter tested in method testNestedFilterEncoding
+             */
+            PropertyIsLike like = ff.like(ff.property("gsml:specification/gsml:GeologicUnit/gml:description"), "*sedimentary*");
+
+            // Encoding of filters involving nested attributes is disabled --> CANNOT be encoded
+            ComplexFilterSplitter splitterLike = new ComplexFilterSplitter(store.getFilterCapabilities(),
+                    rootMapping);
+            splitterLike.visit(like, null);
+            Filter preFilter = splitterLike.getFilterPre();
+            Filter postFilter = splitterLike.getFilterPost();
+
+            assertEquals(Filter.INCLUDE, preFilter);
+            assertEquals(like, postFilter);
+
+            // filter must be "unrolled" (i.e. reverse mapped) first
+            Filter unrolled = AppSchemaDataAccess.unrollFilter(like, rootMapping);
+
+            // Filter is nested
+            assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
+
+            assertContainsFeatures(fs.getFeatures(like), "mf1", "mf2", "mf3");
+        } finally {
+            // reset default
+            AppSchemaDataAccessRegistry.getAppSchemaProperties().setProperty(
+                    AppSchemaDataAccessConfigurator.PROPERTY_ENCODE_NESTED_FILTERS, "true");
+        }
+    }
+
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/ReferenceDataOracleSetup.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/ReferenceDataOracleSetup.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,7 +6,7 @@
 package org.geoserver.test.onlineTest.setup;
 
 import java.io.InputStream;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.geoserver.test.onlineTest.support.AbstractReferenceDataSetup;
@@ -62,7 +62,7 @@ public class ReferenceDataOracleSetup extends AbstractReferenceDataSetup {
 
     protected void runSqlInsertScript() throws Exception {
         DatabaseUtil du = new DatabaseUtil();
-        ArrayList<String> sqls = du.splitOracleSQLScript(script);
+        List<String> sqls = du.splitOracleSQLScript(script);
         for (String sql : sqls) {           
             if (sql.startsWith("CALL")) {
                 String formattedSP = "{" + sql + "}";              

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/ReferenceDataPostgisSetup.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/ReferenceDataPostgisSetup.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,7 +6,7 @@
 package org.geoserver.test.onlineTest.setup;
 
 import java.io.InputStream;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.geoserver.test.onlineTest.support.AbstractReferenceDataSetup;
@@ -40,22 +40,10 @@ public class ReferenceDataPostgisSetup extends AbstractReferenceDataSetup {
 
     protected void runSqlInsertScript() throws Exception {
         DatabaseUtil du = new DatabaseUtil();
-        ArrayList<String> sqls = du.splitPostgisSQLScript(script);
-        // run the script as a single shot, going back and forth line
-        // by line takes forever to run (more than a minute)
-        String pgScript = rebuildAsSingle(sqls);
-        this.run(pgScript);
-        this.setDataVersion(this.scriptVersion);
-
-    }
-
-    private String rebuildAsSingle(ArrayList<String> sqls) {
-        StringBuilder sb = new StringBuilder();
-        for (String sql : sqls) {
-            sb.append(sql).append("\n");
-        }
-        
-        return sb.toString();
+        List<String> sqls = du.splitPostgisSQLScript(script);
+        sqls.add("set search_path = public;");
+        run(du.rebuildAsSingle(sqls));
+        setDataVersion(scriptVersion);
     }
 
     // these private helper class might be useful in the future. feel free to change its access

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/WfsOnlineTestOracleSetup.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/WfsOnlineTestOracleSetup.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,8 +6,9 @@
 package org.geoserver.test.onlineTest.setup;
 
 import java.io.InputStream;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
+
 import org.geoserver.test.onlineTest.support.AbstractReferenceDataSetup;
 import org.geoserver.test.onlineTest.support.DatabaseUtil;
 import org.geotools.data.oracle.OracleNGDataStoreFactory;
@@ -61,7 +62,7 @@ public class WfsOnlineTestOracleSetup extends AbstractReferenceDataSetup {
 
     private void runSqlInsertScript() throws Exception {
         DatabaseUtil du = new DatabaseUtil();
-        ArrayList<String> sqls = du.splitOracleSQLScript(script);
+        List<String> sqls = du.splitOracleSQLScript(script);
         for (String sql : sqls) {          
             if (sql.startsWith("CALL")) {
                 String formattedSP = "{" + sql + "}";            

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/WfsOnlineTestPostgisSetup.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/setup/WfsOnlineTestPostgisSetup.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,8 +6,9 @@
 package org.geoserver.test.onlineTest.setup;
 
 import java.io.InputStream;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
+
 import org.geoserver.test.onlineTest.support.AbstractReferenceDataSetup;
 import org.geoserver.test.onlineTest.support.DatabaseUtil;
 import org.geotools.data.postgis.PostgisNGDataStoreFactory;
@@ -39,12 +40,10 @@ public class WfsOnlineTestPostgisSetup extends AbstractReferenceDataSetup {
 
     private void runSqlInsertScript() throws Exception {
         DatabaseUtil du = new DatabaseUtil();
-        ArrayList<String> sqls = du.splitPostgisSQLScript(script);
-        for (String sql : sqls) {
-            this.run(sql);
-        }
-        this.setDataVersion(this.scriptVersion);
-
+        List<String> sqls = du.splitPostgisSQLScript(script);
+        sqls.add("set search_path = public;");
+        run(du.rebuildAsSingle(sqls));
+        setDataVersion(scriptVersion);
     }
 
     // these private helper class might be useful in the future. feel free to change its access

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/support/DatabaseUtil.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/support/DatabaseUtil.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.List;
 
 
 /**
@@ -34,8 +35,7 @@ public class DatabaseUtil {
      * @return
      * @throws Exception
      */
-
-    public ArrayList<String> splitPostgisSQLScript(InputStream inputStream) throws Exception {
+    public List<String> splitPostgisSQLScript(InputStream inputStream) throws Exception {
 
         StringBuilder contents = new StringBuilder();
 
@@ -102,6 +102,20 @@ public class DatabaseUtil {
             idx += sub.length();
         }
         return count;
+    }
+
+    /**
+     * Return a list of SQL statements as a single string including a newline after each statement.
+     * 
+     * @param sqls list of SQL statements
+     * @return string of statements with newline after each
+     */
+    public String rebuildAsSingle(List<String> sqls) {
+        StringBuilder sb = new StringBuilder();
+        for (String sql : sqls) {
+            sb.append(sql).append("\n");
+        }
+        return sb.toString();
     }
 
     /**
@@ -195,12 +209,10 @@ public class DatabaseUtil {
     /**
      * Splits the oracle sql script file into individual statements.
      * 
-     * @param f
-     *            - The oracle sql script
-     * @return - the list of sql statement
-     * @throws Exception
+     * @param inputStream The oracle sql script
+     * @return list of sql statements
      */
-    public ArrayList<String> splitOracleSQLScript(InputStream inputStream) throws Exception {
+    public List<String> splitOracleSQLScript(InputStream inputStream) throws Exception {
 
         StringBuilder contents = new StringBuilder();
 


### PR DESCRIPTION
Backport to GeoServer 2.8.x of unit tests and docs for GEOT-5526 (see #1847).

Note that:
* build is expected to fail until geotools/geotools#1362 is merged
* commit a92b206bd1f25bbfbfb6b33bfe6a046949d8dfb0, required for fixing postgis online tests, was also backported