### PR TITLE
[GEOS-7771] [GEOS-7873] Upgrade to jettison 1.2

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -1163,8 +1163,6 @@ public class XStreamPersister {
                     writer.addAttribute("type", typeName);
                 }
                 context.convertAnother( item, new ReferenceConverter( clazz ) );
-            } else if (writer instanceof JettisonStaxWriter) {
-                writer.setValue("null");
             }
             writer.endNode();
         }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -655,7 +655,7 @@
    <dependency>
     <groupId>org.codehaus.jettison</groupId>
     <artifactId>jettison</artifactId>
-    <version>1.0.1</version>
+    <version>1.2</version>
    </dependency>
    <dependency>
     <groupId>lucene</groupId>

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/CoverageStoreTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/CoverageStoreTest.java
@@ -62,7 +62,7 @@ public class CoverageStoreTest extends CatalogRESTTestSupport {
         JSON json = getAsJSON( "/rest/workspaces/wcs/coveragestores.json");
         assertTrue( json instanceof JSONObject );
         
-        Object coveragestores = ((JSONObject)json).getJSONObject("coverageStores").get("coverageStore");
+        Object coveragestores = ((JSONObject)json).getJSONArray("coverageStores").getJSONObject(0).get("coverageStore");
         assertNotNull( coveragestores );
         
         if( coveragestores instanceof JSONArray ) {

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/DataStoreTest.java
@@ -59,7 +59,7 @@ public class DataStoreTest extends CatalogRESTTestSupport {
         JSON json = getAsJSON( "/rest/workspaces/sf/datastores.json");
         assertTrue( json instanceof JSONObject );
         
-        Object datastores = ((JSONObject)json).getJSONObject("dataStores").get("dataStore");
+        Object datastores = ((JSONObject)json).getJSONArray("dataStores").getJSONObject(0).get("dataStore");
         assertNotNull( datastores );
         
         if( datastores instanceof JSONArray ) {

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
@@ -133,16 +133,16 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
     public void testGetAsJSON() throws Exception {
         print(get("/rest/layergroups/sfLayerGroup.json"));
         JSON json = getAsJSON( "/rest/layergroups/sfLayerGroup.json");
-        JSONArray arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONObject("publishables").getJSONArray("published");
+        JSONArray arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONArray("publishables").getJSONObject(0).getJSONArray("published");
         assertEquals(2, arr.size());
-        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONObject("styles").getJSONArray("style");
+        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONArray("styles").getJSONObject(0).getJSONArray("style");
         assertEquals(2, arr.size());
 
         print(get("/rest/layergroups/citeLayerGroup.json"));
         json = getAsJSON( "/rest/layergroups/citeLayerGroup.json");
-        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONObject("publishables").getJSONArray("published");
+        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONArray("publishables").getJSONObject(0).getJSONArray("published");
         assertEquals(6, arr.size());
-        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONObject("styles").getJSONArray("style");
+        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONArray("styles").getJSONObject(0).getJSONArray("style");
         assertEquals(6, arr.size());
     }
 

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
@@ -144,6 +144,20 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
         assertEquals(6, arr.size());
         arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONArray("styles").getJSONObject(0).getJSONArray("style");
         assertEquals(6, arr.size());
+
+        //GEOS-7873
+        LayerGroupInfo lg2 = catalog.getLayerGroupByName("citeLayerGroup");
+        List<StyleInfo> styles = lg2.getStyles();
+        styles.set(1, catalog.getStyleByName( StyleInfo.DEFAULT_POINT ) );
+        styles.set(3, catalog.getStyleByName( StyleInfo.DEFAULT_POINT ) );
+        catalog.save(lg2);
+
+        print(get("/rest/layergroups/citeLayerGroup.json"));
+        json = getAsJSON( "/rest/layergroups/citeLayerGroup.json");
+        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONArray("publishables").getJSONObject(0).getJSONArray("published");
+        assertEquals(6, arr.size());
+        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONArray("styles").getJSONObject(0).getJSONArray("style");
+        assertEquals(6, arr.size());
     }
 
 

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/NamespaceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/NamespaceTest.java
@@ -47,7 +47,7 @@ public class NamespaceTest extends CatalogRESTTestSupport {
         JSON json = getAsJSON( "/rest/namespaces.json");
         assertTrue( json instanceof JSONObject );
         
-        JSONArray namespaces = ((JSONObject)json).getJSONObject("namespaces").getJSONArray("namespace");
+        JSONArray namespaces = ((JSONObject)json).getJSONArray("namespaces").getJSONObject(0).getJSONArray("namespace");
         assertNotNull( namespaces );
         
         assertEquals( catalog.getNamespaces().size() , namespaces.size() ); 

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/StyleTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/StyleTest.java
@@ -69,7 +69,7 @@ public class StyleTest extends CatalogRESTTestSupport {
         
         List<StyleInfo> styles = catalog.getStyles();
         assertEquals( styles.size(), 
-            ((JSONObject) json).getJSONObject("styles").getJSONArray("style").size());
+            ((JSONObject) json).getJSONArray("styles").getJSONObject(0).getJSONArray("style").size());
     }
     
     @Test

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/WMSStoreTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/WMSStoreTest.java
@@ -55,7 +55,7 @@ public class WMSStoreTest extends CatalogRESTTestSupport {
         JSON json = getAsJSON( "/rest/workspaces/sf/wmsstores.json");
         assertTrue( json instanceof JSONObject );
         
-        Object stores = ((JSONObject)json).getJSONObject("wmsStores").get("wmsStore");
+        Object stores = ((JSONObject)json).getJSONArray("wmsStores").getJSONObject(0).get("wmsStore");
         assertNotNull( stores );
         
         if( stores instanceof JSONArray ) {

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/WorkspaceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/WorkspaceTest.java
@@ -46,7 +46,7 @@ public class WorkspaceTest extends CatalogRESTTestSupport {
         JSON json = getAsJSON( "/rest/workspaces.json");
         assertTrue( json instanceof JSONObject );
         
-        JSONArray workspaces = ((JSONObject)json).getJSONObject("workspaces").getJSONArray("workspace");
+        JSONArray workspaces = ((JSONObject)json).getJSONArray("workspaces").getJSONObject(0).getJSONArray("workspace");
         assertNotNull( workspaces );
         
         assertEquals( catalog.getNamespaces().size() , workspaces.size() ); 

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceTest.java
@@ -206,14 +206,14 @@ public class ResourceTest extends GeoServerSystemTestSupport {
                 + "  }"
                 + "},"
                 + "\"lastModified\": \"" + FORMAT.format(myRes.parent().lastmodified()) + "\","
-                + "  \"children\": {\"child\": [  {"
+                + "  \"children\": [{\"child\":  {"
                 + "    \"name\": \"myres\","
                 + "    \"link\":     {"
                 + "      \"href\": \"http://localhost:8080/geoserver/rest/resource/mydir/myres\","
                 + "      \"rel\": \"alternate\","
                 + "      \"type\": \"application/octet-stream\""
                 + "    }"
-                + "  }]}"
+                + "  }}]"
                 + "}}";
         JSONAssert.assertEquals(expected, (JSONObject) json);
     }


### PR DESCRIPTION
While working on https://osgeo-org.atlassian.net/browse/GEOS-7873, I revisited my fix for GEOS-7771 and discovered that GeoServer is using jettison 1.0.1, rather than 1.2. Upgrading jettison fixed GEOS-7771 and GEOS-7873 without requiring any workarounds.

This did result in a slight change in JSON syntax for representing arrays, and as such should probably not be backported. (See ResourceTest.java for an example of the syntax change - effectively, objects containing single-element arrays are now single-element arrays containing objects. This appears to occur whenever a List is encoded to JSON.