### PR TITLE
[GEOS-7962] Add a WMS FORMAT vendor parameter (backport 2.10.x)

### DIFF
--- a/doc/en/user/source/services/wms/reference.rst
+++ b/doc/en/user/source/services/wms/reference.rst
@@ -116,6 +116,9 @@ They are fully documented in the :ref:`wms_vendor_parameters` section.
    * - ``namespace``
      - No
      - limits response to layers in a given namespace
+   * - ``format``
+     - No
+     - request the capabilities document in a certain format
 
 
 A example GetCapabilities request is:

--- a/doc/en/user/source/services/wms/vendor.rst
+++ b/doc/en/user/source/services/wms/vendor.rst
@@ -293,3 +293,14 @@ or empty if the default method has to be used for the related layer.
 
 The parameter allows to override the global WMS Raster Rendering Options setting (see :ref:`WMS Settings <services_webadmin_wms>` for more info), on a layer by layer basis. 
 
+format
+------
+
+The ``format`` parameter can be used to request capabilities documents in a certain format. If the requested format is not supported the default format will be used.
+
+An example request:
+
+  http://localhost:8080/geoserver/ows?service=wms&version=1.1.1&request=GetCapabilities&format=text/xml
+
+.. note::  
+  Currently this parameter can only be used to request WMS 1.1.1 capabilities documents encoded in ``text/xml``, if used with other WMS versions or other formats it will have no effect.

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -84,8 +84,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
-import sun.security.action.GetBooleanAction;
-
 import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Envelope;
 import org.geoserver.wfs.json.JSONType;
@@ -100,8 +98,13 @@ import org.geoserver.wfs.json.JSONType;
  *      org.geoserver.platform.Operation)
  */
 public class GetCapabilitiesTransformer extends TransformerBase {
-    /** fixed MIME type for the returned capabilities document */
-    public static final String WMS_CAPS_MIME = "application/vnd.ogc.wms_xml";
+    /** default MIME type for the returned capabilities document */
+    public static final String WMS_CAPS_DEFAULT_MIME = "application/vnd.ogc.wms_xml";
+
+    // available MIME types for the returned capabilities document
+    public static final String[] WMS_CAPS_AVAIL_MIME = {
+            WMS_CAPS_DEFAULT_MIME, "text/xml"
+    };
 
     /** the WMS supported exception formats */
     static final String[] EXCEPTION_FORMATS = { "application/vnd.ogc.se_xml",
@@ -473,7 +476,11 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             start("Request");
 
             start("GetCapabilities");
-            element("Format", WMS_CAPS_MIME);
+
+            // add all the supported MIME types for the capabilities document
+            for (String mimeType : WMS_CAPS_AVAIL_MIME) {
+                element("Format", mimeType);
+            }
 
             // build the service URL and make sure it ends with &
             String serviceUrl = buildURL(request.getBaseUrl(), "wms", params("SERVICE", "WMS"),

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
@@ -10,8 +10,10 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 import static org.custommonkey.xmlunit.XMLUnit.newXpathEngine;
 import static org.junit.Assert.*;
-
 import java.util.ArrayList;
+import static org.hamcrest.CoreMatchers.is;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -37,8 +39,11 @@ import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSTestSupport;
+import org.geoserver.wms.capabilities.GetCapabilitiesTransformer;
+import org.geotools.data.Base64;
 import org.geotools.referencing.CRS;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -92,12 +97,53 @@ public class CapabilitiesTest extends WMSTestSupport {
         catalog.add(containerGroup);
     }
 
-
     @Test
     public void testCapabilities() throws Exception {
         Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
         Element e = dom.getDocumentElement();
         assertEquals("WMT_MS_Capabilities", e.getLocalName());
+    }
+
+    @Test
+    /**
+     * Tests the behavior of the format vendor parameter.
+     */
+    public void testCapabilitiesFormat() throws Exception {
+        // the default and only wms standard conform mime type is application/vnd.ogc.wms_xml
+        MockHttpServletResponse response = getAsServletResponse("wms?request=getCapabilities&version=1.1.1");
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContentType(), is("application/vnd.ogc.wms_xml"));
+        // request with the supported ime type text/xml
+        response = getAsServletResponse("wms?request=getCapabilities&version=1.1.1&format=text/xml");
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContentType(), is("text/xml"));
+        // using an invalid mime type should throw an exception
+        response = getAsServletResponse("wms?request=getCapabilities&version=1.1.1&format=invalid");
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContentType(), is("application/vnd.ogc.se_xml"));
+        // using an empty mime type should fall back to the default mime type
+        response = getAsServletResponse("wms?request=getCapabilities&version=1.1.1&format=");
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContentType(), is("application/vnd.ogc.wms_xml"));
+    }
+
+    @Test
+    /**
+     * Test that all the supported mime types for the get capabilities
+     * operation are listed.
+     */
+    public void testGetCapabilities() throws Exception {
+        // request a wms 1.1.1 capabilities document
+        MockHttpServletResponse response = getAsServletResponse("wms?request=getCapabilities&version=1.1.1");
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContentType(), is("application/vnd.ogc.wms_xml"));
+        // parse the result as a xml document
+        InputStream content = new ByteArrayInputStream(response.getContentAsByteArray());
+        Document document = dom(content, true);
+        // check that all the available mime types are present
+        for(String mimeType : GetCapabilitiesTransformer.WMS_CAPS_AVAIL_MIME) {
+            assertXpathExists(String.format("//GetCapabilities[Format='%s']", mimeType), document);
+        }
     }
 
     @Test


### PR DESCRIPTION
Backport of this pull request: https://github.com/geoserver/geoserver/pull/2080.

Permission to backport asked on the mailing list: http://osgeo-org.1560.x6.nabble.com/Add-a-WMS-vendor-FORMAT-parameter-to-force-the-return-of-WMS-1-1-1-capabilities-in-text-xml-td5305506.html