### PR TITLE
[GEOS-8063] Fix WMS1.3.0 SLD definition can break getcapabilities

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1061,7 +1061,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             }
         }
 
-		private void handleStyles(final LayerInfo layer) {
+        private void handleStyles(final LayerInfo layer) {
             if (layer.getResource() instanceof WMSLayerInfo) {
                 // do nothing for the moment, we may want to list the set of cascaded named styles
                 // in the future (when we add support for that)
@@ -1074,24 +1074,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                     throw new NullPointerException("Layer " + layer.getName()
                             + " has no default style");
                 }
-                Style ftStyle;
-                try {
-                    ftStyle = defaultStyle.getStyle();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                element("Name", defaultStyle.prefixedName());
-                if (ftStyle.getDescription() != null) {
-                    // PMT: WMS capabilities requires at least a title,
-                    // if description's title is null, use the name
-                    // for title.
-                    if (ftStyle.getDescription().getTitle() != null) {
-                        element("Title", ftStyle.getDescription().getTitle());
-                    } else {
-                        element("Title", defaultStyle.prefixedName());
-                    }
-                    element("Abstract", ftStyle.getDescription().getAbstract());
-                }
+                handleCommonStyleElements(defaultStyle);
                 handleLegendURL(layer, defaultStyle.getLegend(), null, defaultStyle);
                 end("Style");
 
@@ -1099,21 +1082,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
 
                 if(styles != null){
                     for (StyleInfo styleInfo : styles) {
-                        try {
-                            ftStyle = styleInfo.getStyle();
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
                         start("Style");
-                        element("Name", styleInfo.prefixedName());
-                        if (ftStyle.getDescription() != null) {
-                            if (ftStyle.getDescription().getTitle() != null) {
-                                element("Title", ftStyle.getDescription().getTitle());
-                            } else {
-                                element("Title", styleInfo.prefixedName());
-                            }
-                            element("Abstract", ftStyle.getDescription().getAbstract());
-                        }
+                        handleCommonStyleElements(styleInfo);
                         handleLegendURL(layer, styleInfo.getLegend(), styleInfo, styleInfo);
                         end("Style");
                     }
@@ -1121,6 +1091,29 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             }
         }
 
+        private void handleCommonStyleElements(StyleInfo defaultStyle) {
+            Style ftStyle;
+            try {
+                ftStyle = defaultStyle.getStyle();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            element("Name", defaultStyle.prefixedName());
+            if (ftStyle.getDescription() != null) {
+                // PMT: WMS capabilities requires at least a title,
+                // if description's title is null, use the name
+                // for title.
+                if (ftStyle.getDescription().getTitle() != null) {
+                    element("Title", ftStyle.getDescription().getTitle());
+                } else {
+                    element("Title", defaultStyle.prefixedName());
+                }
+                element("Abstract", ftStyle.getDescription().getAbstract());
+            } else {
+                element("Title", defaultStyle.prefixedName());
+            }
+        }
+        
         private void element(String element, InternationalString is) {
             if (is != null) {
                 element(element, is.toString());

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1082,7 +1082,14 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                 }
                 element("Name", defaultStyle.prefixedName());
                 if (ftStyle.getDescription() != null) {
-                    element("Title", ftStyle.getDescription().getTitle());
+                    // PMT: WMS capabilities requires at least a title,
+                    // if description's title is null, use the name
+                    // for title.
+                    if (ftStyle.getDescription().getTitle() != null) {
+                        element("Title", ftStyle.getDescription().getTitle());
+                    } else {
+                        element("Title", defaultStyle.prefixedName());
+                    }
                     element("Abstract", ftStyle.getDescription().getAbstract());
                 }
                 handleLegendURL(layer, defaultStyle.getLegend(), null, defaultStyle);
@@ -1100,7 +1107,11 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                         start("Style");
                         element("Name", styleInfo.prefixedName());
                         if (ftStyle.getDescription() != null) {
-                            element("Title", ftStyle.getDescription().getTitle());
+                            if (ftStyle.getDescription().getTitle() != null) {
+                                element("Title", ftStyle.getDescription().getTitle());
+                            } else {
+                                element("Title", styleInfo.prefixedName());
+                            }
                             element("Abstract", ftStyle.getDescription().getAbstract());
                         }
                         handleLegendURL(layer, styleInfo.getLegend(), styleInfo, styleInfo);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/StyleCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/StyleCapabilitiesTest.java
@@ -21,6 +21,7 @@ import org.geoserver.data.test.SystemTestData.LayerProperty;
 import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSTestSupport;
 import org.geoserver.wms.wms_1_1_1.CapabilitiesTest;
+import org.geotools.styling.StyleImpl;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -32,20 +33,24 @@ public class StyleCapabilitiesTest extends WMSTestSupport {
 
     private static final String LAYER_NAME_WITH_STYLE_TITLE = "states_with_style_title";
     private static final String LAYER_NAME_WITHOUT_STYLE_TITLE = "states_without_style_title";
+    private static final String LAYER_NAME_WITHOUT_STYLE_DESCRIPTION = "states_without_style_description";
 
     private static final String STYLE_NAME_WITH_TITLE = "style_with_style_title";
     private static final String STYLE_NAME_WITHOUT_TITLE = "style_without_style_title";
-    
+    private static final String STYLE_NAME_WITHOUT_DESCRIPTION = "style_without_style_description";
+
     private static final QName LAYER_WITH_SYTLE_TITLE = new QName(MockData.DEFAULT_URI, LAYER_NAME_WITH_STYLE_TITLE, MockData.DEFAULT_PREFIX);
     private static final QName LAYER_WITHOUT_STYLE_TITLE = new QName(MockData.DEFAULT_URI, LAYER_NAME_WITHOUT_STYLE_TITLE, MockData.DEFAULT_PREFIX);
+    private static final QName LAYER_WITHOUT_STYLE_DESCRIPTION = new QName(MockData.DEFAULT_URI, LAYER_NAME_WITHOUT_STYLE_DESCRIPTION, MockData.DEFAULT_PREFIX);
 
     private static final String BASE = "src/test/resources/geoserver";
 
     /**
-     * Add 2 layers:
+     * Add 3 layers:
      * <ul>
      * <li>a layer with an sld with a title,
-     * <li>a layer with an sld without a title.
+     * <li>a layer with an sld without a title,
+     * <li>a layer with an sld without a description.
      * </ul>
      */
     @Override
@@ -57,6 +62,7 @@ public class StyleCapabilitiesTest extends WMSTestSupport {
         // add layers
         testData.addStyle(STYLE_NAME_WITH_TITLE, "styleWithTitle.sld", getClass(), catalog);
         testData.addStyle(STYLE_NAME_WITHOUT_TITLE, "styleWithoutTitle.sld", getClass(), catalog);
+        testData.addStyle(STYLE_NAME_WITHOUT_DESCRIPTION, "styleWithoutDescription.sld", getClass(), catalog);
 
         Map<LayerProperty, Object> properties = new HashMap<LayerProperty, Object>();
         properties.put(LayerProperty.STYLE, STYLE_NAME_WITH_TITLE);
@@ -68,6 +74,16 @@ public class StyleCapabilitiesTest extends WMSTestSupport {
 
         testData.addVectorLayer(LAYER_WITHOUT_STYLE_TITLE, properties, "states.properties", CapabilitiesTest.class, catalog);
 
+        properties = new HashMap<LayerProperty, Object>();
+        properties.put(LayerProperty.STYLE, STYLE_NAME_WITHOUT_DESCRIPTION);
+
+        testData.addVectorLayer(LAYER_WITHOUT_STYLE_DESCRIPTION, properties, "states.properties", CapabilitiesTest.class, catalog);        
+        
+        // force the style without description to be null, by default it is not null if not set
+        // https://github.com/geotools/geotools/blob/bdcdaeca35f0cb1c465f2e11dd1b04bb7fff30df/modules/library/main/src/main/java/org/geotools/styling/StyleImpl.java#L45
+        StyleImpl style = (StyleImpl)catalog.getStyleByName(STYLE_NAME_WITHOUT_DESCRIPTION).getStyle();
+        style.setDescription(null);
+        
         // For global set-up
         GeoServerInfo global = getGeoServer().getGlobal();
         global.getSettings().setProxyBaseUrl(BASE);
@@ -100,7 +116,15 @@ public class StyleCapabilitiesTest extends WMSTestSupport {
         // check we have the style name
         assertXpathEvaluatesTo(STYLE_NAME_WITHOUT_TITLE, getLayerStyleTitleXPath(LAYER_NAME_WITHOUT_STYLE_TITLE), dom);
     }
-
+    
+    @Test
+    public void testLayerStyleWithoutDescription() throws Exception {
+        Document dom = dom(get(CAPABILITIES_REQUEST), false);
+        // print(dom);
+        // check we have the style name
+        assertXpathEvaluatesTo(STYLE_NAME_WITHOUT_DESCRIPTION, getLayerStyleTitleXPath(LAYER_NAME_WITHOUT_STYLE_DESCRIPTION), dom);
+    }
+    
     private String getLayerStyleTitleXPath(String layerName) {
         return "//wms:Layer[wms:Name='" + MockData.DEFAULT_PREFIX + ":" + layerName + "']/wms:Style/wms:Title";
     }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/StyleCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/StyleCapabilitiesTest.java
@@ -1,0 +1,107 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.wms_1_3;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.data.test.SystemTestData.LayerProperty;
+import org.geoserver.wms.WMSInfo;
+import org.geoserver.wms.WMSTestSupport;
+import org.geoserver.wms.wms_1_1_1.CapabilitiesTest;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Tests for GEOS-8063: WMS1.3.0 SLD definition can break getcapabilities
+ */
+public class StyleCapabilitiesTest extends WMSTestSupport {
+    private static final String CAPABILITIES_REQUEST = "wms?request=getCapabilities&version=1.3.0";
+
+    private static final String LAYER_NAME_WITH_STYLE_TITLE = "states_with_style_title";
+    private static final String LAYER_NAME_WITHOUT_STYLE_TITLE = "states_without_style_title";
+
+    private static final String STYLE_NAME_WITH_TITLE = "style_with_style_title";
+    private static final String STYLE_NAME_WITHOUT_TITLE = "style_without_style_title";
+    
+    private static final QName LAYER_WITH_SYTLE_TITLE = new QName(MockData.DEFAULT_URI, LAYER_NAME_WITH_STYLE_TITLE, MockData.DEFAULT_PREFIX);
+    private static final QName LAYER_WITHOUT_STYLE_TITLE = new QName(MockData.DEFAULT_URI, LAYER_NAME_WITHOUT_STYLE_TITLE, MockData.DEFAULT_PREFIX);
+
+    private static final String BASE = "src/test/resources/geoserver";
+
+    /**
+     * Add 2 layers:
+     * <ul>
+     * <li>a layer with an sld with a title,
+     * <li>a layer with an sld without a title.
+     * </ul>
+     */
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        Catalog catalog = getCatalog();
+
+        // add layers
+        testData.addStyle(STYLE_NAME_WITH_TITLE, "styleWithTitle.sld", getClass(), catalog);
+        testData.addStyle(STYLE_NAME_WITHOUT_TITLE, "styleWithoutTitle.sld", getClass(), catalog);
+
+        Map<LayerProperty, Object> properties = new HashMap<LayerProperty, Object>();
+        properties.put(LayerProperty.STYLE, STYLE_NAME_WITH_TITLE);
+
+        testData.addVectorLayer(LAYER_WITH_SYTLE_TITLE, properties, "states.properties", CapabilitiesTest.class, catalog);
+
+        properties = new HashMap<LayerProperty, Object>();
+        properties.put(LayerProperty.STYLE, STYLE_NAME_WITHOUT_TITLE);
+
+        testData.addVectorLayer(LAYER_WITHOUT_STYLE_TITLE, properties, "states.properties", CapabilitiesTest.class, catalog);
+
+        // For global set-up
+        GeoServerInfo global = getGeoServer().getGlobal();
+        global.getSettings().setProxyBaseUrl(BASE);
+        getGeoServer().save(global);
+
+        WMSInfo wms = getGeoServer().getService(WMSInfo.class);
+        wms.getSRS().add("EPSG:4326");
+        getGeoServer().save(wms);
+
+        Map<String, String> namespaces = new HashMap<String, String>();
+        namespaces.put("xlink", "http://www.w3.org/1999/xlink");
+        namespaces.put("", "http://www.opengis.net/wms");
+        namespaces.put("wms", "http://www.opengis.net/wms");
+        getTestData().registerNamespaces(namespaces);
+        XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(namespaces));
+    }
+
+    @Test
+    public void testLayerStyleWithTitle() throws Exception {
+        Document dom = dom(get(CAPABILITIES_REQUEST), false);
+        // print(dom);
+        // check we have the userStyle title
+        assertXpathEvaluatesTo("Population in the United States", getLayerStyleTitleXPath(LAYER_NAME_WITH_STYLE_TITLE), dom);
+    }
+
+    @Test
+    public void testLayerStyleWithoutTitle() throws Exception {
+        Document dom = dom(get(CAPABILITIES_REQUEST), false);
+        // print(dom);
+        // check we have the style name
+        assertXpathEvaluatesTo(STYLE_NAME_WITHOUT_TITLE, getLayerStyleTitleXPath(LAYER_NAME_WITHOUT_STYLE_TITLE), dom);
+    }
+
+    private String getLayerStyleTitleXPath(String layerName) {
+        return "//wms:Layer[wms:Name='" + MockData.DEFAULT_PREFIX + ":" + layerName + "']/wms:Style/wms:Title";
+    }
+}

--- a/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/styleWithTitle.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/styleWithTitle.sld
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<Name>A Test Layer</Name>
+<title>The title of the layer</title>
+<abstract>A styling layer used for the unit tests of sldstyler</abstract>
+<UserStyle>
+  <Name>population</Name>
+  <Title>Population in the United States</Title>
+  <Abstract>A sample filter that filters the United States into three categories of population, drawn in different colors</Abstract>
+    <FeatureTypeStyle>
+     <Rule>
+      <Name>r1</Name>
+      <PolygonSymbolizer>
+        <Fill/>
+        <Stroke/>
+      </PolygonSymbolizer>
+     </Rule>
+    </FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/styleWithoutDescription.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/styleWithoutDescription.sld
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<UserStyle>
+    <FeatureTypeStyle>
+     <Rule>
+      <Name>r1</Name>
+      <PolygonSymbolizer>
+        <Fill/>
+        <Stroke/>
+      </PolygonSymbolizer>
+     </Rule>
+    </FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/styleWithoutTitle.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms_1_3/styleWithoutTitle.sld
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<Name>A Test Layer</Name>
+<title>The title of the layer</title>
+<abstract>A styling layer used for the unit tests of sldstyler</abstract>
+<UserStyle>
+  <Name>population</Name>
+  <Abstract>A sample filter that filters the United States into three categories of population, drawn in different colors</Abstract>
+    <FeatureTypeStyle>
+     <Rule>
+      <Name>r1</Name>
+      <PolygonSymbolizer>
+        <Fill/>
+        <Stroke/>
+      </PolygonSymbolizer>
+     </Rule>
+    </FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
This fix proposal aims to add a Title element in the Style's GetCapabilities response.
It resumes the work from https://github.com/geoserver/geoserver/pull/2200
See https://osgeo-org.atlassian.net/browse/GEOS-8063