### PR TITLE
Remove port 80 in cas URL

### DIFF
--- a/src/extension/security/cas/src/main/java/org/geoserver/security/cas/CasAuthenticationHelper.java
+++ b/src/extension/security/cas/src/main/java/org/geoserver/security/cas/CasAuthenticationHelper.java
@@ -223,8 +223,12 @@ public abstract class CasAuthenticationHelper {
         if (getTicketGrantingCookie()==null || getTicketGrantingCookie().getValue().isEmpty()) {
             throw new IOException("na valid TGC ");
         }
-            
-        URL loginUrl = createURLFromCasURI(GeoServerCasConstants.LOGIN_URI+"?service="+service.toExternalForm());
+
+        String serviceUri = service.toExternalForm();
+        serviceUri = serviceUri.replace(":80/", "/");
+        serviceUri = serviceUri.replace("%3A80%2F", "%2F");
+        URL loginUrl = createURLFromCasURI(GeoServerCasConstants.LOGIN_URI+"?service="+serviceUri);
+
         HttpURLConnection conn = (HttpURLConnection) loginUrl.openConnection();
         conn.setInstanceFollowRedirects(false);        
         addCasCookies(conn);

--- a/src/extension/security/cas/src/main/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilter.java
+++ b/src/extension/security/cas/src/main/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilter.java
@@ -129,6 +129,7 @@ public class GeoServerCasAuthenticationFilter extends GeoServerPreAuthenticatedU
         } else {
             serviceBaseUrl = request.getRequestURL().toString();
         }
+        serviceBaseUrl = serviceBaseUrl.replace(":80/", "/");
         StringBuffer buff  = new StringBuffer(serviceBaseUrl);
         
         


### PR DESCRIPTION
We use Geoserver in a docker container, behind HAProxy for https management.
Problem : when no port is specified, service.toExternalForm() returns a service uri starting with https, but with :80 as port.
Of course, this breaks cas checks and redirection.
This PR simply remove :80 from generated uri .