### PR TITLE
[GEOS-8320] Added system property for Hazelcast cache expiration time

### DIFF
--- a/src/community/hz-cluster/src/main/java/org/geoserver/cluster/hazelcast/HzCacheProvider.java
+++ b/src/community/hz-cluster/src/main/java/org/geoserver/cluster/hazelcast/HzCacheProvider.java
@@ -47,6 +47,11 @@ public class HzCacheProvider implements CacheProvider {
 
     private static final TimeUnit DEFAULT_TTL_UNIT = TimeUnit.MINUTES;
 
+    public static final String DEFAULT_TIME_KEY = "evictionTime";
+
+    /** Expiration time in minutes for each entry*/
+    public final long expirationMinutes = Long.parseLong(System.getProperty(DEFAULT_TIME_KEY, DEFAULT_TTL + ""));
+
     private Map<String, Cache<?, ?>> inUse = Maps.newConcurrentMap();
 
     private XStreamPersisterFactory serializationFactory;
@@ -64,10 +69,10 @@ public class HzCacheProvider implements CacheProvider {
         if (distributedCache == null) {
             // distributedCache = new NullCache<K, V>();
             if ("catalog".equals(cacheName)) {
-                distributedCache = (Cache<K, V>) new HzCatalogCache(cacheName, DEFAULT_TTL,
+                distributedCache = (Cache<K, V>) new HzCatalogCache(cacheName, expirationMinutes,
                         DEFAULT_TTL_UNIT, serializationFactory);
             } else {
-                distributedCache = new HzCache<K, V>(cacheName, DEFAULT_TTL, DEFAULT_TTL_UNIT);
+                distributedCache = new HzCache<K, V>(cacheName, expirationMinutes, DEFAULT_TTL_UNIT);
             }
             inUse.put(cacheName, distributedCache);
         }

--- a/src/community/hz-cluster/src/test/java/org/geoserver/cluster/hazelcast/HzCacheProviderTest.java
+++ b/src/community/hz-cluster/src/test/java/org/geoserver/cluster/hazelcast/HzCacheProviderTest.java
@@ -1,0 +1,38 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster.hazelcast;
+
+import java.io.Serializable;
+
+import org.geoserver.catalog.Info;
+import org.geoserver.config.util.XStreamPersisterFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.cache.Cache;
+
+import static org.junit.Assert.assertNotNull;
+
+public class HzCacheProviderTest {
+
+    private HzCacheProvider cacheProvider;
+
+    @Before
+    public void createCacheProvider() {
+        this.cacheProvider = new HzCacheProvider(new XStreamPersisterFactory());
+    }
+
+    @Test
+    public void testGetCache() {
+        Cache<Serializable, Serializable> cache = this.cacheProvider.getCache("test");
+        assertNotNull(cache);
+    }
+
+    @Test
+    public void testGetCacheCatalog() {
+        Cache<String, Info> cache = this.cacheProvider.getCache("catalog");
+        assertNotNull(cache);
+    }
+}


### PR DESCRIPTION
Updated HzCacheProvider to support the same system property to control the cache eviction time that JDBCCacheProvider uses.  This is pretty much a copy and paste from:
https://github.com/geoserver/geoserver/blob/master/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/JDBCCacheProvider.java

This pull request can be backported to 2.11.x and 2.12.x.