### PR TITLE
[GEOS-8212]: Do not report nodata value in CoverageDimensionInfo min/…

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -1113,21 +1113,22 @@ public class CatalogBuilder {
             
             dim.setDimensionType(sd.getSampleDimensionType());
 
+            double sdMin = sd.getMinimumValue();
+            double sdMax = sd.getMaximumValue();
             label.append("[".intern());
-            label.append(sd.getMinimumValue());
+            label.append(sdMin);
             label.append(",".intern());
-            label.append(sd.getMaximumValue());
+            label.append(sdMax);
             label.append("]".intern());
 
             dim.setDescription(label.toString());
+            // Since the nullValues element of the CoverageDimensionInfo reports
+            // the nodata (if available), let's switch to use the 
+            // sampleDimension's min and max as Dimension's Range
+            // instead of the whole SampleDimension Range 
+            // (the latter may include nodata categories).
+            dim.setRange(NumberRange.create(sdMin, sdMax));
 
-            if (sd.getRange() != null) {
-                dim.setRange(sd.getRange());    
-            }
-            else {
-                dim.setRange(NumberRange.create(sd.getMinimumValue(), sd.getMaximumValue()));
-            }
-            
             final List<Category> categories = sd.getCategories();
             if (categories != null) {
                 for (Category cat : categories) {

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
@@ -215,7 +215,7 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
         assertEquals("GRAY_INDEX", dimension.getName());
         assertEquals(1, dimension.getNullValues().size());
         assertEquals(-9999, dimension.getNullValues().get(0), 0d);
-        assertEquals(-9999, dimension.getRange().getMinimum(), 0d);
+        assertEquals(Double.NEGATIVE_INFINITY, dimension.getRange().getMinimum(), 0d);
         // Huston, we have a problem here...
         // assertEquals(9999, dimension.getRange().getMaximum(), 0d);
         assertNull(dimension.getUnit());

--- a/src/restconfig/src/test/java/org/geoserver/catalog/rest/CoverageTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/catalog/rest/CoverageTest.java
@@ -552,9 +552,9 @@ public class CoverageTest extends CatalogRESTTestSupport {
         CoverageDimensionInfo dimension = dimensions.get(0);
         assertEquals( "GRAY_INDEX", dimension.getName());
         NumberRange range = dimension.getRange();
-        assertEquals( -9999.0, range.getMinimum(), DELTA);
-        assertEquals( -9999.0, range.getMaximum(), DELTA);
-        assertEquals("GridSampleDimension[-9999.0,-9999.0]", dimension.getDescription());
+        assertEquals( Double.NEGATIVE_INFINITY, range.getMinimum(), DELTA);
+        assertEquals( Double.POSITIVE_INFINITY, range.getMaximum(), DELTA);
+        assertEquals("GridSampleDimension[-Infinity,Infinity]", dimension.getDescription());
         List<Double> nullValues = dimension.getNullValues();
         assertEquals( -9999.0, nullValues.get(0), DELTA);
         


### PR DESCRIPTION
…Max range (use dedicate nullValues field)
Backport to 2.11.x