### PR TITLE
Fix a wrong use of an indexer in a loop

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -932,7 +932,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements HttpServ
             // styles is beyond me... we'll style each remote layer with all possible
             // styles, feauture type style matching will do the rest during rendering
             for (int j = 0; j < layerStyles.length; j++) {
-                Style style = layerStyles[i];
+                Style style = layerStyles[j];
                 MapLayerInfo info = new MapLayerInfo(fs);
                 layers.add(info);
                 styles.add(style);


### PR DESCRIPTION
This might be a trivial change. (I'm sorry that I could not issue a ticket first.) The indexer of the outer loop was used in the inner loop. I have no idea if this is intended but wanted to issue this pull request just in case. Thanks!