### PR TITLE
[GEOS-8334] Reduced the number of LocalWorkspaceCatalog database queries when using JDBC Configuration.

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
@@ -338,8 +338,8 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
 
         CloseableIterator<T> iterator = delegate.list(of, filter, offset, count, sortBy);
         if (iterator.hasNext() && useNameDequalifyingProxy()) {
-            return CloseableIteratorAdapter.transform(iterator,
-                obj -> NameDequalifyingProxy.create(obj, of));
+            return CloseableIteratorAdapter.transform(iterator, obj ->
+                obj == null ? null : NameDequalifyingProxy.create(obj, of));
         }
         return iterator;
     }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
@@ -27,8 +27,6 @@ import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 
-import com.google.common.base.Function;
-
 /**
  * Catalog decorator handling cases when a {@link LocalWorkspace} is set.
  * <p>
@@ -113,9 +111,10 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
 
     private boolean useNameDequalifyingProxy() {
         WorkspaceInfo workspaceInfo = LocalWorkspace.get();
-        boolean hidePrefix = geoServer == null || !geoServer.getSettings().isLocalWorkspaceIncludesPrefix();
-        boolean useNameDequalifyingProxy = workspaceInfo != null && hidePrefix;
-        return useNameDequalifyingProxy;
+        if (workspaceInfo == null) {
+            return false;
+        }
+        return geoServer == null || !geoServer.getSettings().isLocalWorkspaceIncludesPrefix();
     }
 
     @Override
@@ -338,16 +337,11 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
             final Filter filter, final Integer offset, final Integer count, final SortBy sortBy) {
 
         CloseableIterator<T> iterator = delegate.list(of, filter, offset, count, sortBy);
-        Function<T, T> wrappingFunction = new Function<T, T>() {
-
-            final Class<T> type = of;
-
-            @Override
-            public T apply(T catalogObject) {
-                return wrap(catalogObject, type);
-            }
-        };
-        return CloseableIteratorAdapter.transform(iterator, wrappingFunction);
+        if (iterator.hasNext() && useNameDequalifyingProxy()) {
+            return CloseableIteratorAdapter.transform(iterator,
+                obj -> NameDequalifyingProxy.create(obj, of));
+        }
+        return iterator;
     }
 
     public void removeListeners(Class listenerClass) {

--- a/src/main/src/test/java/org/geoserver/catalog/impl/LocalWorkspaceCatalogTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/LocalWorkspaceCatalogTest.java
@@ -157,9 +157,11 @@ public class LocalWorkspaceCatalogTest {
         layers.add(lc1);
         layers.add(lc2);
         expect(cat.getLayers()).andReturn(layers).anyTimes();
+        List<LayerInfo> layers2 = new ArrayList<>(layers);
+        layers2.add(null);
         expect(cat.list(LayerInfo.class, Filter.INCLUDE, 
                 (Integer) null, (Integer) null, (SortBy) null))
-            .andReturn(new CloseableIteratorAdapter<LayerInfo>(layers.iterator())).anyTimes();
+            .andReturn(new CloseableIteratorAdapter<LayerInfo>(layers2.iterator())).anyTimes();
         replay(cat);
         
         catalog = new LocalWorkspaceCatalog(cat);
@@ -347,6 +349,9 @@ public class LocalWorkspaceCatalogTest {
             Iterator<LayerInfo> layers) {
         while(layers.hasNext()) {
             LayerInfo layerInfo = layers.next();
+            if (layerInfo == null) {
+                continue;
+            }
             String message;
             if(includePrefix) {
                 message = layerInfo.getName() + " should contain a : because the prefix should have been kept";


### PR DESCRIPTION
No unit tests have been added or modified but the behavior from the caller's point of view should not be changed so the existing tests in LocalWorkspaceCatalogTest and LocalWorkspaceLayersTest should be sufficient.

This pull request can be backported to 2.11.x and 2.12.x.