### PR TITLE
[GEOS-8088] WMS 1.3.0 GlobalBoundingBoxForLayerGroups test is locale dependent (2.10.x)

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
@@ -8,7 +8,13 @@ package org.geoserver.wms.wms_1_3;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.custommonkey.xmlunit.XMLUnit.newXpathEngine;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +58,7 @@ import org.geoserver.wms.map.OpenLayersMapOutputFormat;
 import org.geotools.feature.NameImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -772,12 +779,37 @@ public class CapabilitiesIntegrationTest extends WMSTestSupport {
      */
     private void checkGlobalBoundingBox(ReferencedEnvelope expectedBoundingBox, Document capabilitiesResult) throws Exception {
         // check that the returned capabilities document contains the correct bounding box
-        assertXpathEvaluatesTo("1", String.format("count(//wms:Capability/wms:Layer" +
-                        "/wms:EX_GeographicBoundingBox" +
-                        "[wms:westBoundLongitude='%.1f'][wms:eastBoundLongitude='%.1f']" +
-                        "[wms:southBoundLatitude='%.1f'][wms:northBoundLatitude='%.1f'])",
-                expectedBoundingBox.getMinX(), expectedBoundingBox.getMaxX(),
-                expectedBoundingBox.getMinY(), expectedBoundingBox.getMaxY()), capabilitiesResult);
+        XpathEngine xpath = newXpathEngine();
+        // extract bounding box values from the capabilities document
+        String minX = xpath.evaluate("//wms:Capability/wms:Layer/wms:EX_GeographicBoundingBox/wms:westBoundLongitude/text()", capabilitiesResult);
+        String maxX = xpath.evaluate("//wms:Capability/wms:Layer/wms:EX_GeographicBoundingBox/wms:eastBoundLongitude/text()", capabilitiesResult);
+        String minY = xpath.evaluate("//wms:Capability/wms:Layer/wms:EX_GeographicBoundingBox/wms:southBoundLatitude/text()", capabilitiesResult);
+        String maxY = xpath.evaluate("//wms:Capability/wms:Layer/wms:EX_GeographicBoundingBox/wms:northBoundLatitude/text()", capabilitiesResult);
+        // check bounding box values
+        checkNumberSimilar(minX, expectedBoundingBox.getMinX(), 0.0001);
+        checkNumberSimilar(maxX, expectedBoundingBox.getMaxX(), 0.0001);
+        checkNumberSimilar(minY, expectedBoundingBox.getMinY(), 0.0001);
+        checkNumberSimilar(maxY, expectedBoundingBox.getMaxY(), 0.0001);
+    }
+
+    /**
+     * Check that a number represent by a string is similar to the expected number
+     * A number is considered similar to another if the difference between them is
+     * inferior or equal to the provided precision.
+     */
+    private void checkNumberSimilar(String rawValue, double expected, double precision) {
+        // try to extract a double value
+        assertThat(rawValue, is(notNullValue()));
+        assertThat(rawValue.trim().isEmpty(), is(false));
+        double value = 0;
+        try {
+            value = Double.parseDouble(rawValue);
+        } catch (NumberFormatException exception) {
+            fail(String.format("Value '%s' is not a number.", rawValue));
+        }
+        // compare the parsed double value with the expected one
+        double difference = Math.abs(expected - value);
+        assertThat(difference <= precision, is(true));
     }
 
     /**


### PR DESCRIPTION
Backport of this pull request: https://github.com/geoserver/geoserver/pull/2244
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8088