### PR TITLE
[GEOS-7995] Make JMS not serialize properties of type catalog (backport 2.10.x)

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogEventHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogEventHandler.java
@@ -5,22 +5,26 @@
  */
 package org.geoserver.cluster.impl.handlers.catalog;
 
-import java.util.logging.Level;
-
-import javax.jms.JMSException;
-
+import com.thoughtworks.xstream.XStream;
+import org.apache.commons.collections.ArrayStack;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.event.CatalogEvent;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.impl.CatalogModifyEventImpl;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.cluster.JMSEventHandler;
 import org.geoserver.cluster.JMSEventHandlerSPI;
 
-import com.thoughtworks.xstream.XStream;
+import javax.jms.JMSException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
 
 /**
  * Abstract class which use Xstream as message serializer/de-serializer.
  * We extend this class to implementing synchronize method.
- * 
+ *
  * @author Carlo Cancellieri - carlo.cancellieri@geo-solutions.it
  *
  */
@@ -47,7 +51,7 @@ public abstract class JMSCatalogEventHandler extends
 
 	@Override
 	public String serialize(CatalogEvent  event) throws Exception {
-		return xstream.toXML(event);
+		return xstream.toXML(removeCatalogProperties(event));
 	}
 
 	@Override
@@ -66,5 +70,50 @@ public abstract class JMSCatalogEventHandler extends
 			throw new JMSException("Unable to deserialize the following object:\n"+s);
 		}
 
+	}
+
+	/**
+	 * Make sure that properties of type catalog are not serialized
+	 * for catalog modified events.
+	 */
+	private CatalogEvent removeCatalogProperties(CatalogEvent event) {
+		if (!(event instanceof CatalogModifyEvent)) {
+			// not a modify event so nothing to do
+			return event;
+		}
+		CatalogModifyEvent modifyEvent = (CatalogModifyEvent) event;
+		// index all the properties that are not of catalog type
+		List<Integer> indexes = new ArrayList<>();
+		int totalProperties = modifyEvent.getPropertyNames().size();
+		for (int i = 0; i < totalProperties; i++) {
+			// we only need to check the new values
+			Object value = modifyEvent.getNewValues().get(i);
+			if (!(value instanceof Catalog)) {
+				// not a property of type catalog
+				indexes.add(i);
+			}
+		}
+		// let's see if we need to do anything
+		if (indexes.size() == totalProperties) {
+			// no properties of type catalog, we can use the original event
+			return event;
+		}
+		// well we need to create a new modify event and ignore the properties of catalog type
+		List<String> properties = new ArrayList<>();
+		List<Object> oldValues = new ArrayList<>();
+		List<Object> newValues = new ArrayList<>();
+		for (int index : indexes) {
+			// add all the properties that are not of catalog type
+			properties.add(modifyEvent.getPropertyNames().get(index));
+			oldValues.add(modifyEvent.getOldValues().get(index));
+			newValues.add(modifyEvent.getNewValues().get(index));
+		}
+		// crete the new event
+		CatalogModifyEventImpl newEvent = new CatalogModifyEventImpl();
+		newEvent.setPropertyNames(properties);
+		newEvent.setOldValues(oldValues);
+		newEvent.setNewValues(newValues);
+		newEvent.setSource(modifyEvent.getSource());
+		return newEvent;
 	}
 }

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogModifyEventHandlerTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogModifyEventHandlerTest.java
@@ -1,0 +1,45 @@
+package org.geoserver.cluster.impl.handlers.catalog;
+
+import com.thoughtworks.xstream.XStream;
+import org.geoserver.catalog.event.CatalogEvent;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.impl.CatalogModifyEventImpl;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public final class JMSCatalogModifyEventHandlerTest {
+
+    @Test
+    public void testCatalogModifyEventHandling() throws Exception {
+        // create a catalog modify event that include properties of type catalog
+        CatalogModifyEventImpl catalogModifyEvent = new CatalogModifyEventImpl();
+        catalogModifyEvent.setPropertyNames(Arrays.asList("propertyA", "propertyB", "propertyC", "propertyD"));
+        catalogModifyEvent.setOldValues(Arrays.asList("value", new CatalogImpl(), 50, null));
+        catalogModifyEvent.setNewValues(Arrays.asList("new_value", new CatalogImpl(), null, new CatalogImpl()));
+        // serialise the event and deserialize it
+        JMSCatalogModifyEventHandlerSPI handler = new JMSCatalogModifyEventHandlerSPI(0, null, new XStream(), null);
+        String serializedEvent = handler.createHandler().serialize(catalogModifyEvent);
+        CatalogEvent newEvent = handler.createHandler().deserialize(serializedEvent);
+        // check the deserialized event
+        assertThat(newEvent, notNullValue());
+        assertThat(newEvent, instanceOf(CatalogModifyEvent.class));
+        CatalogModifyEvent newModifyEvent = (CatalogModifyEvent) newEvent;
+        // check properties names
+        assertThat(newModifyEvent.getPropertyNames().size(), is(2));
+        assertThat(newModifyEvent.getPropertyNames(), CoreMatchers.hasItems("propertyA", "propertyC"));
+        // check old values
+        assertThat(newModifyEvent.getOldValues().size(), is(2));
+        assertThat(newModifyEvent.getOldValues(), CoreMatchers.hasItems("value", 50));
+        // check new values
+        assertThat(newModifyEvent.getNewValues().size(), is(2));
+        assertThat(newModifyEvent.getNewValues(), CoreMatchers.hasItems("new_value", null));
+    }
+}


### PR DESCRIPTION
Backport of pull request: https://github.com/geoserver/geoserver/pull/2111

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-7995

JMS plugin will not serialize properties of type catalog when propagating modify events. Catalogs are instance specific and most of is fields are transient, so no collateral effects are expected.

A test case for this was also added.