### PR TITLE
[GEOS-8310] Fix geopackage tile image format default handling.

### DIFF
--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormat.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormat.java
@@ -232,7 +232,8 @@ public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputForma
 
         String imageFormat = formatOpts.containsKey("format") ? parseFormatFromOpts(formatOpts)
                 : findBestFormat(request);
-                
+        req.setFormat(imageFormat);
+
         CoordinateReferenceSystem crs = getCoordinateReferenceSystem(request);
         if (crs==null) {
             String srs = getSRS(request);
@@ -246,9 +247,7 @@ public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputForma
         double ySpan = crs.getCoordinateSystem().getAxis(1).getMaximumValue() - crs.getCoordinateSystem().getAxis(1).getMinimumValue();
         double xOffset = crs.getCoordinateSystem().getAxis(0).getMinimumValue();
         double yOffset = crs.getCoordinateSystem().getAxis(1).getMinimumValue();
-    
-        
-        req.setFormat(imageFormat);
+
         req.setCrs(crs);
         
         //column and row bounds

--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/wps/GeoPackageProcess.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/wps/GeoPackageProcess.java
@@ -314,7 +314,9 @@ public class GeoPackageProcess implements GSProcess {
                }
                request.setFormat("none");
                Map formatOptions = new HashMap();
-               formatOptions.put("format",tiles.getFormat());
+               if (tiles.getFormat() != null) {
+                    formatOptions.put("format",tiles.getFormat());
+               }
                if (tiles.getCoverage() != null) {
                    if (tiles.getCoverage().getMinZoom() != null) {
                        formatOptions.put("min_zoom", tiles.getCoverage().getMinZoom());

--- a/src/community/geopkg/src/test/java/org/geoserver/geopkg/wps/gs/GeoPackageProcessTest.java
+++ b/src/community/geopkg/src/test/java/org/geoserver/geopkg/wps/gs/GeoPackageProcessTest.java
@@ -20,14 +20,14 @@ import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 public class GeoPackageProcessTest extends WPSTestSupport {
-    
+
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
         super.setUpTestData(testData);
         testData.setUpDefaultRasterLayers();
     }
-    
-    
+
+
     @Test
     public void testGeoPackageProcess() throws Exception{
         String urlPath = string(post("wps", getXml())).trim();
@@ -38,12 +38,12 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertNotNull(file);
         assertEquals("test.gpkg", file.getName());
         assertTrue(file.exists());
-        
+
         GeoPackage gpkg = new GeoPackage(file);
-        
+
         List<FeatureEntry> features = gpkg.features();
         assertEquals(2, features.size());
-        
+
         FeatureEntry fe = features.get(0);
         assertEquals("Fifteen", fe.getTableName());
         assertEquals("fifteen description", fe.getDescription());
@@ -53,30 +53,30 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(500000, fe.getBounds().getMinY(), 0.0001);
         assertEquals(500100, fe.getBounds().getMaxX(), 0.0001);
         assertEquals(500100, fe.getBounds().getMaxY(), 0.0001);
-        
+
         assertFalse(gpkg.hasSpatialIndex(fe));
         assertTrue(gpkg.hasSpatialIndex(features.get(1)));
-        
+
         SimpleFeatureReader fr = gpkg.reader(fe, null, null);
         assertEquals(1, fr.getFeatureType().getAttributeCount());
         assertEquals("pointProperty", fr.getFeatureType().getAttributeDescriptors().get(0).getLocalName());
         assertTrue(fr.hasNext());
         fr.next();
         fr.close();
-        
+
         fe = features.get(1);
         assertEquals("Lakes", fe.getTableName());
         assertEquals("lakes description", fe.getDescription());
         assertEquals("lakes1", fe.getIdentifier());
-        
+
         fr = gpkg.reader(fe, null, null);
         assertTrue(fr.hasNext());
         fr.next();
         fr.close();
-        
+
         List<TileEntry> tiles = gpkg.tiles();
         assertEquals(2, tiles.size());
-        
+
         TileEntry te = tiles.get(0);
         assertEquals("world_lakes", te.getTableName());
         assertEquals("world and lakes overlay", te.getDescription());
@@ -86,7 +86,7 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(-0.087890625, te.getBounds().getMinY(), 0.0001);
         assertEquals(0.17578125, te.getBounds().getMaxX(), 0.0001);
         assertEquals(0.087890625, te.getBounds().getMaxY(), 0.0001);
-        
+
         List<TileMatrix> matrices = te.getTileMatricies();
         assertEquals(1, matrices.size());
         TileMatrix matrix = matrices.get(0);
@@ -95,12 +95,12 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(256, matrix.getTileHeight().intValue());
         assertEquals(2048, matrix.getMatrixWidth().intValue());
         assertEquals(1024, matrix.getMatrixHeight().intValue());
-        
+
         TileReader tr = gpkg.reader(te, null, null, null, null, null, null);
         assertTrue(tr.hasNext());
         assertEquals(10, tr.next().getZoom().intValue());
         tr.close();
-        
+
         te = tiles.get(1);
         assertEquals("world_lakes2", te.getTableName());
         assertEquals("world and lakes overlay 2", te.getDescription());
@@ -110,7 +110,7 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(-0.087890625, te.getBounds().getMinY(), 0.0001);
         assertEquals(0.17578125, te.getBounds().getMaxX(), 0.0001);
         assertEquals(0.087890625, te.getBounds().getMaxY(), 0.0001);
-        
+
         gpkg.close();
     }
 
@@ -122,16 +122,16 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         MockHttpServletResponse response = getAsServletResponse(resourceUrl);
         File file = new File(getDataDirectory().findOrCreateDir("tmp"), "test.gpkg");
         FileUtils.writeByteArrayToFile(file, getBinary(response));
-        
+
         assertNotNull(file);
         assertEquals("test.gpkg", file.getName());
         assertTrue(file.exists());
-        
+
         GeoPackage gpkg = new GeoPackage(file);
-        
+
         List<TileEntry> tiles = gpkg.tiles();
         assertEquals(1, tiles.size());
-        
+
         TileEntry te = tiles.get(0);
         assertEquals("world_lakes", te.getTableName());
         assertEquals("world and lakes overlay", te.getDescription());
@@ -141,7 +141,7 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(-0.087890625, te.getBounds().getMinY(), 0.0001);
         assertEquals(0.17578125, te.getBounds().getMaxX(), 0.0001);
         assertEquals(0.087890625, te.getBounds().getMaxY(), 0.0001);
-        
+
         List<TileMatrix> matrices = te.getTileMatricies();
         assertEquals(1, matrices.size());
         TileMatrix matrix = matrices.get(0);
@@ -150,29 +150,29 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(256, matrix.getTileHeight().intValue());
         assertEquals(2048, matrix.getMatrixWidth().intValue());
         assertEquals(1024, matrix.getMatrixHeight().intValue());
-        
+
         TileReader tr = gpkg.reader(te, null, null, null, null, null, null);
         assertTrue(tr.hasNext());
         assertEquals(10, tr.next().getZoom().intValue());
         tr.close();
-        
+
         gpkg.close();
     }
-    
+
     @Test
     public void testGeoPackageProcessWithPath() throws Exception{
         File path = getDataDirectory().findOrCreateDataRoot();
-        
+
         String urlPath = string(post("wps", getXml2(path,false))).trim();
         File file = new File(path, "test.gpkg");
         assertNotNull(file);
         assertTrue(file.exists());
-        
+
         GeoPackage gpkg = new GeoPackage(file);
-        
+
         List<TileEntry> tiles = gpkg.tiles();
         assertEquals(1, tiles.size());
-        
+
         TileEntry te = tiles.get(0);
         assertEquals("world_lakes", te.getTableName());
         assertEquals("world and lakes overlay", te.getDescription());
@@ -182,7 +182,7 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(-0.087890625, te.getBounds().getMinY(), 0.0001);
         assertEquals(0.17578125, te.getBounds().getMaxX(), 0.0001);
         assertEquals(0.087890625, te.getBounds().getMaxY(), 0.0001);
-        
+
         List<TileMatrix> matrices = te.getTileMatricies();
         assertEquals(1, matrices.size());
         TileMatrix matrix = matrices.get(0);
@@ -191,12 +191,12 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         assertEquals(256, matrix.getTileHeight().intValue());
         assertEquals(2048, matrix.getMatrixWidth().intValue());
         assertEquals(1024, matrix.getMatrixHeight().intValue());
-        
+
         TileReader tr = gpkg.reader(te, null, null, null, null, null, null);
         assertTrue(tr.hasNext());
         assertEquals(10, tr.next().getZoom().intValue());
         tr.close();
-        
+
         gpkg.close();
     }
 
@@ -234,7 +234,7 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         "    <indexed>true</indexed>" +
         "   </features>" +
         "  <tiles name=\"world_lakes\" identifier=\"wl1\">" +
-        "    <description>world and lakes overlay</description>  " +  
+        "    <description>world and lakes overlay</description>  " +
         "    <srs>EPSG:4326</srs>" +
         "    <bbox>" +
         "      <minx>-0.17578125</minx>" +
@@ -266,7 +266,7 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         "    </gridset>" +
         "  </tiles>" +
         "  <tiles name=\"world_lakes2\" identifier=\"wl2\">" +
-        "    <description>world and lakes overlay 2</description>  " +  
+        "    <description>world and lakes overlay 2</description>  " +
         "    <srs>EPSG:4326</srs>" +
         "    <bbox>" +
         "      <minx>-0.17578125</minx>" +
@@ -300,15 +300,15 @@ public class GeoPackageProcessTest extends WPSTestSupport {
     public String getXml2(File temp, Boolean remove){
         String path = "";
         String removal = "";
-        
+
         if(temp != null){
             path = " path=\"" + DataUtilities.fileToURL(temp) + "\"";
         }
-        
+
         if(remove != null){
             removal = " remove=\"" + remove + "\"";
         }
-        
+
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
         "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">" +
         "  <ows:Identifier>gs:GeoPackage</ows:Identifier>" +
@@ -319,7 +319,7 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         "        <wps:ComplexData mimeType=\"text/xml; subtype=geoserver/geopackage\"><![CDATA[" +
         "<geopackage name=\"test\" xmlns=\"http://www.opengis.net/gpkg\"" +path + removal +">" +
         "  <tiles name=\"world_lakes\" identifier=\"wl1\">" +
-        "    <description>world and lakes overlay</description>  " +  
+        "    <description>world and lakes overlay</description>  " +
         "    <srs>EPSG:4326</srs>" +
         "    <bbox>" +
         "      <minx>-0.17578125</minx>" +
@@ -349,7 +349,105 @@ public class GeoPackageProcessTest extends WPSTestSupport {
         "        </grid> " +
         "      </grids>" +
         "    </gridset>" +
-        "  </tiles>" +        
+        "  </tiles>" +
+        "</geopackage>" +
+        "]]></wps:ComplexData>" +
+        "      </wps:Data>" +
+        "    </wps:Input>" +
+        "  </wps:DataInputs>" +
+        "  <wps:ResponseForm>" +
+        "    <wps:RawDataOutput>" +
+        "      <ows:Identifier>geopackage</ows:Identifier>" +
+        "    </wps:RawDataOutput>" +
+        "  </wps:ResponseForm>" +
+        "</wps:Execute>";
+    }
+
+    @Test
+    public void testGeoPackageProcessTilesNoFormat() throws Exception{
+        String urlPath = string(post("wps", getXmlTilesNoFormat())).trim();
+        String resourceUrl = urlPath.substring("http://localhost:8080/geoserver/".length());
+        MockHttpServletResponse response = getAsServletResponse(resourceUrl);
+        File file = new File(getDataDirectory().findOrCreateDir("tmp"), "test.gpkg");
+        FileUtils.writeByteArrayToFile(file, getBinary(response));
+        assertNotNull(file);
+        assertEquals("test.gpkg", file.getName());
+        assertTrue(file.exists());
+
+        GeoPackage gpkg = new GeoPackage(file);
+
+        List<TileEntry> tiles = gpkg.tiles();
+        assertEquals(1, tiles.size());
+
+        TileEntry te = tiles.get(0);
+        assertEquals("world_lakes", te.getTableName());
+        assertEquals("world and lakes overlay", te.getDescription());
+        assertEquals("wl1", te.getIdentifier());
+        assertEquals(4326, te.getSrid().intValue());
+        assertEquals(-0.17578125, te.getBounds().getMinX(), 0.0001);
+        assertEquals(-0.087890625, te.getBounds().getMinY(), 0.0001);
+        assertEquals(0.17578125, te.getBounds().getMaxX(), 0.0001);
+        assertEquals(0.087890625, te.getBounds().getMaxY(), 0.0001);
+
+        TileReader tr = gpkg.reader(te, null, null, null, null, null, null);
+        assertTrue(tr.hasNext());
+        assertEquals(10, tr.next().getZoom().intValue());
+        tr.close();
+
+        te = tiles.get(0);
+        assertEquals("world_lakes", te.getTableName());
+        assertEquals("world and lakes overlay", te.getDescription());
+        assertEquals("wl1", te.getIdentifier());
+        assertEquals(4326, te.getSrid().intValue());
+        assertEquals(-0.17578125, te.getBounds().getMinX(), 0.0001);
+        assertEquals(-0.087890625, te.getBounds().getMinY(), 0.0001);
+        assertEquals(0.17578125, te.getBounds().getMaxX(), 0.0001);
+        assertEquals(0.087890625, te.getBounds().getMaxY(), 0.0001);
+
+        gpkg.close();
+    }
+
+    private String getXmlTilesNoFormat(){
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+        "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">" +
+        "  <ows:Identifier>gs:GeoPackage</ows:Identifier>" +
+        "  <wps:DataInputs>" +
+        "    <wps:Input>" +
+        "      <ows:Identifier>contents</ows:Identifier>" +
+        "      <wps:Data>" +
+        "        <wps:ComplexData mimeType=\"text/xml; subtype=geoserver/geopackage\"><![CDATA[" +
+        "<geopackage name=\"test\" xmlns=\"http://www.opengis.net/gpkg\">" +
+        "  <tiles name=\"world_lakes\" identifier=\"wl1\">" +
+        "    <description>world and lakes overlay</description>  " +
+        "    <srs>EPSG:4326</srs>" +
+        "    <bbox>" +
+        "      <minx>-0.17578125</minx>" +
+        "      <maxx>0.17578125</maxx>" +
+        "      <miny>-0.087890625</miny>" +
+        "      <maxy>0.087890625</maxy>" +
+        "    </bbox>" +
+        "    <layers>wcs:World,cite:Lakes</layers>" +
+        "    <styles></styles>" +
+        "    <bgcolor>aaaaaa</bgcolor>" +
+        "    <transparent>true</transparent>" +
+        "    <coverage>" +
+        "      <minZoom>10</minZoom>" +
+        "      <maxZoom>11</maxZoom>" +
+        "    </coverage>" +
+        "    <gridset>" +
+        "      <grids>" +
+        "        <grid>" +
+        "          <zoomlevel>10</zoomlevel>" +
+        "          <tilewidth>256</tilewidth>" +
+        "          <tileheight>256</tileheight>" +
+        "          <matrixwidth>2048</matrixwidth>" +
+        "          <matrixheight>1024</matrixheight>" +
+        "          <pixelxsize>0.00068</pixelxsize>" +
+        "          <pixelysize>0.00068</pixelysize>" +
+        "        </grid> " +
+        "      </grids>" +
+        "    </gridset>" +
+        "  </tiles>" +
         "</geopackage>" +
         "]]></wps:ComplexData>" +
         "      </wps:Data>" +


### PR DESCRIPTION
The problem is that if the WPS XML does not include the 
`<format>....</format>`
part, we end up adding a `format:<null>` entry  to the options map, then we only check if the key is present (not the value being null).

An earlier attempt just added a check if the value was non-null, but there is another "is key present, if so, dereference value" check on the mbtiles AbstractTilesGetMapOutputFormat code that is very similar (that I didn't want to have to test), and this seems cleaner in any case. 