### PR TITLE
GEOS-8236: provide proper behavior for Styles that end up having no enabled rules

### DIFF
--- a/src/extension/vectortiles/src/main/java/org/geotools/renderer/lite/VectorMapRenderUtils.java
+++ b/src/extension/vectortiles/src/main/java/org/geotools/renderer/lite/VectorMapRenderUtils.java
@@ -83,7 +83,15 @@ public class VectorMapRenderUtils {
         FeatureType schema = featureSource.getSchema();
         List<LiteFeatureTypeStyle> styleList = getFeatureStyles(layer, screenSize, mapScale,
                 schema);
-        
+
+        //if there aren't any styles to render, we don't need to get any data....
+        if (styleList.isEmpty()) {
+            Query query = new Query(schema.getName().getLocalPart());
+            query.setProperties(Query.NO_PROPERTIES);
+            query.setFilter(Filter.EXCLUDE);
+            return query;
+        }
+
         final int bufferScreen = getComputedBuffer(requestBufferScreen, styleList);
         
         final ReferencedEnvelope queryArea = new ReferencedEnvelope(renderingArea);

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.wms.vector;
 
+import static org.geotools.renderer.lite.VectorMapRenderUtils.getStyleQuery;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -27,6 +28,7 @@ import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WebMap;
 import org.geotools.data.DataUtilities;
+import org.geotools.data.Query;
 import org.geotools.data.memory.MemoryDataStore;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -43,6 +45,7 @@ import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.google.common.collect.ImmutableSet;
@@ -56,7 +59,7 @@ public class VectorTileMapOutputFormatTest {
 
     private static CoordinateReferenceSystem WGS84;
 
-    private static Style defaultPointStyle, defaultLineStyle, defaultPolygonStyle;
+    private static Style defaultPointStyle, defaultLineStyle, defaultPolygonStyle, scaleDependentPolygonStyle;
 
     private WMS wmsMock;
 
@@ -64,13 +67,14 @@ public class VectorTileMapOutputFormatTest {
 
     private VectorTileBuilder tileBuilderMock;
 
-    private FeatureLayer pointLayer, lineLayer, polygonLayer;
+    private FeatureLayer pointLayer, lineLayer, polygonLayer,scaleDependentPolygonLayer;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         defaultPointStyle = parseStyle("default_point.sld");
         defaultLineStyle = parseStyle("default_line.sld");
         defaultPolygonStyle = parseStyle("default_polygon.sld");
+        scaleDependentPolygonStyle = parseStyle("scaleDependentPolygonStyle.sld");
 
         // avoid lots of application context unset warnings in the console
         GeoServerExtensionsHelper.init(new ApplicationContextMock());
@@ -127,6 +131,35 @@ public class VectorTileMapOutputFormatTest {
         pointLayer = new FeatureLayer(ds.getFeatureSource("points"), defaultPointStyle);
         lineLayer = new FeatureLayer(ds.getFeatureSource("lines"), defaultLineStyle);
         polygonLayer = new FeatureLayer(ds.getFeatureSource("polygons"), defaultPolygonStyle);
+        scaleDependentPolygonLayer = new FeatureLayer(ds.getFeatureSource("polygons"), scaleDependentPolygonStyle);
+    }
+
+
+    //Test case for when a style has no active rules (i.e. when the current map scale is not
+    //compatible with the Min/MaxScaleDenominator in the SLD Rule).
+    @Test
+    public void testNoRulesByScale() throws Exception {
+        //----------- normal case, there is a rule that draws
+
+        //this has map scale denominator of about 1:7,700, rule will draw
+        ReferencedEnvelope mapBounds = new ReferencedEnvelope(0, 0.005, 0, 0.005, WGS84);
+        Rectangle renderingArea = new Rectangle(256, 256);
+
+        WMSMapContent mapContent = createMapContent(mapBounds, renderingArea, 0, scaleDependentPolygonLayer);
+
+        Query q = getStyleQuery(scaleDependentPolygonLayer, mapContent);
+        assertTrue(q.getFilter() != Filter.EXCLUDE);
+
+        //------------------- abnormal case, there are no rules in the sld that will draw
+
+        //this has map scale denominator of about 1:77k, rule will NOT draw
+        mapBounds = new ReferencedEnvelope(0, 0.05, 0, 0.05, WGS84);
+        renderingArea = new Rectangle(256, 256);
+
+        mapContent = createMapContent(mapBounds, renderingArea,0, scaleDependentPolygonLayer);
+
+        q = getStyleQuery(scaleDependentPolygonLayer, mapContent);
+        assertTrue(q.getFilter() == Filter.EXCLUDE);
     }
 
     @Test

--- a/src/extension/vectortiles/src/test/resources/org/geoserver/config/scaleDependentPolygonStyle.sld
+++ b/src/extension/vectortiles/src/test/resources/org/geoserver/config/scaleDependentPolygonStyle.sld
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <!-- a named layer is the basic building block of an sld document -->
+
+  <NamedLayer>
+    <Name>Default Polygon</Name>
+    <UserStyle>
+        <!-- they have names, titles and abstracts -->
+
+      <Title>A boring default style</Title>
+      <Abstract>A sample style that just prints out a transparent red interior with a red outline</Abstract>
+      <!-- FeatureTypeStyles describe how to render different features -->
+      <!-- a feature type for polygons -->
+
+      <FeatureTypeStyle>
+        <!--FeatureTypeName>Feature</FeatureTypeName-->
+        <Rule>
+          <Name>Rule 1</Name>
+          <Title>RedFill RedOutline</Title>
+          <Abstract>50% transparent red fill with a red outline 1 pixel in width</Abstract>
+
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
+
+          <!-- like a linesymbolizer but with a fill too -->
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+
+        </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
GEOS-8236 When there are no active rules, use a Query with Filter.EXCLUDE.  This can be combined with other "OR" rules if the layer is used multiple times.