### PR TITLE
[GEOS-8024] Fixed the legend preview failing on non-SLD styles.

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
@@ -1,4 +1,4 @@
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2016 - 2017 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -319,8 +319,9 @@ public class StyleAdminPanel extends StyleEditTabPanel {
                     //No external legend, use generated legend
                     GeoServerDataDirectory dd = GeoServerExtensions.bean(GeoServerDataDirectory.class, stylePage.getGeoServerApplication().getApplicationContext());
                     StyleInfo si = new StyleInfoImpl(stylePage.getCatalog());
+                    si.setFormat(stylePage.getStyleInfo().getFormat());
                     String styleName = "tmp" + UUID.randomUUID().toString();
-                    String styleFileName =  styleName + ".sld";
+                    String styleFileName = styleName + '.' + Styles.handler(si.getFormat()).getFileExtension();
                     si.setFilename(styleFileName);
                     si.setName(styleName);
                     si.setWorkspace(stylePage.styleModel.getObject().getWorkspace());

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleNewPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleNewPageTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2017 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -65,6 +65,32 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
         
         tester.assertRenderedPage(StyleNewPage.class);
         tester.assertModelValue("styleForm:styleEditor", sld);
+    }
+
+    @Test
+    public void testPreviewNoLegendSLD() throws Exception {
+        FormTester form = tester.newFormTester("styleForm");
+        File styleFile = new File(new java.io.File(getClass().getResource("default_point.sld").toURI()));
+        String sld = IOUtils.toString(new FileReader(styleFile)).replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+        form.setValue("styleEditor:editorContainer:editorParent:editor", sld);
+        form.setValue("context:panel:name", "previewsld");
+        form.setValue("context:panel:format", "sld");
+        form.submit();
+        tester.executeAjaxEvent("styleForm:context:panel:preview", "click");
+        tester.assertNoErrorMessage();
+    }
+
+    @Test
+    public void testPreviewNoLegendZIP() throws Exception {
+        FormTester form = tester.newFormTester("styleForm");
+        File styleFile = new File(new java.io.File(getClass().getResource("default_point.sld").toURI()));
+        String sld = IOUtils.toString(new FileReader(styleFile)).replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+        form.setValue("styleEditor:editorContainer:editorParent:editor", sld);
+        form.setValue("context:panel:name", "previewzip");
+        form.setValue("context:panel:format", "zip");
+        form.submit();
+        tester.executeAjaxEvent("styleForm:context:panel:preview", "click");
+        tester.assertErrorMessages("Failed to build legend preview. Check to see if the style is valid.");
     }
     
     @Test


### PR DESCRIPTION
Pull request with bug fix and unit test.  Can be backported to 2.10.x and 2.11.x.