### PR TITLE
[GEOT-5667] Fix app-schema property substitution group support

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SubstitutionGroupCoverageMockData.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SubstitutionGroupCoverageMockData.java
@@ -1,0 +1,41 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.test;
+
+import org.geoserver.data.test.MockData;
+
+/**
+ * Mock data for testing substitution groups {@link SubstitutionGroupCoverageWfsTest}
+ * 
+ * @author Aaron Braeckel (National Center for Atmospheric Research)
+ */
+public class SubstitutionGroupCoverageMockData extends AbstractAppSchemaMockData {
+
+    /**
+     * Prefix for namespace.
+     */
+    protected static final String NAMESPACE_PREFIX = "test";
+
+    /**
+     * URI for namespace.
+     */
+    protected static final String URI = "http://www.geotools.org/test";
+
+    public SubstitutionGroupCoverageMockData() {
+        super(GML32_NAMESPACES);
+    }
+
+    /**
+     * @see AbstractAppSchemaMockData#addContent()
+     */
+    @Override
+    public void addContent() {
+        putNamespace(NAMESPACE_PREFIX, URI);
+        addFeatureType(NAMESPACE_PREFIX, "DiscreteCoverage", "subgrp.xml",
+                "subgrp-coverage.properties", "subgrp.xsd");
+    }
+}

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SubstitutionGroupCoverageWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SubstitutionGroupCoverageWfsTest.java
@@ -1,0 +1,47 @@
+/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.test;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/**
+ * This test ensures that substitution groups in XSD schemas work as expected.  Specifically,
+ * test:DomainSet is substitutable for gml:domainSet and should appear in the response.  This test
+ * case is loosely based upon WXXM 2 schemas, but significant portions of the schemas were removed
+ * or changed to simplify this test case
+ *
+ * @author Aaron Braeckel (National Center for Atmospheric Research)
+ *
+ */
+
+public class SubstitutionGroupCoverageWfsTest extends AbstractAppSchemaTestSupport {
+
+    @Override
+    protected AbstractAppSchemaMockData createTestData() {
+        return new SubstitutionGroupCoverageMockData();
+    }
+
+    @Test
+    public void testGetFeature() {
+        String path = "wfs?request=GetFeature&outputFormat=gml32&typeName=test:DiscreteCoverage";
+        Document doc = getAsDOM(path);
+        LOGGER.info(
+            "WFS GetFeature, typename=test:DiscreteCoverage response:\n" + prettyString(doc));
+        validateGet(path);
+
+        assertXpathEvaluatesTo("1", "/wfs:FeatureCollection/@numberReturned", doc);
+        assertXpathCount(1, "//test:DiscreteCoverage", doc);
+
+        String id = "a9274057-604d-427e-87f7-e6c9d846ceb5";
+        assertXpathEvaluatesTo(id, "(//test:DiscreteCoverage)[1]/@gml:id", doc);
+        assertXpathCount(1, "//test:DiscreteCoverage/test:domainSet", doc);
+        assertXpathCount(1, "//test:DiscreteCoverage/test:domainSet/test:DomainObject", doc);
+        assertXpathCount(1, "//test:DiscreteCoverage/test:domainSet/test:DomainObject/test:elements", doc);
+        assertXpathCount(2, "//test:DiscreteCoverage/test:domainSet/test:DomainObject/test:elements/*", doc);
+    }
+}

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/subgrp-coverage.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/subgrp-coverage.properties
@@ -1,0 +1,2 @@
+_=name:String,amount:Double,amount_uom:String,rule:String,uuid:String,geom:Geometry,geom2:Geometry
+1=http://www.geoserver.org/ontology/...|3.54|kg_m-2|Uniform|a9274057-604d-427e-87f7-e6c9d846ceb5|POLYGON((0.6476 -81.0527,20.6461 -81.0433,20.6446 -81.0338,20.6520 -81.0231,23.6202 -100.5372,23.6114 -100.5273))|POINT(-0.6476 81.0527)

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/subgrp.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/subgrp.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<as:AppSchemaDataAccess xmlns:as="http://www.geotools.org/app-schema"
+    xmlns:ogc="http://www.opengis.net/ogc" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.geotools.org/app-schema AppSchemaDataAccess.xsd
+      http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/expr.xsd">
+    <namespaces>
+        <Namespace>
+            <prefix>test</prefix>
+            <uri>http://www.geotools.org/test</uri>
+        </Namespace>
+        <Namespace>
+            <prefix>gml</prefix>
+            <uri>http://www.opengis.net/gml/3.2</uri>
+        </Namespace>
+        <Namespace>
+            <prefix>xlink</prefix>
+            <uri>http://www.w3.org/1999/xlink</uri>
+        </Namespace>
+    </namespaces>
+    <sourceDataStores>
+        <DataStore>
+            <id>subgrp-coverage</id>
+            <parameters>
+                <Parameter>
+                    <name>directory</name>
+                    <value>file:./</value>
+                </Parameter>
+            </parameters>
+        </DataStore>
+    </sourceDataStores>
+    <targetTypes>
+        <FeatureType>
+            <schemaUri>subgrp.xsd</schemaUri>
+        </FeatureType>
+    </targetTypes>
+    <typeMappings>
+        <FeatureTypeMapping>
+            <!-- arbitrary mapping name -->
+            <mappingName>subgrp-coverage</mappingName>
+            <!-- datastore name from above-->
+            <sourceDataStore>subgrp-coverage</sourceDataStore>
+            <!-- source type must be a table or view from DataStore. For feature links, a sub-table. -->
+            <sourceType>subgrp-coverage</sourceType>
+            <!-- top level element this configuration maps to -->
+            <targetElement>test:DiscreteCoverage</targetElement>
+            <isDenormalized>false</isDenormalized>
+
+            <!-- Feature link needs to be the foreign key that associates this data set with the parent -->
+            <attributeMappings>
+                <AttributeMapping>
+                    <targetAttribute>test:DiscreteCoverage</targetAttribute>
+                    <targetAttributeNode>test:DiscreteCoverageType</targetAttributeNode>
+                    <idExpression>
+                        <OCQL>uuid</OCQL>
+                    </idExpression>
+                </AttributeMapping>
+                <AttributeMapping>
+                    <targetAttribute>gml:identifier</targetAttribute>
+                    <ClientProperty>
+                        <name>codeSpace</name>
+                        <value>'urn:ietf:rfc:1738'</value>
+                    </ClientProperty>
+                    <sourceExpression>
+                        <OCQL>'http://www.geoserver.org/contour'</OCQL>
+                    </sourceExpression>
+                </AttributeMapping>
+                <AttributeMapping>
+                    <targetAttribute>test:domainSet</targetAttribute>
+                    <targetAttributeNode>test:DomainSetType</targetAttributeNode>
+                    <encodeIfEmpty>true</encodeIfEmpty>
+                </AttributeMapping>
+                <AttributeMapping>
+                    <targetAttribute>test:domainSet/test:DomainObject</targetAttribute>
+                    <targetAttributeNode>test:DomainObjectType</targetAttributeNode>
+                    <encodeIfEmpty>true</encodeIfEmpty>
+                    <idExpression>
+                        <OCQL>strConcat(uuid,'-domainObjectId')</OCQL>
+                    </idExpression>
+                </AttributeMapping>
+
+                <AttributeMapping>
+                    <targetAttribute>test:domainSet/test:DomainObject/test:elements</targetAttribute>
+                    <targetAttributeNode>test:SpatioTemporalElementsPropertyType</targetAttributeNode>
+                    <encodeIfEmpty>true</encodeIfEmpty>
+                </AttributeMapping>
+
+                <AttributeMapping>
+                    <targetAttribute>test:domainSet/test:DomainObject/test:elements/gml:MultiCurve</targetAttribute>
+                    <encodeIfEmpty>true</encodeIfEmpty>
+                    <idExpression>
+                        <OCQL>strConcat(uuid,'-geomId')</OCQL>
+                    </idExpression>
+                    <sourceExpression>
+                        <OCQL>geom</OCQL>
+                    </sourceExpression>
+                    <ClientProperty>
+                        <name>srsName</name>
+                        <value>'http://www.opengis.net/def/crs/EPSG/0/4052'</value>
+                    </ClientProperty>
+                    <ClientProperty>
+                        <name>axisLabels</name>
+                        <value>'latitude longitude'</value>
+                    </ClientProperty>
+                </AttributeMapping>
+
+                <AttributeMapping>
+                    <targetAttribute>test:domainSet/test:DomainObject/test:elements/gml:Point</targetAttribute>
+                    <idExpression>
+                        <OCQL>strConcat(uuid,'-geom2Id')</OCQL>
+                    </idExpression>
+                    <sourceExpression>
+                        <OCQL>geom2</OCQL>
+                    </sourceExpression>
+                    <ClientProperty>
+                        <name>srsName</name>
+                        <value>'http://www.opengis.net/def/crs/EPSG/0/4052'</value>
+                    </ClientProperty>
+                    <ClientProperty>
+                        <name>axisLabels</name>
+                        <value>'latitude longitude'</value>
+                    </ClientProperty>
+                </AttributeMapping>
+                <AttributeMapping>
+                    <targetAttribute>gml:rangeSet/gml:ValueArray</targetAttribute>
+                    <idExpression>
+                        <OCQL>strConcat(uuid,'-valueArrayId')</OCQL>
+                    </idExpression>
+                </AttributeMapping>
+                <AttributeMapping>
+                    <targetAttribute>gml:rangeSet/gml:ValueArray/gml:valueComponents/gml:Quantity</targetAttribute>
+                    <ClientProperty>
+                        <name>uom</name>
+                        <value>amount_uom</value>
+                    </ClientProperty>
+                    <sourceExpression>
+                        <OCQL>amount</OCQL>
+                    </sourceExpression>
+                </AttributeMapping>
+                <AttributeMapping>
+                    <targetAttribute>gml:coverageFunction/gml:CoverageMappingRule/gml:ruleDefinition</targetAttribute>
+                    <sourceExpression>
+                        <OCQL>rule</OCQL>
+                    </sourceExpression>
+                </AttributeMapping>
+            </attributeMappings>
+        </FeatureTypeMapping>
+    </typeMappings>
+</as:AppSchemaDataAccess>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/subgrp.xsd
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/subgrp.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.geotools.org/test" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:test="http://www.geotools.org/test" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2" elementFormDefault="qualified">
+    <!-- Portions taken from WXXM 2 -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
+
+    <element name="DiscreteCoverage" type="test:DiscreteCoverageType" substitutionGroup="gml:AbstractDiscreteCoverage"/>
+    <complexType name="DiscreteCoverageType">
+        <complexContent>
+            <extension base="gml:DiscreteCoverageType"/>
+        </complexContent>
+    </complexType>
+    <complexType name="DiscreteCoveragePropertyType">
+        <sequence minOccurs="0">
+            <element ref="test:DiscreteCoverage"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+
+    <element name="DomainObject" type="test:DomainObjectType" substitutionGroup="gml:AbstractFeature"/>
+    <complexType name="DomainObjectType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="elements" type="test:SpatioTemporalElementsPropertyType" minOccurs="0" maxOccurs="1"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="DomainObjectPropertyType">
+        <sequence minOccurs="0">
+            <element ref="test:DomainObject"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </complexType>
+
+    <element name="domainSet" type="test:DomainSetType" substitutionGroup="gml:domainSet"/>
+    <complexType name="DomainSetType">
+        <complexContent>
+            <extension base="gml:DomainSetType">
+                <sequence>
+                    <element ref="test:DomainObject" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="SpatioTemporalElementsPropertyType">
+        <sequence minOccurs="1" maxOccurs="unbounded">
+            <choice>
+                <element ref="gml:AbstractGeometry"/>
+                <element ref="gml:AbstractTimeObject"/>
+            </choice>
+        </sequence>
+        <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+
+</schema>


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5667

This pull request implements a GeoServer test for the GeoTools fix  https://github.com/geotools/geotools/pull/1502.  A new unit test was introduced with a single XML schema and properties file, similar to others in this directory.  This test case should fail when the related GeoTools fix is not integrated.