### PR TITLE
[GEOS-7840] Consistently use java-vector-tile:1.0.9

### DIFF
--- a/src/community/script/groovy/pom.xml
+++ b/src/community/script/groovy/pom.xml
@@ -15,6 +15,12 @@
  <artifactId>gs-script-groovy</artifactId>
  <packaging>jar</packaging>
  <name>Groovy Scripting Extension</name>
+ <repositories>
+  <repository>
+   <id>ECC</id>
+   <url>https://github.com/ElectronicChartCentre/ecc-mvn-repo/raw/master/releases</url>
+  </repository>
+ </repositories>
  <dependencies>
   <dependency>
    <groupId>org.geoserver.script</groupId>
@@ -27,10 +33,9 @@
    <version>1.7-SNAPSHOT</version>
   </dependency>
   <dependency>
-    <!-- this dependency taken from geoscript-groovy pom but upgraded to 1.0.8 -->
+    <!-- this dependency taken from geoscript-groovy pom but upgraded to 1.0.9 -->
     <groupId>no.ecc.vectortile</groupId>
     <artifactId>java-vector-tile</artifactId>
-    <version>1.0.8</version>
     <!-- Exclude protobuf here so gt-geobuf can pull in a more recent version -->
     <exclusions>
       <exclusion>

--- a/src/extension/vectortiles/pom.xml
+++ b/src/extension/vectortiles/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>no.ecc.vectortile</groupId>
       <artifactId>java-vector-tile</artifactId>
-      <version>1.0.9</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1195,6 +1195,11 @@
       <artifactId>imageio-ext-turbojpeg</artifactId>
       <version>${imageio-ext.version}</version>
     </dependency>
+    <dependency>
+      <groupId>no.ecc.vectortile</groupId>
+      <artifactId>java-vector-tile</artifactId>
+      <version>1.0.9</version>
+    </dependency>
   </dependencies>
  </dependencyManagement>
 


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-7840

This one will need to be backported to 2.10.x and 2.9.x