### PR TITLE
[GEOS-7755] [GEOS-7269] [GEOS-7268][GEOS-7758] Makes JMS plugin listen on all services and settings events and be aware of virtual services (backport 2.10.x)

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSEventType.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSEventType.java
@@ -1,0 +1,10 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.events.configuration;
+
+public enum JMSEventType {
+    ADDED, REMOVED, MODIFIED
+}

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSServiceModifyEvent.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSServiceModifyEvent.java
@@ -1,36 +1,54 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.cluster.impl.events.configuration;
 
-import java.util.List;
-
 import org.geoserver.cluster.impl.events.JMSModifyEvent;
 import org.geoserver.cluster.impl.handlers.configuration.JMSServiceHandler;
 import org.geoserver.config.ServiceInfo;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
- * 
  * This Class define a wrapper of the {@link JMSModifyEvent} class to define an
- * event which can be recognized by the {@link JMSServiceHandler} as ServiceInfo modified
- * events.
- * 
+ * event which can be recognized by the {@link JMSServiceHandler} as ServiceInfo
+ * modified events.
+ *
+ * <p>A service modified event can represent three situations, the service was
+ * added, removed or is configuration was modified.
+ *
  * @author Carlo Cancellieri - carlo.cancellieri@geo-solutions.it
- * 
  */
 public class JMSServiceModifyEvent extends JMSModifyEvent<ServiceInfo> {
 
-	public JMSServiceModifyEvent(final ServiceInfo source,
-			final List<String> propertyNames, final List<Object> oldValues,
-			final List<Object> newValues) {
-		super(source, propertyNames, oldValues, newValues);
-	}
+    private static final long serialVersionUID = 1L;
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
+    public enum Type {
+        ADDED, REMOVED, MODIFIED
+    }
 
+    // identifies the type of event (added, removed or service configuration modified)
+    private final Type eventType;
+
+    public JMSServiceModifyEvent(ServiceInfo source, List<String> propertyNames,
+                                 List<Object> oldValues, List<Object> newValues) {
+        this(source, propertyNames, oldValues, newValues, Type.MODIFIED);
+    }
+
+    public JMSServiceModifyEvent(ServiceInfo source, Type eventType) {
+        this(source, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), eventType);
+    }
+
+    public JMSServiceModifyEvent(ServiceInfo source, List<String> propertyNames,
+                                 List<Object> oldValues, List<Object> newValues, Type eventType) {
+        super(source, propertyNames, oldValues, newValues);
+        this.eventType = eventType;
+    }
+
+    public Type getEventType() {
+        return eventType;
+    }
 }

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSSettingsModifyEvent.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSSettingsModifyEvent.java
@@ -1,0 +1,47 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.events.configuration;
+
+import org.geoserver.cluster.impl.events.JMSModifyEvent;
+import org.geoserver.config.SettingsInfo;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class defines an event for modified settings. This settings represents metadata
+ * information for the GeoServer instance or for a specific workspace. By default an
+ * workspace doesn't have any settings and use GeoServer global settings
+ * <p>
+ * <p>A settings modified event can represent three situations, the settings were
+ * added, removed or the settings were modified.
+ */
+public class JMSSettingsModifyEvent extends JMSModifyEvent<SettingsInfo> {
+
+    private static final long serialVersionUID = 1L;
+
+    // identifies the type of event (added, removed or settings modified)
+    private final JMSEventType eventType;
+
+    public JMSSettingsModifyEvent(SettingsInfo source, List<String> propertyNames,
+                                  List<Object> oldValues, List<Object> newValues) {
+        this(source, propertyNames, oldValues, newValues, JMSEventType.MODIFIED);
+    }
+
+    public JMSSettingsModifyEvent(SettingsInfo source, JMSEventType eventType) {
+        this(source, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), eventType);
+    }
+
+    public JMSSettingsModifyEvent(SettingsInfo source, List<String> propertyNames,
+                                  List<Object> oldValues, List<Object> newValues, JMSEventType eventType) {
+        super(source, propertyNames, oldValues, newValues);
+        this.eventType = eventType;
+    }
+
+    public JMSEventType getEventType() {
+        return eventType;
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSServiceHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSServiceHandler.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.apache.commons.lang.NullArgumentException;
+import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.cluster.events.ToggleSwitch;
 import org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent;
 import org.geoserver.cluster.impl.utils.BeanUtils;
@@ -16,6 +17,10 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.ServiceInfo;
 
 import com.thoughtworks.xstream.XStream;
+
+import static org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent.Type.ADDED;
+import static org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent.Type.MODIFIED;
+import static org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent.Type.REMOVED;
 
 /**
  * 
@@ -46,14 +51,29 @@ public class JMSServiceHandler extends JMSConfigurationHandler<JMSServiceModifyE
             throw new NullArgumentException("Incoming event is null");
         }
         try {
-            // localize service
-            final ServiceInfo localObject = localizeService(geoServer, ev);
-
             // disable the message producer to avoid recursion
             producer.disable();
-            // save the localized object
-            geoServer.save(localObject);
-
+            // let's see which type of event we have
+            switch (ev.getEventType()) {
+                case MODIFIED:
+                    // localize service
+                    final ServiceInfo localObject = localizeService(geoServer, ev);
+                    // save the localized object
+                    geoServer.save(localObject);
+                    break;
+                case ADDED:
+                    // checking that this service is not already present, we don't synchronize this check
+                    // if two threads add the same service well one of them will fail and throw an exception
+                    if (geoServer.getService(ev.getSource().getId(), ev.getSource().getClass()) == null) {
+                        // this is a new service so let's add it to this geoserver
+                        geoServer.add(ev.getSource());
+                    }
+                    break;
+                case REMOVED:
+                    // this service was removed so let's remove it from this geoserver
+                    geoServer.remove(ev.getSource());
+                    break;
+            }
         } catch (Exception e) {
             if (LOGGER.isLoggable(java.util.logging.Level.SEVERE))
                 LOGGER.severe(this.getClass() + " is unable to synchronize the incoming event: "
@@ -113,18 +133,18 @@ public class JMSServiceHandler extends JMSConfigurationHandler<JMSServiceModifyE
         // check if name is changed
         final List<String> props = ev.getPropertyNames();
         final int index = props.indexOf("name");
+        String serviceName = service.getName();
         if (index != -1) {
-
+            // the service name was updated so we need to use old service name
             final List<Object> oldValues = ev.getOldValues();
-            // search the Service using the old name
-            localObject = geoServer.getServiceByName(oldValues.get(index).toString(),
-                    ServiceInfo.class);
-        } else {
-            localObject = geoServer.getServiceByName(service.getName(), ServiceInfo.class);
+            serviceName = oldValues.get(index).toString();
         }
-
-        return localObject;
-
+        if (service.getWorkspace() == null) {
+            // no virtual service
+            return geoServer.getServiceByName(serviceName, ServiceInfo.class);
+        }
+        // globals service
+        return geoServer.getServiceByName(service.getWorkspace(), serviceName, ServiceInfo.class);
     }
 
 }

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSSettingsHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSSettingsHandler.java
@@ -1,0 +1,103 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers.configuration;
+
+import com.thoughtworks.xstream.XStream;
+import org.apache.commons.lang.NullArgumentException;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.cluster.events.ToggleSwitch;
+import org.geoserver.cluster.impl.events.configuration.JMSSettingsModifyEvent;
+import org.geoserver.cluster.impl.utils.BeanUtils;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.SettingsInfo;
+
+import java.util.logging.Level;
+
+/**
+ */
+public class JMSSettingsHandler extends JMSConfigurationHandler<JMSSettingsModifyEvent> {
+
+    private final GeoServer geoServer;
+    private final ToggleSwitch producer;
+
+    public JMSSettingsHandler(GeoServer geo, XStream xstream, Class clazz, ToggleSwitch producer) {
+        super(xstream, clazz);
+        this.geoServer = geo;
+        this.producer = producer;
+    }
+
+    @Override
+    protected void omitFields(final XStream xstream) {
+        xstream.omitField(GeoServer.class, "geoServer");
+    }
+
+    @Override
+    public boolean synchronize(JMSSettingsModifyEvent event) throws Exception {
+        if (event == null) {
+            throw new NullArgumentException("Incoming event is NULL.");
+        }
+        try {
+            // disable the message producer to avoid recursion
+            producer.disable();
+            // let's see which type of event we have and handle it
+            switch (event.getEventType()) {
+                case MODIFIED:
+                    handleModifiedSettings(event);
+                    break;
+                case ADDED:
+                    handleAddedSettings(event);
+                    break;
+                case REMOVED:
+                    handleRemovedSettings(event);
+                    break;
+            }
+        } catch (Exception exception) {
+            LOGGER.log(Level.SEVERE, "Error handling settings event.", exception);
+            throw exception;
+        } finally {
+            // enabling the events producer again
+            producer.enable();
+        }
+        return true;
+    }
+
+    private void handleModifiedSettings(JMSSettingsModifyEvent event) {
+        // let's extract some useful information from the event
+        WorkspaceInfo workspace = event.getSource().getWorkspace();
+        // settings are global or specific to a certain workspace
+        SettingsInfo settingsInfo = workspace == null
+                ? geoServer.getSettings() : geoServer.getSettings(workspace);
+        // if not settings were found this means that a user just deleted this workspace
+        // or deleted this workspace settings on this GeoServer instance or that a previously
+        // synchronization problem happened
+        if (settingsInfo == null) {
+            throw new IllegalArgumentException(String.format(
+                    "No settings for workspace '%s' found on this instance.", workspace.getName()));
+        }
+        // well let's update our settings updating only the modified properties
+        try {
+            BeanUtils.smartUpdate(settingsInfo, event.getPropertyNames(), event.getNewValues());
+        } catch (Exception exception) {
+            String message = workspace == null ? "Error updating GeoServer global settings."
+                    : "Error updating workspace '%s' settings.";
+            throw new RuntimeException(String.format(message, workspace), exception);
+        }
+        // save the updated settings
+        geoServer.save(settingsInfo);
+    }
+
+    private void handleAddedSettings(JMSSettingsModifyEvent event) {
+        // we only need to save the new settings, if the workspace associated
+        // with this settings doesn't exists or this settings already exists
+        // GeoServer will complain about it with a proper exception
+        geoServer.add(event.getSource());
+    }
+
+    private void handleRemovedSettings(JMSSettingsModifyEvent event) {
+        // we only need to remove the new settings
+        geoServer.remove(event.getSource());
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSSettingsHandlerSPI.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSSettingsHandlerSPI.java
@@ -1,0 +1,40 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers.configuration;
+
+import com.thoughtworks.xstream.XStream;
+import org.geoserver.cluster.JMSEventHandler;
+import org.geoserver.cluster.JMSEventHandlerSPI;
+import org.geoserver.cluster.events.ToggleSwitch;
+import org.geoserver.cluster.impl.events.configuration.JMSSettingsModifyEvent;
+import org.geoserver.config.GeoServer;
+
+/**
+ * SPI class used by the JMS manager to instantiate the proper handler for a certain event type.
+ */
+public final class JMSSettingsHandlerSPI extends JMSEventHandlerSPI<String, JMSSettingsModifyEvent> {
+
+    private final GeoServer geoserver;
+    private final XStream xstream;
+    private final ToggleSwitch producer;
+
+    public JMSSettingsHandlerSPI(int priority, GeoServer geo, XStream xstream, ToggleSwitch producer) {
+        super(priority);
+        this.geoserver = geo;
+        this.xstream = xstream;
+        this.producer = producer;
+    }
+
+    @Override
+    public boolean canHandle(Object event) {
+        // we can handle only settings modified events
+        return event instanceof JMSSettingsModifyEvent;
+    }
+
+    @Override
+    public JMSEventHandler<String, JMSSettingsModifyEvent> createHandler() {
+        return new JMSSettingsHandler(geoserver, xstream, this.getClass(), producer);
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSConfigurationListener.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSConfigurationListener.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -121,44 +121,61 @@ public class JMSConfigurationListener extends JMSAbstractGeoServerProducer imple
     }
 
     @Override
+    public void handlePostServiceChange(ServiceInfo service) {
+        // this handler is invoked when a new service is added
+        ServiceInfo finalService = ModificationProxy.unwrap(service);
+        JMSServiceModifyEvent event = new JMSServiceModifyEvent(finalService, JMSServiceModifyEvent.Type.ADDED);
+        handleServiceEvent(event);
+    }
+
+    @Override
+    public void handleServiceRemove(ServiceInfo service) {
+        // this handler is invoked when a service is removed
+        ServiceInfo finalService = ModificationProxy.unwrap(service);
+        JMSServiceModifyEvent event = new JMSServiceModifyEvent(finalService, JMSServiceModifyEvent.Type.REMOVED);
+        handleServiceEvent(event);
+    }
+
+    @Override
     public void handleServiceChange(ServiceInfo service, List<String> propertyNames,
-            List<Object> oldValues, List<Object> newValues) {
+                                    List<Object> oldValues, List<Object> newValues) {
+        // this handler is invoked when a service configuration is modified
+        ServiceInfo finalService = ModificationProxy.unwrap(service);
+        JMSServiceModifyEvent event = new JMSServiceModifyEvent(finalService, propertyNames, oldValues, newValues);
+        handleServiceEvent(event);
+    }
 
+    /**
+     * Helper method that publish a service modified event.
+     */
+    private void handleServiceEvent(JMSServiceModifyEvent event) {
+        // if possible log about the received event
         if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {
-            LOGGER.fine("Incoming event of type");
+            LOGGER.fine(String.format("Incoming service '%s' modified event of type '%s'.",
+                    event.getSource().getId(), event.getEventType()));
         }
-
-        // skip incoming events if producer is not Enabled
+        // skip incoming events if producer is not enabled
         if (!isEnabled()) {
             if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {
-                LOGGER.fine("skipping incoming event: context is not initted");
+                LOGGER.fine(String.format(
+                        "Skipping incoming service '%s' modified event of type '%s' since producer is not enabled.",
+                        event.getSource().getId(), event.getEventType()));
             }
             return;
         }
-
+        // let's publish this event
         try {
-            // update properties
-            final Properties options = getProperties();
-            // propagate the event
-            jmsPublisher.publish(getTopic(), getJmsTemplate(), options,
-                    new JMSServiceModifyEvent(ModificationProxy.unwrap(service), propertyNames,
-                            oldValues, newValues));
-
-        } catch (Exception e) {
-            if (LOGGER.isLoggable(java.util.logging.Level.SEVERE)) {
-                LOGGER.severe(e.getLocalizedMessage());
-            }
+            jmsPublisher.publish(getTopic(), getJmsTemplate(), getProperties(), event);
+        } catch (Exception exception) {
+            // failed to publish event
+            LOGGER.severe(String.format("Error publishing service '%s' modified event of type '%s': %s",
+                    event.getSource().getId(), event.getEventType(), exception.getLocalizedMessage()));
         }
     }
 
     @Override
     public void handlePostLoggingChange(LoggingInfo logging) {
         // send(xstream.toXML(logging), JMSConfigEventType.LOGGING_CHANGE);
-    }
-
-    @Override
-    public void handlePostServiceChange(ServiceInfo service) {
-        // send(xstream.toXML(service), JMSConfigEventType.POST_SERVICE_CHANGE);
     }
 
     @Override
@@ -207,12 +224,6 @@ public class JMSConfigurationListener extends JMSAbstractGeoServerProducer imple
 
     @Override
     public void handleSettingsRemoved(SettingsInfo settings) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public void handleServiceRemove(ServiceInfo service) {
         // TODO Auto-generated method stub
 
     }

--- a/src/community/jms-cluster/jms-geoserver/src/main/resources/applicationContext.xml
+++ b/src/community/jms-cluster/jms-geoserver/src/main/resources/applicationContext.xml
@@ -193,4 +193,12 @@
 		<constructor-arg index="2" ref="JMSXstream" />
 		<constructor-arg index="3" ref="JMSToggleProducer" />
 	</bean>
+
+	<bean id="JMSSettingsHandlerSPI"
+		  class="org.geoserver.cluster.impl.handlers.configuration.JMSSettingsHandlerSPI">
+		<constructor-arg index="0" value="1" />
+		<constructor-arg index="1" ref="geoServer" />
+		<constructor-arg index="2" ref="JMSXstream" />
+		<constructor-arg index="3" ref="JMSToggleProducer" />
+	</bean>
 </beans>

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JMSServiceHandlerTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JMSServiceHandlerTest.java
@@ -1,0 +1,185 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers.configuration;
+
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
+import org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class JMSServiceHandlerTest extends GeoServerSystemTestSupport {
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:TestContext.xml");
+    }
+
+    @Before
+    public void setup() {
+        // create a test workspace
+        WorkspaceInfoImpl workspace = new WorkspaceInfoImpl();
+        workspace.setId("jms-test-workspace");
+        workspace.setName("jms-test-workspace");
+        getCatalog().add(workspace);
+    }
+
+    @After
+    public void clean() {
+        // remove test workspace
+        getCatalog().remove(getCatalog().getWorkspace("jms-test-workspace"));
+        // remove any created service
+        Collection<? extends ServiceInfo> services = getGeoServer().getServices();
+        for (ServiceInfo service : services) {
+            ServiceInfo finalService = ModificationProxy.unwrap(service);
+            if (finalService instanceof JmsTestService) {
+                getGeoServer().remove(finalService);
+            }
+        }
+    }
+
+    @Test
+    public void testGlobalServiceSimpleCrud() throws Exception {
+        // service events handler
+        JMSServiceHandler handler = createHandler();
+        // create a new global service
+        handler.synchronize(createNewServiceEvent("jms-test-service-1", "jms-test-service", "global-jms-test-service", null));
+        checkServiceExists("jms-test-service", "global-jms-test-service", null);
+        // update global service
+        handler.synchronize(createModifyServiceEvent("jms-test-service", "global-jms-test-service-updated", null));
+        checkServiceExists("jms-test-service", "global-jms-test-service-updated", null);
+        // delete global service
+        handler.synchronize(createRemoveServiceEvent("jms-test-service", null));
+        assertThat(findService("jms-test-service", null), nullValue());
+    }
+
+    @Test
+    public void testVirtualServiceSimpleCrud() throws Exception {
+        // service events handler
+        JMSServiceHandler handler = createHandler();
+        // create a new virtual service
+        handler.synchronize(createNewServiceEvent("jms-test-service-2", "jms-test-service", "virtual-jms-test-service", "jms-test-workspace"));
+        checkServiceExists("jms-test-service", "virtual-jms-test-service", "jms-test-workspace");
+        // update virtual service
+        handler.synchronize(createModifyServiceEvent("jms-test-service", "virtual-jms-test-service-updated", "jms-test-workspace"));
+        checkServiceExists("jms-test-service", "virtual-jms-test-service-updated", "jms-test-workspace");
+        // delete virtual service
+        handler.synchronize(createRemoveServiceEvent("jms-test-service", "jms-test-workspace"));
+        assertThat(findService("jms-test-service", "jms-test-workspace"), nullValue());
+    }
+
+    @Test
+    public void testGlobalAndVirtualServiceSimpleCrud() throws Exception {
+        // service events handler
+        JMSServiceHandler handler = createHandler();
+        // create a new global and virtual service
+        handler.synchronize(createNewServiceEvent("jms-test-service-1", "jms-test-service", "global-jms-test-service", null));
+        checkServiceExists("jms-test-service", "global-jms-test-service", null);
+        handler.synchronize(createNewServiceEvent("jms-test-service-2", "jms-test-service", "virtual-jms-test-service", "jms-test-workspace"));
+        checkServiceExists("jms-test-service", "virtual-jms-test-service", "jms-test-workspace");
+        // update global service
+        handler.synchronize(createModifyServiceEvent("jms-test-service", "global-jms-test-service-updated", null));
+        checkServiceExists("jms-test-service", "global-jms-test-service-updated", null);
+        checkServiceExists("jms-test-service", "virtual-jms-test-service", "jms-test-workspace");
+        // update virtual service
+        handler.synchronize(createModifyServiceEvent("jms-test-service", "virtual-jms-test-service-updated", "jms-test-workspace"));
+        checkServiceExists("jms-test-service", "virtual-jms-test-service-updated", "jms-test-workspace");
+        checkServiceExists("jms-test-service", "global-jms-test-service-updated", null);
+        // delete virtual service
+        handler.synchronize(createRemoveServiceEvent("jms-test-service", "jms-test-workspace"));
+        assertThat(findService("jms-test-service", "jms-test-workspace"), nullValue());
+        assertThat(findService("jms-test-service", null), notNullValue());
+        // delete global service
+        handler.synchronize(createRemoveServiceEvent("jms-test-service", null));
+        assertThat(findService("jms-test-service", null), nullValue());
+    }
+
+    @Test
+    public void testUpdatingNonExistingVirtualService() throws Exception {
+        // service events handler
+        JMSServiceHandler handler = createHandler();
+        // create a new global and virtual service
+        handler.synchronize(createNewServiceEvent("jms-test-service-3", "jms-test-service", "global-jms-test-service", null));
+        checkServiceExists("jms-test-service", "global-jms-test-service", null);
+        handler.synchronize(createNewServiceEvent("jms-test-service-4", "jms-test-service", "virtual-jms-test-service", "jms-test-workspace"));
+        checkServiceExists("jms-test-service", "virtual-jms-test-service", "jms-test-workspace");
+        // create update virtual service event
+        handler.synchronize(createModifyServiceEvent("jms-test-service", "virtual-jms-test-service-updated", "jms-test-workspace"));
+        // remove virtual service
+        handler.synchronize(createRemoveServiceEvent("jms-test-service", "jms-test-workspace"));
+        assertThat(findService("jms-test-service", "jms-test-workspace"), nullValue());
+        // check the update result
+        checkServiceExists("jms-test-service", "global-jms-test-service", null);
+    }
+
+    private void checkServiceExists(String serviceName, String serviceAbstract, String workspaceName) {
+        ServiceInfo serviceInfo = findService(serviceName, workspaceName);
+        assertThat(serviceInfo, notNullValue());
+        assertThat(serviceInfo.getAbstract(), is(serviceAbstract));
+    }
+
+    private JMSServiceModifyEvent createNewServiceEvent(String serviceId, String serviceName,
+                                                        String serviceAbstract, String workspaceName) {
+        // our virtual service information
+        JmsTestService serviceInfo = new JmsTestService();
+        serviceInfo.setName(serviceName);
+        serviceInfo.setId(serviceId);
+        if (workspaceName != null) {
+            // this is a virtual service
+            serviceInfo.setWorkspace(getCatalog().getWorkspace(workspaceName));
+        }
+        serviceInfo.setAbstract(serviceAbstract);
+        // create jms service modify event
+        return new JMSServiceModifyEvent(serviceInfo, JMSServiceModifyEvent.Type.ADDED);
+    }
+
+    private JMSServiceModifyEvent createModifyServiceEvent(String serviceName, String newServiceAbstract,
+                                                           String workspaceName) {
+        // service information
+        ServiceInfo serviceInfo = findService(serviceName, workspaceName);
+        String oldServiceAbstract = serviceInfo.getAbstract();
+        serviceInfo.setAbstract(newServiceAbstract);
+        // create jms service modify event
+        return new JMSServiceModifyEvent(serviceInfo, Collections.singletonList("abstract"),
+                Collections.singletonList(oldServiceAbstract),
+                Collections.singletonList(newServiceAbstract),
+                JMSServiceModifyEvent.Type.MODIFIED);
+    }
+
+    private JMSServiceModifyEvent createRemoveServiceEvent(String serviceName, String workspaceName) {
+        // our virtual service information
+        ServiceInfo serviceInfo = findService(serviceName, workspaceName);
+        // create jms service modify event
+        return new JMSServiceModifyEvent(serviceInfo, JMSServiceModifyEvent.Type.REMOVED);
+    }
+
+    private ServiceInfo findService(String serviceName, String workspaceName) {
+        if (workspaceName == null) {
+            // global service
+            return ModificationProxy.unwrap(getGeoServer().getServiceByName(serviceName, ServiceInfo.class));
+        }
+        // virtual service
+        WorkspaceInfo workspaceInfo = getCatalog().getWorkspace(workspaceName);
+        return ModificationProxy.unwrap(getGeoServer().getServiceByName(workspaceInfo, serviceName, ServiceInfo.class));
+    }
+
+    private JMSServiceHandler createHandler() {
+        JMSServiceHandlerSPI handlerSpi = GeoServerExtensions.bean(JMSServiceHandlerSPI.class);
+        return (JMSServiceHandler) handlerSpi.createHandler();
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JMSWorkspaceHandlerTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JMSWorkspaceHandlerTest.java
@@ -1,0 +1,105 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers.configuration;
+
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
+import org.geoserver.cluster.impl.events.configuration.JMSEventType;
+import org.geoserver.cluster.impl.events.configuration.JMSSettingsModifyEvent;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.impl.SettingsInfoImpl;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class JMSWorkspaceHandlerTest extends GeoServerSystemTestSupport {
+
+    private WorkspaceInfo testWorkspace;
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:TestContext.xml");
+    }
+
+    @Before
+    public void setup() {
+        // create a test workspace
+        WorkspaceInfoImpl workspace = new WorkspaceInfoImpl();
+        workspace.setId("jms-test-workspace");
+        workspace.setName("jms-test-workspace");
+        getCatalog().add(workspace);
+        testWorkspace = workspace;
+    }
+
+    @After
+    public void clean() {
+        // remove test workspace
+        getCatalog().remove(getCatalog().getWorkspace("jms-test-workspace"));
+    }
+
+    @Test
+    public void testSettingsSimpleCrud() throws Exception {
+        // settings events handler
+        JMSSettingsHandler handler = createHandler();
+        // create a new settings
+        handler.synchronize(createNewSettingsEvent("settings1", "settings1"));
+        checkSettingsExists("settings1");
+        // update settings
+        handler.synchronize(createModifySettingsEvent("settings2"));
+        checkSettingsExists("settings2");
+        // delete settings
+        handler.synchronize(createRemoveSettings());
+        assertThat(getGeoServer().getSettings(testWorkspace), nullValue());
+    }
+
+    private void checkSettingsExists(String settingsTile) {
+        SettingsInfo settingsInfo = getGeoServer().getSettings(testWorkspace);
+        assertThat(settingsInfo, notNullValue());
+        assertThat(settingsInfo.getTitle(), is(settingsTile));
+    }
+
+    private JMSSettingsModifyEvent createNewSettingsEvent(String settingsId, String settingsTitle) {
+        // our settings information
+        SettingsInfoImpl settingsInfo = new SettingsInfoImpl();
+        settingsInfo.setId(settingsId);
+        settingsInfo.setTitle(settingsTitle);
+        settingsInfo.setWorkspace(testWorkspace);
+        // create jms settings modify event
+        return new JMSSettingsModifyEvent(settingsInfo, JMSEventType.ADDED);
+    }
+
+    private JMSSettingsModifyEvent createModifySettingsEvent(String newSettingsTitle) {
+        // settings information
+        SettingsInfo settingsInfo = getGeoServer().getSettings(testWorkspace);
+        String oldSettingsTitle = settingsInfo.getTitle();
+        settingsInfo.setTitle(newSettingsTitle);
+        // create jms settings modify event
+        return new JMSSettingsModifyEvent(settingsInfo, Collections.singletonList("title"),
+                Collections.singletonList(oldSettingsTitle),
+                Collections.singletonList(newSettingsTitle),
+                JMSEventType.MODIFIED);
+    }
+
+    private JMSSettingsModifyEvent createRemoveSettings() {
+        // our settings information
+        SettingsInfo settingsInfo = getGeoServer().getSettings(testWorkspace);
+        // create jms settings modify event
+        return new JMSSettingsModifyEvent(settingsInfo, JMSEventType.REMOVED);
+    }
+
+    private JMSSettingsHandler createHandler() {
+        JMSSettingsHandlerSPI handlerSpi = GeoServerExtensions.bean(JMSSettingsHandlerSPI.class);
+        return (JMSSettingsHandler) handlerSpi.createHandler();
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestService.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestService.java
@@ -1,0 +1,13 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers.configuration;
+
+import org.geoserver.config.impl.ServiceInfoImpl;
+
+/**
+ * Simple test service.
+ */
+public class JmsTestService extends ServiceInfoImpl {
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceLoader.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceLoader.java
@@ -1,0 +1,29 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers.configuration;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.util.XStreamServiceLoader;
+import org.geoserver.platform.GeoServerResourceLoader;
+
+/**
+ * Loader for the test service.
+ */
+public class JmsTestServiceLoader extends XStreamServiceLoader<JmsTestService> {
+
+    public JmsTestServiceLoader(GeoServerResourceLoader resourceLoader) {
+        super(resourceLoader, null);
+    }
+
+    @Override
+    public Class<JmsTestService> getServiceClass() {
+        return JmsTestService.class;
+    }
+
+    @Override
+    protected JmsTestService createServiceFromScratch(GeoServer gs) {
+        return new JmsTestService();
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/resources/TestContext.xml
+++ b/src/community/jms-cluster/jms-geoserver/src/test/resources/TestContext.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean id="jmsTestServiceLoader" class="org.geoserver.cluster.impl.handlers.configuration.JmsTestServiceLoader">
+        <constructor-arg ref="resourceLoader"/>
+    </bean>
+</beans>


### PR DESCRIPTION
Makes JMS plugin listen on all service events (add, modify and remove) and also makes the plugin aware of virtual services. This pull request also makes the JMS plugin aware of settings events.

Tests for the reported issues were added.

The following issues reports different problems for the same root cause:
- https://osgeo-org.atlassian.net/browse/GEOS-7755
- https://osgeo-org.atlassian.net/browse/GEOS-7269
- https://osgeo-org.atlassian.net/browse/GEOS-7268
- https://osgeo-org.atlassian.net/browse/GEOS-7758

This is a backport of this pull request: https://github.com/geoserver/geoserver/pull/1842
