### PR TITLE
[GEOS-8203] Fixed deleting a workspace when using JDBC Configuration returning an error response.

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -590,9 +590,10 @@ public class ConfigDatabase {
      */
     @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
     public void remove(Info info) {
-
-        final Integer oid = findObjectId(info);
-        if (oid == null) {
+        Integer oid;
+        try {
+            oid = findObjectId(info);
+        } catch (EmptyResultDataAccessException notFound) {
             return;
         }
         cache.invalidate(info.getId());

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
@@ -163,6 +163,20 @@ public class ConfigDatabaseTest {
     }
 
     @Test
+    public void testRemoveWorkspace() {
+        WorkspaceInfo ws = new WorkspaceInfoImpl();
+        ((WorkspaceInfoImpl) ws).setId("removeid");
+        ws.setName("remove");
+        ws = database.add(ws);
+        assertNotNull(database.getById(ws.getId(), WorkspaceInfo.class));
+        // org.geoserver.catalog.NamespaceWorkspaceConsistencyListener.handleRemoveEvent(CatalogRemoveEvent)
+        // can cause remove to actually be called twice on the workspace.
+        database.remove(ws);
+        database.remove(ws);
+        assertNull(database.getById(ws.getId(), WorkspaceInfo.class));
+    }
+
+    @Test
     public void testModifyService(){
         
         // Create a service to modify
@@ -251,6 +265,7 @@ public class ConfigDatabaseTest {
         assertEquals("Bar", service.getMaintainer());
     }
 
+    @Test
     public void testGetServiceWithGeoServerRef() {
         WMSInfo service = new WMSInfoImpl();
         ((WMSInfoImpl) service).setId("WMS-TEST");


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8203

Updated to catch EmptyResultDataAccessException which is what gets thrown by Spring instead of returning null.  Added unit test and also added a missing @Test annotation to another unit test.

Can be backported to 2.11.x an 2.10.x.