### PR TITLE
Make tile layer use new legend info structure

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -61,6 +61,8 @@ import org.geotools.util.logging.Logging;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.config.ConfigurationException;
 import org.geowebcache.config.XMLGridSubset;
+import org.geowebcache.config.legends.LegendInfo;
+import org.geowebcache.config.legends.LegendInfoBuilder;
 import org.geowebcache.conveyor.ConveyorTile;
 import org.geowebcache.filter.parameters.ParameterException;
 import org.geowebcache.filter.parameters.ParameterFilter;
@@ -1271,38 +1273,38 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
     }
 
     @Override
-    public Map<String, LegendInfo> getLegendsInfo() {
+    public Map<String, org.geowebcache.config.legends.LegendInfo> getLayerLegendsInfo() {
         LayerInfo layerInfo = getLayerInfo();
         if (layerInfo == null) {
             return null;
         }
-        Map<String, LegendInfo> legends = new HashMap<>();
+        Map<String, org.geowebcache.config.legends.LegendInfo> legends = new HashMap<>();
         Set<StyleInfo> styles = new HashSet<>(layerInfo.getStyles());
         styles.add(layerInfo.getDefaultStyle());
         for (StyleInfo styleInfo : styles) {
             org.geoserver.catalog.LegendInfo legendInfo = styleInfo.getLegend();
-            LegendInfo gwcLegendInfo = new LegendInfo();
+            LegendInfoBuilder gwcLegendInfo = new LegendInfoBuilder();
             if (legendInfo != null) {
-                gwcLegendInfo.id = legendInfo.getId();
-                gwcLegendInfo.width = legendInfo.getWidth();
-                gwcLegendInfo.height = legendInfo.getHeight();
-                gwcLegendInfo.format = legendInfo.getFormat();
-                gwcLegendInfo.legendUrl = buildURL(RequestUtils.baseURL(Dispatcher.REQUEST.get().getHttpRequest()),
-                        legendInfo.getOnlineResource(), null, URLMangler.URLType.RESOURCE);
-                legends.put(styleInfo.prefixedName(), gwcLegendInfo);
+                gwcLegendInfo.withStyleName(styleInfo.getName())
+                        .withWidth(legendInfo.getWidth())
+                        .withHeight(legendInfo.getHeight())
+                        .withFormat(legendInfo.getFormat())
+                        .withCompleteUrl(buildURL(RequestUtils.baseURL(Dispatcher.REQUEST.get().getHttpRequest()),
+                                legendInfo.getOnlineResource(), null, URLMangler.URLType.RESOURCE));
+                legends.put(styleInfo.prefixedName(), gwcLegendInfo.build());
             } else {
+                int finalWidth = GetLegendGraphicRequest.DEFAULT_WIDTH;
+                int finalHeight = GetLegendGraphicRequest.DEFAULT_HEIGHT;
+                String finalFormat = GetLegendGraphicRequest.DEFAULT_FORMAT;
                 try {
-                    gwcLegendInfo.width = GetLegendGraphicRequest.DEFAULT_WIDTH;
-                    gwcLegendInfo.height = GetLegendGraphicRequest.DEFAULT_HEIGHT;
                     Dimension dimension = getLegendSample().getLegendURLSize(styleInfo);
                     if (dimension != null) {
-                        gwcLegendInfo.width = (int) dimension.getWidth();
-                        gwcLegendInfo.height = (int) dimension.getHeight();
+                        finalWidth = (int) dimension.getWidth();
+                        finalHeight = (int) dimension.getHeight();
                     }
-                    gwcLegendInfo.format = GetLegendGraphicRequest.DEFAULT_FORMAT;
-                    if (null == getWms().getLegendGraphicOutputFormat(gwcLegendInfo.format)) {
+                    if (null == getWms().getLegendGraphicOutputFormat(finalFormat)) {
                         if (LOGGER.isLoggable(Level.WARNING)) {
-                            LOGGER.warning("Default legend format (" + gwcLegendInfo.format +
+                            LOGGER.warning("Default legend format (" + finalFormat +
                                     ")is not supported (jai not available?), can't add LegendURL element");
                         }
                         continue;
@@ -1312,15 +1314,19 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
                 }
                 String layerName = layerInfo.prefixedName();
                 Map<String, String> params = params("service", "WMS", "request",
-                        "GetLegendGraphic", "format", gwcLegendInfo.format, "width",
-                        String.valueOf(gwcLegendInfo.width), "height",
-                        String.valueOf(gwcLegendInfo.height), "layer", layerName);
+                        "GetLegendGraphic", "format", finalFormat, "width",
+                        String.valueOf(finalWidth), "height",
+                        String.valueOf(finalHeight), "layer", layerName);
                 if (!styleInfo.getName().equals(layerInfo.getDefaultStyle().getName())) {
                     params.put("style", styleInfo.getName());
                 }
-                gwcLegendInfo.legendUrl = buildURL(RequestUtils.baseURL(Dispatcher.REQUEST.get().getHttpRequest()),
-                        "ows", params, URLMangler.URLType.SERVICE);
-                legends.put(styleInfo.prefixedName(), gwcLegendInfo);
+                gwcLegendInfo.withStyleName(styleInfo.getName())
+                        .withWidth(finalWidth)
+                        .withHeight(finalHeight)
+                        .withFormat(finalFormat)
+                        .withCompleteUrl(buildURL(RequestUtils.baseURL(
+                                Dispatcher.REQUEST.get().getHttpRequest()), "ows", params, URLMangler.URLType.SERVICE));
+                legends.put(styleInfo.prefixedName(), gwcLegendInfo.build());
             }
         }
         return legends;

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -770,28 +770,28 @@ public class GeoServerTileLayerTest {
         GeoServerTileLayer tileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
         tileLayer.setLegendSample(legendSample);
         tileLayer.setWms(wms);
-        Map<String, TileLayer.LegendInfo> legendsInfo = tileLayer.getLegendsInfo();
+        Map<String, org.geowebcache.config.legends.LegendInfo> legendsInfo = tileLayer.getLayerLegendsInfo();
         assertThat(legendsInfo.size(), is(3));
         // default_style
         assertThat(legendsInfo.get("default_style"), notNullValue());
-        assertThat(legendsInfo.get("default_style").width, is(120));
-        assertThat(legendsInfo.get("default_style").height, is(150));
-        assertThat(legendsInfo.get("default_style").format, is("image/png"));
-        assertThat(legendsInfo.get("default_style").legendUrl, is("http://localhost:8080/geoserver/ows?service=" +
+        assertThat(legendsInfo.get("default_style").getWidth(), is(120));
+        assertThat(legendsInfo.get("default_style").getHeight(), is(150));
+        assertThat(legendsInfo.get("default_style").getFormat(), is("image/png"));
+        assertThat(legendsInfo.get("default_style").getLegendUrl(), is("http://localhost:8080/geoserver/ows?service=" +
                 "WMS&request=GetLegendGraphic&format=image%2Fpng&width=120&height=150&layer=workspace%3AMockLayerInfoName"));
         // alternateStyle-1
         assertThat(legendsInfo.get("alternateStyle-1"), notNullValue());
-        assertThat(legendsInfo.get("alternateStyle-1").width, is(120));
-        assertThat(legendsInfo.get("alternateStyle-1").height, is(150));
-        assertThat(legendsInfo.get("alternateStyle-1").format, is("image/png"));
-        assertThat(legendsInfo.get("alternateStyle-1").legendUrl, is("http://localhost:8080/geoserver/ows?service" +
+        assertThat(legendsInfo.get("alternateStyle-1").getWidth(), is(120));
+        assertThat(legendsInfo.get("alternateStyle-1").getHeight(), is(150));
+        assertThat(legendsInfo.get("alternateStyle-1").getFormat(), is("image/png"));
+        assertThat(legendsInfo.get("alternateStyle-1").getLegendUrl(), is("http://localhost:8080/geoserver/ows?service" +
                 "=WMS&request=GetLegendGraphic&format=image%2Fpng&width=120&height=150&layer=workspace%3AMockLayerInfoName&style=alternateStyle-1"));
         // alternateStyle-2
         assertThat(legendsInfo.get("alternateStyle-2"), notNullValue());
-        assertThat(legendsInfo.get("alternateStyle-2").width, is(150));
-        assertThat(legendsInfo.get("alternateStyle-2").height, is(200));
-        assertThat(legendsInfo.get("alternateStyle-2").format, is("image/png"));
-        assertThat(legendsInfo.get("alternateStyle-2").legendUrl.trim(), is("http://localhost:8080/geoserver/some-url"));
+        assertThat(legendsInfo.get("alternateStyle-2").getWidth(), is(150));
+        assertThat(legendsInfo.get("alternateStyle-2").getHeight(), is(200));
+        assertThat(legendsInfo.get("alternateStyle-2").getFormat(), is("image/png"));
+        assertThat(legendsInfo.get("alternateStyle-2").getLegendUrl().trim(), is("http://localhost:8080/geoserver/some-url"));
     }
 
     private void setupUrlContext() {


### PR DESCRIPTION
Stop using deprecated ``TileLayer.LegendInfo`` class.

GWC associated PR: https://github.com/GeoWebCache/geowebcache/pull/502