### PR TITLE
Update antrun plugin in docs to use same version of ant as the root pom

### DIFF
--- a/doc/en/pom.xml
+++ b/doc/en/pom.xml
@@ -345,14 +345,20 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <dependencies>
           <dependency>
-            <groupId>ant</groupId>
+            <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.6.5</version>
+            <version>1.8.4</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>
             <artifactId>ant-contrib</artifactId>
             <version>1.0b3</version>
+            <exclusions>
+              <exclusion>
+                <groupId>ant</groupId>
+                <artifactId>ant</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Update antrun plugin in docs to use same version of ant as the root pom.  Docs is not a submodule of root so `${ant.version}` is not available.