### PR TITLE
[GEOS-8039] Fix JMS plugin styles workspaces change handling (backport 2.11.x)

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/events/StyleModifyEvent.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/events/StyleModifyEvent.java
@@ -1,0 +1,48 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.server.events;
+
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+
+import java.util.List;
+
+/**
+ * Catalog modify event for styles that include the style file as an array of bytes.
+ */
+public class StyleModifyEvent implements CatalogModifyEvent {
+
+    private final CatalogModifyEvent event;
+    private final byte[] file;
+
+    public StyleModifyEvent(CatalogModifyEvent event, byte[] file) {
+        this.event = event;
+        this.file = file;
+    }
+
+    @Override
+    public CatalogInfo getSource() {
+        return event.getSource();
+    }
+
+    @Override
+    public List<String> getPropertyNames() {
+        return event.getPropertyNames();
+    }
+
+    @Override
+    public List<Object> getOldValues() {
+        return event.getOldValues();
+    }
+
+    @Override
+    public List<Object> getNewValues() {
+        return event.getNewValues();
+    }
+
+    public byte[] getFile() {
+        return file;
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
@@ -5,22 +5,38 @@
 package org.geoserver.cluster;
 
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.StyleHandler;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.Styles;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.event.CatalogEvent;
+import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.cluster.impl.handlers.DocumentFile;
 import org.geoserver.cluster.impl.handlers.catalog.JMSCatalogAddEventHandlerSPI;
+import org.geoserver.cluster.impl.handlers.catalog.JMSCatalogModifyEventHandlerSPI;
+import org.geoserver.cluster.impl.handlers.catalog.JMSCatalogRemoveEventHandlerSPI;
 import org.geoserver.cluster.impl.handlers.catalog.JMSCatalogStylesFileHandlerSPI;
+import org.geoserver.cluster.server.events.StyleModifyEvent;
+import org.geoserver.data.test.MockData;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.styling.RasterSymbolizer;
+import org.geotools.styling.Style;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.jms.Message;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.List;
 
 import static org.geoserver.cluster.JmsEventsListener.getMessagesForHandler;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -32,11 +48,19 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
     private static final String TEST_STYLE_NAME = "test_style";
     private static final String TEST_STYLE_FILE = "/test_style.sld";
 
-    private static final String CATALOG_ADD_EVENT_HANDLER_KEY = "JMSCatalogAddEventHandlerSPI";
-    private static final String CATALOG_STYLES_FILE_EVENT_HANDLER_KEY = "JMSCatalogStylesFileHandlerSPI";
+    private static final String TEST_WORKSPACE_NAME = MockData.DEFAULT_PREFIX;
 
-    private static JMSEventHandler<String, DocumentFile> styleFileHandler;
-    private static JMSEventHandler<String, CatalogEvent> addEventHandler;
+    private static final String CATALOG_ADD_EVENT_HANDLER_KEY = "JMSCatalogAddEventHandlerSPI";
+    private static final String CATALOG_MODIFY_EVENT_HANDLER_KEY = "JMSCatalogModifyEventHandlerSPI";
+    private static final String CATALOG_STYLES_FILE_EVENT_HANDLER_KEY = "JMSCatalogStylesFileHandlerSPI";
+    private static final String CATALOG_REMOVE_EVENT_HANDLER_KEY = "JMSCatalogRemoveEventHandlerSPI";
+
+    private WorkspaceInfo testWorkspace;
+
+    private JMSEventHandler<String, DocumentFile> styleFileHandler;
+    private JMSEventHandler<String, CatalogEvent> addEventHandler;
+    private JMSEventHandler<String, CatalogEvent> modifyEventHandler;
+    private JMSEventHandler<String, CatalogEvent> removeEventHandler;
 
     @Override
     protected void setUpSpring(List<String> springContextLocations) {
@@ -47,9 +71,18 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
 
     @Before
     public void beforeTest() {
+        // get the test workspace from the catalog
+        testWorkspace = getCatalog().getWorkspaceByName(TEST_WORKSPACE_NAME);
+        assertThat(testWorkspace, notNullValue());
         // initiate the handlers related to styles
         styleFileHandler = GeoServerExtensions.bean(JMSCatalogStylesFileHandlerSPI.class).createHandler();
+        assertThat(styleFileHandler, notNullValue());
         addEventHandler = GeoServerExtensions.bean(JMSCatalogAddEventHandlerSPI.class).createHandler();
+        assertThat(addEventHandler, notNullValue());
+        modifyEventHandler = GeoServerExtensions.bean(JMSCatalogModifyEventHandlerSPI.class).createHandler();
+        assertThat(modifyEventHandler, notNullValue());
+        removeEventHandler = GeoServerExtensions.bean(JMSCatalogRemoveEventHandlerSPI.class).createHandler();
+        assertThat(removeEventHandler, notNullValue());
     }
 
     @After
@@ -57,6 +90,12 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // search the test style in the catalog
         Catalog catalog = getCatalog();
         StyleInfo style = catalog.getStyleByName(TEST_STYLE_NAME);
+        if (style != null) {
+            // the test style exists so let's remove it
+            catalog.remove(style);
+        }
+        // search the test style in the catalog by workspace
+        style = catalog.getStyleByName(MockData.DEFAULT_PREFIX, TEST_STYLE_NAME);
         if (style != null) {
             // the test style exists so let's remove it
             catalog.remove(style);
@@ -79,11 +118,141 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         List<DocumentFile> styleFile = getMessagesForHandler(messages, CATALOG_STYLES_FILE_EVENT_HANDLER_KEY, styleFileHandler);
         assertThat(styleFile.size(), is(1));
         assertThat(styleFile.get(0).getResourceName(), is("test_style.sld"));
-        // checking that the correct catalog style was published
+        // checking that the correct style was published
         List<CatalogEvent> styleAddEvent = getMessagesForHandler(messages, CATALOG_ADD_EVENT_HANDLER_KEY, addEventHandler);
         assertThat(styleAddEvent.size(), is(1));
         assertThat(styleAddEvent.get(0).getSource(), instanceOf(StyleInfo.class));
-        StyleInfo style = (StyleInfo) styleAddEvent.get(0).getSource();
-        assertThat(style.getName(), is(TEST_STYLE_NAME));
+        StyleInfo styleInfo = (StyleInfo) styleAddEvent.get(0).getSource();
+        assertThat(styleInfo.getName(), is(TEST_STYLE_NAME));
+        assertThat(styleInfo.getWorkspace(), nullValue());
+    }
+
+    @Test
+    public void testAddStyleToWorkspace() throws Exception {
+        // add the test to the style catalog
+        getTestData().addStyle(testWorkspace, TEST_STYLE_NAME, TEST_STYLE_FILE, this.getClass(), getCatalog());
+        // waiting for a catalog add event and a style file event
+        List<Message> messages = JmsEventsListener.getMessagesByHandlerKey(5000,
+                (selected) -> selected.size() >= 2,
+                CATALOG_ADD_EVENT_HANDLER_KEY, CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
+        // let's check if the new added style was correctly published
+        assertThat(messages.size(), is(2));
+        // checking that the correct style file was published
+        List<DocumentFile> styleFile = getMessagesForHandler(messages, CATALOG_STYLES_FILE_EVENT_HANDLER_KEY, styleFileHandler);
+        assertThat(styleFile.size(), is(1));
+        assertThat(styleFile.get(0).getResourceName(), is("test_style.sld"));
+        // checking that the correct style was published
+        List<CatalogEvent> styleAddEvent = getMessagesForHandler(messages, CATALOG_ADD_EVENT_HANDLER_KEY, addEventHandler);
+        assertThat(styleAddEvent.size(), is(1));
+        assertThat(styleAddEvent.get(0).getSource(), instanceOf(StyleInfo.class));
+        StyleInfo styleInfo = (StyleInfo) styleAddEvent.get(0).getSource();
+        assertThat(styleInfo.getName(), is(TEST_STYLE_NAME));
+        assertThat(styleInfo.getWorkspace(), is(testWorkspace));
+    }
+
+    @Test
+    public void testModifyStyleWorkspace() throws Exception {
+        // add the test to the style catalog
+        addTestStyle();
+        // modify the style associated file
+        StyleInfo styleInfo = getCatalog().getStyleByName(TEST_STYLE_NAME);
+        assertThat(styleInfo, notNullValue());
+        getCatalog().getResourcePool().writeStyle(styleInfo,
+                JmsStylesTest.class.getResourceAsStream("/test_style_modified.sld"));
+        // modify the style workspace
+        styleInfo.setWorkspace(testWorkspace);
+        getCatalog().save(styleInfo);
+        // waiting for a catalog modify event and a style file event
+        List<Message> messages = JmsEventsListener.getMessagesByHandlerKey(5000,
+                (selected) -> selected.size() >= 1, CATALOG_MODIFY_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(1));
+        // checking that the correct catalog style was published
+        List<CatalogEvent> styleModifiedEvent = getMessagesForHandler(messages, CATALOG_MODIFY_EVENT_HANDLER_KEY, addEventHandler);
+        assertThat(styleModifiedEvent.size(), is(1));
+        assertThat(styleModifiedEvent.get(0).getSource(), instanceOf(StyleInfo.class));
+        StyleInfo modifiedStyle = (StyleInfo) styleModifiedEvent.get(0).getSource();
+        assertThat(modifiedStyle.getName(), is(TEST_STYLE_NAME));
+        // check that the catalog modify event contains the correct workspace
+        WorkspaceInfo workspace = searchPropertyNewValue((CatalogModifyEvent)
+                styleModifiedEvent.get(0), "workspace", WorkspaceInfo.class);
+        assertThat(workspace, is(testWorkspace));
+        // check that the correct file style was published
+        assertThat(styleModifiedEvent.get(0), instanceOf(StyleModifyEvent.class));
+        byte[] fileContent = ((StyleModifyEvent) styleModifiedEvent.get(0)).getFile();
+        assertThat(fileContent, notNullValue());
+        assertThat(fileContent.length, not(0));
+        // parse the published style file and check the opacity value
+        Style style = parseStyleFile(styleInfo, new ByteArrayInputStream(fileContent));
+        RasterSymbolizer symbolizer = (RasterSymbolizer) style.featureTypeStyles()
+                .get(0).rules().get(0).symbolizers().get(0);
+        assertThat(symbolizer.getOpacity().evaluate(null), is("0.5"));
+    }
+
+    @Test
+    public void testRemoveStyle() throws Exception {
+        // add the test to the style catalog
+        addTestStyle();
+        // remove style from catalog
+        StyleInfo style = getCatalog().getStyleByName(TEST_STYLE_NAME);
+        assertThat(style, notNullValue());
+        getCatalog().remove(style);
+        // waiting for a catalog remove event
+        List<Message> messages = JmsEventsListener.getMessagesByHandlerKey(5000,
+                (selected) -> selected.size() >= 1, CATALOG_REMOVE_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(1));
+        // checking that the correct style was published
+        List<CatalogEvent> styleRemoveEvent = getMessagesForHandler(messages, CATALOG_REMOVE_EVENT_HANDLER_KEY, addEventHandler);
+        assertThat(styleRemoveEvent.size(), is(1));
+        assertThat(styleRemoveEvent.get(0).getSource(), instanceOf(StyleInfo.class));
+        StyleInfo removedStyle = (StyleInfo) styleRemoveEvent.get(0).getSource();
+        assertThat(removedStyle.getName(), is(TEST_STYLE_NAME));
+    }
+
+    /**
+     * Helper method that adds the test style to the catalog
+     * and consume the produced events.
+     */
+    private void addTestStyle() throws Exception {
+        // add the test to the style catalog
+        getTestData().addStyle(TEST_STYLE_NAME, TEST_STYLE_FILE, this.getClass(), getCatalog());
+        // waiting for a catalog add event and a style file event
+        // waiting for a catalog add event and a style file event
+        List<Message> messages = JmsEventsListener.getMessagesByHandlerKey(5000,
+                (selected) -> selected.size() >= 2,
+                CATALOG_ADD_EVENT_HANDLER_KEY, CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(2));
+    }
+
+    /**
+     * Helper method that parses the file associated with a style.
+     */
+    private Style parseStyleFile(StyleInfo styleInfo, InputStream input) throws Exception {
+        StyleHandler styleHandler = Styles.handler(styleInfo.getFormat());
+        StyledLayerDescriptor styleDescriptor = styleHandler.parse(input, styleInfo.getFormatVersion(), null, null);
+        return Styles.style(styleDescriptor);
+    }
+
+    /**
+     * Helper method that searches a modified property in a catalog modify event.
+     */
+    private <T> T searchPropertyNewValue(CatalogModifyEvent event, String propertyName, Class<WorkspaceInfo> propertyType) {
+        // sanity check of the modify event properties and values
+        assertThat(event.getPropertyNames(), notNullValue());
+        assertThat(event.getPropertyNames().isEmpty(), not(true));
+        assertThat(event.getNewValues(), notNullValue());
+        assertThat(event.getNewValues().isEmpty(), not(true));
+        assertThat(event.getPropertyNames().size(), is(event.getNewValues().size()));
+        // find the property we want
+        Object propertyValue = null;
+        for(int i = 0; i < event.getPropertyNames().size(); i++) {
+            String candidatePropertyName = event.getPropertyNames().get(i);
+            if (candidatePropertyName != null && candidatePropertyName.equalsIgnoreCase(propertyName)) {
+                propertyValue = event.getNewValues().get(i);
+            }
+        }
+        // return the found value
+        assertThat(propertyValue, notNullValue());
+        assertThat(propertyValue, instanceOf(propertyType));
+        return (T) propertyValue;
     }
 }

--- a/src/community/jms-cluster/jms-geoserver/src/test/resources/test_style_modified.sld
+++ b/src/community/jms-cluster/jms-geoserver/src/test/resources/test_style_modified.sld
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+ xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+ xmlns="http://www.opengis.net/sld" 
+ xmlns:ogc="http://www.opengis.net/ogc" 
+ xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>test_sld</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <RasterSymbolizer>
+            <Opacity>0.5</Opacity>
+          </RasterSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Backport of this PR: https://github.com/geoserver/geoserver/pull/2164

This PR makes JMS plugin handle correctly styles workspaces changes, style names changes were the content of the style is also changed and were the workspace is also changed. To avoid any synchronization issues when a style is modified the style file is propagated in the same event.

Tests cases for this situations were added.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8039