### PR TITLE
[GEOS-8004] Adds back the possibility to externalize GWC configuration using GEOWEBCACHE_CACHE_DIR (backport 2.9.x)

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
@@ -835,19 +835,17 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
             throws Exception {
         // Restore configuration files form source and Test that everything went well
         try {
+
             // - Prepare folder
-            Files.delete(
-                    baseDir.get(GeoserverXMLResourceProvider.DEFAULT_CONFIGURATION_DIR_NAME).dir());
+            GeoserverXMLResourceProvider gwcConfigProvider = (GeoserverXMLResourceProvider) GeoServerExtensions.bean("gwcXmlConfigResourceProvider");
+            Resource targetGWCProviderRestoreDir = gwcConfigProvider.getConfigDirectory();
+            Files.delete(targetGWCProviderRestoreDir.dir());
 
             // Restore GWC Providers Configurations
-            Resource targetGWCProviderRestoreDir = BackupUtils.dir(baseDir,
-                    GeoserverXMLResourceProvider.DEFAULT_CONFIGURATION_DIR_NAME);
-
             for (GeoserverXMLResourceProvider gwcProvider : GeoServerExtensions
                     .extensions(GeoserverXMLResourceProvider.class)) {
-                final File gwcProviderConfigFile = new File(gwcProvider.getLocation());
                 Resource providerConfigFile = sourceRestoreFolder.get(Paths
-                        .path(gwcProviderConfigFile.getParent(), gwcProviderConfigFile.getName()));
+                        .path(GeoserverXMLResourceProvider.DEFAULT_CONFIGURATION_DIR_NAME, gwcProvider.getConfigFileName()));
                 if (Resources.exists(providerConfigFile)
                         && FileUtils.sizeOf(providerConfigFile.file()) > 0) {
                     Resources.copy(providerConfigFile.in(), targetGWCProviderRestoreDir,

--- a/src/gwc/src/main/java/org/geoserver/gwc/JDBCConfigurationStorage.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/JDBCConfigurationStorage.java
@@ -47,7 +47,9 @@ class JDBCConfigurationStorage implements ApplicationContextAware, SecurityManag
 
     public JDBCConfigurationStorage(ResourceStore store,
             GeoServerSecurityManager securityManager) {
-        this.configDir = store.get(GeoserverXMLResourceProvider.DEFAULT_CONFIGURATION_DIR_NAME);
+        GeoserverXMLResourceProvider configProvider = (GeoserverXMLResourceProvider)
+                GeoServerExtensions.bean("jdbcDiskQuotaConfigResourceProvider");
+        this.configDir = configProvider.getConfigDirectory();
         this.passwordHelper = new JDBCPasswordEncryptionHelper(securityManager);
         securityManager.addListener(this);
     }

--- a/src/gwc/src/main/java/org/geoserver/gwc/config/GeoserverXMLResourceProvider.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/config/GeoserverXMLResourceProvider.java
@@ -1,30 +1,43 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.gwc.config;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geoserver.data.util.IOUtils;
 import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.platform.resource.Resources;
 import org.geoserver.util.Filter;
 import org.geowebcache.config.ConfigurationException;
 import org.geowebcache.config.ConfigurationResourceProvider;
+import org.geowebcache.config.XMLFileResourceProvider;
+import org.geowebcache.storage.DefaultStorageFinder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 public class GeoserverXMLResourceProvider implements ConfigurationResourceProvider {
 
-    private static Log log = LogFactory.getLog(org.geowebcache.config.XMLFileResourceProvider.class);
-    
+    private static Log LOGGER = LogFactory.getLog(GeoserverXMLResourceProvider.class);
+
+    static final String GEOWEBCACHE_CONFIG_DIR_PROPERTY = XMLFileResourceProvider.GWC_CONFIG_DIR_VAR;
+
+    static final String GEOWEBCACHE_CACHE_DIR_PROPERTY = DefaultStorageFinder.GWC_CACHE_DIR;
+
     public static final String DEFAULT_CONFIGURATION_DIR_NAME = "gwc";
     
     /**
@@ -39,33 +52,68 @@ public class GeoserverXMLResourceProvider implements ConfigurationResourceProvid
     
     private String templateLocation;
 
-    public GeoserverXMLResourceProvider(final String configFileDirectory,
-            final String configFileName,
-            final ResourceStore resourceStore) throws ConfigurationException {
-        
+    public GeoserverXMLResourceProvider(String providedConfigDirectory, String configFileName,
+                                        ResourceStore resourceStore) throws ConfigurationException {
         this.configFileName = configFileName;
-        
-        if(configFileDirectory != null) {
-            // Use the given path
-            if ((new File(configFileDirectory)).isAbsolute()) {
-                
-                log.info("Provided configuration directory as absolute path '" + configFileDirectory + "'");
-                this.configDirectory = Files.asResource(new File(configFileDirectory));
-            } else {
-                log.info("Provided configuration directory in the resource store. ");
-                this.configDirectory = resourceStore.get(configFileDirectory);
-            }
-        } else {
-            this.configDirectory = resourceStore.get(DEFAULT_CONFIGURATION_DIR_NAME);
-        }
-        log.info("Will look for geowebcache.xml in '" + configDirectory + "'");
+        this.configDirectory = inferConfigDirectory(resourceStore, providedConfigDirectory);
+        LOGGER.info(String.format(
+                "Will look for '%s' in directory '%s'.",
+                configFileName, configDirectory.dir().getAbsolutePath()));
     }
     
     public GeoserverXMLResourceProvider(final String configFileName,
             final ResourceStore resourceStore) throws ConfigurationException {
         this(null, configFileName, resourceStore);        
     }
-   
+
+    /**
+     * Helper method that infers the directory that contains or will contain GWC configuration. First we will
+     * check if a specific location was set using properties GEOWEBCACHE_CONFIG_DIR and GEOWEBCACHE_CACHE_DIR,
+     * then we will check if a location was provided and then fallback on the default location.
+     */
+    private static Resource inferConfigDirectory(ResourceStore resourceStore, String providedConfigDirectory) {
+        // check if a specific location was provided using a context property otherwise use the provided directory
+        String configDirectoryPath = findFirstDefined(
+                GEOWEBCACHE_CONFIG_DIR_PROPERTY, GEOWEBCACHE_CACHE_DIR_PROPERTY)
+                .orElse(providedConfigDirectory);
+        // if the configuration directory stills not defined we use the default location
+        if (configDirectoryPath == null) {
+            configDirectoryPath = DEFAULT_CONFIGURATION_DIR_NAME;
+        }
+        // instantiate a resource for the configuration directory
+        File configurationDirectory = new File(configDirectoryPath);
+        if (configurationDirectory.isAbsolute()) {
+            return Resources.fromPath(configurationDirectory.getAbsolutePath());
+        }
+        // configuration directory path is relative to geoserver data directory
+        return resourceStore.get(configDirectoryPath);
+    }
+
+    /**
+     * Returns an {@link Optional} containing the value of the first defined property,
+     * or an empty {@code Optional} if no property is defined in the current context.
+     */
+    private static Optional<String> findFirstDefined(String... propertiesNames) {
+        for (String propertyName : propertiesNames) {
+            // looks the property using GeoServer extensions mechanism
+            String propertyValue = GeoServerExtensions.getProperty(propertyName);
+            if (propertyValue != null) {
+                // this property is defined so let's use is value
+                LOGGER.debug(String.format("Property '%s' is set with value '%s'.", propertyName, propertyValue));
+                return Optional.of(propertyValue);
+            }
+        }
+        // no property is defined
+        return Optional.empty();
+    }
+
+    public Resource getConfigDirectory() {
+        return configDirectory;
+    }
+
+    public String getConfigFileName() {
+        return configFileName;
+    }
 
     @Override
     public InputStream in() throws IOException {
@@ -104,9 +152,9 @@ public class GeoserverXMLResourceProvider implements ConfigurationResourceProvid
         Resource xmlFile = findConfigFile();
 
         if (Resources.exists(xmlFile)) {
-            log.info("Found configuration file in " + configDirectory.path());
+            LOGGER.info("Found configuration file in " + configDirectory.path());
         } else if (templateLocation != null) {
-            log.warn("Found no configuration file in config directory, will create one at '"
+            LOGGER.warn("Found no configuration file in config directory, will create one at '"
                     + xmlFile.path() + "' from template "
                     + getClass().getResource(templateLocation).toExternalForm());
             // grab template from classpath
@@ -121,14 +169,14 @@ public class GeoserverXMLResourceProvider implements ConfigurationResourceProvid
 
         return xmlFile;
     }
-    
+
 
     private void backUpConfig(final Resource xmlFile) throws IOException {
         String timeStamp = new SimpleDateFormat("yyyy-MM-dd'T'HHmmss").format(new Date());
         String backUpFileName = "geowebcache_" + timeStamp + ".bak";
         Resource parentFile = xmlFile.parent();
 
-        log.debug("Backing up config file " + xmlFile.name() + " to " + backUpFileName);
+        LOGGER.debug("Backing up config file " + xmlFile.name() + " to " + backUpFileName);
 
         List<Resource> previousBackUps = Resources.list(parentFile, new Filter<Resource>() {
             public boolean accept(Resource res) {
@@ -153,14 +201,14 @@ public class GeoserverXMLResourceProvider implements ConfigurationResourceProvid
                 
             });
             Resource oldest = previousBackUps.get(0);
-            log.debug("Deleting oldest config backup " + oldest + " to keep a maximum of "
+            LOGGER.debug("Deleting oldest config backup " + oldest + " to keep a maximum of "
                     + maxBackups + " backups.");
             oldest.delete();
         }
 
         Resource backUpFile = parentFile.get(backUpFileName);
         IOUtils.copy(xmlFile.in(), backUpFile.out());
-        log.debug("Config backup done");
+        LOGGER.debug("Config backup done");
     }
 
     @Override
@@ -176,6 +224,4 @@ public class GeoserverXMLResourceProvider implements ConfigurationResourceProvid
     public boolean hasOutput() {
         return true;
     }
-
-
 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/config/GWCExternalConfigTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/config/GWCExternalConfigTest.java
@@ -1,0 +1,91 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.config;
+
+import org.geoserver.data.util.IOUtils;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests that is possible to set a different GWC configuration directory
+ * using properties GEOWEBCACHE_CONFIG_DIR_PROPERTY and GEOWEBCACHE_CACHE_DIR_PROPERTY.
+ */
+public final class GWCExternalConfigTest extends GeoServerSystemTestSupport {
+
+    private static final File rootTempDirectory;
+
+    private static final String tempDirectory1;
+    private static final String tempDirectory2;
+    private static final String tempDirectory3;
+    private static final String tempDirectory4;
+
+    static {
+        try {
+            // init target directories
+            rootTempDirectory = IOUtils.createTempDirectory("gwc");
+            tempDirectory1 = new File(rootTempDirectory, "test-case-1").getCanonicalPath();
+            tempDirectory2 = new File(rootTempDirectory, "test-case-2").getCanonicalPath();
+            tempDirectory3 = new File(rootTempDirectory, "test-case-3").getCanonicalPath();
+            tempDirectory4 = new File(rootTempDirectory, "test-case-4").getCanonicalPath();
+        } catch (Exception exception) {
+            throw new RuntimeException("Error initializing temporary directory.", exception);
+        }
+    }
+
+    @Test
+    public void testThatExternalDirectoryIsUsed() throws Exception {
+        testUseCase(tempDirectory1, null, tempDirectory1);
+        testUseCase(null, tempDirectory2, tempDirectory2);
+        testUseCase(tempDirectory3, tempDirectory4, tempDirectory3);
+    }
+
+    /**
+     * Helper method that setup the correct configuration variables, force Spring beans to be
+     * reloaded and checks GWC configuration beans.
+     */
+    private void testUseCase(String configDirPath, String cacheDirPath, String expectedConfigFirPath) {
+        // set or clear the gwc configuration directory property
+        if (configDirPath == null) {
+            System.clearProperty(GeoserverXMLResourceProvider.GEOWEBCACHE_CONFIG_DIR_PROPERTY);
+        } else {
+            System.setProperty(GeoserverXMLResourceProvider.GEOWEBCACHE_CONFIG_DIR_PROPERTY, configDirPath);
+        }
+        // set or clear the gwc cache directory property
+        if (cacheDirPath == null) {
+            System.clearProperty(GeoserverXMLResourceProvider.GEOWEBCACHE_CACHE_DIR_PROPERTY);
+        } else {
+            System.setProperty(GeoserverXMLResourceProvider.GEOWEBCACHE_CACHE_DIR_PROPERTY, cacheDirPath);
+        }
+        // rebuild the spring beans
+        applicationContext.refresh();
+        // check that the correct configuration directory is used
+        applicationContext.getBeansOfType(GeoserverXMLResourceProvider.class)
+                .values().forEach(bean -> {
+            try {
+                // check that configuration files are located in our custom directory
+                assertThat(bean.getConfigDirectory(), notNullValue());
+                assertThat(bean.getConfigDirectory().dir().getCanonicalPath(), is(expectedConfigFirPath));
+                // rely on canonical path for comparisons
+                assertThat(new File(bean.getLocation()).getCanonicalPath(),
+                        is(new File(expectedConfigFirPath, bean.getConfigFileName()).getCanonicalPath()));
+            } catch (Exception exception) {
+                throw new RuntimeException(exception);
+            }
+        });
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        // remove the root temporary directory we created
+        IOUtils.delete(rootTempDirectory);
+    }
+}


### PR DESCRIPTION
Backport of this pull request: https://github.com/geoserver/geoserver/pull/2131

Mailing list discussion: http://osgeo-org.1560.x6.nabble.com/Add-back-the-possibility-to-externalize-GWC-configuration-using-GEOWEBCACHE-CACHE-DIR-td5309333.html

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8004

This [commit](https://github.com/geoserver/geoserver/commit/a72682bc5f86114dc56ba9d68f19b670da76cd99#diff-5b32e54953013fe49c4405ac132f9d3eR18) removed the possibility to externalize GWC configuration using Java property ``GEOWEBCACHE_CACHE_DIR``.

This pull request fix the issue above and adds a new test case. Code that assumed only the default location was also updated.

This changes were manually tested and everything seems to be working as expected. The ``back-restore`` module was also tested.

Since this restores a functionality that is already documented no documentation was updated.

This pull request makes it also possible to use ``GEOWEBCACHE_CONFIG_DIR`` to set GWC configuration directory.