### PR TITLE
Prevent image being serialized, form uses wicketImage [GEOS-7689]

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
@@ -95,8 +95,7 @@ public class StyleAdminPanel extends StyleEditTabPanel {
     protected FileUploadField fileUploadField;
     protected AjaxSubmitLink uploadLink;
     
-    
-    BufferedImage legendImage;
+    transient BufferedImage legendImage;
     
     public StyleAdminPanel(String id, AbstractStylePage parent) {
         super(id, parent);


### PR DESCRIPTION
For details see: https://osgeo-org.atlassian.net/browse/GEOS-7689