### PR TITLE
GEOS-7941:WfsCompatibilityTest fails if a local GeoServer is running without the sf:archsites layer

### DIFF
--- a/src/main/src/test/java/org/geoserver/wfsng/WfsCompatibilityTest.java
+++ b/src/main/src/test/java/org/geoserver/wfsng/WfsCompatibilityTest.java
@@ -67,12 +67,19 @@ public class WfsCompatibilityTest extends GeoServerSystemTestSupport {
         }
                 
         assertTrue(store instanceof WFSDataStore);
+        
+        try{
+            FeatureType type = ftInfo.getFeatureType();
+            
+            assertEquals("sf_archsites", type.getName().getLocalPart());        
+            
+            assertEquals("sf_archsites", ftInfo.getFeatureSource(null, null).getName().getLocalPart());
+        }catch(IOException e){
+            String expectedMessage = "Schema 'sf_archsites' does not exist.";
+            assertEquals("Exception message must be correct", expectedMessage, e.getMessage());
+        }
                 
-        FeatureType type = ftInfo.getFeatureType();
         
-        assertEquals("sf_archsites", type.getName().getLocalPart());        
-        
-        assertEquals("sf_archsites", ftInfo.getFeatureSource(null, null).getName().getLocalPart());
 
     }
 }

--- a/src/main/src/test/java/org/geoserver/wfsng/WfsCompatibilityTest.java
+++ b/src/main/src/test/java/org/geoserver/wfsng/WfsCompatibilityTest.java
@@ -70,16 +70,11 @@ public class WfsCompatibilityTest extends GeoServerSystemTestSupport {
         
         try{
             FeatureType type = ftInfo.getFeatureType();
-            
-            assertEquals("sf_archsites", type.getName().getLocalPart());        
-            
+            assertEquals("sf_archsites", type.getName().getLocalPart());
             assertEquals("sf_archsites", ftInfo.getFeatureSource(null, null).getName().getLocalPart());
-        }catch(IOException e){
+        } catch(IOException e){
             String expectedMessage = "Schema 'sf_archsites' does not exist.";
             assertEquals("Exception message must be correct", expectedMessage, e.getMessage());
         }
-                
-        
-
     }
 }

--- a/src/main/src/test/java/org/geoserver/wfsng/WfsCompatibilityTest.java
+++ b/src/main/src/test/java/org/geoserver/wfsng/WfsCompatibilityTest.java
@@ -68,11 +68,11 @@ public class WfsCompatibilityTest extends GeoServerSystemTestSupport {
                 
         assertTrue(store instanceof WFSDataStore);
         
-        try{
+        try {
             FeatureType type = ftInfo.getFeatureType();
             assertEquals("sf_archsites", type.getName().getLocalPart());
             assertEquals("sf_archsites", ftInfo.getFeatureSource(null, null).getName().getLocalPart());
-        } catch(IOException e){
+        } catch(IOException e) {
             String expectedMessage = "Schema 'sf_archsites' does not exist.";
             assertEquals("Exception message must be correct", expectedMessage, e.getMessage());
         }


### PR DESCRIPTION
Added try/catch clause to the test to catpure the IOException being thrown when the Schema isn't present.