### PR TITLE
[GEOS-8166] Allow image mosaic to refer a GeoServer configured store

### DIFF
--- a/doc/en/user/source/data/raster/imagemosaic/configuration.rst
+++ b/doc/en/user/source/data/raster/imagemosaic/configuration.rst
@@ -119,6 +119,18 @@ If needed, different storage can be used for the index — like a spatial DBMS, 
    * - Parameter
      - Mandatory?
      - Description
+   * - StoreName
+     - N
+     - Can be used to refer to a GeoServer registered store, using a "workspace:storeName" syntax. When this is used,
+       the no other connection parameters need to be provided. The SPI can still be provided to inform the mosaic of
+       the resulting type of store (e.g., Oracle) in case specific behavior need to be enacted for it (e.g., in the
+       case of Oracle the attributes are all uppercase and cannot be longer than 30 chars, the mosaic will respect
+       the limits but the `SPI` parameter needs to be explicitly set to `org.geotools.data.oracle.OracleNGDataStoreFactory`
+       as the actual store type is hidden when it reaches the mosaic code). 
+       Also, as a reminder, the code is picking up a Store reference, not a layer one, meaning that security restrictions
+       that might have been applied to a layer exposing the feature type do not apply to the mosaic code (e.g., if
+       a user has restrictions such as a spatial filter on said layer, it won't transfer to the mosaic, which needs to
+       be secured separately) 
    * - SPI
      - Y
      - The DataStoreFactory used to connect to the index store:

--- a/doc/en/user/source/data/raster/imagemosaic/tutorial.rst
+++ b/doc/en/user/source/data/raster/imagemosaic/tutorial.rst
@@ -351,3 +351,36 @@ In this example, we will serve up overlapping granules that have varying resolut
    .. figure:: images/tutorial_reproj_noartifact.png
 
       Closeup of granule overlap (high resolution granule on right)
+
+Referring to a datastore configured in GeoServer
+------------------------------------------------
+
+It is possible to make the mosaic refer to an existing data store. The **``datastore.properties``** file in this case will
+contain only one or two properties, referring to the store to be used via the ``StoreName`` property.
+For simple cases, e.g., a PostGIS store, the following will be sufficient::
+
+   StoreName=workspace:storename
+
+For Oracle or H2, it's best to also specify the SPI in order to inform the mosaic that it needs to work around
+specific limitations of the storage (e.g., forced uppercase attribute usage, limitation in attribute name length and the like)::
+
+   StoreName=workspace:storename
+   SPI=org.geotools.data.oracle.OracleNGDataStoreFactory
+
+The above will be sufficient in case the image mosaic can create the index table and perform normal indexing, using 
+the directory name as the table name.
+In case a specific table name needs to be used, add an **``indexer.properties``** specifying the ``TypeName`` property,
+e.g.:
+
+   TypeName=myMosaicTypeName
+
+In case the index "table" already exists instead, then a **``indexer.properties``** file will be required, with the following contents::
+
+   UseExistingSchema=true
+   TypeName=nameOfTheFeatureTypeContainingTheIndex
+   AbsolutePath=true
+
+The above assumes ``location`` attribute provides absolute paths to the mosaic granules, instead of ones relative to
+the mosaic configuration files directory.
+
+

--- a/src/main/src/main/java/org/geoserver/catalog/CatalogRepository.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogRepository.java
@@ -50,7 +50,9 @@ public class CatalogRepository implements Repository, Serializable {
             return (DataStore) da;
         }
         
-        LOGGER.severe( name + " is not a data store.");
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine(name + " is not a data store.");
+        }
         return null;
     }
 


### PR DESCRIPTION
This pull request passes a Repository reference to readers, allowing them to refer to GeoServer datastore/dataaccess.

Working on it I noticed code duplication and oddities in the way readers are created and cached in the resource pool, cleaning it up and ended with one significant change to ResourcePool (one public method removed), but eliminating in the process the need to have two separate coverage reader caches and making sure readers get the hints they need no matter what the context is. 

ResourcePool is not meant to be used by "client" code, and its actual usage is limited to catalog classes and configuration related bits, such as REST config and Web UI, so I'm not too much concerned about the removal of that one public method to get the non hinted coverage cache reference (nothing was using it as far as I could tell, a full build passed locally, although I did a few cleanups after it).

That said, given the nature of the change, it's probably best if either @jodygarnett or @tbarsballe has a look at the pull request (or any PSC member, really).