### PR TITLE
[GEOS-8117] Improve support for null service/version/request in KvpUtils

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
@@ -453,12 +453,12 @@ public class KvpUtils {
         for (Iterator<KvpParser> p = parsers.iterator(); p.hasNext();) {
             KvpParser parser = p.next();
 
-            if (parser.getService() != null && !parser.getService().equalsIgnoreCase(service)) {
+            if (service != null && parser.getService() != null && !parser.getService().equalsIgnoreCase(service)) {
                 p.remove();
-            } else if (parser.getVersion() != null
+            } else if (version != null && parser.getVersion() != null
                     && !parser.getVersion().toString().equals(version)) {
                 p.remove();
-            } else if (parser.getRequest() != null
+            } else if (request != null && parser.getRequest() != null
                     && !parser.getRequest().equalsIgnoreCase(request)) {
                 p.remove();
             }
@@ -487,26 +487,27 @@ public class KvpUtils {
                 if (parser == null) {
                     parser = candidate;
                 } else {
-                    // if target service matches, it is a closer match
+
                     String trgService = candidate.getService();
-                    if (trgService != null && trgService.equalsIgnoreCase(service)) {
+                    String curService = parser.getService();
+
+                    // if target service matches the request, it is a closer match.
+                    if (((service == null && trgService == null) || (trgService != null && trgService.equalsIgnoreCase(service))) ||
+                            // If target service matches the current parser, it may be a closer match
+                            (trgService == null && curService == null || (trgService != null && trgService.equalsIgnoreCase(trgService)))) {
+
                         // determine if this parser more closely matches the request
-                        String curService = parser.getService();
-                        if (curService == null) {
+                        if ((service != null && curService == null) || (service == null && curService != null)) {
                             parser = candidate;
                         } else {
                             // both match, filter by version
                             Version curVersion = parser.getVersion();
                             Version trgVersion = candidate.getVersion();
-                            if (trgVersion != null) {
-                                if (curVersion == null && trgVersion.toString().equals(version)) {
+                            if ((version == null && trgVersion == null) || (trgVersion != null && trgVersion.toString().equals(version))) {
+                                if ((version != null && curVersion == null) || (version == null && curVersion != null)) {
                                     parser = candidate;
-                                }
-                            } else {
-                                if (curVersion == null) {
-                                    // ambiguous, unable to match
-                                    throw new IllegalStateException("Multiple kvp parsers: "
-                                            + parser + "," + candidate);
+                                } else if (curVersion == null) {
+                                    throw new IllegalStateException("Multiple kvp parsers: " + parser + "," + candidate);
                                 }
                             }
                         }

--- a/src/wfs/src/main/java/applicationContext.xml
+++ b/src/wfs/src/main/java/applicationContext.xml
@@ -397,7 +397,8 @@
     <bean id="strictKvpParser" class="org.geoserver.ows.kvp.BooleanKvpParser">
         <constructor-arg value="strict"/>
     </bean>
-    <bean id="wfsFormatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser"/>
+    <!-- between WMS and WFS, we only need one generic FormatOptionsKvpParser, so these beans have the same name -->
+    <bean id="formatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser"/>
     <bean id="charsetKvpParser" class="org.geoserver.ows.kvp.CharsetKVPParser">
         <constructor-arg value="charset"/>
     </bean>

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
@@ -120,6 +120,41 @@ public class GetFeatureTest extends WFSTestSupport {
         XMLAssert.assertXpathEvaluatesTo("1", "count(//ogc:ServiceException)", doc);
         XMLAssert.assertXpathEvaluatesTo("MissingParameterValue", "//ogc:ServiceException/@code", doc);
     }
+
+    //[GEOS-8117] Tests a number of known cases where excluding service can cause an error
+    @Test
+    public void testGetMissingVersion() throws Exception {
+        getWithServiceVersionQuery("&service=wfs");
+    }
+    @Test
+    public void testGetMissingService() throws Exception {
+        getWithServiceVersionQuery("&version=2.0.0");
+    }
+    @Test
+    public void testGetMissingServiceVersion() throws Exception {
+        getWithServiceVersionQuery("");
+    }
+    public void getWithServiceVersionQuery(String query) throws Exception {
+        //All properties (no filter)
+        Document doc = getAsDOM("wfs?request=GetFeature&typename=cite:NamedPlaces" + query);
+        assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
+
+        //All properties (empty filter)
+        doc = getAsDOM("wfs?request=GetFeature&typename=cite:NamedPlaces" + query + "&propertyname=*");
+        assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
+
+        //All properties (with filter)
+        doc = getAsDOM("wfs?request=GetFeature&typename=cite:NamedPlaces" + query + "&propertyname=*");
+        assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
+
+        //One property
+        doc = getAsDOM("wfs?request=GetFeature&typename=cite:NamedPlaces" + query + "&propertyname=NAME");
+        assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
+
+        //Two properties
+        doc = getAsDOM("wfs?request=GetFeature&typename=cite:NamedPlaces" + query + "&propertyname=NAME,FID");
+        assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
+    }
     
     @Test
     public void testAlienNamespace() throws Exception {

--- a/src/wms/src/main/java/applicationContext.xml
+++ b/src/wms/src/main/java/applicationContext.xml
@@ -242,7 +242,8 @@
  	<bean id="heightKvpParser" class="org.geoserver.ows.kvp.IntegerKvpParser">
 		<constructor-arg value="height"/>
  	</bean>
- 	<bean id="wmsFormatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser"/>
+    <!-- between WMS and WFS, we only need one generic FormatOptionsKvpParser, so these beans have the same name -->
+ 	<bean id="formatOptionsKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser"/>
  	<bean id="wmsEnviromentKvpParser" class="org.geoserver.ows.kvp.FormatOptionsKvpParser">
  		<constructor-arg index="0" value="env"/>
  	</bean>


### PR DESCRIPTION
Fixes support for null service / version / request in KvpUtils.purgeParsers and KvpUtils.findParser (according to the javadoc, this was already supported, but it appears the implementation was bugged).

KvpUtils.purgeParsers will now no longer purge parsers based on service / version / request if the applicable parameter is null in the original Kvp map.

KvpUtils.findParser now properly handles cases where both the kvp map and kvp parser have a null service / version / parser.

The beans "wfsFormatOptionsKvpParser" and "wmsFormatOptionsKvpParser" are functionally identical and have been renamed to "formatOptionsKvpParser" - in the case that both WFS and WMS are enabled, one will override the other. This prevents us throwing an IllegalStateException due to multiple identical KvpParsers (this didn't happen before because null service / version / request was not implemented properly).

See https://osgeo-org.atlassian.net/browse/GEOS-8117 for more details

