### PR TITLE
REST API refresh - Disable failing community modules

### DIFF
--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -37,8 +37,8 @@
       <configuration>
         <descriptors>
           <descriptor>release/ext-authkey.xml</descriptor>
-          <descriptor>release/ext-groovy.xml</descriptor>
-          <descriptor>release/ext-javascript.xml</descriptor>
+          <!-- <descriptor>release/ext-groovy.xml</descriptor> -->
+          <!-- <descriptor>release/ext-javascript.xml</descriptor> -->
           <descriptor>release/ext-spatialite.xml</descriptor>
           <descriptor>release/ext-jdbcconfig.xml</descriptor>
           <descriptor>release/ext-dds.xml</descriptor>
@@ -49,17 +49,17 @@
           <descriptor>release/ext-geopkg.xml</descriptor>
           <descriptor>release/ext-pgraster.xml</descriptor>
           <descriptor>release/ext-dyndimension.xml</descriptor>
-          <descriptor>release/ext-rest-ext.xml</descriptor>
+          <!-- <descriptor>release/ext-rest-ext.xml</descriptor> -->
           <descriptor>release/ext-kmlppio.xml</descriptor>
           <descriptor>release/ext-gpx.xml</descriptor>
           <descriptor>release/ext-wps-download.xml</descriptor>
-          <descriptor>release/ext-jms-cluster.xml</descriptor>
+          <!-- <descriptor>release/ext-jms-cluster.xml</descriptor> -->
           <descriptor>release/ext-hz-cluster.xml</descriptor>
           <descriptor>release/ext-activeMQ.xml</descriptor>	
           <descriptor>release/ext-solr.xml</descriptor>		  
-          <descriptor>release/ext-geofence.xml</descriptor>
-          <descriptor>release/ext-sldservice.xml</descriptor>
-          <descriptor>release/ext-rest-upload.xml</descriptor>
+          <!-- <descriptor>release/ext-geofence.xml</descriptor> -->
+          <!-- <descriptor>release/ext-sldservice.xml</descriptor> -->
+          <!-- <descriptor>release/ext-rest-upload.xml</descriptor> -->
           <descriptor>release/ext-gwc-distributed.xml</descriptor>  
           <descriptor>release/ext-geofence-server.xml</descriptor>
           <descriptor>release/ext-gwc-s3.xml</descriptor>	
@@ -72,14 +72,14 @@
           <descriptor>release/ext-jdbcstore.xml</descriptor>
           <descriptor>release/ext-ncwms.xml</descriptor>
           <descriptor>release/ext-gwc-sqlite.xml</descriptor> 
-          <descriptor>release/ext-geogig.xml</descriptor>
+          <!-- <descriptor>release/ext-geogig.xml</descriptor> -->
           <descriptor>release/ext-oauth2-google.xml</descriptor>
           <descriptor>release/ext-oauth2-github.xml</descriptor>
           <descriptor>release/ext-oauth2-geonode.xml</descriptor>
-          <descriptor>release/ext-backup-restore.xml</descriptor>
+          <!-- <descriptor>release/ext-backup-restore.xml</descriptor> -->
           <descriptor>release/ext-wmts-multi-dimensional.xml</descriptor> 
           <descriptor>release/ext-onelogin.xml</descriptor> 
-          <descriptor>release/ext-notification.xml</descriptor> 
+          <!-- <descriptor>release/ext-notification.xml</descriptor> -->
           <descriptor>release/ext-ows-simulate.xml</descriptor> 
           <descriptor>release/ext-jdbc-metrics.xml</descriptor>
           <descriptor>release/ext-opensearch-eo.xml</descriptor>  
@@ -199,34 +199,34 @@
         <module>spatialite</module>
         <module>jdbcconfig</module>
         <module>feature-aggregate</module>
-        <module>script</module>
+        <!-- <module>script</module> -->
         <module>wms-eo</module>
         <module>colormap</module>
         <module>mbtiles</module>
         <module>geopkg</module>
         <module>pgraster</module>
         <module>dyndimension</module>
-        <module>rest-ext</module>
+        <!-- <module>rest-ext</module> -->
         <module>gpxppio</module>
         <module>kmlppio</module>
         <module>wps-download</module>
-        <module>jms-cluster</module>
+        <!-- <module>jms-cluster</module> -->
         <module>hz-cluster</module>
         <module>solr</module>
