### PR TITLE
correct typo in maven command parameter

### DIFF
--- a/doc/en/README.md
+++ b/doc/en/README.md
@@ -16,18 +16,18 @@ To generate the REST API documentation:
     mvn process-resources
 
 To build all restructured text documentation:
-    
+
     mvn compile
 
 Profiles are defined to build individual manuals:
-    
+
     mvn compile -Puser
     mvn compile -Pdeveloper
     mvn compile -Pdocguide
 
 To package documentation into zip archives:
-    
-    mvn aseembly:single
+
+    mvn assembly:single
 
 ## Building with ANT
 


### PR DESCRIPTION
Just fixed a small typo in maven command.
I've also trimmed trailing spaces. I hope (🙏) this is not a problem during PR review.

Any feedback is welcome.

Keep rocking this great project - Thank you.