### PR TITLE
Make sure geogig's ConfigStore works on a clustered environment

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/ConfigStore.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/ConfigStore.java
@@ -6,18 +6,19 @@ package org.geogig.geoserver.config;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Iterators.filter;
 import static com.google.common.collect.Lists.newArrayList;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.net.URI;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,10 +26,13 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.ResourceListener;
@@ -37,12 +41,11 @@ import org.geoserver.platform.resource.ResourceNotification.Event;
 import org.geoserver.platform.resource.ResourceNotificationDispatcher;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geotools.util.logging.Logging;
-import org.locationtech.geogig.repository.RepositoryResolver;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
-import com.google.common.base.Predicate;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.thoughtworks.xstream.XStream;
 
 /**
@@ -67,6 +70,12 @@ public class ConfigStore {
 
     private static final Logger LOGGER = Logging.getLogger(ConfigStore.class);
 
+    private static final Predicate<Resource> FILENAMEFILTER = (res) -> res.name().endsWith(".xml");
+
+    public static interface RepositoryInfoChangedCallback {
+        public void repositoryInfoChanged(String repoId);
+    }
+
     /**
      * Regex pattern to assert the format of ids on {@link #save(RepositoryInfo)}
      */
@@ -75,47 +84,80 @@ public class ConfigStore {
 
     private static final String CONFIG_DIR_NAME = "geogig/config/repos";
 
-    private ResourceStore resourceLoader;
+    private ResourceStore resourceStore;
 
     private final ReadWriteLock lock;
 
     private Queue<RepositoryInfoChangedCallback> callbacks;
 
-    /**
-     * Map of cached {@link RepositoryInfo} instances key'ed by id
-     */
-    private ConcurrentMap<String, RepositoryInfo> cache = new ConcurrentHashMap<>();
+    private ConcurrentMap<String, RepositoryInfo> infosById = new ConcurrentHashMap<>();
 
     public ConfigStore(ResourceStore resourceLoader) {
         checkNotNull(resourceLoader, "resourceLoader");
-        this.resourceLoader = resourceLoader;
+        this.resourceStore = resourceLoader;
         if (resourceLoader.get(CONFIG_DIR_NAME) == null) {
             throw new IllegalStateException("Unable to create config directory " + CONFIG_DIR_NAME);
         }
         this.lock = new ReentrantReadWriteLock();
         this.callbacks = new ConcurrentLinkedQueue<RepositoryInfoChangedCallback>();
-        populateCache();
+        preload();
 
-        ResourceNotificationDispatcher dispatcher = resourceLoader
-                .getResourceNotificationDispatcher();
+        ResourceNotificationDispatcher dispatcher;
+        dispatcher = resourceLoader.getResourceNotificationDispatcher();
+
         dispatcher.addListener(CONFIG_DIR_NAME, new ResourceListener() {
             @Override
             public void changed(ResourceNotification notify) {
                 for (Event event : notify.events()) {
-                    String path = event.getPath().startsWith(CONFIG_DIR_NAME) ? event.getPath()
-                            : CONFIG_DIR_NAME + "/" + event.getPath();
-                    String repoId = idFromPath(path);
+                    final String repoId;
+                    {
+                        final String path = event.getPath().startsWith(CONFIG_DIR_NAME)
+                                ? event.getPath() : CONFIG_DIR_NAME + "/" + event.getPath();
+                        repoId = idFromPath(path);
+                    }
+                    final String thread = Thread.currentThread().getName();
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.finer("Processing event " + event.getKind() + " for repo " + repoId
+                                + " on thread " + thread);
+                    }
                     switch (event.getKind()) {
-                    case ENTRY_CREATE:
-                    case ENTRY_MODIFY:
-                        cache.remove(repoId);
-                        loadResource(resourceLoader.get(path));
-                        break;
-                    case ENTRY_DELETE:
-                        cache.remove(repoId);
+                    case ENTRY_CREATE: {
+                        // ResourceStore may issue entry_create before or after the contents where
+                        // written, but it'll always issue an entry_modify event just after the
+                        // contents are written, so we ignore the create events and wait for the
+                        // modify events to avoid double processing
+                        if (LOGGER.isLoggable(Level.FINE)) {
+                            LOGGER.fine("Received an ENTRY_CREATE event for repo id " + repoId
+                                    + " Event ignored, waiting for the ENTRY_MODIFY event to process it");
+                        }
                         break;
                     }
-                    repositoryInfoChanged(repoId);
+                    case ENTRY_MODIFY: {
+                        lock.writeLock().lock();
+                        try {
+                            get(repoId);
+                        } catch (NoSuchElementException e) {
+                            LOGGER.info("Error loading repo " + repoId + " upon event " + event
+                                    + ". Thread: " + thread);
+                            Preconditions.checkState(!infosById.containsKey(repoId));
+                            // ignore, exception already logged by get(), but call
+                            // repositoryInfoChanged for
+                            // RepositoryManager to close the live Repository
+                        } finally {
+                            lock.writeLock().unlock();
+                        }
+                        repositoryInfoChanged(repoId);
+                        break;
+                    }
+                    case ENTRY_DELETE:
+                        infosById.remove(repoId);
+                        repositoryInfoChanged(repoId);
+                        break;
+                    }
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.finer("Finished processing event " + event.getKind() + " for repo "
+                                + repoId + " on thread " + thread);
+                    }
                 }
             }
         });
