### PR TITLE
Make applicable OWS Dispatcher utility methods accessible

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -578,7 +578,12 @@ public class Dispatcher extends AbstractController {
         return service;
     }
 
-    String normalize(String value) {
+    /**
+     * Normalize a parameter, trimming whitespace
+     * @param value
+     * @return The value with whitespace trimmed, or null if this would result in an empty string.
+     */
+    public static String normalize(String value) {
         if (value == null) {
             return null;
         }
@@ -592,8 +597,10 @@ public class Dispatcher extends AbstractController {
 
     /**
      * Normalize the version, handling cases like forcing "x.y" to "x.y.z".
+     * @param version
+     * @return normalized version
      */
-    String normalizeVersion(String version) {
+    public static String normalizeVersion(String version) {
         if (version == null) {
             return null;
         }
@@ -1249,7 +1256,7 @@ public class Dispatcher extends AbstractController {
         return (KvpRequestReader) matches.get(0);
     }
 
-    Collection loadXmlReaders() {
+    static Collection loadXmlReaders() {
         List<XmlRequestReader> xmlReaders = GeoServerExtensions.extensions(XmlRequestReader.class);
 
         if (!(new HashSet<XmlRequestReader>(xmlReaders).size() == xmlReaders.size())) {
@@ -1273,7 +1280,16 @@ public class Dispatcher extends AbstractController {
         return xmlReaders;
     }
 
-    XmlRequestReader findXmlReader(String namespace, String element, String serviceId, String ver) {
+    /**
+     * Finds a registered {@link XmlRequestReader} bean able to read a request, given the request details
+     *
+     * @param namespace The XML namespace of the request body
+     * @param element The OWS request, e.g. "GetMap"
+     * @param serviceId The OWS service, e.g. "WMS"
+     * @param ver The OWS service version, e.g "1.1.1"
+     * @return An {@link XmlRequestReader} capable of reading the request body
+     */
+    public static XmlRequestReader findXmlReader(String namespace, String element, String serviceId, String ver) {
         Collection xmlReaders = loadXmlReaders();
 
         //first just match on namespace, element
@@ -1558,7 +1574,14 @@ public class Dispatcher extends AbstractController {
         return xmlReader.read( requestBean, input, request.getKvp() );
     }
 
-    Map readOpContext(Request request) {
+    /**
+     * Reads the following parameters from an OWS XML request body:
+     * * service
+     *
+     * @param request {@link Request} object
+     * @return a {@link Map} containing the parsed parameters.
+     */
+    public static Map readOpContext(Request request) {
         
         Map map = new HashMap();
         if (request.getPath() != null) {
@@ -1568,7 +1591,20 @@ public class Dispatcher extends AbstractController {
         return map;
     }
 
-    Map readOpPost(BufferedReader input) throws Exception {
+    /**
+     * Reads the following parameters from an OWS XML request body:
+     * * request
+     * * namespace
+     * * service
+     * * version
+     * * outputFormat
+     * Resets the input reader after reading
+     *
+     * @param input {@link BufferedReader} containing a valid OWS XML request body
+     * @return a {@link Map} containing the parsed parameters.
+     * @throws Exception if there was an error reading the input.
+     */
+    public static Map readOpPost(BufferedReader input) throws Exception {
         //create stream parser
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         factory.setNamespaceAware(true);
@@ -1731,7 +1767,12 @@ public class Dispatcher extends AbstractController {
         handler.handleServiceException(se, request);
     }
 
-    protected boolean  isSecurityException(Throwable t) {
+    /**
+     * Examines a {@link Throwable} object and returns true if it represents a security exception.
+     * @param t Throwable
+     * @return true if t is a security exception
+     */
+    protected static boolean isSecurityException(Throwable t) {
         return t != null && 
             t.getClass().getPackage().getName().startsWith("org.springframework.security");
     }


### PR DESCRIPTION
The OWS Dispatcher class contains a bunch of what are essentially utility methods.

I feel like these could be useful outside of Dispatcher (mainly for DispatcherCallbacks) and could therefore be made `public static`.

These methods all have no notable side effects.
