### PR TITLE
Geos 7923: Concurrent GeoRSS requests contain malformed template content

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/georss/AtomGeoRSSTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/AtomGeoRSSTransformer.java
@@ -24,25 +24,25 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryCollection;
 
 public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
-    
+
     private WMS wms;
 
-    public AtomGeoRSSTransformer(WMS wms){
+    public AtomGeoRSSTransformer(WMS wms) {
         this.wms = wms;
     }
-    
+
     public Translator createTranslator(ContentHandler handler) {
-        return new AtomGeoRSSTranslator(wms,handler);
+        return new AtomGeoRSSTranslator(wms, handler);
     }
 
     public class AtomGeoRSSTranslator extends GeoRSSTranslatorSupport {
-        
+
         private WMS wms;
 
         public AtomGeoRSSTranslator(WMS wms, ContentHandler contentHandler) {
             super(contentHandler, null, "http://www.w3.org/2005/Atom");
             this.wms = wms;
-            nsSupport.declarePrefix("georss","http://www.georss.org/georss");
+            nsSupport.declarePrefix("georss", "http://www.georss.org/georss");
         }
 
         public void encode(Object o) throws IllegalArgumentException {
@@ -50,10 +50,10 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
 
             start("feed");
 
-            //title
+            // title
             element("title", AtomUtils.getFeedTitle(map));
 
-            //TODO: Revist URN scheme
+            // TODO: Revist URN scheme
             element("id", AtomUtils.getFeedURI(map));
 
             AttributesImpl atts = new AttributesImpl();
@@ -61,25 +61,24 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
             atts.addAttribute(null, "rel", "rel", null, "self");
             element("link", null, atts);
 
-            //updated
+            // updated
             element("updated", AtomUtils.dateToRFC3339(new Date()));
 
-            //entries
+            // entries
             try {
                 encodeEntries(map);
-            } 
-            catch (IOException e) {
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             }
 
             end("feed");
         }
 
-        void encodeEntries(WMSMapContent map) throws IOException{
+        void encodeEntries(WMSMapContent map) throws IOException {
             List featureCollections = loadFeatureCollections(map);
             for (Iterator f = featureCollections.iterator(); f.hasNext();) {
                 SimpleFeatureCollection features = (SimpleFeatureCollection) f.next();
-                FeatureIterator <SimpleFeature> iterator = null;
+                FeatureIterator<SimpleFeature> iterator = null;
 
                 try {
                     iterator = features.features();
@@ -88,12 +87,11 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
                         SimpleFeature feature = iterator.next();
                         try {
                             encodeEntry(feature, map);
-                        }
-                        catch( Exception e ) {
+                        } catch (Exception e) {
                             LOGGER.warning("Encoding failed for feature: " + feature.getID());
-                            LOGGER.log(Level.FINE, "", e );
+                            LOGGER.log(Level.FINE, "", e);
                         }
-                        
+
                     }
                 } finally {
                     if (iterator != null) {
@@ -106,14 +104,14 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
         void encodeEntry(SimpleFeature feature, WMSMapContent map) {
             start("entry");
 
-            //title
+            // title
             element("title", feature.getID());
 
             start("author");
             element("name", wms.getGeoServer().getSettings().getContact().getContactPerson());
             end("author");
 
-            //id
+            // id
             element("id", AtomUtils.getEntryURI(wms, feature, map));
 
             String link = AtomUtils.getEntryURL(wms, feature, map);
@@ -122,35 +120,36 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
             atts.addAttribute(null, "rel", "rel", null, "self");
             element("link", null, atts);
 
-            //updated
+            // updated
             element("updated", AtomUtils.dateToRFC3339(new Date()));
 
-            //content
+            // content
             atts = new AttributesImpl();
             atts.addAttribute(null, "type", "type", null, "html");
             element("content", AtomUtils.getFeatureDescription(feature), atts);
 
-            //where
-            if (geometryEncoding == GeometryEncoding.LATLONG 
-                || !(feature.getDefaultGeometry() instanceof GeometryCollection)){
+            // where
+            if (geometryEncoding == GeometryEncoding.LATLONG
+                    || !(feature.getDefaultGeometry() instanceof GeometryCollection)) {
                 start("georss:where");
-                geometryEncoding.encode((Geometry)feature.getDefaultGeometry(), this);
+                geometryEncoding.encode((Geometry) feature.getDefaultGeometry(), this);
                 end("georss:where");
                 end("entry");
             } else {
-                GeometryCollection col = (GeometryCollection)feature.getDefaultGeometry();
+                GeometryCollection col = (GeometryCollection) feature.getDefaultGeometry();
                 start("georss:where");
                 geometryEncoding.encode(col.getGeometryN(0), this);
                 end("georss:where");
                 end("entry");
 
-                for (int i = 1; i < col.getNumGeometries(); i++){
-                    encodeRelatedGeometryEntry(col.getGeometryN(i), feature.getID(), link, link + "#" + i);
+                for (int i = 1; i < col.getNumGeometries(); i++) {
+                    encodeRelatedGeometryEntry(col.getGeometryN(i), feature.getID(), link,
+                            link + "#" + i);
                 }
             }
         }
 
-        void encodeRelatedGeometryEntry(Geometry g, String title, String link, String id){
+        void encodeRelatedGeometryEntry(Geometry g, String title, String link, String id) {
             start("entry");
             element("id", id);
             AttributesImpl atts = new AttributesImpl();

--- a/src/wms/src/main/java/org/geoserver/wms/georss/AtomGeoRSSTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/AtomGeoRSSTransformer.java
@@ -13,6 +13,7 @@ import java.util.logging.Level;
 
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSMapContent;
+import org.geoserver.wms.featureinfo.FeatureTemplate;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.xml.transform.Translator;
@@ -39,10 +40,13 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
 
         private WMS wms;
 
+        private FeatureTemplate featureTemplate;
+
         public AtomGeoRSSTranslator(WMS wms, ContentHandler contentHandler) {
             super(contentHandler, null, "http://www.w3.org/2005/Atom");
             this.wms = wms;
             nsSupport.declarePrefix("georss", "http://www.georss.org/georss");
+            featureTemplate = new FeatureTemplate();
         }
 
         public void encode(Object o) throws IllegalArgumentException {
@@ -112,9 +116,9 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
             end("author");
 
             // id
-            element("id", AtomUtils.getEntryURI(wms, feature, map));
+            element("id", AtomUtils.getEntryURI(wms, feature, featureTemplate, map));
 
-            String link = AtomUtils.getEntryURL(wms, feature, map);
+            String link = AtomUtils.getEntryURL(wms, feature, featureTemplate, map);
             AttributesImpl atts = new AttributesImpl();
             atts.addAttribute(null, "href", "href", null, link);
             atts.addAttribute(null, "rel", "rel", null, "self");
@@ -126,7 +130,7 @@ public class AtomGeoRSSTransformer extends GeoRSSTransformerBase {
             // content
             atts = new AttributesImpl();
             atts.addAttribute(null, "type", "type", null, "html");
-            element("content", AtomUtils.getFeatureDescription(feature), atts);
+            element("content", AtomUtils.getFeatureDescription(feature, featureTemplate), atts);
 
             // where
             if (geometryEncoding == GeometryEncoding.LATLONG

--- a/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
@@ -27,17 +27,15 @@ import org.geotools.map.Layer;
 import org.opengis.feature.simple.SimpleFeature;
 
 /**
- * The AtomUtils class provides some static methods useful in producing atom metadata related to 
- * GeoServer features.
+ * The AtomUtils class provides some static methods useful in producing atom metadata related to GeoServer features.
  *
  * @author David Winslow
  */
 public final class AtomUtils {
 
     /**
-     * A date formatting object that does most of the formatting work for RFC3339.  Note that since 
-     * Java's SimpleDateFormat does not provide all the facilities needed for RFC3339 there is still
-     * some custom code to finish the job.
+     * A date formatting object that does most of the formatting work for RFC3339. Note that since Java's SimpleDateFormat does not provide all the
+     * facilities needed for RFC3339 there is still some custom code to finish the job.
      */
     private static DateFormat rfc3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
@@ -48,6 +46,7 @@ public final class AtomUtils {
 
     /**
      * A FeatureTemplate used for formatting feature info.
+     * 
      * @TODO: Are these things threadsafe?
      */
     private static FeatureTemplate featureTemplate = new FeatureTemplate();
@@ -55,14 +54,16 @@ public final class AtomUtils {
     /**
      * This is a utility class so don't allow instantiation.
      */
-    private AtomUtils(){ /* Nothing to do */ }
+    private AtomUtils() {
+        /* Nothing to do */ }
 
     /**
      * Format dates as specified in rfc3339 (required for Atom dates)
+     * 
      * @param d the Date to be formatted
      * @return the formatted date
      */
-    public static String dateToRFC3339(Date d){
+    public static String dateToRFC3339(Date d) {
         StringBuilder result = new StringBuilder(rfc3339.format(d));
         Calendar cal = new GregorianCalendar();
         cal.setTime(d);
@@ -74,70 +75,66 @@ public final class AtomUtils {
         if (offset_millis == 0) {
             result.append("Z");
         } else {
-            result
-                .append((offset_millis > 0) ? "+" : "-")
-                .append(doubleDigit.format(offset_hours))
-                .append(":")
-                .append(doubleDigit.format(offset_minutes));
+            result.append((offset_millis > 0) ? "+" : "-").append(doubleDigit.format(offset_hours))
+                    .append(":").append(doubleDigit.format(offset_minutes));
         }
 
         return result.toString();
     }
 
-    //TODO: use an html based output format
-    public static String getEntryURL(WMS wms, SimpleFeature feature, WMSMapContent context){
+    // TODO: use an html based output format
+    public static String getEntryURL(WMS wms, SimpleFeature feature, WMSMapContent context) {
         try {
             return featureTemplate.link(feature);
-        } catch (IOException ioe){
+        } catch (IOException ioe) {
             String nsUri = feature.getType().getName().getNamespaceURI();
             String nsPrefix = wms.getNameSpacePrefix(nsUri);
 
-            HashMap<String,String> params = new HashMap<String,String>();
+            HashMap<String, String> params = new HashMap<String, String>();
             params.put("format", "application/atom+xml");
-            params.put("layers",  nsPrefix + ":" + feature.getType().getTypeName());
+            params.put("layers", nsPrefix + ":" + feature.getType().getTypeName());
             params.put("featureid", feature.getID());
-         
-            return ResponseUtils.buildURL(context.getRequest().getBaseUrl(),
-                    "wms/reflect",
-                    params,
+
+            return ResponseUtils.buildURL(context.getRequest().getBaseUrl(), "wms/reflect", params,
                     URLType.SERVICE);
         }
     }
 
-    public static String getEntryURI(WMS wms, SimpleFeature feature, WMSMapContent context){
+    public static String getEntryURI(WMS wms, SimpleFeature feature, WMSMapContent context) {
         return getEntryURL(wms, feature, context);
     }
 
-    public static String getFeatureTitle(SimpleFeature feature){
-        try{
+    public static String getFeatureTitle(SimpleFeature feature) {
+        try {
             return featureTemplate.title(feature);
-        } catch (IOException ioe){
+        } catch (IOException ioe) {
             return feature.getID();
         }
     }
 
-    public static String getFeatureDescription(SimpleFeature feature){
-        try{
+    public static String getFeatureDescription(SimpleFeature feature) {
+        try {
             return featureTemplate.description(feature);
         } catch (IOException ioe) {
             return feature.getID();
         }
     }
 
-    public static String getFeedURL(WMSMapContent context){
-        return WMSRequests.getGetMapUrl(context.getRequest(), null, 0, null, null).replace(' ', '+');
+    public static String getFeedURL(WMSMapContent context) {
+        return WMSRequests.getGetMapUrl(context.getRequest(), null, 0, null, null).replace(' ',
+                '+');
     }
 
-    public static String getFeedURI(WMSMapContent context){
+    public static String getFeedURI(WMSMapContent context) {
         return getFeedURL(context);
     }
 
-    public static String getFeedTitle(WMSMapContent context){
+    public static String getFeedTitle(WMSMapContent context) {
         StringBuffer title = new StringBuffer();
-        for( Layer layer : context.layers() ){
+        for (Layer layer : context.layers()) {
             title.append(layer.getTitle()).append(",");
         }
-        title.setLength(title.length()-1);
+        title.setLength(title.length() - 1);
         return title.toString();
     }
 
@@ -154,13 +151,13 @@ public final class AtomUtils {
         }
     }
 
-
-    private static String commaSeparatedLayers(WMSMapContent con){
+    private static String commaSeparatedLayers(WMSMapContent con) {
         StringBuilder layers = new StringBuilder();
         List<Layer> mapLayers = con.layers();
-        for (int i = 0; i < mapLayers.size(); i++){
+        for (int i = 0; i < mapLayers.size(); i++) {
             layers.append(mapLayers.get(i).getTitle());
-            if (i < mapLayers.size() - 1) layers.append(",");
+            if (i < mapLayers.size() - 1)
+                layers.append(",");
         }
         return layers.toString();
     }

--- a/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/AtomUtils.java
@@ -45,13 +45,6 @@ public final class AtomUtils {
     private static NumberFormat doubleDigit = new DecimalFormat("00");
 
     /**
-     * A FeatureTemplate used for formatting feature info.
-     * 
-     * @TODO: Are these things threadsafe?
-     */
-    private static FeatureTemplate featureTemplate = new FeatureTemplate();
-
-    /**
      * This is a utility class so don't allow instantiation.
      */
     private AtomUtils() {
@@ -83,7 +76,8 @@ public final class AtomUtils {
     }
 
     // TODO: use an html based output format
-    public static String getEntryURL(WMS wms, SimpleFeature feature, WMSMapContent context) {
+    public static String getEntryURL(WMS wms, SimpleFeature feature,
+            FeatureTemplate featureTemplate, WMSMapContent context) {
         try {
             return featureTemplate.link(feature);
         } catch (IOException ioe) {
@@ -100,11 +94,12 @@ public final class AtomUtils {
         }
     }
 
-    public static String getEntryURI(WMS wms, SimpleFeature feature, WMSMapContent context) {
-        return getEntryURL(wms, feature, context);
+    public static String getEntryURI(WMS wms, SimpleFeature feature,
+            FeatureTemplate featureTemplate, WMSMapContent context) {
+        return getEntryURL(wms, feature, featureTemplate, context);
     }
 
-    public static String getFeatureTitle(SimpleFeature feature) {
+    public static String getFeatureTitle(SimpleFeature feature, FeatureTemplate featureTemplate) {
         try {
             return featureTemplate.title(feature);
         } catch (IOException ioe) {
@@ -112,7 +107,8 @@ public final class AtomUtils {
         }
     }
 
-    public static String getFeatureDescription(SimpleFeature feature) {
+    public static String getFeatureDescription(SimpleFeature feature,
+            FeatureTemplate featureTemplate) {
         try {
             return featureTemplate.description(feature);
         } catch (IOException ioe) {

--- a/src/wms/src/main/java/org/geoserver/wms/georss/RSSGeoRSSTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/RSSGeoRSSTransformer.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSMapContent;
+import org.geoserver.wms.featureinfo.FeatureTemplate;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.xml.transform.Translator;
@@ -41,13 +42,17 @@ public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
     }
 
     class RSSGeoRSSTranslator extends GeoRSSTranslatorSupport {
+
         private WMS wms;
+
+        private FeatureTemplate featureTemplate;
 
         public RSSGeoRSSTranslator(WMS wms, ContentHandler contentHandler) {
             super(contentHandler, null, null);
             this.wms = wms;
             nsSupport.declarePrefix("georss", "http://www.georss.org/georss");
             nsSupport.declarePrefix("atom", "http://www.w3.org/2005/Atom");
+            featureTemplate = new FeatureTemplate();
         }
 
         public void encode(Object o) throws IllegalArgumentException {
@@ -118,9 +123,9 @@ public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
             String description = "[Error while loading description]";
 
             try {
-                title = AtomUtils.getFeatureTitle(feature);
-                link = AtomUtils.getEntryURL(wms, feature, map);
-                description = AtomUtils.getFeatureDescription(feature);
+                title = AtomUtils.getFeatureTitle(feature, featureTemplate);
+                link = AtomUtils.getEntryURL(wms, feature, featureTemplate, map);
+                description = AtomUtils.getFeatureDescription(feature, featureTemplate);
             } catch (Exception e) {
                 String msg = "Error occured executing title template for: " + feature.getID();
                 LOGGER.log(Level.WARNING, msg, e);
@@ -138,7 +143,7 @@ public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
             end("guid");
 
             start("description");
-            cdata(AtomUtils.getFeatureDescription(feature));
+            cdata(AtomUtils.getFeatureDescription(feature, featureTemplate));
             end("description");
 
             GeometryCollection col = feature.getDefaultGeometry() instanceof GeometryCollection

--- a/src/wms/src/main/java/org/geoserver/wms/georss/RSSGeoRSSTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/georss/RSSGeoRSSTransformer.java
@@ -29,13 +29,13 @@ import com.vividsolutions.jts.geom.GeometryCollection;
  *
  */
 public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
-    
+
     private WMS wms;
 
-    public RSSGeoRSSTransformer(WMS wms){
+    public RSSGeoRSSTransformer(WMS wms) {
         this.wms = wms;
     }
-    
+
     public Translator createTranslator(ContentHandler handler) {
         return new RSSGeoRSSTranslator(wms, handler);
     }
@@ -58,20 +58,20 @@ public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
 
             start("rss", atts);
             start("channel");
-            
-            element( "title", AtomUtils.getFeedTitle(map) );
-            element("description", AtomUtils.getFeedDescription(map) );
-            
-            start( "link" );
+
+            element("title", AtomUtils.getFeedTitle(map));
+            element("description", AtomUtils.getFeedDescription(map));
+
+            start("link");
             cdata(AtomUtils.getFeedURL(map));
-            end( "link" );
-            
+            end("link");
+
             atts = new AttributesImpl();
             atts.addAttribute(null, "href", "href", null, AtomUtils.getFeedURL(map));
             atts.addAttribute(null, "rel", "rel", null, "self");
             element("atom:link", null, atts);
 
-            //items
+            // items
             try {
                 encodeItems(map);
             } catch (IOException e) {
@@ -84,9 +84,9 @@ public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
 
         void encodeItems(WMSMapContent map) throws IOException {
             List featureCollections = loadFeatureCollections(map);
-            for (Iterator f = featureCollections.iterator(); f.hasNext(); ) {
+            for (Iterator f = featureCollections.iterator(); f.hasNext();) {
                 SimpleFeatureCollection features = (SimpleFeatureCollection) f.next();
-                FeatureIterator <SimpleFeature> iterator = null;
+                FeatureIterator<SimpleFeature> iterator = null;
 
                 try {
                     iterator = features.features();
@@ -94,43 +94,41 @@ public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
                     while (iterator.hasNext()) {
                         SimpleFeature feature = iterator.next();
                         try {
-                            encodeItem(feature, map);    
-                        }
-                        catch( Exception e ) {
+                            encodeItem(feature, map);
+                        } catch (Exception e) {
                             LOGGER.warning("Encoding failed for feature: " + feature.getID());
-                            LOGGER.log(Level.FINE, "", e );
+                            LOGGER.log(Level.FINE, "", e);
                         }
-                        
+
                     }
                 } finally {
                     if (iterator != null) {
                         iterator.close();
                     }
                 }
-                
+
             }
         }
 
-        void encodeItem(SimpleFeature feature, WMSMapContent map)
-            throws IOException {
+        void encodeItem(SimpleFeature feature, WMSMapContent map) throws IOException {
             start("item");
 
             String title = feature.getID();
-            String link = null; 
+            String link = null;
             String description = "[Error while loading description]";
 
             try {
                 title = AtomUtils.getFeatureTitle(feature);
                 link = AtomUtils.getEntryURL(wms, feature, map);
                 description = AtomUtils.getFeatureDescription(feature);
-            } catch( Exception e ) {
+            } catch (Exception e) {
                 String msg = "Error occured executing title template for: " + feature.getID();
-                LOGGER.log( Level.WARNING, msg, e );
+                LOGGER.log(Level.WARNING, msg, e);
             }
 
             element("title", title);
-            
-            //create the link as getFeature request with fid filter
+
+            // create the link as getFeature request with fid filter
             start("link");
             cdata(link);
             end("link");
@@ -142,26 +140,25 @@ public class RSSGeoRSSTransformer extends GeoRSSTransformerBase {
             start("description");
             cdata(AtomUtils.getFeatureDescription(feature));
             end("description");
-            
-            GeometryCollection col = feature.getDefaultGeometry() instanceof GeometryCollection 
-                ? (GeometryCollection) feature.getDefaultGeometry()
-                : null;
 
-            if (geometryEncoding == GeometryEncoding.LATLONG 
-                || (col == null && feature.getDefaultGeometry() != null)) {
-                geometryEncoding.encode((Geometry)feature.getDefaultGeometry(), this);
+            GeometryCollection col = feature.getDefaultGeometry() instanceof GeometryCollection
+                    ? (GeometryCollection) feature.getDefaultGeometry() : null;
+
+            if (geometryEncoding == GeometryEncoding.LATLONG
+                    || (col == null && feature.getDefaultGeometry() != null)) {
+                geometryEncoding.encode((Geometry) feature.getDefaultGeometry(), this);
                 end("item");
             } else {
                 geometryEncoding.encode(col.getGeometryN(0), this);
                 end("item");
 
-                for (int i = 1; i < col.getNumGeometries(); i++){
+                for (int i = 1; i < col.getNumGeometries(); i++) {
                     encodeRelatedGeometryItem(col.getGeometryN(i), title, link, i);
                 }
             }
         }
 
-        void encodeRelatedGeometryItem(Geometry g, String title, String link, int count){
+        void encodeRelatedGeometryItem(Geometry g, String title, String link, int count) {
             start("item");
             element("title", "Continuation of " + title);
             element("link", link);

--- a/src/wms/src/test/java/org/geoserver/wms/georss/AtomGeoRSSTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/georss/AtomGeoRSSTransformerTest.java
@@ -22,19 +22,16 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-
 public class AtomGeoRSSTransformerTest extends WMSTestSupport {
     static WMSMapContent map;
-    
- 
+
     @Before
     public void initializeMap() throws Exception {
-       
 
         map = new WMSMapContent(createGetMapRequest(MockData.BASIC_POLYGONS));
         map.addLayer(createMapLayer(MockData.BASIC_POLYGONS));
     }
-    
+
     @org.junit.Test
     public void testLatLongInternal() throws Exception {
         AtomGeoRSSTransformer tx = new AtomGeoRSSTransformer(getWMS());
@@ -66,9 +63,9 @@ public class AtomGeoRSSTransformerTest extends WMSTestSupport {
     @org.junit.Test
     public void testLatLongWMS() throws Exception {
         Document document = getAsDOM(
-                "wms/reflect?format_options=encoding:latlong&format=application/atom+xml&layers=" 
-                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
-                );
+                "wms/reflect?format_options=encoding:latlong&format=application/atom+xml&layers="
+                        + MockData.BASIC_POLYGONS.getPrefix() + ":"
+                        + MockData.BASIC_POLYGONS.getLocalPart());
 
         Element element = document.getDocumentElement();
         assertEquals("feed", element.getNodeName());
@@ -85,7 +82,7 @@ public class AtomGeoRSSTransformerTest extends WMSTestSupport {
             assertEquals(1, entry.getElementsByTagName("geo:long").getLength());
         }
     }
-    
+
     @org.junit.Test
     public void testSimpleInternal() throws Exception {
         AtomGeoRSSTransformer tx = new AtomGeoRSSTransformer(getWMS());
@@ -113,12 +110,13 @@ public class AtomGeoRSSTransformerTest extends WMSTestSupport {
             assertEquals(1, entry.getElementsByTagName("georss:polygon").getLength());
         }
     }
+
     @org.junit.Test
     public void testSimpleWMS() throws Exception {
         Document document = getAsDOM(
-                "wms/reflect?format_options=encoding:simple&format=application/atom+xml&layers=" 
-                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
-                );
+                "wms/reflect?format_options=encoding:simple&format=application/atom+xml&layers="
+                        + MockData.BASIC_POLYGONS.getPrefix() + ":"
+                        + MockData.BASIC_POLYGONS.getLocalPart());
 
         Element element = document.getDocumentElement();
         assertEquals("feed", element.getNodeName());
@@ -135,12 +133,13 @@ public class AtomGeoRSSTransformerTest extends WMSTestSupport {
             assertEquals(1, entry.getElementsByTagName("georss:polygon").getLength());
         }
     }
+
     @org.junit.Test
     public void testGmlWMS() throws Exception {
         Document document = getAsDOM(
-                "wms/reflect?format_options=encoding:gml&format=application/atom+xml&layers=" 
-                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
-                );
+                "wms/reflect?format_options=encoding:gml&format=application/atom+xml&layers="
+                        + MockData.BASIC_POLYGONS.getPrefix() + ":"
+                        + MockData.BASIC_POLYGONS.getLocalPart());
 
         Element element = document.getDocumentElement();
         assertEquals("feed", element.getNodeName());

--- a/src/wms/src/test/java/org/geoserver/wms/georss/AtomGeoRSSTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/georss/AtomGeoRSSTransformerTest.java
@@ -9,17 +9,33 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 import org.geoserver.data.test.MockData;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WMSTestSupport;
 import org.geotools.data.Query;
 import org.junit.Before;
+import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class AtomGeoRSSTransformerTest extends WMSTestSupport {
@@ -131,6 +147,42 @@ public class AtomGeoRSSTransformerTest extends WMSTestSupport {
             Element entry = (Element) entries.item(i);
             assertEquals(1, entry.getElementsByTagName("georss:where").getLength());
             assertEquals(1, entry.getElementsByTagName("georss:polygon").getLength());
+        }
+    }
+
+    /**
+     * Check for errors in concurrent output from WMS, such as in templated fields. This is a
+     * best-effort test that will usually, but not always, fail in the presence of bugs.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConcurrentWMS() throws Exception {
+        Callable<Document> getter = () -> getAsDOM(
+                "wms/reflect?format_options=encoding:simple&format=application/atom+xml&layers="
+                        + MockData.BASIC_POLYGONS.getPrefix() + ":"
+                        + MockData.BASIC_POLYGONS.getLocalPart());
+        StringWriter writer = new StringWriter();
+        Transformer t = TransformerFactory.newInstance().newTransformer();
+
+        // Filter timestamps to prevent time-based errors in test
+        Document document = filterTimestamps(getter.call());
+        t.transform(new DOMSource(document), new StreamResult(writer));
+        String expected = writer.toString();
+
+        int calls = 100;
+        CompletionService<Document> cs = new ExecutorCompletionService<>(
+                Executors.newFixedThreadPool(calls));
+        for (int i = 0; i < calls; i++) {
+            cs.submit(getter);
+        }
+
+        for (int i = 0; i < calls; i++) {
+            writer = new StringWriter();
+            t.transform(new DOMSource(filterTimestamps(cs.take().get())),
+                    new StreamResult(writer));
+
+            assertEquals(expected, writer.toString());
         }
     }
 

--- a/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/georss/RSSGeoRSSTransformerTest.java
@@ -36,7 +36,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-
 public class RSSGeoRSSTransformerTest extends WMSTestSupport {
     FilterFactory ff = CommonFactoryFinder.getFilterFactory(GeoTools.getDefaultHints());
 
@@ -59,14 +58,15 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         NodeList description = channel.getElementsByTagName("description");
         assertEquals("Test Abstract", description.item(0).getChildNodes().item(0).getNodeValue());
     }
-	
+
     @Test
     public void testLinkTemplate() throws Exception {
         WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.BASIC_POLYGONS));
         map.addLayer(createMapLayer(MockData.BASIC_POLYGONS));
 
         try {
-            File linkFile = new File(testData.getDataDirectoryRoot().getAbsolutePath() + "/workspaces/cite/cite/BasicPolygons/link.ftl");
+            File linkFile = new File(testData.getDataDirectoryRoot().getAbsolutePath()
+                    + "/workspaces/cite/cite/BasicPolygons/link.ftl");
             FileOutputStream out = new FileOutputStream(linkFile);
             out.write("http://dummp.com".getBytes());
             out.close();
@@ -90,7 +90,8 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         assertEquals(n, items.getLength());
         for (int i = 0; i < items.getLength(); i++) {
             Element item = (Element) items.item(i);
-			assertEquals("http://dummp.com", item.getElementsByTagName("link").item(0).getChildNodes().item(0).getNodeValue());
+            assertEquals("http://dummp.com", item.getElementsByTagName("link").item(0)
+                    .getChildNodes().item(0).getNodeValue());
         }
     }
 
@@ -120,13 +121,13 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
             assertEquals(1, item.getElementsByTagName("geo:long").getLength());
         }
     }
-    
-    @Test 
+
+    @Test
     public void testLatLongWMS() throws Exception {
         Document document = getAsDOM(
-                "wms/reflect?format_options=encoding:latlong&format=application/rss+xml&layers=" 
-                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
-                );
+                "wms/reflect?format_options=encoding:latlong&format=application/rss+xml&layers="
+                        + MockData.BASIC_POLYGONS.getPrefix() + ":"
+                        + MockData.BASIC_POLYGONS.getLocalPart());
 
         Element element = document.getDocumentElement();
         assertEquals("rss", element.getNodeName());
@@ -143,7 +144,7 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
             assertEquals(1, item.getElementsByTagName("geo:long").getLength());
         }
     }
-    
+
     @Test
     public void testSimpleInternal() throws Exception {
         WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.BASIC_POLYGONS));
@@ -171,12 +172,12 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         }
     }
 
-    @Test 
+    @Test
     public void testSimpleWMS() throws Exception {
         Document document = getAsDOM(
-                "wms/reflect?format_options=encoding:simple&format=application/rss+xml&layers=" 
-                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
-                );
+                "wms/reflect?format_options=encoding:simple&format=application/rss+xml&layers="
+                        + MockData.BASIC_POLYGONS.getPrefix() + ":"
+                        + MockData.BASIC_POLYGONS.getLocalPart());
 
         Element element = document.getDocumentElement();
         assertEquals("rss", element.getNodeName());
@@ -192,13 +193,13 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
             assertEquals(1, entry.getElementsByTagName("georss:polygon").getLength());
         }
     }
-    
-    @Test 
+
+    @Test
     public void testGmlWMS() throws Exception {
         Document document = getAsDOM(
-                "wms/reflect?format_options=encoding:gml&format=application/rss+xml&layers=" 
-                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
-                );
+                "wms/reflect?format_options=encoding:gml&format=application/rss+xml&layers="
+                        + MockData.BASIC_POLYGONS.getPrefix() + ":"
+                        + MockData.BASIC_POLYGONS.getLocalPart());
 
         Element element = document.getDocumentElement();
         assertEquals("rss", element.getNodeName());
@@ -215,7 +216,7 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         }
     }
 
-    @Test 
+    @Test
     public void testFilter() throws Exception {
         // Set up a map context with a filtered layer
         WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.BUILDINGS));
@@ -233,13 +234,13 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
         NodeList items = document.getDocumentElement().getElementsByTagName("item");
         assertEquals(1, items.getLength());
     }
-    
+
     @Test
     public void testReproject() throws Exception {
         // Set up a map context with a projected layer
         WMSMapContent map = new WMSMapContent(createGetMapRequest(MockData.LINES));
         map.addLayer(createMapLayer(MockData.LINES));
-        
+
         Document document;
         try {
             document = getRSSResponse(map, AtomGeoRSSTransformer.GeometryEncoding.LATLONG);
@@ -247,10 +248,10 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
             map.dispose();
         }
         NodeList items = document.getDocumentElement().getElementsByTagName("item");
-        
+
         // check all items are there
         assertEquals(1, items.getLength());
-        
+
         // check coordinates are in wgs84, originals aren't
         for (int i = 0; i < items.getLength(); i++) {
             Element item = (Element) items.item(i);
@@ -264,7 +265,7 @@ public class RSSGeoRSSTransformerTest extends WMSTestSupport {
     String getOrdinate(Element item, String ordinate) {
         return item.getElementsByTagName(ordinate).item(0).getChildNodes().item(0).getNodeValue();
     }
-    
+
     /**
      * Returns a DOM given a map context and a geometry encoder
      */


### PR DESCRIPTION
Patch for [GEOS-7923](https://osgeo-org.atlassian.net/browse/GEOS-7923
)

The AtomUtils class held a static reference to a FeatureTemplate instance, which caused issues in a concurrent context (there was a TODO asking if they were threadsafe). This patch transfers ownership of the feature template from the utility class to the transformer instances handling the request. I've added a test case that checks for concurrency violations by comparing the output of WMS requests made by multiple threads, but it's not a foolproof test, as one could imagine. It should help catch some such violations, though.

Corporate contributor license agreement is pending.