### PR TITLE
[GEOS-8072] [GEOS-5176] WMS 1.3.0 capabilities global bounding box computation doesn't use layer groups (backport 2.11.x)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -658,13 +658,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             }
             
             // filter the layers if a namespace filter has been set
-            if (request.getNamespace() != null) {
-                //build a query predicate for the namespace prefix
-                final String nsPrefix = request.getNamespace();
-                final String nsProp = "resource.namespace.prefix";
-                Filter equals = equal(nsProp, nsPrefix);
-                filter = and(filter, equals);
-            }
+            filter = addNameSpaceFilterIfNeed(filter, "resource.namespace.prefix");
 
             final Catalog catalog = wmsConfig.getCatalog();
                         
@@ -682,10 +676,17 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             }
             handleRootCrsList(srs);
 
-            CloseableIterator<LayerInfo> layers;
-            layers = catalog.list(LayerInfo.class, filter);
+            // create layer groups filter
+            Filter lgFilter = Predicates.acceptAll();
+
+            // filter layer groups by namespace if needed
+            lgFilter = addNameSpaceFilterIfNeed(lgFilter, "workspace.name");
+
+            // handle root bounding box
+            CloseableIterator<LayerInfo> layers = catalog.list(LayerInfo.class, filter);
+            CloseableIterator<LayerGroupInfo> layerGroups = catalog.list(LayerGroupInfo.class, lgFilter);
             try{
-                handleRootBbox(layers);
+                handleRootBbox(layers, layerGroups);
             }finally{
                 layers.close();
             }
@@ -699,9 +700,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             Set<LayerInfo> layersAlreadyProcessed = new HashSet<LayerInfo>();
             
             // encode layer groups
-            CloseableIterator<LayerGroupInfo> layerGroups;
             {
-                final Filter lgFilter = Predicates.acceptAll();
                 SortBy layerGroupOrder = asc("name");
                 layerGroups = catalog.list(LayerGroupInfo.class, lgFilter, null, null,
                         layerGroupOrder);
@@ -725,6 +724,21 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             }
 
             end("Layer");
+        }
+
+        /**
+         * If the current request contains a namespace we build a filter using
+         * the provided property and request namespace and adds it to the provided
+         * filter. If the request doesn't contain a namespace the original filter
+         * is returned as is.
+         */
+        private Filter addNameSpaceFilterIfNeed(Filter filter, String nameSpaceProperty) {
+            String nameSpacePrefix = request.getNamespace();
+            if (nameSpacePrefix == null) {
+                return filter;
+            }
+            Filter equals = equal(nameSpaceProperty, nameSpacePrefix);
+            return and(filter, equals);
         }
 
         /**
@@ -785,32 +799,49 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
         }
 
         /**
-         * Called by <code>handleLayers()</code>, iterates over the available featuretypes and
-         * coverages to summarize their LatLonBBox'es and write the aggregated bounds for the root
-         * layer.
-         * 
-         * @param ftypes
-         *            the collection of FeatureTypeInfo and CoverageInfo objects to traverse
+         * Called by <code>handleLayers()</code>, iterates over the available layers and
+         * layers groups to summarize their LatLonBBox'es and write the aggregated bounds
+         * for the root layer.
+         *
+         * @param layers available layers iterator
+         * @param layersGroups available layer groups iterator
          */
