### PR TITLE
[GEOS-8324] Avoid recursion in FeatureTypeInfoImpl.equals

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/AttributeTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/AttributeTypeInfo.java
@@ -118,4 +118,9 @@ public interface AttributeTypeInfo extends Serializable {
      * @param length
      */
     void setLength(Integer length);
+
+    /**
+     * The same as {@link #equals(Object)}, except doesn't compare {@link FeatureTypeInfo}s, to avoid recursion.
+     */
+    boolean equalsIngnoreFeatureType(Object obj);
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
@@ -177,6 +177,52 @@ public class AttributeTypeInfoImpl implements AttributeTypeInfo {
             return false;
         return true;
     }
-    
-    
+
+    @Override
+    public boolean equalsIngnoreFeatureType(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AttributeTypeInfoImpl other = (AttributeTypeInfoImpl) obj;
+        if (attribute == null) {
+            if (other.attribute != null)
+                return false;
+        } else if (!attribute.equals(other.attribute))
+            return false;
+        if (binding == null) {
+            if (other.binding != null)
+                return false;
+        } else if (!binding.equals(other.binding))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (length == null) {
+            if (other.length != null)
+                return false;
+        } else if (!length.equals(other.length))
+            return false;
+        if (maxOccurs != other.maxOccurs)
+            return false;
+        if (metadata == null) {
+            if (other.metadata != null)
+                return false;
+        } else if (!metadata.equals(other.metadata))
+            return false;
+        if (minOccurs != other.minOccurs)
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (nillable != other.nillable)
+            return false;
+        return true;
+    }
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
@@ -8,6 +8,7 @@ package org.geoserver.catalog.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.Catalog;
@@ -185,8 +186,73 @@ public class FeatureTypeInfoImpl extends ResourceInfoImpl implements
         if (attributes == null) {
             if (other.getAttributes() != null)
                 return false;
-        } else if (!attributes.equals(other.getAttributes()))
-            return false;
+        } else {
+            List<AttributeTypeInfo> otherAttributes = other.getAttributes();
+            if (otherAttributes == attributes)
+                return true;
+
+            ListIterator<AttributeTypeInfo> attributesIterator = attributes.listIterator();
+            ListIterator<AttributeTypeInfo> otherAttributesIterator = otherAttributes.listIterator();
+            while (attributesIterator.hasNext() && otherAttributesIterator.hasNext()) {
+                AttributeTypeInfo attr = attributesIterator.next();
+                AttributeTypeInfo otherAttr = otherAttributesIterator.next();
+
+                if (attr == null) {
+                    if (otherAttr != null)
+                        return false;
+                }
+
+                /*
+                 * Compare attributes, excluding the feature type to avoid recursion.
+                 * This should be updated whenever AttributeTypeInfoImpl.equals() changes.
+                 */
+                if (attr instanceof AttributeTypeInfoImpl && otherAttr instanceof AttributeTypeInfoImpl) {
+                    AttributeTypeInfoImpl attribute = (AttributeTypeInfoImpl) attr;
+                    AttributeTypeInfoImpl otherAttribute = (AttributeTypeInfoImpl) otherAttr;
+
+                    if (attribute.attribute == null) {
+                        if (otherAttribute.attribute != null)
+                            return false;
+                    } else if (!attribute.attribute.equals(otherAttribute.attribute))
+                        return false;
+                    if (attribute.binding == null) {
+                        if (otherAttribute.binding != null)
+                            return false;
+                    } else if (!attribute.binding.equals(otherAttribute.binding))
+                        return false;
+                    if (attribute.id == null) {
+                        if (otherAttribute.id != null)
+                            return false;
+                    } else if (!attribute.id.equals(otherAttribute.id))
+                        return false;
+                    if (attribute.length == null) {
+                        if (otherAttribute.length != null)
+                            return false;
+                    } else if (!attribute.length.equals(otherAttribute.length))
+                        return false;
+                    if (attribute.maxOccurs != otherAttribute.maxOccurs)
+                        return false;
+                    if (attribute.metadata == null) {
+                        if (otherAttribute.metadata != null)
+                            return false;
+                    } else if (!attribute.metadata.equals(otherAttribute.metadata))
+                        return false;
+                    if (attribute.minOccurs != otherAttribute.minOccurs)
+                        return false;
+                    if (attribute.name == null) {
+                        if (otherAttribute.name != null)
+                            return false;
+                    } else if (!attribute.name.equals(otherAttribute.name))
+                        return false;
+                    if (attribute.nillable != otherAttribute.nillable)
+                        return false;
+                } else if (!attr.equals(otherAttr)) {
+                    return false;
+                }
+            }
+            if (attributesIterator.hasNext() || otherAttributesIterator.hasNext())
+              return false;
+        }
         if (responseSRS == null) {
             if (other.getResponseSRS() != null)
                 return false;

--- a/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
@@ -200,53 +200,7 @@ public class FeatureTypeInfoImpl extends ResourceInfoImpl implements
                 if (attr == null) {
                     if (otherAttr != null)
                         return false;
-                }
-
-                /*
-                 * Compare attributes, excluding the feature type to avoid recursion.
-                 * This should be updated whenever AttributeTypeInfoImpl.equals() changes.
-                 */
-                if (attr instanceof AttributeTypeInfoImpl && otherAttr instanceof AttributeTypeInfoImpl) {
-                    AttributeTypeInfoImpl attribute = (AttributeTypeInfoImpl) attr;
-                    AttributeTypeInfoImpl otherAttribute = (AttributeTypeInfoImpl) otherAttr;
-
-                    if (attribute.attribute == null) {
-                        if (otherAttribute.attribute != null)
-                            return false;
-                    } else if (!attribute.attribute.equals(otherAttribute.attribute))
-                        return false;
-                    if (attribute.binding == null) {
-                        if (otherAttribute.binding != null)
-                            return false;
-                    } else if (!attribute.binding.equals(otherAttribute.binding))
-                        return false;
-                    if (attribute.id == null) {
-                        if (otherAttribute.id != null)
-                            return false;
-                    } else if (!attribute.id.equals(otherAttribute.id))
-                        return false;
-                    if (attribute.length == null) {
-                        if (otherAttribute.length != null)
-                            return false;
-                    } else if (!attribute.length.equals(otherAttribute.length))
-                        return false;
-                    if (attribute.maxOccurs != otherAttribute.maxOccurs)
-                        return false;
-                    if (attribute.metadata == null) {
-                        if (otherAttribute.metadata != null)
-                            return false;
-                    } else if (!attribute.metadata.equals(otherAttribute.metadata))
-                        return false;
-                    if (attribute.minOccurs != otherAttribute.minOccurs)
-                        return false;
-                    if (attribute.name == null) {
-                        if (otherAttribute.name != null)
-                            return false;
-                    } else if (!attribute.name.equals(otherAttribute.name))
-                        return false;
-                    if (attribute.nillable != otherAttribute.nillable)
-                        return false;
-                } else if (!attr.equals(otherAttr)) {
+                } else if (!attr.equalsIngnoreFeatureType(otherAttr)) {
                     return false;
                 }
             }

