### PR TITLE
added product_thumb table in opensearch db

### DIFF
--- a/src/community/oseo/oseo-core/src/test/resources/postgis.sql
+++ b/src/community/oseo/oseo-core/src/test/resources/postgis.sql
@@ -162,7 +162,12 @@ create table product_metadata (
   metadata text
 );
 
- 
+-- the eo thumbs storage (small binary files, not used for search, thus separate table)
+create table product_thumb (
+	id int primary key references product(id),
+	thumb bytea
+);
+
 -- links for collections
 create table collection_ogclink (
   id serial primary key,


### PR DESCRIPTION
This PR adds to the postgis.sql script the DDL for the thumbs table of the opensearch db