### PR TITLE
Import Existing GeoGig repo via web API

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
@@ -8,6 +8,7 @@ import static org.locationtech.geogig.web.api.RESTUtils.getStringAttribute;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,8 @@ import org.geogig.geoserver.config.RepositoryManager;
 import org.locationtech.geogig.plumbing.ResolveGeogigURI;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.RepositoryConnectionException;
+import org.locationtech.geogig.repository.RepositoryResolver;
 import org.locationtech.geogig.repository.impl.GeoGIG;
 import org.locationtech.geogig.rest.RestletException;
 import org.locationtech.geogig.rest.repository.InitRequestUtil;
@@ -42,6 +45,11 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
      * Init request command string.
      */
     public static final String INIT_CMD = "init";
+
+    /**
+     * Import Existing Repository command string.
+     */
+    public static final String IMPORT_CMD = "importExistingRepo";
 
     private Optional<String> getRepositoryName(Request request) {
         final String repo = getStringAttribute(request, "repository");
@@ -140,6 +148,20 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
         return false;
     }
 
+    private boolean isImportRequest(Request request) {
+        // if the request is a POST, and the request path ends in "importExistingRepo"
+        if (Method.POST.equals(request.getMethod())) {
+            Map<String, Object> attributes = request.getAttributes();
+            if (attributes != null && attributes.containsKey("command")) {
+                return IMPORT_CMD.equals(attributes.get("command"));
+            } else if (request.getResourceRef() != null) {
+                String path = request.getResourceRef().getPath();
+                return path != null && path.contains(IMPORT_CMD);
+            }
+        }
+        return false;
+    }
+
     @Override
     public Optional<Repository> getGeogig(Request request) {
         Optional<String> repositoryName = getRepositoryName(request);
@@ -148,9 +170,14 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
         }
         // look for one with the provided name first
         Optional<Repository> geogig = getGeogig(repositoryName.get());
-        if (!geogig.isPresent() && isInitRequest(request)) {
-            // special handling of INIT requests
-            geogig = InitRequestHandler.createGeoGIG(request);
+        if (!geogig.isPresent()) {
+            if (isInitRequest(request)) {
+                // special handling of INIT requests
+                geogig = AddRepoRequestHandler.createGeoGIG(request);
+            } else if (isImportRequest(request)){
+                // handles IMPORT requests
+                geogig = AddRepoRequestHandler.importGeogig(request);
+            }
         }
         if (!geogig.isPresent()) {
             // if it's still not present, just generate one.
@@ -182,7 +209,7 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
         }
     }
 
