### PR TITLE
[GEOS-7926] Fix WMTS blind re-enabling

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/wmts/WMTSXStreamLoader.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/wmts/WMTSXStreamLoader.java
@@ -35,7 +35,6 @@ public class WMTSXStreamLoader extends XStreamServiceLoader<WMTSInfo> {
     @Override
     protected WMTSInfo initialize(WMTSInfo service) {
         service = super.initialize(service);
-        service.setEnabled(true);
         if (service.getMaintainer() == null) {
             service.setMaintainer("http://geoserver.org/com");
         }

--- a/src/gwc/src/test/java/org/geoserver/gwc/wmts/WMTSXStreamLoaderTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/wmts/WMTSXStreamLoaderTest.java
@@ -26,7 +26,7 @@ public class WMTSXStreamLoaderTest extends GeoServerSystemTestSupport {
         loader.initXStreamPersister(xp, getGeoServer());
         // parsing service information
         try (InputStream is = getClass().getResourceAsStream("/wmts-test.xml")) {
-            WMTSInfo serviceInfo = xp.load(is, WMTSInfo.class);
+            WMTSInfo serviceInfo = loader.initialize(xp.load(is, WMTSInfo.class));
             assertThat(serviceInfo.getId(), is("WMTS-TEST"));
             assertThat(serviceInfo.isEnabled(), is(false));
             assertThat(serviceInfo.getName(), is("WMTS"));


### PR DESCRIPTION
Removes the WMTS service blind enabling in the initialization and fix the test that was not invoking the initialization.

Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-7926