### PR TITLE
[GEOS-8316] Fixed LoggingFilter ignoring the X-Forwarded-For request header

### DIFF
--- a/src/main/src/main/java/org/geoserver/filters/LoggingFilter.java
+++ b/src/main/src/main/java/org/geoserver/filters/LoggingFilter.java
@@ -19,6 +19,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.io.IOUtils;
+import org.geoserver.ows.util.RequestUtils;
 
 /**
  * Filter to log requests for debugging or statistics-gathering purposes.
@@ -43,7 +44,7 @@ public class LoggingFilter implements Filter {
             if (req instanceof HttpServletRequest){
                 HttpServletRequest hreq = (HttpServletRequest) req;
 
-                path = hreq.getRemoteHost() + " \"" + hreq.getMethod() + " " + hreq.getRequestURI();
+                path = RequestUtils.getRemoteAddr(hreq) + " \"" + hreq.getMethod() + " " + hreq.getRequestURI();
                 if (hreq.getQueryString() != null){
                     path += "?" + hreq.getQueryString();
                 }
@@ -51,7 +52,7 @@ public class LoggingFilter implements Filter {
 
                 message = "" + path;
                 message += " \"" + noNull(hreq.getHeader("User-Agent"));
-                message += "\" \"" + noNull(hreq.getHeader("Referer")) + "\" ";
+                message += "\" \"" + noNull(hreq.getHeader("Referer"));
                 message += "\" \"" + noNull(hreq.getHeader("Content-type")) + "\" ";
 
                 if (logBodies && (hreq.getMethod().equals("PUT") || hreq.getMethod().equals("POST"))){

--- a/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
@@ -45,6 +45,20 @@ public class RequestUtils {
         return sb.toString();
     }
     
+    /**
+     * Pulls out the first IP address from the X-Forwarded-For request header
+     * if it was provided; otherwise just gets the client IP address.
+     * @return the IP address of the client that sent the request
+     */
+    public static String getRemoteAddr(HttpServletRequest req) {
+        String forwardedFor = req.getHeader("X-Forwarded-For");
+        if (forwardedFor != null) {
+            String[] ips = forwardedFor.split(", ");
+            return ips[0];
+        } else {
+            return req.getRemoteAddr();
+        }
+    }
     
     /**
      * Given a list of provided versions, and a list of accepted versions, this method will

--- a/src/ows/src/test/java/org/geoserver/ows/util/RequestUtilsTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/util/RequestUtilsTest.java
@@ -1,0 +1,42 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+
+public class RequestUtilsTest {
+
+    @Test
+    public void testGetRemoteAddrNotForwarded() {
+        HttpServletRequest req = request("192.168.1.1", null);
+        assertEquals("192.168.1.1", RequestUtils.getRemoteAddr(req));
+    }
+
+    @Test
+    public void testGetRemoteAddrSingleForwardedIP() {
+        HttpServletRequest req = request("192.168.1.2", "192.168.1.1");
+        assertEquals("192.168.1.1", RequestUtils.getRemoteAddr(req));
+    }
+
+    @Test
+    public void testGetRemoteAddrMultipleForwardedIP() {
+        HttpServletRequest req = request("192.168.1.4", "192.168.1.1, 192.168.1.2, 192.168.1.3");
+        assertEquals("192.168.1.1", RequestUtils.getRemoteAddr(req));
+    }
+
+    private static HttpServletRequest request(String remoteAddr, String forwardedFor) {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRemoteAddr(remoteAddr);
+        if (forwardedFor != null) {
+            req.addHeader("X-Forwarded-For", forwardedFor);
+        }
+        return req;
+    }
+}


### PR DESCRIPTION
Added a utility method to get the client IP address, checking the X-Forwarded-For request header, and updated Logging Filter to use it.  This method was copied from org.geoserver.monitor.MonitorFilter and made public static and unit tests were added to test it.  Extensions that uses this same duplicated code block have not been modified in this pull request since it is not necessary and I am not familiar with every one of those extensions.

Also, removed an extra double quotes character in the logging filter output.

This pull request can be backported to 2.11.x and 2.12.x.