-        <module>rest-upload</module>
-        <module>geofence</module>
+        <!-- <module>rest-upload</module> -->
+        <!-- <module>geofence</module> -->
         <module>geofence-server</module>
-        <module>sldService</module>
+        <!-- <module>sldService</module> -->
         <module>params-extractor</module>
         <module>wps-remote</module>
         <module>wps-jdbc</module>
         <module>release</module>
-        <module>geogig</module>
+        <!-- <module>geogig</module> -->
         <module>gwc-distributed</module>
         <module>jdbcstore</module>
         <module>gdal</module>
         <module>gwc-s3</module>
-        <module>backup-restore</module>
+        <!-- <module>backup-restore</module> -->
         <module>ncwms</module>
         <module>web-resource</module>
         <module>gwc-sqlite</module>
@@ -236,7 +236,7 @@
         <module>security/oauth2-geonode</module>
         <module>wmts-multi-dimensional</module>
         <module>onelogin</module>
-        <module>notification</module>
+        <!-- <module>notification</module> -->
         <module>notification-common</module>
         <module>notification-geonode</module>
         <module>ows-simulate</module>

--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -33,7 +33,7 @@
      <artifactId>gs-wps-download</artifactId>
      <version>${project.version}</version>
    </dependency>   
-   <dependency>
+   <!-- <dependency>
      <groupId>org.geoserver.script</groupId>
      <artifactId>gs-script-py</artifactId>
      <version>${project.version}</version>
@@ -47,7 +47,7 @@
      <groupId>org.geoserver.script</groupId>
      <artifactId>gs-script-groovy</artifactId>
      <version>${project.version}</version>
-   </dependency>
+   </dependency> -->
    <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-jdbcconfig</artifactId>
@@ -93,11 +93,11 @@
      <artifactId>gs-dyndimension</artifactId>
      <version>${project.version}</version>
    </dependency>
-   <dependency>
+   <!-- <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-rest-ext</artifactId>
      <version>${project.version}</version>
-   </dependency>
+   </dependency> -->
    <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-pgraster</artifactId>
@@ -113,36 +113,36 @@
      <artifactId>gs-gpxppio</artifactId>
      <version>${project.version}</version>
    </dependency>
-   <dependency>
+   <!-- <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-jms-geoserver</artifactId>
      <version>${project.version}</version>
-   </dependency>  
+   </dependency>
    <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-jms-commons</artifactId>
      <version>${project.version}</version>
-   </dependency>
+   </dependency> -->
    <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-hz-cluster</artifactId>
       <version>${project.version}</version>
    </dependency>  
-   <dependency>
+   <!-- <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-geofence</artifactId>
      <version>${project.version}</version>
-   </dependency>   
+   </dependency> -->
    <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-geofence-server</artifactId>
      <version>${project.version}</version>
    </dependency>   
-   <dependency>
+   <!-- <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-sldservice</artifactId>
      <version>${project.version}</version>
-   </dependency>
+   </dependency> -->
    <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-web-solr</artifactId>
@@ -193,12 +193,12 @@
      <artifactId>gs-gwc-sqlite</artifactId>
      <version>${project.version}</version>
    </dependency>
-   <dependency>
+   <!-- <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-geogig</artifactId>
      <version>${project.version}</version>
-   </dependency>
-   <dependency>
+   </dependency>. -->
+   <!-- <dependency>
      <groupId>org.geoserver.community.backuprestore</groupId>
      <artifactId>gs-backup-restore-core</artifactId>
      <version>${project.version}</version>
@@ -217,7 +217,7 @@
      <groupId>org.geoserver.community.backuprestore</groupId>
      <artifactId>gs-backup-restore-web</artifactId>
      <version>${project.version}</version>
-   </dependency>
+   </dependency> -->
    <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-wmts-multi-dimensional</artifactId>
@@ -243,11 +243,11 @@
      <artifactId>gs-onelogin</artifactId>
      <version>${project.version}</version>
    </dependency>
-   <dependency>
+   <!-- <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-notification</artifactId>
      <version>${project.version}</version>
-   </dependency>
+   </dependency> -->
    <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-notification-common</artifactId>


### PR DESCRIPTION
Now that #2216 is merged, there are some failing community modules.

This PR disables these modules, until such time that they can be updated.