### PR TITLE
Replace Jettison libraries with JSONP (JSR-353)

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
@@ -4,7 +4,7 @@
  */
 package org.geogig.geoserver.rest;
 
-import static org.locationtech.geogig.rest.repository.RESTUtils.getStringAttribute;
+import static org.locationtech.geogig.web.api.RESTUtils.getStringAttribute;
 
 import java.io.IOException;
 import java.net.URI;

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitRequestHandler.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitRequestHandler.java
@@ -4,7 +4,7 @@
  */
 package org.geogig.geoserver.rest;
 
-import static org.locationtech.geogig.rest.repository.RESTUtils.getStringAttribute;
+import static org.locationtech.geogig.web.api.RESTUtils.getStringAttribute;
 import static org.restlet.data.Status.CLIENT_ERROR_BAD_REQUEST;
 
 import java.io.File;

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryListResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryListResource.java
@@ -6,21 +6,20 @@ package org.geogig.geoserver.rest;
 
 import static org.locationtech.geogig.rest.Variants.JSON;
 import static org.locationtech.geogig.rest.Variants.XML;
-import static org.locationtech.geogig.rest.repository.RESTUtils.repositoryProvider;
+import static org.locationtech.geogig.web.api.RESTUtils.repositoryProvider;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geoserver.rest.PageInfo;
 import org.geoserver.rest.format.FreemarkerFormat;
-import org.locationtech.geogig.rest.JettisonRepresentation;
+import org.locationtech.geogig.rest.StreamingWriterRepresentation;
 import org.locationtech.geogig.rest.Variants;
 import org.locationtech.geogig.rest.repository.RepositoryProvider;
+import org.locationtech.geogig.web.api.StreamWriterException;
+import org.locationtech.geogig.web.api.StreamingWriter;
 import org.restlet.Context;
 import org.restlet.data.MediaType;
 import org.restlet.data.Preference;
@@ -115,7 +114,7 @@ public class RepositoryListResource extends Resource {
         return repos;
     }
 
-    private static class RepositoryListRepresentation extends JettisonRepresentation {
+    private static class RepositoryListRepresentation extends StreamingWriterRepresentation {
 
         private final List<RepositoryInfo> repos;
 
@@ -126,22 +125,24 @@ public class RepositoryListResource extends Resource {
         }
 
         @Override
-        protected void write(XMLStreamWriter w) throws XMLStreamException {
+        public void write(StreamingWriter w) throws StreamWriterException {
             w.writeStartElement("repos");
+            w.writeStartArray("repo");
             for (RepositoryInfo repo : repos) {
                 write(w, repo);
             }
+            w.writeEndArray();
             w.writeEndElement();
         }
 
-        private void write(XMLStreamWriter w, RepositoryInfo repo) throws XMLStreamException {
-            w.writeStartElement("repo");
-            element(w, "id", repo.getId());
+        private void write(StreamingWriter w, RepositoryInfo repo) throws StreamWriterException {
+            w.writeStartArrayElement("repo");
+            w.writeElement("id", repo.getId());
 
-            element(w, "name", repo.getRepoName());
+            w.writeElement("name", repo.getRepoName());
             encodeAlternateAtomLink(w, RepositoryProvider.BASE_REPOSITORY_ROUTE + "/" +
                     repo.getRepoName());
-            w.writeEndElement();
+            w.writeEndArrayElement();
         }
 
     }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryResource.java
@@ -6,21 +6,20 @@ package org.geogig.geoserver.rest;
 
 import static org.locationtech.geogig.rest.Variants.JSON;
 import static org.locationtech.geogig.rest.Variants.XML;
-import static org.locationtech.geogig.rest.repository.RESTUtils.repositoryProvider;
+import static org.locationtech.geogig.web.api.RESTUtils.repositoryProvider;
 
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geoserver.rest.PageInfo;
 import org.geoserver.rest.format.FreemarkerFormat;
-import org.locationtech.geogig.rest.JettisonRepresentation;
+import org.locationtech.geogig.rest.StreamingWriterRepresentation;
 import org.locationtech.geogig.rest.RestletException;
 import org.locationtech.geogig.rest.Variants;
 import org.locationtech.geogig.rest.repository.DeleteRepository;
+import org.locationtech.geogig.web.api.StreamWriterException;
+import org.locationtech.geogig.web.api.StreamingWriter;
 import org.restlet.Context;
 import org.restlet.data.MediaType;
 import org.restlet.data.Preference;
@@ -117,7 +116,7 @@ public class RepositoryResource extends DeleteRepository {
         return (PageInfo) getRequest().getAttributes().get(PageInfo.KEY);
     }
 
-    private static class RepositorytRepresentation extends JettisonRepresentation {
+    private static class RepositorytRepresentation extends StreamingWriterRepresentation {
 
         private final RepositoryInfo repo;
 
@@ -127,11 +126,11 @@ public class RepositoryResource extends DeleteRepository {
         }
 
         @Override
-        protected void write(XMLStreamWriter w) throws XMLStreamException {
+        public void write(StreamingWriter w) throws StreamWriterException {
             w.writeStartElement("repository");
-            element(w, "id", repo.getId());
-            element(w, "name", repo.getRepoName());
-            element(w, "location", repo.getLocation());
+            w.writeElement("id", repo.getId());
+            w.writeElement("name", repo.getRepoName());
+            w.writeElement("location", repo.getLocation());
             w.writeEndElement();
         }
     }

--- a/src/community/geogig/src/test/resources/org/geogig/geoserver/functional/PluginListRepositories.feature
+++ b/src/community/geogig/src/test/resources/org/geogig/geoserver/functional/PluginListRepositories.feature
@@ -6,7 +6,7 @@
 Feature: Plugin list repositories
   Listing all repositories on the server is done by issuing a GET request to "/repos".
   The response should be a 200 OK and contain a list of repositories configured. For each repository
-  in the returned list, the NAME, ID a a link to the repository's info should be included.
+  in the returned list, the NAME, ID and a link to the repository's info should be included.
 
   Scenario: Get list of Repositories in JSON format
     Given There is a default multirepo server

--- a/src/community/release/ext-geogig.xml
+++ b/src/community/release/ext-geogig.xml
@@ -40,6 +40,8 @@
             <include>org.restlet.ext.fileupload-*.jar</include>
             <!-- GeoTools Geopackage libs -->
             <include>gt-geopkg-*.jar</include>
+            <!-- JSONP (JSR-353) libs -->
+            <include>javax.json-*.jar</include>
         </includes>
         <excludes>
             <exclude>*test*</exclude>


### PR DESCRIPTION
Update the GeoGig plugin to use the new Response Representation framework in GeoGig that removes the coupling to XMLStreamWriter and Jettison bridging libraries.