### PR TITLE
Adding wps requirement before installation

### DIFF
--- a/doc/en/user/source/community/mbtiles/installing.rst
+++ b/doc/en/user/source/community/mbtiles/installing.rst
@@ -1,6 +1,8 @@
 Installing the GeoServer MBTiles extension
 ==========================================
 
+    .. warning:: Make sure to install corresponding WPS extinsion for GeoServer instance before installing GeoServer MBTiles!
+    
  #. Download the extension from the `nightly GeoServer community module builds <http://ares.opengeo.org/geoserver/master/community-latest/>`_.
 
     .. warning:: Make sure to match the version of the extension to the version of the GeoServer instance!


### PR DESCRIPTION
MBTiles for GeoServer needs WPS extinsion to be installed before any process and this is not included in documentation. 