-    private static class InitRequestHandler {
+    private static class AddRepoRequestHandler {
 
         private static Optional<Repository> createGeoGIG(Request request) {
             try {
@@ -191,6 +218,37 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
                 return Optional.fromNullable(RepositoryManager.get().createRepo(hints));
             } catch (Exception ex) {
                 Throwables.propagate(ex);
+            }
+            return Optional.absent();
+        }
+
+        private static Optional<Repository> importGeogig(Request request) {
+
+            try {
+                // build URI
+                Hints hint = InitRequestUtil.createHintsFromRequest(request);
+
+                // now build the repo with the Hints
+                RepositoryInfo repoInfo = new RepositoryInfo();
+
+                // set the repo location from the URI
+                URI uri = new URI(hint.get(Hints.REPOSITORY_URL).get().toString());
+                repoInfo.setLocation(uri);
+
+                // check to see if repo is initialized
+                RepositoryResolver repoResolver = RepositoryResolver.lookup(uri);
+                if(!repoResolver.repoExists(uri)) {
+                    return Optional.absent();
+                }
+
+                // save the repo, this will set a UUID
+                RepositoryManager.get().save(repoInfo);
+
+                return Optional.of(RepositoryManager.get().getRepository(repoInfo.getId()));
+            } catch (IOException | URISyntaxException e) {
+                Throwables.propagate(e);
+            } catch (RepositoryConnectionException e) {
+                e.printStackTrace();
             }
             return Optional.absent();
         }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeogigDispatcher.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeogigDispatcher.java
@@ -60,7 +60,7 @@ public class GeogigDispatcher extends AbstractController {
     private GeoServerRepositoryProvider repositoryProvider;
 
     /**
-     * converter for turning servlet requests into resetlet requests.
+     * converter for turning servlet requests into restlet requests.
      */
     private ServletConverter converter;
 
@@ -106,6 +106,8 @@ public class GeogigDispatcher extends AbstractController {
         router.attach("/repos.{extension}", RepositoryListResource.class);
         router.attach("/repos/", RepositoryListResource.class);
         router.attach("/repos.{extension}/", RepositoryListResource.class);
+        router.attach("/repos/{repository}/importExistingRepo", ImportRepoCommandResource.class);
+        router.attach("/repos/{repository}/importExistingRepo.{extension}", ImportRepoCommandResource.class);
 
         router.attach("/tasks.{extension}", TaskStatusResource.class);
         router.attach("/tasks", TaskStatusResource.class);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/ImportExistingRepo.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/ImportExistingRepo.java
@@ -1,0 +1,72 @@
+package org.geogig.geoserver.rest;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import org.locationtech.geogig.plumbing.ResolveGeogigURI;
+import org.locationtech.geogig.plumbing.ResolveRepositoryName;
+import org.locationtech.geogig.repository.Context;
+import org.locationtech.geogig.repository.RepositoryConnectionException;
+import org.locationtech.geogig.repository.RepositoryResolver;
+import org.locationtech.geogig.rest.repository.RepositoryProvider;
+import org.locationtech.geogig.web.api.*;
+import org.restlet.data.Method;
+import org.restlet.data.Status;
+
+import java.net.URI;
+
+public class ImportExistingRepo extends AbstractWebAPICommand {
+
+    public ImportExistingRepo(ParameterSet options) {
+        super(options);
+    }
+
+    @Override
+    public boolean supports(final Method method) {
+        return Method.POST.equals(method);
+    }
+
+    @Override
+    protected boolean requiresOpenRepo() {
+        return true;
+    }
+
+    @Override
+    public boolean requiresTransaction() {
+        return false;
+    }
+
+    /**
+     * Runs the command and builds the appropriate response
+     *
+     * @param context - the context to use for this command
+     *
+     * @throws CommandSpecException
+     */
+    @Override
+    protected void runInternal(CommandContext context) {
+
+        final Context geogig = this.getRepositoryContext(context);
+        Optional<URI> repoUri = geogig.command(ResolveGeogigURI.class).call();
+        Preconditions.checkState(repoUri.isPresent(),
+                "Unable to resolve URI of imported repository.");
+
+        try {
+            final String repositoryName = RepositoryResolver.load(repoUri.get())
+                    .command(ResolveRepositoryName.class).call();
+            context.setResponseContent(new CommandResponse() {
+                @Override
+                public void write(ResponseWriter out) throws Exception {
+                    out.start();
+                    out.writeRepoInitResponse(repositoryName, context.getBaseURL(),
+                            RepositoryProvider.BASE_REPOSITORY_ROUTE + "/" + repositoryName);
+                    out.finish();
+                }
+            });
+            // repo was created successfully
+            setStatus(Status.SUCCESS_OK);
+        } catch (RepositoryConnectionException e) {
+            throw new CommandSpecException(
+                    "Repository was imported, but was unable to connect to it immediately.");
+        }
+    }
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/ImportRepoCommandResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/ImportRepoCommandResource.java
@@ -1,0 +1,18 @@
+package org.geogig.geoserver.rest;
+
+import org.locationtech.geogig.rest.repository.CommandResource;
+import org.locationtech.geogig.web.api.ParameterSet;
+import org.locationtech.geogig.web.api.WebAPICommand;
+
+public class ImportRepoCommandResource extends CommandResource {
+
+    @Override
+    protected String getCommandName() {
+        return "importExistingRepo";
+    }
+
+    @Override
+    protected WebAPICommand buildCommand(String commandName, ParameterSet options) {
+        return new ImportExistingRepo(options);
+    }
+}

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
@@ -34,7 +34,7 @@ public class InitCommandResource extends org.locationtech.geogig.rest.repository
 
     private RepositoryInfo saveRepository() {
         // repo was just created, need to register it with an ID in the manager
-        // cretae a RepositoryInfo object
+        // create a RepositoryInfo object
         RepositoryInfo repoInfo = new RepositoryInfo();
         URI location = geogig.get().getLocation().normalize();
         if ("file".equals(location.getScheme())) {

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/GeoServerFunctionalTestContext.java
@@ -268,6 +268,35 @@ public class GeoServerFunctionalTestContext extends FunctionalTestContext {
     }
 
     /**
+     * Create a repository with the given name for testing.
+     * Repository is not saved to GeoServer context.
+     *
+     * @param name the repository name
+     *
+     * @return a newly created {@link TestData} for the repository.
+     *
+     * @throws Exception
+     */
+    protected TestData createRepoNoImport(String name) throws Exception {
+        GeoGigTestData testData = new GeoGigTestData(RunWebAPIFunctionalTest.TEMP_ROOT.getRoot());
+        testData.setUp(name);
+        testData.init().config("user.name", "John").config("user.email", "John.Doe@example.com");
+        GeoGIG geogig = testData.getGeogig();
+
+        Catalog catalog = helper.getCatalog();
+        CatalogBuilder catalogBuilder = testData.newCatalogBuilder(catalog);
+        int i = rnd.nextInt();
+        catalogBuilder.namespace("geogig.org/" + i).workspace("geogigws" + i)
+                .store("geogigstore" + i);
+        catalogBuilder.addAllRepoLayers().build();
+
+        // resolve the repo
+        catalog.dispose();
+
+        return new TestData(geogig);
+    }
+
+    /**
      * Helper function that asserts that there is a last response and returns it.
      *
      * @return the last response

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/PluginWebAPICucumberHooks.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/PluginWebAPICucumberHooks.java
@@ -1,0 +1,74 @@
+package org.geogig.geoserver.functional;
+
+import com.google.inject.Inject;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.StepDefAnnotation;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.geogig.web.functional.WebAPICucumberHooks;
+import org.locationtech.geogig.web.api.TestData;
+import org.restlet.data.MediaType;
+import org.restlet.data.Method;
+
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Extensions to the GeoGig Web API Functional tests. These these are specific to the GeoServer
+ * plugin.
+ */
+@ScenarioScoped
+@StepDefAnnotation
+public class PluginWebAPICucumberHooks {
+
+    public GeoServerFunctionalTestContext context;
+
+    /**
+     * Create an instance of this set of Steps with the GeoGig Web API Hooks as a parent. Since you
+     * cannot extend a Step Definition class, just inject the one that gets created during the test
+     * run and grab the Context. It <i>should</i> be an instance of
+     * {@link GeoServerFunctionalTestContext}.
+     *
+     * @param parent
+     */
+    @Inject
+    public PluginWebAPICucumberHooks(WebAPICucumberHooks parent) {
+        if (GeoServerFunctionalTestContext.class.isAssignableFrom(parent.context.getClass())) {
+            this.context = GeoServerFunctionalTestContext.class.cast(parent.context);
+        }
+    }
+
+    String systemTempPath() throws IOException {
+        return context.getTempFolder().getCanonicalPath().replace("\\", "/");
+    }
+
+    @Given("^A repository named \"([^\"]*)\" is initialized$")
+    public void initEmptyRepo(String repoName) throws Exception {
+        context.createRepoNoImport(repoName);
+    }
+
+    @When("^A JSON POST request is made to \"([^\"]*)\"$")
+    public void callURLWithJSONPayload(final String methodAndURL) throws JsonException, IOException {
+        // build JSON payload
+        JsonObject payload = Json.createObjectBuilder().add("parentDirectory", systemTempPath())
+                .add("leafDirectory", "geogigRepo")
+                .add("authorName", "GeoGig User")
+                .add("authorEmail", "geogig@geogig.org")
+                .build();
+        callURLWithJSONPayload(methodAndURL, payload);
+    }
+
+    private void callURLWithJSONPayload(final String methodAndURL, JsonObject payload)
+            throws JsonException {
+        final int idx = methodAndURL.indexOf(' ');
+        checkArgument(idx > 0, "No METHOD given in URL definition: '%s'", methodAndURL);
+        final String httpMethod = methodAndURL.substring(0, idx);
+        String resourceUri = methodAndURL.substring(idx + 1).trim();
+        Method method = Method.valueOf(httpMethod);
+        context.call(method, resourceUri, payload.toString(), MediaType.APPLICATION_JSON.getName());
+    }
+}

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/functional/RunWebAPIFunctionalTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/functional/RunWebAPIFunctionalTest.java
@@ -21,9 +21,9 @@ import cucumber.api.junit.Cucumber;
  */
 @RunWith(Cucumber.class)
 @CucumberOptions(strict = true,
-        features = {"classpath:features/commands/", "classpath:features/repo/"},
+        features = {"classpath:features/commands/", "classpath:features/repo/", "classpath:features/webCommand"},
         tags = {"~@HttpTest"},
-        glue = {"org.geogig.web.functional"},
+        glue = {"org.geogig.web.functional", "org.geogig.geoserver.functional"},
         plugin = {"pretty", "html:cucumber-report","json:cucumber-report/cucumber.json"})
 public class RunWebAPIFunctionalTest {
 

--- a/src/community/geogig/src/test/resources/features/webCommand/importExistingRepo.feature
+++ b/src/community/geogig/src/test/resources/features/webCommand/importExistingRepo.feature
@@ -1,0 +1,47 @@
+# (c) 2017 Open Source Geospatial Foundation - all rights reserved
+# This code is licensed under the GPL 2.0 license, available at the root
+# application directory.
+
+Feature: Import an Existing GeoGig repository
+  The import of a repository is done by issuing a POST request
+  to "/repos/<REPO_NAME>/importExistingRepo" API (for an XML response)
+  and "/repos/<REPO_NAME>/importExistingRepo.json" API (for a JSON response).
+  The response should be a 200 OK and contain the name of the new repository as well as
+  an href URL.
+
+  @newtest
+  Scenario: No provided "Content Type" returns "Bad Request" code (400)
+    Given There is a default multirepo server
+    When I post to "/repos/nonExistentRepo/importExistingRepo" with
+      """
+      {
+        "parentDirectory":"data/geogig/config",
+        "leafDirectory"="geogigRepo"
+      }
+      """
+    Then the response status should be '400'
+    Then there should be no "nonExistentRepo" created
+
+  @newtest
+  Scenario: Import of non existent repository fails
+    Given There is a default multirepo server
+    Given A repository named "geogigRepo" is initialized
+    When A JSON POST request is made to "POST /repos/nonExistentRepo/importExistingRepo"
+    Then there should be no "nonExistentRepo" created
+    And the response body should contain "Repository not found"
+
+  @newtest
+  Scenario: Import of existent repository succeeds with an XML response
+    Given There is a default multirepo server
+    Given A repository named "geogigRepo" is initialized
+    When A JSON POST request is made to "POST /repos/geogigRepo/importExistingRepo"
+    Then the response status should be '200'
+    And the response body should contain "http://localhost:8080/geoserver/geogig/repos/geogigRepo.xml"
+
+  @newtest
+  Scenario: Import of existent repository succeeds with a JSON response
+    Given There is a default multirepo server
+    Given A repository named "geogigRepo" is initialized
+    When A JSON POST request is made to "POST /repos/geogigRepo/importExistingRepo.json"
+    Then the response status should be '200'
+    And the response body should contain "http://localhost:8080/geoserver/geogig/repos/geogigRepo.json"


### PR DESCRIPTION
This commit adds the functionality of importing existing PostGres and directory
backed GeoGig repositories into GeoServer via the web API.