### PR TITLE
[GEOS-8221] GeoServerDataDir - treat null workspace as global workspace

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
@@ -813,13 +813,14 @@ public class GeoServerDataDirectory {
     /**
      * Retrieve a resource in the the workspace configuration directory. An empty path will retrieve
      * the directory itself.
+     * A null workspace will retrieve the resouce in the global configuration directory.
      * @param ws The workspace
      * @return A {@link Resource}
      */
     public @Nonnull Resource get(WorkspaceInfo ws, String... path) {
         Resource r;
         if(ws==null) {
-            return resourceLoader.get("");
+            r = get(Paths.path(path));
         } else {
             r = getWorkspaces(  ws.getName(), Paths.path(path));
         }
@@ -841,11 +842,17 @@ public class GeoServerDataDirectory {
     /**
      * Retrieve a resource in the the configuration directory of the workspace associated with a 
      * namespace.  An empty path will retrieve the directory itself.
-     * @param ws The namespace
+     * A null namespace will retrieve the resouce in the global configuration directory.
+     * @param ns The namespace
      * @return A {@link Resource}
      */
     public @Nonnull Resource get(NamespaceInfo ns, String... path) {
-        Resource r = getWorkspaces(ns.getPrefix(), Paths.path(path));
+        Resource r;
+        if(ns==null) {
+            r = get(Paths.path(path));
+        } else {
+            r = getWorkspaces(ns.getPrefix(), Paths.path(path));
+        }
         assert r!=null;
         return r;
     }
@@ -1038,7 +1045,7 @@ public class GeoServerDataDirectory {
      * @return A {@link Resource}
      */
     public @Nonnull Resource getLayerGroups(String... path) {
-        Resource r = get(  Paths.path( LAYERGROUP_DIR, Paths.path(path)));
+        Resource r = getLayerGroups(null, path);
         assert r!=null;
         return r;
     }
@@ -1046,6 +1053,7 @@ public class GeoServerDataDirectory {
     /**
      * Retrieve a resource in the the layer groups directory of a workspace. An empty path will retrieve
      * the directory itself.
+     * A null workspace will return the resource in the global layer groups directory
      * @return A {@link Resource}
      */
     public @Nonnull Resource getLayerGroups(WorkspaceInfo wsi, String... path) {
@@ -1062,12 +1070,7 @@ public class GeoServerDataDirectory {
      */
     public @Nonnull Resource get(LayerGroupInfo lgi, String... path) {
         WorkspaceInfo wsi = lgi.getWorkspace();
-        final Resource r;
-        if(wsi==null) {
-            r = getLayerGroups(path);
-        } else {
-            r = getLayerGroups(wsi, path);
-        }
+        Resource r = getLayerGroups(wsi, path);
         assert r!=null;
         return r;
     }
@@ -1090,7 +1093,7 @@ public class GeoServerDataDirectory {
      * @return A {@link Resource}
      */
     public @Nonnull Resource getStyles(String... path) {
-        Resource r = get(  Paths.path( STYLE_DIR, Paths.path(path)));
+        Resource r = getStyles(null, path);
         assert r!=null;
         return r;
     }
@@ -1098,6 +1101,7 @@ public class GeoServerDataDirectory {
     /**
      * Retrieve a resource in the the styles directory of a workspace. An empty path will retrieve
      * the directory itself.
+     * A null workspace will return the resource in the global styles directory
      * @return A {@link Resource}
      */
     public @Nonnull Resource getStyles(WorkspaceInfo wsi, String... path) {
@@ -1114,12 +1118,7 @@ public class GeoServerDataDirectory {
      */
     public @Nonnull Resource get(StyleInfo si, String... path) {
         WorkspaceInfo workspace = si != null ? si.getWorkspace() : null;
-        final Resource r;
-        if (workspace == null) {
-            r = getStyles(path);
-        } else {
-            r = getStyles(workspace, path);
-        }
+        final Resource r = getStyles(workspace, path);
         assert r!=null;
         return r;
     }

--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
@@ -10,9 +10,11 @@ import java.nio.file.Files;
 
 import org.geoserver.catalog.CatalogFactory;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogFactoryImpl;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.StyleInfoImpl;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geotools.styling.ExternalGraphic;
 import org.geotools.styling.Graphic;
 import org.geotools.styling.PointSymbolizer;
@@ -49,6 +51,13 @@ public class GeoServerDataDirectoryTest {
     @After
     public void tearDown() throws Exception {
         ctx.destroy();
+    }
+
+    @Test
+    public void testNullWorkspace() {
+        assertEquals(dataDir.get((WorkspaceInfo) null, "test").path(), dataDir.get("test").path());
+        assertEquals(dataDir.getStyles((WorkspaceInfo) null, "test").path(), dataDir.getStyles("test").path());
+        assertEquals(dataDir.getLayerGroups((WorkspaceInfo) null, "test").path(), dataDir.getLayerGroups("test").path());
     }
     
     @Test

--- a/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerPersisterTest.java
@@ -637,6 +637,28 @@ public class GeoServerPersisterTest extends GeoServerSystemTestSupport {
     }
 
     @Test
+    public void testModifyStyleChangeWorkspaceToGlobal() throws Exception {
+        testAddStyleWithWorkspace();
+
+        //copy an sld into place
+        FileUtils.copyURLToFile(getClass().getResource("default_line.sld"),
+                new File(testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.sld"));
+
+        assertTrue(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.xml").exists());
+        assertTrue(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.sld").exists());
+
+        StyleInfo s = catalog.getStyleByName( "foostyle" );
+        s.setWorkspace(null);
+        catalog.save( s );
+
+        assertTrue(new File( testData.getDataDirectoryRoot(), "styles/foostyle.xml").exists());
+        assertTrue(new File( testData.getDataDirectoryRoot(), "styles/foostyle.sld").exists());
+
+        assertFalse(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.xml").exists());
+        assertFalse(new File( testData.getDataDirectoryRoot(), "workspaces/gs/styles/foostyle.sld").exists());
+    }
+
+    @Test
     public void testModifyStyleWithResourceChangeWorkspace() throws Exception {
         testAddStyle();
 

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -55,6 +55,7 @@ import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.catalog.event.CatalogRemoveEvent;
+import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.data.test.TestData;
@@ -638,6 +639,49 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
 
         // check the correct style modified event was published
         assertThat(gotValidEvent[0], is(true));
+    }
+
+    //Test that a user can non-destructively move the style out of a workspace.
+    @Test
+    public void testMoveFromWorkspace() throws Exception {
+        //Move into sf
+        Catalog catalog = getCatalog();
+        StyleInfo si = catalog.getStyleByName(STYLE_TO_MOVE_NAME);
+        si.setWorkspace(catalog.getWorkspaceByName("sf"));
+        catalog.save(si);
+
+        GeoServerDataDirectory dataDir = new GeoServerDataDirectory(catalog.getResourceLoader());
+        //verify move to workspace was successful
+        assertEquals(Resource.Type.UNDEFINED, dataDir.get("styles/"+STYLE_TO_MOVE_FILENAME).getType());
+        assertEquals(Resource.Type.RESOURCE, dataDir.get("workspaces/sf/styles/"+STYLE_TO_MOVE_FILENAME).getType());
+
+        // test moving back to default workspace using the UI
+        edit = new StyleEditPage(si);
+        tester.startPage(edit);
+
+        // Before the edit, the style should have one <FeatureTypeStyle> and be in the sf workspace
+        assertEquals(1, si.getStyle().featureTypeStyles().size());
+        assertEquals("sf", si.getWorkspace().getName());
+
+        FormTester form = tester.newFormTester("styleForm", false);
+
+        // Update the workspace (select "sf" from the dropdown)
+        DropDownChoice<WorkspaceInfo> typeDropDown = (DropDownChoice<WorkspaceInfo>) tester
+                .getComponentFromLastRenderedPage("styleForm:context:panel:workspace");
+
+        form.setValue("context:panel:workspace", "");
+
+
+        // Submit the form and verify that both the new workspace and new rawStyle saved.
+        form.submit();
+
+        si = getCatalog().getStyleByName(STYLE_TO_MOVE_NAME);
+        assertNotNull(si);
+        assertNull(si.getWorkspace());
+
+        //verify move out of the workspace was successful
+        assertEquals(Resource.Type.RESOURCE, dataDir.get("styles/"+STYLE_TO_MOVE_FILENAME).getType());
+        assertEquals(Resource.Type.UNDEFINED, dataDir.get("workspaces/sf/styles/"+STYLE_TO_MOVE_FILENAME).getType());
     }
     
     @Test


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8221

This also fixes https://osgeo-org.atlassian.net/browse/GEOS-8134 , superseding https://github.com/geoserver/geoserver/pull/2445 (and includes the test cases from that PR)