### PR TITLE
[GEOS-7757] Fix empty row during legend creation.

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -331,4 +331,13 @@ public class GetLegendGraphicTest extends WMSTestSupport {
                         "&format=image/png&width=20&height=20&scale=150000", "image/png");
         assertEquals(1, image.getHeight());
     }
+
+    @Test
+    public void testLegendHeight() throws Exception {
+        String base = "wms?service=WMS&version=1.1.1&request=GetLegendGraphic" +
+            "&layer=sf:states&style=Population" +
+            "&format=image/png&width=20&height=20";
+        BufferedImage image = getAsImage(base, "image/png");
+        assertEquals(80, image.getHeight());
+    }
 }


### PR DESCRIPTION
This commit stops the generation of an empty row on a vertical non-raster
legend when there is a text symbolizer used in the style SLD.