### PR TITLE
Remove FeatureTypeName tag from default raster SLD template

### DIFF
--- a/src/main/src/main/resources/org/geoserver/catalog/template_raster.sld
+++ b/src/main/src/main/resources/org/geoserver/catalog/template_raster.sld
@@ -6,7 +6,6 @@ http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
     <UserStyle>
       <Title>A raster style</Title>
       <FeatureTypeStyle>
-        <FeatureTypeName>Raster</FeatureTypeName>
         <Rule>
           <RasterSymbolizer>
             <Opacity>1.0</Opacity>


### PR DESCRIPTION
This PR is meant to address [GEOS-8079](https://osgeo-org.atlassian.net/browse/GEOS-8079)

The problem is caused by the `<FeatureTypeName>` tag being set arbitrarily to "Raster" which GeoServer does not understand for any raster layer.

My instinct was just to remove the line, in order to make the default template simpler and more generic. Custom styles can still be defined with their own `<FeatureTypeName>` such that they'll work and render correctly, but the default style should work generically.