### PR TITLE
[GEOS-7946] Using java.nio.file.Files.move() with ATOMIC_MOVE option to avoid case sensitivity issues

### DIFF
--- a/src/platform/pom.xml
+++ b/src/platform/pom.xml
@@ -72,7 +72,6 @@
   <dependency>
    <groupId>junit</groupId>
    <artifactId>junit</artifactId>
-   <scope>test</scope>
   </dependency>
   <dependency>
    <groupId>xmlunit</groupId>

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -136,7 +136,10 @@ public class FileSystemResourceStore implements ResourceStore {
 
         try {
             dest.getParentFile().mkdirs(); // Make sure there's somewhere to move to.
-            return Files.move(file, dest);
+            java.nio.file.Files.move(java.nio.file.Paths.get(file.getAbsolutePath()),
+                    java.nio.file.Paths.get(dest.getAbsolutePath()),
+                    StandardCopyOption.ATOMIC_MOVE);
+            return true;
         } catch (IOException e) {
             throw new IllegalStateException("Unable to move " + path + " to " + target, e);
         }

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -379,13 +379,14 @@ public final class Files {
         if( dest == null ){
             throw new NullPointerException("File dest required");
         }
-        // same path? Do nothing
-        if (source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath())){
-            return true;
-        }
+
+        boolean win = System.getProperty("os.name").startsWith("Windows");
+        boolean samePath = win ?
+            source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath()) :
+            source.getCanonicalPath().equals(dest.getCanonicalPath());
+        if (samePath) return true;
 
         // windows needs special treatment, we cannot rename onto an existing file
-        boolean win = System.getProperty("os.name").startsWith("Windows");
         if ( win && dest.exists() ) {
             // windows does not do atomic renames, and can not rename a file if the dest file
             // exists
@@ -422,7 +423,7 @@ public final class Files {
      * (but not the directory itself). For each
      * file that cannot be deleted a warning log will be issued.
      * 
-     * @param dir
+     * @param directory
      * @throws IOException
      * @returns true if all the directory contents could be deleted, false otherwise
      */

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceStoreTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceStoreTest.java
@@ -1,0 +1,100 @@
+package org.geoserver.platform.resource;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class FileSystemResourceStoreTest {
+
+    TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void initTmpFolder() throws IOException {
+        folder = new TemporaryFolder();
+        folder.create();
+    }
+
+    @After
+    public void deleteTmpFolder() throws IOException {
+        folder.delete();
+    }
+
+    @Test
+    public void renameSameFileName() throws IOException, InterruptedException {
+        String sameName = "Filea";
+
+        attemptRenameFile(sameName, sameName);
+
+        assertEquals(sameName, folder.getRoot().list()[0]);
+    }
+
+    @Test
+    public void renameFileNamesCaseDiffer() throws IOException, InterruptedException {
+        String newName = "Filea";
+
+        attemptRenameFile("FileA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+    @Test
+    public void renameFileNamesDiffer() throws IOException, InterruptedException {
+        String newName = "FileB";
+
+        attemptRenameFile("FileA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+    @Test
+    public void renameSameDirName() throws IOException, InterruptedException {
+        String sameName = "Dira";
+
+        attemptRenameDir(sameName, sameName);
+
+        assertEquals(sameName, folder.getRoot().list()[0]);
+    }
+
+    @Test
+    public void renameDirNamesCaseDiffer() throws IOException, InterruptedException {
+        String newName = "Dira";
+
+        attemptRenameDir("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+    @Test
+    public void renameDirNamesDiffer() throws IOException, InterruptedException {
+        String newName = "DirB";
+
+        attemptRenameDir("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+    private void attemptRenameDir(String oldName, String newName) throws IOException {
+        File toBeRenamed = folder.newFolder(oldName);
+        attemptRename(oldName, newName);
+    }
+
+    private void attemptRenameFile(String oldName, String newName) throws IOException {
+        File toBeRenamed = folder.newFile(oldName);
+        attemptRename(oldName, newName);
+    }
+
+    private void attemptRename(String oldName, String newName) throws IOException {
+        assertEquals(1, folder.getRoot().list().length);
+        FileSystemResourceStore toTest = new FileSystemResourceStore(folder.getRoot());
+
+        toTest.move(oldName, newName);
+
+        assertEquals(1, folder.getRoot().list().length);
+    }
+}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -596,6 +596,7 @@
     <groupId>junit</groupId>
     <artifactId>junit</artifactId>
     <version>4.11</version>
+    <scope>test</scope>
    </dependency>
    <dependency>
     <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Backport of #2202 #2217 #2243 , after squashing.