### PR TITLE
[GEOS-7991] Re-initialize null LegendInfo after Style Page “apply”

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -327,6 +327,15 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
                     });
                 }
             }
+
+            @Override
+            protected void onAfterSubmit(AjaxRequestTarget target, Form<?> form) {
+                // Re-initialize the Legend model object, if it is null.
+                if (styleModel.getObject().getLegend() == null) {
+                    styleModel.getObject().setLegend(getCatalog().getFactory().createLegend());
+                }
+            }
+
             @Override
             protected void onError(AjaxRequestTarget target, Form<?> form) {
                 target.add(feedbackPanel);

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -580,4 +580,11 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
         assertEquals(2, si.getStyle().featureTypeStyles().size());
     }
     
+    @Test
+    public void applyThenSubmit() throws Exception {
+        tester.executeAjaxEvent("apply", "click");
+        tester.executeAjaxEvent("submit", "click");
+        tester.assertNoErrorMessage();
+    }
+    
 }


### PR DESCRIPTION
Fix for https://osgeo-org.atlassian.net/browse/GEOS-7991 -- Re-initialize LegendInfo when it is null after an "apply".