### PR TITLE
[GEOS-8176] RetypingFeatureCollection doesn't retype subCollections

### DIFF
--- a/src/main/src/main/java/org/geoserver/feature/RetypingFeatureCollection.java
+++ b/src/main/src/main/java/org/geoserver/feature/RetypingFeatureCollection.java
@@ -24,6 +24,7 @@ import org.opengis.feature.IllegalAttributeException;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.filter.Filter;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.identity.FeatureId;
@@ -35,6 +36,8 @@ import org.opengis.filter.identity.FeatureId;
  * 
  */
 public class RetypingFeatureCollection extends DecoratingSimpleFeatureCollection {
+
+
     SimpleFeatureType target;
 
     public RetypingFeatureCollection(SimpleFeatureCollection delegate,
@@ -56,6 +59,13 @@ public class RetypingFeatureCollection extends DecoratingSimpleFeatureCollection
         return ReTypingFeatureCollection.isTypeCompatible(visitor, target);
     }
 
+    @Override
+    public SimpleFeatureCollection subCollection(Filter filter) {
+        
+        SimpleFeatureCollection delegateCollection = delegate.subCollection(filter);
+        
+        return new ReTypingFeatureCollection(delegateCollection, target);
+    }
 
     static SimpleFeature retype(SimpleFeature source, SimpleFeatureBuilder builder)
             throws IllegalAttributeException {

--- a/src/main/src/test/java/org/geoserver/feature/RetypingFeatureCollectionTest.java
+++ b/src/main/src/test/java/org/geoserver/feature/RetypingFeatureCollectionTest.java
@@ -4,12 +4,13 @@
  */
 package org.geoserver.feature;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 
 import org.geotools.data.DataUtilities;
 import org.geotools.data.collection.ListFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -19,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
 import org.opengis.util.ProgressListener;
 
 public class RetypingFeatureCollectionTest {
@@ -59,5 +61,20 @@ public class RetypingFeatureCollectionTest {
         RetypingFeatureCollection retypedCollection = new RetypingFeatureCollection(collection, renamedSchema);
         retypedCollection.accepts(visitor, null);
         assertSame(lastVisitor, visitor);
+    }
+    
+    /**
+     * TEST for GEOS-8176 [https://osgeo-org.atlassian.net/browse/GEOS-8176].
+     * 
+     * Make sure that the subCollection returned is retyped.
+     * 
+     * @author Ian Turton
+     */
+    @Test
+    public void testSubCollectionRetyping() {
+        RetypingFeatureCollection retypedCollection = new RetypingFeatureCollection(collection,
+                renamedSchema);
+        SimpleFeatureCollection subCollection = retypedCollection.subCollection(Filter.INCLUDE);
+        assertSame(renamedSchema, subCollection.getSchema());
     }
 }


### PR DESCRIPTION
Fix for [GEOS-8176](https://osgeo-org.atlassian.net/browse/GEOS-8176) which forces the subCollections returned by the RetypeingFeatureCollection to be retyped.