### PR TITLE
[GEOS-8124] Add extension point in backup / restore module for generic resources handler (backport 2.10.x)

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/BackupRestoreJobExecutionListener.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/BackupRestoreJobExecutionListener.java
@@ -1,0 +1,30 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore.listener;
+
+import org.springframework.batch.core.JobExecution;
+
+/**
+ * Beans implementing this interface will be invoked as listeners of backup and restore jobs.
+ */
+public interface BackupRestoreJobExecutionListener {
+
+    // a job is a backup or a restore job
+    enum JobType {
+        BACKUP, RESTORE
+    }
+
+    /**
+     * Callback before a job executes.
+     */
+    void beforeJob(JobType type, JobExecution jobExecution);
+
+    /**
+     * Callback after completion of a job. Called after both both successful and
+     * failed executions. To perform logic on a particular status, use
+     * "if (jobExecution.getStatus() == BatchStatus.X)".
+     */
+    void afterJob(JobType type, JobExecution jobExecution);
+}

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/GenericListenersExecutor.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/GenericListenersExecutor.java
@@ -1,0 +1,42 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore.listener;
+
+import org.geoserver.backuprestore.listener.BackupRestoreJobExecutionListener.JobType;
+import org.geoserver.platform.GeoServerExtensions;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+
+import java.util.List;
+
+/**
+ * Job execution listener that will invoke listeners contributed by extensions.
+ */
+public final class GenericListenersExecutor implements JobExecutionListener {
+
+    // type of the job associated to this listener instance (backup or restore)
+    private final JobType jobType;
+
+    public GenericListenersExecutor(boolean backup) {
+        jobType = backup ? JobType.BACKUP : JobType.RESTORE;
+    }
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        getListeners().forEach(listener -> listener.beforeJob(jobType, jobExecution));
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        getListeners().forEach(listener -> listener.afterJob(jobType, jobExecution));
+    }
+
+    /**
+     * Helper method that returns all the available job execution listeners.
+     */
+    private List<BackupRestoreJobExecutionListener> getListeners() {
+        return GeoServerExtensions.extensions(BackupRestoreJobExecutionListener.class);
+    }
+}

--- a/src/community/backup-restore/core/src/main/resources/applicationContext.xml
+++ b/src/community/backup-restore/core/src/main/resources/applicationContext.xml
@@ -63,6 +63,11 @@
 			<constructor-arg ref="backupFacade"/>
 		</bean>
 
+	<!-- Extension point for backup jobs listeners -->
+	<bean id="genericBackupJobExecutionListener" class="org.geoserver.backuprestore.listener.GenericListenersExecutor">
+		<constructor-arg value="true"/>
+	</bean>
+
 	<!-- CatalogAdditionalResourcesWriter extensions: those can be triggered by the CatalogWriter -->
 		<bean id="styleInfoAdditionalResourceWriter" class="org.geoserver.backuprestore.writer.StyleInfoAdditionalResourceWriter" />
 	
@@ -75,6 +80,7 @@
 	        <!-- Any job specific listeners here -->
 	        <batch:listener ref="backupFacade" />
 	        <batch:listener ref="backupJobExecutionListener" />
+					<batch:listener ref="genericBackupJobExecutionListener" />
 	    </batch:listeners>
     	
     	<!-- Backup GeoServer Globals/Logging/Services -->
@@ -429,6 +435,11 @@
 			<constructor-arg ref="backupFacade"/>
 		</bean>
 
+	<!-- Extensions point for restore jobs listeners -->
+	<bean id="genericRestoreJobExecutionListener" class="org.geoserver.backuprestore.listener.GenericListenersExecutor">
+		<constructor-arg value="false"/>
+	</bean>
+
 		<!-- This specific Listener allows to promote properties setted on Steps to Job Context Scope -->
 		<bean id="restoreExecutionPromotionListener" 
 				class="org.springframework.batch.core.listener.ExecutionContextPromotionListener">
@@ -444,6 +455,7 @@
 	        <!-- Any job specific listeners here -->
 	        <batch:listener ref="backupFacade" />
 	        <batch:listener ref="restoreJobExecutionListener" />
