### PR TITLE
GEOS-7883 Return empty transaction result when no properties are given

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/UpdateElementHandler.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/UpdateElementHandler.java
@@ -134,7 +134,7 @@ public class UpdateElementHandler extends AbstractTransactionElementHandler {
         Update update = (Update) element;
         final QName elementName = update.getTypeName();
         String handle = update.getHandle();
-        
+
         long updated = response.getTotalUpdated().longValue();
 
         SimpleFeatureStore store = DataUtilities.simple((FeatureStore) featureStores.get(elementName));
@@ -162,6 +162,11 @@ public class UpdateElementHandler extends AbstractTransactionElementHandler {
             AttributeDescriptor[] types = new AttributeDescriptor[properties.size()];
             String[] names = new String[properties.size()];
             Object[] values = new Object[properties.size()];
+
+            //If no properties are defined for an update, there's nothing to do
+            if (properties.isEmpty()) {
+                return;
+            }
 
             for (int j = 0; j < properties.size(); j++) {
                 Property property = properties.get(j);

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/TransactionTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/TransactionTest.java
@@ -777,4 +777,21 @@ public class TransactionTest extends WFSTestSupport {
         print(dom);
        XMLAssert.assertXpathExists("//gs:bar[@gml:id = 'bar.1234']",dom);
    }
+
+   @Test
+   public void testEmptyUpdate() throws Exception {
+       String xml =
+           "<wfs:Transaction service=\"WFS\" version=\"1.1.0\"" +
+               " xmlns:cite=\"http://www.opengis.net/cite\"" +
+               " xmlns:ogc=\"http://www.opengis.net/ogc\"" +
+               " xmlns:gml=\"http://www.opengis.net/gml\"" +
+               " xmlns:wfs=\"http://www.opengis.net/wfs\">" +
+               " <wfs:Update typeName=\"cite:RoadSegments\">" +
+               " </wfs:Update>" +
+               "</wfs:Transaction>";
+
+       Document dom = postAsDOM( "wfs", xml );
+       assertEquals("wfs:TransactionResponse", dom.getDocumentElement().getNodeName());
+       assertEquals( "0", getFirstElementByTagName(dom, "wfs:totalUpdated").getFirstChild().getNodeValue());
+   }
 }


### PR DESCRIPTION
When there's no properties given to update in the transaction there's nothing to do, so update should just return immediately.