### PR TITLE
#[GEOS-7981] fixed imageio-ext-gdalgeotiff.jar classpath conflicts

### DIFF
--- a/src/release/ext-gdal.xml
+++ b/src/release/ext-gdal.xml
@@ -26,6 +26,7 @@
 				<exclude>*imageio-ext-gdal-bindings*.jar</exclude>
         <exclude>*arcgrid*.jar</exclude>
         <exclude>*customstreams*.jar</exclude>
+        <exclude>*imageio-ext-gdalgeotiff*.jar</exclude>
       </excludes>
 		</fileSet>
 		<fileSet>


### PR DESCRIPTION
When the GDAL extension is installed the presence of the imageio-ext-gdalgeotiff.jar in the classpath can cause classpath loading problems: only classes in imageio-ext-tiff.jar should be loaded.
When this happen (the cp conflict is not predictable and the error may occurs depending on which layers are loaded in GS) geoserver fails at startup (see this stacktrace)
Since the imageio-ext-gdalgeotiff dependency is never used it can be removed explicitly from the gdal extension zip pkg and from the related geootols module's pom (see [GT related issue](https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-5636))