### PR TITLE
[GEOS-8062] Include links to nested LayerGroups in REST LayerGroup representation (2.11 backport)

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/catalog/rest/LayerGroupResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/catalog/rest/LayerGroupResource.java
@@ -162,6 +162,13 @@ public class LayerGroupResource extends AbstractCatalogResource {
                }
                if ( obj instanceof LayerInfo ) {
                    encodeLink("/layers/" + encode(ref), writer);
+               }  else if ( obj instanceof LayerGroupInfo) {
+                   LayerGroupInfo lg = (LayerGroupInfo) obj;
+                   if (lg.getWorkspace() != null) {
+                       encodeLink("/workspaces/"+lg.getWorkspace().getName()+"/layergroups/" + encode(ref), writer);
+                   } else {
+                       encodeLink("/layergroups/" + encode(ref), writer);
+                   }
                }
            } 
         });

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/LayerGroupTest.java
@@ -36,8 +36,8 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
     @Before
     public void revertChanges() throws Exception {
         removeLayerGroup(null, "nestedLayerGroupTest");
-        removeLayerGroup(null, "sfLayerGroup");
         removeLayerGroup(null, "citeLayerGroup");
+        removeLayerGroup(null, "sfLayerGroup");
         removeLayerGroup("sf", "foo");
         removeLayerGroup(null, "newLayerGroup");
         removeLayerGroup(null, "newLayerGroupWithTypeCONTAINER");
@@ -127,6 +127,21 @@ public class LayerGroupTest extends CatalogRESTTestSupport {
         assertXpathEvaluatesTo("citeLayerGroup", "/layerGroup/name", dom );
         assertXpathEvaluatesTo( "6", "count(//published)", dom );
         assertXpathEvaluatesTo( "6", "count(//style)", dom );
+    }
+
+    @Test
+    public void testGetAsXMLNestedLinks() throws Exception {
+        LayerGroupInfo cite = catalog.getLayerGroupByName("citeLayerGroup");
+        cite.getLayers().add(catalog.getLayerGroupByName("sfLayerGroup"));
+        cite.getStyles().add(null);
+        catalog.save(cite);
+
+        Document dom = getAsDOM( "rest/layergroups/citeLayerGroup.xml");
+        assertEquals( "layerGroup", dom.getDocumentElement().getNodeName() );
+        assertXpathEvaluatesTo("citeLayerGroup", "/layerGroup/name", dom );
+        assertXpathEvaluatesTo( "7", "count(//published)", dom );
+        assertXpathEvaluatesTo( "7", "count(//style)", dom );
+        assertXpathEvaluatesTo( "7", "count(//published/atom:link)", dom );
     }
 
     @Test


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8062

Pre rest-api-refresh version of https://github.com/geoserver/geoserver/pull/2447