### PR TITLE
Do not check stores when capabilites generation is set in tolerant mode

### DIFF
--- a/doc/en/user/source/configuration/globalsettings.rst
+++ b/doc/en/user/source/configuration/globalsettings.rst
@@ -46,6 +46,7 @@ There are two options:
 **OGC_EXCEPTION_REPORT**: This is the default behavior. Any layer errors will show up as Service Exceptions in the capabilities document, making it invalid.
 
 **SKIP_MISCONFIGURED_LAYERS**: With this setting, GeoServer will elect simply to not describe the problem layer at all, removing it from the capabilities document, and preserving the integrity of the rest of the document. Note that having a layer "disappear" may cause other errors in client functionality.
+    This is the default setting starting with GeoServer 2.11 and allows for faster startups, as the stores connectivity does not need to be checked in advance.
 
 Number of Decimals
 ------------------

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
@@ -355,10 +355,10 @@ public class GeoServerInfoImpl implements GeoServerInfo {
             return false;
         }
         
-        if (resourceErrorHandling == null) {
+        if (getResourceErrorHandling() == null) {
             if (other.getResourceErrorHandling() != null) return false;
         } else {
-            if (!resourceErrorHandling.equals(other.getResourceErrorHandling())) return false;
+            if (!getResourceErrorHandling().equals(other.getResourceErrorHandling())) return false;
         }
         
         if (lockProviderName == null) {
@@ -437,7 +437,11 @@ public class GeoServerInfoImpl implements GeoServerInfo {
     }
 
     public ResourceErrorHandling getResourceErrorHandling() {
-        return this.resourceErrorHandling;
+        if(this.resourceErrorHandling == null) {
+            return ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS;
+        }
+        
+        return resourceErrorHandling;
     }
 
     @Override

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesModifyingTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesModifyingTest.java
@@ -29,7 +29,7 @@ public class CapabilitiesModifyingTest extends GeoServerSystemTestSupport {
     @Before
     public void resetWmsConfigChanges() {
         GeoServerInfo global = getGeoServer().getGlobal();
-        global.setResourceErrorHandling(null);
+        global.setResourceErrorHandling(ResourceErrorHandling.OGC_EXCEPTION_REPORT);
         getGeoServer().save(global);
     }
     


### PR DESCRIPTION
This is a tentative, and incomplete, pull request disabling data store check on startup when the capabilities document generation is configured to skip over invalid layers. There is a test failure in geogig that seems to be related to code not being up to date (I also had a app-schema one, but that seems to be only local, I probably need to update code there).