### PR TITLE
[GEOS-8122][GEOS-8123] Fixes for FileUtils.deleteDirectory test failures

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -178,7 +178,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     /**
      * @see #getResponseEncoder(MimeType, RenderedImageMap)
      */
-    private static Map<String, Response> cachedTileEncoders = new HashMap<String, Response>();
+    private Map<String, Response> cachedTileEncoders = new HashMap<String, Response>();
 
     private final TileLayerDispatcher tld;
 

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -276,7 +276,7 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
         if (applicationContext == null) {
             return;
         }
-
+        getGeoServer().dispose();
         try {
             //dispose WFS XSD schema's - they will otherwise keep geoserver instance alive forever!!
             disposeIfExists(getXSD11());


### PR DESCRIPTION
[[GEOS-8122] Intermittent failure of FileUtils.deleteDirectory in SystemTestData.tearDown](https://osgeo-org.atlassian.net/browse/GEOS-8122)
[[GEOS-8123] GWC caches stale response encoders](https://osgeo-org.atlassian.net/browse/GEOS-8123)
