### PR TITLE
[GEOS-8134] Move style file when moving style from workspace to global

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerPersister.java
@@ -171,7 +171,12 @@ public class GeoServerPersister implements CatalogListener, ConfigurationListene
                 i = event.getPropertyNames().indexOf("workspace");
                 if (i > -1) {
                     WorkspaceInfo newWorkspace = (WorkspaceInfo) event.getNewValues().get( i );
-                    Resource newDir = dd.getStyles(newWorkspace);
+                    Resource newDir;
+                    if (newWorkspace == null) {
+                        newDir = dd.getStyles();
+                    } else {
+                        newDir = dd.getStyles(newWorkspace);
+                    }
 
                     // look for any resource files (image, etc...) and copy them over, don't move 
                     // since they could be shared among other styles

--- a/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
@@ -637,6 +637,28 @@ public class GeoServerPersisterTest extends GeoServerSystemTestSupport {
     }
 
     @Test
+    public void testModifyStyleChangeWorkspaceToGlobal() throws Exception {
+        testAddStyleWithWorkspace();
+
+        //copy an sld into place
+        FileUtils.copyURLToFile(getClass().getResource("default_line.sld"),
+                new File(testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.sld"));
+
+        assertTrue(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.xml").exists());
+        assertTrue(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.sld").exists());
+
+        StyleInfo s = catalog.getStyleByName( "foostyle" );
+        s.setWorkspace(null);
+        catalog.save( s );
+
+        assertTrue(new File( testData.getDataDirectoryRoot(), "styles/foostyle.xml").exists());
+        assertTrue(new File( testData.getDataDirectoryRoot(), "styles/foostyle.sld").exists());
+
+        assertFalse(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.xml").exists());
+        assertFalse(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.sld").exists());
+    }
+
+    @Test
     public void testModifyStyleWithResourceChangeWorkspace() throws Exception {
         testAddStyle();
 

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -55,6 +55,7 @@ import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.catalog.event.CatalogRemoveEvent;
+import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.data.test.TestData;
@@ -638,6 +639,49 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
 
         // check the correct style modified event was published
         assertThat(gotValidEvent[0], is(true));
+    }
+
+    //Test that a user can non-destructively move the style out of a workspace.
+    @Test
+    public void testMoveFromWorkspace() throws Exception {
+        //Move into sf
+        Catalog catalog = getCatalog();
+        StyleInfo si = catalog.getStyleByName(STYLE_TO_MOVE_NAME);
+        si.setWorkspace(catalog.getWorkspaceByName("sf"));
+        catalog.save(si);
+
+        GeoServerDataDirectory dataDir = new GeoServerDataDirectory(catalog.getResourceLoader());
+        //verify move to workspace was successful
+        assertEquals(Resource.Type.UNDEFINED, dataDir.get("styles/"+STYLE_TO_MOVE_FILENAME).getType());
+        assertEquals(Resource.Type.RESOURCE, dataDir.get("workspaces/sf/styles/"+STYLE_TO_MOVE_FILENAME).getType());
+
+        // test moving back to default workspace using the UI
+        edit = new StyleEditPage(si);
+        tester.startPage(edit);
+
+        // Before the edit, the style should have one <FeatureTypeStyle> and be in the sf workspace
+        assertEquals(1, si.getStyle().featureTypeStyles().size());
+        assertEquals("sf", si.getWorkspace().getName());
+
+        FormTester form = tester.newFormTester("styleForm", false);
+
+        // Update the workspace (select "sf" from the dropdown)
+        DropDownChoice<WorkspaceInfo> typeDropDown = (DropDownChoice<WorkspaceInfo>) tester
+                .getComponentFromLastRenderedPage("styleForm:context:panel:workspace");
+
+        form.setValue("context:panel:workspace", "");
+
+
+        // Submit the form and verify that both the new workspace and new rawStyle saved.
+        form.submit();
+
+        si = getCatalog().getStyleByName(STYLE_TO_MOVE_NAME);
+        assertNotNull(si);
+        assertNull(si.getWorkspace());
+
+        //verify move out of the workspace was successful
+        assertEquals(Resource.Type.RESOURCE, dataDir.get("styles/"+STYLE_TO_MOVE_FILENAME).getType());
+        assertEquals(Resource.Type.UNDEFINED, dataDir.get("workspaces/sf/styles/"+STYLE_TO_MOVE_FILENAME).getType());
     }
     
     @Test


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8134

This turned out to be a bug in the GeoServerPersister, and was exposed by https://github.com/geoserver/geoserver/pull/2162

It turns out, the persister didn't handle moving style files to the global 'workspace' from a workspace, only moving styles to an actual workspace.