### PR TITLE
[GEOS-8080] Style in default workspace no longer overrides global style in rest GET

### DIFF
--- a/src/extension/css/src/test/java/org/geoserver/rest/catalog/CssStyleControllerTest.java
+++ b/src/extension/css/src/test/java/org/geoserver/rest/catalog/CssStyleControllerTest.java
@@ -61,7 +61,7 @@ public class CssStyleControllerTest extends GeoServerSystemTestSupport {
     @Test
     public void getGetAsCSS() throws Exception {
         MockHttpServletResponse response = getAsServletResponse(
-                RestBaseController.ROOT_PATH + "/styles/test.css");
+                RestBaseController.ROOT_PATH + "/workspaces/" + catalog.getDefaultWorkspace().getName() + "/styles/test.css");
         assertEquals(200, response.getStatus());
         assertEquals(CssHandler.MIME_TYPE, response.getContentType());
         String content = response.getContentAsString();
@@ -71,7 +71,7 @@ public class CssStyleControllerTest extends GeoServerSystemTestSupport {
     @Test
     public void getGetAsSLD10() throws Exception {
         MockHttpServletResponse response = getAsServletResponse(
-                RestBaseController.ROOT_PATH + "/styles/test.sld");
+                RestBaseController.ROOT_PATH + "/workspaces/" + catalog.getDefaultWorkspace().getName() + "/styles/test.sld");
         assertEquals(200, response.getStatus());
         assertEquals(SLDHandler.MIMETYPE_10, response.getContentType());
         Document dom = dom(new ByteArrayInputStream(response.getContentAsByteArray()));
@@ -81,11 +81,11 @@ public class CssStyleControllerTest extends GeoServerSystemTestSupport {
     @Test
     public void getGetAsHTML() throws Exception {
         MockHttpServletResponse response = getAsServletResponse(
-                RestBaseController.ROOT_PATH + "/styles/test.html");
+                RestBaseController.ROOT_PATH + "/workspaces/" + catalog.getDefaultWorkspace().getName() + "/styles/test.html");
         assertEquals(200, response.getStatus());
         assertEquals(MediaType.TEXT_HTML_VALUE, response.getContentType());
         String content = response.getContentAsString();
-        assertThat(content, containsString("<a href=\"http://localhost:8080/geoserver/rest/styles/test.css\">test.css</a>"));
+        assertThat(content, containsString("<a href=\"http://localhost:8080/geoserver/rest/workspaces/" + catalog.getDefaultWorkspace().getName() + "/styles/test.css\">test.css</a>"));
     }
 
     @Test

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
@@ -245,9 +245,7 @@ public class StyleController extends AbstractCatalogController {
 
     protected StyleInfo getStyleInternal(String styleName, String workspace) {
         LOGGER.fine("GET style " + styleName);
-        StyleInfo sinfo = workspace == null ?
-            catalog.getStyleByName(styleName) :
-            catalog.getStyleByName(workspace, styleName);
+        StyleInfo sinfo = catalog.getStyleByName(workspace, styleName);
 
         if (sinfo == null) {
             String message = "No such style: " + styleName;

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
+import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.LayerInfo;
@@ -57,6 +58,7 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
     public void removeStyles() throws IOException {
         removeStyle("gs", "foo");
         removeStyle(null, "foo");
+        removeStyle(getCatalog().getDefaultWorkspace().getName(), "foo");
     }
 
     @Before
@@ -212,6 +214,41 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
         Document dom = getAsDOM(RestBaseController.ROOT_PATH + "/workspaces/gs/styles/foo.xml");
         assertXpathEvaluatesTo("foo", "/style/name", dom);
         assertXpathEvaluatesTo("gs", "/style/workspace/name", dom);
+    }
+
+    //GEOS-8080
+    @Test
+    public void testGetGlobalWithDuplicateInDefaultWorkspace() throws Exception {
+        Catalog cat = getCatalog();
+        String styleName = "foo";
+        String wsName = cat.getDefaultWorkspace().getName();
+
+        //Add a workspace style
+        StyleInfo s = cat.getFactory().createStyle();
+        s.setName(styleName);
+        s.setFilename(styleName + ".sld");
+        s.setWorkspace(cat.getDefaultWorkspace());
+        cat.add(s);
+
+        //Verify this style cannot retrieved by a non-workspaced GET
+        MockHttpServletResponse resp = getAsServletResponse(RestBaseController.ROOT_PATH + "/styles/foo.xml");
+        assertEquals(404, resp.getStatus());
+
+        //Add a global style
+        s = cat.getFactory().createStyle();
+        s.setName(styleName);
+        s.setFilename(styleName + ".sld");
+        cat.add(s);
+
+        //Verify the global style is returned by a non-workspaced GET
+        Document dom = getAsDOM(RestBaseController.ROOT_PATH + "/styles/foo.xml");
+        assertXpathEvaluatesTo("foo", "/style/name", dom);
+        assertXpathEvaluatesTo("", "/style/workspace/name", dom);
+
+        //Verify the workspaced style is returned by a workspaced GET
+        dom = getAsDOM(RestBaseController.ROOT_PATH + "/workspaces/" + wsName + "/styles/foo.xml");
+        assertXpathEvaluatesTo("foo", "/style/name", dom);
+        assertXpathEvaluatesTo(wsName, "/style/workspace/name", dom);
     }
 
     String newSLDXML() {


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8080

This version of the fix is for the new (>= 2.12) REST API. See also https://github.com/geoserver/geoserver/pull/2364