### PR TITLE
Change the default X-Frame-Options header to be DENY

### DIFF
--- a/doc/en/user/source/production/config.rst
+++ b/doc/en/user/source/production/config.rst
@@ -74,3 +74,18 @@ In some circumstances, you might want to completely disable the web administrati
 * Set the Java system property GEOSERVER_CONSOLE_DISABLED to true by adding -DGEOSERVER_CONSOLE_DISABLED=true to your container's JVM options
 * Remove all of the gs-web*-.jar files from WEB-INF/lib
 
+X-Frame-Options Policy
+----------------------
+
+In order to prevent clickjacking attacks GeoServer defaults to setting the X-Frame-Options HTTP 
+header to DENY. This prevents GeoServer from being embedded into an iFrame, which prevents certain
+kinds of security vulnerabilities. See the `OWASP Clickjacking entry https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet`_ for details.
+
+If you wish to change this behavior you can do so through the following properties:
+
+* geoserver.xframe.shouldSetPolicy: controls whether the X-Frame-Options filter should be set at all. Default is true.
+* geoserver.xframe.policy: controls what the set the X-Frame-Options header to. Default is DENY valid options are DENY, SAMEORIGIN and ALLOW-FROM [uri]
+
+These properties can be set either via Java system property, command line argument (-D), environment
+variable or web.xml init parameter.
+

--- a/src/main/src/main/java/org/geoserver/filters/XFrameOptionsFilter.java
+++ b/src/main/src/main/java/org/geoserver/filters/XFrameOptionsFilter.java
@@ -1,0 +1,83 @@
+package org.geoserver.filters;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.geoserver.platform.GeoServerExtensions;
+
+/**
+ * Simple filter to set X-Frame-Options header to prevent click jacking attacks. This filter is
+ * controlled by two system properties:
+ * <br/>
+ *
+ * - geoserver.xframe.shouldSetPolicy: controls whether the X-Frame-Options filter should be set
+ *   at all. Default is true.
+ * <br/>
+ * - geoserver.xframe.policy: controls what the set the X-Frame-Options header to. Default is DENY
+ *   valid options are DENY, SAMEORIGIN and ALLOW-FROM [uri]
+ *
+ * <br/>
+ *
+ * These properties can be set via command line -D arg, web.xml init or environment variable.
+ */
+public class XFrameOptionsFilter implements Filter {
+
+    private static final boolean DEFAULT_SHOULD_SET_POLICY = true;
+    private static final String DEFAULT_FRAME_POLICY = "DENY";
+    private static final String X_FRAME_OPTIONS = "X-Frame-Options";
+    public static final String GEOSERVER_XFRAME_SHOULD_SET_POLICY =
+        "geoserver.xframe.shouldSetPolicy";
+    public static final String GEOSERVER_XFRAME_POLICY = "geoserver.xframe.policy";
+
+    /**
+     * Whether the X-Frame-Option header should be set at all. Check this on the fly for easier
+     * testing and in order to potentially make this a GUI controlled option in the future.
+     * @return
+     */
+    private static boolean shouldSetPolicy() {
+        boolean shouldSetPolicy = DEFAULT_SHOULD_SET_POLICY;
+        if (StringUtils.isNotEmpty(GeoServerExtensions.getProperty(GEOSERVER_XFRAME_SHOULD_SET_POLICY))) {
+            shouldSetPolicy = Boolean.parseBoolean(GeoServerExtensions.getProperty(GEOSERVER_XFRAME_SHOULD_SET_POLICY));
+        }
+
+        return shouldSetPolicy;
+    }
+
+    private static String getFramePolicy() {
+        String framePolicy = DEFAULT_FRAME_POLICY;
+        if (StringUtils.isNotEmpty(GeoServerExtensions.getProperty(GEOSERVER_XFRAME_POLICY))) {
+            framePolicy = GeoServerExtensions.getProperty(GEOSERVER_XFRAME_POLICY);
+        }
+
+        return framePolicy;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+
+        if (shouldSetPolicy()) {
+            HttpServletResponse httpResponse = (HttpServletResponse)response;
+            httpResponse.setHeader(X_FRAME_OPTIONS, getFramePolicy());
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/src/main/src/test/java/org/geoserver/filters/XFrameOptionsFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/XFrameOptionsFilterTest.java
@@ -1,0 +1,68 @@
+package org.geoserver.filters;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Simple test to make sure the XFrameOptions filter works and is configurable.
+ */
+public class XFrameOptionsFilterTest {
+
+    @Test
+    public void doFilter() throws Exception {
+        String header = getXStreamHeader();
+        assertEquals("Expect default XFrameOption to be DENY", "DENY", header);
+    }
+
+    @Test
+    public void testFilterWithNoSetPolicy() throws IOException, ServletException {
+        String currentShouldSetProperty =
+            System.getProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY);
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY, "false");
+        String header = getXStreamHeader();
+
+        assertEquals("Expect default XFrameOption to be null", null, header);
+
+        if (currentShouldSetProperty != null) {
+            System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY, currentShouldSetProperty);
+        }
+    }
+
+    @Test
+    public void testFilterWithSameOrigin() throws IOException, ServletException {
+        String currentShouldSetProperty =
+            System.getProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY);
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY, "SAMEORIGIN");
+        String header = getXStreamHeader();
+
+        assertEquals("Expect default XFrameOption to be SAMEORIGIN", "SAMEORIGIN", header);
+
+        if (currentShouldSetProperty != null) {
+            System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY, currentShouldSetProperty);
+        }
+    }
+
+    private String getXStreamHeader() throws IOException, ServletException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "http://www.geoserver.org");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        XFrameOptionsFilter filter = new XFrameOptionsFilter();
+        MockServletContext context = new MockServletContext();
+        MockFilterConfig config = new MockFilterConfig(context);
+        MockFilterChain mockChain = new MockFilterChain();
+
+        filter.doFilter(request, response, mockChain);
+
+        return response.getHeader("X-Frame-Options");
+    }
+
+}

--- a/src/web/app/src/main/webapp/WEB-INF/web.xml
+++ b/src/web/app/src/main/webapp/WEB-INF/web.xml
@@ -86,6 +86,11 @@
      <filter-class> org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     </filter>
 
+    <filter>
+      <filter-name>xFrameOptionsFilter</filter-name>
+      <filter-class>org.geoserver.filters.XFrameOptionsFilter</filter-class>
+    </filter>
+
    <filter>
      <filter-name>GZIP Compression Filter</filter-name>
      <filter-class>org.geoserver.filters.GZIPFilter</filter-class>
@@ -187,6 +192,11 @@
 
     <filter-mapping>
       <filter-name>GZIP Compression Filter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+      <filter-name>xFrameOptionsFilter</filter-name>
       <url-pattern>/*</url-pattern>
     </filter-mapping>
     


### PR DESCRIPTION
Set the default X-Frame-Options header to be DENY, to disallow embedding GeoServer in iframes.