### PR TITLE
[GEOS-7962] Add a WMS FORMAT vendor parameter

### DIFF
--- a/doc/en/user/source/services/wms/reference.rst
+++ b/doc/en/user/source/services/wms/reference.rst
@@ -116,6 +116,9 @@ They are fully documented in the :ref:`wms_vendor_parameters` section.
    * - ``namespace``
      - No
      - limits response to layers in a given namespace
+   * - ``format``
+     - No
+     - request the capabilities document in a certain format
 
 
 A example GetCapabilities request is:

--- a/doc/en/user/source/services/wms/vendor.rst
+++ b/doc/en/user/source/services/wms/vendor.rst
@@ -293,3 +293,14 @@ or empty if the default method has to be used for the related layer.
 
 The parameter allows to override the global WMS Raster Rendering Options setting (see :ref:`WMS Settings <services_webadmin_wms>` for more info), on a layer by layer basis. 
 
+format
+------
+
+The ``format`` parameter can be used to request capabilities documents in a certain format. If the requested format is not supported the default format will be used.
+
+An example request:
+
+  http://localhost:8080/geoserver/ows?service=wms&version=1.1.1&request=GetCapabilities&format=text/xml
+
+.. note::  
+  Currently this parameter can only be used to request WMS 1.1.1 capabilities documents encoded in ``text/xml``, if used with other WMS versions or other formats it will have no effect.

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -84,8 +84,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
-import sun.security.action.GetBooleanAction;
-
 import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Envelope;
 import org.geoserver.wfs.json.JSONType;
@@ -100,8 +98,13 @@ import org.geoserver.wfs.json.JSONType;
  *      org.geoserver.platform.Operation)
  */
 public class GetCapabilitiesTransformer extends TransformerBase {
-    /** fixed MIME type for the returned capabilities document */
-    public static final String WMS_CAPS_MIME = "application/vnd.ogc.wms_xml";
+    /** default MIME type for the returned capabilities document */
+    public static final String WMS_CAPS_DEFAULT_MIME = "application/vnd.ogc.wms_xml";
+
+    // available MIME types for the returned capabilities document
+    public static final String[] WMS_CAPS_AVAIL_MIME = {
+            WMS_CAPS_DEFAULT_MIME, "text/xml"
+    };
 
     /** the WMS supported exception formats */
     static final String[] EXCEPTION_FORMATS = { "application/vnd.ogc.se_xml",
@@ -473,7 +476,11 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             start("Request");
 
             start("GetCapabilities");
-            element("Format", WMS_CAPS_MIME);
+
+            // add all the supported MIME types for the capabilities document
+            for (String mimeType : WMS_CAPS_AVAIL_MIME) {
+                element("Format", mimeType);
+            }
 
             // build the service URL and make sure it ends with &
             String serviceUrl = buildURL(request.getBaseUrl(), "wms", params("SERVICE", "WMS"),


### PR DESCRIPTION
This pull request implements the support for the WMS ``format`` vendor parameter. WMS 1.1.1 capabilities document supported mime types were extend to include the ``text/xml`` mime type. Tests and documentation were also updated.

Associated issue: 
- https://osgeo-org.atlassian.net/browse/GEOS-7962

Mailing list discussion: 
- http://osgeo-org.1560.x6.nabble.com/Add-a-WMS-vendor-FORMAT-parameter-to-force-the-return-of-WMS-1-1-1-capabilities-in-text-xml-td5305506.html

  
