### PR TITLE
Add required namespaces to SLD InlineFeature example

### DIFF
--- a/doc/en/user/source/styling/sld/reference/layers.rst
+++ b/doc/en/user/source/styling/sld/reference/layers.rst
@@ -103,6 +103,7 @@ It displays the US States layer, with a labelled red box surrounding the Pacific
 
    <sld:StyledLayerDescriptor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+      xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ogc="http://www.opengis.net/ogc"
       xmlns:sld="http://www.opengis.net/sld" version="1.0.0">
       <sld:NamedLayer>
          <sld:Name>usa:states</sld:Name>


### PR DESCRIPTION
I just tried out the InlineFeature example at http://docs.geoserver.org/latest/en/user/styling/sld/reference/layers.html#example using a WMS request with the SLD parameter.

GeoServer gave an error response with SAXParseExceptions indicating that the "gml" and "ogc" namespaces were not defined in the SLD.

After adding these namespaces the SLD rendered fine.

I have updated the doc example accordingly.