### PR TITLE
[GEOS-8234] HTML converter shouldn't close the HTTP Response outputstream

### DIFF
--- a/src/rest/src/main/java/org/geoserver/rest/converters/FreemarkerHTMLMessageConverter.java
+++ b/src/rest/src/main/java/org/geoserver/rest/converters/FreemarkerHTMLMessageConverter.java
@@ -95,10 +95,6 @@ public class FreemarkerHTMLMessageConverter extends BaseMessageConverter<RestWra
             templateWriter.flush();
         } catch (TemplateException te) {
             throw new IOException("Template processing error " + te.getMessage());
-        } finally {
-            if (templateWriter != null) {
-                templateWriter.close();
-            }
         }
     }
 


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8234

FreemarkerHTMLMessageConverter was erroneously closing the output stream, causing GZIPResponseStream to throw this error.
Since the tests don't use GZIPResponseStream, the issue was not affecting them.
Consequently, can't really add a test case for this one.