### PR TITLE
Fix for (GEOS-7805) CSW Service does not work anymore due to EntityResolver bean circular reference

### DIFF
--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -280,7 +280,11 @@
   <bean id="cascadedStoredQueryCallback" class="org.geoserver.catalog.CascadedStoredQueryCallback"/>
   
   <!-- Entity resolver provider, to stop xml attacks via system entity resolution -->
-  <bean id="entityResolverProvider" class="org.geoserver.util.EntityResolverProvider">
+  <!-- The depends-on is important to avoid circularities, when a depends-on is setup a bean does not
+       start creation until the bean it depends onto is created. This ensures GeoServer post-processing
+       inside GeoServerLoader ends up causing the initialization of entityResolverProvider instead of the 
+       opposite, via the ResourcePoolInitializer, and breaks the circularity that would otherwise happen -->
+  <bean id="entityResolverProvider" class="org.geoserver.util.EntityResolverProvider" depends-on="geoServer">
     <constructor-arg ref="geoServer"/>
   </bean>
 </beans>


### PR DESCRIPTION
Replacement for #1903 that is fixing the underlying problem, instead of the circumstance triggering it.
The real issue is that if by any accident Spring initializes EntityResolverProvider before having created GeoServer we end up in a circularity of this kind:

- EntityResolverProvider needs GeoServer (and the bean creation of EntityResolverProvider starts)
- GeoServer is initialized and post-processed by GeoServerLoader before EntityResolverProvider creation can finish, and the post-processing looks for all GeoServerInitializer
- ResourcePoolInitializer needs EntityResolverProvider, which is under construction, boom

The patch ensure that GeoServer is built before EntityResolverProvider bean creation is even attempted, allowing for a working startup instead. 
An alternative approach could be to have ResourcePool lookup the EntityResolverProvider dynamically via GeoServerExtensions, and have ResourcePoolInitializer stop statically depending on it.