-        private void handleRootBbox(Iterator<LayerInfo> layers) {
+        private void handleRootBbox(Iterator<LayerInfo> layers, Iterator<LayerGroupInfo> layersGroups) {
 
             final Envelope world = new Envelope(-180, 180, -90, 90);
-            
             Envelope latlonBbox = new Envelope();
-            Envelope layerBbox = null;
 
             LOGGER.finer("Collecting summarized latlonbbox and common SRS...");
 
-            while(layers.hasNext()) {
-                LayerInfo layer = layers.next();
-                ResourceInfo resource = layer.getResource();
-                layerBbox = resource.getLatLonBoundingBox();
-                if (layerBbox != null) {
-                    latlonBbox.expandToInclude(layerBbox);    
+            // handle layers
+            while (layers.hasNext()) {
+                if (expandEnvelopeToContain(world, latlonBbox,
+                        layers.next().getResource().getLatLonBoundingBox())) {
+                    // our envelope already contains the world
+                    break;
                 }
+            }
 
-                //short cut for the case where we already reached the whole world bounds
-                if(latlonBbox.contains(world)){
+            // handle layer groups
+            while (layersGroups.hasNext()) {
+                LayerGroupInfo layerGroup = layersGroups.next();
+                ReferencedEnvelope referencedEnvelope = layerGroup.getBounds();
+                if (referencedEnvelope == null) {
+                    // no bounds available move on
+                    continue;
+                }
+                if (!CRS.equalsIgnoreMetadata(referencedEnvelope, DefaultGeographicCRS.WGS84)) {
+                    try {
+                        // we need to reproject the envelope to lat / lon
+                        referencedEnvelope = referencedEnvelope.transform(DefaultGeographicCRS.WGS84, true);
+                    } catch (Exception exception) {
+                        LOGGER.log(Level.WARNING, String.format(
+                                "Failed to transform layer group '%s' bounds to WGS84.",
+                                layerGroup.getName()), exception);
+                    }
+                }
+                if (expandEnvelopeToContain(world, latlonBbox, referencedEnvelope)) {
+                    // our envelope already contains the world
                     break;
                 }
             }
@@ -823,6 +854,17 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             handleBBox(latlonBbox, "CRS:84");
             handleAdditionalBBox(
                 new ReferencedEnvelope(latlonBbox, DefaultGeographicCRS.WGS84), null, null);
+        }
+
+        /**
+         * Helper method that expand a provided envelope to contain a resource envelope.
+         * If the extended envelope contains the world envelope TRUE is returned.
+         */
+        private boolean expandEnvelopeToContain(Envelope world, Envelope envelope, Envelope resourceEnvelope) {
+            if (resourceEnvelope != null) {
+                envelope.expandToInclude(resourceEnvelope);
+            }
+            return envelope.contains(world);
         }
 
         private void handleLayerTree(final Iterator<LayerInfo> layers, Set<LayerInfo> layersAlreadyProcessed) {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
@@ -20,6 +20,7 @@ import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.AttributionInfo;
+import org.geoserver.catalog.CascadeDeleteVisitor;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.DataLinkInfo;
@@ -34,19 +35,33 @@ import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.AbstractDecorator;
+import org.geoserver.catalog.impl.DataStoreInfoImpl;
+import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
+import org.geoserver.catalog.impl.LayerInfoImpl;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.NamespaceInfoImpl;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ows.util.OwsUtils;
 import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSTestSupport;
 import org.geoserver.wms.map.OpenLayersMapOutputFormat;
+import org.geotools.feature.NameImpl;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import java.lang.reflect.Proxy;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * WMS 1.3 GetCapabilities integration tests
@@ -190,7 +205,7 @@ public class CapabilitiesIntegrationTest extends WMSTestSupport {
         assertEquals(0, xpath
                 .getMatchingNodes("//wms:Layer/wms:Name[starts-with(., 'cite:Forests')]", dom)
                 .getLength());
-        assertEquals(3, xpath.getMatchingNodes("//wms:Layer/wms:Layer", dom).getLength());
+        assertEquals(1, xpath.getMatchingNodes("//wms:Layer/wms:Layer", dom).getLength());
 
         NodeList nodes = xpath.getMatchingNodes("//wms:Layer//wms:OnlineResource", dom);
         assertTrue(nodes.getLength() > 0);
@@ -675,4 +690,219 @@ public class CapabilitiesIntegrationTest extends WMSTestSupport {
         }
     }
 
+    @Test
+    public void testGlobalBoundingBoxForLayerGroups() throws Exception {
+        Catalog catalog = getCatalog();
+        // create a new workspace for this tests
+        WorkspaceInfoImpl workspace = new WorkspaceInfoImpl();
+        workspace.setName("NON_ADVERTISED");
+        NamespaceInfoImpl nameSpace = new NamespaceInfoImpl();
+        nameSpace.setPrefix("NON_ADVERTISED");
+        nameSpace.setURI("http://non-advertised.org");
+        // remove all layer groups and store them
+        List<LayerGroupInfo> layerGroups = catalog.getLayerGroups().stream()
+                .map(this::unwrapLayerGroup).collect(Collectors.toList());
+        catalog.getLayerGroups().forEach(catalog::remove);
+        try {
+            catalog.add(workspace);
+            catalog.add(nameSpace);
+            // add some layers by duplicating existing layers and create a layer group
+            LayerInfo layer1 = cloneVectorLayerIntoWorkspace(workspace, nameSpace, MockData.BUILDINGS.getLocalPart());
+            LayerInfo layer2 = cloneVectorLayerIntoWorkspace(workspace, nameSpace, MockData.BRIDGES.getLocalPart());
+            LayerGroupInfo layerGroup = createLayerGroup(workspace, "NON_ADVERTISED", layer1, layer2);
+            // reduce layer group bounds and store the original bounds which correspond to all layers bounds
+            ReferencedEnvelope layersBounds = layerGroup.getBounds();
+            ReferencedEnvelope layerGroupBounds = new ReferencedEnvelope(-10, 10, -20, 20, layersBounds.getCoordinateReferenceSystem());
+            layerGroup.setBounds(layerGroupBounds);
+            catalog.save(layerGroup);
+            // perform a get capabilities request targeting only the created workspace
+            Document document = getAsDOM("NON_ADVERTISED/wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+            checkGlobalBoundingBox(layersBounds, document);
+            // make layers non advertised
+            layer1.setAdvertised(false);
+            layer2.setAdvertised(false);
+            catalog.save(layer1);
+            catalog.save(layer2);
+            // perform a get capabilities request targeting only the created workspace
+            document = getAsDOM("NON_ADVERTISED/wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+            checkGlobalBoundingBox(layerGroupBounds, document);
+        } finally {
+            // add layer groups back
+            layerGroups.forEach(catalog::add);
+            // remove the created workspace and namespace
+            CascadeDeleteVisitor deleteVisitor = new CascadeDeleteVisitor(catalog);
+            deleteVisitor.visit(workspace);
+            catalog.remove(nameSpace);
+            catalog.remove(workspace);
+        }
+    }
+
+    @Test
+    public void testLayerGroupsPerWorkspace() throws Exception {
+        Catalog catalog = getCatalog();
+        // create workspace A
+        WorkspaceInfoImpl workspaceA = new WorkspaceInfoImpl();
+        workspaceA.setName("LG_TEST_WORKSPACE_A");
+        NamespaceInfoImpl nameSpaceA = new NamespaceInfoImpl();
+        nameSpaceA.setPrefix("LG_TEST_WORKSPACE_A");
+        nameSpaceA.setURI("http://lg-test-workspace-a.org");
+        // create workspace B
+        WorkspaceInfoImpl workspaceB = new WorkspaceInfoImpl();
+        workspaceB.setName("LG_TEST_WORKSPACE_B");
+        NamespaceInfoImpl nameSpaceB = new NamespaceInfoImpl();
+        nameSpaceB.setPrefix("LG_TEST_WORKSPACE_B");
+        nameSpaceB.setURI("http://lg-test-workspace-b.org");
+        // keep global layers group reference
+        LayerGroupInfo globalLayerGroup = null;
+        try {
+            // save workspace A
+            catalog.add(workspaceA);
+            catalog.add(nameSpaceA);
+            // save workspace B
+            catalog.add(workspaceB);
+            catalog.add(nameSpaceB);
+            // create layers groups
+            createLayerGroup(workspaceA, "LAYER_GROUP_A",
+                    cloneVectorLayerIntoWorkspace(workspaceA, nameSpaceA, MockData.BUILDINGS.getLocalPart()),
+                    cloneVectorLayerIntoWorkspace(workspaceA, nameSpaceA, MockData.BRIDGES.getLocalPart()));
+            createLayerGroup(workspaceB, "LAYER_GROUP_B",
+                    cloneVectorLayerIntoWorkspace(workspaceB, nameSpaceB, MockData.BUILDINGS.getLocalPart()),
+                    cloneVectorLayerIntoWorkspace(workspaceB, nameSpaceB, MockData.BRIDGES.getLocalPart()));
+            globalLayerGroup = createLayerGroup("LAYER_GROUP_C",
+                    catalog.getLayerByName(MockData.BUILDINGS.getLocalPart()),
+                    catalog.getLayerByName(MockData.BRIDGES.getLocalPart()));
+            // perform a get capabilities request targeting the global service
+            Document document = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+            assertXpathEvaluatesTo("1", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LG_TEST_WORKSPACE_A:LAYER_GROUP_A'])", document);
+            assertXpathEvaluatesTo("1", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LG_TEST_WORKSPACE_B:LAYER_GROUP_B'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_A'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_B'])", document);
+            assertXpathEvaluatesTo("1", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_C'])", document);
+            // perform a get capabilities request targeting workspace A service
+            document = getAsDOM("LG_TEST_WORKSPACE_A/wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LG_TEST_WORKSPACE_A:LAYER_GROUP_A'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LG_TEST_WORKSPACE_B:LAYER_GROUP_B'])", document);
+            assertXpathEvaluatesTo("1", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_A'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_B'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_C'])", document);
+            // perform a get capabilities request targeting workspace B service
+            document = getAsDOM("LG_TEST_WORKSPACE_B/wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LG_TEST_WORKSPACE_A:LAYER_GROUP_A'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LG_TEST_WORKSPACE_B:LAYER_GROUP_B'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_A'])", document);
+            assertXpathEvaluatesTo("1", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_B'])", document);
+            assertXpathEvaluatesTo("0", "count(//wms:Capability/wms:Layer/wms:Layer[wms:Name='LAYER_GROUP_C'])", document);
+        } finally {
+            // remove the created workspaces and namespaces
+            CascadeDeleteVisitor deleteVisitor = new CascadeDeleteVisitor(catalog);
+            deleteVisitor.visit(workspaceA);
+            catalog.remove(nameSpaceA);
+            catalog.remove(workspaceA);
+            deleteVisitor.visit(workspaceB);
+            catalog.remove(nameSpaceB);
+            catalog.remove(workspaceB);
+            // remove global layer group
+            if (globalLayerGroup != null) {
+                catalog.remove(globalLayerGroup);
+            }
+        }
+    }
+
+    /**
+     * Check that the global bounding box matches the expected envelope
+     */
+    private void checkGlobalBoundingBox(ReferencedEnvelope expectedBoundingBox, Document capabilitiesResult) throws Exception {
+        // check that the returned capabilities document contains the correct bounding box
+        assertXpathEvaluatesTo("1", String.format("count(//wms:Capability/wms:Layer" +
+                        "/wms:EX_GeographicBoundingBox" +
+                        "[wms:westBoundLongitude='%.1f'][wms:eastBoundLongitude='%.1f']" +
+                        "[wms:southBoundLatitude='%.1f'][wms:northBoundLatitude='%.1f'])",
+                expectedBoundingBox.getMinX(), expectedBoundingBox.getMaxX(),
+                expectedBoundingBox.getMinY(), expectedBoundingBox.getMaxY()), capabilitiesResult);
+    }
+
+    /**
+     * Helper method that unwraps a layer group making him suitable to be added
+     * to the catalog. If proxyfied the proxy will also be removed.
+     */
+    private LayerGroupInfo unwrapLayerGroup(LayerGroupInfo layerGroup) {
+        // get the original layer group object
+        while (layerGroup instanceof AbstractDecorator) {
+            AbstractDecorator decorator = (AbstractDecorator) layerGroup;
+            layerGroup = (LayerGroupInfo) decorator.unwrap(LayerGroupInfo.class);
+        }
+        // catalog detach doesn't work for layer groups
+        if (Proxy.isProxyClass(layerGroup.getClass())) {
+            // we have a proxy we need to get rid of the proxy
+            ModificationProxy proxy = (ModificationProxy) Proxy.getInvocationHandler(layerGroup);
+            proxy.commit();
+            layerGroup = (LayerGroupInfo) proxy.getProxyObject();
+        }
+        return layerGroup;
+    }
+
+    /**
+     * Helper method that creates a layer group using the provided name and layers.
+     */
+    private LayerGroupInfo createLayerGroup(String layerGroupName, LayerInfo... layers) throws Exception {
+        return createLayerGroup(null, layerGroupName, layers);
+    }
+
+    /**
+     * Helper method that creates a layer group using the provided name, workspace and layers.
+     */
+    private LayerGroupInfo createLayerGroup(WorkspaceInfo workspace, String layerGroupName, LayerInfo... layers) throws Exception {
+        // create a new layer group using the provided name
+        LayerGroupInfo layerGroup = getCatalog().getFactory().createLayerGroup();
+        layerGroup.setName(layerGroupName);
+        // set workspace
+        layerGroup.setWorkspace(workspace);
+        // add the provided layers
+        for (LayerInfo layerInfo : layers) {
+            layerGroup.getLayers().add(layerInfo);
+        }
+        // set the layer group bounds by merging all layers bounds
+        CatalogBuilder catalogBuilder = new CatalogBuilder(getCatalog());
+        catalogBuilder.calculateLayerGroupBounds(layerGroup);
+        getCatalog().add(layerGroup);
+        // retrieve the created layer group by name
+        if (workspace == null) {
+            return getCatalog().getLayerGroupByName(layerGroupName);
+        }
+        return getCatalog().getLayerGroupByName(workspace, layerGroupName);
+    }
+
+    /**
+     * Helper method that clones vector layer into a certain workspace.
+     */
+    private LayerInfo cloneVectorLayerIntoWorkspace(WorkspaceInfoImpl workspace, NamespaceInfoImpl nameSpace, String layerName) {
+        Catalog catalog = getCatalog();
+        // get the original object from the catalog
+        LayerInfo originalLayerInfo = catalog.getLayerByName(layerName);
+        FeatureTypeInfo originalFeatureTypeInfo = (FeatureTypeInfo) originalLayerInfo.getResource();
+        DataStoreInfo originalStoreInfo = originalFeatureTypeInfo.getStore();
+        // copy the data store, changing is workspace, id and name
+        DataStoreInfoImpl copyDataStoreInfo = new DataStoreInfoImpl(catalog);
+        OwsUtils.copy(originalStoreInfo, copyDataStoreInfo, DataStoreInfo.class);
+        copyDataStoreInfo.setId(UUID.randomUUID().toString());
+        copyDataStoreInfo.setName(UUID.randomUUID().toString());
+        copyDataStoreInfo.setWorkspace(workspace);
+        // copy the feature type info, changing the data store and name space
+        FeatureTypeInfoImpl copyFeatureTypeInfo = new FeatureTypeInfoImpl(catalog);
+        OwsUtils.copy(originalFeatureTypeInfo, copyFeatureTypeInfo, FeatureTypeInfo.class);
+        copyFeatureTypeInfo.setNamespace(nameSpace);
+        copyFeatureTypeInfo.setStore(copyDataStoreInfo);
+        // copy the layer, changing the feature type
+        LayerInfoImpl copyLayerInfo = new LayerInfoImpl();
+        OwsUtils.copy(originalLayerInfo, copyLayerInfo, LayerInfo.class);
+        copyLayerInfo.setId(layerName);
+        copyLayerInfo.setName(layerName);
+        copyLayerInfo.setResource(copyFeatureTypeInfo);
+        // add everything to the catalog
+        catalog.add(copyDataStoreInfo);
+        catalog.add(copyFeatureTypeInfo);
+        catalog.add(copyLayerInfo);
+        // retrieve the cloned layer by name
+        return catalog.getLayerByName(new NameImpl(nameSpace.getPrefix(), layerName));
+    }
 }


### PR DESCRIPTION
Backport of this pull requests: https://github.com/geoserver/geoserver/pull/2203

Makes WMS 1.3.0 capabilities transform use layer groups to compute the global bounding box. This pull request also adds a test case.

Makes WMS capabilities also filter layer groups by namespaces like layers a test case for this is also added.

Associated issues:
- https://osgeo-org.atlassian.net/browse/GEOS-8072
- https://osgeo-org.atlassian.net/browse/GEOS-5176
