### PR TITLE
[GEOS-7858] Verify layer group is not used before removing from catalog

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -930,6 +930,14 @@ public class CatalogImpl implements Catalog {
     }
     
     public void remove(LayerGroupInfo layerGroup) {
+        //ensure no references to the layer group
+        for ( LayerGroupInfo lg : facade.getLayerGroups() ) {
+            if ( lg.getLayers().contains( layerGroup ) || layerGroup.equals( lg.getRootLayer() ) ) {
+                String msg = "Unable to delete layer group referenced by layer group '"+lg.getName()+"'";
+                throw new IllegalArgumentException( msg );
+            }
+        }
+
         facade.remove(layerGroup);
         removed( layerGroup );
     }

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CascadeDeleteVisitorTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CascadeDeleteVisitorTest.java
@@ -45,14 +45,15 @@ public class CascadeDeleteVisitorTest extends CascadeVisitorAbstractTest {
         if (style != null) {
             catalog.remove(style);
         }
-        LayerGroupInfo group = catalog.getLayerGroupByName(LAKES_GROUP);
+        LayerGroupInfo group = catalog.getLayerGroupByName(NEST_GROUP);
         if (group != null) {
             catalog.remove(group);
         }
-        group = catalog.getLayerGroupByName(NEST_GROUP);
+        group = catalog.getLayerGroupByName(LAKES_GROUP);
         if (group != null) {
             catalog.remove(group);
         }
+
 
         setupExtras(getTestData(), catalog);
     }

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -2211,6 +2211,29 @@ public class CatalogImplTest {
         assertEquals(l, lg2.layers().iterator().next());
         assertEquals(s, lg2.styles().iterator().next());        
     }
+
+    @Test
+    public void testRemoveLayerGroupInLayerGroup() throws Exception {
+        addLayerGroup();
+
+        LayerGroupInfo lg2 = catalog.getFactory().createLayerGroup();
+
+        lg2.setName("layerGroup2");
+        lg2.getLayers().add(lg);
+        lg2.getStyles().add(s);
+        catalog.add(lg2);
+
+
+        try {
+            catalog.remove(lg);
+            fail("should have failed because lg is in another lg");
+        }
+        catch(IllegalArgumentException expected) {}
+
+        //removing the containing layer first should work
+        catalog.remove(lg2);
+        catalog.remove(lg);
+    }
     
     static class TestListener implements CatalogListener {
 

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
@@ -35,14 +35,14 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
 
     @Before
     public void revertChanges() throws Exception {
+        removeLayerGroup(null, "nestedLayerGroupTest");
         removeLayerGroup(null, "sfLayerGroup");
         removeLayerGroup(null, "citeLayerGroup");
         removeLayerGroup("sf", "foo");
         removeLayerGroup(null, "newLayerGroup");
         removeLayerGroup(null, "newLayerGroupWithTypeCONTAINER");
         removeLayerGroup(null, "newLayerGroupWithTypeEO");
-        removeLayerGroup(null, "nestedLayerGroupTest");
-        
+
         LayerGroupInfo lg = catalog.getFactory().createLayerGroup();
         lg.setName( "sfLayerGroup" );
         lg.getLayers().add( catalog.getLayerByName( "sf:PrimitiveGeoFeature" ) );

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LayerGroupWorkspaceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LayerGroupWorkspaceTest.java
@@ -65,13 +65,13 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
     @After
     public void rollback() throws Exception {
         Catalog cat = getCatalog();
+        if(nested != null) {
+            cat.remove(nested);
+        }
         cat.remove(cite);
         cat.remove(sf);
         cat.remove(global);
         cat.remove(global2);
-        if(nested != null) {
-            cat.remove(nested);
-        }
     }
 
     LayerInfo layer(Catalog cat, QName name) {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LayerGroupWorkspaceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LayerGroupWorkspaceTest.java
@@ -59,13 +59,14 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
     @After
     public void rollback() throws Exception {
         Catalog cat = getCatalog();
+        if(nested != null) {
+            cat.remove(nested);
+        }
         cat.remove(cite);
         cat.remove(sf);
         cat.remove(global);
         cat.remove(global2);
-        if(nested != null) {
-            cat.remove(nested);
-        }
+
     }
     
     protected void registerNamespaces(java.util.Map<String,String> namespaces) {


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7858

Actual bugfix is in CatalogImpl/CatalogImplTest 

There are a bunch of additional test fixes to make other downstream test cases behave properly