### PR TITLE
[GEOS-8101] Remove FeatureTypeName from raster_template.sld

### DIFF
--- a/src/main/src/main/resources/org/geoserver/catalog/template_raster.sld
+++ b/src/main/src/main/resources/org/geoserver/catalog/template_raster.sld
@@ -6,7 +6,6 @@ http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
     <UserStyle>
       <Title>A raster style</Title>
       <FeatureTypeStyle>
-        <FeatureTypeName>Raster</FeatureTypeName>
         <Rule>
           <RasterSymbolizer>
             <Opacity>1.0</Opacity>

--- a/src/wms/src/test/java/org/geoserver/wms/WMSTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSTestSupport.java
@@ -46,6 +46,7 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.LayerGroupInfo.Mode;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.data.test.TestData;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.platform.GeoServerExtensions;
@@ -94,7 +95,8 @@ public abstract class WMSTestSupport extends GeoServerSystemTestSupport {
 
     protected static final Color COLOR_PLACES_GRAY = new Color(170, 170, 170);
     protected static final Color COLOR_LAKES_BLUE = new Color(64, 64, 192);
-    
+
+    protected static QName WORLD = new QName(MockData.SF_URI, "world", MockData.SF_PREFIX);
     
     /**
      * @return The global wms singleton from the application context.
@@ -128,6 +130,9 @@ public abstract class WMSTestSupport extends GeoServerSystemTestSupport {
         testData.registerNamespaces(namespaces);
         registerNamespaces(namespaces);
         XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(namespaces));
+
+        //Add a raster layer
+        testData.setUpRasterLayer(WORLD, "world.tiff", null, null, TestData.class);
         
 
     }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
@@ -5,19 +5,12 @@
  */
 package org.geoserver.wms.wms_1_3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.awt.Color;
-import java.awt.image.BufferedImage;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.util.Collections;
-
-import javax.xml.namespace.QName;
-
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.StyleGenerator;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.Styles;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
@@ -29,10 +22,21 @@ import org.geoserver.wms.WMSTestSupport;
 import org.geoserver.wms.map.OpenLayersMapOutputFormat;
 import org.geoserver.wms.map.RenderedImageMapOutputFormat;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import org.springframework.mock.web.MockHttpServletResponse;
+import javax.imageio.ImageIO;
+import javax.xml.namespace.QName;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class GetMapIntegrationTest extends WMSTestSupport {
 
@@ -263,6 +267,26 @@ public class GetMapIntegrationTest extends WMSTestSupport {
                 + "&layers=" + layers + "&Format=image/png" + "&request=GetMap" + "&width=550"
                 + "&height=250" + "&srs=EPSG:4326" + "&SLD_BODY="
                 + STATES_SLD11.replaceAll("=", "%3D") + "&VALIDATESCHEMA=true");
+        checkImage(response);
+    }
+
+    @Test
+    public void testSldGenerateRaster() throws Exception {
+        Catalog catalog = getCatalog();
+        StyleGenerator generator = new StyleGenerator(catalog);
+        CoverageInfo coverage = catalog.getCoverageByName(WORLD.getLocalPart());
+
+        StyleInfo style = generator.createStyle(Styles.handler("SLD"), coverage);
+        catalog.add(style);
+
+        MockHttpServletResponse response = getAsServletResponse("wms?bbox=-120,35,-100,45" +
+                "&styles=" + style.getName() + "&layers=" + coverage.getName() +
+                "&format=image/png&request=GetMap&width=80&height=40&srs=EPSG:4326");
+
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(response.getContentAsByteArray()));
+        Color rgb = new Color(image.getRGB(5,5));
+        assertEquals(rgb, new Color(170,170,170));
+
         checkImage(response);
     }
     


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8101

Best place I could fit the test case is gs-wms, as that is the only straightforward way I can find to actually render a style.