### PR TITLE
[GEOS-8050] Preserve external graphic URL #fragments during GeoServerDataDirectory.parsedStyle(..)

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
@@ -1211,14 +1211,27 @@ public class GeoServerDataDirectory {
                         //GEOS-7025: Just get the path; don't try to create the file
                         file = Paths.toFile(root(), resource.path());
                     }
+                    
                     URL u = fileToUrlPreservingCqlTemplates(file);
+                    
                     if (url.getQuery() != null) {
                         try {
-                            return new URL(u.toString() + "?" + url.getQuery());
+                            u = new URL(u.toString() + "?" + url.getQuery());
                         } catch (MalformedURLException ex) {
+                            GeoServerPersister.LOGGER.log(Level.WARNING, "Error processing query string for resource with uri: " + uri, ex);
                             return null;
                         }
                     }
+                    
+                    if (url.getRef() != null) {
+                        try {
+                            u = new URL(u.toString() + "#" + url.getRef());
+                        } catch (MalformedURLException ex) {
+                            GeoServerPersister.LOGGER.log(Level.WARNING, "Error processing # fragment for resource with uri: " + uri, ex);
+                            return null;
+                        }
+                    }
+                    
                     return u;
                 } else {
                     return url;

--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
@@ -113,5 +113,48 @@ public class GeoServerDataDirectoryTest {
         
         //GEOS-7025: verify the icon file is not created if it doesn't already exist
         assertFalse(iconFile.exists());
-    } 
+    }    
+
+    /**
+     * Test loading a parsed style with an external graphic URL that contains both ?queryParams and
+     * a URL #fragment, and assert that those URL components are preserved. 
+     *  
+     * @throws IOException
+     */
+    @Test
+    public void testParsedStyleExternalWithParamsAndFragment() throws IOException {
+        File styleDir = new File(dataDir.root(), "styles");
+        styleDir.mkdir();
+
+        // Copy the sld to the temp style dir
+        File styleFile = new File(styleDir, "external_with_params_and_fragment.sld");
+        Files.copy(this.getClass().getResourceAsStream("external_with_params_and_fragment.sld"),
+                styleFile.toPath());
+
+        File iconFile = new File(styleDir, "icon.png");
+        assertFalse(iconFile.exists());
+
+        StyleInfoImpl si = new StyleInfoImpl(null);
+        si.setName("");
+        si.setId("");
+        si.setFormat("sld");
+        si.setFormatVersion(new Version("1.0.0"));
+        si.setFilename(styleFile.getName());
+
+        Style s = dataDir.parsedStyle(si);
+        // Verify style is actually parsed correctly
+        Symbolizer symbolizer = s.featureTypeStyles().get(0).rules().get(0).symbolizers().get(0);
+        assertTrue(symbolizer instanceof PointSymbolizer);
+        GraphicalSymbol graphic = ((PointSymbolizer) symbolizer).getGraphic().graphicalSymbols()
+                .get(0);
+        assertTrue(graphic instanceof ExternalGraphic);
+        assertEquals(((ExternalGraphic) graphic).getLocation().getPath(),
+                iconFile.toURI().toURL().getPath());
+
+        assertEquals("param1=1", ((ExternalGraphic) graphic).getLocation().getQuery());
+        assertEquals("textAfterHash", ((ExternalGraphic) graphic).getLocation().getRef());
+
+        // GEOS-7025: verify the icon file is not created if it doesn't already exist
+        assertFalse(iconFile.exists());
+    }
 }

--- a/src/main/src/test/resources/org/geoserver/config/external_with_params_and_fragment.sld
+++ b/src/main/src/test/resources/org/geoserver/config/external_with_params_and_fragment.sld
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>external</Name>
+    <UserStyle>
+      <Name>external</Name> 
+      <Title>An external graphic</Title>
+      <Abstract>A sample point symbolizer with an external graphic with a URL containing both query parameters and a # fragment</Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <Title>Red flag</Title>
+          <PointSymbolizer>
+            <Graphic>
+              <ExternalGraphic>
+                <OnlineResource xlink:type="simple" xlink:href="icon.png?param1=1#textAfterHash" />
+                <Format>image/png</Format>
+              </ExternalGraphic>
+              <Size>
+                <ogc:Literal>20</ogc:Literal>
+              </Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor> 


### PR DESCRIPTION
This PR adds support for preservation of external graphic URL fragments during the load of a parsedStyle.

When GeoServerDataDirectory loads a parsedStyle, it locates external graphics (while preserving Cql templates) using only the URL base path, ignoring query parameters and URL #fragments. It then attempts to preserve the original URL by re-adding query parameters, but fails to re-add the fragment.

Supporting URL fragments would be generally useful to designate subordinate resources, e.g., an individual icon inside a sprite sheet. This pattern has already been established for [bulk WKT shapes](http://docs.geoserver.org/stable/en/user/styling/sld/extensions/pointsymbols.html#bulk-wkt-shapes), for which you can write: `<OnlineResource xlink:type="simple" xlink:href="example.properties#zig" />`