### PR TITLE
[GEOS-8288] Check that name has actually been changed in the style change listener

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogStyleChangeListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogStyleChangeListener.java
@@ -93,8 +93,8 @@ public class CatalogStyleChangeListener implements CatalogListener {
                 return;
             }
             final int nameIdx = propertyNames.indexOf("name");
-            final String oldName = (String) event.getOldValues().get(nameIdx);
-            final String newName = (String) event.getNewValues().get(nameIdx);
+            final String oldName = nameIdx != -1 ? (String) event.getOldValues().get(nameIdx) : null;
+            final String newName = nameIdx != -1 ? (String) event.getNewValues().get(nameIdx) : null;
             final int workspaceIdx = propertyNames.indexOf("wokspace");
             final String oldWorkspaceName = workspaceIdx != -1 ? (String) event.getOldValues().get(
                     workspaceIdx) : null;
@@ -103,7 +103,11 @@ public class CatalogStyleChangeListener implements CatalogListener {
             final String oldStyleName = getPrefixedName(oldWorkspaceName, oldName);
             final String newStyleName = getPrefixedName(newWorkspaceName, newName);
 
-            handleStyleRenamed(oldStyleName, newStyleName);
+            if (nameIdx != -1) {
+                //for now, only handle the even if the name changes. most likely we should also do the truncate if
+                //the workspace changes too, but that needs a more thorough investigation
+                handleStyleRenamed(oldStyleName, newStyleName);
+            }
         } else if (source instanceof WorkspaceInfo) {
             PRE_MODIFY_EVENT.set(event);
         }

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogStyleChangeListenerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogStyleChangeListenerTest.java
@@ -180,4 +180,16 @@ public class CatalogStyleChangeListenerTest {
 
         verify(mockMediator, times(1)).truncate(eq("mockGroup"));
     }
+
+    @Test
+    public void testChangeWorkspaceWithoutName() {
+        CatalogModifyEventImpl modifyEvent = new CatalogModifyEventImpl();
+        modifyEvent.setSource(mockStyle);
+        modifyEvent.setPropertyNames(Collections.singletonList("workspace"));
+        modifyEvent.setOldValues(Collections.singletonList(""));
+        modifyEvent.setNewValues(Collections.singletonList("test"));
+
+        //should occur without exception
+        listener.handleModifyEvent(modifyEvent);
+    }
 }


### PR DESCRIPTION
Fixes an exception generated when changing just the workspace of a style, but not the name.

Looking through this code though, it seems like there may be other logistical issues in what happens here though. It seems as though the listener truncates every layer associated with a style of the same name without taking into consideration the workspace of the style? I need to look at it further. For now though this fixes the ArrayIndexOutOfBoundsException.