### PR TITLE
#[GEOS-7981] fixed imageio-ext-gdalgeotiff.jar classpath conflicts

### DIFF
--- a/src/release/ext-gdal.xml
+++ b/src/release/ext-gdal.xml
@@ -25,6 +25,7 @@
 			<excludes>
         <exclude>*arcgrid*.jar</exclude>
         <exclude>*customstreams*.jar</exclude>
+        <exclude>*imageio-ext-gdalgeotiff*.jar</exclude>
       </excludes>
 		</fileSet>
 		<fileSet>


### PR DESCRIPTION
Backport of [this PR](https://github.com/geoserver/geoserver/pull/2097)