### PR TITLE
[GEOS-8068] Add GeoJson encoder for complex features

### DIFF
--- a/src/extension/app-schema/app-schema-oracle-test/pom.xml
+++ b/src/extension/app-schema/app-schema-oracle-test/pom.xml
@@ -211,6 +211,7 @@
 		    	    <include>**/*.sql</include>
                     <include>**/*.sld</include>
                     <include>**/*.png</include>
+							<include>**/*.json</include>
 	            </includes>
 		    </testResource>
 	    </testResources>

--- a/src/extension/app-schema/app-schema-postgis-test/pom.xml
+++ b/src/extension/app-schema/app-schema-postgis-test/pom.xml
@@ -206,6 +206,7 @@
 		    	    <include>**/*.sql</include>
                     <include>**/*.sld</include>
                     <include>**/*.png</include>
+							<include>**/*.json</include>
 	            </includes>
 		    </testResource>
 	    </testResources>

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -217,6 +217,7 @@
 							<include>**/*.sql</include>
 							<include>**/*.sld</include>
 			   				<include>**/*.png</include>
+                  <include>**/*.json</include>
 					    </includes>
 			        </testResource>
 		        </testResources>
@@ -269,6 +270,7 @@
 				    	    <include>**/*.sql</include>
 					    	<include>**/*.sld</include>
 					    	<include>**/*.png</include>
+									<include>**/*.json</include>
 				        </includes>
 			        </testResource>
 		        </testResources>

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -6,21 +6,30 @@
 
 package org.geoserver.test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.util.IOUtils;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.xml.v1_1_0.WFS;
 import org.geotools.data.DataUtilities;
@@ -403,7 +412,7 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
      * Test whether GetFeature returns wfs:FeatureCollection.
      */
     @Test
