### PR TITLE
[GEOS-8073] Performing a WMTS GetCapabilities request with layer groups provokes a NPE

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -1276,7 +1276,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
     public Map<String, org.geowebcache.config.legends.LegendInfo> getLayerLegendsInfo() {
         LayerInfo layerInfo = getLayerInfo();
         if (layerInfo == null) {
-            return null;
+            return Collections.emptyMap();
         }
         Map<String, org.geowebcache.config.legends.LegendInfo> legends = new HashMap<>();
         Set<StyleInfo> styles = new HashSet<>(layerInfo.getStyles());


### PR DESCRIPTION
This issue fix the NPE exception and adds an integration test where a capabilities document that contains a layer group is invoked (yes is a simple test that is important but didn't existed).

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8073