### PR TITLE
Restrict hamcrest-library to test scope and harmonise versions (master)

### DIFF
--- a/src/community/hz-cluster/pom.xml
+++ b/src/community/hz-cluster/pom.xml
@@ -62,13 +62,11 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-integration</artifactId>
-      <version>1.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/extension/monitor/core/pom.xml
+++ b/src/extension/monitor/core/pom.xml
@@ -65,6 +65,11 @@
     <artifactId>jsoup</artifactId>
     <scope>test</scope>
   </dependency>
+  <dependency>
+    <groupId>org.hamcrest</groupId>
+    <artifactId>hamcrest-library</artifactId>
+    <scope>test</scope>
+  </dependency>
  </dependencies>
 
  <build>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -628,6 +628,11 @@
     <version>1.3</version>
    </dependency>
    <dependency>
+    <groupId>org.hamcrest</groupId>
+    <artifactId>hamcrest-integration</artifactId>
+    <version>1.3</version>
+   </dependency>
+   <dependency>
     <groupId>xmlunit</groupId>
     <artifactId>xmlunit</artifactId>
     <version>1.3</version>

--- a/src/restconfig/pom.xml
+++ b/src/restconfig/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geotools.jdbc</groupId>


### PR DESCRIPTION
This PR also harmonises hz-cluster hamcrest versions and places them under dependency management. Backports of this latter change to 2.11.x and 2.10.x in https://github.com/geoserver/geoserver/pull/2239 and https://github.com/geoserver/geoserver/pull/2240 respectively.