### PR TITLE
Add geogig module status reporting to UI and REST

### DIFF
--- a/src/community/geogig/pom.xml
+++ b/src/community/geogig/pom.xml
@@ -411,4 +411,32 @@
       </dependencies>
     </profile>
   </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>process-resources</id>
+            <phase>process-resources</phase>
+            <configuration>
+              <tasks>
+	      <replace dir="${project.build.outputDirectory}/org/geogig/geoserver/config" encoding="UTF-8">
+                  <include name="module_version.properties"/> 
+                  <replacefilter token="@project.version@" value="${project.version}"/>
+                  <replacefilter token="@build.revision@" value="${build.commit.id}"/>
+                  <replacefilter token="@build.timestamp@" value="${build.timestamp}"/>
+                </replace>
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeogigModuleStatus.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeogigModuleStatus.java
@@ -1,0 +1,85 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geogig.geoserver.config;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.geoserver.platform.ModuleStatus;
+import org.locationtech.geogig.porcelain.VersionOp;
+
+/**
+ * Spring defined bean publishing geogig module status to the web UI and REST API
+ *
+ */
+public class GeogigModuleStatus implements ModuleStatus {
+
+    private static final String VERSION;
+
+    private static final String MESSAGE;
+
+    static {
+        String version;
+        String revision = "Unknown";
+        String date = "Unknown";
+
+        Properties props = new Properties();
+        try (InputStream in = GeogigModuleStatus.class
+                .getResourceAsStream("module_version.properties")) {
+            try (InputStreamReader reader = new InputStreamReader(in)) {
+                props.load(reader);
+            }
+
+            version = props.getProperty("version");
+            revision = props.getProperty("build.revision");
+            date = props.getProperty("build.date");
+        } catch (Exception e) {
+            version = "Error obtaining version: " + e.getMessage();
+        }
+
+        VERSION = version;
+
+        String geogigInfo = new VersionOp().call().toString();
+        MESSAGE = String.format(
+                "GeoGig plugin:\n version: %s\n revision: %s\n build date: %s\n\nGeoGig info:\n%s",
+                version, revision, date, geogigInfo);
+    }
+
+    public @Override String getModule() {
+        return "gs-geogig";
+    }
+
+    public @Override Optional<String> getComponent() {
+        return Optional.empty();
+    }
+
+    public @Override String getName() {
+        return "GeoGig GeoServer Plugin";
+    }
+
+    public @Override Optional<String> getVersion() {
+        return Optional.of(VERSION);
+    }
+
+    public @Override boolean isAvailable() {
+        return true;
+    }
+
+    public @Override boolean isEnabled() {
+        return true;
+    }
+
+    public @Override Optional<String> getMessage() {
+        return Optional.of(MESSAGE);
+    }
+
+    public @Override Optional<String> getDocumentation() {
+        // not being used as far as I can see
+        return Optional.empty();
+    }
+
+}

--- a/src/community/geogig/src/main/resources/applicationContext.xml
+++ b/src/community/geogig/src/main/resources/applicationContext.xml
@@ -2,6 +2,9 @@
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
 <beans>
 
+  <bean class="org.geogig.geoserver.config.GeogigModuleStatus">
+  </bean>
+
   <bean id="geogigConfigStore" class="org.geogig.geoserver.config.ConfigStore">
     <constructor-arg ref="resourceLoader"/>
   </bean>

--- a/src/community/geogig/src/main/resources/org/geogig/geoserver/config/module_version.properties
+++ b/src/community/geogig/src/main/resources/org/geogig/geoserver/config/module_version.properties
@@ -1,0 +1,4 @@
+#version info added by ant-run plugin executed by maven. See pom.xml
+version = @project.version@
+build.revision = @build.revision@
+build.date = @build.timestamp@


### PR DESCRIPTION
Adds a ModuleStatus spring bean for geogig to report
module's version in the web UI's status/modules tab
and REST's /rest/about/status