+				  <batch:listener ref="genericRestoreJobExecutionListener" />
 	    </batch:listeners>
 
 		<!-- Restore NamespaceInfos -->

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
@@ -43,6 +43,8 @@ public class BackupTest extends BackupRestoreTestSupport {
     public void beforeTest() {
         // reset invocations counter of continuable handler
         ContinuableHandler.resetInvocationsCount();
+        // reset invocation of generic listener
+        GenericListener.reset();
     }
 
     @Test
@@ -77,6 +79,11 @@ public class BackupTest extends BackupRestoreTestSupport {
 
         assertTrue(backupExecution.getStatus() == BatchStatus.COMPLETED);
         assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
+        // check that generic listener was invoked for the backup job
+        assertThat(GenericListener.getBackupAfterInvocations(), is(1));
+        assertThat(GenericListener.getBackupBeforeInvocations(), is(1));
+        assertThat(GenericListener.getRestoreAfterInvocations(), is(0));
+        assertThat(GenericListener.getRestoreBeforeInvocations(), is(0));
     }
 
     @Test
@@ -182,6 +189,11 @@ public class BackupTest extends BackupRestoreTestSupport {
 
         checkExtraPropertiesExists();
         assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
+        // check that generic listener was invoked for the backup job
+        assertThat(GenericListener.getBackupAfterInvocations(), is(0));
+        assertThat(GenericListener.getBackupBeforeInvocations(), is(0));
+        assertThat(GenericListener.getRestoreAfterInvocations(), is(1));
+        assertThat(GenericListener.getRestoreBeforeInvocations(), is(1));
     }
 
     @Test

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/GenericListener.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/GenericListener.java
@@ -1,0 +1,67 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore;
+
+import org.geoserver.backuprestore.listener.BackupRestoreJobExecutionListener;
+import org.springframework.batch.core.JobExecution;
+
+/**
+ * Tests listener that keeps a trace of how many times it was invoked.
+ */
+public final class GenericListener implements BackupRestoreJobExecutionListener {
+
+    private static int backupBeforeInvocations = 0;
+    private static int backupAfterInvocations = 0;
+    private static int restoreBeforeInvocations = 0;
+    private static int restoreAfterInvocations = 0;
+
+    @Override
+    public void beforeJob(JobType type, JobExecution jobExecution) {
+        switch (type) {
+            case BACKUP:
+                backupBeforeInvocations++;
+                break;
+            case RESTORE:
+                restoreBeforeInvocations++;
+                break;
+        }
+    }
+
+    @Override
+    public void afterJob(JobType type, JobExecution jobExecution) {
+        switch (type) {
+            case BACKUP:
+                backupAfterInvocations++;
+                break;
+            case RESTORE:
+                restoreAfterInvocations++;
+                break;
+        }
+    }
+
+    public static int getBackupBeforeInvocations() {
+        return backupBeforeInvocations;
+    }
+
+    public static int getBackupAfterInvocations() {
+        return backupAfterInvocations;
+    }
+
+    public static int getRestoreBeforeInvocations() {
+        return restoreBeforeInvocations;
+    }
+
+    public static int getRestoreAfterInvocations() {
+        return restoreAfterInvocations;
+    }
+
+    public static void reset() {
+        // reset all counter to zero.
+        backupBeforeInvocations = 0;
+        backupAfterInvocations = 0;
+        restoreBeforeInvocations = 0;
+        restoreAfterInvocations = 0;
+    }
+}

--- a/src/community/backup-restore/core/src/test/resources/applicationContext.xml
+++ b/src/community/backup-restore/core/src/test/resources/applicationContext.xml
@@ -22,4 +22,7 @@
 	</bean>
 
 	<bean id="continuableHandler" class="org.geoserver.backuprestore.ContinuableHandler"/>
+
+	<bean id="genericListener" class="org.geoserver.backuprestore.GenericListener"/>
+
 </beans>


### PR DESCRIPTION
Backport of this pull request: https://github.com/geoserver/geoserver/pull/2314

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8124

Adds an extension point that will execute generic listeners. 