### PR TITLE
Re-enable GeoGig plugin in communityRelease module

### DIFF
--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -72,7 +72,7 @@
           <descriptor>release/ext-jdbcstore.xml</descriptor>
           <descriptor>release/ext-ncwms.xml</descriptor>
           <descriptor>release/ext-gwc-sqlite.xml</descriptor> 
-          <!--descriptor>release/ext-geogig.xml</descriptor-->
+          <descriptor>release/ext-geogig.xml</descriptor>
           <descriptor>release/ext-oauth2-google.xml</descriptor>
           <descriptor>release/ext-oauth2-github.xml</descriptor>
           <descriptor>release/ext-oauth2-geonode.xml</descriptor>
@@ -221,7 +221,7 @@
         <module>wps-remote</module>
         <module>wps-jdbc</module>
         <module>release</module>
-        <!--module>geogig</module-->
+        <module>geogig</module>
         <module>gwc-distributed</module>
         <module>jdbcstore</module>
         <module>gdal</module>


### PR DESCRIPTION
The LocationTech builds for GeoGig seem to be stable again.