### PR TITLE
[GEOS-8026] Fix services configuration events handling in JMS community module (backport 2.10.x)

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/JMSActiveMQFactory.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/JMSActiveMQFactory.java
@@ -333,7 +333,7 @@ public class JMSActiveMQFactory extends JMSFactory implements
 
 					} else {
 						if (LOGGER.isLoggable(Level.SEVERE)) {
-							LOGGER.severe("Started the embedded brokerURI: "
+							LOGGER.info("Started the embedded brokerURI: "
 									+ brokerService.toString());
 						}
 					}

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/JMSModifyEvent.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/JMSModifyEvent.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.cluster.impl.events;
 
+import org.geoserver.cluster.impl.events.configuration.JMSEventType;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -26,12 +28,25 @@ public class JMSModifyEvent<S extends Serializable> {
 
     private final S source;
 
+    // identifies the type of event (added, removed or modified)
+    private final JMSEventType eventType;
+
     public JMSModifyEvent(final S source, final List<String> propertyNames,
             final List<Object> oldValues, final List<Object> newValues) {
         this.source = source;
         this.propertyNames = propertyNames;
         this.oldValues = oldValues;
         this.newValues = newValues;
+        this.eventType = JMSEventType.MODIFIED;
+    }
+
+    public JMSModifyEvent(final S source, final List<String> propertyNames,
+            final List<Object> oldValues, final List<Object> newValues, JMSEventType eventType) {
+        this.source = source;
+        this.propertyNames = propertyNames;
+        this.oldValues = oldValues;
+        this.newValues = newValues;
+        this.eventType = eventType;
     }
 
     /**
@@ -59,9 +74,7 @@ public class JMSModifyEvent<S extends Serializable> {
         return (S) source;
     }
 
-    /**
-	 * 
-	 */
-    private static final long serialVersionUID = 1L;
-
+    public JMSEventType getEventType() {
+        return eventType;
+    }
 }

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSServiceModifyEvent.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/events/configuration/JMSServiceModifyEvent.java
@@ -26,29 +26,25 @@ public class JMSServiceModifyEvent extends JMSModifyEvent<ServiceInfo> {
 
     private static final long serialVersionUID = 1L;
 
-    public enum Type {
-        ADDED, REMOVED, MODIFIED
-    }
-
     // identifies the type of event (added, removed or service configuration modified)
-    private final Type eventType;
+    private final JMSEventType eventType;
 
     public JMSServiceModifyEvent(ServiceInfo source, List<String> propertyNames,
                                  List<Object> oldValues, List<Object> newValues) {
-        this(source, propertyNames, oldValues, newValues, Type.MODIFIED);
+        this(source, propertyNames, oldValues, newValues, JMSEventType.MODIFIED);
     }
 
-    public JMSServiceModifyEvent(ServiceInfo source, Type eventType) {
+    public JMSServiceModifyEvent(ServiceInfo source, JMSEventType eventType) {
         this(source, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), eventType);
     }
 
     public JMSServiceModifyEvent(ServiceInfo source, List<String> propertyNames,
-                                 List<Object> oldValues, List<Object> newValues, Type eventType) {
-        super(source, propertyNames, oldValues, newValues);
+                                 List<Object> oldValues, List<Object> newValues, JMSEventType eventType) {
+        super(source, propertyNames, oldValues, newValues, eventType);
         this.eventType = eventType;
     }
 
-    public Type getEventType() {
+    public JMSEventType getEventType() {
         return eventType;
     }
 }

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSServiceHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/configuration/JMSServiceHandler.java
@@ -9,7 +9,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.apache.commons.lang.NullArgumentException;
-import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.cluster.events.ToggleSwitch;
 import org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent;
 import org.geoserver.cluster.impl.utils.BeanUtils;
@@ -17,10 +16,6 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.ServiceInfo;
 
 import com.thoughtworks.xstream.XStream;
-
-import static org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent.Type.ADDED;
-import static org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent.Type.MODIFIED;
-import static org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent.Type.REMOVED;
 
 /**
  * 
@@ -64,8 +59,9 @@ public class JMSServiceHandler extends JMSConfigurationHandler<JMSServiceModifyE
                 case ADDED:
                     // checking that this service is not already present, we don't synchronize this check
                     // if two threads add the same service well one of them will fail and throw an exception
-                    if (geoServer.getService(ev.getSource().getId(), ev.getSource().getClass()) == null) {
-                        // this is a new service so let's add it to this geoserver
+                    // this event may be generated for a service that already exists
+                    if (geoServer.getService(ev.getSource().getId(), ServiceInfo.class) == null) {
+                        // this is a new service so let's add it to this GeoServer instance
                         geoServer.add(ev.getSource());
                     }
                     break;

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSConfigurationListener.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSConfigurationListener.java
@@ -124,17 +124,15 @@ public class JMSConfigurationListener extends JMSAbstractGeoServerProducer imple
 
     @Override
     public void handlePostServiceChange(ServiceInfo service) {
-        // this handler is invoked when a new service is added
-        ServiceInfo finalService = ModificationProxy.unwrap(service);
-        JMSServiceModifyEvent event = new JMSServiceModifyEvent(finalService, JMSServiceModifyEvent.Type.ADDED);
+        // this handler is invoked when a new service is added or modified
+        JMSServiceModifyEvent event = new JMSServiceModifyEvent(service, JMSEventType.ADDED);
         handleServiceEvent(event);
     }
 
     @Override
     public void handleServiceRemove(ServiceInfo service) {
         // this handler is invoked when a service is removed
-        ServiceInfo finalService = ModificationProxy.unwrap(service);
-        JMSServiceModifyEvent event = new JMSServiceModifyEvent(finalService, JMSServiceModifyEvent.Type.REMOVED);
+        JMSServiceModifyEvent event = new JMSServiceModifyEvent(service, JMSEventType.REMOVED);
         handleServiceEvent(event);
     }
 
@@ -142,8 +140,7 @@ public class JMSConfigurationListener extends JMSAbstractGeoServerProducer imple
     public void handleServiceChange(ServiceInfo service, List<String> propertyNames,
                                     List<Object> oldValues, List<Object> newValues) {
         // this handler is invoked when a service configuration is modified
-        ServiceInfo finalService = ModificationProxy.unwrap(service);
-        JMSServiceModifyEvent event = new JMSServiceModifyEvent(finalService, propertyNames, oldValues, newValues);
+        JMSServiceModifyEvent event = new JMSServiceModifyEvent(service, propertyNames, oldValues, newValues);
         handleServiceEvent(event);
     }
 

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsServicesTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsServicesTest.java
@@ -1,0 +1,123 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster;
+
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
+import org.geoserver.cluster.impl.events.configuration.JMSEventType;
+import org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent;
+import org.geoserver.cluster.impl.handlers.configuration.JMSServiceHandlerSPI;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geoserver.wms.WMSInfo;
+import org.geoserver.wms.WMSInfoImpl;
+import org.junit.After;
+import org.junit.Test;
+
+import javax.jms.Message;
+import java.util.List;
+import java.util.UUID;
+
+import static org.geoserver.cluster.JmsEventsListener.getMessagesForHandler;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests related with services events.
+ */
+public final class JmsServicesTest extends GeoServerSystemTestSupport {
+
+    private static final String SERVICE_EVENT_HANDLER_KEY = "JMSServiceHandlerSPI";
+
+    private WorkspaceInfoImpl workspace;
+    private static JMSEventHandler<String, JMSServiceModifyEvent> serviceHandler;
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        // adding our test spring context
+        springContextLocations.add("classpath:TestContext.xml");
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        // create the test workspace if it doesn't exsist
+        workspace = new WorkspaceInfoImpl();
+        workspace.setId("test-workspace");
+        workspace.setName("test-workspace");
+        getCatalog().add(workspace);
+        // initiate the handlers related with services
+        serviceHandler = GeoServerExtensions.bean(JMSServiceHandlerSPI.class).createHandler();
+    }
+
+    @After
+    public void afterTest() {
+        // clear all pending events
+        JmsEventsListener.clear();
+    }
+
+    @Test
+    public void testAddService() throws Exception {
+        // create a WMS service for the test workspace
+        WMSInfoImpl serviceInfo = new WMSInfoImpl();
+        serviceInfo.setName("TEST-WMS-NAME");
+        serviceInfo.setId("TEST-WMS-ID");
+        serviceInfo.setWorkspace(workspace);
+        serviceInfo.setAbstract("TEST-WMS-ABSTRACT");
+        // add the new service to GeoServer
+        getGeoServer().add(serviceInfo);
+        // waiting for a service add event
+        List<Message> messages = JmsEventsListener.getMessagesByHandlerKey(5000,
+                (selected) -> selected.size() >= 1, SERVICE_EVENT_HANDLER_KEY);
+        // let's check if the new added service was correctly published
+        assertThat(messages.size(), is(1));
+        List<JMSServiceModifyEvent> serviceEvents = getMessagesForHandler(messages, SERVICE_EVENT_HANDLER_KEY, serviceHandler);
+        assertThat(serviceEvents.size(), is(1));
+        assertThat(serviceEvents.get(0).getEventType(), is(JMSEventType.ADDED));
+        // check the service content
+        ServiceInfo publishedService = serviceEvents.get(0).getSource();
+        assertThat(publishedService.getName(), is("TEST-WMS-NAME"));
+        assertThat(publishedService.getId(), is("TEST-WMS-ID"));
+        assertThat(publishedService.getAbstract(), is("TEST-WMS-ABSTRACT"));
+    }
+
+    @Test
+    public void testModifyService() throws Exception {
+        // modify the abstract of the WMS service
+        WMSInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        assertThat(serviceInfo, notNullValue());
+        String newAbstract = UUID.randomUUID().toString();
+        serviceInfo.setAbstract(newAbstract);
+        getGeoServer().save(serviceInfo);
+        // waiting for the service modify events
+        List<Message> messages = JmsEventsListener.getMessagesByHandlerKey(5000,
+                (selected) -> selected.size() >= 2, SERVICE_EVENT_HANDLER_KEY);
+        // checking if we got the correct events, modify event and a post modify event
+        assertThat(messages.size(), is(2));
+        List<JMSServiceModifyEvent> serviceEvents = getMessagesForHandler(messages, SERVICE_EVENT_HANDLER_KEY, serviceHandler);
+        assertThat(serviceEvents.size(), is(2));
+        // check the modify event
+        JMSServiceModifyEvent modifyEvent = serviceEvents.stream()
+                .filter(event -> event.getEventType() == JMSEventType.MODIFIED)
+                .findFirst().orElse(null);
+        assertThat(modifyEvent, notNullValue());
+        ServiceInfo modifiedService = serviceEvents.get(0).getSource();
+        assertThat(modifiedService.getName(), is(serviceInfo.getName()));
+        assertThat(modifiedService.getId(), is(serviceInfo.getId()));
+        assertThat(modifiedService.getAbstract(), is(newAbstract));
+        // check the post modify event
+        JMSServiceModifyEvent postModifyEvent = serviceEvents.stream()
+                .filter(event -> event.getEventType() == JMSEventType.ADDED)
+                .findFirst().orElse(null);
+        assertThat(postModifyEvent, notNullValue());
+        ServiceInfo postModifiedService = serviceEvents.get(0).getSource();
+        assertThat(postModifiedService.getName(), is(serviceInfo.getName()));
+        assertThat(postModifiedService.getId(), is(serviceInfo.getId()));
+        assertThat(postModifiedService.getAbstract(), is(newAbstract));
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsServiceHandlerTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsServiceHandlerTest.java
@@ -7,6 +7,7 @@ package org.geoserver.cluster.impl.handlers.configuration;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.WorkspaceInfoImpl;
+import org.geoserver.cluster.impl.events.configuration.JMSEventType;
 import org.geoserver.cluster.impl.events.configuration.JMSServiceModifyEvent;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.platform.GeoServerExtensions;
@@ -47,7 +48,7 @@ public class JmsServiceHandlerTest extends GeoServerSystemTestSupport {
         Collection<? extends ServiceInfo> services = getGeoServer().getServices();
         for (ServiceInfo service : services) {
             ServiceInfo finalService = ModificationProxy.unwrap(service);
-            if (finalService instanceof JmsTestService) {
+            if (finalService instanceof JmsTestServiceInfoImpl) {
                 getGeoServer().remove(finalService);
             }
         }
@@ -136,7 +137,7 @@ public class JmsServiceHandlerTest extends GeoServerSystemTestSupport {
     private JMSServiceModifyEvent createNewServiceEvent(String serviceId, String serviceName,
                                                         String serviceAbstract, String workspaceName) {
         // our virtual service information
-        JmsTestService serviceInfo = new JmsTestService();
+        JmsTestServiceInfoImpl serviceInfo = new JmsTestServiceInfoImpl();
         serviceInfo.setName(serviceName);
         serviceInfo.setId(serviceId);
         if (workspaceName != null) {
@@ -145,7 +146,7 @@ public class JmsServiceHandlerTest extends GeoServerSystemTestSupport {
         }
         serviceInfo.setAbstract(serviceAbstract);
         // create jms service modify event
-        return new JMSServiceModifyEvent(serviceInfo, JMSServiceModifyEvent.Type.ADDED);
+        return new JMSServiceModifyEvent(serviceInfo, JMSEventType.ADDED);
     }
 
     private JMSServiceModifyEvent createModifyServiceEvent(String serviceName, String newServiceAbstract,
@@ -158,14 +159,14 @@ public class JmsServiceHandlerTest extends GeoServerSystemTestSupport {
         return new JMSServiceModifyEvent(serviceInfo, Collections.singletonList("abstract"),
                 Collections.singletonList(oldServiceAbstract),
                 Collections.singletonList(newServiceAbstract),
-                JMSServiceModifyEvent.Type.MODIFIED);
+                JMSEventType.MODIFIED);
     }
 
     private JMSServiceModifyEvent createRemoveServiceEvent(String serviceName, String workspaceName) {
         // our virtual service information
         ServiceInfo serviceInfo = findService(serviceName, workspaceName);
         // create jms service modify event
-        return new JMSServiceModifyEvent(serviceInfo, JMSServiceModifyEvent.Type.REMOVED);
+        return new JMSServiceModifyEvent(serviceInfo, JMSEventType.REMOVED);
     }
 
     private ServiceInfo findService(String serviceName, String workspaceName) {

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceInfo.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceInfo.java
@@ -1,0 +1,13 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.impl.handlers.configuration;
+
+import org.geoserver.config.ServiceInfo;
+
+/**
+ * Simple test service interface.
+ */
+public interface JmsTestServiceInfo extends ServiceInfo {
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceInfoImpl.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceInfoImpl.java
@@ -1,4 +1,4 @@
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -7,7 +7,7 @@ package org.geoserver.cluster.impl.handlers.configuration;
 import org.geoserver.config.impl.ServiceInfoImpl;
 
 /**
- * Simple test service.
+ * Simple test service implementation.
  */
-public class JmsTestService extends ServiceInfoImpl {
+public class JmsTestServiceInfoImpl extends ServiceInfoImpl implements JmsTestServiceInfo {
 }

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceLoader.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/configuration/JmsTestServiceLoader.java
@@ -11,19 +11,19 @@ import org.geoserver.platform.GeoServerResourceLoader;
 /**
  * Loader for the test service.
  */
-public class JmsTestServiceLoader extends XStreamServiceLoader<JmsTestService> {
+public class JmsTestServiceLoader extends XStreamServiceLoader<JmsTestServiceInfo> {
 
     public JmsTestServiceLoader(GeoServerResourceLoader resourceLoader) {
         super(resourceLoader, null);
     }
 
     @Override
-    public Class<JmsTestService> getServiceClass() {
-        return JmsTestService.class;
+    public Class<JmsTestServiceInfo> getServiceClass() {
+        return JmsTestServiceInfo.class;
     }
 
     @Override
-    protected JmsTestService createServiceFromScratch(GeoServer gs) {
-        return new JmsTestService();
+    protected JmsTestServiceInfo createServiceFromScratch(GeoServer gs) {
+        return new JmsTestServiceInfoImpl();
     }
 }


### PR DESCRIPTION
Backport of PR: #2159

This PR amend the services configuration handling in JMS community module. Integration tests for the found issues were added and existing tests improved (removing some annoying exceptions \ logs).

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8026