### PR TITLE
Use dependency management for hz-cluster hamcrest versions (2.11.x)

### DIFF
--- a/src/community/hz-cluster/pom.xml
+++ b/src/community/hz-cluster/pom.xml
@@ -62,13 +62,11 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-integration</artifactId>
-      <version>1.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -608,6 +608,11 @@
     <version>1.3</version>
    </dependency>
    <dependency>
+    <groupId>org.hamcrest</groupId>
+    <artifactId>hamcrest-integration</artifactId>
+    <version>1.3</version>
+   </dependency>
+   <dependency>
     <groupId>xmlunit</groupId>
     <artifactId>xmlunit</artifactId>
     <version>1.3</version>


### PR DESCRIPTION
Backport of the hz-cluster part of https://github.com/geoserver/geoserver/pull/2238 .