### PR TITLE
[GEOS-8328] Updated GeoServerResourceLoader to stop setting its logging level.

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerResourceLoader.java
@@ -60,10 +60,7 @@ import org.springframework.web.context.ServletContextAware;
  * 
  */
 public class GeoServerResourceLoader extends DefaultResourceLoader implements ResourceStore, ServletContextAware {
-    private static final Logger LOGGER = org.geotools.util.logging.Logging.getLogger("org.vfny.geoserver.global");
-    static {
-        LOGGER.setLevel(Level.FINER);
-    }
+    private static final Logger LOGGER = org.geotools.util.logging.Logging.getLogger("org.geoserver.platform");
     
     /**
      * ResourceStore used for configuration resources.


### PR DESCRIPTION
Also, changed the logger name to the correct package name.  This is a simple logging change and does not have any unit tests.

This pull request can be backported to 2.11.x and 2.12.x.