### PR TITLE
[GEOS-7873] Workaround for JSON array serialization of nulls

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -233,7 +233,11 @@
     <version>${gt.version}</version>
     <scope>test</scope>
   </dependency>
-</dependencies> 
+     <dependency>
+         <groupId>org.codehaus.jettison</groupId>
+         <artifactId>jettison</artifactId>
+     </dependency>
+ </dependencies>
 
  <build>
   <plugins>

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
@@ -144,6 +144,20 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
         assertEquals(6, arr.size());
         arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONObject("styles").getJSONArray("style");
         assertEquals(6, arr.size());
+
+        //GEOS-7873
+        LayerGroupInfo lg2 = catalog.getLayerGroupByName("citeLayerGroup");
+        List<StyleInfo> styles = lg2.getStyles();
+        styles.set(1, catalog.getStyleByName( StyleInfo.DEFAULT_POINT ) );
+        styles.set(3, catalog.getStyleByName( StyleInfo.DEFAULT_POINT ) );
+        catalog.save(lg2);
+
+        print(get("/rest/layergroups/citeLayerGroup.json"));
+        json = getAsJSON( "/rest/layergroups/citeLayerGroup.json");
+        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONObject("publishables").getJSONArray("published");
+        assertEquals(6, arr.size());
+        arr = ((JSONObject)json).getJSONObject("layerGroup").getJSONObject("styles").getJSONArray("style");
+        assertEquals(6, arr.size());
     }
 
 


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-7873

Alternative to https://github.com/geoserver/geoserver/pull/2072 that doesn't alter the rest API output, but instead uses reflection to hack around the jettison 1.0.1 bug.
