### PR TITLE
[GEOS-7946] Remove leftover PowerMock dependencies from POM

### DIFF
--- a/src/platform/pom.xml
+++ b/src/platform/pom.xml
@@ -74,14 +74,6 @@
    <artifactId>junit</artifactId>
   </dependency>
   <dependency>
-   <groupId>org.powermock</groupId>
-   <artifactId>powermock-module-junit4</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>org.powermock</groupId>
-   <artifactId>powermock-api-mockito</artifactId>
-  </dependency>
-  <dependency>
    <groupId>xmlunit</groupId>
    <artifactId>xmlunit</artifactId>
    <scope>test</scope>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -599,25 +599,6 @@
     <scope>test</scope>
    </dependency>
    <dependency>
-    <groupId>org.powermock</groupId>
-    <artifactId>powermock-module-junit4</artifactId>
-    <version>${powermock.version}</version>
-    <scope>test</scope>
-   </dependency>
-   <dependency>
-    <groupId>org.powermock</groupId>
-    <artifactId>powermock-api-mockito</artifactId>
-    <version>${powermock.version}</version>
-    <scope>test</scope>
-   </dependency>
-   <!-- forcing javassist to 3.20.0-GA helps powermock mocking System.getProperty -->
-   <dependency>
-    <groupId>org.javassist</groupId>
-    <artifactId>javassist</artifactId>
-    <version>3.20.0-GA</version>
-    <scope>test</scope>
-   </dependency>
-   <dependency>
     <groupId>org.hamcrest</groupId>
     <artifactId>hamcrest-library</artifactId>
     <version>1.3</version>
@@ -1861,7 +1842,6 @@
   <jackson1.version>1.9.13</jackson1.version>
   <jackson2.version>2.5.0</jackson2.version>
   <compress-lzf.version>1.0.3</compress-lzf.version>
-  <powermock.version>1.4.9</powermock.version>
  </properties>
 
  <profiles>


### PR DESCRIPTION
I forgot to remove these deps that are no longer needed after the refactoring to `FileSystemResourceStoreTest`.