### PR TITLE
[GEOS-8209] Online app-schema tests fail for NamespacesWfsTest test (backport 2.10.x)

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaMockData.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaMockData.java
@@ -711,6 +711,12 @@ public abstract class AbstractAppSchemaMockData extends SystemTestData
                     } else {
                         copyFileToFeatureTypeDir(namespacePrefix, typeName, propertyFileName);
                         if (propertyFileName.endsWith(".properties")) {
+                            // extract the file name if needed
+                            File file = new File(propertyFileName);
+                            if (file.exists()) {
+                                // extract the file name
+                                propertyFileName = file.getName();
+                            }
                             propertiesFiles.put(propertyFileName, getFeatureTypeDir(
                                     featureTypesBaseDir, namespacePrefix, typeName));
                         }


### PR DESCRIPTION
Backport of this PR: https://github.com/geoserver/geoserver/pull/2453
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8209