### PR TITLE
[GEOS-8039] Fix JMS plugin styles workspaces change handling (backport 2.11.x)

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
@@ -28,6 +28,9 @@ public class DocumentFile {
 
     private final String body;
 
+    private String styleName;
+    private String workspaceName;
+
     /**
      * @return the body containing the parsed file
      */
@@ -69,6 +72,22 @@ public class DocumentFile {
 
     public String getResourcePath() {
         return resourcePath;
+    }
+
+    public String getStyleName() {
+        return styleName;
+    }
+
+    public void setStyleName(String styleName) {
+        this.styleName = styleName;
+    }
+
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
     }
 
     /**

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogStylesFileHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogStylesFileHandler.java
@@ -5,14 +5,15 @@
  */
 package org.geoserver.cluster.impl.handlers.catalog;
 
-import java.io.File;
-
 import org.apache.commons.lang.NullArgumentException;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.cluster.configuration.JMSConfiguration;
 import org.geoserver.cluster.configuration.ReadOnlyConfiguration;
 import org.geoserver.cluster.impl.handlers.DocumentFile;
 import org.geoserver.cluster.impl.handlers.DocumentFileHandler;
+import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Resource;
@@ -50,17 +51,14 @@ public class JMSCatalogStylesFileHandler extends DocumentFileHandler {
 			throw new IllegalStateException("Unable to load configuration");
 		} else if (!ReadOnlyConfiguration.isReadOnly(config)) {
 			try {
-				GeoServerResourceLoader loader = GeoServerExtensions.bean(GeoServerResourceLoader.class);
-				Resource file = loader.get("styles").get(event.getResourceName());
-				
-				if ( !Resources.exists(file) ) {
-					final String styleAbsolutePath = event.getResourcePath();
-					if ( styleAbsolutePath.indexOf("workspaces") > 0 ) {
-						file = loader.get(styleAbsolutePath.substring(styleAbsolutePath.indexOf("workspaces")));
-					}
+				// find the style associated with this document
+				Resource styleFile = getStyleResource(event);
+				if (styleFile == null) {
+					throw new RuntimeException(String.format(
+							"Style for style file '%s' not found.", event.getResourceName()));
 				}
-				
-				event.writeTo(file);
+				// write the style file
+				event.writeTo(styleFile);
 				return true;
 			} catch (Exception e) {
 				if (LOGGER.isLoggable(java.util.logging.Level.SEVERE))
@@ -73,4 +71,27 @@ public class JMSCatalogStylesFileHandler extends DocumentFileHandler {
 		return true;
 	}
 
+	/**
+	 * Helper method the gets the style associated with a document file.
+	 */
+	private Resource getStyleResource(DocumentFile event) {
+		if (event.getStyleName() == null) {
+			// no style name provided os nothing to do
+			return null;
+		}
+		// find the associated style
+		StyleInfo styleInfo = catalog.getStyleByName(event.getStyleName());
+		if (event.getWorkspaceName() != null) {
+			styleInfo = catalog.getStyleByName(event.getWorkspaceName(), event.getStyleName());
+		}
+		// check if we found the associated style
+		if (styleInfo == null) {
+			throw new RuntimeException(String.format(
+					"Style '%s' not found when handling style file '%s'.",
+					event.getStyleName(), event.getResourceName()));
+		}
+		// get the path of style file associated with the found style
+		GeoServerDataDirectory dataDirectory = GeoServerExtensions.bean(GeoServerDataDirectory.class);
+		return dataDirectory.get(styleInfo, styleInfo.getFilename());
+	}
 }


### PR DESCRIPTION
Backport of pull request: https://github.com/geoserver/geoserver/pull/2162

This PR makes sure that the style file is saved before the style info is stored in the catalog, this way someone listen on the catalog modified event can have access to the correct style file. This PR cotnains also a test for this behavior.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8037
Mailing list discussion: http://osgeo-org.1560.x6.nabble.com/Style-modify-event-and-changed-resource-td5311789.html