### PR TITLE
Support for MBStyle StyleGroups

### DIFF
--- a/src/community/mbstyle/src/test/java/org/geoserver/community/mbstyle/web/MBStyleHandlerTest.java
+++ b/src/community/mbstyle/src/test/java/org/geoserver/community/mbstyle/web/MBStyleHandlerTest.java
@@ -1,13 +1,16 @@
 package org.geoserver.community.mbstyle.web;
 
-import org.geoserver.catalog.Styles;
+import org.geoserver.catalog.*;
 import org.geoserver.community.mbstyle.MBStyleHandler;
+import org.geoserver.data.test.MockData;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.styling.*;
 import org.junit.Test;
 
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.Files;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class MBStyleHandlerTest extends GeoServerSystemTestSupport {
@@ -26,5 +29,33 @@ public class MBStyleHandlerTest extends GeoServerSystemTestSupport {
 
         LineSymbolizer ls = SLD.lineSymbolizer(Styles.style(sld));
         assertNotNull(ls);
+    }
+
+    @Test
+    public void testRoundTripMBStyleGroup() throws IOException {
+        Catalog catalog = getCatalog();
+        LayerGroupInfo lg = catalog.getFactory().createLayerGroup();
+        lg.setName("citeGroup");
+        lg.getLayers().add(catalog.getLayerByName(getLayerId(MockData.LAKES)));
+        lg.getLayers().add(catalog.getLayerByName(getLayerId(MockData.BASIC_POLYGONS)));
+        lg.getLayers().add(catalog.getLayerByName(getLayerId(MockData.NAMED_PLACES)));
+        lg.getStyles().add(null);
+        lg.getStyles().add(null);
+        lg.getStyles().add(null);
+
+        catalog.add(lg);
+
+        StyledLayerDescriptor sld = Styles.handler(MBStyleHandler.FORMAT).parse(getClass()
+                .getResourceAsStream("citeGroup.json"), null, null, null);
+
+        assertEquals(4, sld.getStyledLayers().length);
+
+        StyleHandler sldHandler = Styles.handler(SLDHandler.FORMAT);
+        File sldFile = Files.createTempFile("citeGroup", "sld").toFile();
+        OutputStream fout = new FileOutputStream(sldFile);
+        sldHandler.encode(sld, SLDHandler.VERSION_10, true, fout);
+
+        StyledLayerDescriptor sld2 = sldHandler.parse(new FileInputStream(sldFile), SLDHandler.VERSION_10, null, null);
+        assertEquals(4, sld2.getStyledLayers().length);
     }
 }

--- a/src/community/mbstyle/src/test/resources/org/geoserver/community/mbstyle/web/citeGroup.json
+++ b/src/community/mbstyle/src/test/resources/org/geoserver/community/mbstyle/web/citeGroup.json
@@ -1,0 +1,61 @@
+{
+  "version": 8,
+  "name": "citeGroup",
+  "center": [0,0],
+  "zoom": 7,
+  "sources": {
+    "cite": {
+      "type": "vector",
+      "tiles": [
+        "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=citeGroup&STYLE=&TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector&TILECOL={x}&TILEROW={y}"
+      ],
+      "minZoom": 0,
+      "maxZoom": 14
+    }
+  },
+  "layers": [
+    {
+      "type": "background",
+      "id": "background",
+      "paint": {
+        "background-color": "#E3E3E9"
+      }
+    },
+    {
+      "type": "fill",
+      "id": "fill",
+      "source": "cite",
+      "source-layer": "Lakes",
+      "paint": {
+        "fill-color": "#C3C3C3",
+        "fill-opacity": 0.9
+      }
+    },
+    {
+      "type": "line",
+      "id": "line",
+      "source": "cite",
+      "source-layer": "BasicPolygons",
+      "paint": {
+        "line-color": "#777777",
+        "line-width": 1,
+        "line-dasharray": [4, 4]
+      }
+    },
+    {
+      "type": "symbol",
+      "id": "names",
+      "source": "cite",
+      "source-layer": "NamedPlaces",
+      "layout": {
+        "text-field": "{Name}",
+        "text-size": 14,
+        "text-font": ["Open Sans"],
+        "text-max-width": 100
+      },
+      "paint": {
+        "text-color": "#333333"
+      }
+    }
+  ]
+}

