### PR TITLE
[GEOS-7944] Fix for null LegendInfo objects in StyleEditPage

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -134,6 +134,9 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
             styleModel.getObject().setName("");
             styleModel.getObject().setLegend(getCatalog().getFactory().createLegend());
         } else {
+            if (style.getLegend() == null) {
+                style.setLegend(getCatalog().getFactory().createLegend());
+            }
             styleModel = new CompoundPropertyModel<StyleInfo>(style);
         }
         

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/ExternalGraphicPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/ExternalGraphicPanel.java
@@ -28,6 +28,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.NumberTextField;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
@@ -41,6 +42,7 @@ import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.LegendInfoImpl;
 import org.geoserver.config.GeoServer;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.platform.GeoServerExtensions;
@@ -207,11 +209,13 @@ public class ExternalGraphicPanel extends Panel {
 
         width = new TextField<Integer>("width", styleModel.bind("legend.width"), Integer.class);
         width.add(RangeValidator.minimum(0));
+        width.setRequired(true);
         width.setOutputMarkupId(true);
         table.add(width);
 
         height = new TextField<Integer>("height", styleModel.bind("legend.height"), Integer.class);
         height.add(RangeValidator.minimum(0));
+        height.setRequired(true);        
         height.setOutputMarkupId(true);
         table.add(height);
         
@@ -248,9 +252,13 @@ public class ExternalGraphicPanel extends Panel {
             @Override
             protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
                 onlineResource.setModelObject("");
+                onlineResource.clearInput();
                 format.setModelObject("");
+                format.clearInput();
                 width.setModelObject(0);
+                width.clearInput();
                 height.setModelObject(0);
+                height.clearInput();
                 
                 updateVisibility(false);
                 target.add(ExternalGraphicPanel.this);

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -10,7 +10,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileReader;
+import java.io.IOException;
 import java.io.Serializable;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Locale;
 
@@ -25,9 +28,11 @@ import org.apache.wicket.behavior.AbstractAjaxBehavior;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.util.file.File;
 import org.apache.wicket.util.tester.FormTester;
 import org.apache.wicket.util.tester.WicketTesterHelper;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.DataStoreInfo;
@@ -362,6 +367,160 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
             session.clear();
             session.setLocale(Locale.getDefault());
         }
+    }
+
+    /**
+     * Test that while editing a style, the user can create and then discard a legend without ever saving it.
+     */
+    @Test
+    public void testDiscardNewLegendInfo() {
+        tester.assertRenderedPage(StyleEditPage.class);
+        tester.assertNoErrorMessage();
+
+        // Show the legend panel (The test style does not initially have a legend)
+        tester.executeAjaxEvent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:showhide:show",
+                "click");
+
+        // Assert that the legend panel components exist
+        tester.assertComponent("styleForm:context:panel:legendPanel", ExternalGraphicPanel.class);
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:onlineResource",
+                TextField.class);
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:width",
+                TextField.class);
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:height",
+                TextField.class);
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:format",
+                TextField.class);
+
+        // Hide the legend panel (= "Discard Legend")
+        tester.executeAjaxEvent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:showhide:hide",
+                "click");
+        tester.assertNoErrorMessage();
+
+        // Submit the style (no legend should be saved)
+        tester.executeAjaxEvent("submit", "click");
+
+        StyleInfo style = getCatalog().getStyleByName(MockData.BUILDINGS.getLocalPart());
+        assertNotNull(style);
+        assertNull(style.getLegend());
+
+    }
+
+    /**
+     * Test that while editing a style, the user can discard a previously saved legend.
+     */
+    @Test
+    public void testDiscardExistingLegend() throws IOException, URISyntaxException {
+
+        // Create a legend for the style
+        StyleInfo style = getCatalog().getStyleByName(MockData.BUILDINGS.getLocalPart());
+        LegendInfo legendInfo = getCatalog().getFactory().createLegend();
+        legendInfo.setFormat("jpg");
+        legendInfo.setOnlineResource("test.jpg");
+        legendInfo.setHeight(100);
+        legendInfo.setWidth(100);
+        style.setLegend(legendInfo);
+        getCatalog().save(style);
+
+        // Reload the page
+        tester.startPage(
+                new StyleEditPage(getCatalog().getStyleByName(MockData.BUILDINGS.getLocalPart())));
+
+        // Make sure the legend fields exist and are populated as expected
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:onlineResource",
+                TextField.class);
+        tester.assertModelValue(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:onlineResource",
+                "test.jpg");
+
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:width",
+                TextField.class);
+        tester.assertModelValue(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:width", 100);
+
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:height",
+                TextField.class);
+        tester.assertModelValue(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:height", 100);
+
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:format",
+                TextField.class);
+        tester.assertModelValue(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:format", "jpg");
+
+        // Hide the legend panel (= "Discard Legend")
+        tester.executeAjaxEvent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:showhide:hide",
+                "click");
+
+        // Submit the form. (The legend should be discarded)
+        FormTester form = tester.newFormTester("styleForm", false);
+        form.submit();
+        tester.assertNoErrorMessage();
+
+        style = getCatalog().getStyleByName(MockData.BUILDINGS.getLocalPart());
+        assertNotNull(style);
+        assertNull(style.getLegend());
+    }
+
+    /**
+     * Test that while editing a style, the user can discard a legend, even if the legend has invalid values at the time, and then continue to save
+     * the style.
+     */
+    @Test
+    public void testDiscardLegendWithBadValues() throws IOException, URISyntaxException {
+        tester.executeAjaxEvent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:showhide:show",
+                "click");
+
+        // Make sure the fields we are editing actually exist
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:onlineResource",
+                TextField.class);
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:width",
+                TextField.class);
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:height",
+                TextField.class);
+        tester.assertComponent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:list:format",
+                TextField.class);
+
+        // Set some bad values for the legend
+        FormTester form = tester.newFormTester("styleForm", false);
+        form.setValue("context:panel:legendPanel:externalGraphicContainer:list:onlineResource",
+                "missing.ong");
+        form.setValue("context:panel:legendPanel:externalGraphicContainer:list:width", "-100");
+        form.setValue("context:panel:legendPanel:externalGraphicContainer:list:height", "");
+        form.setValue("context:panel:legendPanel:externalGraphicContainer:list:format",
+                "bad/value");
+
+        // Hide the legend panel (= "Discard Legend")
+        tester.executeAjaxEvent(
+                "styleForm:context:panel:legendPanel:externalGraphicContainer:showhide:hide",
+                "click");
+
+        // Refresh the state of the FormTester after the executeAjaxEvent
+        form = tester.newFormTester("styleForm", false);
+
+        // Submit the form. (The bad legend values should no longer be set).
+        form.submit();
+        tester.assertNoErrorMessage();
+
+        StyleInfo style = getCatalog().getStyleByName(MockData.BUILDINGS.getLocalPart());
+        assertNotNull(style);
+        assertNull(style.getLegend());
     }
 
 }


### PR DESCRIPTION
When the AbstractStylePage is loaded with an existing style, it will now check if the StyleInfo object has a null LegendInfo. If so, it will insert a blank LegendInfo into the StyleInfo to act as the model for the ExternalGraphicPanel. This was already being done for new styles, but was missing for existing styles.

Added additional tests for discarding a legend on the StyleEditPage.

Also fixed another issue that was uncovered by this fix: Changed the “discard legend” functionality to fully reset user input — otherwise, supposedly discarded values could still fail to validate and prevent a save.