### PR TITLE
Fix GeoGig CatalogVisitor so that it handles "autoIndexing" correctly.

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/wms/GeoGigCatalogVisitor.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/wms/GeoGigCatalogVisitor.java
@@ -159,7 +159,8 @@ public class GeoGigCatalogVisitor implements CatalogVisitor {
             Serializable autoIndexingParam = connectionParams
                     .get(GeoGigDataStoreFactory.AUTO_INDEXING.key);
             
-            final boolean autoIndexing = Boolean.TRUE.equals(autoIndexingParam);
+            final boolean autoIndexing = autoIndexingParam != null && Boolean.TRUE.equals(
+                    Boolean.valueOf(autoIndexingParam.toString()));
 
             if (!autoIndexing) {
                 if (LOGGER.isLoggable(Level.FINE)) {

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/GeoGigTestData.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/GeoGigTestData.java
@@ -488,6 +488,19 @@ public class GeoGigTestData extends ExternalResource {
             return catalog;
         }
 
+        public Catalog buildWithoutDataStores() {
+            setUpNamespace(workspace, nsUri);
+            setUpWorkspace(workspace);
+            return catalog;
+        }
+
+        public Catalog setUpLayers(DataStoreInfo ds) {
+            for (String layerName : layerNames) {
+                setUpLayer(ds, layerName);
+            }
+            return catalog;
+        }
+
         private LayerInfo setUpLayer(DataStoreInfo ds, String layerName) {
             FeatureTypeInfo ft = setUpFeatureType(ds, layerName);
             LayerInfo li = catalog.getFactory().createLayer();


### PR DESCRIPTION
When POSTing a GeoGig DataStore via the GeoServer REST API, the
"autoIndexing" connectionParameter value seems to be interpreted
as a String ("true"/"false") instead of a boolean (true/false).
This isn't the case when creating the DataStore via the GeoServer
UI. This change handles the value correctly in either case.

Signed-off-by: Erik Merkle <emerkle@boundlessgeo.com>