### PR TITLE
Fixed display info of memory usage inside server status page

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/admin/StatusPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/admin/StatusPanel.java
@@ -267,7 +267,7 @@ public class StatusPanel extends Panel {
 
         String formattedUsedMemory;
         if (bytes > GB) {
-            formattedUsedMemory = formatter.format(bytes / GB) + " GB";
+            formattedUsedMemory = formatter.format((float)bytes / GB) + " GB";
         } else if (bytes > MB) {
             formattedUsedMemory = formatter.format(bytes / MB) + " MB";
         } else {


### PR DESCRIPTION
When you start GeoServer with -Xmx higher than 1g (for e.g: 2g), the memory usage inside the "Server status" page displays the wrong number.

With -Xmx2g before my fix :
![before](https://cloud.githubusercontent.com/assets/1693044/22672748/ce0ca746-eca3-11e6-9cae-e236b5011b5d.png)

With -Xmx2g after my fix :
![after](https://cloud.githubusercontent.com/assets/1693044/22672749/ce0fc8d6-eca3-11e6-92c9-34963408c9cc.png)

