### PR TITLE
Upgrade XStream to the latest version

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1107,7 +1107,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.7</version>
+      <version>1.4.10</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>


### PR DESCRIPTION
We are on 1.4.7, see the changelog to 1.4.8, 1.4.9 and 1.4.10 for good reasons to upgrade:
http://x-stream.github.io/changes.html