### PR TITLE
Copy editing (especially in ImageMosaic sections)

### DIFF
--- a/doc/en/developer/source/findbugs-guide/index.rst
+++ b/doc/en/developer/source/findbugs-guide/index.rst
@@ -73,7 +73,7 @@ For more information on installing and using the Findbugs plugin for Eclipse, se
 
 .. figure:: findbugs-eclipse.png
 
-    The Findbugs Eclipse perspective browsing the Geoserver Main module
+    The Findbugs Eclipse perspective browsing the GeoServer Main module
 
 Fixing Bugs from Findbugs
 -------------------------

--- a/doc/en/developer/source/maven-guide/index.rst
+++ b/doc/en/developer/source/maven-guide/index.rst
@@ -220,7 +220,7 @@ Installing the Oracle module
 
 To configure GeoServer to include the Oracle datastore extension module, do the following:
 
-Obtain the appropriate Oracle JDBC driver (possibly by downloading from Oracle or from the Geoserver ORACLE-extension on http://geoserver.org/release/stable/).
+Obtain the appropriate Oracle JDBC driver (possibly by downloading from Oracle or from the GeoServer ORACLE-extension on http://geoserver.org/release/stable/).
 Install it in the Maven repository using the command::
 	
   mvn install:install-file -Dfile=ojdbc7.jar -DgroupId=com.oracle -DartifactId=ojdbc7 -Dversion=12.1.0.2 -Dpackaging=jar -DgeneratePom=true

--- a/doc/en/developer/source/programming-guide/ows-services/implementing.rst
+++ b/doc/en/developer/source/programming-guide/ows-services/implementing.rst
@@ -3,7 +3,7 @@
 Implementing a simple OWS service
 =================================
 
-This section explains How to Create a Simple GeoServer OWS service for Geoserver using the following scenario. The service should supply a capabilities document which advertises a single operation called "sayHello". The result of a sayHello operation is the simple string "Hello World".
+This section explains How to Create a Simple GeoServer OWS service for GeoServer using the following scenario. The service should supply a capabilities document which advertises a single operation called "sayHello". The result of a sayHello operation is the simple string "Hello World".
 
 .. contents::
 

--- a/doc/en/user/source/community/dds/index.rst
+++ b/doc/en/user/source/community/dds/index.rst
@@ -15,7 +15,7 @@ mime-types supported are:
 Installing the DDS/BIL extension
 -----------------------------------
 
- #. Download the DDS/BIL extension from the `nightly GeoServer community module builds <http://ares.boundlessgeo.com/geoserver/master/community-latest/>`_. A prebuilt version for Geoserver 2.0.x can be found on Jira - :geos:`3586`.
+ #. Download the DDS/BIL extension from the `nightly GeoServer community module builds <http://ares.boundlessgeo.com/geoserver/master/community-latest/>`_. A prebuilt version for GeoServer 2.0.x can be found on Jira - :geos:`3586`.
 
     .. warning:: Make sure to match the version of the extension to the version of the GeoServer instance!
 

--- a/doc/en/user/source/community/jdbcstore/index.rst
+++ b/doc/en/user/source/community/jdbcstore/index.rst
@@ -3,7 +3,7 @@
 JDBCStore
 ==========
 
-The ``JDBCStore module`` allows efficient sharing of configuration data in a clustered deployment of Geoserver. It allows externalising the storage of all configuration resources to a Relational Database Management System, rather than using the default File System based :ref:`datadir`. This way the multiple instances of Geoserver can use the same Database and therefore share in the same configuration.
+The ``JDBCStore module`` allows efficient sharing of configuration data in a clustered deployment of GeoServer. It allows externalising the storage of all configuration resources to a Relational Database Management System, rather than using the default File System based :ref:`datadir`. This way the multiple instances of GeoServer can use the same Database and therefore share in the same configuration.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/en/user/source/community/jms-cluster/index.rst
+++ b/doc/en/user/source/community/jms-cluster/index.rst
@@ -49,7 +49,7 @@ This structure allows to have:
 This full blown deployment is composed by:
 
 * A pure Master GeoServer(s), this instance can only send events to the topic. It cannot act as a slave
-* A set of Geoserver which can work as both Master and Slave. These instances can send and receive messages to/from the topic. They can work as Masters (sending message to other subscribers) as well as Slaves (these instances are also subscribers of the topic).
+* A set of GeoServer which can work as both Master and Slave. These instances can send and receive messages to/from the topic. They can work as Masters (sending message to other subscribers) as well as Slaves (these instances are also subscribers of the topic).
 * A set of pure Slaves GeoServer instances whic can only receive messages from the topic.
 * A set of MOM brokers so that each GeoServer instance is configured with a set of available brokers (failover). Each broker use the shared database as persistence. Doing so if a broker fails for some reason, messages can still be written and read from the shared database.
 

--- a/doc/en/user/source/community/onelogin/index.rst
+++ b/doc/en/user/source/community/onelogin/index.rst
@@ -5,25 +5,25 @@ OneLogin Authentication Filter
 
 This plugin adds to GeoServer the support for SAML based Single Sign On (SSO), a process that 
 allows users to authenticate themselves against an external Identity Provider (such as OneLogin) 
-rather than obtaining and using a separate username and password handled by Geoserver.
+rather than obtaining and using a separate username and password handled by GeoServer.
 
 What you will need is an account in OneLogin: https://www.onelogin.com/ that will handle the sign-in
-process and will eventually provide the authentication credentials of your users to Geoserver.
+process and will eventually provide the authentication credentials of your users to GeoServer.
 
-Geoserver users authenticated through OneLogin are handled from OneLogin and any change performed on the
-account is used by Geoserver. The only user data that is necessary for Geoserver is a unique identifier for each user.
+GeoServer users authenticated through OneLogin are handled from OneLogin and any change performed on the
+account is used by GeoServer. The only user data that is necessary for GeoServer is a unique identifier for each user.
 
-User's email is used by default as a unique identifier for each user. Geoserver does not store passwords.
+User's email is used by default as a unique identifier for each user. GeoServer does not store passwords.
 
 OneLogin Configuration
 ----------------------
 
-Actually Geoserver is not present within the OneLogin application catalog so we can use the OneLogin SAML test connector.
+Actually GeoServer is not present within the OneLogin application catalog so we can use the OneLogin SAML test connector.
 For more details about configuring the SAML Test Connector follow the guide at:
 
     https://support.onelogin.com/hc/en-us/articles/202673944-How-to-Use-the-OneLogin-SAML-Test-Connector
     
-In the example we assume that Geoserver URL is http://localhost:8080/geoserver, if you have a specific domain 
+In the example we assume that GeoServer URL is http://localhost:8080/geoserver, if you have a specific domain 
 for geoserver use it instead.
 
 On the SAML Test Connector (IdP) configuration page, use the following values as parameters:
@@ -73,8 +73,8 @@ Configuring the OneLogin Authentication Filter
    :align: center
    
 
-5. Fill in the fields of the settings form as follows; you can use Geoserver role sources to assign
-a specific group or role to OneLogin user. OneLogin user email must be mapped to Geoserver user name.
+5. Fill in the fields of the settings form as follows; you can use GeoServer role sources to assign
+a specific group or role to OneLogin user. OneLogin user email must be mapped to GeoServer user name.
 
 .. list-table::
    :header-rows: 1

--- a/doc/en/user/source/community/rest-upload/index.rst
+++ b/doc/en/user/source/community/rest-upload/index.rst
@@ -32,7 +32,7 @@ Here is a description of general workflow that clients must follow to handle fil
 
 #.	The client starts the file upload with an *application/octet-stream* **REST PUT** at url returned from the POST (relative url is **/rest/resumableupload/${uploadId}** ). The body of the **PUT** contains the file bytes to upload. It is mandatory to set the header attribute **Content-Length** with the total number of byte of the current upload (same as the complete size of file in bytes). 
 
-#.	The server saves a temporary file into the desired path relative to a configurable folder (default is *tmp/upload* subfolder of *Geoserver data directory*). 
+#.	The server saves a temporary file into the desired path relative to a configurable folder (default is *tmp/upload* subfolder of *GeoServer data directory*). 
 	
 #.	The server reply can be:
 
@@ -52,7 +52,7 @@ Here is a description of general workflow that clients must follow to handle fil
 The uploads which are not completed and are not resumed from too much time (default value is 300000 milliseconds) will be removed from server.
 The completed files will be reachable via GET request for a limited time (default value is 300000 milliseconds).
 
-The timeout of files cleaner task and the temporary subfolder path can be configured by adding a **resumableUpload.properties** file to the Geoserver data directory with the definition of properties *resumable.tempPath* and *resumable.expirationDelay* (in milliseconds). Each modification of this file requires to restart GeoServer.
+The timeout of files cleaner task and the temporary subfolder path can be configured by adding a **resumableUpload.properties** file to the GeoServer data directory with the definition of properties *resumable.tempPath* and *resumable.expirationDelay* (in milliseconds). Each modification of this file requires to restart GeoServer.
 
 Example of usage
 -------------------------

--- a/doc/en/user/source/data/app-schema/data-access-integration.rst
+++ b/doc/en/user/source/data/app-schema/data-access-integration.rst
@@ -75,7 +75,7 @@ How to use filters
 From the user point of view, filters are configured as per normal, using the mapped/output target attribute XPath expressions. 
 However, when one or more attributes in the expression is a multi-valued property, we need to specify a function such as "contains_text" in the filter. 
 This is because when multiple values are returned, comparing them to a single value would only return true if there is only one value returned, and it is the same value. 
-Please note that the "contains_text" function used in the following example is not available in Geoserver API, but defined in the database. 
+Please note that the "contains_text" function used in the following example is not available in GeoServer API, but defined in the database. 
 
 **Example:**
 

--- a/doc/en/user/source/data/cascaded/wfs.rst
+++ b/doc/en/user/source/data/cascaded/wfs.rst
@@ -61,7 +61,7 @@ Connecting to an external WFS layer via a proxy server
 
 In a corporate environment it may be necessary to connect to an external WFS through a proxy server. To achieve this, various java variables need to be set.
 
-For a Windows install running Geoserver as a service, this is done by modifying the wrapper.conf file. For a default Windows install, modify :file:`C:\\Program Files\\GeoServer x.x.x\\wrapper\\wrapper.conf` similarly to the following.
+For a Windows install running GeoServer as a service, this is done by modifying the wrapper.conf file. For a default Windows install, modify :file:`C:\\Program Files\\GeoServer x.x.x\\wrapper\\wrapper.conf` similarly to the following.
 
    # Java Additional Parameters
 
@@ -76,6 +76,6 @@ For a Windows install running Geoserver as a service, this is done by modifying 
 
 Note that the :command:`http.proxySet=true` parameter is required. Also, the parameter numbers must be consecutive - ie. no gaps.
 
-For a Windows install not running Geoserver as a service, modify :file:`startup.bat` so that the :command:`java` command runs with similar -D parameters.
+For a Windows install not running GeoServer as a service, modify :file:`startup.bat` so that the :command:`java` command runs with similar -D parameters.
 
 For a Linux/UNIX install, modify :file:`startup.sh` so that the :command:`java` command runs with similar -D parameters.

--- a/doc/en/user/source/data/database/connection-pooling.rst
+++ b/doc/en/user/source/data/database/connection-pooling.rst
@@ -27,7 +27,7 @@ Connection pool options
    * - connection timeout
      - Time, in seconds, the connection pool will wait before giving up its attempt to get a new connection from the database. Defaults to 20 seconds. 
    * - Test while idle
-     - Periodically test if the connections are still valid also while idle in the pool. Sometimes performing a test query using an idle connection can make the datastore unavailable for a while. Often the cause of this troublesome behaviour is related to a network firewall placed between Geoserver and the Database that force the closing of the underlying idle TCP connections.
+     - Periodically test if the connections are still valid also while idle in the pool. Sometimes performing a test query using an idle connection can make the datastore unavailable for a while. Often the cause of this troublesome behaviour is related to a network firewall placed between GeoServer and the Database that force the closing of the underlying idle TCP connections.
    * - Evictor run periodicity
      - Number of seconds between idle object evictor runs.
    * - Max connection idle time

--- a/doc/en/user/source/data/raster/imagemosaic/configuration.rst
+++ b/doc/en/user/source/data/raster/imagemosaic/configuration.rst
@@ -1,6 +1,6 @@
   .. _data_imagemosaic_config:
 
-Imagemosaic configuration
+ImageMosaic configuration
 =========================
 
 Granules
@@ -14,12 +14,12 @@ Each individual image is commonly referred to as a **granule**. Individual granu
 
 .. warning:: The last limtation has been relaxed when JAI-Ext is enabled to allow users to mix data of the following colormodels RGB, Gray, Paletted. Of course it does not make sense to mosaic data coming from a DEM (usually single band Float or Short) with data coming from Aerial imagery (usually RGB or Gray) but it does make sense to create global mosaics with data coming from different sources and having different colormodels.
 
-In addition it is worth to remark on the fact that currently the ImageMosaic is able to handle raster data whose grid-to-world transformation is a scale and translate transformation, hence no rotation or skew.
+In addition it is worth remarking on the fact that currently the ImageMosaic is able to handle raster data whose grid-to-world transformation is a scale and translate transformation, hence no rotation or skew.
 
 Index and configuration file creation
 -------------------------------------
 
-When a new store is created, an index shapefile will be generated to associate each granule file with its bounding box. The index creation respects directory trees as well as single directories. All you need to do is point the store to the root of the hierarchy, and all images will be considered for inclusion in the imagemosaic.
+When a new store is created, an index shapefile will be generated to associate each granule file with its bounding box. The index creation respects directory trees as well as single directories. All you need to do is point the store to the root of the hierarchy, and all images will be considered for inclusion in the ImageMosaic.
 
 The index will contain the enclosing polygon for each raster file (in an appropriate coordinate reference system) and the path to each of these files. The location attribute can be relative to the configuration folder or absolute. By default, the name of this attribute is ``location``, but this can be changed in the main configuration file.
 
@@ -33,7 +33,7 @@ Within each store there are multiple configuration files that determine how the 
 Primary configuration file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The mosaic configuration file is the primary file used to store the configuration parameters that control the imagemosaic plugin. When created by GeoServer it is by default called ``<directory>.properties``, where ``<directory>`` is the name of the root directory of the store. (It is not related to the store name in GeoServer.) It can have other names, as long as it does not conflict with other files such as :file:`datastore.properties` or :file:`indexer.properties`. This file usually does not require manual editing.
+The mosaic configuration file is the primary file used to store the configuration parameters that control the ImageMosaic plugin. When created by GeoServer it is by default called ``<directory>.properties``, where ``<directory>`` is the name of the root directory of the store. (It is not related to the store name in GeoServer.) It can have other names, as long as it does not conflict with other files such as :file:`datastore.properties` or :file:`indexer.properties`. This file usually does not require manual editing.
 
 The table below describes the various elements in this configuration file.
 
@@ -62,7 +62,7 @@ The table below describes the various elements in this configuration file.
      - Featuretype name for this mosaic. Usually the name as ``Name``.
    * - Caching
      - N
-     - Boolean value to enable caching. When set to ``true``, the imagemosaic will try to save in memory the entire contents of the index to reduce loading/query time. Set to ``false`` for a large granule index and/or if new granules are to be ingested (for example, when the index is on a database and we interact directly with it). Default is ``false``.
+     - Boolean value to enable caching. When set to ``true``, the ImageMosaic will try to save in memory the entire contents of the index to reduce loading/query time. Set to ``false`` for a large granule index and/or if new granules are to be ingested (for example, when the index is on a database and we interact directly with it). Default is ``false``.
    * - ExpandToRGB
      - N
      - Boolean flag to force color expansion from index color model (paletted datasets) to component color model (RGB). Default is ``false``.
@@ -73,11 +73,11 @@ The table below describes the various elements in this configuration file.
      - Y
      - Suggested plugin for reading the image files.
    * - Envelope2D
-     - Y
-     - Envelope for the mosaic formatted as ```LLX,LLY URX,URY`` (notice the space between the lower left and upper right coordinate pairs).
+     - N
+     - Envelope for the mosaic formatted as ``LLX,LLY URX,URY`` (notice the space between the lower left and upper right coordinate pairs).
    * - CheckAuxiliaryMetadata
      - N
-     - This parameter allows to specify whether the ImageMosaic plugin should check for the presence of a GDAL aux.xml file beside each granule file. For most common use cases, you don't need to set or specify this parameter. Being disabled by Default, ImageMosaic won't look for an ancillary file for each granule being initialized in the GranuleCatalog. This avoid useless checks, especially when dealing with thousand of granules. You should set that parameter to true when you want to instruct the ImageMosaic to look for a GDAL generated aux.xml file containing PAM (Persistent Auxiliary Metadata) for each granule, to be attached to the Granule info (GranuleDescriptor). This is specially useful when you have setup a `Dynamic ColorMap rendering transformation <http://docs.geoserver.org/stable/en/user/community/colormap/index.html>`_ which dynamically set a color map based on the statistics collected into the granule's GDAL PAM being previously generated with a gdalinfo -stats parameter.
+     - This parameter allows to specify whether the ImageMosaic plugin should check for the presence of a GDAL aux.xml file beside each granule file. For most common use cases, you don't need to set or specify this parameter. Being disabled by Default, ImageMosaic won't look for an ancillary file for each granule being initialized in the GranuleCatalog. This avoid useless checks, especially when dealing with thousand of granules. You should set that parameter to ``true`` when you want to instruct the ImageMosaic to look for a GDAL generated aux.xml file containing PAM (Persistent Auxiliary Metadata) for each granule, to be attached to the Granule info (GranuleDescriptor). This is specially useful when you have setup a `Dynamic ColorMap rendering transformation <http://docs.geoserver.org/stable/en/user/community/colormap/index.html>`_ which dynamically set a color map based on the statistics collected into the granule's GDAL PAM being previously generated with a gdalinfo -stats parameter.
    * - LevelsNum
      - Y
      - Represents the number of reduced resolution layers that we currently have for the granules of this mosaic.
@@ -104,11 +104,11 @@ A sample configuration file follows::
 
 By default the ImageMosaic index is specified by a shapefile, which is located at the root of the ImageMosaic directory, just like the primary configuration file.
 
-If needed different storage can be used for the index like a spatial DBMS which is the preferred solution when willing to share the ImageMosaic itself in a cluster of GeoServer intances. In this case the user must supply GeoSerer with the proper onnection parameters which can be specified by using a :file:`datastore.properties` file placed at the root of the ImageMosaic directory.
+If needed, different storage can be used for the index — like a spatial DBMS, which is the preferred solution when you wish to share the ImageMosaic itself in a cluster of GeoServer instances. In this case the user must supply GeoServer with the proper connection parameters, which can be specified by using a :file:`datastore.properties` file placed at the root of the ImageMosaic directory.
 
 .. note:: A shapefile is created automagically if it does not exist or if there is no :file:`datastore.properties` file.
 
-.. warning:: At the time of speaking the following spatisl DBMS have been tested successfully: Oracle, PostgreSQL, H2. SQl Server is not yet supported.
+.. warning:: At the time of writing the following spatial DBMS have been tested successfully: Oracle, PostgreSQL, H2. SQl Server is not yet supported.
 
 
 .. list-table::
@@ -127,7 +127,7 @@ If needed different storage can be used for the index like a spatial DBMS which 
        * Oracle: ``org.geotools.data.oracle.OracleNGDataStoreFactory`` 
        * H2: ``org.geotools.data.h2.H2DataStoreFactory``
 
-       :ref:`JNDI <tomcat_jndi>` can also be used with any of these stores. If JNDI is used, the DataStoreFactory name differ from the above.
+       :ref:`JNDI <tomcat_jndi>` can also be used with any of these stores. If JNDI is used, the DataStoreFactory name will differ from the above.
 
    * - Connection parameters
      - Y
@@ -180,7 +180,7 @@ Here is a sample :file:`datastore.properties` file for a PostGIS index via JNDI:
 :file:`indexer.properties`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to the required envelope and location attributes, the schema for the index store may expose other custom attributes which can be later on used for filterin on the fly the ImageMosaic granules during a WMS or WCS request or to diver WMS and WCS dimensions like TIME, ELEVATION and so on. This is configured by the :file:`indexer.properties` file:
+In addition to the required envelope and location attributes, the schema for the index store may expose other custom attributes which can be used later for filtering the ImageMosaic granules on the fly during a WMS or WCS request or to diver WMS and WCS dimensions like TIME, ELEVATION and so on. This is configured by the :file:`indexer.properties` file:
 
 .. list-table::
    :widths: 15 5 80
@@ -206,40 +206,40 @@ In addition to the required envelope and location attributes, the schema for the
      - N
      - Path to an auxiliary file to be used for internal purposes (For example: when dealing with NetCDF granules, it refers to the NetCDF XML ancillary file.)
    * - AbsolutePath
-     - Y
-     - Controls whether or not the path stored inside the ``location`` attribute represents an absolute path or a path relative to the location of the shapefile index. Notice that a relative index ensures much more portability of the mosaic itself. Default value for this parameter is ``false``, which means relative paths.
+     - N
+     - Controls whether or not the path stored inside the ``location`` attribute represents an absolute path or a path relative to the location of the shapefile index. Notice that a relative index ensures better portability of the mosaic itself. Default value for this parameter is ``false``, which means relative paths.
    * - Caching
      - N
-     - Boolean value to enable caching. When set to ``true``, the imagemosaic will try to save in memory the entire contents of the index to reduce loading/query time. Set to ``false`` for a large granule index and/or if new granules are to be ingested (for example, when the index is on a database and we interact directly with it). Default is ``false``.
+     - Boolean value to enable caching. When set to ``true``, the ImageMosaic will try to save in memory the entire contents of the index to reduce loading/query time. Set to ``false`` for a large granule index and/or if new granules are to be ingested (for example, when the index is on a database and we interact directly with it). Default is ``false``.
    * - CanBeEmpty
      - N
-     - Boolean flag used for configuring empty mosaics. When enabled the imagemosaic will not throw an exception caused by the absence of any coverage. By default it is set to false.
+     - Boolean flag used for configuring empty mosaics. When enabled the ImageMosaic will not throw an exception caused by the absence of any coverage. By default it is set to ``false``.
    * - Envelope2D
-     - Y
-     - Envelope for the mosaic formatted as ```LLX,LLY URX,URY`` (notice the space between the lower left and upper right coordinate pairs).
+     - N
+     - Envelope for the mosaic formatted as ``LLX,LLY URX,URY`` (notice the space between the lower left and upper right coordinate pairs).
    * - ExpandToRGB
      - N
      - Boolean flag to force color expansion from index color model (paletted datasets) to component color model (RGB). Default is ``false``.
    * - IndexingDirectories
      - N
-     - Comma separated values list of paths referring to directories containing granules to be indexed. If unspecified, the IndexingDirectory will be the mosaic configuration directory. This parameter allows to configure a mosaic on a folder which contains configuration files only while the real granules to be indexed are stored somewhere else.
+     - Comma separated values list of paths referring to directories containing granules to be indexed. If unspecified, the IndexingDirectory will be the mosaic configuration directory. This parameter allows configuration of a mosaic in a folder which contains only configuration files, while the granules to be indexed are stored somewhere else.
    * - Name
      - N
      - The name to be assigned to the index. If unspecified, the index name will usually match the name of the folder containing the mosaic.
    * - CoverageNameCollector
      - N
-     - As described in the previous row, the Name parameter allows to specify the name of the coverage to be exposed by the ImageMosaic. ImageMosaic of NetCDFs exposes instead a coverage for each supported variable found in the NetCDF, using the variable's name as coverage name (as an instance, air_temperature, wind_speed,...). The optional CoverageNameCollectorSPI property allows to specify a CoverageNameCollector plugin to be used to instruct the ImageMosaic on how to setup different coverageNames for granules. It should contains the full name of the implementing class plus an optional set of semicolon-separated set of keyValue pairs prefixed by ":".  See below for an example
+     - As described in the previous row, the Name parameter allows specification of the coverage name to be exposed by the ImageMosaic. An ImageMosaic of NetCDFs instead exposes a coverage for each supported variable found in the NetCDF, using the variable's name as the coverage name (for instance, air_temperature, wind_speed, etc.) The optional CoverageNameCollectorSPI property allows specification of a CoverageNameCollector plugin to be used to instruct the ImageMosaic on how to setup different coverageNames for granules. It should contains the full name of the implementing class plus an optional set of semicolon-separated keyValue pairs prefixed by ":". See below for an example.
    * - Recursive
      - N
-     - Boolean flag used at indexing time. When set the true, the indexer will look for granules by scanning any subdirectory contained in the indexing directory. If false, only the main folder will be analyzed. Default is "true".
+     - Boolean flag used at indexing time. When set to ``true``, the indexer will look for granules by scanning any subdirectory contained in the indexing directory. If ``false``, only the main folder will be analyzed. Default is ``true``.
    * - UseExistingSchema
      - N
-     - Boolean flag used for enabling/disabling the use of existing schemas. When enabled the imagemosaic will start indexing granules using the existing database schema (from :file:`datastore.properties`) instead of populating it. It is useful when you already have a database with a valid mosaic schema (the_geom, location and other attributes, take a look at gdalindex) or when you do not want to rename the images to add times and dimensions (you should simply add them to the table, to AdditionalDomainAttributes and to PropertyCollectors). Default is "false".
+     - Boolean flag used for enabling/disabling the use of existing schemas. When enabled, the ImageMosaic will start indexing granules using the existing database schema (from :file:`datastore.properties`) instead of populating it. This is useful when you already have a database with a valid mosaic schema (the_geom, location and other attributes, take a look at gdalindex) or when you do not want to rename the images to add times and dimensions (you should simply add them to the table, to AdditionalDomainAttributes and to PropertyCollectors). Default is ``false``.
    * - Wildcard
      - N
      - Wildcard used to specify which files should be scanned by the indexer. (For instance: ".")
 
-Here is a sample :file:`indexer.properties` file. 
+Here is a sample :file:`indexer.properties` file::
 
     Schema=*the_geom:Polygon,location:String,ingestion:java.util.Date,elevation:Double
     PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](ingestion),DoubleFileNameExtractorSPI[elevationregex](elevation)
@@ -248,11 +248,11 @@ Here is a sample :file:`indexer.properties` file.
     Caching=false
     AbsolutePath=false
 
-An example of optional CoverageNameCollectorSPI could be
+An example of optional CoverageNameCollectorSPI could be::
 
     org.geotools.gce.imagemosaic.namecollector.FileNameRegexNameCollectorSPI:regex=^([a-zA-Z0-9]+)
     
-A filename regex based name collector which extracts the coverage name from the prefix of the file name. So that an ImageMosaic with temperature_2015.tif, temperature_2016.tif, pressure_2015.tif, pressure_2016.tif will put temperature* granules on a ``temperature`` coverage and pressure* granules on a ``pressure`` coverage.
+This defines a regex-based name collector which extracts the coverage name from the prefix of the file name, so that an ImageMosaic with temperature_2015.tif, temperature_2016.tif, pressure_2015.tif, pressure_2016.tif will put temperature* granules on a ``temperature`` coverage and pressure* granules on a ``pressure`` coverage.
     
 Other properties files
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -275,11 +275,11 @@ By default, :guilabel:`ImageMosaic` will be an option in the :guilabel:`Raster D
 
 .. figure:: images/imagemosaiccreate.png
 
-   Imagemosaic in the list of raster data stores
+   ImageMosaic in the list of raster data stores
 
 .. figure:: images/imagemosaicconfigure.png
 
-   Configuring an imagemosaic data store
+   Configuring an ImageMosaic data store
 
 .. list-table::
    :widths: 20 80
@@ -302,7 +302,7 @@ By default, :guilabel:`ImageMosaic` will be an option in the :guilabel:`Raster D
 Coverage parameters
 -------------------
 
-Creation of the store is the first step to getting an imagemosaic published in GeoServer. Most of the configuration is done when publishing the resulting coverage (layer).
+Creation of the store is the first step to getting an ImageMosaic published in GeoServer. Most of the configuration is done when publishing the resulting coverage (layer).
 
 The Coverage Editor gives users the possibility to set a few control parameters to further control the mosaic creation process.
 
@@ -320,20 +320,20 @@ The parameters are as follows:
    * - Parameter
      - Description
    * - Accurate resolution computation
-     - Boolean value. If true, computes the resolution of the granules in 9 points: the corners of the requested area and the middle points, taking the better one. This will provide better results for cases where there is a lot more deformation on a subregion (top/bottom/sides) of the requested bounding box with respect to others. If false, computes the resolution using a basic affine scale transform.
+     - Boolean value. If ``true``, computes the resolution of the granules in 9 points: the corners of the requested area and the middle points, taking the better one. This will provide better results for cases where there is a lot more deformation on a subregion (top/bottom/sides) of the requested bounding box with respect to others. If ``false``, computes the resolution using a basic affine scale transform.
    * - AllowMultithreading
-     - If true, enables tiles multithreading loading. This allows to perform parallelized loading of the granules that compose the mosaic. Setting this to true makes sense only if you set USE_JAI_IMAGEREAD to false at the same time to force immediate loading in memory of data.
+     - If ``true``, enables multithreaded tile loading. This allows performing parallelized loading of the granules that compose the mosaic. Setting this to ``true`` makes sense only if you set USE_JAI_IMAGEREAD to ``false`` at the same time to force immediate loading of data into memory.
    * - BackgroundValues
      - Sets the value of the mosaic background. Depending on the nature of the mosaic it is wise to set a value for the "nodata" area (usually -9999). This value is repeated on all the mosaic bands.
    * - Filter
-     - Sets the default mosaic filter. It should be a valid :ref:`ECQL query <cql_tutorial>` which will be used as default if no ``cql_filter`` is specified (instead of Filter.INCLUDE). This filter will be applied against the mosaic index, and may include any attributes exposed by the index store. If the ``cql_filter`` is specified in the request it will be overridden.
+     - Sets the default mosaic filter. It should be a valid :ref:`ECQL query <cql_tutorial>` to be used by default if no ``cql_filter`` is specified (instead of Filter.INCLUDE). This filter will be applied against the mosaic index, and may include any attributes exposed by the index store. If the ``cql_filter`` is specified in the request it will be overridden.
 
        .. note:: Do not use this filter to change time or elevation dimensions defaults. It will be added as AND condition with CURRENT for "time" and LOWER for "elevation".
 
    * - FootprintBehavior
-     - Sets the behavior of the regions of a granule that are outside of the granule footprint. Can be ``None`` (ignore the footprint), ``Cut`` (remove regions outside the footprint from the image and don't add an alpha channel), or ``Transparent`` (make regions outside the footprint completely transparent, will add an alpha channel if one is not already present). Defaults to ``None``.
+     - Sets the behavior of the regions of a granule that are outside of the granule footprint. Can be ``None`` (ignore the footprint), ``Cut`` (remove regions outside the footprint from the image and don't add an alpha channel), or ``Transparent`` (make regions outside the footprint completely transparent, and add an alpha channel if one is not already present). Defaults to ``None``.
    * - InputTransparentColor
-     - Sets the transparent color for the granules prior to the mosaic process them in order to control the superimposition process between them. When GeoServer composes the granules to satisfy the user request, some of them can overlap some others, therefore, setting this parameter with an appropriate color avoids the overlap of "nodata" areas between granules. See below for an example:
+     - Sets the transparent color of the granules prior to processing by the ImageMosaic plugin, in order to control how they are superimposed. When GeoServer composes the granules to satisfy a user request, some can overlap others; setting this parameter with an appropriate color avoids the overlap of "nodata" areas between granules. See below for an example:
 
        .. figure:: images/input_color.png
 
@@ -344,11 +344,11 @@ The parameters are as follows:
           InputTransparentColor parameter configured
 
    * - MaxAllowedTiles
-     - Sets the maximum number of the tiles that can be loaded simultaneously for a request. In case of a large mosaic this parameter should be opportunely set to not saturate the server with too many granules loaded at the same time.
+     - Sets the maximum number of tiles that can be loaded simultaneously for a request. For large mosaics, this parameter should be set to avoid saturating the server by loading too many granules simultaneously.
    * - MergeBehavior
      - The method used to handle overlapping granules during the mosaic operation. Can be ``FLAT`` (only the topmost granule is visible in the case of an overlap) or ``STACK`` (a band-stacking merge is applied to the overlapping granules). Default is ``FLAT``.
    * - OutputTransparentColor
-     - Set the transparent color for the created mosaic. This parameter make sense for mosaic which are RGB or paletted, it does not if you have a DEM or MetOc data. See below for an example:
+     - Set the transparent color for the mosaic. This parameter make sense for RGB or paletted mosaics, but not for a DEM or MetOc data. See below for an example:
 
        .. figure:: images/output_color.png
 
@@ -359,16 +359,16 @@ The parameters are as follows:
           OutputTransparentColor parameter configured with "nodata" color
 
    * - SORTING
-     - Controls the order the granules are passed to the mosaic operation. Only useful for if MergeBehavior is set to ``FLAT``. Should be the name of an attribute in the index file, followed by a space, followed by `A` for ascending, or `D` for descending. For example: ``sortattr D```.
+     - Controls the order in which the granules are passed to the mosaic operation. Only useful if MergeBehavior is set to ``FLAT``. Should be the name of an attribute in the index file, followed by a space, followed by `A` for ascending, or `D` for descending. For example: ``sortattr D``.
    * - SUGGESTED_TILE_SIZE
-     - Controls the tile size of the input granules as well as the tile size of the output mosaic. It consists of two positive integers separated by a comma. Default is ``512,512`` if your data is properly tiled you might want to set this parameter to blank so to avoide reformatting on reading (unnecessarily).
+     - Controls the tile size of the input granules as well as the tile size of the output mosaic. It consists of two positive integers separated by a comma. Default is ``512,512``. If your data is properly tiled, you might want to set this parameter to blank to avoid unnecessarily reformatting when reading.
    * - USE_JAI_IMAGEREAD
-     - Controls the low level mechanism to read the granules. If ``true`` GeoServer will make use of JAI ImageRead operation and its deferred loading mechanism. If ``false`` GeoServer will perform direct ImageIO read calls which will result in immediate loading.
+     - Controls the low-level mechanism used to read the granules. If set to ``true``, GeoServer will use the JAI ImageRead operation and its deferred loading mechanism. If set to ``false``, GeoServer will perform direct ImageIO read calls, which will result in immediate loading.
    
        .. note::
 
-          Deferred loading consumes less memory since it uses a streaming approach to only load into memory the data that is needed for processing at a given time, but may cause problems under heavy load since it keeps the granule files open for a long time to support deferred loading.
+          Deferred loading consumes less memory since it uses a streaming approach to only load into memory the data immediately needed for processing, but may cause problems under heavy load since it keeps the granule files open for a long time.
 
-          Immediate loading consumes more memory since it loads the requested mosaic at into memory all at once, but usually performs faster and does not leave room for the "too many files open" error conditions that can occur with deferred loading.
+          Immediate loading consumes more memory since it loads the requested mosaic into memory all at once, but usually performs faster and prevents the "too many files open" error conditions that can occur with deferred loading.
 
-Continue on with the :ref:`imagemosaic tutorial <data_imagemosaic_tutorial>` to learn more and see examples.
+Continue on with the :ref:`ImageMosaic tutorial <data_imagemosaic_tutorial>` to learn more and see examples.

--- a/doc/en/user/source/data/raster/imagemosaic/index.rst
+++ b/doc/en/user/source/data/raster/imagemosaic/index.rst
@@ -1,11 +1,11 @@
 .. _data_imagemosaic:
 
-Imagemosaic
+ImageMosaic
 =====================
 
-The imagemosaic data store allows the creation of a mosaic from a number of georeferenced rasters.
+The ImageMosaic data store allows the creation of a mosaic from a number of georeferenced rasters.
 
-The mosaic operation creates a mosaic of two or more source images. This operation could be used to assemble a set of overlapping geospatially rectified images into a contiguous image. It could also be used to create a montage of photographs such as a panorama.
+The mosaic operation creates a mosaic from two or more source images. This operation could be used to assemble a set of overlapping geospatially rectified images into a contiguous image. It could also be used to create a montage of photographs such as a panorama.
 
 The plugin can be used with GeoTIFFs, as well as rasters accompanied by a world file (``.wld``, ``.pgw`` for PNG files, ``.jgw`` for JPG files, etc.). In addition, if imageIO-ext :ref:`GDAL extension <data_gdal>` is properly installed, the plugin can also serve all the formats supported by it such as MrSID, ECW, JPEG2000. It also supports NetCDF and GRIB.
 

--- a/doc/en/user/source/data/raster/imagemosaic/tutorial.rst
+++ b/doc/en/user/source/data/raster/imagemosaic/tutorial.rst
@@ -1,9 +1,9 @@
 .. _data_imagemosaic_tutorial:
 
-Using the imagemosaic extension
+Using the ImageMosaic extension
 ===============================
 
-This tutorial will show you how to configure and publish an imagemosaic store and coverage, followed by some configuration examples.
+This tutorial will show you how to configure and publish an ImageMosaic store and coverage, followed by some configuration examples.
 
 Configuring a coverage in GeoServer
 -----------------------------------
@@ -19,7 +19,7 @@ Create a new store
 
    .. figure:: images/imagemosaiccreate.png
 
-      Imagemosaic in the list of raster data stores
+      ImageMosaic in the list of raster data stores
 
 #. In order to create a new mosaic it is necessary to choose a workspace and store name in the :guilabel:`Basic Store Info` section, as well as a URL in the :guilabel:`Connection Parameters` section. Valid URLs include:
 
@@ -27,13 +27,13 @@ Create a new store
 
      * The absolute path to the configuration file (`*.properties``) or a directory containing the configuration file. If ``datastore.properties`` and ``indexer.properties`` exist, they should be in the same directory as this configuration file.
 
-     * The absolute path of a directory where the files you want to mosaic to reside. In this case GeoServer automatically creates the needed mosaic files (.dbf, .prj, .properties, .shp and .shx) by inspecting the data that is present in the given directory (GeoServer will also find the data in any subdirectories).
+     * The absolute path of a directory where the files you want to mosaic reside. In this case GeoServer automatically creates the needed mosaic files (.dbf, .prj, .properties, .shp and .shx) by inspecting the data present in the given directory and any subdirectories.
 
 #. Click :guilabel:`Save`:
 
    .. figure:: images/imagemosaicconfigure.png
 
-      Configuring an imagemosaic data store
+      Configuring an ImageMosaic data store
 
 Create a new coverage
 ~~~~~~~~~~~~~~~~~~~~~
@@ -58,19 +58,19 @@ Create a new coverage
 
 #. Use the :guilabel:`Layer Preview` to view the mosaic.
 
-.. warning:: If the created layer appears to be all black, it may be that GeoServer has not found any acceptable granules in the provided index. It is also possible that the shapefile index is empty (no granules were found in in the provided directory) or it might be that the granules' paths in the shapefile index are not correct, which could happen if an existing index (using absolute paths) is moved to another place. If the shapefile index paths are not correct, then the DBF file can be opened and fixed with an editor. Alternately, you can delete the index and let GeoServer recreate it from the root directory.
+.. warning:: If the created layer appears to be all black, it may be that GeoServer has not found any acceptable granules in the provided index. It is also possible that the shapefile index is empty (no granules were found in the provided directory) or it might be that the granules' paths in the shapefile index are not correct, which could happen if an existing index (using absolute paths) is moved to another place. If the shapefile index paths are not correct, then the DBF file can be opened and fixed with an editor. Alternately, you can delete the index and let GeoServer recreate it from the root directory.
 
 
 Configuration examples
 ----------------------
 
-Below are a few examples of mosaic configurations to demonstrate how we can make use of the imagemosaic parameters.
+Below are a few examples of mosaic configurations to demonstrate how we can make use of the ImageMosaic parameters.
 
 
 DEM/Bathymetry
 ~~~~~~~~~~~~~~
 
-Such a mosaic can be use to serve large amount of data which represents altitude or depth and therefore does not specify colors directly while it rather needs an SLD to generate pictures. In our case we have a DEM dataset which consists of a set of raw GeoTIFF files.
+Such a mosaic can be used to serve large amounts of data representing altitude or depth and therefore does not specify colors directly (it needs an SLD to generate pictures). In our case, we have a DEM dataset which consists of a set of raw GeoTIFF files.
 
 The first operation is to create the CoverageStore specifying, for example, the path of the shapefile in the :guilabel:`URL` field.
 
@@ -121,9 +121,9 @@ The result is the following:
 
    Basic configuration
 
-By setting the other configuration parameters appropriately, it is possible to improve at the same time both the appearance of the mosaic as well as the its performances. As an instance we could:
+By setting the other configuration parameters appropriately, it is possible to improve both the appearance of the mosaic as well as its performance. For instance, we could:
 
-* Make the "nodata" areas transparent and coherent with the real data. To achieve this we need to change the opacity of the "nodata" ColorMapEntry in the ``dem`` style to ``0.0`` and set ``BackgroundValues`` parameter to ``-9999`` so that empty areas will be filled with this value. The result is as follows:
+* Make the "nodata" areas transparent and coherent with the real data. To achieve this we need to change the opacity of the "nodata" ColorMapEntry in the ``dem`` style to ``0.0`` and set the ``BackgroundValues`` parameter to ``-9999`` so that empty areas will be filled with this value. The result is as follows:
 
   .. figure:: images/vito_2.png
 
@@ -132,7 +132,7 @@ By setting the other configuration parameters appropriately, it is possible to i
 * Allow multithreaded granules loading. By setting the ``AllowMultiThreading`` parameter to ``true``, GeoServer will load the granules in parallel using multiple threads with a increase in performance on some architectures.
 
 
-The configuration parameters are the followings:
+The configuration parameters are as follows:
 
 .. list-table::
    :widths: 25 75
@@ -190,7 +190,7 @@ In this example we are going to create a mosaic that will serve aerial imagery, 
 The result is the following:
 
 .. figure:: images/prato_1.png
-   
+
    Basic configuration
 
 .. note:: Those ugly black areas are the result of applying the default mosaic parameters to a mosaic that does not entirely cover its bounding box. The areas within the BBOX that are not covered with data will default to a value of 0 on each band. Since this mosaic is RGB we can simply set the ``OutputTransparentColor`` to ``0,0,0`` in order to get transparent fills for the BBOX.
@@ -239,8 +239,8 @@ The result is the following.
 
    Basic configuration
 
-This mosaic, formed by two single granules, shows a typical case where the "nodata" collar areas of the granules overlap, as hown in the picture above.
-In this case we can use the ``InputTransparentColor`` parameter to make the collar areas disappear during the superimposition process, as instance, in this case, by using an ``InputTransparentColor`` of ``#FFFFFF``  
+This mosaic, formed by two single granules, shows a typical case where the "nodata" collar areas of the granules overlap, as shown in the picture above.
+In this case we can use the ``InputTransparentColor`` parameter to make the collar areas disappear during the superimposition process — in this case, by using an ``InputTransparentColor`` of ``#FFFFFF``.
 
 
 The final configuration parameters are the following:
@@ -290,11 +290,11 @@ To add new granules, the index that was created when the mosaic was originally c
 * Manually through the file system
 * Through the :ref:`rest` interface
 
-To update an imagemosaic through the file system:
+To update an ImageMosaic through the file system:
 
-#. Update the contents of the mosaic by copying the new files into place. (Sub-directories are acceptable.)
+#. Update the contents of the mosaic by copying the new files into place. (Subdirectories are acceptable.)
 
-#. Delete the index files. These files are contained in the top level directory containing the mosaic files. These files consist of (but are not limited to) the following:
+#. Delete the index files. These files are contained in the top level directory containing the mosaic files and include (but are not limited to) the following:
 
    * :file:`<mosaic_name>.dbf`
    * :file:`<mosaic_name>.fix`
@@ -318,13 +318,13 @@ Multi-resolution imagery with reprojection
 
 As a general rule, we want to have the highest resolution granules shown "on top", with the lower-resolution granules filling in the gaps as necessary.
 
-In this example, we will serve up overlapping granules that have varying resolutions. In addition, we will mix resolutions, such that the higher resolution granule is reprojected to match the resolution of the 
+In this example, we will serve up overlapping granules that have varying resolutions. In addition, we will mix resolutions, such that the higher resolution granule is reprojected to match the resolution of the lower resolution granules.
 
 #. In the Coverage Editor, use the basic ``raster`` style.
 
 #. Create the mosaic in GeoServer.
 
-#. One important configuration setting is the :guilabel:`SORTING` parameter of the layer. In order to see the highest resolution imagery on top (as is the typical case), it must be set to :kbd:`resolution A`. (For the case of lowest resolution on top, use :kbd:`resolution D` .)
+#. One important configuration setting is the :guilabel:`SORTING` parameter of the layer. In order to see the highest resolution imagery on top (the typical case), it must be set to :kbd:`resolution A`. (For the case of lowest resolution on top, use :kbd:`resolution D` .)
 
 #. Make any other configuration changes.
 

--- a/doc/en/user/source/extensions/printing/configuration.rst
+++ b/doc/en/user/source/extensions/printing/configuration.rst
@@ -107,7 +107,7 @@ or
     - 254
     - 190
 
-A chosen DPI value from the above configuration is used in WMS GetMap requests as an added format_options (GeoServer) or map_resolution (MapServer) parameter. This is used for symbol/label-rescaling suitable for high resolution printouts, see `Geoserver format_options specification <http://docs.geoserver.org/latest/en/user/services/wms/vendor.html>`_ (Geoserver 2.1) and `MapServer defresolution keyword <http://mapserver.org/development/rfc/ms-rfc-55.html>`_ (MapServer 5.6) for more information.
+A chosen DPI value from the above configuration is used in WMS GetMap requests as an added format_options (GeoServer) or map_resolution (MapServer) parameter. This is used for symbol/label-rescaling suitable for high resolution printouts, see `GeoServer format_options specification <http://docs.geoserver.org/latest/en/user/services/wms/vendor.html>`_ (GeoServer 2.1) and `MapServer defresolution keyword <http://mapserver.org/development/rfc/ms-rfc-55.html>`_ (MapServer 5.6) for more information.
 
 In general, PDF dimensions and positions are specified in points. 72 points == 1 inch == 25.4 mm.
 

--- a/doc/en/user/source/extensions/vectortiles/index.rst
+++ b/doc/en/user/source/extensions/vectortiles/index.rst
@@ -7,7 +7,7 @@ GeoServer supports "vector tile" output in addition to the more standard image t
 
 .. note:: This is an output format, not a data source.
 
-.. note:: Here are two background video talks about "Vector Tiles with Geoserver and OpenLayers":
+.. note:: Here are two background video talks about "Vector Tiles with GeoServer and OpenLayers":
 
            * `FOSS4G.NA 2016 <https://www.youtube.com/watch?v=xdc67aZVO7E>`__
            * `FOSS4G 2016 <http://ftp5.gwdg.de/pub/misc/openstreetmap/FOSS4G-2016/foss4g-2016-1154-vector_tiles_with_geoserver_and_openlayers-hd.webm>`__

--- a/doc/en/user/source/filter/function_reference.rst
+++ b/doc/en/user/source/filter/function_reference.rst
@@ -5,7 +5,7 @@ Filter Function Reference
 
 This reference describes all filter functions that can be used in WFS/WMS filtering or in SLD expressions.
 
-The list of functions available on a Geoserver instance can be determined by 
+The list of functions available on a GeoServer instance can be determined by 
 browsing to http://localhost:8080/geoserver/wfs?request=GetCapabilities 
 and searching for ``ogc:FunctionNames`` in the returned XML.  
 If a function is described in the Capabilities document but is not in this reference, 

--- a/doc/en/user/source/geowebcache/config.rst
+++ b/doc/en/user/source/geowebcache/config.rst
@@ -56,7 +56,7 @@ For stability reasons, it is not recommended to use the embedded GeoWebCache wit
 
 .. _gwc_data_security:
 
-Geoserver Data Security
+GeoServer Data Security
 -----------------------
 
 GWC Data Security is an option that can be turned on and turned off through the :ref:`gwc_webadmin_defaults` page. By default it is turned off. 

--- a/doc/en/user/source/production/data.rst
+++ b/doc/en/user/source/production/data.rst
@@ -38,14 +38,14 @@ As soon as your Geotiffs gets beyond some tens of megabytes you'll want to add t
     * inner tiling
     * overviews
 
-Inner tiling sets up the image layout so that it's organized in tiles instead of simple stripes (rows). This allows much quicker access to a certain area of the geotiff, and the Geoserver readers will leverage this by accessing only the tiles needed to render the current display area. The following sample command instructs `gdal_translate <http://www.gdal.org/gdal_translate.html>`_ to create a tiled
+Inner tiling sets up the image layout so that it's organized in tiles instead of simple stripes (rows). This allows much quicker access to a certain area of the geotiff, and the GeoServer readers will leverage this by accessing only the tiles needed to render the current display area. The following sample command instructs `gdal_translate <http://www.gdal.org/gdal_translate.html>`_ to create a tiled
 `geotiff <http://www.gdal.org/frmt_gtiff.html>`_.
 
 .. code-block:: xml
 
    gdal_translate -of GTiff -projwin -180 90 -50 -10 -co "TILED=YES" bigDataSet.ecw myTiff.tiff
 
-An overview is a downsampled version of the same image, that is, a zoomed out version, which is usually much smaller. When Geoserver needs to render the Geotiff, it'll look for the most appropriate overview as a starting point, thus reading and converting way less data. Overviews can be added using 
+An overview is a downsampled version of the same image, that is, a zoomed out version, which is usually much smaller. When GeoServer needs to render the Geotiff, it'll look for the most appropriate overview as a starting point, thus reading and converting way less data. Overviews can be added using 
 `gdaladdo <http://www.gdal.org/gdaladdo.html>`_, or the the OverviewsEmbedded command included in Geotools. Here is a sample of using gdaladdo to add overviews that are downsampled 2, 4, 8 and 16 times compared to the original:
 
 .. code-block:: xml

--- a/doc/en/user/source/rest/examples/php.rst
+++ b/doc/en/user/source/rest/examples/php.rst
@@ -4,7 +4,7 @@ PHP
 ===
 
 The examples in this section use the server-side scripting language `PHP <http://php.net/index.php/>`_, a popular language for dynamic webpages. PHP has `cURL functions <http://php.net/manual/en/ref.curl.php/>`_ , as well as 
-`XML functions <http://www.php.net/manual/en/refs.xml.php/>`_, making it a convenient method for performing batch processing through the Geoserver REST interface. The following scripts execute single requests, but can be easily modified with looping structures to perform batch processing.
+`XML functions <http://www.php.net/manual/en/refs.xml.php/>`_, making it a convenient method for performing batch processing through the GeoServer REST interface. The following scripts execute single requests, but can be easily modified with looping structures to perform batch processing.
 
 POST with PHP/cURL
 ------------------
@@ -102,7 +102,7 @@ Here are some possible values:
 +------------+---------------------------------------------------------------+ 
 | 405        |  Method not Allowed: check request syntax                     |
 +------------+---------------------------------------------------------------+ 
-| 500        |  Geoserver is unable to process the request,                  |
+| 500        |  GeoServer is unable to process the request,                  |
 |            |  e.g. the workspace already exists, the xml is malformed, ... |
 +------------+---------------------------------------------------------------+ 
 

--- a/doc/en/user/source/security/passwd.rst
+++ b/doc/en/user/source/security/passwd.rst
@@ -22,7 +22,7 @@ The password encryption scheme is specified as a global setting that affects the
 Empty
 ~~~~~
 
-The scheme is not reversible. Any password is encoded as an empty string, and as a consequence it is not possible to recalculate the plain text password. This scheme is used for user/group services in combination with an authentication mechanism using a back end system. Examples are user name/password authentication against a LDAP server or a JDBC database. In these scenarios, storing passwords locally to Geoserver does not make sense.
+The scheme is not reversible. Any password is encoded as an empty string, and as a consequence it is not possible to recalculate the plain text password. This scheme is used for user/group services in combination with an authentication mechanism using a back end system. Examples are user name/password authentication against a LDAP server or a JDBC database. In these scenarios, storing passwords locally to GeoServer does not make sense.
 
 Plain text
 ~~~~~~~~~~

--- a/doc/en/user/source/security/tutorials/credentialsfromheaders/index.rst
+++ b/doc/en/user/source/security/tutorials/credentialsfromheaders/index.rst
@@ -9,8 +9,8 @@ Introduction
 When using Apache HTTPD as a proxy frontend for GeoServer, it is possible to share
 authentication with a proper configuration of both.
 
-This requires enabling Session for the Geoserver location in Apache HTTPD and adding 
-a custom Request Header with the session content, so that the Geoserver security system
+This requires enabling Session for the GeoServer location in Apache HTTPD and adding 
+a custom Request Header with the session content, so that the GeoServer security system
 can receive user credentials and use them to authenticate the user with its internal 
 filters.
 
@@ -125,7 +125,7 @@ This can be done with an HTTPD configuration that looks like the following:
 			RequestHeader set X-Credentials "%{HTTP_SESSION}e"
 		</Location>
 
-This configuration adds a new `X-Credentials` Request Header to each Geoserver request.
+This configuration adds a new `X-Credentials` Request Header to each GeoServer request.
 The request header will contain the HTTPD Session information in a special format.
 
 An example of the Session content is the following:

--- a/doc/en/user/source/security/usergrouprole/roles.rst
+++ b/doc/en/user/source/security/usergrouprole/roles.rst
@@ -13,7 +13,7 @@ GeoServer roles support inheritance—a child role inherits all the access grant
 
 Key/value pairs are implementation-specific and may be configured by the :ref:`role service <security_rolesystem_roleservices>` the user or group belongs to. For example, a role service that assigns roles based on employee organization may wish to associate additional information with the role such as Department Name.
 
-Geoserver has a number of system roles, the names of which are reserved. Adding a new GeoServer role with reserved name is not permitted.
+GeoServer has a number of system roles, the names of which are reserved. Adding a new GeoServer role with reserved name is not permitted.
 
 * ``ROLE_ADMINISTRATOR``—Provides access to all operations and resources
 * ``ROLE_GROUP_ADMIN``—Special role for administrating user groups

--- a/doc/en/user/source/services/wfs/webadmin.rst
+++ b/doc/en/user/source/services/wfs/webadmin.rst
@@ -34,7 +34,7 @@ Service Levels
    
    WFS configuration options - Service Level section
 
-GeoServer is compliant with the full "Transactional Web Feature Server" (WFS-T) level of service as defined by the OGC. Specifying the WFS service level limits the capabilities of Geoserver while still remaining compliant. The WFS Service Level setting defines what WFS operations are "turned on". 
+GeoServer is compliant with the full "Transactional Web Feature Server" (WFS-T) level of service as defined by the OGC. Specifying the WFS service level limits the capabilities of GeoServer while still remaining compliant. The WFS Service Level setting defines what WFS operations are "turned on". 
 
 **Basic** — Basic service levels provides facilities for searching and retrieving feature data with the GetCapabilities, DescribeFeatureType and GetFeature operations. It is compliant with the OGC basic Web Feature Service. This is considered a READ-ONLY web feature service. 
 

--- a/doc/en/user/source/services/wms/googleearth/tutorials/kmlplacemark/index.rst
+++ b/doc/en/user/source/services/wms/googleearth/tutorials/kmlplacemark/index.rst
@@ -52,7 +52,7 @@ And voila. Your first template
 
 	   *Hello World template.*
 	
-**Refreshing Templates**: One nice aspect of templates is that they are read upon every request. So one can simply edit the template in place and have it picked up by Geoserver as soon as the file is saved. So when after editing and saving a template simply "Refresh" the network link in Google Earth to have the new content picked up.
+**Refreshing Templates**: One nice aspect of templates is that they are read upon every request. So one can simply edit the template in place and have it picked up by GeoServer as soon as the file is saved. So when after editing and saving a template simply "Refresh" the network link in Google Earth to have the new content picked up.
 
 	.. figure:: refresh.png
 	   :align: center

--- a/doc/en/user/source/services/wms/reference.rst
+++ b/doc/en/user/source/services/wms/reference.rst
@@ -369,7 +369,7 @@ The standard parameters for the GetFeatureInfo operation are:
 
 **Note:**  If you are sending a GetFeatureInfo request against a layergroup, all the layers in that layergroup must be set as "Queryable" to get a result (See :ref:`WMS Settings on Layers page<data_webadmin_layers>`)
        
-Geoserver supports a number of output formats for the ``GetFeatureInfo`` response.
+GeoServer supports a number of output formats for the ``GetFeatureInfo`` response.
 Server-styled HTML is the most commonly-used format. 
 For maximum control and customisation the client should use GML3 and style the raw data itself.
 The supported formats are:
@@ -552,7 +552,7 @@ The standard parameters for the DescribeLayer operation are:
      - Format in which to report exceptions.
        The default value is ``application/vnd.ogc.se_xml``.
 
-Geoserver supports a number of output formats for the ``DescribeLayer`` response.
+GeoServer supports a number of output formats for the ``DescribeLayer`` response.
 Server-styled HTML is the most commonly-used format. 
 The supported formats are:
 

--- a/doc/en/user/source/styling/sld/reference/labeling.rst
+++ b/doc/en/user/source/styling/sld/reference/labeling.rst
@@ -231,7 +231,7 @@ So, for example, if you wanted to have the state abbreviation sitting on the nex
   ]]>(<ogc:PropertyName>STATE_ABBR</ogc:PropertyName>)
   </Label>
 
-Geoserver Enhanced Options
+GeoServer Enhanced Options
 -----------------------------------
 
 GeoServer provides a number of label styling options as extensions to the SLD specification.
@@ -521,7 +521,7 @@ This means the label will be drawn even if it overlaps with other labels, and ot
 goodnessOfFit
 ^^^^^^^^^^^^^
 
-Geoserver will remove labels if they are a particularly bad fit for the geometry they are labeling.
+GeoServer will remove labels if they are a particularly bad fit for the geometry they are labeling.
 
 .. list-table::
    :widths: 30 70 

--- a/doc/en/user/source/styling/sld/reference/pointsymbolizer.rst
+++ b/doc/en/user/source/styling/sld/reference/pointsymbolizer.rst
@@ -185,7 +185,7 @@ The next example uses an external graphic loaded from the file system:
       </Graphic>
     </PointSymbolizer>
 
-For ``file://`` URLs, the file must be readable by the user the Geoserver process is running as. You can also use ``href://`` URLs to reference remote graphics. 
+For ``file://`` URLs, the file must be readable by the user the GeoServer process is running as. You can also use ``href://`` URLs to reference remote graphics. 
 
 Further examples can be found in the :ref:`sld_cookbook_points` section of the :ref:`sld_cookbook`.
 

--- a/doc/en/user/source/styling/sld/tipstricks/transformation-func.rst
+++ b/doc/en/user/source/styling/sld/tipstricks/transformation-func.rst
@@ -10,7 +10,7 @@ The Symbology Encoding 1.1 specification defines the following **transformation 
 * ``Interpolate`` transforms a continuous-valued attribute into another continuous range of values
 
 These functions provide a concise way to compute styling parameters from feature attribute values.
-Geoserver implements them as :ref:`filter_function` with the same names.
+GeoServer implements them as :ref:`filter_function` with the same names.
 
 .. note::
 

--- a/doc/en/user/source/tutorials/GetFeatureInfo/index.rst
+++ b/doc/en/user/source/tutorials/GetFeatureInfo/index.rst
@@ -37,7 +37,7 @@ The *header template* is invoked just once, and usually contains the start of th
 	-->
 	<html>
 	  <head>
-	    <title>Geoserver GetFeatureInfo output</title>
+	    <title>GeoServer GetFeatureInfo output</title>
 	  </head>
 	  <style type="text/css">
 		table.featureInfo, table.featureInfo td, table.featureInfo th {

--- a/doc/en/user/source/tutorials/feature-pregeneralized/feature-pregeneralized_tutorial.rst
+++ b/doc/en/user/source/tutorials/feature-pregeneralized/feature-pregeneralized_tutorial.rst
@@ -98,7 +98,7 @@ The next form you see is
 
 .. note::
 
-   **RepositoryClassName** and  **GeneralizationInfosProviderClassName** have default values which suit for GeoTools, not for GeoServer. Change **GeoTools** to **GeoServer** in the package names to instantiate the correct objects for GeoServer. **GeneralizationInfosProviderParam** could be an URL or a datastore from the Geoserver catalog. A datastore is referenced by using *workspacename:datastorename*. This makes sense if you have your own implementation for the **GeneralizationInfosProvider** interface and this implementation reads the infos from a database.
+   **RepositoryClassName** and  **GeneralizationInfosProviderClassName** have default values which suit for GeoTools, not for GeoServer. Change **GeoTools** to **GeoServer** in the package names to instantiate the correct objects for GeoServer. **GeneralizationInfosProviderParam** could be an URL or a datastore from the GeoServer catalog. A datastore is referenced by using *workspacename:datastorename*. This makes sense if you have your own implementation for the **GeneralizationInfosProvider** interface and this implementation reads the infos from a database.
 
 The configuration should look like this
 

--- a/doc/en/user/source/tutorials/freemarker.rst
+++ b/doc/en/user/source/tutorials/freemarker.rst
@@ -16,7 +16,7 @@ Most of the relevant information about how to approach template writing is inclu
 Template Lookup
 ```````````````
 
-Geoserver looks up templates in three different places, allowing for various level of customization. For example given the ``content.ftl`` template used to generate WMS GetFeatureInfo content:
+GeoServer looks up templates in three different places, allowing for various level of customization. For example given the ``content.ftl`` template used to generate WMS GetFeatureInfo content:
 
 * Look into ``GEOSERVER_DATA_DIR/workspaces/<workspace>/<datastore>/<featuretype>/content.ftl`` to see if there is a feature type specific template
 * Look into ``GEOSERVER_DATA_DIR/workspaces/<workspace>/<datastore>/content.ftl`` to see if there is a store specific template
@@ -30,7 +30,7 @@ Each templated output format tutorial should provide you with the template names
 Common Data Models
 ``````````````````
 
-Freemarker calls "data model" the set of data provided to the template. Each output format used by Geoserver will inject a different data model according to the informations it's managing, yet there are three very common elements that appear in almost each template, Feature, FeatureType and FeatureCollection. Here we provide a data model of each.
+Freemarker calls "data model" the set of data provided to the template. Each output format used by GeoServer will inject a different data model according to the informations it's managing, yet there are three very common elements that appear in almost each template, Feature, FeatureType and FeatureCollection. Here we provide a data model of each.
 
 The data model is a sort of a tree, where each element has a name and a type. Besides basic types, we'll use:
 

--- a/doc/en/user/source/tutorials/georss/georss.rst
+++ b/doc/en/user/source/tutorials/georss/georss.rst
@@ -15,7 +15,7 @@ If you are using a web browser which can render rss feeds simply visit the url `
 
 Templating
 ----------
-Geoserver uses freemarker templates to customize the returned GeoRSS feed. If you are not familiar with freemarker templates you may wish to read the :ref:`tutorial_freemarkertemplate` tutorial, and the :ref:`getutorial_kmlplacemark` page, which has simple examples.
+GeoServer uses freemarker templates to customize the returned GeoRSS feed. If you are not familiar with freemarker templates you may wish to read the :ref:`tutorial_freemarkertemplate` tutorial, and the :ref:`getutorial_kmlplacemark` page, which has simple examples.
 
 Three template files are currently supported:
 

--- a/doc/en/user/source/tutorials/imagemosaic_timeseries/imagemosaic_time-elevationseries.rst
+++ b/doc/en/user/source/tutorials/imagemosaic_timeseries/imagemosaic_time-elevationseries.rst
@@ -7,7 +7,7 @@ Using the ImageMosaic plugin for raster with time and elevation data
 Introduction
 ------------
 
-This tutorial is the following of :ref:`tutorial_imagemosaic_timeseries` and explains how manage an Imagemosaic using both **Time** and **Elevation** attributes.
+This tutorial is the following of :ref:`tutorial_imagemosaic_timeseries` and explains how manage an ImageMosaic using both **Time** and **Elevation** attributes.
 
 The dataset used is a set of raster images used in weather forecast, representing the temperature in a certain zone at different times and elevations.
 
@@ -17,7 +17,7 @@ This tutorial explains just how to configure the **elevationregex.properties** t
 
 The dataset used is different so also a fix to the **timeregex.properties** used in the previous tutorial is needed.
 
-Will be shown also how query geoserver asking for layers specifying both time and elevation dimensions.
+Will be shown also how query GeoServer asking for layers specifying both time and elevation dimensions.
 
 The dataset used in the tutorial can be downloaded :download:`Here <temperatureLZWdataset.zip>`
 
@@ -32,7 +32,7 @@ The additional configurations needed in order to handle also the elevation attri
 indexer.properties:
 """""""""""""""""""
 
-Here the user can specify the information that needs Geoserver for creating the table in the database. 
+Here the user can specify the information that needs GeoServer for creating the table in the database. 
 
 In this case the time values are stored in the column ingestion as shown in the previous tutorial but now is mandatory specify the elevation column too.
 
@@ -52,7 +52,7 @@ an example of filename, that is used in this tutorial is::
 
 		gfs50kmTemperature20130310T180000000Z_0600.000_.tiff
 
-The geoserver imagemosaic plugin scans the filename and search for the first occurrence that match with the pattern specified. Here the content of **timeregex.properties**:
+The GeoServer ImageMosaic plugin scans the filename and search for the first occurrence that match with the pattern specified. Here the content of **timeregex.properties**:
 
 .. include:: src/elevationregex.properties
    :literal:
@@ -73,7 +73,7 @@ Instead of the form **yyyymmdd** as in the previous tutorial. So the regex to sp
 Coverage based on filestore
 ---------------------------
 
-Once the mosaic configuration is ready the store mosaic could be loaded on geoserver.
+Once the mosaic configuration is ready the store mosaic could be loaded on GeoServer.
 
 The steps needed are the same shown the previous chapter. After the store is loaded and a layer published note the differences in WMS Capabilities document and in the table on postgres.
 

--- a/doc/en/user/source/tutorials/imagemosaic_timeseries/imagemosaic_timeseries.rst
+++ b/doc/en/user/source/tutorials/imagemosaic_timeseries/imagemosaic_timeseries.rst
@@ -15,7 +15,7 @@ This tutorial contains four sections:
 
 * The first section, **Configuration**, describes the configuration files needed to set up an ImageMosaic store from GeoServer.
 * The second section, **Configuration examples**, providing examples of the configuration files needed.
-* The last two sections, **Coverage based on filestore** and **Coverage based on database** describe, once the previous configurations steps are done, how to create and configure an Imagemosaic store using the GeoServer GUI.
+* The last two sections, **Coverage based on filestore** and **Coverage based on database** describe, once the previous configurations steps are done, how to create and configure an ImageMosaic store using the GeoServer GUI.
 
 The dataset used in the tutorial can be downloaded :download:`Here <snowLZWdataset.zip>`. It contains 3 image files and a .sld file representing a style needed for correctly render the images.
 
@@ -216,7 +216,7 @@ In the timeregex property file you specify the pattern describing the date(time)
 
 indexer.properties:
 """""""""""""""""""
-Here the user can specify the information that Geoserver uses to create the index table in the database. In this example, the time values are stored in the column ingestion.
+Here the user can specify the information that GeoServer uses to create the index table in the database. In this example, the time values are stored in the column ingestion.
 
 .. include:: src/indexer.properties
    :literal:
@@ -233,7 +233,7 @@ We create a new data store of type raster data and choose ImageMosaic.
    :align: center
 
 
-.. note:: Be aware that Geoserver creates a table which is identical with the name of your layer. If the table already exists, it will not be dropped from the DB and the following error message will appear. The same message wwill appear if the generated property file already exists in the directory or there are incorrect connection parameters in datastore.properties file.
+.. note:: Be aware that GeoServer creates a table which is identical with the name of your layer. If the table already exists, it will not be dropped from the DB and the following error message will appear. The same message wwill appear if the generated property file already exists in the directory or there are incorrect connection parameters in datastore.properties file.
 
 .. figure:: img/errormessage.png
    :align: center

--- a/doc/en/user/source/tutorials/palettedimage/palettedimage.rst
+++ b/doc/en/user/source/tutorials/palettedimage/palettedimage.rst
@@ -3,7 +3,7 @@
 Paletted Images
 ===============
 
-Geoserver has the ability to output high quality 256 color images. This tutorial introduces you to the palette concepts, the various image generation options, and offers a quality/resource comparison of them in different situations.
+GeoServer has the ability to output high quality 256 color images. This tutorial introduces you to the palette concepts, the various image generation options, and offers a quality/resource comparison of them in different situations.
 
 What are Paletted Images?
 -------------------------

--- a/doc/en/user/source/tutorials/tomcat-jndi/tomcat-jndi.rst
+++ b/doc/en/user/source/tutorials/tomcat-jndi/tomcat-jndi.rst
@@ -14,7 +14,7 @@ In order to setup a connection pool Tomcat needs a JDBC driver and the necessary
 First off, you need to find the JDBC driver for your database. Most often it is distributed on the web site of your DBMS provider, or available in the installed version of your database.
 For example, a Oracle XE install on a Linux system provides the driver at  :file:`/usr/lib/oracle/xe/app/oracle/product/10.2.0/server/jdbc/lib/ojdbc14.jar`, and that file needs to be moved into Tomcat shared libs directory, :file:`{TOMCAT_HOME}/lib`
 
-.. note:: be careful to remove the jdbc driver from the Geoserver WEB-INF/lib folder when copied to the Tomcat shared libs, to avoid issues in JNDI DataStores usage.
+.. note:: be careful to remove the jdbc driver from the GeoServer WEB-INF/lib folder when copied to the Tomcat shared libs, to avoid issues in JNDI DataStores usage.
 
 Once that is done, the Tomcat configuration file :file:`{TOMCAT_HOME}/conf/context.xml` needs to be edited in order to setup the connection pool. In the case of a local Oracle XE the setup might look like:
 

--- a/doc/en/user/source/tutorials/wmsreflector.rst
+++ b/doc/en/user/source/tutorials/wmsreflector.rst
@@ -103,7 +103,7 @@ Say you have a webpage and you wish to include a picture that is 400 pixels wide
 
   <img src="http://localhost:8080/geoserver/wms/reflect?layers=topp:states&width=400" />
 
-If you want the page to render in the browser before Geoserver is done, you should specify the height and width of the picture. You could just pick any approximate value, but it may be a good idea to look at the generated image first and then use those values. In the case of the layer above, the height becomes 169 pixels, so we can specify that as an attribute in the <img> tag:
+If you want the page to render in the browser before GeoServer is done, you should specify the height and width of the picture. You could just pick any approximate value, but it may be a good idea to look at the generated image first and then use those values. In the case of the layer above, the height becomes 169 pixels, so we can specify that as an attribute in the <img> tag:
 
 .. code-block:: html
 


### PR DESCRIPTION
I have been carefully reading the ImageMosaic sections to address some issues I am having, and have noticed some typos, inconsistencies and syntax issues I thought I would try to help correct.

In many files, the only changes are to consistently capitalize "GeoServer" and "ImageMosaic". There are probably still instances of "geoserver" used where "GeoServer" should be, but these are more difficult to differentiate from legitimate uses in filenames and code examples, and I don't have time at the moment to hunt them all down.

In other places, I have made changes that I believe lead to more idiomatic English.

I have made inline comments in other places where I thought my intent might be less obvious.