### PR TITLE
Mbstyle - Source URL syntax & walkthrough

### DIFF
--- a/doc/en/user/source/production/container.rst
+++ b/doc/en/user/source/production/container.rst
@@ -54,6 +54,8 @@ For more information about JVM configuration, see the article `Performance tunin
     
    The above results (from a 16 GB laptop) amount to initial heap size of 256m, and a max heap size of around 4 GB (or around 1/4 of system memory).
    
+.. _production_container.enable_cors:
+
 Enable CORS
 -----------
 

--- a/doc/en/user/source/styling/mbstyle/index.rst
+++ b/doc/en/user/source/styling/mbstyle/index.rst
@@ -13,6 +13,7 @@ MBStyle is not a part of GeoServer by default, but is available as an optional i
    :maxdepth: 2
 
    installing
+   source
    reference/index
    reference/spec
    cookbook/index

--- a/doc/en/user/source/styling/mbstyle/reference/spec.rst
+++ b/doc/en/user/source/styling/mbstyle/reference/spec.rst
@@ -149,7 +149,15 @@ Data source specifications.
     "sources": {
       "mapbox-streets": {
         "type": "vector",
-        "url": "mapbox://mapbox.mapbox-streets-v6"
+        "tiles": [
+          "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile
+              &SERVICE=WMTS&VERSION=1.0.0&LAYER=mapbox:streets&STYLE=
+              &TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913
+              &FORMAT=application/x-protobuf;type=mapbox-vector
+              &TILECOL={x}&TILEROW={y}"
+        ],
+        "minZoom": 0,
+        "maxZoom": 14
       }
     }
 
@@ -427,7 +435,14 @@ Mapbox, the ``"url"`` value should be of the form ``mapbox://mapid``.
 
     "mapbox-streets": {
       "type": "vector",
-      "url": "mapbox://mapbox.mapbox-streets-v6"
+      "tiles": [
+        "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS
+            &VERSION=1.0.0&LAYER=mapbox:streets&STYLE=&TILEMATRIX=EPSG:900913:{z}
+            &TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector
+            &TILECOL={x}&TILEROW={y}"
+      ],
+      "minZoom": 0,
+      "maxZoom": 14
     }
 
 url
@@ -492,8 +507,13 @@ value should be of the form ``mapbox://mapid``.
 
     "mapbox-satellite": {
       "type": "raster",
-      "url": "mapbox://mapbox.satellite",
-      "tileSize": 256
+      "tiles": [
+        "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS
+            &VERSION=1.0.0&LAYER=mapbox:satellite&STYLE=&TILEMATRIX=EPSG:900913:{z}
+            &TILEMATRIXSET=EPSG:900913&FORMAT=image/png&TILECOL={x}&TILEROW={y}"
+      ],
+      "minzoom": 0,
+      "maxzoom": 14
     }
 
 url

--- a/doc/en/user/source/styling/mbstyle/source.rst
+++ b/doc/en/user/source/styling/mbstyle/source.rst
@@ -1,0 +1,40 @@
+.. _mbstyle_source:
+
+Publishing a GeoServer Layer for use with Mapbox Styles
+=======================================================
+
+GeoServer can be configured to serve layers as vector tiles which can be used as sources for Mapbox styles rendered by client-side applications such as OpenLayers.
+
+1. :ref:`production_container.enable_cors` in GeoServer.
+
+2. Install the :ref:`Vector Tiles <vectortiles.install>` extension.
+
+3. Follow the :ref:`vectortiles.tutorial` to publish your layers in ``application/x-protobuf;type=mapbox-vector`` format (You only need to do the "Publish vector tiles in GeoWebCache" step).
+
+Once these steps are complete, you will be able to use your GeoServer layers in any Mapbox-compatible client application that can access your GeoServer.
+
+The source syntax to use these GeoServer layers in your MapBox Style is::
+
+    "<source-name>": {
+      "type": "vector",
+      "tiles": [
+        "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS
+            &VERSION=1.0.0&LAYER=<workspace>:<layer>&STYLE=&TILEMATRIX=EPSG:900913:{z}
+            &TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector
+            &TILECOL={x}&TILEROW={y}"
+      ],
+      "minZoom": 0,
+      "maxZoom": 14
+    }
+
+.. note:: 
+
+   ``<workspace>`` and ``<layer>`` should be replaced by the workspace and name of the layer in question. ``{x}``, ``{y}``, and ``{z}`` are placeholder values for the tile indices and should be preserved as written.
+
+.. note:: 
+
+   ``<source-name>`` should be replaced by a source name of your choice. It will be used to refer to the source elsewhere in the Mapbox Style.
+
+.. note:: 
+
+   If geoserver is not being served from ``localhost:8080``, update the domain accordingly.


### PR DESCRIPTION
Added a basic walkthrough of how to publish vector tiles for use with MapBox Style clients to MBStyle docs.

All `mapbox://` examples in the spec have been replaced with GeoServer examples. Places where the syntax is a actually described have remained unchanged.