### PR TITLE
[GEOS-8037] Save style file before savign the style info (backport 2.11.x)

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
@@ -37,7 +37,7 @@ public class StyleEditPage extends AbstractStylePage {
         String name = parameters.get(NAME).toString();
         String workspace = parameters.get(WORKSPACE).toOptionalString();
 
-        StyleInfo si = workspace != null ? getCatalog().getStyleByName(workspace, name) : 
+        StyleInfo si = workspace != null ? getCatalog().getStyleByName(workspace, name) :
             getCatalog().getStyleByName(name);
 
         if(si == null) {
@@ -100,29 +100,31 @@ public class StyleEditPage extends AbstractStylePage {
             style.setFormat(format);
             Version version = Styles.handler(format).version(rawStyle);
             style.setFormatVersion(version);
-
             // make sure the legend is null if there is no URL
             if (null == style.getLegend()
                     || null == style.getLegend().getOnlineResource()
                     || style.getLegend().getOnlineResource().isEmpty()) {
                 style.setLegend(null);
             }
-
-            // save the updated StyleInfo
-            getCatalog().save(style);
-
-            // save the updated style contents to the new file location
+            // write out the SLD, we try to use the old style so the same path is used
+            StyleInfo stylePath = getCatalog().getStyle(style.getId());
+            if (stylePath == null) {
+                // the old style is no available anymore, so use the new path
+                stylePath = style;
+            }
+            // ask the catalog to write the style
             try {
-                getCatalog().getResourcePool().writeStyle(style,
-                        new ByteArrayInputStream(rawStyle.getBytes()));
+                getCatalog().getResourcePool().writeStyle(stylePath, new ByteArrayInputStream(rawStyle.getBytes()));
             } catch (IOException e) {
                 throw new WicketRuntimeException(e);
             }
-
+            // update the catalog
+            getCatalog().save(style);
+            // provide feedback to the user
             styleForm.info("Style saved");
-        } catch (Exception e) {
+        } catch( Exception e ) {
             LOGGER.log(Level.SEVERE, "Error occurred saving the style", e);
-            styleForm.error(e);
+            styleForm.error( e );
         }
     }
 }

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -7,6 +7,8 @@ package org.geoserver.wms.web.data;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
@@ -19,6 +21,7 @@ import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -34,6 +37,7 @@ import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.util.tester.FormTester;
 import org.apache.wicket.util.tester.WicketTesterHelper;
+import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.Catalog;
@@ -46,6 +50,11 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.data.test.TestData;
@@ -57,6 +66,7 @@ import org.geoserver.web.GeoServerWicketTestSupport;
 import org.geoserver.web.wicket.GeoServerTablePanel;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.geotools.styling.Style;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -543,6 +553,53 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
      */
     @Test
     public void testMoveWorkspaceAndEdit() throws Exception {
+        // add catalog listener so we can validate the style modified event
+        final boolean[] gotValidEvent = {false};
+        getCatalog().addListener(new CatalogListener() {
+
+            @Override
+            public void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+                // not interest, ignore this events
+            }
+
+            @Override
+            public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
+                // not interest, ignore this events
+            }
+
+            @Override
+            public void handleModifyEvent(CatalogModifyEvent event) throws CatalogException {
+                // not interest, ignore this events
+            }
+
+            @Override
+            public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {
+                assertThat(event, notNullValue());
+                assertThat(event.getSource(), notNullValue());
+                if (!(event.getSource() instanceof StyleInfo)) {
+                    // only interested in style info events
+                    return;
+                }
+                try {
+                    // get the associated style and check that you got the correct content
+                    StyleInfo styleInfo = (StyleInfo) event.getSource();
+                    assertThat(styleInfo, notNullValue());
+                    Style style = getCatalog().getResourcePool().getStyle(styleInfo);
+                    assertThat(style, notNullValue());
+                    assertThat(style.featureTypeStyles().size(), is(2));
+                    // ok everything looks good
+                    gotValidEvent[0] = true;
+                } catch (Exception exception) {
+                    LOGGER.log(Level.SEVERE, "Error handling catalog modified style event.", exception);
+                }
+            }
+
+            @Override
+            public void reloaded() {
+                // not interest, ignore this events
+            }
+        });
+
         edit = new StyleEditPage(styleInfoToMove);
         tester.startPage(edit);
 
@@ -578,6 +635,9 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
         assertNotNull(si.getWorkspace());
         assertEquals("sf", si.getWorkspace().getName());
         assertEquals(2, si.getStyle().featureTypeStyles().size());
+
+        // check the correct style modified event was published
+        assertThat(gotValidEvent[0], is(true));
     }
     
     @Test


### PR DESCRIPTION
Backport of pull request: https://github.com/geoserver/geoserver/pull/2162

This PR makes sure that the style file is saved before the style info is stored in the catalog, this way someone listen on the catalog modified event can have access to the correct style file. This PR cotnains also a test for this behavior.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8037
Mailing list discussion: http://osgeo-org.1560.x6.nabble.com/Style-modify-event-and-changed-resource-td5311789.html