### PR TITLE
[GEOS-7907] Import of SoftValueHashMap fixed

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/EPSGCodeLookupCache.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/EPSGCodeLookupCache.java
@@ -9,7 +9,7 @@ import org.geotools.referencing.CRS;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import it.geosolutions.imageio.utilities.SoftValueHashMap;
+import org.geotools.util.SoftValueHashMap;
 
 /**
  * Caches expensive EPSG code lookups 


### PR DESCRIPTION
Fixed the import of SoftValueHashMap in GT (not in imageio-ext)