### PR TITLE
[GEOS-6799] place dxf attributes on interior point

### DIFF
--- a/src/extension/dxf/core/src/main/java/org/geoserver/wfs/response/dxf/Rel14DXFWriter.java
+++ b/src/extension/dxf/core/src/main/java/org/geoserver/wfs/response/dxf/Rel14DXFWriter.java
@@ -274,17 +274,18 @@ public class Rel14DXFWriter extends AbstractDXFWriter {
     }
 
     private void writeAttributes(String layer, String ownerHandle, SimpleFeature f) throws IOException {
-        // TODO Auto-generated method stub
+        Geometry geometry = (Geometry)f.getDefaultGeometry();
+        Point intPoint = geometry.getInteriorPoint();
         for ( Property p : f.getProperties()) {
             Name name = p.getName();
             LOGGER.warning("    attr: " + name.getLocalPart() + " = " + p.getValue());
             if (!(p.getValue() instanceof Geometry)) {
-                writeAttribute(layer, ownerHandle, name.getLocalPart(), p.getValue());
+                writeAttribute(layer, ownerHandle, name.getLocalPart(), p.getValue(), intPoint);
             }
         }
     }
 
-    private void writeAttribute(String layer, String ownerHandle, String attribName, Object value) throws IOException {
+    private void writeAttribute(String layer, String ownerHandle, String attribName, Object value, Point intPoint) throws IOException {
         writeGroup(0, "ATTRIB");
         writeHandle("Geometry");
         // String handle = getNewHandle("Attrib");
@@ -293,8 +294,8 @@ public class Rel14DXFWriter extends AbstractDXFWriter {
         writeSubClass("AcDbEntity");
         writeLayer(layer);
         writeSubClass("AcDbText");
-        writeDoubleGroup(10, 0.0);
-        writeDoubleGroup(20, 0.0);
+        writeDoubleGroup(10, intPoint.getX());
+        writeDoubleGroup(20, intPoint.getY());
         writeDoubleGroup(30, 0.0);
         writeDoubleGroup(40, 0.72 /*(Double) textConfig.get("height")*/);
         String valueString = "";
@@ -413,12 +414,12 @@ public class Rel14DXFWriter extends AbstractDXFWriter {
                 String endHandle = getNewHandle("Block");
                 writeStartBlock(startHandle, ownerHandle, false, "0", name);
                 String attributesLayer = getLayerName(coll) + "_attributes";
-                // writeGeometryStart("POINT", layer, ownerHandle);
-                writeGeometryStart("CIRCLE", attributesLayer, ownerHandle);
-                // writeSubClass("AcDbPoint");
-                writeSubClass("AcDbCircle");
+                writeGeometryStart("POINT", attributesLayer, ownerHandle);
+                // writeGeometryStart("CIRCLE", attributesLayer, ownerHandle);
+                writeSubClass("AcDbPoint");
+                // writeSubClass("AcDbCircle");
                 writePoint(0.0, 0.0, 0.0);
-                writeDoubleGroup(40, 1.0);
+                // writeDoubleGroup(40, 1.0);
                 writeAttributeDefinitions(attributesLayer, ownerHandle, coll);
                 writeEndBlock(endHandle, ownerHandle, false, "0", name);
             }

--- a/src/extension/dxf/core/src/test/java/org/geoserver/wfs/response/DXFOutputFormatTest.java
+++ b/src/extension/dxf/core/src/test/java/org/geoserver/wfs/response/DXFOutputFormatTest.java
@@ -150,6 +150,20 @@ public class DXFOutputFormatTest extends WFSTestSupport {
         // has to insert an attribute
         checkSequence(sResponse,new String[] {"ATTRIB", "AcDbAttribute"},pos);
     }
+    
+    
+    /**
+     * Test writeattributes option, check position of attributes.
+     */
+    @Test
+    public void testWriteAttributesPosition() throws Exception {
+        MockHttpServletResponse resp = getAsServletResponse("wfs?request=GetFeature&version=1.1.0&typeName=Polygons&outputFormat=dxf&format_options=withattributes:true");
+        String sResponse = testBasicResult(resp, "Polygons");
+        int pos = getGeometrySearchStart(sResponse);
+        assertTrue(pos != -1);
+        // has to insert an attribute
+        checkSequence(sResponse,new String[] {"POLYGONS_attributes", "ATTRIB", "POLYGONS_attributes", "AcDbText", "10", "500250.0", "20", "500050.0", "t0002"},pos);
+    }
 
     /**
      * Test a MultiPolygon geometry.


### PR DESCRIPTION
With this change autocad, draftsight and others shows the attributes in dxf as labels at the correct position.