### PR TITLE
[GEOS-7995] Make JMS not serialize properties of type catalog

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogModifyEventHandlerTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogModifyEventHandlerTest.java
@@ -1,0 +1,45 @@
+package org.geoserver.cluster.impl.handlers.catalog;
+
+import com.thoughtworks.xstream.XStream;
+import org.geoserver.catalog.event.CatalogEvent;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.impl.CatalogModifyEventImpl;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public final class JMSCatalogModifyEventHandlerTest {
+
+    @Test
+    public void testCatalogModifyEventHandling() throws Exception {
+        // create a catalog modify event that include properties of type catalog
+        CatalogModifyEventImpl catalogModifyEvent = new CatalogModifyEventImpl();
+        catalogModifyEvent.setPropertyNames(Arrays.asList("propertyA", "propertyB", "propertyC", "propertyD"));
+        catalogModifyEvent.setOldValues(Arrays.asList("value", new CatalogImpl(), 50, null));
+        catalogModifyEvent.setNewValues(Arrays.asList("new_value", new CatalogImpl(), null, new CatalogImpl()));
+        // serialise the event and deserialize it
+        JMSCatalogModifyEventHandlerSPI handler = new JMSCatalogModifyEventHandlerSPI(0, null, new XStream(), null);
+        String serializedEvent = handler.createHandler().serialize(catalogModifyEvent);
+        CatalogEvent newEvent = handler.createHandler().deserialize(serializedEvent);
+        // check the deserialized event
+        assertThat(newEvent, notNullValue());
+        assertThat(newEvent, instanceOf(CatalogModifyEvent.class));
+        CatalogModifyEvent newModifyEvent = (CatalogModifyEvent) newEvent;
+        // check properties names
+        assertThat(newModifyEvent.getPropertyNames().size(), is(2));
+        assertThat(newModifyEvent.getPropertyNames(), CoreMatchers.hasItems("propertyA", "propertyC"));
+        // check old values
+        assertThat(newModifyEvent.getOldValues().size(), is(2));
+        assertThat(newModifyEvent.getOldValues(), CoreMatchers.hasItems("value", 50));
+        // check new values
+        assertThat(newModifyEvent.getNewValues().size(), is(2));
+        assertThat(newModifyEvent.getNewValues(), CoreMatchers.hasItems("new_value", null));
+    }
+}


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7995

JMS plugin will not serialize properties of type catalog when propagating modify events. Catalogs are instance specific and most of is fields are transient, so no collateral effects are expected.

A test case for this was also added.