### PR TITLE
API Changes in GWC and cross parameter autotruncation, GEOS-8074

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/ConfigurableQuotaStore.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/ConfigurableQuotaStore.java
@@ -113,4 +113,9 @@ public class ConfigurableQuotaStore implements QuotaStore {
         delegate.close();
     }
 
+    @Override
+    public void deleteParameters(String layerName, String parametersId) {
+        delegate.deleteParameters(layerName, parametersId);
+    }
+
 }

--- a/src/gwc/src/main/java/org/geoserver/gwc/DummyQuotaStore.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/DummyQuotaStore.java
@@ -148,4 +148,8 @@ public class DummyQuotaStore implements QuotaStore {
     public void close() throws Exception {
     }
 
+    @Override
+    public void deleteParameters(String layerName, String parametersId) {
+    }
+
 }

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -119,6 +119,7 @@ import org.geowebcache.seed.GWCTask;
 import org.geowebcache.seed.GWCTask.TYPE;
 import org.geowebcache.seed.SeedRequest;
 import org.geowebcache.seed.TileBreeder;
+import org.geowebcache.seed.TruncateBboxRequest;
 import org.geowebcache.service.Service;
 import org.geowebcache.storage.BlobStore;
 import org.geowebcache.storage.CompositeBlobStore;
@@ -394,9 +395,12 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             if (intersectingBounds == null) {
                 continue;
             }
-            String styleName = null;// all of them
-            String format = null;// all of them
-            truncate(layerName, styleName, gridSetId, intersectingBounds, format);
+            try {
+                // This iterates over all cached parameters and all formats
+                new TruncateBboxRequest(layerName, intersectingBounds, gridSetId).doTruncate(storageBroker, tileBreeder);
+            } catch (StorageException | GeoWebCacheException e) {
+                log.log(Level.WARNING, e, ()->String.format("Error while truncating modified bounds for layer %s gridset %s",layerName, gridSetId));
+            }
         }
     }
 

--- a/src/gwc/src/main/resources/geowebcache-diskquota-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-diskquota-context.xml
@@ -37,6 +37,7 @@
 
   <bean id="gwcTilePageCalculator" class="org.geowebcache.diskquota.storage.TilePageCalculator">
     <constructor-arg ref="gwcTLDispatcher" />
+    <constructor-arg ref="gwcStorageBroker" />
   </bean>
 
   <bean id="gwcCacheCleaner" class="org.geowebcache.diskquota.CacheCleaner">

--- a/src/gwc/src/main/resources/geowebcache-rest-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-rest-context.xml
@@ -13,6 +13,7 @@
   <bean id="gwcMassTruncateRestlet" class="org.geowebcache.rest.seed.MassTruncateRestlet">
     <property name="xmlConfig" ref="gwcXmlConfig"/>
     <property name="storageBroker" ref="gwcStorageBroker"/>
+    <property name="tileBreeder" ref="gwcTileBreeder"/>
   </bean>
   
   <bean id="gwcSeedFormRestlet" class="org.geowebcache.rest.seed.SeedFormRestlet">

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
@@ -17,11 +17,13 @@ import static org.geoserver.gwc.GWCTestHelpers.mockGroup;
 import static org.geoserver.gwc.GWCTestHelpers.mockLayer;
 import static org.geoserver.gwc.layer.TileLayerInfoUtil.updateAcceptAllFloatParameterFilter;
 import static org.geoserver.gwc.layer.TileLayerInfoUtil.updateStringParameterFilter;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -44,11 +46,13 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.geoserver.catalog.Catalog;
@@ -90,6 +94,7 @@ import org.geowebcache.conveyor.ConveyorTile;
 import org.geowebcache.diskquota.DiskQuotaMonitor;
 import org.geowebcache.diskquota.QuotaStore;
 import org.geowebcache.diskquota.jdbc.JDBCConfiguration;
+import org.geowebcache.filter.parameters.StringParameterFilter;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
@@ -99,6 +104,7 @@ import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.mime.MimeType;
 import org.geowebcache.seed.GWCTask;
+import org.geowebcache.seed.SeedRequest;
 import org.geowebcache.seed.TileBreeder;
 import org.geowebcache.service.Service;
 import org.geowebcache.storage.CompositeBlobStore;
