### PR TITLE
Include plugin for GeoGig in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: java
 before_install:
   - rm ~/.m2/settings.xml
 script:
-  - mvn -f src/pom.xml -B -U -T2 -fae -Prelease clean install && mvn -f src/community/pom.xml -B -U -T2 -fae -DskipTests -Prelease -PcommunityRelease clean install
+  - mvn -f src/pom.xml -B -U -T2 -fae -Prelease clean install && mvn -f src/community/pom.xml -B -U -T2 -fae -DskipTests -Prelease -PcommunityRelease -Pgeogig clean install
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
GeoGig and the GeoServer plugin for GeoGig are currently under pretty heavy development. As such, API changes tend to cause breaks in the builds, which is particularly disruptive to GeoServer. For now, the plugin for GeoGig is being removed from the `communityRelease` module to keep GeoGig build issues from breaking GeoServer. However, it is desirable to have Travis build the GeoGig plugin when PRs are submitted (to catch build issues prior to merging things). This PR adds the geogig module to the Travis build to retain that functionality when PRs are created.