### PR TITLE
Add troubleshooting information for installing geoserver on a Mac with an old version of JAI

### DIFF
--- a/doc/en/user/source/installation/osx_binary.rst
+++ b/doc/en/user/source/installation/osx_binary.rst
@@ -1,1 +1,68 @@
-.. _installation_osx_bin:Mac OS X binary===============.. note:: For the installer on OS X, please see the section on the :ref:`installation_osx_installer`. For installing on OS X with an existing application server such as Tomcat, please see the :ref:`installation_war` section.An alternate way of installing GeoServer on OS X is to use the platform-independent binary. This version is a GeoServer web application bundled inside `Jetty <http://eclipse.org/jetty/>`_, a lightweight and portable application server. It has the advantages of working very similarly across all operating systems and is very simple to set up.Installation------------#. Make sure you have a Java Runtime Environment (JRE) installed on your system. GeoServer requires a **Java 8** environment, and the JRE supplied by OS X is not sufficient. For more information, please see the `instructions for installing Oracle Java on OS X <http://java.com/en/download/faq/java_mac.xml>`_.   .. note:: Java 9 is not currently supported.   .. note:: For more information about Java and GeoServer, please see the section on :ref:`production_java`.#. Navigate to the `GeoServer Download page <http://geoserver.org/download>`_.#. Select the version of GeoServer that you wish to download.  If you're not sure, select `Stable <http://geoserver.org/release/stable>`_.#. Select :guilabel:`Platform Independent Binary` on the download page.#. Download the archive and unpack to the directory where you would like the program to be located.   .. note:: A suggested location would be :file:`/usr/local/geoserver`.#. Add an environment variable to save the location of GeoServer by typing the following command:   .. code-block:: bash          echo "export GEOSERVER_HOME=/usr/local/geoserver" >> ~/.profile      . ~/.profile#. Make yourself the owner of the ``geoserver`` folder, by typing the following command:    .. code-block:: bash       sudo chown -R <USERNAME> /usr/local/geoserver/   where ``USER_NAME`` is your user name #. Start GeoServer by changing into the directory ``geoserver/bin`` and executing the ``startup.sh`` script:    .. code-block:: bash              cd geoserver/bin       sh startup.sh#. In a web browser, navigate to ``http://localhost:8080/geoserver``.If you see the GeoServer logo, then GeoServer is successfully installed.   .. figure:: images/success.png      GeoServer installed and running successfullyTo shut down GeoServer, either close the persistent command-line window, or run the :file:`shutdown.sh` file inside the :file:`bin` directory.Uninstallation--------------#. Stop GeoServer (if it is running).#. Delete the directory where GeoServer is installed.
+.. _installation_osx_bin:
+
+Mac OS X binary
+===============
+
+.. note:: For the installer on OS X, please see the section on the :ref:`installation_osx_installer`. For installing on OS X with an existing application server such as Tomcat, please see the :ref:`installation_war` section.
+
+An alternate way of installing GeoServer on OS X is to use the platform-independent binary. This version is a GeoServer web application bundled inside `Jetty <http://eclipse.org/jetty/>`_, a lightweight and portable application server. It has the advantages of working very similarly across all operating systems and is very simple to set up.
+
+Installation
+------------
+
+#. Make sure you have a Java Runtime Environment (JRE) installed on your system. GeoServer requires a **Java 8** environment, and the JRE supplied by OS X is not sufficient. For more information, please see the `instructions for installing Oracle Java on OS X <http://java.com/en/download/faq/java_mac.xml>`_.
+
+   .. note:: Java 9 is not currently supported.
+
+   .. note:: For more information about Java and GeoServer, please see the section on :ref:`production_java`.
+
+#. Navigate to the `GeoServer Download page <http://geoserver.org/download>`_.
+
+#. Select the version of GeoServer that you wish to download.  If you're not sure, select `Stable <http://geoserver.org/release/stable>`_.
+
+#. Select :guilabel:`Platform Independent Binary` on the download page.
+
+#. Download the archive and unpack to the directory where you would like the program to be located.
+
+   .. note:: A suggested location would be :file:`/usr/local/geoserver`.
+
+#. Add an environment variable to save the location of GeoServer by typing the following command:
+
+   .. code-block:: bash
+    
+      echo "export GEOSERVER_HOME=/usr/local/geoserver" >> ~/.profile
+      . ~/.profile
+
+#. Make yourself the owner of the ``geoserver`` folder, by typing the following command:
+
+    .. code-block:: bash
+
+       sudo chown -R <USERNAME> /usr/local/geoserver/
+
+   where ``USER_NAME`` is your user name 
+
+#. Start GeoServer by changing into the directory ``geoserver/bin`` and executing the ``startup.sh`` script:
+
+    .. code-block:: bash
+       
+       cd geoserver/bin
+       sh startup.sh
+
+    .. include:: ./osx_jaierror.txt
+
+#. In a web browser, navigate to ``http://localhost:8080/geoserver``.
+
+If you see the GeoServer logo, then GeoServer is successfully installed.
+
+   .. figure:: images/success.png
+
+      GeoServer installed and running successfully
+
+To shut down GeoServer, either close the persistent command-line window, or run the :file:`shutdown.sh` file inside the :file:`bin` directory.
+
+Uninstallation
+--------------
+
+#. Stop GeoServer (if it is running).
+
+#. Delete the directory where GeoServer is installed.

