### PR TITLE
Add ldap binded search for authentication

### DIFF
--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPSecurityProvider.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPSecurityProvider.java
@@ -71,6 +71,9 @@ public class LDAPSecurityProvider extends GeoServerSecurityProvider {
         authenticator.setUserFilter(ldapConfig.getUserFilter());
         authenticator.setUserFormat(ldapConfig.getUserFormat());
 
+        authenticator.setBindUsername(ldapConfig.getBindUsername());
+        authenticator.setBindPassword(ldapConfig.getBindPassword());
+
         // authenticate and extract user using a distinguished name
         if (ldapConfig.getUserDnPattern() != null) {
             authenticator.setUserDnPatterns(new String[] { ldapConfig

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPSecurityServiceConfig.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPSecurityServiceConfig.java
@@ -17,7 +17,9 @@ public class LDAPSecurityServiceConfig extends LDAPBaseSecurityServiceConfig
     
     String userGroupServiceName;
     
-    
+    String bindUsername;
+
+    String bindPassword;
      
     // format username before doing authentication using the given format
     String userFormat; 
@@ -30,6 +32,8 @@ public class LDAPSecurityServiceConfig extends LDAPBaseSecurityServiceConfig
         userDnPattern = other.getUserDnPattern();        
         userGroupServiceName = other.getUserGroupServiceName();        
         userFormat = other.getUserFormat();
+        bindUsername = other.getBindUsername();
+        bindPassword = other.getBindPassword();
     }
     
 
@@ -41,7 +45,13 @@ public class LDAPSecurityServiceConfig extends LDAPBaseSecurityServiceConfig
         this.userFormat = userFormat;
     }
 
-    
+    public String getBindUsername() { return bindUsername; }
+
+    public void setBindUsername(String bindUsername) { this.bindUsername = bindUsername; }
+
+    public String getBindPassword() { return bindPassword; }
+
+    public void setBindPassword(String bindPassword) { this.bindPassword = bindPassword; }
 
     public String getUserDnPattern() {
         return userDnPattern;

--- a/src/security/ldap/src/main/resources/GeoServerApplication.properties
+++ b/src/security/ldap/src/main/resources/GeoServerApplication.properties
@@ -21,6 +21,9 @@ LDAPAuthProviderPanel.userGroupServiceName=User Group Service
 LDAPAuthProviderPanel.username=Username
 LDAPAuthProviderPanel.useTLS=TLS
 LDAPAuthProviderPanel.useLdapAuthorization=Use LDAP groups for authorization
+LDAPAuthProviderPanel.authentication=LDAP privileged user authentication
+LDAPAuthProviderPanel.bindUsername=Username (or bind DN)
+LDAPAuthProviderPanel.bindPassword=Password
 
 LDAPUserGroupServicePanel.short=LDAP
 LDAPUserGroupServicePanel.title=LDAP User Group Service

--- a/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.html
+++ b/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.html
@@ -36,6 +36,23 @@
         </fieldset>
       </li>
       <li>
+        <fieldset>
+          <legend>
+            <span><wicket:message key="authentication"></wicket:message></span>
+          </legend>
+          <ul>
+            <li>
+                <label for="bindUsername"><wicket:message key="bindUsername"></wicket:message></label>
+                <input id="bindUsername" wicket:id="bindUsername" type="text" class="text"></input>
+            </li>
+            <li>
+                <label for="bindPassword"><wicket:message key="bindPassword"></wicket:message></label>
+                <input id="bindPassword" wicket:id="bindPassword" type="password" class="text"></input>
+            </li>
+          </ul>
+        </fieldset>
+      </li>
+      <li>
          <fieldset>
           <legend>
             <span><wicket:message key="authorization"></wicket:message></span>

--- a/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.java
+++ b/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.java
@@ -48,6 +48,11 @@ public class LDAPAuthProviderPanel extends AuthenticationProviderPanel<LDAPSecur
         add(new TextField<String>("userDnPattern"));
         add(new TextField<String>("userFilter"));
         add(new TextField<String>("userFormat"));
+        add(new TextField<String>("bindUsername"));
+        PasswordTextField pwdField = new PasswordTextField("bindPassword");
+        pwdField.setResetPassword(false);
+        pwdField.setRequired(false);
+        add(pwdField);
 
         boolean useLdapAuth = model.getObject().getUserGroupServiceName() == null;
         add(new AjaxCheckBox("useLdapAuthorization", new Model<Boolean>(useLdapAuth)) {
@@ -158,7 +163,9 @@ public class LDAPAuthProviderPanel extends AuthenticationProviderPanel<LDAPSecur
                     ((FormComponent<?>)LDAPAuthProviderPanel.this.get("userDnPattern")).processInput();
                     ((FormComponent<?>)LDAPAuthProviderPanel.this.get("userFilter")).processInput();
                     ((FormComponent<?>)LDAPAuthProviderPanel.this.get("userFormat")).processInput();
-                    
+                    ((FormComponent<?>)LDAPAuthProviderPanel.this.get("bindUsername")).processInput();
+                    ((FormComponent<?>)LDAPAuthProviderPanel.this.get("bindPassword")).processInput();
+
                     String username = (String)((FormComponent<?>)TestLDAPConnectionPanel.this.get("username")).getConvertedInput();
                     String password = (String)((FormComponent<?>)TestLDAPConnectionPanel.this.get("password")).getConvertedInput();
                     


### PR DESCRIPTION
LDAP anonymous search is disabled on our server. As we authenticate on all our systems using email address, we need to authenticate on LDAP server with a privileged user, search the user, then authenticate the user with the provided credentials.

With this PR, we can set `(&(objectClass=inetOrgPerson)(mail={0}))` as user lookup filter, `cn=ldapreader,dc=mycompany,dc=com` as LDAP username, set the password, and authenticate using the mail attribute.