### PR TITLE
Parallelize loading GWC tile layer config files by using parallel streams

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
@@ -109,14 +109,14 @@ public class DefaultTileLayerCatalog implements TileLayerCatalog {
         });
 
         LOGGER.info("Loading tile layers from " + baseDir.path());
-        for (Resource res : tileLayerFiles) {
+        tileLayerFiles.parallelStream().forEach(res -> {
             GeoServerTileLayerInfoImpl info;
             try {
                 info = depersist(res);
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "Error depersisting tile layer information from file "
                         + res.name(), e);
-                continue;
+                return;
             }
 
             layersById.put(info.getId(), info.getName());
@@ -124,7 +124,7 @@ public class DefaultTileLayerCatalog implements TileLayerCatalog {
             if (LOGGER.isLoggable(Level.FINER)) {
                 LOGGER.finer("Loaded tile layer '" + info.getName() + "'");
             }
-        }
+        });
         this.initialized = true;
     }
 


### PR DESCRIPTION
This is a simple follow up for GSIP-155, reducing the time it takes to load the GWC config files