### PR TITLE
Fix the NPE message when requesting the WPS GetCapabilities

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/GetCapabilities.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/GetCapabilities.java
@@ -34,6 +34,7 @@ import org.eclipse.emf.common.util.ECollections;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.ows.Ows11Util;
 import org.geoserver.ows.util.RequestUtils;
+import org.geoserver.platform.ServiceException;
 import org.geoserver.wps.ppio.ProcessParameterIO;
 import org.geoserver.wps.process.GeoServerProcessors;
 import org.geotools.data.Parameter;
@@ -85,7 +86,12 @@ public class GetCapabilities {
         // ServiceIdentification
         ServiceIdentificationType si = owsf.createServiceIdentificationType();
         caps.setServiceIdentification(si);
-
+        
+        // Check if WPS config is loaded
+        if (wps==null){
+            throw new ServiceException("WPS config not loaded. Check logs for details.");
+        }
+        
         si.getTitle().add(Ows11Util.languageString(wps.getTitle()));
         si.getAbstract().add(Ows11Util.languageString(wps.getAbstract()));
 

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetCapabilitiesTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetCapabilitiesTest.java
@@ -8,17 +8,10 @@ package org.geoserver.wps;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.*;
-
-import java.io.InputStream;
-
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.config.GeoServer;
-import org.geoserver.config.util.XStreamPersister;
-import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.data.test.MockData;
-import org.geoserver.platform.GeoServerExtensions;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -48,7 +41,7 @@ public class GetCapabilitiesTest extends WPSTestSupport {
     }
     
     @Test
-    public void testWPSScriptEnable() throws Exception {
+    public void testInvalidWPSConfig() throws Exception {
         GeoServer gs = getGeoServer();
         WPSInfo wpsInfo = gs.getService(WPSInfo.class);
         
@@ -56,7 +49,6 @@ public class GetCapabilitiesTest extends WPSTestSupport {
         gs.getFacade().remove(wpsInfo);
         try {
             Document dom = getAsDOM("wps?service=wps&request=getcapabilities");
-            print(dom);
             checkOws11Exception(dom);
         } finally {
             gs.getFacade().add(wpsInfo);
@@ -228,20 +220,6 @@ public class GetCapabilitiesTest extends WPSTestSupport {
         // print( dom );
         assertEquals("wps:Capabilities", dom.getFirstChild().getNodeName());
     }
-    
-    /**
-     * Helper method tha reads a WPS configuration from a XML file and return that info.
-     */
-    private WPSInfo loadFromXml(String resource) throws Exception {
-        XStreamPersisterFactory factory = GeoServerExtensions.bean(XStreamPersisterFactory.class);
-        XStreamPersister xp = factory.createXMLPersister();
-        WPSXStreamLoader loader = GeoServerExtensions.bean(WPSXStreamLoader.class);
-        loader.initXStreamPersister(xp, getGeoServer());
-        try (InputStream is = getClass().getResourceAsStream(resource)) {
-            return xp.load(is, WPSInfo.class);
-        }
-    }
-
     
     /* TODO Update Sequence tests
     public void testUpdateSequenceInferiorGet() throws Exception { // Standard Test A.4.2.6

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetCapabilitiesTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetCapabilitiesTest.java
@@ -8,11 +8,17 @@ package org.geoserver.wps;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
 
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.data.test.MockData;
+import org.geoserver.platform.GeoServerExtensions;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -38,6 +44,22 @@ public class GetCapabilitiesTest extends WPSTestSupport {
         } finally {
             info.setEnabled(true);
             gs.save(info);
+        }
+    }
+    
+    @Test
+    public void testWPSScriptEnable() throws Exception {
+        GeoServer gs = getGeoServer();
+        WPSInfo wpsInfo = gs.getService(WPSInfo.class);
+        
+        // Simulates the config failing to load due to xstream error GEOS-7903
+        gs.getFacade().remove(wpsInfo);
+        try {
+            Document dom = getAsDOM("wps?service=wps&request=getcapabilities");
+            print(dom);
+            checkOws11Exception(dom);
+        } finally {
+            gs.getFacade().add(wpsInfo);
         }
     }
 
@@ -206,6 +228,20 @@ public class GetCapabilitiesTest extends WPSTestSupport {
         // print( dom );
         assertEquals("wps:Capabilities", dom.getFirstChild().getNodeName());
     }
+    
+    /**
+     * Helper method tha reads a WPS configuration from a XML file and return that info.
+     */
+    private WPSInfo loadFromXml(String resource) throws Exception {
+        XStreamPersisterFactory factory = GeoServerExtensions.bean(XStreamPersisterFactory.class);
+        XStreamPersister xp = factory.createXMLPersister();
+        WPSXStreamLoader loader = GeoServerExtensions.bean(WPSXStreamLoader.class);
+        loader.initXStreamPersister(xp, getGeoServer());
+        try (InputStream is = getClass().getResourceAsStream(resource)) {
+            return xp.load(is, WPSInfo.class);
+        }
+    }
+
     
     /* TODO Update Sequence tests
     public void testUpdateSequenceInferiorGet() throws Exception { // Standard Test A.4.2.6


### PR DESCRIPTION
Rather than 'java.lang.NullPointerException', the error message now contains a little bit more explanation.