### PR TITLE
[GEOS-7495] Fix WFS Operations in Data Security view don't match WFS 2.0 Capabilities

### DIFF
--- a/src/web/security/core/src/main/java/org/geoserver/security/web/service/AbstractServiceAccessRulePage.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/service/AbstractServiceAccessRulePage.java
@@ -134,13 +134,15 @@ public abstract class AbstractServiceAccessRulePage extends AbstractSecurityPage
 
         @Override
         public List<String> getObject() {
-            ArrayList<String> result = new ArrayList<String>();
-            boolean flag = true;
+            List<String> result = new ArrayList<String>();
             for (Service ows : GeoServerExtensions.extensions(Service.class)) {
                 String service = rule.getService();
-                if (ows.getId().equals(service) && !result.contains(ows.getOperations()) && flag) {
-                    flag = false;
-                    result.addAll(ows.getOperations());
+                if (ows.getId().equals(service)) {
+                    for (String operation : ows.getOperations()) {
+                        if (!result.contains(operation)) {
+                            result.add(operation);
+                        }
+                    }
                 }
             }
             Collections.sort(result);

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/service/NewServiceAccessRulePageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/service/NewServiceAccessRulePageTest.java
@@ -93,7 +93,6 @@ public class NewServiceAccessRulePageTest extends AbstractSecurityWicketTestSupp
         int index = indexOf(page.serviceChoice.getChoices(), "wfs");
         form.select("service", index);
         tester.executeAjaxEvent("form:service", "change");
-        form = tester.newFormTester("form");
 
         List<String> wfsOperations = (List<String>) page.methodChoice.getChoices();
         List<String> expectedWfsOperations = Arrays.asList(

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/service/NewServiceAccessRulePageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/service/NewServiceAccessRulePageTest.java
@@ -7,6 +7,7 @@ package org.geoserver.security.web.service;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.wicket.extensions.markup.html.form.palette.component.Recorder;
@@ -75,6 +76,43 @@ public class NewServiceAccessRulePageTest extends AbstractSecurityWicketTestSupp
         assertNotNull(foundRule);
         assertEquals(1,foundRule.getRoles().size());
         assertEquals("ROLE_NEW",foundRule.getRoles().iterator().next());        
+    }
+    
+    /**
+     * See GEOS-7495
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testListWfsOperations() throws Exception {
+        initializeForXML();
+        // insertValues();
+        tester.startPage(page = new NewServiceAccessRulePage());
+        tester.assertRenderedPage(NewServiceAccessRulePage.class);
+
+        FormTester form = tester.newFormTester("form");
+        int index = indexOf(page.serviceChoice.getChoices(), "wfs");
+        form.select("service", index);
+        tester.executeAjaxEvent("form:service", "change");
+        form = tester.newFormTester("form");
+
+        List<String> wfsOperations = (List<String>) page.methodChoice.getChoices();
+        List<String> expectedWfsOperations = Arrays.asList(
+                "*", 
+                "GetCapabilities", 
+                "DescribeFeatureType", 
+                "GetFeature",
+                "LockFeature", 
+                "Transaction", 
+                "GetGmlObject", 
+                "DropStoredQuery", 
+                "CreateStoredQuery",
+                "GetFeatureWithLock", 
+                "DescribeStoredQueries", 
+                "GetPropertyValue", 
+                "ListStoredQueries");
+        
+        assertEquals(expectedWfsOperations.size(), wfsOperations.size());
+        assertTrue(wfsOperations.containsAll(expectedWfsOperations));
     }
     
     @Test


### PR DESCRIPTION
Add missing WFS 2.0.0 operations in Data Security view
See https://osgeo-org.atlassian.net/browse/GEOS-7495