### PR TITLE
Mask the GeoGig repository location in UI and API responses

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
@@ -1,4 +1,4 @@
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -35,6 +35,7 @@ public class RepositoryInfo implements Serializable {
 
     private java.net.URI location;
 
+    private String maskedLocation;
     /**
      * Stores the "nice" name for a repo. This is the name that is shown in the Repository list, as
      * well as what is stored in the GeoGIG repository config. It is transient, as we don't want to
@@ -72,6 +73,16 @@ public class RepositoryInfo implements Serializable {
     public URI getLocation() {
         readResolve();
         return this.location;
+    }
+
+    public String getMaskedLocation() {
+        if (maskedLocation == null) {
+            // ensure the location is set
+            getLocation();
+            // get the masked version of the URI
+            this.maskedLocation = GeoServerGeoGigRepositoryResolver.getURI(getRepoName());
+        }
+        return this.maskedLocation;
     }
 
     public void setLocation(URI location) {

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/RepositoryResource.java
@@ -1,4 +1,4 @@
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -130,7 +130,7 @@ public class RepositoryResource extends DeleteRepository {
             w.writeStartElement("repository");
             w.writeElement("id", repo.getId());
             w.writeElement("name", repo.getRepoName());
-            w.writeElement("location", repo.getLocation());
+            w.writeElement("location", repo.getMaskedLocation());
             w.writeEndElement();
         }
     }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/data/store/geogig/GeoGigDataStoreEditPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/data/store/geogig/GeoGigDataStoreEditPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -258,7 +258,7 @@ public class GeoGigDataStoreEditPanel extends StoreEditPanel {
                 URI repoUri = new URI(repoUriStr);
                 RepositoryResolver resolver = RepositoryResolver.lookup(repoUri);
                 RepositoryInfo info = RepositoryManager.get().getByRepoName(resolver.getName(repoUri));
-                return info.getRepoName() + " (" + info.getLocation() + ")";
+                return info.getRepoName() + " (" + info.getMaskedLocation()+ ")";
             } catch (URISyntaxException e) {
                 throw Throwables.propagate(e);
             }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoriesListPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoriesListPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -231,7 +231,7 @@ public class RepositoriesListPanel extends GeoServerTablePanel<RepositoryInfo> {
 
         static final Property<RepositoryInfo> NAME = new BeanProperty<>("name", "repoName");
 
-        static final Property<RepositoryInfo> LOCATION = new BeanProperty<>("location", "location");
+        static final Property<RepositoryInfo> LOCATION = new BeanProperty<>("location", "maskedLocation");
 
         static final Property<RepositoryInfo> REMOVELINK = new AbstractProperty<RepositoryInfo>(
                 "remove") {

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/config/RepositoryInfoTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/config/RepositoryInfoTest.java
@@ -1,0 +1,48 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the RepositoryInfo object.
+ */
+public class RepositoryInfoTest {
+
+    @Test
+    public void testLocationMaskUtility() {
+        // make sure that, given a repository name, the masking utility reutrns the expected masked location URI
+        final String repositoryName = "myRepo";
+        final String actualMaskedLocation = GeoServerGeoGigRepositoryResolver.getURI(repositoryName);
+        assertEquals("Location masking produced unexpected URI", "geoserver://myRepo", actualMaskedLocation);
+    }
+
+    @Test
+    public void testMaksedLocation() {
+        final RepositoryInfo repositoryInfo = new RepositoryInfo();
+        // make a location URI and set it
+        final String fakeRepoName = "fakeRepo";
+        final URI fakeUri = URI.create("file:///tmp/" + fakeRepoName);
+        repositoryInfo.setLocation(fakeUri);
+        // get the name
+        final String reposiotoryName = repositoryInfo.getRepoName();
+        // get the maksed location
+        final String actualMaskedLocation = repositoryInfo.getMaskedLocation();
+        // assert the masked location matches the resolver maksing pattern
+        final String expectedMaskedLocation = GeoServerGeoGigRepositoryResolver.getURI(reposiotoryName);
+        assertEquals("Masked location value does not match Resolver pattern",
+                expectedMaskedLocation, actualMaskedLocation);
+        final String uriPrefix = GeoServerGeoGigRepositoryResolver.GEOSERVER_URI_SCHEME + "://";
+        assertTrue(String.format("Maksed URI doesn't have '%s' prefix", uriPrefix),
+                actualMaskedLocation.startsWith(uriPrefix));
+        final String actualRepoName = actualMaskedLocation.substring(GeoServerGeoGigRepositoryResolver.SCHEME_LENGTH);
+        assertEquals("Unexpected Repository name in masked location", fakeRepoName, actualRepoName);
+    }
+}


### PR DESCRIPTION
Use the `geoserver://<repo_name>` psuedo URI in places where we
do not want to expose GeoGig backend connection information, like
PostgreSQL passwords.