### PR TITLE
Property to control global layer group visibility in virtual services, GEOS-8091

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/util/GeoServerPropertyFactoryBean.java
+++ b/src/platform/src/main/java/org/geoserver/platform/util/GeoServerPropertyFactoryBean.java
@@ -1,0 +1,97 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.platform.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.geoserver.platform.GeoServerExtensions;
+import org.geotools.util.logging.Logging;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * Spring FactoryBean that can create a bean based on the value of a system property, context 
+ * parameter, or environment variable
+ * 
+ * @author Kevin Smith, Boundless
+ *
+ * @param <T>
+ */
+public abstract class GeoServerPropertyFactoryBean<T> extends AbstractFactoryBean<T> implements ApplicationContextAware {
+    private static final Logger LOGGER = Logging.getLogger(GeoServerPropertyFactoryBean.class);
+    
+    private ApplicationContext applicationContext;
+    
+    private final String propertyName;
+    private String defaultValue;
+    
+    /**
+     * @param propertyName The property to check when creating a bean
+     */
+    public GeoServerPropertyFactoryBean(final String propertyName) {
+        super();
+        this.propertyName = propertyName;
+    }
+    
+    @Override
+    protected T createInstance() throws Exception {
+        String value = GeoServerExtensions.getProperty(propertyName, applicationContext);
+        Object[] logParams = new Object[]{propertyName, value, getDefaultValue()};
+        if(value == null || value.isEmpty()) {
+            LOGGER.log(Level.INFO, "{0} was empty or undefined, using default \"{2}\" instead", logParams);
+            return getDefaultBean();
+        }
+        T bean = createInstance(value);
+        if(bean==null) {
+            LOGGER.log(Level.WARNING, "{0} had unexpected value \"{1}\", using default \"{2}\" instead", logParams);
+            bean = getDefaultBean();
+        }
+        return bean;
+    }
+    
+    private T getDefaultBean() throws Exception {
+        String value = getDefaultValue();
+        if(value == null) {
+            throw new IllegalStateException("No default value for "+propertyName);
+        }
+        T defaultBean = createInstance(value);
+        if(defaultBean == null) {
+            throw new IllegalStateException(propertyName+" default value \""+value+"\" did not prduce a bean");
+        }
+        return defaultBean;
+    }
+
+    /**
+     * Create a bean based on the given property value
+     * @param propertyValue
+     * @return
+     */
+    protected abstract T createInstance(final String propertyValue) throws Exception;
+    
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext)
+            throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+    
+    /**
+     * @return the defaultValue
+     */
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * @param defaultValue the defaultValue to set
+     */
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+}

--- a/src/platform/src/test/java/org/geoserver/platform/util/GeoServerPropertyFactoryBeanTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/util/GeoServerPropertyFactoryBeanTest.java
@@ -1,0 +1,85 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.platform.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+
+import org.easymock.classextension.EasyMock;
+import org.geoserver.util.PropertyRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.context.ApplicationContext;
+
+public class GeoServerPropertyFactoryBeanTest {
+    
+    public static final String PROPERTY_NAME = "FOO";
+    
+    public @Rule PropertyRule foo = PropertyRule.system(PROPERTY_NAME);
+    public @Rule ExpectedException exception = ExpectedException.none();
+    
+    GeoServerPropertyFactoryBean<String> factory;
+    
+    @Before
+    public void setUp() {
+        factory = new GeoServerPropertyFactoryBean<String>(PROPERTY_NAME) {
+
+            @Override
+            protected String createInstance(String propertyValue) {
+                if(propertyValue.equals("UNKNOWN")) return null;
+                return "Bean: "+propertyValue;
+            }
+
+            @Override
+            public Class<?> getObjectType() {
+                return String.class;
+            }
+            
+        };
+        ApplicationContext context = EasyMock.createMock(ApplicationContext.class);
+        EasyMock.replay(context);
+        factory.setApplicationContext(context);
+    }
+    
+    @Test
+    public void testGetBean() throws Exception {
+        factory.setDefaultValue("Default");
+        foo.setValue("testValue1");
+        
+        assertThat(factory.createInstance(), equalTo("Bean: testValue1"));
+    }
+    
+    @Test
+    public void testGetDefault() throws Exception {
+        factory.setDefaultValue("Default");
+        
+        assertThat(factory.createInstance(), equalTo("Bean: Default"));
+    }
+    
+    @Test
+    public void testGetUnsetDefault() throws Exception {
+        exception.expect(IllegalStateException.class);
+        factory.createInstance();
+    }
+    
+    @Test
+    public void testGetBadDefault() throws Exception {
+        exception.expect(IllegalStateException.class);
+        factory.setDefaultValue("UNKNOWN");
+        factory.createInstance();
+    }
+    
+    @Test
+    public void testFallBackToDefault() throws Exception {
+        factory.setDefaultValue("Default");
+        foo.setValue("UNKNOWN");
+        
+        assertThat(factory.createInstance(), equalTo("Bean: Default"));
+    }
+}


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8091
Revised version of abandoned PR #1362

Still uses `GEOSERVER_GLOBAL_LAYER_GROUP_INHERIT` as I can't think of a better term for this than inherit even though it's admittedly not entirely intuitive.