### PR TITLE
GSIP-157 / GEOS-7987 - Track modified properties in CatalogPostModifyEvent

### DIFF
--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
@@ -19,6 +19,8 @@ package org.geoserver.jdbcconfig.internal;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.easymock.Capture;
@@ -203,7 +205,7 @@ public class ConfigDatabaseTest {
         assertEquals("name1", ws2.getName());
         
         // Notify of update
-        testSupport.getCatalog().firePostModified(ws2);
+        testSupport.getCatalog().firePostModified(ws2, Arrays.asList("name"), Arrays.asList("name1"), Arrays.asList("name2"));
         
         // Should show the new value
         WorkspaceInfo ws3 = database.getById(ws.getId(), WorkspaceInfo.class);

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogPostModifyEventHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogPostModifyEventHandler.java
@@ -90,43 +90,43 @@ public class JMSCatalogPostModifyEventHandler extends JMSCatalogEventHandler {
 		if (info instanceof LayerGroupInfo) {
 			
 			final LayerGroupInfo localizedObject = CatalogUtils.localizeLayerGroup((LayerGroupInfo) info, catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 
 	
 		} else if (info instanceof LayerInfo) {
 	
 			final LayerInfo localizedObject=CatalogUtils.localizeLayer((LayerInfo) info, catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 			
 		} else if (info instanceof MapInfo) {
 	
 			final MapInfo localizedObject = CatalogUtils.localizeMapInfo((MapInfo) info,catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 			
 		} else if (info instanceof NamespaceInfo) {
 	
 			final NamespaceInfo localizedObject=CatalogUtils.localizeNamespace((NamespaceInfo) info, catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 			
 		} else if (info instanceof StoreInfo) {
 	
 			final StoreInfo localizedObject=CatalogUtils.localizeStore((StoreInfo)info,catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 	
 		} else if (info instanceof ResourceInfo) {
 			
 			final ResourceInfo localizedObject=CatalogUtils.localizeResource((ResourceInfo)info,catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 	
 		} else if (info instanceof StyleInfo) {
 	
 			final StyleInfo localizedObject = CatalogUtils.localizeStyle((StyleInfo) info, catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 	
 		} else if (info instanceof WorkspaceInfo) {
 			
 			final WorkspaceInfo localizedObject= CatalogUtils.localizeWorkspace((WorkspaceInfo) info, catalog);
-			catalog.firePostModified(ModificationProxy.unwrap(localizedObject));
+			catalog.firePostModified(ModificationProxy.unwrap(localizedObject), modifyEv.getPropertyNames(), modifyEv.getOldValues(), modifyEv.getNewValues());
 	
 		} else if (info instanceof CatalogInfo) {
 

--- a/src/main/src/main/java/org/geoserver/catalog/Catalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Catalog.java
@@ -1593,7 +1593,8 @@ public interface Catalog extends CatalogInfo {
      * interally by the catalog subsystem.
      * </p>
      */
-    void firePostModified(CatalogInfo object);
+    void firePostModified(CatalogInfo object, List<String> propertyNames, List oldValues,
+            List newValues);
     
     /**
      * Fires the event for an object being removed from the catalog.

--- a/src/main/src/main/java/org/geoserver/catalog/event/CatalogPostModifyEvent.java
+++ b/src/main/src/main/java/org/geoserver/catalog/event/CatalogPostModifyEvent.java
@@ -5,12 +5,32 @@
  */
 package org.geoserver.catalog.event;
 
+import java.util.List;
+
 /**
  * Event for the modification of an object in the catalog.
+ * <p>
+ * The {@link #getSource()} method returns the object modified. For access to the object
+ * before it has been modified, see {@link CatalogModifyEvent}.
+ * </p>
  * 
  * @author Justin Deoliveira, OpenGeo
  *
  */
 public interface CatalogPostModifyEvent extends CatalogEvent {
 
+    /**
+     * The names of the properties that were modified.
+     */
+    List<String> getPropertyNames();
+
+    /**
+     * The old values of the properties that were modified.
+     */
+    List<Object> getOldValues();
+
+    /**
+     * The new values of the properties that were modified.
+     */
+    List<Object> getNewValues();
 }

--- a/src/main/src/main/java/org/geoserver/catalog/event/impl/CatalogPostModifyEventImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/event/impl/CatalogPostModifyEventImpl.java
@@ -7,6 +7,36 @@ package org.geoserver.catalog.event.impl;
 
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CatalogPostModifyEventImpl extends CatalogEventImpl implements CatalogPostModifyEvent {
 
+    List propertyNames = new ArrayList();
+    List oldValues = new ArrayList();
+    List newValues = new ArrayList();
+
+    public List getPropertyNames() {
+        return propertyNames;
+    }
+
+    public void setPropertyNames(List propertyNames) {
+        this.propertyNames = propertyNames;
+    }
+
+    public List getNewValues() {
+        return newValues;
+    }
+
+    public void setNewValues(List newValues) {
+        this.newValues = newValues;
+    }
+
+    public List getOldValues() {
+        return oldValues;
+    }
+
+    public void setOldValues(List oldValues) {
+        this.oldValues = oldValues;
+    }
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogDecorator.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogDecorator.java
@@ -648,8 +648,9 @@ public class AbstractCatalogDecorator extends AbstractDecorator<Catalog> impleme
         delegate.fireModified(object, propertyNames, oldValues, newValues);
     }
     
-    public void firePostModified(CatalogInfo object) {
-        delegate.firePostModified(object);
+    public void firePostModified(CatalogInfo object, List<String> propertyNames,
+            List oldValues, List newValues) {
+        delegate.firePostModified(object, propertyNames, oldValues, newValues);
     }
     
     public void fireRemoved(CatalogInfo object) {

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractFilteredCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractFilteredCatalog.java
@@ -659,8 +659,9 @@ public abstract class AbstractFilteredCatalog extends AbstractDecorator<Catalog>
         delegate.fireModified(object, propertyNames, oldValues, newValues);
     }
     
-    public void firePostModified(CatalogInfo object) {
-        delegate.firePostModified(object);
+    public void firePostModified(CatalogInfo object, List<String> propertyNames, List oldValues,
+            List newValues) {
+        delegate.firePostModified(object, propertyNames, oldValues, newValues);
     }
     
     public void fireRemoved(CatalogInfo object) {

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1489,10 +1489,13 @@ public class CatalogImpl implements Catalog {
         event(event);
     }
 
-    public void firePostModified(CatalogInfo object) {
+    public void firePostModified(CatalogInfo object, List propertyNames, List oldValues,
+            List newValues) {
         CatalogPostModifyEventImpl event = new CatalogPostModifyEventImpl();
         event.setSource( object);
-        
+        event.setPropertyNames(propertyNames);
+        event.setOldValues(oldValues);
+        event.setNewValues(newValues);
         event(event);
     }
     

--- a/src/main/src/main/java/org/geoserver/catalog/impl/DefaultCatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/DefaultCatalogFacade.java
@@ -200,10 +200,17 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     }
     
     public void save(StoreInfo store) {
-        beforeSaved(store);
+        ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(store);
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
+
+        beforeSaved(store, propertyNames, oldValues, newValues);
         stores.update(store);
         commitProxy(store);
-        afterSaved(store);
+        afterSaved(store, propertyNames, oldValues, newValues);
     }
     
     public <T extends StoreInfo> T detach(T store) {
@@ -258,6 +265,11 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     
     public void setDefaultDataStore(WorkspaceInfo workspace, DataStoreInfo store) {
         DataStoreInfo old = defaultStores.get(workspace.getId());
+
+        //fire modify event before change
+        catalog.fireModified(catalog,
+                Arrays.asList("defaultDataStore"), Arrays.asList(old), Arrays.asList(store));
+
         synchronized(defaultStores) {
             if (store != null) {
                 defaultStores.put(workspace.getId(), store);    
@@ -267,8 +279,8 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
             }
         }
         
-        //fire change event
-        catalog.fireModified(catalog, 
+        //fire postmodify event after change
+        catalog.firePostModified(catalog,
             Arrays.asList("defaultDataStore"), Arrays.asList(old), Arrays.asList(store));
     }
     
@@ -292,11 +304,18 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     
    
     public void save(ResourceInfo resource) {
-        beforeSaved(resource);
+        ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(resource);
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
+
+        beforeSaved(resource, propertyNames, oldValues, newValues);
         resources.update(resource);
         layers.update(resource);
         commitProxy(resource);
-        afterSaved(resource);
+        afterSaved(resource, propertyNames, oldValues, newValues);
     }
     
     public <T extends ResourceInfo> T detach(T resource) {
@@ -384,10 +403,17 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     }
     
     public void save(LayerInfo layer) {
-        beforeSaved(layer);
+        ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(layer);
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
+
+        beforeSaved(layer, propertyNames, oldValues, newValues);
         layers.update(layer);
         commitProxy(layer);
-        afterSaved(layer);
+        afterSaved(layer, propertyNames, oldValues, newValues);
     }
     
     public LayerInfo detach(LayerInfo layer) {
@@ -452,9 +478,16 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     }
 
     public void save(MapInfo map) {
-        beforeSaved(map);
+        ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(map);
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
+
+        beforeSaved(map, propertyNames, oldValues, newValues);
         commitProxy(map);
-        afterSaved(map);
+        afterSaved(map, propertyNames, oldValues, newValues);
     }
     
     public MapInfo detach(MapInfo map) {
@@ -509,10 +542,17 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
      * @see org.geoserver.catalog.impl.CatalogDAO#save(org.geoserver.catalog.LayerGroupInfo)
      */
     public void save(LayerGroupInfo layerGroup) {
-        beforeSaved(layerGroup);
+        ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(layerGroup);
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
+
+        beforeSaved(layerGroup, propertyNames, oldValues, newValues);
         layerGroups.update(layerGroup);
         commitProxy(layerGroup);
-        afterSaved(layerGroup);
+        afterSaved(layerGroup, propertyNames, oldValues, newValues);
     }
     
     public LayerGroupInfo detach(LayerGroupInfo layerGroup) {
@@ -587,10 +627,17 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     }
 
     public void save(NamespaceInfo namespace) {
-        beforeSaved(namespace);
+        ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(namespace);
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
+
+        beforeSaved(namespace, propertyNames, oldValues, newValues);
         namespaces.update(namespace);
         commitProxy(namespace);
-        afterSaved(namespace);
+        afterSaved(namespace, propertyNames, oldValues, newValues);
     }
 
     public NamespaceInfo detach(NamespaceInfo namespace) {
@@ -603,10 +650,14 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
 
     public void setDefaultNamespace(NamespaceInfo defaultNamespace) {
         NamespaceInfo old = this.defaultNamespace;
+        //fire modify event before change
+        catalog.fireModified(catalog,
+                Arrays.asList("defaultNamespace"), Arrays.asList(old), Arrays.asList(defaultNamespace));
+
         this.defaultNamespace = defaultNamespace;
         
-        //fire change event
-        catalog.fireModified(catalog, 
+        //fire postmodify event after change
+        catalog.firePostModified(catalog,
             Arrays.asList("defaultNamespace"), Arrays.asList(old), Arrays.asList(defaultNamespace));
         
     }
@@ -657,11 +708,16 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
                 defaultStores.put(workspace.getName(), ds);
             }
         }
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
         
-        beforeSaved(workspace);
+        beforeSaved(workspace, propertyNames, oldValues, newValues);
         workspaces.update(workspace);
         commitProxy(workspace);     
-        afterSaved(workspace);
+        afterSaved(workspace, propertyNames, oldValues, newValues);
     }
 
     public WorkspaceInfo detach(WorkspaceInfo workspace) {
@@ -674,10 +730,14 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     
     public void setDefaultWorkspace(WorkspaceInfo workspace) {
         WorkspaceInfo old = defaultWorkspace;
+        //fire modify event before change
+        catalog.fireModified(catalog,
+                Arrays.asList("defaultWorkspace"), Arrays.asList(old), Arrays.asList(workspace));
+
         this.defaultWorkspace = workspace;
         
-        //fire change event
-        catalog.fireModified(catalog, 
+        //fire postmodify event after change
+        catalog.firePostModified(catalog,
             Arrays.asList("defaultWorkspace"), Arrays.asList(old), Arrays.asList(workspace));
     }
     
@@ -713,10 +773,17 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     }
 
     public void save(StyleInfo style) {
-        beforeSaved(style);
+        ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(style);
+
+        // figure out what changed
+        List<String> propertyNames = h.getPropertyNames();
+        List<Object> newValues = h.getNewValues();
+        List<Object> oldValues = h.getOldValues();
+
+        beforeSaved(style, propertyNames, oldValues, newValues);
         styles.update(style);
         commitProxy(style);
-        afterSaved(style);
+        afterSaved(style, propertyNames, oldValues, newValues);
     }
 
     public StyleInfo detach(StyleInfo style) {

--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -1276,8 +1276,9 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         delegate.fireModified(object, propertyNames, oldValues, newValues);
     }
     
-    public void firePostModified(CatalogInfo object) {
-        delegate.firePostModified(object);
+    public void firePostModified(CatalogInfo object, List<String> propertyNames, List oldValues,
+            List newValues) {
+        delegate.firePostModified(object, propertyNames, oldValues, newValues);
     }
     
     public void fireRemoved(CatalogInfo object) {

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -423,6 +423,9 @@ public class CatalogImplTest {
         assertEquals( 1, l.modified.size() );
         assertEquals( catalog, l.modified.get(0).getSource());
         assertEquals( "defaultNamespace", l.modified.get(0).getPropertyNames().get(0));
+        assertEquals( 1, l.postModified.size() );
+        assertEquals( catalog, l.postModified.get(0).getSource());
+        assertEquals( "defaultNamespace", l.postModified.get(0).getPropertyNames().get(0));
         
         ns = catalog.getNamespaceByPrefix( "ns2Prefix" );
         ns.setURI( "changed");
@@ -433,6 +436,11 @@ public class CatalogImplTest {
         assertTrue(l.modified.get(1).getPropertyNames().get(0).equalsIgnoreCase("uri" ));
         assertTrue(l.modified.get(1).getOldValues().contains( "ns2URI" ));
         assertTrue(l.modified.get(1).getNewValues().contains( "changed" ));
+        assertEquals( 2, l.postModified.size() );
+        assertEquals( 1, l.postModified.get(1).getPropertyNames().size());
+        assertTrue(l.postModified.get(1).getPropertyNames().get(0).equalsIgnoreCase("uri" ));
+        assertTrue(l.postModified.get(1).getOldValues().contains( "ns2URI" ));
+        assertTrue(l.postModified.get(1).getNewValues().contains( "changed" ));
         
         assertTrue( l.removed.isEmpty() );
         catalog.remove( ns );
@@ -637,6 +645,8 @@ public class CatalogImplTest {
         assertEquals( ws, l.added.get(0).getSource());
         assertEquals( catalog, l.modified.get(0).getSource());
         assertEquals( "defaultWorkspace", l.modified.get(0).getPropertyNames().get(0));
+        assertEquals( catalog, l.postModified.get(0).getSource());
+        assertEquals( "defaultWorkspace", l.postModified.get(0).getPropertyNames().get(0));
         
         ws = catalog.getWorkspaceByName( "ws2" );
         ws.setName( "changed");
@@ -646,6 +656,9 @@ public class CatalogImplTest {
         assertTrue(l.modified.get(1).getPropertyNames().contains( "name" ));
         assertTrue(l.modified.get(1).getOldValues().contains( "ws2" ));
         assertTrue(l.modified.get(1).getNewValues().contains( "changed" ));
+        assertTrue(l.postModified.get(1).getPropertyNames().contains( "name" ));
+        assertTrue(l.postModified.get(1).getOldValues().contains( "ws2" ));
+        assertTrue(l.postModified.get(1).getNewValues().contains( "changed" ));
         
         assertTrue( l.removed.isEmpty() );
         catalog.remove( ws );
@@ -842,6 +855,8 @@ public class CatalogImplTest {
         assertEquals( ds, l.added.get(0).getSource() );
         assertEquals( 1, l.modified.size() );
         assertEquals( catalog, l.modified.get(0).getSource() );
+        assertEquals( 1, l.postModified.size() );
+        assertEquals( catalog, l.postModified.get(0).getSource() );
         
         DataStoreInfo ds2 = catalog.getDataStoreByName( ds.getName() );
         ds2.setDescription( "changed" );
@@ -854,12 +869,23 @@ public class CatalogImplTest {
         assertEquals( ds2, me.getSource() );
         assertEquals( 1, me.getPropertyNames().size() );
         assertEquals( "description", me.getPropertyNames().get(0));
-        
+
         assertEquals( 1, me.getOldValues().size() );
         assertEquals( 1, me.getNewValues().size() );
-        
+
         assertEquals( "dsDescription", me.getOldValues().get(0));
         assertEquals( "changed", me.getNewValues().get(0));
+
+        CatalogPostModifyEvent pme = l.postModified.get(1);
+        assertEquals( ds2, pme.getSource() );
+        assertEquals( 1, pme.getPropertyNames().size() );
+        assertEquals( "description", pme.getPropertyNames().get(0));
+
+        assertEquals( 1, pme.getOldValues().size() );
+        assertEquals( 1, pme.getNewValues().size() );
+
+        assertEquals( "dsDescription", pme.getOldValues().get(0));
+        assertEquals( "changed", pme.getNewValues().get(0));
         
         assertEquals( 0, l.removed.size() );
         catalog.remove( ds );
@@ -1169,6 +1195,11 @@ public class CatalogImplTest {
         assertTrue( l.modified.get(0).getPropertyNames().contains( "description"));
         assertTrue( l.modified.get(0).getOldValues().contains( "ftDescription"));
         assertTrue( l.modified.get(0).getNewValues().contains( "changed"));
+        assertEquals( 1, l.modified.size() );
+        assertEquals( ft, l.postModified.get(0).getSource() );
+        assertTrue( l.postModified.get(0).getPropertyNames().contains( "description"));
+        assertTrue( l.postModified.get(0).getOldValues().contains( "ftDescription"));
+        assertTrue( l.postModified.get(0).getNewValues().contains( "changed"));
         
         assertTrue( l.removed.isEmpty() );
         catalog.remove( ft );
@@ -1499,6 +1530,11 @@ public class CatalogImplTest {
         assertTrue( tl.modified.get(0).getPropertyNames().contains( "path") );
         assertTrue( tl.modified.get(0).getOldValues().contains( null ) );
         assertTrue( tl.modified.get(0).getNewValues().contains( "newPath") );
+        assertEquals( 1, tl.postModified.size() );
+        assertEquals( l2, tl.postModified.get(0).getSource() );
+        assertTrue( tl.postModified.get(0).getPropertyNames().contains( "path") );
+        assertTrue( tl.postModified.get(0).getOldValues().contains( null ) );
+        assertTrue( tl.postModified.get(0).getNewValues().contains( "newPath") );
         
         assertTrue( tl.removed.isEmpty() );
         catalog.remove( l2 );
@@ -1732,12 +1768,18 @@ public class CatalogImplTest {
         s2.setFilename( "changed");
         
         assertTrue( l.modified.isEmpty() );
+        assertTrue( l.postModified.isEmpty() );
         catalog.save( s2 );
         assertEquals( 1, l.modified.size() );
         assertEquals( s2, l.modified.get(0).getSource() );
         assertTrue( l.modified.get(0).getPropertyNames().contains( "filename") );
         assertTrue( l.modified.get(0).getOldValues().contains( "styleFilename") );
         assertTrue( l.modified.get(0).getNewValues().contains( "changed") );
+        assertEquals( 1, l.postModified.size() );
+        assertEquals( s2, l.postModified.get(0).getSource() );
+        assertTrue( l.postModified.get(0).getPropertyNames().contains( "filename") );
+        assertTrue( l.postModified.get(0).getOldValues().contains( "styleFilename") );
+        assertTrue( l.postModified.get(0).getNewValues().contains( "changed") );
         
         assertTrue( l.removed.isEmpty() );
         catalog.remove( s2 );
@@ -2301,9 +2343,9 @@ public class CatalogImplTest {
     }
     
     static class TestListener implements CatalogListener {
-
         public List<CatalogAddEvent> added = new CopyOnWriteArrayList<>();
         public List<CatalogModifyEvent> modified = new CopyOnWriteArrayList<>();
+        public List<CatalogPostModifyEvent> postModified = new CopyOnWriteArrayList<>();
         public List<CatalogRemoveEvent> removed = new CopyOnWriteArrayList<>();
         
         public void handleAddEvent(CatalogAddEvent event) {
@@ -2315,6 +2357,7 @@ public class CatalogImplTest {
         }
 
         public void handlePostModifyEvent(CatalogPostModifyEvent event) {
+            postModified.add( event );
         }
         
         public void handleRemoveEvent(CatalogRemoveEvent event) {

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -361,7 +362,7 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
         long previousTime = sldResource.lastmodified();
         sldResource.file().setLastModified(lastTime + 1000);
         
-        catalog.firePostModified(catalog.getStyleByName("Bridges"));
+        catalog.firePostModified(catalog.getStyleByName("Bridges"), new ArrayList<String>(), new ArrayList(), new ArrayList());
         
         TransformerBase tr = createTransformer();
         tr.setIndentation(2);


### PR DESCRIPTION
GSIP Here: https://github.com/geoserver/geoserver/wiki/GSIP-157

API Changes:

* Public methods `getPropertyNames`,`getOldValues`,`getNewValues` added to **CatalogPostModifyEvent** interface.
* Public methods `getPropertyNames`, `setPropertyNames`, `getNewValues`, `setNewValues`, `getOldValues`, `setOldValues` added to **CatalogPostModifyEventImpl**.
* The arguments `List<String> propertyNames`, `List oldValues`, `List newValues` have been added to the package private method `firePostModified` of **AbstractCatalogDecorator**, **AbstractFilteredCatalog**, **CatalogImpl**, and **SecureCatalogImpl**, and to the protected methods `beforeSaved` and `afterSaved` of **AbstractCatalogFacade**.

All invocations of above methods and classes have been updated accordingly.

~Given that all the changes are internal (protected or package private) to the Catalog, this seems likely to be a relatively safe change (Although I think it should not be backported, as it is still an API change)~