@@ -146,18 +188,25 @@ public class ConfigStore {
      * xml file is replaced meaning it has been modified.
      * 
      * @return {@code info}, possibly with its id set if it was {@code null}
-     * 
+     * @implNote this method saves the {@link RepositoryInfo} to the internal cache, setting its
+     *           {@link RepositoryInfo#getLastModified() timestamp} to {@code -1}, meaning it was
+     *           just saved on this node. The resourcestore event listener will not reload it but
+     *           just update its timestamp, while on other nodes it'll load/reload it as needed.
+     *           This ensures on this node the {@link RepositoryInfo} will be available right after
+     *           this method returns, regardless of how long it takes the resource store event
+     *           dispatcher to notify this or other nodes.
      */
     public RepositoryInfo save(RepositoryInfo info) {
         checkNotNull(info, "null RepositoryInfo");
         ensureIdPresent(info);
         checkNotNull(info.getLocation(), "null location URI: %s", info);
 
-        lock.writeLock().lock();
         Resource resource = resource(info.getId());
+        lock.writeLock().lock();
         try (OutputStream out = resource.out()) {
+            info.setLastModified(-1L);// meaning just saved on this node
+            infosById.put(info.getId(), info);
             getConfigredXstream().toXML(info, new OutputStreamWriter(out, Charsets.UTF_8));
-            cache.put(info.getId(), info);
         } catch (IOException e) {
             throw Throwables.propagate(e);
         } finally {
@@ -171,7 +220,7 @@ public class ConfigStore {
         checkIdFormat(id);
         lock.writeLock().lock();
         try {
-            cache.remove(id);
+            infosById.remove(id);
             return resource(id).delete();
         } finally {
             lock.writeLock().unlock();
@@ -193,12 +242,12 @@ public class ConfigStore {
     }
 
     private Resource resource(String id) {
-        Resource resource = resourceLoader.get(path(id));
+        Resource resource = resourceStore.get(path(id));
         return resource;
     }
 
     public Resource getConfigRoot() {
-        return resourceLoader.get(CONFIG_DIR_NAME);
+        return resourceStore.get(CONFIG_DIR_NAME);
     }
 
     static String path(String infoId) {
@@ -208,33 +257,29 @@ public class ConfigStore {
     static String idFromPath(String path) {
         List<String> names = Paths.names(path);
         String resourceName = names.get(names.size() - 1);
-        return resourceName.substring(0, resourceName.length() - 4);
+        return resourceName.substring(0, resourceName.length() - ".xml".length());
     }
 
-    @VisibleForTesting
-    void populateCache() {
-        cache.clear();
-        Resource configRoot = getConfigRoot();
-        List<Resource> list = configRoot.list();
-        if (null == list) {
-            return;
-        }
-        Iterator<Resource> xmlfiles = filter(list.iterator(), FILENAMEFILTER);
-        while (xmlfiles.hasNext()) {
-            loadResource(xmlfiles.next());
-        }
-    }
-
-    private void loadResource(Resource resource) {
-        try {
-            RepositoryInfo info = load(resource);
-            if (info != null) {
-                cache.put(info.getId(), info);
+    private RepositoryInfo loadInfo(Resource resource) throws IllegalStateException {
+        RepositoryInfo info;
+        try (Reader reader = new InputStreamReader(resource.in(), Charsets.UTF_8)) {
+            info = (RepositoryInfo) getConfigredXstream().fromXML(reader);
+            if (info.getLocation() == null) {
+                throw new IllegalStateException(
+                        "Repository info has incomplete information: " + info);
             }
-        } catch (IOException e) {
-            // log the bad info
-            LOGGER.log(Level.WARNING, "Error loading RepositoryInfo", e);
+            info.setLastModified(resource.lastmodified());
+        } catch (Exception e) {
+            // the contract for Resource.in() is not clear on what to expect but both the
+            // FileSystem
+            // and Redis implementations throw IllegalStateException for well known causes like
+            // resource not existing or being a directory.
+            Throwables.propagateIfInstanceOf(e, IllegalStateException.class);
+            String msg = "Unable to load repo config " + resource.name();
+            LOGGER.log(Level.WARNING, msg, e);
+            throw new IllegalStateException(msg, e);
         }
+        return info;
     }
 
     private void repositoryInfoChanged(String repoId) {
@@ -248,7 +293,44 @@ public class ConfigStore {
      * <data-dir>/geogig/config/repos/}; any xml file that can't be parsed is ignored.
      */
     public List<RepositoryInfo> getRepositories() {
-        return newArrayList(cache.values());
+        lock.readLock().lock();
+        try {
+            return ImmutableList.copyOf(infosById.values());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    private void preload() {
+        List<RepositoryInfo> repos = loadRepositories();
+        repos.forEach((info) -> infosById.put(info.getId(), info));
+    }
+
+    /**
+     * Loads and returns all {@link RepositoryInfo}s directly from the {@link ResourceStore}
+     */
+    private List<RepositoryInfo> loadRepositories() {
+        Resource configRoot = getConfigRoot();
+        List<Resource> resources = configRoot.list();
+        if (null == resources || resources.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<RepositoryInfo> infos = resources//
+                .parallelStream()//
+                .filter(FILENAMEFILTER)//
+                .map((res) -> {
+                    try {
+                        return loadInfo(res);
+                    } catch (RuntimeException e) {
+                        LOGGER.log(Level.INFO, "Ignoring malformed resource", e);
+                    }
+                    return null;
+                })//
+                .filter(Objects::nonNull)//
+                .collect(Collectors.toList());
+
+        return infos;
     }
 
     /**
@@ -265,7 +347,7 @@ public class ConfigStore {
     }
 
     private Resource whitelistResource() {
-        return resourceLoader.get("geogig/config/whitelist.xml");
+        return resourceStore.get("geogig/config/whitelist.xml");
     }
 
     private static List<WhitelistRule> loadWhitelist(Resource input) throws IOException {
@@ -302,81 +384,95 @@ public class ConfigStore {
     /**
      * Loads a {@link RepositoryInfo} by {@link RepositoryInfo#getId() id} from its xml file under
      * {@code <data-dir>/geogig/config/repos/}
+     * 
+     * @implNote Ensures to return the most current version of the {@link RepositoryInfo} by
+     *           comparing its {@link RepositoryInfo#getLastModified()} with the
+     *           {@link Resource#lastmodified()}, and reloading in case it was cached but the
+     *           timestamps don't match
      */
-    public RepositoryInfo get(final String id) throws IOException {
+    public RepositoryInfo get(final String id) throws NoSuchElementException {
         checkNotNull(id, "provided a null id");
         checkIdFormat(id);
         lock.readLock().lock();
         try {
-            RepositoryInfo info = cache.get(id);
-            if (info == null) {
-                throw new FileNotFoundException("Repository not found: " + id);
+            Resource resource = resource(id);
+            final @Nullable RepositoryInfo cached = infosById.get(id);
+            final long currentTimeStamp = resource.lastmodified();
+            final long cachedTimestamp = cached == null ? Long.MIN_VALUE : cached.getLastModified();
+            RepositoryInfo info;
+            if (currentTimeStamp != cachedTimestamp) {
+                if (0L == currentTimeStamp) {
+                    throw new NoSuchElementException("Repository not found: " + id);
+                } else {
+                    if (-1L == cachedTimestamp) {
+                        cached.setLastModified(currentTimeStamp);
+                        info = cached;
+                    } else {
+                        try {
+                            info = loadInfo(resource);
+                            infosById.put(info.getId(), info);
+                        } catch (IllegalStateException failed) {
+                            infosById.remove(id);
+                            throw failed;
+                        }
+                    }
+                }
+            } else {
+                info = cached;
             }
             return info;
+        } catch (RuntimeException e) {
+            Throwables.propagateIfInstanceOf(e, NoSuchElementException.class);
+            NoSuchElementException nse = new NoSuchElementException(e.getMessage());
+            nse.initCause(e);
+            throw nse;
         } finally {
             lock.readLock().unlock();
         }
     }
 
-    public RepositoryInfo getByName(final String name) {
-        for (RepositoryInfo cached : cache.values()) {
-            final String cachedRepoName = cached.getRepoName();
-            if (cachedRepoName != null && cachedRepoName.equals(name)) {
-                return cached;
-            }
-        }
-        return null;
+    public @Nullable RepositoryInfo getByName(final String name) {
+        checkNotNull(name);
+        Optional<RepositoryInfo> match = infosById.values().parallelStream()
+                .filter((info) -> name.equals(info.getRepoName())).findFirst();
+
+        return match.orElse(null);
     }
 
-    public RepositoryInfo getByLocation(final URI location) {
-        for (RepositoryInfo cached : cache.values()) {
-            if (cached.getLocation().equals(location)) {
-                return cached;
-            }
-        }
-        return null;
+    public boolean repoExistsByName(String name) {
+        checkNotNull(name);
+        Optional<RepositoryInfo> match = infosById.values().parallelStream()
+                .filter((info) -> name.equals(info.getRepoName())).findFirst();
+
+        return match.isPresent();
     }
 
-    private static RepositoryInfo load(Resource input) throws IOException {
-        Resource parent = input.parent();
-        if (!(parent.getType().equals(Resource.Type.DIRECTORY)
-                && input.getType().equals(Resource.Type.RESOURCE))) {
-            throw new FileNotFoundException("File not found: " + input.path());
-        }
-        RepositoryInfo info;
-        try (Reader reader = new InputStreamReader(input.in(), Charsets.UTF_8)) {
-            info = (RepositoryInfo) getConfigredXstream().fromXML(reader);
-        } catch (Exception e) {
-            String msg = "Unable to load repo config " + input.name();
-            LOGGER.log(Level.WARNING, msg, e);
-            throw new IOException(msg, e);
-        }
-        if (info.getLocation() == null) {
-            throw new IOException("Repository info has incomplete information: " + info);
-        }
-        // we have a location, make sure we have a resolver for the scheme
-        if (!RepositoryResolver.resolverAvailableForURIScheme(info.getLocation().getScheme())) {
-            LOGGER.log(Level.WARNING, "No RepositoryResolver available for URI: {0}",
-                    info.getLocation().toString());
-            return null;
-        }
-        return info;
+    public @Nullable RepositoryInfo getByLocation(final URI location) {
+        checkNotNull(location);
+        Optional<RepositoryInfo> match = infosById.values().parallelStream()
+                .filter((info) -> location.equals(info.getLocation())).findFirst();
+
+        return match.orElse(null);
+    }
+
+    public boolean repoExistsByLocation(URI location) {
+        checkNotNull(location);
+        Optional<RepositoryInfo> match = infosById.values().parallelStream()
+                .filter((info) -> location.equals(info.getLocation())).findFirst();
+
+        return match.isPresent();
+    }
+
+    /**
+     * According to http://x-stream.github.io/faq.html#Scalability_Thread_safety, XStream instances
+     * are thread safe and it's recommended to share them as they're pretty expensive to create
+     */
+    private static final XStream xStream = new XStream();
+    static {
+        xStream.alias("RepositoryInfo", RepositoryInfo.class);
     }
 
     private static XStream getConfigredXstream() {
-        XStream xStream = new XStream();
-        xStream.alias("RepositoryInfo", RepositoryInfo.class);
         return xStream;
-    }
-
-    private static final Predicate<Resource> FILENAMEFILTER = new Predicate<Resource>() {
-        @Override
-        public boolean apply(Resource input) {
-            return input.name().endsWith(".xml");
-        }
-    };
-
-    public static abstract class RepositoryInfoChangedCallback {
-        public abstract void repositoryInfoChanged(String repoId);
     }
 }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
@@ -93,10 +93,11 @@ class RepositoryCache {
     public Repository get(final String repositoryId) throws IOException {
         try {
             return repoCache.get(repositoryId);
-        } catch (ExecutionException e) {
+        } catch (Throwable e) {
             Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
-            throw new IOException("Error obtaining cached geogig instance for repo " + repositoryId,
-                    e.getCause());
+            Throwable cause = e.getCause();
+            throw new IOException("Error obtaining cached geogig instance for repo " + repositoryId
+                    + ": " + cause.getMessage(), cause);
         }
     }
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/RepositoryInfo.java
@@ -14,8 +14,9 @@ import org.locationtech.geogig.repository.RepositoryResolver;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
 
-public class RepositoryInfo implements Serializable {
+public class RepositoryInfo implements Serializable, Cloneable {
 
     private static final long serialVersionUID = -5946705936987075713L;
 
@@ -36,6 +37,7 @@ public class RepositoryInfo implements Serializable {
     private java.net.URI location;
 
     private String maskedLocation;
+
     /**
      * Stores the "nice" name for a repo. This is the name that is shown in the Repository list, as
      * well as what is stored in the GeoGIG repository config. It is transient, as we don't want to
@@ -44,12 +46,22 @@ public class RepositoryInfo implements Serializable {
      */
     private transient String repoName;
 
+    private transient long lastModified;
+
     public RepositoryInfo() {
         this(null);
     }
 
     RepositoryInfo(String id) {
         this.id = id;
+    }
+
+    public @Override RepositoryInfo clone() {
+        try {
+            return (RepositoryInfo) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw Throwables.propagate(e);
+        }
     }
 
     private Object readResolve() {
@@ -134,5 +146,13 @@ public class RepositoryInfo implements Serializable {
     public String toString() {
         return new StringBuilder("[id:").append(getId()).append(", URI:").append(getLocation())
                 .append("]").toString();
+    }
+
+    long getLastModified() {
+        return lastModified;
+    }
+
+    void setLastModified(long timestamp) {
+        this.lastModified = timestamp;
     }
 }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
@@ -12,7 +12,6 @@ import java.net.URISyntaxException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geogig.geoserver.config.RepositoryManager;
@@ -72,7 +71,7 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
             } else {
                 return Optional.absent();
             }
-        } catch (NoSuchElementException | IOException e) {
+        } catch (RuntimeException e) {
             return Optional.absent();
         }
     }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/ImportRepoCommandResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/ImportRepoCommandResource.java
@@ -35,13 +35,11 @@ public class ImportRepoCommandResource extends CommandResource {
         // before importing the repository, extract the repository name from the request and see if
         // a repository with that name already exists
         final String repoName = RESTUtils.getStringAttribute(request, "repository");
-        if (repoName != null) {
-            if (RepositoryManager.get().getByRepoName(repoName) != null) {
-                // repo already exists
-                throw new CommandSpecException(
+        if (repoName != null && RepositoryManager.get().repoExistsByName(repoName)) {
+            // repo already exists
+            throw new CommandSpecException(
                     "The specified repository name is already in use, please try a different name",
                     Status.CLIENT_ERROR_CONFLICT);
-            }
         }
         // all good
         return super.runCommand(variant, request, outputFormat);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/InitCommandResource.java
@@ -24,13 +24,11 @@ public class InitCommandResource extends org.locationtech.geogig.rest.repository
         // before running the Init command, extract the repository name from the request and see if
         // a repository with that name already exists
         final String repoName = RESTUtils.getStringAttribute(request, "repository");
-        if (repoName != null) {
-            if (RepositoryManager.get().getByRepoName(repoName) != null) {
-                // repo already exists
-                throw new CommandSpecException(
-                        "The specified repository name is already in use, please try a different name",
-                        Status.CLIENT_ERROR_CONFLICT);
-            }
+        if (repoName != null && RepositoryManager.get().repoExistsByName(repoName)) {
+            // repo already exists
+            throw new CommandSpecException(
+                    "The specified repository name is already in use, please try a different name",
+                    Status.CLIENT_ERROR_CONFLICT);
         }
         Representation representation = super.runCommand(variant, request, outputFormat);
 

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/data/store/geogig/BranchSelectionPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/data/store/geogig/BranchSelectionPanel.java
@@ -34,7 +34,7 @@ public class BranchSelectionPanel extends FormComponentPanel<String> {
 
     private final IModel<String> repositoryUriModel;
 
-    private Supplier<RepositoryManager> manager = RepositoryManager.supplier();
+    private Supplier<RepositoryManager> manager = () -> RepositoryManager.get();
 
     public BranchSelectionPanel(String id, IModel<String> repositoryUriModel,
             IModel<String> branchNameModel, Form<DataStoreInfo> storeEditForm) {
@@ -103,7 +103,7 @@ public class BranchSelectionPanel extends FormComponentPanel<String> {
                 if (reportError) {
                     form.error("Could not list branches: " + e.getMessage());
                 }
-            } 
+            }
             String current = (String) choice.getModelObject();
             if (current != null && !branchNames.contains(current)) {
                 branchNames.add(0, current);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryEditPanel.java
@@ -50,7 +50,9 @@ public class RepositoryEditPanel extends FormComponentPanel<RepositoryInfo> {
                 final URI location = repo.getLocation();
                 final RepositoryResolver resolver = RepositoryResolver.lookup(location);
                 final String scheme = location.getScheme();
-                if (isNew && repoNameExists(repo.getRepoName())) {
+                final boolean nameExists = RepositoryManager.get()
+                        .repoExistsByName(repo.getRepoName());
+                if (isNew && nameExists) {
                     error.addKey("errRepositoryNameExists");
                 } else if ("file".equals(scheme)) {
                     File repoDir = new File(location);
@@ -97,9 +99,5 @@ public class RepositoryEditPanel extends FormComponentPanel<RepositoryInfo> {
     public void convertInput() {
         RepositoryInfo modelObject = getModelObject();
         setConvertedInput(modelObject);
-    }
-
-    private boolean repoNameExists(String repoName) {
-        return RepositoryManager.get().getByRepoName(repoName) != null;
     }
 }

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryImportPanel.java
@@ -128,20 +128,16 @@ public class RepositoryImportPanel extends FormComponentPanel<RepositoryInfo> {
                 ValidationError error = new ValidationError();
                 RepositoryInfo repo = validatable.getValue();
                 // block duplicate names first
-                if (null != RepositoryManager.get().getByRepoName(repo.getRepoName())) {
+                if (RepositoryManager.get().repoExistsByName(repo.getRepoName())) {
                     error.addKey("errRepositoryNameExists");
                     validatable.error(error);
                     return;
                 }
                 final URI location = repo.getLocation();
                 // look for already configured repos
-                List<RepositoryInfo> existingRepos = RepositoryManager.get().getAll();
-                for (RepositoryInfo configuredRepo : existingRepos) {
-                    if (configuredRepo.getLocation().equals(location)) {
-                        error.addKey("errRepositoryAlreadyConfigured");
-                        // quit looking
-                        break;
-                    }
+                if (RepositoryManager.get().repoExistsByLocation(location)) {
+                    error.addKey("errRepositoryAlreadyConfigured");
+                    return;
                 }
                 if (error.getKeys().isEmpty()) {
                     final RepositoryResolver resolver = RepositoryResolver.lookup(location);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryInfoDetachableModel.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/web/repository/RepositoryInfoDetachableModel.java
@@ -4,13 +4,9 @@
  */
 package org.geogig.geoserver.web.repository;
 
-import java.io.IOException;
-
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.geogig.geoserver.config.RepositoryInfo;
 import org.geogig.geoserver.config.RepositoryManager;
-
-import com.google.common.base.Throwables;
 
 /**
  * A RepositoryInfo detachable model that holds the store id to retrieve it on demand from the
@@ -29,10 +25,6 @@ public class RepositoryInfoDetachableModel extends LoadableDetachableModel<Repos
 
     @Override
     protected RepositoryInfo load() {
-        try {
-            return RepositoryManager.get().get(id);
-        } catch (IOException e) {
-            throw Throwables.propagate(e);
-        }
+        return RepositoryManager.get().get(id);
     }
 }

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/HeapResourceStore.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/HeapResourceStore.java
@@ -162,6 +162,8 @@ public class HeapResourceStore implements ResourceStore {
         private Type type;
 
         private byte[] bytes;
+        
+        private long lastModified;
 
         final private HeapResourceStore store;
 
@@ -181,6 +183,7 @@ public class HeapResourceStore implements ResourceStore {
                 this.parent = parent;
                 this.path = buildPath();
             }
+            this.lastModified = 0L;// no timestamp until it's first written
             this.bytes = null;
             this.children = new LinkedList<>();
         }
@@ -255,6 +258,7 @@ public class HeapResourceStore implements ResourceStore {
                         // close the stream first
                         delegate.close();
                         bytes = delegate.toByteArray();
+                        lastModified = System.currentTimeMillis();
                         // fire any deferred create events stored
                         if (createNotification != null) {
                             dispatcher.changed(createNotification);
@@ -306,7 +310,7 @@ public class HeapResourceStore implements ResourceStore {
 
         @Override
         public long lastmodified() {
-            return 0;
+            return lastModified;
         }
 
         @Override

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/config/RepositoryManagerConfigStoreIntegrationTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/config/RepositoryManagerConfigStoreIntegrationTest.java
@@ -1,0 +1,216 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+import java.util.HashSet;
+
+import org.geogig.geoserver.HeapResourceStore;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.platform.resource.ResourceStore;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Integration test suite that simulates a clustered setup where two {@link RepositoryManager}/
+ * {@link ConfigStore} combos work against the same {@link ResourceStore}, making sure events issued
+ * by the {@code ResourceStore} are properly handled both by the node that triggered it and the one
+ * that didn't.
+ *
+ */
+public class RepositoryManagerConfigStoreIntegrationTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ResourceStore dataDir;
+
+    /**
+     * Do not access directly but through {@link #store1()}/ {@link #store2()}. They're lazily
+     * created to let test cases decide when they get initialized
+     */
+    private ConfigStore _store1, _store2;
+
+    /**
+     * Do not access directly but through {@link #repoManager1()}/ {@link #repoManager2()}. They're
+     * lazily created to let test cases decide when they get initialized. Calling these methods
+     * imply the corresponding {@link #store1()} or {@link #store2()}
+     */
+    private RepositoryManager _repoManager1, _repoManager2;
+
+    private RepositoryInfo repo1;
+
+    private RepositoryInfo repo2;
+
+    private RepositoryInfo repo3;
+
+    private RepositoryInfo repo4;
+
+    @Before
+    public void before() {
+        dataDir = new HeapResourceStore();
+
+        repo1 = dummy(1);
+        repo2 = dummy(2);
+        repo3 = dummy(3);
+        repo4 = dummy(4);
+    }
+
+    private ConfigStore store1() {
+        if (_store1 == null) {
+            _store1 = new ConfigStore(dataDir);
+        }
+        return _store1;
+    }
+
+    private ConfigStore store2() {
+        if (_store2 == null) {
+            _store2 = new ConfigStore(dataDir);
+        }
+        return _store2;
+    }
+
+    private RepositoryManager repoManager1() {
+        if (_repoManager1 == null) {
+            _repoManager1 = spy(new RepositoryManager());
+            _repoManager1.init(store1(), dataDir);
+            _repoManager1.setCatalog(mock(Catalog.class, RETURNS_DEEP_STUBS));
+        }
+        return _repoManager1;
+    }
+
+    private RepositoryManager repoManager2() {
+        if (_repoManager2 == null) {
+            _repoManager2 = spy(new RepositoryManager());
+            _repoManager2.init(store2(), dataDir);
+            _repoManager2.setCatalog(mock(Catalog.class, RETURNS_DEEP_STUBS));
+        }
+        return _repoManager2;
+    }
+
+    private RepositoryInfo dummy(int i) {
+        Preconditions.checkArgument(i > -1 && i < 10);
+        final String dummyId = "94bcb762-9ee9-4b43-a912-063509966988";
+        final String id = dummyId.substring(0, dummyId.length() - 1) + String.valueOf(i);
+        RepositoryInfo info = new RepositoryInfo();
+        info.setId(id);
+        info.setLocation(URI.create("file:/parent/directory/" + i + "/name-" + i));
+        return info;
+    }
+
+    /**
+     * repos added to {@link #store1()} are immediately available on {@link #store2()} when it
+     * "joins the cluster"
+     */
+    public @Test void testJoinCluster() {
+        ConfigStore store1 = store1();
+
+        store1.save(repo1.clone());
+        store1.save(repo2.clone());
+        store1.save(repo3.clone());
+        store1.save(repo4.clone());
+
+        ImmutableSet<RepositoryInfo> expected = ImmutableSet.of(repo1, repo2, repo3, repo4);
+        assertEquals(expected, new HashSet<>(store1.getRepositories()));
+
+        // "join cluster" since it's lazily created
+        ConfigStore store2 = store2();
+        assertEquals(expected, new HashSet<>(store2.getRepositories()));
+    }
+
+    /**
+     * both {@link #store1()} and {@link #store2()} are in the cluster, repos added to #1 get
+     * reflected in #2
+     */
+    public @Test void verifyResourceCreateEvents() {
+        ConfigStore store1 = store1();
+        ConfigStore store2 = store2();
+
+        store1.save(repo1.clone());
+        store1.save(repo2.clone());
+        store1.save(repo3.clone());
+        store1.save(repo4.clone());
+
+        assertEquals(4, store1.getRepositories().size());
+        ImmutableSet<RepositoryInfo> expected = ImmutableSet.of(repo1, repo2, repo3, repo4);
+        assertEquals(expected, new HashSet<>(store1.getRepositories()));
+        assertEquals(4, store2.getRepositories().size());
+        assertEquals(expected, new HashSet<>(store2.getRepositories()));
+    }
+
+    /**
+     * both {@link #store1()} and {@link #store2()} are in the cluster, repos changed on #1 get
+     * reflected in #2
+     */
+    public @Test void verifyResourceEditEvents() {
+        ConfigStore store1 = store1();
+        ConfigStore store2 = store2();
+
+        store1.save(repo1.clone());
+        store1.save(repo2.clone());
+
+        // preflight asserts
+        ImmutableSet<RepositoryInfo> expected = ImmutableSet.of(repo1, repo2);
+        assertEquals(expected, new HashSet<>(store1.getRepositories()));
+        assertEquals(expected, new HashSet<>(store2.getRepositories()));
+
+        URI uri1 = URI.create(repo1.getLocation().toString() + "-changed");
+
+        // make a change to #1
+        repo1.setLocation(uri1);
+        assertNotEquals(repo1, store1.get(repo1.getId()));
+        assertNotEquals(repo1, store2.get(repo1.getId()));
+
+        RepositoryManager repoManager2 = repoManager2();
+
+        store1.save(repo1);
+
+        assertEquals(repo1, store1.get(repo1.getId()));
+        assertEquals(repo1, store2.get(repo1.getId()));
+
+        verify(repoManager2, times(1)).invalidate(eq(repo1.getId()));
+    }
+
+    /**
+     * both {@link #store1()} and {@link #store2()} are in the cluster, repos removed on #2 get
+     * reflected in #1
+     */
+    public @Test void verifyResourceRemovedEvents() {
+        ConfigStore store1 = store1();
+        ConfigStore store2 = store2();
+
+        store1.save(repo1.clone());
+        store1.save(repo2.clone());
+
+        store2.save(repo3.clone());
+        store2.save(repo4.clone());
+
+        // preflight asserts
+        ImmutableSet<RepositoryInfo> expected = ImmutableSet.of(repo1, repo2, repo3, repo4);
+        assertEquals(expected, new HashSet<>(store1.getRepositories()));
+        assertEquals(expected, new HashSet<>(store2.getRepositories()));
+
+        RepositoryManager repoManager1 = repoManager1();
+        RepositoryManager repoManager2 = repoManager2();
+
+        repoManager1.delete(repo1.getId());
+        verify(repoManager2, times(1)).invalidate(eq(repo1.getId()));
+
+        repoManager2.delete(repo2.getId());
+        verify(repoManager1, times(1)).invalidate(eq(repo2.getId()));
+    }
+}

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/config/RepositoryManagerTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/config/RepositoryManagerTest.java
@@ -77,7 +77,7 @@ public class RepositoryManagerTest extends GeoServerSystemTestSupport {
     @Test
     public void testGet() {
         assertNotNull(repoManager);
-        RepositoryManager repoManager2 = RepositoryManager.supplier().get();
+        RepositoryManager repoManager2 = RepositoryManager.get();
         assertNotNull(repoManager2);
         assertEquals(repoManager, repoManager2);
     }
@@ -137,7 +137,7 @@ public class RepositoryManagerTest extends GeoServerSystemTestSupport {
             fail();
         } catch (NoSuchElementException e) {
             // expected;
-            assertEquals("No repository with ID " + randomUUID + " exists", e.getMessage());
+            assertEquals("Repository not found: " + randomUUID, e.getMessage());
         }
 
         info1Get = repoManager.getByRepoName("repo1");
@@ -439,8 +439,9 @@ public class RepositoryManagerTest extends GeoServerSystemTestSupport {
             repoManager.getRepository(info.getId());
             fail();
         } catch (Exception e) {
+            e.printStackTrace();
             //expected
-            assertTrue(e.getMessage().contains("No repository with ID " + info.getId() + " exists"));
+            assertTrue(e.getMessage().contains("Repository not found: " + info.getId()));
         }
         
         geogigDataStores = repoManager.findGeogigStores();


### PR DESCRIPTION
Geogig plugin's ConfigStore saves serialized RepositoryInfo instances
to GeoServers ResourceStore. Initially developer against the
default file based ResourceStore, it assumed it could freely
cache the RepositoryInfo instances.

On a clustered environemnt, modifications might occur on different
cluster nodes. This patch makes it so ResourceStore events are
properly handled for create/changed/deleted notifications by keeping
ConfigStore (in charge of storing the serialized RepositoryInfo instances)
and RepositoryManager (in charge of actual geogig Repository instances)
in synch, even when events come from different servers.