-    public void testGetFeature() {
+    public void testGetFeatureGML() {
         Document doc = getAsDOM("wfs?request=GetFeature&version=1.1.0&typename=gsml:MappedFeature");
         LOGGER.info("WFS GetFeature&typename=gsml:MappedFeature response:\n" + prettyString(doc));
         assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
@@ -412,6 +421,11 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         LOGGER.info("WFS GetFeature&typename=gsml:CompositionPart response, exception expected:\n"
                 + prettyString(doc));
         assertEquals("ows:ExceptionReport", doc.getDocumentElement().getNodeName());
+    }
+
+    @Test
+    public void testGetFeatureJSON() throws Exception {
+        testJsonRequest("gsml:MappedFeature", "/test-data/MappedFeature.json");
     }
     
     @Test
@@ -443,7 +457,7 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
      * feature type can have multiple FEATURE_LINK to be referred by different types.
      */
     @Test
-    public void testComplexTypeWithSimpleContent() {
+    public void testComplexTypeWithSimpleContentGML() {
         Document doc = getAsDOM("wfs?request=GetFeature&version=1.1.0&typename=ex:FirstParentFeature");
         LOGGER
                 .info("WFS GetFeature&typename=ex:FirstParentFeature response:\n"
@@ -488,6 +502,11 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
                 "string_three",
                 "//ex:SecondParentFeature[@gml:id='cc.2']/ex:nestedFeature[3]/ex:SimpleContent/ex:someAttribute",
                 doc);
+    }
+
+    @Test
+    public void testComplexTypeWithSimpleContentJSON() throws Exception {
+        testJsonRequest("ex:FirstParentFeature", "/test-data/FirstParentFeature.json");
     }
 
     /**
@@ -1059,7 +1078,7 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
      * <any/> element.
      */
     @Test
-    public void testAnyTypeAndAnyElement() {
+    public void testAnyTypeAndAnyElementGML() {
         final String OBSERVATION_ID_PREFIX = "observation:";
         Document doc = getAsDOM("wfs?request=GetFeature&version=1.1.0&typename=om:Observation");
         LOGGER.info("WFS GetFeature&typename=om:Observation response:\n" + prettyString(doc));
@@ -1118,6 +1137,11 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         // om:result
         assertXpathEvaluatesTo(id, "(//om:Observation)[4]/om:result/gsml:MappedFeature/@gml:id",
                 doc);
+    }
+
+    @Test
+    public void testAnyTypeAndAnyElementJSON() throws Exception {
+        testJsonRequest("om:Observation", "/test-data/Observation.json");
     }
 
     /**
@@ -1355,7 +1379,7 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
      * Test FeatureCollection is encoded with one featureMembers element
      */
     @Test
-    public void testEncodeFeatureMembers() throws Exception {
+    public void testEncodeFeatureMembersGML() throws Exception {
         // change fixture settings (must restore this at end)
         WFSInfo wfs = getGeoServer().getService(WFSInfo.class);
         boolean encodeFeatureMember = wfs.isEncodeFeatureMember();
@@ -1414,6 +1438,11 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         wfs = getGeoServer().getService(WFSInfo.class);
         wfs.setEncodeFeatureMember(encodeFeatureMember);
         getGeoServer().save(wfs);
+    }
+
+    @Test
+    public void testEncodeFeatureMembersJSON() throws Exception {
+        testJsonRequest("gsml:MappedFeature,gsml:GeologicUnit", "/test-data/MultipleCollections.json");
     }
 
     @Test
@@ -1574,5 +1603,37 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         assertXpathCount(1, "//ex:ParentFeature[@gml:id='sc.3']/ex:nestedFeature/ex:nestedValue[text()='1GRAV']", result);
         assertXpathCount(1, "//ex:ParentFeature[@gml:id='sc.3']/ex:nestedFeature/ex:nestedValue[text()='1TILL']", result);
         assertXpathCount(1, "//ex:ParentFeature[@gml:id='sc.3']/ex:nestedFeature/ex:nestedValue[text()='6ALLU']", result);
+    }
+
+    @Test
+    public void testNonValidNestedJSON() throws Exception {
+        testJsonRequest("ex:ParentFeature", "/test-data/ParentFeature.json");
+    }
+
+    private void testJsonRequest(String featureType, String expectResultPath) throws Exception {
+        // get the complex features encoded in JSON
+        String request = String.format(
+                "wfs?request=GetFeature&version=1.1.0&typename=%s&outputFormat=application/json", featureType);
+        JSON result = getAsJSON(request);
+        // check that we got a valida JSON object
+        assertThat(result, instanceOf(JSONObject.class));
+        JSONObject resultJson = (JSONObject) result;
+        // check the returned JSON againts the expected result
+        JSONObject expectedJson = readJsonObject(expectResultPath);
+        assertThat(resultJson, is(expectedJson));
+    }
+
+    /**
+     * Helper method that just reads a JSON object from a resource file.
+     */
+    private JSONObject readJsonObject(String resourcePath) throws Exception {
+        // read the JSON file content
+        InputStream input = this.getClass().getResourceAsStream(resourcePath);
+        assertThat(input, notNullValue());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        IOUtils.copy(input, output);
+        // parse the JSON file
+        String jsonText = new String(output.toByteArray());
+        return JSONObject.fromObject(jsonText);
     }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/FirstParentFeature.json
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/FirstParentFeature.json
@@ -1,0 +1,46 @@
+{
+  "crs": null,
+  "features": [
+    {
+      "geometry": null,
+      "id": "cc.1",
+      "properties": {
+        "nestedFeature": [
+          {
+            "someAttribute": "string_one"
+          },
+          {
+            "someAttribute": "string_two"
+          }
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "cc.2",
+      "properties": {},
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "cc.3",
+      "properties": {},
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "cc.4",
+      "properties": {},
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "cc.5",
+      "properties": {},
+      "type": "Feature"
+    }
+  ],
+  "totalFeatures": "unknown",
+  "type": "FeatureCollection"
+}

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/MappedFeature.json
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/MappedFeature.json
@@ -1,0 +1,457 @@
+{
+  "crs": {
+    "properties": {
+      "name": "urn:ogc:def:crs:EPSG::4326"
+    },
+    "type": "name"
+  },
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.1,
+              52.6
+            ],
+            [
+              -1.1,
+              52.5
+            ],
+            [
+              -1.2,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf1",
+      "properties": {
+        "name": "GUNTHORPE FORMATION",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 200
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_5",
+                      "name_cc_5"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "nonexistent"
+                  }
+                },
+                "role": "fictitious component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": {
+              "CGI_TermValue": {
+                "value": "Blue"
+              }
+            },
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": {},
+            "outcropCharacter": {
+              "CGI_TermValue": {
+                "value": "x"
+              }
+            },
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.3,
+              52.5
+            ],
+            [
+              -1.3,
+              52.6
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.3,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf2",
+      "properties": {
+        "name": "MERCIA MUDSTONE GROUP",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 100
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_3",
+                      "name_cc_3"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              },
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_4",
+                      "name_cc_4"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "minor"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": [
+              {
+                "CGI_TermValue": {
+                  "value": "Blue"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "Yellow"
+                }
+              }
+            ],
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group 1",
+              "Yaugher Volcanic Group 2",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": [
+              {},
+              {}
+            ],
+            "outcropCharacter": [
+              {
+                "CGI_TermValue": {
+                  "value": "x"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "y"
+                }
+              }
+            ],
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.1,
+              52.6
+            ],
+            [
+              -1.1,
+              52.5
+            ],
+            [
+              -1.2,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf3",
+      "properties": {
+        "name": "CLIFTON FORMATION",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 150
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_3",
+                      "name_cc_3"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              },
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_4",
+                      "name_cc_4"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "minor"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": [
+              {
+                "CGI_TermValue": {
+                  "value": "Blue"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "Yellow"
+                }
+              }
+            ],
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group 1",
+              "Yaugher Volcanic Group 2",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": [
+              {},
+              {}
+            ],
+            "outcropCharacter": [
+              {
+                "CGI_TermValue": {
+                  "value": "x"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "y"
+                }
+              }
+            ],
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.3,
+              52.5
+            ],
+            [
+              -1.3,
+              52.6
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.3,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf4",
+      "properties": {
+        "name": "MURRADUC BASALT",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 120
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_a",
+                      "name_b",
+                      "name_c",
+                      "name_a",
+                      "name_b",
+                      "name_c"
+                    ],
+                    "vocabulary": {}
+                  },
+                  {
+                    "name": [
+                      "name_2",
+                      "name_2"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt",
+            "exposureColor": {
+              "CGI_TermValue": {
+                "value": "Red"
+              }
+            },
+            "geologicUnitType": {},
+            "name": [
+              "New Group",
+              "-Xy"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": {},
+            "outcropCharacter": {
+              "CGI_TermValue": {
+                "value": "z"
+              }
+            },
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    }
+  ],
+  "totalFeatures": "unknown",
+  "type": "FeatureCollection"
+}

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/MultipleCollections.json
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/MultipleCollections.json
@@ -1,0 +1,650 @@
+{
+  "crs": {
+    "properties": {
+      "name": "urn:ogc:def:crs:EPSG::4326"
+    },
+    "type": "name"
+  },
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.1,
+              52.6
+            ],
+            [
+              -1.1,
+              52.5
+            ],
+            [
+              -1.2,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf1",
+      "properties": {
+        "name": "GUNTHORPE FORMATION",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 200
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_5",
+                      "name_cc_5"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "nonexistent"
+                  }
+                },
+                "role": "fictitious component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": {
+              "CGI_TermValue": {
+                "value": "Blue"
+              }
+            },
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": {},
+            "outcropCharacter": {
+              "CGI_TermValue": {
+                "value": "x"
+              }
+            },
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.3,
+              52.5
+            ],
+            [
+              -1.3,
+              52.6
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.3,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf2",
+      "properties": {
+        "name": "MERCIA MUDSTONE GROUP",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 100
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_3",
+                      "name_cc_3"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              },
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_4",
+                      "name_cc_4"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "minor"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": [
+              {
+                "CGI_TermValue": {
+                  "value": "Blue"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "Yellow"
+                }
+              }
+            ],
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group 1",
+              "Yaugher Volcanic Group 2",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": [
+              {},
+              {}
+            ],
+            "outcropCharacter": [
+              {
+                "CGI_TermValue": {
+                  "value": "x"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "y"
+                }
+              }
+            ],
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.1,
+              52.6
+            ],
+            [
+              -1.1,
+              52.5
+            ],
+            [
+              -1.2,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf3",
+      "properties": {
+        "name": "CLIFTON FORMATION",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 150
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_3",
+                      "name_cc_3"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              },
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_4",
+                      "name_cc_4"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "minor"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": [
+              {
+                "CGI_TermValue": {
+                  "value": "Blue"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "Yellow"
+                }
+              }
+            ],
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group 1",
+              "Yaugher Volcanic Group 2",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": [
+              {},
+              {}
+            ],
+            "outcropCharacter": [
+              {
+                "CGI_TermValue": {
+                  "value": "x"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "y"
+                }
+              }
+            ],
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -1.3,
+              52.5
+            ],
+            [
+              -1.3,
+              52.6
+            ],
+            [
+              -1.2,
+              52.6
+            ],
+            [
+              -1.2,
+              52.5
+            ],
+            [
+              -1.3,
+              52.5
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "mf4",
+      "properties": {
+        "name": "MURRADUC BASALT",
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "positionalAccuracy": {
+          "CGI_NumericValue": {
+            "principalValue": 120
+          }
+        },
+        "samplingFrame": {},
+        "specification": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_a",
+                      "name_b",
+                      "name_c",
+                      "name_a",
+                      "name_b",
+                      "name_c"
+                    ],
+                    "vocabulary": {}
+                  },
+                  {
+                    "name": [
+                      "name_2",
+                      "name_2"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt",
+            "exposureColor": {
+              "CGI_TermValue": {
+                "value": "Red"
+              }
+            },
+            "geologicUnitType": {},
+            "name": [
+              "New Group",
+              "-Xy"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": {},
+            "outcropCharacter": {
+              "CGI_TermValue": {
+                "value": "z"
+              }
+            },
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "gu.25678",
+      "properties": {
+        "composition": [
+          {
+            "lithology": [
+              {
+                "name": [
+                  "name_cc_3",
+                  "name_cc_3"
+                ],
+                "vocabulary": {}
+              }
+            ],
+            "proportion": {
+              "CGI_TermValue": {
+                "value": "significant"
+              }
+            },
+            "role": "interbedded component"
+          },
+          {
+            "lithology": [
+              {
+                "name": [
+                  "name_cc_4",
+                  "name_cc_4"
+                ],
+                "vocabulary": {}
+              }
+            ],
+            "proportion": {
+              "CGI_TermValue": {
+                "value": "minor"
+              }
+            },
+            "role": "interbedded component"
+          }
+        ],
+        "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+        "exposureColor": [
+          {
+            "CGI_TermValue": {
+              "value": "Blue"
+            }
+          },
+          {
+            "CGI_TermValue": {
+              "value": "Yellow"
+            }
+          }
+        ],
+        "geologicUnitType": {},
+        "name": [
+          "Yaugher Volcanic Group 1",
+          "Yaugher Volcanic Group 2",
+          "-Py"
+        ],
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "occurrence": [
+          {},
+          {}
+        ],
+        "outcropCharacter": [
+          {
+            "CGI_TermValue": {
+              "value": "x"
+            }
+          },
+          {
+            "CGI_TermValue": {
+              "value": "y"
+            }
+          }
+        ],
+        "purpose": "instance"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "gu.25682",
+      "properties": {
+        "composition": [
+          {
+            "lithology": [
+              {
+                "name": [
+                  "name_a",
+                  "name_b",
+                  "name_c",
+                  "name_a",
+                  "name_b",
+                  "name_c"
+                ],
+                "vocabulary": {}
+              },
+              {
+                "name": [
+                  "name_2",
+                  "name_2"
+                ],
+                "vocabulary": {}
+              }
+            ],
+            "proportion": {
+              "CGI_TermValue": {
+                "value": "significant"
+              }
+            },
+            "role": "interbedded component"
+          }
+        ],
+        "description": "Olivine basalt",
+        "exposureColor": {
+          "CGI_TermValue": {
+            "value": "Red"
+          }
+        },
+        "geologicUnitType": {},
+        "name": [
+          "New Group",
+          "-Xy"
+        ],
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "occurrence": {},
+        "outcropCharacter": {
+          "CGI_TermValue": {
+            "value": "z"
+          }
+        },
+        "purpose": "instance"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "gu.25699",
+      "properties": {
+        "composition": [
+          {
+            "lithology": [
+              {
+                "name": [
+                  "name_cc_5",
+                  "name_cc_5"
+                ],
+                "vocabulary": {}
+              }
+            ],
+            "proportion": {
+              "CGI_TermValue": {
+                "value": "nonexistent"
+              }
+            },
+            "role": "fictitious component"
+          }
+        ],
+        "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+        "exposureColor": {
+          "CGI_TermValue": {
+            "value": "Blue"
+          }
+        },
+        "geologicUnitType": {},
+        "name": [
+          "Yaugher Volcanic Group",
+          "-Py"
+        ],
+        "observationMethod": {
+          "CGI_TermValue": {
+            "value": "urn:ogc:def:nil:OGC::missing"
+          }
+        },
+        "occurrence": {},
+        "outcropCharacter": {
+          "CGI_TermValue": {
+            "value": "x"
+          }
+        },
+        "purpose": "instance"
+      },
+      "type": "Feature"
+    }
+  ],
+  "totalFeatures": "unknown",
+  "type": "FeatureCollection"
+}

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/Observation.json
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/Observation.json
@@ -1,0 +1,757 @@
+{
+  "crs": null,
+  "features": [
+    {
+      "geometry": null,
+      "id": "observation:mf1",
+      "properties": {
+        "metadata": {
+          "CGI_NumericValue": {
+            "principalValue": 651
+          }
+        },
+        "result": [
+          {
+            "name": "GUNTHORPE FORMATION",
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "positionalAccuracy": {
+              "CGI_NumericValue": {
+                "principalValue": 200
+              }
+            },
+            "samplingFrame": {},
+            "shape": {
+              "coordinates": [
+                [
+                  [
+                    52.5,
+                    -1.2
+                  ],
+                  [
+                    52.6,
+                    -1.2
+                  ],
+                  [
+                    52.6,
+                    -1.1
+                  ],
+                  [
+                    52.5,
+                    -1.1
+                  ],
+                  [
+                    52.5,
+                    -1.2
+                  ]
+                ]
+              ],
+              "type": "Polygon"
+            },
+            "specification": {
+              "GeologicUnit": {
+                "composition": [
+                  {
+                    "lithology": [
+                      {
+                        "name": [
+                          "name_cc_5",
+                          "name_cc_5"
+                        ],
+                        "vocabulary": {}
+                      }
+                    ],
+                    "proportion": {
+                      "CGI_TermValue": {
+                        "value": "nonexistent"
+                      }
+                    },
+                    "role": "fictitious component"
+                  }
+                ],
+                "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+                "exposureColor": {
+                  "CGI_TermValue": {
+                    "value": "Blue"
+                  }
+                },
+                "geologicUnitType": {},
+                "name": [
+                  "Yaugher Volcanic Group",
+                  "-Py"
+                ],
+                "observationMethod": {
+                  "CGI_TermValue": {
+                    "value": "urn:ogc:def:nil:OGC::missing"
+                  }
+                },
+                "occurrence": {},
+                "outcropCharacter": {
+                  "CGI_TermValue": {
+                    "value": "x"
+                  }
+                },
+                "purpose": "instance"
+              }
+            }
+          }
+        ],
+        "resultQuality": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_5",
+                      "name_cc_5"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "nonexistent"
+                  }
+                },
+                "role": "fictitious component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": {
+              "CGI_TermValue": {
+                "value": "Blue"
+              }
+            },
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": {},
+            "outcropCharacter": {
+              "CGI_TermValue": {
+                "value": "x"
+              }
+            },
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "observation:mf2",
+      "properties": {
+        "metadata": {
+          "CGI_NumericValue": {
+            "principalValue": 269
+          }
+        },
+        "result": [
+          {
+            "name": "MERCIA MUDSTONE GROUP",
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "positionalAccuracy": {
+              "CGI_NumericValue": {
+                "principalValue": 100
+              }
+            },
+            "samplingFrame": {},
+            "shape": {
+              "coordinates": [
+                [
+                  [
+                    52.5,
+                    -1.3
+                  ],
+                  [
+                    52.6,
+                    -1.3
+                  ],
+                  [
+                    52.6,
+                    -1.2
+                  ],
+                  [
+                    52.5,
+                    -1.2
+                  ],
+                  [
+                    52.5,
+                    -1.3
+                  ]
+                ]
+              ],
+              "type": "Polygon"
+            },
+            "specification": {
+              "GeologicUnit": {
+                "composition": [
+                  {
+                    "lithology": [
+                      {
+                        "name": [
+                          "name_cc_3",
+                          "name_cc_3"
+                        ],
+                        "vocabulary": {}
+                      }
+                    ],
+                    "proportion": {
+                      "CGI_TermValue": {
+                        "value": "significant"
+                      }
+                    },
+                    "role": "interbedded component"
+                  },
+                  {
+                    "lithology": [
+                      {
+                        "name": [
+                          "name_cc_4",
+                          "name_cc_4"
+                        ],
+                        "vocabulary": {}
+                      }
+                    ],
+                    "proportion": {
+                      "CGI_TermValue": {
+                        "value": "minor"
+                      }
+                    },
+                    "role": "interbedded component"
+                  }
+                ],
+                "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+                "exposureColor": [
+                  {
+                    "CGI_TermValue": {
+                      "value": "Blue"
+                    }
+                  },
+                  {
+                    "CGI_TermValue": {
+                      "value": "Yellow"
+                    }
+                  }
+                ],
+                "geologicUnitType": {},
+                "name": [
+                  "Yaugher Volcanic Group 1",
+                  "Yaugher Volcanic Group 2",
+                  "-Py"
+                ],
+                "observationMethod": {
+                  "CGI_TermValue": {
+                    "value": "urn:ogc:def:nil:OGC::missing"
+                  }
+                },
+                "occurrence": [
+                  {},
+                  {}
+                ],
+                "outcropCharacter": [
+                  {
+                    "CGI_TermValue": {
+                      "value": "x"
+                    }
+                  },
+                  {
+                    "CGI_TermValue": {
+                      "value": "y"
+                    }
+                  }
+                ],
+                "purpose": "instance"
+              }
+            }
+          }
+        ],
+        "resultQuality": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_3",
+                      "name_cc_3"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              },
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_4",
+                      "name_cc_4"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "minor"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": [
+              {
+                "CGI_TermValue": {
+                  "value": "Blue"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "Yellow"
+                }
+              }
+            ],
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group 1",
+              "Yaugher Volcanic Group 2",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": [
+              {},
+              {}
+            ],
+            "outcropCharacter": [
+              {
+                "CGI_TermValue": {
+                  "value": "x"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "y"
+                }
+              }
+            ],
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "observation:mf3",
+      "properties": {
+        "metadata": {
+          "CGI_NumericValue": {
+            "principalValue": 123
+          }
+        },
+        "result": [
+          {
+            "name": "CLIFTON FORMATION",
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "positionalAccuracy": {
+              "CGI_NumericValue": {
+                "principalValue": 150
+              }
+            },
+            "samplingFrame": {},
+            "shape": {
+              "coordinates": [
+                [
+                  [
+                    52.5,
+                    -1.2
+                  ],
+                  [
+                    52.6,
+                    -1.2
+                  ],
+                  [
+                    52.6,
+                    -1.1
+                  ],
+                  [
+                    52.5,
+                    -1.1
+                  ],
+                  [
+                    52.5,
+                    -1.2
+                  ]
+                ]
+              ],
+              "type": "Polygon"
+            },
+            "specification": {
+              "GeologicUnit": {
+                "composition": [
+                  {
+                    "lithology": [
+                      {
+                        "name": [
+                          "name_cc_3",
+                          "name_cc_3"
+                        ],
+                        "vocabulary": {}
+                      }
+                    ],
+                    "proportion": {
+                      "CGI_TermValue": {
+                        "value": "significant"
+                      }
+                    },
+                    "role": "interbedded component"
+                  },
+                  {
+                    "lithology": [
+                      {
+                        "name": [
+                          "name_cc_4",
+                          "name_cc_4"
+                        ],
+                        "vocabulary": {}
+                      }
+                    ],
+                    "proportion": {
+                      "CGI_TermValue": {
+                        "value": "minor"
+                      }
+                    },
+                    "role": "interbedded component"
+                  }
+                ],
+                "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+                "exposureColor": [
+                  {
+                    "CGI_TermValue": {
+                      "value": "Blue"
+                    }
+                  },
+                  {
+                    "CGI_TermValue": {
+                      "value": "Yellow"
+                    }
+                  }
+                ],
+                "geologicUnitType": {},
+                "name": [
+                  "Yaugher Volcanic Group 1",
+                  "Yaugher Volcanic Group 2",
+                  "-Py"
+                ],
+                "observationMethod": {
+                  "CGI_TermValue": {
+                    "value": "urn:ogc:def:nil:OGC::missing"
+                  }
+                },
+                "occurrence": [
+                  {},
+                  {}
+                ],
+                "outcropCharacter": [
+                  {
+                    "CGI_TermValue": {
+                      "value": "x"
+                    }
+                  },
+                  {
+                    "CGI_TermValue": {
+                      "value": "y"
+                    }
+                  }
+                ],
+                "purpose": "instance"
+              }
+            }
+          }
+        ],
+        "resultQuality": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_3",
+                      "name_cc_3"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              },
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_cc_4",
+                      "name_cc_4"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "minor"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt, tuff, microgabbro, minor sedimentary rocks",
+            "exposureColor": [
+              {
+                "CGI_TermValue": {
+                  "value": "Blue"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "Yellow"
+                }
+              }
+            ],
+            "geologicUnitType": {},
+            "name": [
+              "Yaugher Volcanic Group 1",
+              "Yaugher Volcanic Group 2",
+              "-Py"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": [
+              {},
+              {}
+            ],
+            "outcropCharacter": [
+              {
+                "CGI_TermValue": {
+                  "value": "x"
+                }
+              },
+              {
+                "CGI_TermValue": {
+                  "value": "y"
+                }
+              }
+            ],
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "observation:mf4",
+      "properties": {
+        "metadata": {
+          "CGI_NumericValue": {
+            "principalValue": 456
+          }
+        },
+        "result": [
+          {
+            "name": "MURRADUC BASALT",
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "positionalAccuracy": {
+              "CGI_NumericValue": {
+                "principalValue": 120
+              }
+            },
+            "samplingFrame": {},
+            "shape": {
+              "coordinates": [
+                [
+                  [
+                    52.5,
+                    -1.3
+                  ],
+                  [
+                    52.6,
+                    -1.3
+                  ],
+                  [
+                    52.6,
+                    -1.2
+                  ],
+                  [
+                    52.5,
+                    -1.2
+                  ],
+                  [
+                    52.5,
+                    -1.3
+                  ]
+                ]
+              ],
+              "type": "Polygon"
+            },
+            "specification": {
+              "GeologicUnit": {
+                "composition": [
+                  {
+                    "lithology": [
+                      {
+                        "name": [
+                          "name_a",
+                          "name_b",
+                          "name_c",
+                          "name_a",
+                          "name_b",
+                          "name_c"
+                        ],
+                        "vocabulary": {}
+                      },
+                      {
+                        "name": [
+                          "name_2",
+                          "name_2"
+                        ],
+                        "vocabulary": {}
+                      }
+                    ],
+                    "proportion": {
+                      "CGI_TermValue": {
+                        "value": "significant"
+                      }
+                    },
+                    "role": "interbedded component"
+                  }
+                ],
+                "description": "Olivine basalt",
+                "exposureColor": {
+                  "CGI_TermValue": {
+                    "value": "Red"
+                  }
+                },
+                "geologicUnitType": {},
+                "name": [
+                  "New Group",
+                  "-Xy"
+                ],
+                "observationMethod": {
+                  "CGI_TermValue": {
+                    "value": "urn:ogc:def:nil:OGC::missing"
+                  }
+                },
+                "occurrence": {},
+                "outcropCharacter": {
+                  "CGI_TermValue": {
+                    "value": "z"
+                  }
+                },
+                "purpose": "instance"
+              }
+            }
+          }
+        ],
+        "resultQuality": {
+          "GeologicUnit": {
+            "composition": [
+              {
+                "lithology": [
+                  {
+                    "name": [
+                      "name_a",
+                      "name_b",
+                      "name_c",
+                      "name_a",
+                      "name_b",
+                      "name_c"
+                    ],
+                    "vocabulary": {}
+                  },
+                  {
+                    "name": [
+                      "name_2",
+                      "name_2"
+                    ],
+                    "vocabulary": {}
+                  }
+                ],
+                "proportion": {
+                  "CGI_TermValue": {
+                    "value": "significant"
+                  }
+                },
+                "role": "interbedded component"
+              }
+            ],
+            "description": "Olivine basalt",
+            "exposureColor": {
+              "CGI_TermValue": {
+                "value": "Red"
+              }
+            },
+            "geologicUnitType": {},
+            "name": [
+              "New Group",
+              "-Xy"
+            ],
+            "observationMethod": {
+              "CGI_TermValue": {
+                "value": "urn:ogc:def:nil:OGC::missing"
+              }
+            },
+            "occurrence": {},
+            "outcropCharacter": {
+              "CGI_TermValue": {
+                "value": "z"
+              }
+            },
+            "purpose": "instance"
+          }
+        }
+      },
+      "type": "Feature"
+    }
+  ],
+  "totalFeatures": "unknown",
+  "type": "FeatureCollection"
+}

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/ParentFeature.json
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/ParentFeature.json
@@ -1,0 +1,64 @@
+{
+  "crs": null,
+  "features": [
+    {
+      "geometry": null,
+      "id": "sc.1",
+      "properties": {
+        "nestedFeature": [
+          {
+            "nestedValue": "1GRAV"
+          },
+          {
+            "nestedValue": "1TILL"
+          },
+          {
+            "nestedValue": "6ALLU"
+          }
+        ],
+        "parentValue": "string_one"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "sc.2",
+      "properties": {
+        "nestedFeature": [
+          {
+            "nestedValue": "1GRAV"
+          },
+          {
+            "nestedValue": "1TILL"
+          },
+          {
+            "nestedValue": "6ALLU"
+          }
+        ],
+        "parentValue": "string_two"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": null,
+      "id": "sc.3",
+      "properties": {
+        "nestedFeature": [
+          {
+            "nestedValue": "1GRAV"
+          },
+          {
+            "nestedValue": "1TILL"
+          },
+          {
+            "nestedValue": "6ALLU"
+          }
+        ],
+        "parentValue": "string_three"
+      },
+      "type": "Feature"
+    }
+  ],
+  "totalFeatures": "unknown",
+  "type": "FeatureCollection"
+}

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
@@ -1,0 +1,429 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import com.vividsolutions.jts.geom.Geometry;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.referencing.CRS;
+import org.opengis.feature.Attribute;
+import org.opengis.feature.ComplexAttribute;
+import org.opengis.feature.Feature;
+import org.opengis.feature.Property;
+import org.opengis.feature.type.ComplexType;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.Name;
+import org.opengis.feature.type.PropertyDescriptor;
+import org.opengis.feature.type.PropertyType;
+import org.opengis.filter.identity.Identifier;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GeoJSON writer capable of handling complex features.
+ */
+public final class ComplexGeoJsonWriter {
+
+    private final GeoJSONBuilder jsonWriter;
+
+    private boolean geometryFound = false;
+    private CoordinateReferenceSystem crs;
+    private long featuresCount = 0;
+
+    public ComplexGeoJsonWriter(GeoJSONBuilder jsonWriter) {
+        this.jsonWriter = jsonWriter;
+    }
+
+    public void write(List<FeatureCollection> collections) {
+        for (FeatureCollection collection : collections) {
+            // encode the feature collection making sure that the collection is closed
+            try (FeatureIterator iterator = collection.features()) {
+                encodeFeatureCollection(iterator);
+            }
+        }
+    }
+
+    /**
+     * Encode all available features by iterating over the iterator.
+     */
+    private void encodeFeatureCollection(FeatureIterator iterator) {
+        while (iterator.hasNext()) {
+            // encode the next feature
+            encodeFeature(iterator.next());
+            featuresCount++;
+        }
+    }
+
+    /**
+     * Encode a feature in GeoJSON.
+     */
+    private void encodeFeature(Feature feature) {
+        // start the feature JSON object
+        jsonWriter.object();
+        jsonWriter.key("type").value("Feature");
+        // encode the feature identifier if available
+        Identifier identifier = feature.getIdentifier();
+        if (identifier != null) {
+            jsonWriter.key("id").value(identifier.getID());
+        }
+        // geometry attribute has some special handling
+        Property geometryAttribute = encodeGeometry(feature);
+        // start the JSON object that will contain all the others properties
+        jsonWriter.key("properties");
+        jsonWriter.object();
+        // encode object properties, we pass the geometry attribute to avoid duplicate encodings
+        encodeProperties(geometryAttribute, feature.getType(), feature.getProperties());
+        // close the feature JSON object
+        jsonWriter.endObject();
+        // close the properties JSON object
+        jsonWriter.endObject();
+    }
+
+    /**
+     * Encode feature geometry attribute which may not exist or be NULL.
+     * Returns the geometry attribute name for the provided feature, NULL
+     * will be returned if the provided feature has no geometry attribute.
+     */
+    private Property encodeGeometry(Feature feature) {
+        // get feature geometry attribute description
+        GeometryDescriptor geometryType = feature.getType().getGeometryDescriptor();
+        Property geometryAttribute = null;
+        Geometry geometry = null;
+        if (geometryType != null) {
+            // extract CRS information from the geometry attribute description
+            CoordinateReferenceSystem crs = geometryType.getCoordinateReferenceSystem();
+            // we let the setAxisOrder method handle the NULL case
+            jsonWriter.setAxisOrder(CRS.getAxisOrder(crs));
+            if (crs != null) {
+                // store the found CRS, this may be useful for the invoker
+                this.crs = crs;
+            }
+            // store the attribute name and geometry value of the current feature
+            geometryAttribute = feature.getProperty(geometryType.getName());
+            geometry = (Geometry) geometryAttribute.getValue();
+        } else {
+            // this feature seems to not have a geometry, write the default axis order
+            jsonWriter.setAxisOrder(CRS.AxisOrder.EAST_NORTH);
+        }
+        // start the JSON geometry object
+        jsonWriter.key("geometry");
+        if (geometry != null) {
+            // the feature has a geometry so encode it
+            jsonWriter.writeGeom(geometry);
+            // store that we found a geometry, this may be useful for the invoker
+            geometryFound = true;
+        } else {
+            // no geometry just write a NULL value
+            jsonWriter.value(null);
+        }
+        // return the found geometry attribute, may be NULL
+        return geometryAttribute;
+    }
+
+    /**
+     * Encode a feature properties. Geometry attribute will be ignored.
+     */
+    private void encodeProperties(Property geometryAttribute, PropertyType parentType, Collection<Property> properties) {
+        // index all the feature available properties by their type
+        Map<PropertyType, List<Property>> index = indexPropertiesByType(geometryAttribute, properties);
+        for (Map.Entry<PropertyType, List<Property>> entry : index.entrySet()) {
+            // encode properties per type
+            encodePropertiesByType(parentType, entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Index the provided properties by their type, geometry property
+     * will be ignored.
+     */
+    private Map<PropertyType, List<Property>> indexPropertiesByType(Property geometryAttribute, Collection<Property> properties) {
+        Map<PropertyType, List<Property>> index = new HashMap<>();
+        for (Property property : properties) {
+            if (geometryAttribute != null && property.equals(geometryAttribute)) {
+                // ignore the geometry attribute that should have been encoded already
+                continue;
+            }
+            // update the index with the current property
+            List<Property> propertiesWithSameType = index.get(property.getType());
+            if (propertiesWithSameType == null) {
+                // first time we see a property fo this type
+                propertiesWithSameType = new ArrayList<>();
+                index.put(property.getType(), propertiesWithSameType);
+            }
+            propertiesWithSameType.add(property);
+        }
+        return index;
+    }
+
+    /**
+     * Encode feature properties by type, we do this way so we can handle the case were
+     * these properties should be encoded as a list or as elements that appear multiple
+     * times.
+     */
+    private void encodePropertiesByType(PropertyType parentType, PropertyType type, List<Property> properties) {
+        PropertyDescriptor multipleType = isMultipleType(parentType, type);
+        if (multipleType == null) {
+            // simple JSON objects
+            properties.forEach(this::encodeProperty);
+        } else {
+            // possible chained features that need to be encoded as a list
+            List<Feature> chainedFeatures = getChainedFeatures(properties);
+            if (chainedFeatures == null || chainedFeatures.isEmpty()) {
+                // no chained features just encode each property
+                properties.forEach(this::encodeProperty);
+            } else {
+                // chained features so we need to encode the chained features as an array
+                encodeChainedFeatures(multipleType.getName().getLocalPart(), chainedFeatures);
+            }
+        }
+    }
+
+    /**
+     * Encodes a list of features (chained features) as a JSON array.
+     */
+    private void encodeChainedFeatures(String attributeName, List<Feature> chainedFeatures) {
+        // start the JSON object
+        jsonWriter.key(attributeName);
+        jsonWriter.array();
+        for (Feature feature : chainedFeatures) {
+            // encode each chained feature
+            jsonWriter.object();
+            encodeProperties(null, feature.getType(), feature.getProperties());
+            jsonWriter.endObject();
+        }
+        // end the JSON chained features array
+        jsonWriter.endArray();
+    }
+
+    /**
+     * Check if a property type should appear multiple times or be encoded as a list.
+     */
+    private PropertyDescriptor isMultipleType(PropertyType parentType, PropertyType type) {
+        if (!(parentType instanceof ComplexType)) {
+            // only properties that belong to a complex type can be chained features
+            return null;
+        }
+        // search the current type on the parent properties
+        ComplexType complexType = (ComplexType) parentType;
+        PropertyDescriptor foundType = null;
+        for (PropertyDescriptor descriptor : complexType.getDescriptors()) {
+            if (descriptor.getType().equals(type)) {
+                // found our type
+                foundType = descriptor;
+            }
+        }
+        // if the found type can appear multiples time is not a chained feature
+        if (foundType == null) {
+            return null;
+        }
+        if (foundType.getMaxOccurs() > 1) {
+            // this type can appear more than once so it should not be encoded as a list
+            return foundType;
+        }
+        return null;
+    }
+
+    /**
+     * Get a list of chained features, NULL will be returned if this properties
+     * are not chained features.
+     */
+    private List<Feature> getChainedFeatures(List<Property> properties) {
+        List<Feature> features = new ArrayList<>();
+        for (Property property : properties) {
+            if (!(property instanceof ComplexAttribute)) {
+                // only the chaining of complex features is supported
+                return null;
+            }
+            ComplexAttribute complexProperty = (ComplexAttribute) property;
+            Collection<Property> subProperties = complexProperty.getProperties();
+            if (subProperties.size() > 1) {
+                // more than one property means that this are not chained features
+                return null;
+            }
+            Property subProperty = getElementAt(subProperties, 0);
+            if (!(subProperty instanceof Feature)) {
+                // if the only property is not a feature this are no chained features
+                return null;
+            }
+            features.add((Feature) subProperty);
+        }
+        // this are chained features
+        return features;
+    }
+
+    /**
+     * Helper method that just gets an element from a collection at a certain index.
+     */
+    private <T> T getElementAt(Collection<T> collection, int index) {
+        Iterator<T> iterator = collection.iterator();
+        T element = null;
+        for (int i = 0; i <= index && iterator.hasNext(); i++) {
+            element = iterator.next();
+        }
+        return element;
+    }
+
+    /**
+     * Encode a feature property, we only support complex attributes and
+     * simple attributes, if another tye of attribute is used an exception
+     * will be throw.
+     */
+    private void encodeProperty(Property property) {
+        if (property instanceof ComplexAttribute) {
+            // check if we have a simple content
+            ComplexAttribute complexAttribute = (ComplexAttribute) property;
+            Object simpleValue = getSimpleContent(complexAttribute);
+            if (simpleValue != null) {
+                encodeSimpleAttribute(complexAttribute.getName().getLocalPart(), simpleValue);
+            } else {
+                // we need to encode a complex attribute
+                encodeComplexAttribute((ComplexAttribute) property);
+            }
+        } else if (property instanceof Attribute) {
+            // check if we have a feature or list of features (chained features)
+            List<Feature> features = getFeatures((Attribute) property);
+            if (features != null) {
+                encodeChainedFeatures(property.getName().getLocalPart(), features);
+            } else {
+                // we need to encode a simple attribute
+                encodeSimpleAttribute((Attribute) property);
+            }
+        } else {
+            // unsupported attribute type provided, this will unlikely happen
+            throw new RuntimeException(String.format(
+                    "Invalid property '%s' of type '%s', only 'Attribute' and 'ComplexAttribute' properties types are supported.",
+                    property.getName(), property.getClass().getCanonicalName()));
+        }
+    }
+
+    /**
+     * Helper method that try to extract a list of features from
+     * an attribute. If no features can be found NULL is returned.
+     */
+    private List<Feature> getFeatures(Attribute attribute) {
+        Object value = attribute.getValue();
+        if (value instanceof Feature) {
+            // feature found return it in a single ton list
+            return Collections.singletonList((Feature) value);
+        }
+        if (!(value instanceof Collection)) {
+            // not a feature or list of features
+            return null;
+        }
+        Collection collection = (Collection) value;
+        if (collection.isEmpty()) {
+            // we cannot be sure that this is a list of features
+            return Collections.emptyList();
+        }
+        if (!(getElementAt(collection, 0) instanceof Feature)) {
+            // list doesn't contain features
+            return null;
+        }
+        // make sure we have only features
+        List<Feature> features = new ArrayList<>();
+        for (Object object : collection) {
+            if (!(object instanceof Feature)) {
+                // not a feature this is a mixed collection
+                throw new RuntimeException(String.format(
+                        "Unable to handle attribute '%s'.", attribute));
+            }
+            features.add((Feature) object);
+        }
+        return features;
+    }
+
+    /**
+     * Helper method that try to extract a simple content from a complex
+     * attribute, NULL is returned if no simple content is present.
+     */
+    private Object getSimpleContent(ComplexAttribute property) {
+        Collection<Property> properties = property.getProperties();
+        if (properties.isEmpty() || properties.size() > 1) {
+            // no properties or more than property mean no simple content
+            return null;
+        }
+        Property simpleContent = getElementAt(properties, 0);
+        if (simpleContent == null) {
+            // simple content is NULL end extraction here
+            return null;
+        }
+        Name name = simpleContent.getName();
+        if (name == null || !name.getLocalPart().equals("simpleContent")) {
+            // not a simple content node
+            return null;
+        }
+        Object value = simpleContent.getValue();
+        if (value instanceof Number
+                || value instanceof String
+                || value instanceof Character) {
+            // the extract value is a simple Java type
+            return value;
+        }
+        // not a valid simple content type
+        return null;
+    }
+
+    /**
+     * Encode a complex attribute as a JSON object.
+     */
+    private void encodeComplexAttribute(ComplexAttribute attribute) {
+        // get the attribute name and start a JSON object
+        String name = attribute.getName().getLocalPart();
+        jsonWriter.key(name);
+        jsonWriter.object();
+        // encode the object properties, since this is not a top feature or a
+        // chained feature we don't need to explicitly handle the geometry attribute
+        encodeProperties(null, attribute.getType(), attribute.getProperties());
+        // end the attribute JSON object
+        jsonWriter.endObject();
+    }
+
+    /**
+     * Encode a simple attribute, this means that this property
+     * will be encoded as a simple JSON attribute.
+     */
+    private void encodeSimpleAttribute(Attribute attribute) {
+        String name = attribute.getName().getLocalPart();
+        Object value = attribute.getValue();
+        encodeSimpleAttribute(name, value);
+    }
+
+    /**
+     * Encode a simple attribute, this means that this property
+     * will be encoded as a simple JSON attribute.
+     */
+    private void encodeSimpleAttribute(String name, Object value) {
+        // add a simple JSON attribute to the current object
+        jsonWriter.key(name).value(value);
+    }
+
+    /**
+     * Return TRUE if a geometry was found during the features collections encoding.
+     */
+    public boolean geometryFound() {
+        return geometryFound;
+    }
+
+    /**
+     * Return a CRS if one was found during the features collections encoding.
+     */
+    public CoordinateReferenceSystem foundCrs() {
+        return crs;
+    }
+
+    /**
+     * Return the number of top encoded features.
+     */
+    public long getFeaturesCount() {
+        return featuresCount;
+    }
+}

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -5,18 +5,8 @@
  */
 package org.geoserver.wfs.json;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import com.vividsolutions.jts.geom.Geometry;
+import net.sf.json.JSONException;
 import org.geoserver.config.GeoServer;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
@@ -40,9 +30,17 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.ReferenceIdentifier;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.vividsolutions.jts.geom.Geometry;
-
-import net.sf.json.JSONException;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A GetFeatureInfo response handler specialized in producing Json and JsonP data for a GetFeatureInfo request.
@@ -89,6 +87,20 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
         }
     }
 
+    /**
+     * Helper method that checks if the results feature collections contain complex features.
+     */
+    private static boolean isComplexFeature(FeatureCollectionResponse results) {
+        for (FeatureCollection featureCollection : results.getFeatures()) {
+            if (!(featureCollection.getSchema() instanceof SimpleFeatureType)) {
+                // this feature collection contains complex features
+                return true;
+            }
+        }
+        // all features collections contain only simple features
+        return false;
+    }
+
     @Override
     protected void write(FeatureCollectionResponse featureCollection, OutputStream output,
             Operation describeFeatureType) throws IOException {
@@ -111,7 +123,6 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
         // prepare to write out
         OutputStreamWriter osw = null;
         Writer outWriter = null;
-        boolean hasGeom = false;
 
         // get feature count for request
         BigInteger totalNumberOfFeatures = featureCollection.getTotalNumberOfFeatures();
@@ -124,6 +135,13 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
 
             if (jsonp) {
                 outWriter.write(getCallbackFunction() + "(");
+            }
+
+            // currently complex features count always return zero
+            boolean isComplex = isComplexFeature(featureCollection);
+            if (featureCount != null && isComplex && featureCount.equals(BigInteger.ZERO)) {
+                // a zero count when dealing with complex features means that features count is not supported
+                featureCount = null;
             }
             
             final GeoJSONBuilder jsonWriter = new GeoJSONBuilder(outWriter);
@@ -142,104 +160,19 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
             //
             // execute should also fail if all of the locks could not be acquired
             List<FeatureCollection> resultsList = featureCollection.getFeature();
-            CoordinateReferenceSystem crs = null;
-            for (int i = 0; i < resultsList.size(); i++) {
-                FeatureCollection collection = resultsList.get(i);
-                FeatureIterator iterator = collection.features();
-
-                
-                try {
-                    SimpleFeatureType fType;
-                    List<AttributeDescriptor> types;
-
-                    while (iterator.hasNext()) {
-                        SimpleFeature feature = (SimpleFeature) iterator.next();
-                        jsonWriter.object();
-                        jsonWriter.key("type").value("Feature");
-
-                        fType = feature.getFeatureType();
-                        types = fType.getAttributeDescriptors();
-
-                        if( id_option == null ){
-                            jsonWriter.key("id").value(feature.getID());
-                        }
-                        else if ( id_option.length() != 0){
-                            Object value = feature.getAttribute(id_option);
-                            jsonWriter.key("id").value(value);
-                        }
-                        
-                        GeometryDescriptor defaultGeomType = fType.getGeometryDescriptor();
-                        if(defaultGeomType != null) {
-                            CoordinateReferenceSystem featureCrs =
-                                    defaultGeomType.getCoordinateReferenceSystem();
-                            
-                            jsonWriter.setAxisOrder(CRS.getAxisOrder(featureCrs));
-                            
-                            if (crs == null)
-                                crs = featureCrs;
-                        } else  {
-                            // If we don't know, assume EAST_NORTH so that no swapping occurs
-                            jsonWriter.setAxisOrder(CRS.AxisOrder.EAST_NORTH);
-                        }
-                        
-                        jsonWriter.key("geometry");
-                        Geometry aGeom = (Geometry) feature.getDefaultGeometry();
-
-                        // Write the geometry, whether it is a null or not
-                        if (aGeom != null) {
-                            jsonWriter.writeGeom(aGeom);
-                            hasGeom = true;
-                        } else {
-                            jsonWriter.value(null);
-                        }
-                        if (defaultGeomType != null)
-                            jsonWriter.key("geometry_name").value(defaultGeomType.getLocalName());
-
-                        jsonWriter.key("properties");
-                        jsonWriter.object();
-
-                        for (int j = 0; j < types.size(); j++) {
-                            Object value = feature.getAttribute(j);
-                            AttributeDescriptor ad = types.get(j);
-                            
-                            if( id_option != null && id_option.equals(ad.getLocalName()) ){
-                            	continue; // skip this value as it is used as the id
-                            }
-                            if (ad instanceof GeometryDescriptor) {
-                                // This is an area of the spec where they
-                                // decided to 'let convention evolve',
-                                // that is how to handle multiple
-                                // geometries. My take is to print the
-                                // geometry here if it's not the default.
-                                // If it's the default that you already
-                                // printed above, so you don't need it here.
-                                if (ad.equals(defaultGeomType)) {
-                                    // Do nothing, we wrote it above
-                                    // jsonWriter.value("geometry_name");
-                                } else if(value == null){
-                                    jsonWriter.key(ad.getLocalName());
-                                    jsonWriter.value(null);
-                                } else {
-                                    jsonWriter.key(ad.getLocalName());
-                                    jsonWriter.writeGeom((Geometry) value);
-                                }
-                            } else {
-                                jsonWriter.key(ad.getLocalName());
-                                jsonWriter.value(value);
-                            }
-                        }
-                        // Bounding box for feature in properties
-                        ReferencedEnvelope refenv = ReferencedEnvelope.reference(feature.getBounds());
-                        if (featureBounding && !refenv.isEmpty())
-                            jsonWriter.writeBoundingBox(refenv);
-
-                        jsonWriter.endObject(); // end the properties
-                        jsonWriter.endObject(); // end the feature
-                    }
-                } // catch an exception here?
-                finally {
-                    iterator.close();
-                }
+            // encode the features and extract information about the CRS and if geometry exists
+            boolean hasGeom = false;
+            CoordinateReferenceSystem crs;
+            if (!isComplex) {
+                FeaturesInfo featuresInfo = encodeSimpleFeatures(jsonWriter, resultsList, id_option, featureBounding);
+                hasGeom = featuresInfo.hasGeometry;
+                crs = featuresInfo.crs;
+            } else {
+                // encode collection with complex features
+                ComplexGeoJsonWriter complexWriter = new ComplexGeoJsonWriter(jsonWriter);
+                complexWriter.write(resultsList);
+                hasGeom = complexWriter.geometryFound();
+                crs = complexWriter.foundCrs();
             }
             jsonWriter.endArray(); // end features
 
@@ -288,6 +221,116 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
             serviceException.initCause(jsonException);
             throw serviceException;
         }
+    }
+
+    /**
+     * Container class for information related with a group of features.
+     */
+    private class FeaturesInfo {
+
+        final CoordinateReferenceSystem crs;
+        final boolean hasGeometry;
+
+        private FeaturesInfo(CoordinateReferenceSystem crs, boolean hasGeometry) {
+            this.crs = crs;
+            this.hasGeometry = hasGeometry;
+        }
+    }
+
+    private FeaturesInfo encodeSimpleFeatures(GeoJSONBuilder jsonWriter, List<FeatureCollection> resultsList,
+                                              String id_option, boolean featureBounding) {
+        CoordinateReferenceSystem crs = null;
+        boolean hasGeom = false;
+        for (FeatureCollection collection : resultsList) {
+            try (FeatureIterator iterator = collection.features()) {
+                SimpleFeatureType fType;
+                List<AttributeDescriptor> types;
+                // encode each simple feature
+                while (iterator.hasNext()) {
+                    // get next simple feature
+                    SimpleFeature simpleFeature = (SimpleFeature) iterator.next();
+                    // start writing the JSON feature object
+                    jsonWriter.object();
+                    jsonWriter.key("type").value("Feature");
+                    fType = simpleFeature.getFeatureType();
+                    types = fType.getAttributeDescriptors();
+                    // write the simple feature id
+                    if (id_option == null) {
+                        // no specific attribute nominated, use the simple feature id
+                        jsonWriter.key("id").value(simpleFeature.getID());
+                    } else if (id_option.length() != 0) {
+                        // a specific attribute was nominated to be used as id
+                        Object value = simpleFeature.getAttribute(id_option);
+                        jsonWriter.key("id").value(value);
+                    }
+                    // set that axis order that should be used to write geometries
+                    GeometryDescriptor defaultGeomType = fType.getGeometryDescriptor();
+                    if (defaultGeomType != null) {
+                        CoordinateReferenceSystem featureCrs =
+                                defaultGeomType.getCoordinateReferenceSystem();
+                        jsonWriter.setAxisOrder(CRS.getAxisOrder(featureCrs));
+                        if (crs == null) {
+                            crs = featureCrs;
+                        }
+                    } else {
+                        // If we don't know, assume EAST_NORTH so that no swapping occurs
+                        jsonWriter.setAxisOrder(CRS.AxisOrder.EAST_NORTH);
+                    }
+                    // start writing the simple feature geometry JSON object
+                    jsonWriter.key("geometry");
+                    Geometry aGeom = (Geometry) simpleFeature.getDefaultGeometry();
+                    // Write the geometry, whether it is a null or not
+                    if (aGeom != null) {
+                        jsonWriter.writeGeom(aGeom);
+                        hasGeom = true;
+                    } else {
+                        jsonWriter.value(null);
+                    }
+                    if (defaultGeomType != null) {
+                        jsonWriter.key("geometry_name").value(defaultGeomType.getLocalName());
+                    }
+                    // start writing feature properties JSON object
+                    jsonWriter.key("properties");
+                    jsonWriter.object();
+                    for (int j = 0; j < types.size(); j++) {
+                        Object value = simpleFeature.getAttribute(j);
+                        AttributeDescriptor ad = types.get(j);
+                        if (id_option != null && id_option.equals(ad.getLocalName())) {
+                            continue; // skip this value as it is used as the id
+                        }
+                        if (ad instanceof GeometryDescriptor) {
+                            // This is an area of the spec where they
+                            // decided to 'let convention evolve',
+                            // that is how to handle multiple
+                            // geometries. My take is to print the
+                            // geometry here if it's not the default.
+                            // If it's the default that you already
+                            // printed above, so you don't need it here.
+                            if (ad.equals(defaultGeomType)) {
+                                // Do nothing, we wrote it above
+                                // jsonWriter.value("geometry_name");
+                            } else if (value == null) {
+                                jsonWriter.key(ad.getLocalName());
+                                jsonWriter.value(null);
+                            } else {
+                                jsonWriter.key(ad.getLocalName());
+                                jsonWriter.writeGeom((Geometry) value);
+                            }
+                        } else {
+                            jsonWriter.key(ad.getLocalName());
+                            jsonWriter.value(value);
+                        }
+                    }
+                    // Bounding box for feature in properties
+                    ReferencedEnvelope refenv = ReferencedEnvelope.reference(simpleFeature.getBounds());
+                    if (featureBounding && !refenv.isEmpty())
+                        jsonWriter.writeBoundingBox(refenv);
+                    jsonWriter.endObject(); // end the properties
+                    jsonWriter.endObject(); // end the feature
+                }
+            }
+        }
+        return new FeaturesInfo(crs, hasGeom);
     }
 
     private void writeCrs(final GeoJSONBuilder jsonWriter,


### PR DESCRIPTION
Adds a GeoJSON encoder for complex features. The workflow is similar to the GML one, if the response result only contain simple features the actual simple features GeoJSON encoder is used otherwise the complex features GeoJSON encoder will be used.

Tests for the complex GeoJSON encoder were added in the app-schema module since this is the only place were complex features can actually be produced.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8068