### PR TITLE
[GEOS-8237] UI page table contents get ruined once page is serialized and read back

### DIFF
--- a/src/community/dyndimension/src/main/java/org/geoserver/web/data/resource/DynamicDimensionsTabPanel.java
+++ b/src/community/dyndimension/src/main/java/org/geoserver/web/data/resource/DynamicDimensionsTabPanel.java
@@ -28,6 +28,7 @@ import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.markup.repeater.ReuseIfModelsEqualStrategy;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
@@ -158,8 +159,13 @@ public class DynamicDimensionsTabPanel extends PublishedEditTabPanel<LayerInfo> 
         public Editor(String id, final Collection<String> enabledDimensionNames,
                 IModel<DefaultValueConfigurations> model) {
             super(id, model);
-            List<Property<DefaultValueConfiguration>> properties = Arrays.asList(DIMENSION, POLICY,
-                    DEFAULT_VALUE_EXPRESSION);
+            IModel<List<Property<DefaultValueConfiguration>>> properties = new LoadableDetachableModel<List<Property<DefaultValueConfiguration>>>() {
+
+                @Override
+                protected List<Property<DefaultValueConfiguration>> load() {
+                    return Arrays.asList(DIMENSION, POLICY, DEFAULT_VALUE_EXPRESSION);
+                }
+            };
 
             table = new ReorderableTablePanel<DefaultValueConfiguration>("defaultConfigs",
                     configurations, properties) {

--- a/src/web/core/src/main/java/org/geoserver/web/data/layergroup/LayerGroupEntryPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layergroup/LayerGroupEntryPanel.java
@@ -21,6 +21,7 @@ import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.DefaultItemReuseStrategy;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -46,19 +47,19 @@ public class LayerGroupEntryPanel extends Panel {
 
     private static final long serialVersionUID = -5483938812185582866L;
 
-    public static Property<LayerGroupEntry> LAYER = new PropertyPlaceholder<LayerGroupEntry>(
+    public static final Property<LayerGroupEntry> LAYER = new PropertyPlaceholder<LayerGroupEntry>(
             "layer");
 
-    public static Property<LayerGroupEntry> DEFAULT_STYLE = new PropertyPlaceholder<LayerGroupEntry>(
+    public static final Property<LayerGroupEntry> DEFAULT_STYLE = new PropertyPlaceholder<LayerGroupEntry>(
             "defaultStyle");
 
-    public static Property<LayerGroupEntry> STYLE = new PropertyPlaceholder<LayerGroupEntry>(
+    public static final Property<LayerGroupEntry> STYLE = new PropertyPlaceholder<LayerGroupEntry>(
             "style");
 
-    public static Property<LayerGroupEntry> REMOVE = new PropertyPlaceholder<LayerGroupEntry>(
+    public static final Property<LayerGroupEntry> REMOVE = new PropertyPlaceholder<LayerGroupEntry>(
             "remove");
 
-    static List<Property<LayerGroupEntry>> PROPERTIES = Arrays.asList(LAYER, DEFAULT_STYLE, STYLE, REMOVE);
+    static final List<Property<LayerGroupEntry>> PROPERTIES = Arrays.asList(LAYER, DEFAULT_STYLE, STYLE, REMOVE);
 
     ModalWindow popupWindow;
     GeoServerTablePanel<LayerGroupEntry> layerTable;
@@ -79,8 +80,16 @@ public class LayerGroupEntryPanel extends Panel {
         add(dialog = new GeoServerDialog("dialog"));
         add(new HelpLink("layersHelp").setDialog(dialog));
         
-        //layers
-        add(layerTable = new ReorderableTablePanel<LayerGroupEntry>("layers", items, PROPERTIES) {
+        // make sure we don't end up serializing the list, but get it fresh from the dataProvider, 
+        // to avoid serialization issues seen in GEOS-8273
+        LoadableDetachableModel<List<Property<LayerGroupEntry>>> propertiesModel = new LoadableDetachableModel<List<Property<LayerGroupEntry>>>() {
+            @Override
+            protected List<Property<LayerGroupEntry>> load() {
+                return PROPERTIES;
+            }
+        };
+        // layers
+        add(layerTable = new ReorderableTablePanel<LayerGroupEntry>("layers", items, propertiesModel) {
 
             private static final long serialVersionUID = -3270471094618284639L;
 

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerTablePanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/GeoServerTablePanel.java
@@ -35,6 +35,7 @@ import org.apache.wicket.markup.repeater.OddEvenItem;
 import org.apache.wicket.markup.repeater.ReuseIfModelsEqualStrategy;
 import org.apache.wicket.markup.repeater.data.DataView;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
@@ -208,8 +209,18 @@ public abstract class GeoServerTablePanel<T> extends Panel {
 
     protected void buildRowListView(final GeoServerDataProvider<T> dataProvider, Item<T> item,
             final IModel<T> itemModel) {
+        // make sure we don't serialize the list, but get it fresh from the dataProvider, 
+        // to avoid serialization issues seen in GEOS-8273
+        IModel propertyList = new LoadableDetachableModel() {
+
+            @Override
+            protected Object load() {
+                return dataProvider.getVisibleProperties();
+            }
+            
+        };
         // create one component per viewable property
-        ListView<Property<T>> items = new ListView<Property<T>>("itemProperties", dataProvider.getVisibleProperties()) {
+        ListView<Property<T>> items = new ListView<Property<T>>("itemProperties", propertyList) {
 
             private static final long serialVersionUID = -4552413955986008990L;
 


### PR DESCRIPTION
So, this one is a bit nasty. The code working against tables is written under the assumption that one can use the constant Property values in the providers and compare by identity.
Which works, until sessions serialization kicks in (happens if one tries to use the GeoServer UI in multiple tabs with the same login, for example), at which point the properties get serialized, deserialized, and are the clone of the original ones.

I've made changes so that the code avoids keeping a copy of the property list and always defer to a fresh call to the provider to get them, going back to the normal case.

Another option could have been to go everywhere and use equality comparison instead of identity comparison, but decided not to go there because:

- Property is an interface, none of the implementations have equals today, many implementations are anonymous inner classes that we'd have to hunt down
- Property does not have a requirement for implementing equals/hashcode, so that would be new and backwards incompatible
- There would have been hundreds of places to manually change

I've requested a review since the change is not trivial, but at the same time, I could not find a way to write a test.