### PR TITLE
[GEOS-8077] Fixed custom dimension values being dropped from GetMap URLs in the response KML document.

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2017 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -356,6 +356,9 @@ public class WMSRequests {
               // semantics of feature id slightly different, replicate entire value
               params.put("elevation", req.getRawKvp().get("elevation"));
             }
+            req.getRawKvp().entrySet().stream()
+                .filter(e -> e.getKey().toLowerCase().startsWith("dim_"))
+                .forEach(e -> params.put(e.getKey().toLowerCase(), e.getValue()));
 
         } else {
             // include all

--- a/src/wms/src/test/java/org/geoserver/wms/WMSRequestsTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSRequestsTest.java
@@ -1,0 +1,45 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms;
+
+import java.net.URLDecoder;
+
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ows.util.KvpMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class WMSRequestsTest extends WMSTestSupport {
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        testData.addDefaultRasterLayer(MockData.TASMANIA_DEM, getCatalog());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetGetMapUrlWithDimensions() throws Exception {
+        GetMapRequest request = createGetMapRequest(MockData.TASMANIA_DEM);
+        KvpMap rawKvp = new KvpMap(request.getRawKvp());
+        rawKvp.put("time", "2017-04-07T19:56:00.000Z");
+        rawKvp.put("elevation", "1013.2");
+        rawKvp.put("dim_my_dimension", "010");
+        request.setRawKvp(rawKvp);
+        request.setFormat(DefaultWebMapService.FORMAT);
+        DefaultWebMapService.autoSetBoundsAndSize(request);
+        String url = WMSRequests.getGetMapUrl(request,
+            request.getLayers().get(0).getName(), 0, null, null, null);
+        url = URLDecoder.decode(url, "UTF-8");
+        assertTrue("Missing time in GetMap URL: " + url,
+            url.contains("&time=2017-04-07T19:56:00.000Z"));
+        assertTrue("Missing elevation in GetMap URL: " + url,
+            url.contains("&elevation=1013.2"));
+        assertTrue("Missing custom dimension in GetMap URL: " + url,
+            url.contains("&dim_my_dimension=010"));
+    }
+}


### PR DESCRIPTION
Pull request with bug fix and unit test.  Can be backported to 2.10.x and 2.11.x.