### PR TITLE
[GEOS-7826] Add check for no layers when instantiating Style Editor page

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -44,6 +44,7 @@ import org.geoserver.catalog.ResourcePool;
 import org.geoserver.catalog.StyleHandler;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.Styles;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.web.ComponentAuthorizer;
 import org.geoserver.web.GeoServerApplication;
@@ -98,14 +99,17 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
         }
         
         //Try getting the first layer in the default store in the default workspace
-        DataStoreInfo defaultStore = catalog.getDefaultDataStore(catalog.getDefaultWorkspace());
-        if (defaultStore != null) {
-            List<ResourceInfo> resources = catalog.getResourcesByStore(defaultStore, ResourceInfo.class);
-            for (ResourceInfo resource : resources) {
-                layers = catalog.getLayers(resource);
-                if (layers.size() > 0) {
-                    layerModel = new Model<LayerInfo>(layers.get(0));
-                    return;
+        WorkspaceInfo defaultWs = catalog.getDefaultWorkspace();
+        if (defaultWs != null) {
+            DataStoreInfo defaultStore = catalog.getDefaultDataStore(defaultWs);
+            if (defaultStore != null) {
+                List<ResourceInfo> resources = catalog.getResourcesByStore(defaultStore, ResourceInfo.class);
+                for (ResourceInfo resource : resources) {
+                    layers = catalog.getLayers(resource);
+                    if (layers.size() > 0) {
+                        layerModel = new Model<LayerInfo>(layers.get(0));
+                        return;
+                    }
                 }
             }
         }
@@ -250,6 +254,25 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
 
                     @Override
                     public void onSubmit(AjaxRequestTarget target, Form<?> form) {
+                        if (getLayerInfo() == null || getLayerInfo().getId() == null) {
+                            switch (index) {
+                                case 1:
+                                    tabbedPanel.error("Cannot show Publishing options: No Layers available.");
+                                    target.add(feedbackPanel);
+                                    return;
+                                case 2:
+                                    tabbedPanel.error("Cannot show Layer Preview: No Layers available.");
+                                    target.add(feedbackPanel);
+                                    return;
+                                case 3:
+                                    tabbedPanel.error("Cannot show Attribute Preview: No Layers available.");
+                                    target.add(feedbackPanel);
+                                    return;
+                                default:
+                                    break;
+                            }
+                        }
+
                         setSelectedTab(index);
                         target.add(tabbedPanel);
                     }

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageNoLayersTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageNoLayersTest.java
@@ -1,0 +1,73 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.web.data;
+
+import org.apache.wicket.markup.html.form.TextArea;
+import org.apache.wicket.markup.html.form.TextField;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StyleEditPageNoLayersTest extends GeoServerWicketTestSupport {
+    
+    StyleInfo buildingsStyle;
+    StyleEditPage edit;
+
+    @Before
+    public void setUp() throws Exception {
+        Catalog catalog = getCatalog();
+        login();
+        
+        buildingsStyle = catalog.getStyleByName(MockData.BUILDINGS.getLocalPart());
+        if(buildingsStyle == null) {
+            // undo the rename performed in one of the test methods
+            StyleInfo si = catalog.getStyleByName("BuildingsNew");
+            if(si != null) {
+                si.setName(MockData.BUILDINGS.getLocalPart());
+                catalog.save(si);
+            }
+            buildingsStyle = catalog.getStyleByName(MockData.BUILDINGS.getLocalPart());
+        }
+        //Clear all layers
+        catalog.getLayers().forEach(catalog::remove);
+
+        edit = new StyleEditPage(buildingsStyle);
+        tester.startPage(edit);
+    }
+
+    @Test
+    public void testLoad() throws Exception {
+        tester.assertRenderedPage(StyleEditPage.class);
+        tester.assertNoErrorMessage();
+
+        tester.debugComponentTrees();
+        tester.assertComponent("styleForm:context:panel:name", TextField.class);
+        tester.assertComponent("styleForm:styleEditor:editorContainer:editorParent:editor", TextArea.class);
+    }
+    
+    @Test
+    public void testPublishingTab() {
+
+        tester.executeAjaxEvent("styleForm:context:tabs-container:tabs:1:link", "click");
+        tester.assertErrorMessages(new String[] {"Cannot show Publishing options: No Layers available."});
+    }
+
+    @Test
+    public void testLayerPreviewTab() {
+
+        tester.executeAjaxEvent("styleForm:context:tabs-container:tabs:2:link", "click");
+        tester.assertErrorMessages(new String[] {"Cannot show Layer Preview: No Layers available."});
+    }
+
+    @Test
+    public void testLayerAttributesTab() {
+
+        tester.executeAjaxEvent("styleForm:context:tabs-container:tabs:3:link", "click");
+        tester.assertErrorMessages(new String[] {"Cannot show Attribute Preview: No Layers available."});
+    }
+}


### PR DESCRIPTION
Fix for https://osgeo-org.atlassian.net/browse/GEOS-7826

Added null check to the page constructor.
Added error messages when trying to navigate to other tabs when no layers are available.