--- a/doc/en/user/source/installation/osx_installer.rst
+++ b/doc/en/user/source/installation/osx_installer.rst
@@ -1,1 +1,38 @@
-.. _installation_osx_installer:Mac OS X installer==================The Windows installer provides an easy way to set up GeoServer on your system, as it requires no configuration files to be edited or command line settings.#. Make sure you have a Java Runtime Environment (JRE) installed on your system. GeoServer requires a **Java 8** environment, and the JRE supplied by OS X is not sufficient. For more information, please see the `instructions for installing Oracle Java on OS X <http://java.com/en/download/faq/java_mac.xml>`_.   .. note:: Java 9 is not currently supported.   .. note:: For more information about Java and GeoServer, please see the section on :ref:`production_java`.#. Navigate to the `GeoServer Download page <http://geoserver.org/download>`_.#. Select the version of GeoServer that you wish to download. If you're not sure, select `Stable <http://geoserver.org/release/stable>`_.#. Click the link for the Mac OS X installer to begin the download.#. When downloaded, double click on the file to open it.      #. Drag the GeoServer icon to the Applications folder.     .. figure:: images/osx1.png              Drag the GeoServer icon to Applications to install#. Navigate to your Applications folder and double click the GeoServer icon.#. In the resulting GeoServer console window, start GeoServer by going to :menuselection:`Server --> Start`.    .. figure:: images/osx2.png          Starting GeoServer#. The console window will be populated with log entries showing the GeoServer loading process. Once GeoServer is completely started, a browser window will open at ``http://localhost:8080/geoserver``, which is the :ref:`web_admin` for GeoServer.
+.. _installation_osx_installer:
+
+Mac OS X installer
+==================
+
+The Mac OS X installer provides an easy way to set up GeoServer on your system, as it requires no configuration files to be edited or command line settings.
+
+#. Make sure you have a Java Runtime Environment (JRE) installed on your system. GeoServer requires a **Java 8** environment, and the JRE supplied by OS X is not sufficient. For more information, please see the `instructions for installing Oracle Java on OS X <http://java.com/en/download/faq/java_mac.xml>`_.
+
+   .. note:: Java 9 is not currently supported.
+
+   .. note:: For more information about Java and GeoServer, please see the section on :ref:`production_java`.
+
+#. Navigate to the `GeoServer Download page <http://geoserver.org/download>`_.
+
+#. Select the version of GeoServer that you wish to download. If you're not sure, select `Stable <http://geoserver.org/release/stable>`_.
+
+#. Click the link for the Mac OS X installer to begin the download.
+
+#. When downloaded, double click on the file to open it.
+      
+#. Drag the GeoServer icon to the Applications folder. 
+
+    .. figure:: images/osx1.png
+       
+       Drag the GeoServer icon to Applications to install
+
+#. Navigate to your Applications folder and double click the GeoServer icon.
+
+#. In the resulting GeoServer console window, start GeoServer by going to :menuselection:`Server --> Start`.
+
+    .. figure:: images/osx2.png
+   
+       Starting GeoServer
+
+#. The console window will be populated with log entries showing the GeoServer loading process. Once GeoServer is completely started, a browser window will open at ``http://localhost:8080/geoserver``, which is the :ref:`web_admin` for GeoServer.
+
+    .. include:: ./osx_jaierror.txt

--- a/doc/en/user/source/installation/osx_jaierror.txt
+++ b/doc/en/user/source/installation/osx_jaierror.txt
@@ -1,0 +1,15 @@
+.. warning:: If you encounter the following error during startup, you may have some invalid JAI jars from the default Mac Java install:
+
+    .. code-block:: bash
+
+        java.lang.NoClassDefFoundError: Could not initialize class javax.media.jai.JAI
+    
+    To fix this error, locate your Java extensions folder (Usually ``/System/Library/Java/Extensions`` and/or ``~/Library/Java/Extensions``), and delete the following jars:
+
+    .. code-block:: bash
+
+        jai_codec-1.1.3.jar
+        jai_core-1.1.3.jar
+        jai_imageio-1.1.jar
+
+    If you have upgraded your OS from an older version, you may not have permission to delete these jars. In this case, you will first need to `disable System Integrity Protection <https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html#//apple_ref/doc/uid/TP40016462-CH5-SW1>`_.


### PR DESCRIPTION
This is stemming from some feedback we got at the code sprint at FOSS4G 2017.

Note: The line endings in the changed files have been converted to standard unix for sanity, only actual changes are adding `    .. include:: ./osx_jaierror.txt`.