### PR TITLE
[GEOS-7959] Disallow changing default styles

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1390,6 +1390,21 @@ public class CatalogImpl implements Catalog {
             throw new IllegalArgumentException(msg); 
         }
 
+        if (!isNew) {
+            StyleInfo current = getStyle(style.getId());
+
+            //Default style validation
+            if (isDefaultStyle(current)) {
+
+                if (!current.getName().equals(style.getName())) {
+                    throw new IllegalArgumentException("Cannot rename default styles");
+                }
+                if (null != style.getWorkspace()) {
+                    throw new IllegalArgumentException("Cannot change the workspace of default styles");
+                }
+            }
+        }
+
         return postValidate(style, isNew);
     }
     
@@ -1405,9 +1420,19 @@ public class CatalogImpl implements Catalog {
                 throw new IllegalArgumentException( msg );
             }
         }
+
+        if (isDefaultStyle(style)) {
+            throw new IllegalArgumentException("Unable to delete a default style");
+        }
         
         facade.remove(style);
         removed(style);
+    }
+
+    private boolean isDefaultStyle(StyleInfo s) {
+        return s.getWorkspace() == null && (StyleInfo.DEFAULT_POINT.equals(s.getName())
+                || StyleInfo.DEFAULT_LINE.equals(s.getName()) || StyleInfo.DEFAULT_POLYGON.equals(s.getName())
+                || StyleInfo.DEFAULT_RASTER.equals(s.getName()) || StyleInfo.DEFAULT_GENERIC.equals(s.getName()));
     }
 
     public void save(StyleInfo style) {

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -103,6 +103,7 @@ public class CatalogImplTest {
     protected WMSLayerInfo wl;
     protected LayerInfo l;
     protected StyleInfo s;
+    protected StyleInfo defaultLineStyle;
     protected LayerGroupInfo lg;
     
     @Before
@@ -188,6 +189,10 @@ public class CatalogImplTest {
         s = factory.createStyle();
         s.setName( "styleName" );
         s.setFilename( "styleFilename" );
+
+        defaultLineStyle = factory.createStyle();
+        defaultLineStyle.setName( StyleInfo.DEFAULT_LINE );
+        defaultLineStyle.setFilename( StyleInfo.DEFAULT_LINE+".sld" );
         
         l = factory.createLayer();
         l.setResource( ft );
@@ -247,6 +252,10 @@ public class CatalogImplTest {
     
     protected void addStyle() {
         catalog.add(s);
+    }
+
+    protected void addDefaultStyle() {
+        catalog.add(defaultLineStyle);
     }
     
     protected void addLayer() {
@@ -1466,7 +1475,7 @@ public class CatalogImplTest {
     }
     
     @Test
-    public void testModifyDefaultStyle() {
+    public void testModifyLayerDefaultStyle() {
         // create new style
         CatalogFactory factory = catalog.getFactory();
         StyleInfo s2 = factory.createStyle();
@@ -1744,6 +1753,29 @@ public class CatalogImplTest {
         s3 = catalog.getStyleByName( s2.getName() );
         assertEquals( s2, s3 );
     }
+
+    @Test
+    public void testModifyDefaultStyle() {
+        addWorkspace();
+        addDefaultStyle();
+        StyleInfo s = catalog.getStyleByName(StyleInfo.DEFAULT_LINE);
+
+        s.setName("foo");
+
+        try {
+            catalog.save(s);
+            fail("changing name of default style should fail");
+        }
+        catch( Exception e ) {}
+
+        s = catalog.getStyleByName(StyleInfo.DEFAULT_LINE);
+        s.setWorkspace(ws);
+        try {
+            catalog.save(s);
+            fail("changing workspace of default style should fail");
+        }
+        catch( Exception e ) {}
+    }
     
     @Test
     public void testRemoveStyle() {
@@ -1752,6 +1784,19 @@ public class CatalogImplTest {
         
         catalog.remove(s);
         assertTrue( catalog.getStyles().isEmpty() );
+    }
+
+    @Test
+    public void testRemoveDefaultStyle() {
+        addWorkspace();
+        addDefaultStyle();
+        StyleInfo s = catalog.getStyleByName(StyleInfo.DEFAULT_LINE);
+
+        try {
+            catalog.remove(s);
+            fail("removing default style should fail");
+        }
+        catch( Exception e ) {}
     }
     
     @Test

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
@@ -439,6 +439,23 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
             putAsServletResponse(RestBaseController.ROOT_PATH + "/workspaces/gs/styles/foo", xml, "application/xml");
         assertEquals(403, response.getStatus());
     }
+
+    @Test
+    public void testPutRenameDefault() throws Exception {
+        StyleInfo style = catalog.getStyleByName( "Ponds");
+        assertEquals( "Ponds.sld", style.getFilename() );
+
+        String xml =
+                "<style>" +
+                        "<name>Ponds</name>" +
+                        "<filename>Forests.sld</filename>" +
+                        "</style>";
+
+        MockHttpServletResponse response =
+                putAsServletResponse(RestBaseController.ROOT_PATH + "/styles/line", xml.getBytes(), "text/xml");
+        assertEquals( 500, response.getStatus() );
+    }
+
     @Test
     public void testStyleNotFoundGloballyWhenInWorkspace() throws Exception {
         testPostToWorkspace();
@@ -472,6 +489,13 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
         assertEquals( 200, response.getStatus() );
 
         assertNull( catalog.getStyleByName( "dummy" ) );
+    }
+    @Test
+    public void testDeleteDefault() throws Exception {
+
+        MockHttpServletResponse response =
+                deleteAsServletResponse(RestBaseController.ROOT_PATH + "/styles/line");
+        assertEquals( 500, response.getStatus() );
     }
 
     @Test


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-7959

This prevents the global default styles (point, line, polygon, raster, generic) from being renamed, assigned to a workspace, or deleted. This change is implemented at the CatalogImpl level.

Several changes have already been made to the UI to support this; those changes will remain as they provide useful behaviour (displaying dialogs and error messages)

This change will automatically affect the REST API. REST tests have been added as a separate commit to make any future backporting easier (given the resent REST rewrite).

Since this is a change to a core catalog class, care should be taken when deciding whether or not to backport. I would be happiest waiting a month on master before backporting, even though this is technically a bugfix.