### PR TITLE
Update snapshot version

### DIFF
--- a/src/community/geogig/pom.xml
+++ b/src/community/geogig/pom.xml
@@ -15,7 +15,7 @@
   <name>GeoGig GeoServer integration</name>
 
   <properties>
-    <geogig.version>1.0-SNAPSHOT</geogig.version>
+    <geogig.version>1.1-SNAPSHOT</geogig.version>
     <jline.version>2.12</jline.version>
     <mockito.version>1.8.5</mockito.version>
     <logback.version>1.1.2</logback.version>


### PR DESCRIPTION
Changed the SNAPSHOT version for GeoGig plugin to 1.1 (backport)

Signed-off-by: goudine <agoudine@boundlessgeo.com>