### PR TITLE
[GEOS-7918] Invalid scope attribute in gs-restconfig applicationContext.xml (master)

### DIFF
--- a/src/restconfig/src/main/java/applicationContext.xml
+++ b/src/restconfig/src/main/java/applicationContext.xml
@@ -4,7 +4,7 @@
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 <bean class="org.geoserver.platform.ModuleStatusImpl">
   <constructor-arg index="0" value="gs-restconfig"/>


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-7918