### PR TITLE
GEOS-8151 - escape escape chars in XML

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/AboutStatusController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/AboutStatusController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ModuleStatus;
@@ -104,7 +105,10 @@ public class AboutStatusController extends RestBaseController {
                                 hash.put("isEnabled", Boolean.toString(status.isEnabled()));
                                 status.getComponent().ifPresent(component -> hash.put("component", component));
                                 status.getVersion().ifPresent(version -> hash.put("version", version));
-                                status.getMessage().ifPresent(message -> hash.put("message", message.replace("\n", "<br/>")));
+                                //Make sure to escape the string, otherwise strange chars here will bork the XML parser later
+                                
+                                status.getMessage().ifPresent(message -> hash.put("message", 
+                                        StringEscapeUtils.escapeXml(message.replace("\u001b", "ESC")).replace("\n", "<br/>")));
 
                                 return hash;
                             }

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/AboutControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/AboutControllerTest.java
@@ -96,6 +96,8 @@ public class AboutControllerTest extends GeoServerSystemTestSupport {
     
     @Test
     public void testGetStatusAsHTML() throws Exception {
+        //add an escape char to the environment
+        System.setProperty("badString", "[46m");
         // make the request, parsing the result into a Dom object
         Document dom = getAsDOM(BASEPATH + "/about/status");
         checkHTMLModel(dom);


### PR DESCRIPTION
A fix for [GEOS-8151](https://osgeo-org.atlassian.net/browse/GEOS-8151) to prevent users with escape chars in their environment variables breaking the tests.