### PR TITLE
[GEOS-8323] Added debug logging to all JDBC Configuration database queries

### DIFF
--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/config/JDBCGeoServerImplTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/config/JDBCGeoServerImplTest.java
@@ -55,6 +55,7 @@ public class JDBCGeoServerImplTest extends GeoServerImplTest {
         facade.setResourceLoader(testSupport.getResourceLoader());
 
         super.setUp();
+        facade.setLogging(geoServer.getFactory().createLogging());
     }
 
     @After


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8323

This pull requests adds a call to logStatement for all JDBC Configuration queries that weren't already being logged.  It also removes an unnecessary use of the Guava Joiner class to do the query result size and timing logging and adds that logging to getAll.  A few java.* and org.* imports were also moved to be grouped with other imports from those packages.

No new new unit tests were added but the modified methods are covered by many of the tests in CatalogImplWithJDBCFacadeTest and JDBCGeoServerImplTest which inherit the tests from CatalogImplTest and GeoServerImplTest.  This pull request also fixes an NPE when JDBCGeoServerImplTest runs org.geoserver.config.GeoServerImplTest.testModifyLogging().

This pull request can be backported to 2.11.x and 2.12.x.