### PR TITLE
[GEOS-8216] Fix MenuPageInfo Generics

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/MenuPageInfo.java
+++ b/src/web/core/src/main/java/org/geoserver/web/MenuPageInfo.java
@@ -22,7 +22,7 @@ import org.geoserver.web.services.ServiceMenuPageInfo;
  * @author David Winslow <dwinslow@opengeo.org>
  */
 @SuppressWarnings("serial")
-public class MenuPageInfo extends ComponentInfo<GeoServerBasePage> implements Comparable<MenuPageInfo> {
+public class MenuPageInfo<T extends GeoServerBasePage> extends ComponentInfo<T> implements Comparable<MenuPageInfo<T>> {
     Category category;
     int order;
     String icon;
@@ -62,7 +62,7 @@ public class MenuPageInfo extends ComponentInfo<GeoServerBasePage> implements Co
         return order;
     }
 
-    public int compareTo(MenuPageInfo other){
+    public int compareTo(MenuPageInfo<T> other){
         return getOrder() - other.getOrder();
     }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage.java
@@ -362,7 +362,7 @@ public class WorkspaceEditPage extends GeoServerSecuredPage {
         Boolean enabled;
 
         /** the admin page for the service */ 
-        ServiceMenuPageInfo adminPage;
+        ServiceMenuPageInfo<?> adminPage;
 
         /** created service, not yet added to configuration */
         IModel<ServiceInfo> model;

--- a/src/web/core/src/main/java/org/geoserver/web/services/ServiceMenuPageInfo.java
+++ b/src/web/core/src/main/java/org/geoserver/web/services/ServiceMenuPageInfo.java
@@ -6,6 +6,7 @@
 package org.geoserver.web.services;
 
 import org.geoserver.config.ServiceInfo;
+import org.geoserver.web.GeoServerBasePage;
 import org.geoserver.web.MenuPageInfo;
 
 /**
@@ -14,7 +15,7 @@ import org.geoserver.web.MenuPageInfo;
  * @author David Winslow <dwinslow@opengeo.org>
  */
 @SuppressWarnings("serial")
-public class ServiceMenuPageInfo extends MenuPageInfo {
+public class ServiceMenuPageInfo<T extends GeoServerBasePage> extends MenuPageInfo<T> {
 
     Class<? extends ServiceInfo> serviceClass;
 


### PR DESCRIPTION
It is impossible to create a MenuPageInfo programmatically, because of a wrong usage of generics. 
It only works through Spring, because spring ignores generics.

MenuPageInfo has an associated class, which should be a subclass of GeoServerBasePage.

However. MenuPageInfo extends ComponentInfo<GeoServerBasePage>, rather than ComponentInfo<?extends GeoServerBasePage> that means that the associated class   MUST be GeoServerBasePage.class itself, which doesn't make sense.