@@ -106,11 +112,13 @@ import org.geowebcache.storage.DefaultStorageFinder;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.StorageException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.opengis.filter.Filter;
@@ -712,8 +720,17 @@ public class GWCTest {
 
     @Test
     public void testTruncateByBounds() throws Exception {
-
         String layerName = tileLayer.getName();
+        
+        when(tileBreeder.findTileLayer(layerName))
+            .thenReturn(tileLayer);
+        final Set<Map<String, String>> cachedParameters = tileLayer.getInfo().cachedStyles().stream()
+            .map(style->Collections.singletonMap("STYLES",style))
+            .collect(Collectors.toSet());
+        
+        when(storageBroker.getCachedParameters(layerName))
+            .thenReturn(cachedParameters);
+        
         ReferencedEnvelope bounds;
         // bounds outside layer bounds (which are -180,0,0,90)
         bounds = new ReferencedEnvelope(10, 20, 10, 20, DefaultGeographicCRS.WGS84);
@@ -736,22 +753,77 @@ public class GWCTest {
         int numFormats = tileLayer.getMimeTypes().size();
         int numStyles = 1/* default */ + tileLayer.getInfo().cachedStyles().size();
         final int expected = numGridsets * numFormats * numStyles;
-        verify(tileBreeder, times(expected)).dispatchTasks(any(GWCTask[].class));
+        verify(tileBreeder, times(expected)).seed(eq(layerName), any(SeedRequest.class));
 
         reset(tileBreeder);
+        when(tileBreeder.findTileLayer(layerName))
+            .thenReturn(tileLayer);
         bounds = bounds.transform(CRS.decode("EPSG:900913"), true);
         mediator.truncate(layerName, bounds);
-        verify(tileBreeder, times(expected)).dispatchTasks(any(GWCTask[].class));
+        verify(tileBreeder, times(expected)).seed(eq(layerName), any(SeedRequest.class));
 
         reset(tileBreeder);
-        bounds = mediator.getAreaOfValidity(CRS.decode("EPSG:2083"));// Terra del Fuego
+        when(tileBreeder.findTileLayer(layerName))
+            .thenReturn(tileLayer);
+        bounds = mediator.getAreaOfValidity(CRS.decode("EPSG:2083"));// Terra del Fuego Does not intersect subset
         mediator.truncate(layerName, bounds);
-        verify(tileBreeder, never()).dispatchTasks(any(GWCTask[].class));
+        verify(tileBreeder, times(0)).seed(eq(layerName), any(SeedRequest.class));
 
         reset(tileBreeder);
+        when(tileBreeder.findTileLayer(layerName))
+            .thenReturn(tileLayer);
         bounds = mediator.getAreaOfValidity(CRS.decode("EPSG:26986"));// Massachussets
         mediator.truncate(layerName, bounds);
-        verify(tileBreeder, times(expected)).dispatchTasks(any(GWCTask[].class));
+        verify(tileBreeder, times(expected)).seed(eq(layerName), any(SeedRequest.class));
+    }
+    
+    @Test
+    public void testTruncateByBoundsWithDimension() throws Exception {
+        TileLayerInfoUtil.updateAcceptAllRegExParameterFilter(tileLayerInfo, "TIME", true);
+        Collection <String> cachedTimes = Arrays.asList("time1", "time2");
+        String layerName = tileLayer.getName();
+        
+        when(tileBreeder.findTileLayer(layerName))
+            .thenReturn(tileLayer);
+        final Set<Map<String, String>> cachedParameters = tileLayer.getInfo().cachedStyles().stream()
+            .flatMap(style->cachedTimes.stream()
+                    .map(time->{
+                        Map<String, String> map = new HashMap();
+                        map.put("STYLE", style);
+                        map.put("TIME", time);
+                        return map;
+                    }))
+            .collect(Collectors.toSet());
+        
+        when(storageBroker.getCachedParameters(layerName))
+            .thenReturn(cachedParameters);
+        
+        ReferencedEnvelope bounds;
+        // bounds outside layer bounds (which are -180,0,0,90)
+        bounds = new ReferencedEnvelope(10, 20, 10, 20, DefaultGeographicCRS.WGS84);
+        BoundingBox layerBounds = tileLayer.getGridSubset("EPSG:4326").getGridSet()
+                .getOriginalExtent();
+
+        assertFalse(bounds.intersects(layerBounds.getMinX(), layerBounds.getMinY()));
+        assertFalse(bounds.intersects(layerBounds.getMaxX(), layerBounds.getMaxY()));
+
+        mediator.truncate(layerName, bounds);
+
+        verify(tileBreeder, never()).dispatchTasks(any(GWCTask[].class));
+
+        // bounds intersecting layer bounds
+        bounds = new ReferencedEnvelope(-10, -10, 10, 10, DefaultGeographicCRS.WGS84);
+
+        mediator.truncate(layerName, bounds);
+
+        int numGridsets = tileLayer.getGridSubsets().size();
+        int numFormats = tileLayer.getMimeTypes().size();
+        int numStyles = tileLayer.getInfo().cachedStyles().size();
+        int numTimes = cachedTimes.size();
+        int numParameters = numStyles * numTimes +1;
+        final int expected = numGridsets * numFormats * numParameters;
+        verify(tileBreeder, times(expected)).seed(eq(layerName), any(SeedRequest.class));
+        
     }
 
     @Test


### PR DESCRIPTION
Depends on: https://github.com/GeoWebCache/geowebcache/pull/505

Allows the GWC transaction listener to truncate all parameters including non-enumerable ones (such as regexps) when it detects a change.  Also corrects for API changes in GWC.