### PR TITLE
[GEOS-8265] Move GeoPackage support into core

### DIFF
--- a/src/community/release/ext-geopkg.xml
+++ b/src/community/release/ext-geopkg.xml
@@ -11,9 +11,7 @@
       <includes>	
         <include>gt-mbtiles-*.jar</include>
         <include>gs-mbtiles-*.jar</include>
-        <include>gt-geopkg-*.jar</include>
         <include>gs-geopkg-*.jar</include>
-        <include>sqlite*.jar</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -468,6 +468,12 @@
     <artifactId>gt-process-feature</artifactId>
     <version>${gt.version}</version>
    </dependency>
+   <dependency>
+    <groupId>org.geotools</groupId>
+    <artifactId>gt-geopkg</artifactId>
+    <version>${gt.version}</version>
+   </dependency>
+
 
    <dependency>
      <groupId>com.google.code.gson</groupId>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -143,6 +143,10 @@
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
+      <artifactId>gt-geopkg</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
       <artifactId>gt-wfs-ng</artifactId>
     </dependency>
     <dependency>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -134,6 +134,10 @@
     <groupId>com.github.svenmeier.wicket-dnd</groupId>
     <artifactId>wicket-dnd</artifactId>
   </dependency>
+   <dependency>
+    <groupId>org.geotools</groupId>
+    <artifactId>gt-geopkg</artifactId>
+   </dependency>
   </dependencies>
 
   <build>

--- a/src/web/core/src/main/java/applicationContext.xml
+++ b/src/web/core/src/main/java/applicationContext.xml
@@ -355,6 +355,15 @@
     <property name="componentClass"
       value="org.geoserver.web.data.store.raster.WorldImageEditPanel" />
   </bean>
+  
+  <bean id="geopkgStorePanel" class="org.geoserver.web.data.resource.DataStorePanelInfo">
+    <property name="id" value="geopackageRaster" />
+    <property name="factoryClass" value="org.geotools.geopkg.mosaic.GeoPackageFormat" />
+    <property name="iconBase" value="org.geoserver.web.GeoServerApplication" />
+    <property name="icon" value="img/icons/geosilk/page_white_raster.png" />
+    <property name="componentClass"
+      value="org.geoserver.web.data.store.raster.FileRasterEditPanel" />
+  </bean>
 
   <bean id="postgisDataStorePanel" class="org.geoserver.web.data.resource.DataStorePanelInfo">
     <property name="id" value="postgis" />

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
@@ -32,6 +32,7 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.web.data.resource.DataStorePanelInfo;
 import org.geoserver.web.data.store.panel.CheckBoxParamPanel;
 import org.geoserver.web.data.store.panel.DropDownChoiceParamPanel;
+import org.geoserver.web.data.store.panel.FileParamPanel;
 import org.geoserver.web.data.store.panel.LabelParamPanel;
 import org.geoserver.web.data.store.panel.NamespacePanel;
 import org.geoserver.web.data.store.panel.ParamPanel;
@@ -176,6 +177,10 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
             // TODO Add prefix for better i18n?
             parameterPanel = new CheckBoxParamPanel(componentId, new MapModel(paramsModel,
                     paramName), new ResourceModel(paramLabel, paramLabel));
+
+        } else if (File.class == binding) {
+            parameterPanel = new FileParamPanel(componentId, new MapModel(paramsModel,
+                    paramName), new ResourceModel(paramLabel, paramLabel), required);
 
         } else if (String.class == binding && paramMetadata.isPassword()) {
             parameterPanel = new PasswordParamPanel(componentId, new MapModel(paramsModel,

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/CoverageStoreNewPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/CoverageStoreNewPageTest.java
@@ -5,11 +5,18 @@
  */
 package org.geoserver.web.data.store;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.apache.wicket.Component;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.data.store.panel.FileParamPanel;
 import org.geoserver.web.data.store.panel.WorkspacePanel;
 import org.geotools.gce.gtopo30.GTopo30FormatFactory;
+import org.geotools.geopkg.mosaic.GeoPackageFormat;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.coverage.grid.Format;
@@ -99,5 +106,16 @@ public class CoverageStoreNewPageTest extends GeoServerWicketTestSupport {
         tester.assertModelValue("rasterStoreForm:parametersPanel:url",
                 "file:data/example.extension");
 
+    }
+    
+    @Test
+    public void testGeoPackageRaster() {
+        formatType = new GeoPackageFormat().getName();
+        final CoverageStoreNewPage page = new CoverageStoreNewPage(formatType);
+        tester.startPage(page);
+        
+        tester.debugComponentTrees();
+        Component urlComponent = tester.getComponentFromLastRenderedPage("rasterStoreForm:parametersPanel:url");
+        assertThat(urlComponent, instanceOf(FileParamPanel.class));
     }
 }

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessNewPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessNewPageTest.java
@@ -5,17 +5,22 @@
  */
 package org.geoserver.web.data.store;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.wicket.Component;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.data.store.panel.FileParamPanel;
 import org.geoserver.web.data.store.panel.WorkspacePanel;
 import org.geotools.data.property.PropertyDataStoreFactory;
+import org.geotools.geopkg.GeoPkgDataStoreFactory;
+import org.geotools.geopkg.mosaic.GeoPackageFormatFactorySpi;
 import org.junit.Test;
 
 /**
@@ -135,6 +140,18 @@ public class DataAccessNewPageTest extends GeoServerWicketTestSupport {
         //
         // assertEquals(expectedNamespace, assignedNamespace);
 
+    }
+    
+    @Test
+    public void testGeoPackagePage() {
+        final String displayName = new GeoPkgDataStoreFactory().getDisplayName();
+        final AbstractDataAccessPage page = new DataAccessNewPage(displayName);
+        tester.startPage(page);
+        
+        tester.debugComponentTrees();
+        // the "database" key is the second, should be a file panel
+        Component component = tester.getComponentFromLastRenderedPage("dataStoreForm:parametersPanel:parameters:1:parameterPanel");
+        assertThat(component, instanceOf(FileParamPanel.class));
     }
 
 }


### PR DESCRIPTION
This moves the read part of the GeoPackage module into core.
Vector data works fine, but is slow extracting small portions because the spatial index is not used.
Raster data unfortunately does not work, seems like there is an axis flipping issue.