### PR TITLE
[GEOS-8179] Fixed control flow ip.blacklist/ip.whitelist error messages during startup.

### DIFF
--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/config/DefaultControlFlowConfigurator.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/config/DefaultControlFlowConfigurator.java
@@ -119,7 +119,7 @@ public class DefaultControlFlowConfigurator implements ControlFlowConfigurator, 
             StringTokenizer tokenizer = new StringTokenizer(value, ",");
             try {
                 // some properties are not integers
-                if("ip.blacklist".equals(key) && "ip.whitelist".equals(key)) {
+                if("ip.blacklist".equals(key) || "ip.whitelist".equals(key)) {
                     continue;
                 } else {
                     if (!key.startsWith("user.ows") && !key.startsWith("ip.ows")) {

--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/config/DefaultControlFlowConfigurationTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/config/DefaultControlFlowConfigurationTest.java
@@ -43,6 +43,8 @@ public class DefaultControlFlowConfigurationTest {
         p.put("ip", "12");
         p.put("ip.192.168.1.8", "14");
         p.put("ip.192.168.1.10", "15");
+        p.put("ip.blacklist", "192.168.1.1,192.168.1.2");
+        p.put("ip.whitelist", "192.168.1.3,192.168.1.4");
         p.put("user.ows", "20/s");
         p.put("user.ows.wms", "300/m;3s");
         p.put("ip.ows.wms.getmap", "100/m;3s");


### PR DESCRIPTION
Fixes the Control Flow plugin logging error messages during the GeoServer startup when the ip.blacklist and/or ip.whitelist properties are being used.  The only difference in behavior is whether or not an error message is logged and an existing unit test was modified but it requires manual inspection of the logs to verify the bug/fix.

This pull request can be backported to 2.11.x and 2.10.x.