--- a/src/main/src/main/java/org/geoserver/catalog/GeoServerSLDVisitor.java
+++ b/src/main/src/main/java/org/geoserver/catalog/GeoServerSLDVisitor.java
@@ -8,16 +8,12 @@ import org.geoserver.catalog.impl.DataStoreInfoImpl;
 import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.platform.ServiceException;
-import org.geotools.data.DataAccess;
-import org.geotools.data.DataStore;
-import org.geotools.data.FeatureReader;
-import org.geotools.data.FeatureSource;
-import org.geotools.data.Query;
-import org.geotools.data.Transaction;
+import org.geotools.data.*;
 import org.geotools.data.collection.CollectionFeatureSource;
 import org.geotools.data.crs.ForceCoordinateSystemFeatureReader;
 import org.geotools.data.memory.MemoryDataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.data.store.ContentDataStore;
 import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.factory.Hints;
@@ -416,6 +412,7 @@ public abstract class GeoServerSLDVisitor extends AbstractStyleVisitor {
         }
         featureTypeInfo.setName(featureSource.getName().getLocalPart());
         featureTypeInfo.setEnabled(true);
+        featureTypeInfo.setCatalog(catalog);
         LayerInfo layerInfo = catalog.getFactory().createLayer();
         layerInfo.setResource(featureTypeInfo);
         layerInfo.setEnabled(true);
@@ -443,6 +440,10 @@ public abstract class GeoServerSLDVisitor extends AbstractStyleVisitor {
             return featureSource;
         }
         @Override
+        public FeatureType getFeatureType() throws IOException {
+            return featureSource.getSchema();
+        }
+        @Override
         public Name getQualifiedName() {
             return featureSource.getName();
         }
@@ -460,7 +461,7 @@ public abstract class GeoServerSLDVisitor extends AbstractStyleVisitor {
                 @Override
                 public DataAccess<? extends FeatureType, ? extends Feature> getDataStore(
                         ProgressListener listener) throws IOException {
-                    return featureSource.getDataStore();
+                    return DataUtilities.dataStore((SimpleFeatureSource)featureSource);
                 }
             };
         }

--- a/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
@@ -498,7 +498,9 @@ public class LayerGroupHelper {
         @Override
         public void visitUserStyleInternal(Style userStyle) {
             layers.add((LayerInfo)info);
-            styles.add(new StyleWrappingStyleInfoImpl(userStyle));
+            StyleInfoImpl style = new StyleWrappingStyleInfoImpl(userStyle);
+            style.setCatalog(catalog);
+            styles.add(style);
         }
     }
 }

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/OpenLayersPreviewPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/OpenLayersPreviewPanel.java
@@ -198,7 +198,10 @@ public class OpenLayersPreviewPanel extends StyleEditTabPanel implements IHeader
             context.put("styleWorkspace", workspace.getName());
             styleUrl = styleUrl + "/" + workspace.getName();
         }
-        styleUrl = styleUrl + "/" + getStylePage().getStyleInfo().getFilename();
+        String styleFile = getStylePage().getStyleInfo().getFilename();
+        //If we are in a format other than sld, convert to sld
+        styleFile = styleFile.substring(0, styleFile.lastIndexOf(".")) + ".sld";
+        styleUrl = styleUrl + "/" + styleFile;
         context.put("styleUrl", styleUrl);
         context.put("previewStyleGroup", isPreviewStyleGroup);
 


### PR DESCRIPTION
Support non-sld formats for "Preview as Style Group"
Improvements to GeoServerSLDVisitor and LayerGroupHelper to support InlineFeature elements for use with background layers

Depends upon https://github.com/geotools/geotools/pull/1704