--- a/src/main/src/test/java/org/geoserver/catalog/impl/FeatureTypeInfoImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/FeatureTypeInfoImplTest.java
@@ -1,0 +1,51 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import org.geoserver.catalog.AttributeTypeInfo;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class FeatureTypeInfoImplTest {
+
+    Catalog catalog;
+
+
+    @Before
+    public void setUp() throws Exception {
+        catalog = new CatalogImpl();
+    }
+
+    @Test
+    public void testEqualsWithAttributes() {
+        CatalogFactory factory = catalog.getFactory();
+
+        FeatureTypeInfoImpl ft1 = (FeatureTypeInfoImpl) factory.createFeatureType();
+        FeatureTypeInfoImpl ft2 = (FeatureTypeInfoImpl) factory.createFeatureType();
+
+        ft1.setName("featureType");
+        ft2.setName("featureType");
+
+        AttributeTypeInfo at1 = factory.createAttribute();
+        AttributeTypeInfo at2 = factory.createAttribute();
+
+        at1.setName("attribute");
+        at2.setName("attribute");
+
+        at1.setFeatureType(ft1);
+        at2.setFeatureType(ft2);
+
+        ft1.setAttributes(Collections.singletonList(at1));
+        ft2.setAttributes(Collections.singletonList(at2));
+
+        assertEquals(ft1, ft2);
+    }
+}


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8324

My solution has been to duplicate the behaviour from `AttributeTypeInfoImpl.equals()` inside of `FeatureTypeInfoImpl.equals()`, excluding the check for whether the FeatureTypeInfos are equal to avoid recursion. This is a bit brittle to API changes, but is at least a complete equality check.

An alternative solution would be to remove the equality check on FeatureTypeInfo from `AttributeTypeInfoImpl.equals()`