### PR TITLE
[GEOS-8010] dbtype and filetype store arguments should not be visible

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
@@ -161,14 +161,7 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
         final List<Serializable> options = paramMetadata.getOptions();
 
         Panel parameterPanel;
-        if("dbtype".equals(paramName) || "filetype".equals(paramName)) {
-            // skip the two well known discriminators
-            IModel model = new MapModel(paramsModel, paramName);
-            TextParamPanel tp = new TextParamPanel(componentId,
-                    model, new ResourceModel(paramLabel, paramLabel), required);
-            tp.setVisible(false);
-            parameterPanel = tp;
-        } else  if ("namespace".equals(paramName)) {
+        if ("namespace".equals(paramName)) {
             IModel namespaceModel = new NamespaceParamModel(paramsModel, paramName);
             IModel paramLabelModel = new ResourceModel(paramLabel, paramLabel);
             parameterPanel = new NamespacePanel(componentId, namespaceModel, paramLabelModel, true);
@@ -231,7 +224,7 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
         }
         
         Object parameterValue = parameterPanel.getDefaultModelObject();
-        boolean visible = !(deprecated && isEmpty(parameterValue));
+        boolean visible = !(deprecated && isEmpty(parameterValue)) && !paramMetadata.getLevel().equals("program");
         parameterPanel.setVisible(visible);
         parameterPanel.setVisibilityAllowed(visible);
         

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/ParamInfo.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/ParamInfo.java
@@ -34,6 +34,8 @@ public class ParamInfo implements Serializable {
     
     private boolean largeText;
 
+    private String level;
+
     private Class<?> binding;
 
     private boolean required;
@@ -53,6 +55,7 @@ public class ParamInfo implements Serializable {
         this.title = param.title != null && !param.title.toString().equals(param.key) ? param.title
                 .toString() : param.getDescription().toString();
         this.password = param.isPassword();
+        this.level = param.getLevel();
         this.largeText = param.metadata != null && Boolean.TRUE.equals(param.metadata.get(Param.IS_LARGE_TEXT));
         Object defaultValue = this.deprecated ? null : param.sample;
         if (Serializable.class.isAssignableFrom(param.type)) {
@@ -105,7 +108,11 @@ public class ParamInfo implements Serializable {
     public boolean isPassword() {
         return password;
     }
-    
+
+    public String getLevel() {
+        return level;
+    }
+
     public boolean isLargeText() {
         return largeText;
     }

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessNewPageDatabaseTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessNewPageDatabaseTest.java
@@ -1,0 +1,52 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.data.store;
+
+import org.apache.wicket.MarkupContainer;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.data.store.panel.WorkspacePanel;
+import org.geotools.data.postgis.PostgisNGDataStoreFactory;
+import org.geotools.jdbc.JDBCDataStoreFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test suite for {@link DataAccessNewPage}, using {@link PostgisNGDataStoreFactory}
+ */
+public class DataAccessNewPageDatabaseTest extends GeoServerWicketTestSupport {
+    final JDBCDataStoreFactory dataStoreFactory = new PostgisNGDataStoreFactory();
+
+    private AbstractDataAccessPage startPage() {
+
+        final AbstractDataAccessPage page = new DataAccessNewPage(dataStoreFactory.getDisplayName());
+        login();
+        tester.startPage(page);
+
+        return page;
+    }
+
+    @Test
+    public void testPageRendersOnLoad() {
+        startPage();
+
+        tester.assertLabel("dataStoreForm:storeType", dataStoreFactory.getDisplayName());
+        tester.assertLabel("dataStoreForm:storeTypeDescription", dataStoreFactory.getDescription());
+
+        tester.assertComponent("dataStoreForm:workspacePanel", WorkspacePanel.class);
+    }
+
+    @Test
+    public void testDbtypeParameterHidden() {
+        startPage();
+
+        // check the dbtype field is not visible
+        MarkupContainer container = (MarkupContainer) tester
+                .getComponentFromLastRenderedPage("dataStoreForm:parametersPanel:parameters:0");
+        assertEquals("dbtype", container.getDefaultModelObject());
+        assertFalse(container.get("parameterPanel").isVisible());
+    }
+}


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8010

Depends upon https://github.com/geotools/geotools/pull/1659. Travis CI will fail until that is merged.

Supersedes https://github.com/geoserver/geoserver/pull/2449; only one of these PRs should be merged.