### PR TITLE
[GEOS-8125] making featureCount processor more robust for missing params

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/FeatureCountProcessor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/FeatureCountProcessor.java
@@ -290,6 +290,11 @@ class FeatureCountProcessor {
         // ... and bbox as well
         rawKvp.putIfAbsent("BBOX", legend.getLayerInfo().getResource().boundingBox().toString());
         kvp.putIfAbsent("BBOX", legend.getLayerInfo().getResource().boundingBox());
+        // ... and dont forget srs
+        rawKvp.putIfAbsent("SRS", legend.getLayerInfo().getResource().getSRS());
+        kvp.putIfAbsent("SRS", legend.getLayerInfo().getResource().getSRS());
+
+        
 
         // remove decoration to avoid infinite recursion
         final Map formatOptions = (Map) kvp.get("FORMAT_OPTIONS");

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/FeatureCountProcessor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/FeatureCountProcessor.java
@@ -16,6 +16,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.vividsolutions.jts.geom.Envelope;
 import org.apache.commons.lang.StringUtils;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.ows.util.CaseInsensitiveMap;
@@ -280,8 +281,16 @@ class FeatureCountProcessor {
         rawKvp.put("STYLES", "");
         // ... width and height
         rawKvp.put("WIDTH", rawKvp.get("SRCWIDTH"));
-        rawKvp.put("HEIGTH", rawKvp.get("SRCHEIGHT"));
-        
+        rawKvp.put("HEIGHT", rawKvp.get("SRCHEIGHT"));
+        // ... set default values if not yet set
+        rawKvp.putIfAbsent("HEIGHT", String.valueOf(GetLegendGraphicRequest.DEFAULT_HEIGHT));
+        rawKvp.putIfAbsent("WIDTH", String.valueOf(GetLegendGraphicRequest.DEFAULT_WIDTH));
+        kvp.putIfAbsent("HEIGHT", String.valueOf(GetLegendGraphicRequest.DEFAULT_HEIGHT));
+        kvp.putIfAbsent("WIDTH", String.valueOf(GetLegendGraphicRequest.DEFAULT_WIDTH));
+        // ... and bbox as well
+        rawKvp.putIfAbsent("BBOX", legend.getLayerInfo().getResource().boundingBox().toString());
+        kvp.putIfAbsent("BBOX", legend.getLayerInfo().getResource().boundingBox());
+
         // remove decoration to avoid infinite recursion
         final Map formatOptions = (Map) kvp.get("FORMAT_OPTIONS");
         if(formatOptions != null) {

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/FeatureCountProcessor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/FeatureCountProcessor.java
@@ -108,6 +108,7 @@ class FeatureCountProcessor {
         @Override
         protected void onBeforeRender(StreamingRenderer renderer) {
             super.onBeforeRender(renderer);
+            renderer.setGeneralizationDistance(0);
             renderer.addRenderListener(new RenderListener() {
 
                 @Override

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/FeatureCountLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/FeatureCountLegendGraphicTest.java
@@ -245,7 +245,7 @@ public class FeatureCountLegendGraphicTest extends WMSTestSupport {
         assertLabel("(49)", rules[3]);
     }
 
-    /*@Test
+    @Test
     public void testStatesMissingHeightWidthBboxSrs() throws Exception {
         runGetLegendGraphics(
                 "wms?service=WMS&version=1.1.1&request=GetLegendGraphic&format=image/png"
@@ -263,7 +263,7 @@ public class FeatureCountLegendGraphicTest extends WMSTestSupport {
         // this is the rule for outline and text symbolizer, Alaska and Hawaii are not in the
         // map but Washington DC is and it's not a state (50 - 2 + 1)
         assertLabel("(49)", rules[3]);
-    }*/
+    }
 
     @Test
     public void testStatesCqlFilter() throws Exception {

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/FeatureCountLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/FeatureCountLegendGraphicTest.java
@@ -162,6 +162,110 @@ public class FeatureCountLegendGraphicTest extends WMSTestSupport {
     }
 
     @Test
+    public void testStatesMissingBbox() throws Exception {
+        runGetLegendGraphics(
+                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic&format=image/png"
+                        + "&layer=" + getLayerId(SF_STATES)
+                        + "&style=Population"
+                        + "&width=550&height=250&srs=EPSG:4326"
+                        + "&legend_options="
+                        + GetLegendGraphicRequest.COUNT_MATCHED_KEY + ":true");
+        assertEquals(1, ruleSets.size());
+        Rule[] rules = ruleSets.get(0);
+        logLabels(rules);
+        assertEquals(4, rules.length);
+        assertLabel("2M - 4M (10)", rules[0]);
+        assertLabel("< 2M (16)", rules[1]);
+        assertLabel("> 4M (23)", rules[2]);
+        // this is the rule for outline and text symbolizer, Alaska and Hawaii are not in the
+        // map but Washington DC is and it's not a state (50 - 2 + 1)
+        assertLabel("(49)", rules[3]);
+    }
+
+    @Test
+    public void testStatesMissingHeightWidth() throws Exception {
+        runGetLegendGraphics(
+                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic&format=image/png"
+                        + "&layer=" + getLayerId(SF_STATES)
+                        + "&style=Population"
+                        + "&srs=EPSG:4326&bbox=" + "-130,24,-66,50"
+                        + "&legend_options="
+                        + GetLegendGraphicRequest.COUNT_MATCHED_KEY + ":true");
+        assertEquals(1, ruleSets.size());
+        Rule[] rules = ruleSets.get(0);
+        logLabels(rules);
+        assertEquals(4, rules.length);
+        assertLabel("2M - 4M (10)", rules[0]);
+        assertLabel("< 2M (16)", rules[1]);
+        assertLabel("> 4M (23)", rules[2]);
+        // this is the rule for outline and text symbolizer, Alaska and Hawaii are not in the
+        // map but Washington DC is and it's not a state (50 - 2 + 1)
+        assertLabel("(49)", rules[3]);
+    }
+
+    @Test
+    public void testStatesMissingHeightWidthSrs() throws Exception {
+        runGetLegendGraphics(
+                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic&format=image/png"
+                        + "&layer=" + getLayerId(SF_STATES)
+                        + "&style=Population"
+                        + "&bbox=" + "-130,24,-66,50"
+                        + "&legend_options="
+                        + GetLegendGraphicRequest.COUNT_MATCHED_KEY + ":true");
+        assertEquals(1, ruleSets.size());
+        Rule[] rules = ruleSets.get(0);
+        logLabels(rules);
+        assertEquals(4, rules.length);
+        assertLabel("2M - 4M (10)", rules[0]);
+        assertLabel("< 2M (16)", rules[1]);
+        assertLabel("> 4M (23)", rules[2]);
+        // this is the rule for outline and text symbolizer, Alaska and Hawaii are not in the
+        // map but Washington DC is and it's not a state (50 - 2 + 1)
+        assertLabel("(49)", rules[3]);
+    }
+
+    @Test
+    public void testStatesMissingBboxSrs() throws Exception {
+        runGetLegendGraphics(
+                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic&format=image/png"
+                        + "&layer=" + getLayerId(SF_STATES)
+                        + "&style=Population"
+                        + "&width=550&height=250"
+                        + "&legend_options="
+                        + GetLegendGraphicRequest.COUNT_MATCHED_KEY + ":true");
+        assertEquals(1, ruleSets.size());
+        Rule[] rules = ruleSets.get(0);
+        logLabels(rules);
+        assertEquals(4, rules.length);
+        assertLabel("2M - 4M (10)", rules[0]);
+        assertLabel("< 2M (16)", rules[1]);
+        assertLabel("> 4M (23)", rules[2]);
+        // this is the rule for outline and text symbolizer, Alaska and Hawaii are not in the
+        // map but Washington DC is and it's not a state (50 - 2 + 1)
+        assertLabel("(49)", rules[3]);
+    }
+
+    /*@Test
+    public void testStatesMissingHeightWidthBboxSrs() throws Exception {
+        runGetLegendGraphics(
+                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic&format=image/png"
+                        + "&layer=" + getLayerId(SF_STATES)
+                        + "&style=Population"
+                        + "&legend_options="
+                        + GetLegendGraphicRequest.COUNT_MATCHED_KEY + ":true");
+        assertEquals(1, ruleSets.size());
+        Rule[] rules = ruleSets.get(0);
+        logLabels(rules);
+        assertEquals(4, rules.length);
+        assertLabel("2M - 4M (10)", rules[0]);
+        assertLabel("< 2M (16)", rules[1]);
+        assertLabel("> 4M (23)", rules[2]);
+        // this is the rule for outline and text symbolizer, Alaska and Hawaii are not in the
+        // map but Washington DC is and it's not a state (50 - 2 + 1)
+        assertLabel("(49)", rules[3]);
+    }*/
+
+    @Test
     public void testStatesCqlFilter() throws Exception {
         runGetLegendGraphics(
                 "wms?service=WMS&version=1.1.1&request=GetLegendGraphic&format=image/png"


### PR DESCRIPTION
This PR imroves the featureCount option in GetLegendGraphics requests introduced with GEOS-8114 - ticket for this improvement is GEOS-8125 https://osgeo-org.atlassian.net/browse/GEOS-8125

This PR sets default values from LegendRequest class for WIDTH and HEIGHT if not yet set from request and sets BBOX as well from the layers envelope: legend.getLayerInfo().getResource().boundingBox()