### PR TITLE
[GEOS-7873] Use Logger.log for errors, not e.printStackTrace

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -1188,10 +1188,8 @@ public class XStreamPersister {
                     if (nodes.peek() instanceof JSONArray) {
                         nodes.pop();
                     }
-                } catch (IllegalAccessException e) {
-                    e.printStackTrace();
-                } catch (NoSuchFieldException e) {
-                    e.printStackTrace();
+                } catch (IllegalAccessException | NoSuchFieldException e) {
+                    LOGGER.log(Level.WARNING, "Unexpected reflection error serializing json array", e);
                 }
             }
             writer.endNode();


### PR DESCRIPTION
Fix an issue with #2084