### PR TITLE
[GEOS-8138] Prevent StyleFinder from overwriting existing MediaType mappings

### DIFF
--- a/src/community/mbstyle/src/test/java/org/geoserver/community/mbstyle/web/MBStyleHandlerTest.java
+++ b/src/community/mbstyle/src/test/java/org/geoserver/community/mbstyle/web/MBStyleHandlerTest.java
@@ -2,13 +2,15 @@ package org.geoserver.community.mbstyle.web;
 
 import org.geoserver.catalog.Styles;
 import org.geoserver.community.mbstyle.MBStyleHandler;
+import org.geoserver.rest.format.MediaTypes;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.styling.*;
 import org.junit.Test;
+import org.restlet.data.MediaType;
 
 import java.io.IOException;
+import static org.junit.Assert.*;
 
-import static org.junit.Assert.assertNotNull;
 
 public class MBStyleHandlerTest extends GeoServerSystemTestSupport {
 
@@ -26,5 +28,14 @@ public class MBStyleHandlerTest extends GeoServerSystemTestSupport {
 
         LineSymbolizer ls = SLD.lineSymbolizer(Styles.style(sld));
         assertNotNull(ls);
+    }
+    
+    /**
+     * Verify that the {@link MBStyleHandler} does not take precedence for the "json" extension in the {@link MediaTypes} registry.
+     */
+    @Test
+    public void testForFileExtensionCollision() {
+        MediaType mt = MediaTypes.getMediaTypeForExtension("json");
+        assertEquals(mt, new MediaType("application/json"));
     }
 }

--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/StyleFinder.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/StyleFinder.java
@@ -22,6 +22,13 @@ import org.restlet.resource.Resource;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 
+/**
+ * {@link AbstractCatalogFinder} implementation for Styles.
+ * 
+ * Implements {@link ApplicationListener} in order to register style file extensions as shortcuts for the corresponding media type in the
+ * {@link MediaTypes} registry, but only if the file extension is not already mapped to another media type.
+ *
+ */
 public class StyleFinder extends AbstractCatalogFinder implements ApplicationListener {
 
     public StyleFinder(Catalog catalog) {
@@ -99,8 +106,12 @@ public class StyleFinder extends AbstractCatalogFinder implements ApplicationLis
         if (event instanceof ContextLoadedEvent) {
             // register style format mime types
             for (StyleHandler sh : Styles.handlers()) {
-                Version ver = sh.getVersions().iterator().next();
-                MediaTypes.registerExtension(sh.getFileExtension(), new MediaType(sh.mimeType(ver)));
+                // Only map the StyleHandler's extension to its mime type 
+                // if the extension does not conflict with existing mappings.
+                if (MediaTypes.getMediaTypeForExtension(sh.getFileExtension()) == null) {
+                    Version ver = sh.getVersions().iterator().next();
+                    MediaTypes.registerExtension(sh.getFileExtension(), new MediaType(sh.mimeType(ver)));
+                }
             }
         }
     }

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/TestStyleHandlerExtensionConflict.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/TestStyleHandlerExtensionConflict.java
@@ -1,0 +1,59 @@
+package org.geoserver.catalog.rest;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.geoserver.catalog.StyleHandler;
+import org.geotools.styling.ResourceLocator;
+import org.geotools.styling.StyledLayerDescriptor;
+import org.geotools.util.Version;
+import org.xml.sax.EntityResolver;
+
+/**
+ * An implementation of {@link StyleHandler} whose format and extension collide with the extension-based content negotiation, used only in order to
+ * verify that the conflicting StyleHandler does *not* take precedence for requests with that extension.
+ * 
+ * For example, file extension for this class is {@link StyleHandler} "xml", and the point is to verify that it does not take precedence for unrelated
+ * style requests that end in ".xml" (like a request for the style info in xml format).
+ */
+public class TestStyleHandlerExtensionConflict extends StyleHandler {
+
+    protected TestStyleHandlerExtensionConflict() {
+        super("testStyleHandler", "xmlFormat");
+    }
+
+    @Override
+    public String getFormat() {
+        return super.getFormat();
+    }
+
+    @Override
+    public String getFileExtension() {
+        return "xml";
+    }
+
+    @Override
+    public String mimeType(Version version) {
+        return "test.mime.type+xml";
+    }
+
+    @Override
+    public StyledLayerDescriptor parse(Object input, Version version,
+            ResourceLocator resourceLocator, EntityResolver entityResolver) throws IOException {
+        return null;
+    }
+
+    @Override
+    public void encode(StyledLayerDescriptor sld, Version version, boolean pretty,
+            OutputStream output) throws IOException {
+
+    }
+
+    @Override
+    public List<Exception> validate(Object input, Version version,
+            EntityResolver entityResolver) throws IOException {
+        return null;
+    }
+    
+}

--- a/src/restconfig/src/test/resources/testStyleHandlerExtensionConflict.xml
+++ b/src/restconfig/src/test/resources/testStyleHandlerExtensionConflict.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ Copyright (C) 2017 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd.spring-beans.dtd">
+
+<beans>
+  <!-- 
+    Register a StyleHandler whose format and extension collide with the extension-based content negotiation in Restlet, 
+    in order to verify that the conflicting StyleHandler does *not* take precedence.
+    -->
+  <bean id="TestStyleHandlerExtensionConflict" class="org.geoserver.catalog.rest.TestStyleHandlerExtensionConflict" />    
+</beans>


### PR DESCRIPTION
Updates StyleFinder to only create MediaType mappings for StyleHandler extensions IF the extension is not already being used. This will prevent styles that use general extensions (e.g., “style.json”) from interfering with the existing Restlet content negotiation (which allows .json to be used as a shortcut for an “application/json” accept header).

This effectively preserves the current behavior of the REST API for styles: using *.json will still always map to "application/json" and thus return the style info object in json format. If a user specifically wants the style definition body from a StyleHandler with a conflicting extension, they must use the StyleHandler's mime type (e.g., "application/vnd.geoserver.mbstyle+json").

Issue: https://osgeo-org.atlassian.net/browse/GEOS-8138