### PR TITLE
[GEOS-8080] Style in default workspace no longer overrides global style in rest GET

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/StyleResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/StyleResource.java
@@ -86,10 +86,7 @@ public class StyleResource extends AbstractCatalogResource {
         String style = getAttribute("style");
         
         LOGGER.fine( "GET style " + style );
-        StyleInfo sinfo = workspace == null ? catalog.getStyleByName( style ) : 
-            catalog.getStyleByName(workspace,style);
-
-        return sinfo;
+        return catalog.getStyleByName(workspace,style);
     }
 
     @Override

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/StyleTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/StyleTest.java
@@ -224,6 +224,33 @@ public class StyleTest extends CatalogRESTTestSupport {
         assertXpathEvaluatesTo("gs", "/style/workspace/name", dom);
     }
 
+    //GEOS-8080
+    @Test
+    public void testGetGlobalWithDuplicateInDefaultWorkspace() throws Exception {
+        Catalog cat = getCatalog();
+        String styleName = "foo";
+        String wsName = cat.getDefaultWorkspace().getName();
+
+        StyleInfo s = cat.getFactory().createStyle();
+        s.setName(styleName);
+        s.setFilename(styleName + ".sld");
+        cat.add(s);
+
+        s = cat.getFactory().createStyle();
+        s.setName(styleName);
+        s.setFilename(styleName + ".sld");
+        s.setWorkspace(cat.getDefaultWorkspace());
+        cat.add(s);
+
+        Document dom = getAsDOM("/rest/styles/foo.xml");
+        assertXpathEvaluatesTo(styleName, "/style/name", dom);
+        assertXpathEvaluatesTo("", "/style/workspace/name", dom);
+
+        dom = getAsDOM("/rest/workspaces/" + wsName + "/styles/foo.xml");
+        assertXpathEvaluatesTo(styleName, "/style/name", dom);
+        assertXpathEvaluatesTo(wsName, "/style/workspace/name", dom);
+    }
+
     String newSLDXML() {
         return 
              "<sld:StyledLayerDescriptor xmlns:sld='http://www.opengis.net/sld'>"+


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8080

This version of the fix is for the old (<= 2.11) REST API and should also be backported to 2.10.x. See also https://github.com/geoserver/geoserver/pull/2365