### PR TITLE
[GEOS-8117] Fix CITE WFS compliance

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -1151,6 +1151,10 @@ public class Dispatcher extends AbstractController {
         if (matches.size() > 1) {
             List vmatches = new ArrayList(matches);
 
+            if (isCiteCompliant() && version == null && "WFS".equals(id)) {
+                version = new Version("1.1.0");
+            }
+
             //match up the version
             if (version != null) {
                 //version specified, look for a match

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
@@ -398,6 +398,24 @@ public class GetFeatureTest extends WFSTestSupport {
     }
 
     @Test
+    public void testStrictComplianceVersionNegotiation() throws Exception {
+        GeoServer geoServer = getGeoServer();
+        WFSInfo service = geoServer.getService(WFSInfo.class);
+        try {
+            service.setCiteCompliant(true);
+            geoServer.save(service);
+
+            Document doc = getAsDOM("wfs?service=WFS&request=GetCapabilities");
+            XMLAssert.assertXpathEvaluatesTo("true", "//wfs:WFS_Capabilities/@version='1.1.0'", doc);
+        } finally {
+            service.setCiteCompliant(false);
+            geoServer.save(service);
+        }
+        Document doc = getAsDOM("wfs?service=WFS&request=GetCapabilities");
+        XMLAssert.assertXpathEvaluatesTo("false", "//wfs:WFS_Capabilities/@version='1.1.0'", doc);
+    }
+
+    @Test
     public void testRequestDisabledResource() throws Exception {
         Catalog catalog = getCatalog();
         ResourceInfo fifteen = catalog.getResourceByName(getLayerId(MockData.FIFTEEN),


### PR DESCRIPTION
Preliminary fix for WFS CITE failures caused by https://github.com/geoserver/geoserver/pull/2289

While the new test case passes, [CITE tests still fail](http://ares.boundlessgeo.com/jenkins/job/cite-wfs-1.1-troubleshooting/3/consoleFull), so this is not yet mergable.

I'm also not quite happy with the fix itself, as it seems quite hacky, but I can't see a better way of doing this so far.