### PR TITLE
[GEOS-8046] Fixed ProcessParameterIO performing extension lookups with a null ApplicationContext.

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/ProcessParameterIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/ProcessParameterIO.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2017 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -184,8 +184,12 @@ public abstract class ProcessParameterIO {
         }
 
         // load by factory
-        List<PPIOFactory> ppioFactories = GeoServerExtensions
-                .extensions(PPIOFactory.class, context);
+        List<PPIOFactory> ppioFactories;
+        if (context != null) {
+            ppioFactories = GeoServerExtensions.extensions(PPIOFactory.class, context);
+        } else {
+            ppioFactories = GeoServerExtensions.extensions(PPIOFactory.class);
+        }
         for (PPIOFactory factory : ppioFactories) {
             l.addAll(factory.getProcessParameterIO());
         }

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ppio/ProcessParameterIOTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ppio/ProcessParameterIOTest.java
@@ -1,0 +1,67 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps.ppio;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geotools.data.Parameter;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.context.support.GenericApplicationContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class ProcessParameterIOTest {
+
+    public static class TestType {};
+
+    private static ProcessParameterIO testPPIO =
+        new ProcessParameterIO(TestType.class, TestType.class, "testPPIO") {};
+
+    private static GenericApplicationContext context = new GenericApplicationContext();
+
+    @BeforeClass
+    public static void initAppContext() {
+        PPIOFactory testPPIOFactory = () -> Collections.singletonList(testPPIO);
+        context.getBeanFactory().registerSingleton("testPPIOFactory", testPPIOFactory);
+        context.refresh();
+        new GeoServerExtensions().setApplicationContext(context);
+    }
+
+    @AfterClass
+    public static void destroyAppContext() {
+        GeoServerExtensionsHelper.init(null);
+    }
+
+    @Test
+    public void testFindAllWithNullContext() {
+        List<ProcessParameterIO> matches = ProcessParameterIO
+            .findAll(new Parameter<>("testPPIO", TestType.class), null);
+        assertEquals(1, matches.size());
+        assertSame(testPPIO, matches.get(0));
+    }
+
+    @Test
+    public void testFindAllWithSameContext() {
+        List<ProcessParameterIO> matches = ProcessParameterIO
+            .findAll(new Parameter<>("testPPIO", TestType.class), context);
+        assertEquals(1, matches.size());
+        assertSame(testPPIO, matches.get(0));
+    }
+
+    @Test
+    public void testFindAllWithDifferentContext() {
+        GenericApplicationContext myContext = new GenericApplicationContext();
+        myContext.refresh();
+        List<ProcessParameterIO> matches = ProcessParameterIO
+            .findAll(new Parameter<>("testPPIO", TestType.class), myContext);
+        assertEquals(0, matches.size());
+    }
+}


### PR DESCRIPTION
Fix with unit test for:
https://osgeo-org.atlassian.net/browse/GEOS-8046

This bug only causes annoying but harmless warning messages in the logs if the environment does not contain any PPIOFactory implementations.  I've found two, one in gs-gdal-wps and another in gs-ogr-wps, but I don't use either plugin.