### PR TITLE
[GEOS-8353] Ensure KML validates without being online.

### DIFF
--- a/src/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
@@ -72,6 +72,8 @@ import org.xml.sax.InputSource;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import de.micromata.opengis.kml.v_2_2_0.Kml;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 
 /**
  * Some functional tests for kml reflector
@@ -892,7 +894,10 @@ public class KMLReflectorTest extends WMSTestSupport {
         // Validate against the KML 2.2 schema.
         Unmarshaller unmarshaller = JAXBContext.newInstance(Kml.class).createUnmarshaller();
         unmarshaller.setSchema(SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-            .newSchema(getClass().getResource("/schema/ogckml/ogckml22.xsd")));
+            .newSchema(new Source[] {
+                new StreamSource(getClass().getResource("/org/geoserver/kml/xAL.xsd").toExternalForm()),
+                new StreamSource(getClass().getResource("/schema/ogckml/ogckml22.xsd").toExternalForm())
+            }));
         unmarshaller.unmarshal(document);
     }
 

--- a/src/kml/src/test/resources/org/geoserver/kml/xAL.xsd
+++ b/src/kml/src/test/resources/org/geoserver/kml/xAL.xsd
@@ -1,0 +1,1714 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Modified by Ram Kumar (MSI) on 24 July 2002-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0"
+           xmlns="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" elementFormDefault="qualified">
+	<xs:annotation>
+		<xs:documentation>xAL: eXtensible Address Language 
+This is an XML document type definition (DTD) for
+defining addresses.
+Original Date of Creation: 1 March 2001
+Copyright(c) 2000, OASIS. All Rights Reserved [http://www.oasis-open.org]
+Contact: Customer Information Quality Technical Committee, OASIS
+http://www.oasis-open.org/committees/ciq
+VERSION: 2.0 [MAJOR RELEASE] Date of Creation: 01 May 2002
+Last Update: 24 July 2002
+Previous Version: 1.3</xs:documentation>
+	</xs:annotation>
+	<xs:annotation>
+		<xs:documentation>Common Attributes:Type - If not documented then it means, possible values of Type not limited to: Official, Unique, Abbreviation, OldName, Synonym
+Code:Address element codes are used by groups like postal groups like ECCMA, ADIS, UN/PROLIST for postal services</xs:documentation>
+	</xs:annotation>
+	<xs:attributeGroup name="grPostal">
+		<xs:attribute name="Code">
+			<xs:annotation>
+				<xs:documentation>Used by postal services to encode the name of the element.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:element name="xAL">
+		<xs:annotation>
+			<xs:documentation>Root element for a list of addresses</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressDetails" maxOccurs="unbounded"/>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Version">
+				<xs:annotation>
+					<xs:documentation>Specific to DTD to specify the version number of DTD</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AddressDetails" type="AddressDetails">
+		<xs:annotation>
+			<xs:documentation>This container defines the details of the address. Can define multiple addresses including tracking address history</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="AddressDetails">
+		<xs:sequence>
+			<xs:element name="PostalServiceElements" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Postal authorities use specific postal service data to expedient delivery of mail</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="AddressIdentifier" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>A unique identifier of an address assigned by postal authorities. Example: DPID in Australia</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="IdentifierType">
+									<xs:annotation>
+										<xs:documentation>Type of identifier. eg. DPID as in Australia</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="Type"/>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="EndorsementLineCode" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Directly affects postal service distribution</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="KeyLineCode" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Required for some postal services</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Barcode" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Required for some postal services</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="SortingCode" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Used for sorting addresses. Values may for example be CEDEX 16 (France)</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AddressLatitude" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Latitude of delivery address</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AddressLatitudeDirection" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Latitude direction of delivery address;N = North and S = South</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:annotation>
+									<xs:documentation>Specific to postal service</xs:documentation>
+								</xs:annotation>
+								<xs:attribute name="Type"/>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AddressLongitude" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Longtitude of delivery address</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AddressLongitudeDirection" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Longtitude direction of delivery address;N=North and S=South</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="SupplementaryPostalServiceData" minOccurs="0"
+                                    maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>any postal service elements not covered by the container can be represented using this element</xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:attribute name="Type">
+									<xs:annotation>
+										<xs:documentation>Specific to postal service</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="grPostal"/>
+								<xs:anyAttribute namespace="##other"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="Type">
+						<xs:annotation>
+							<xs:documentation>USPS, ECMA, UN/PROLIST, etc</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Use the most suitable option. Country contains the most detailed information while Locality is missing Country and AdminArea</xs:documentation>
+				</xs:annotation>
+				<xs:element name="Address">
+					<xs:annotation>
+						<xs:documentation>Address as one line of free text</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type">
+							<xs:annotation>
+								<xs:documentation>Postal, residential, corporate, etc</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="AddressLines" type="AddressLinesType">
+					<xs:annotation>
+						<xs:documentation>Container for Address lines</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="Country">
+					<xs:annotation>
+						<xs:documentation>Specification of a country</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="CountryNameCode" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>A country code according to the specified scheme</xs:documentation>
+								</xs:annotation>
+								<xs:complexType mixed="true">
+									<xs:attribute name="Scheme">
+										<xs:annotation>
+											<xs:documentation>Country code scheme possible values, but not limited to: iso.3166-2, iso.3166-3 for two and three character country codes.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attributeGroup ref="grPostal"/>
+									<xs:anyAttribute namespace="##other"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="CountryName" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:choice minOccurs="0">
+								<xs:element ref="AdministrativeArea"/>
+								<xs:element ref="Locality"/>
+								<xs:element ref="Thoroughfare"/>
+							</xs:choice>
+							<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="AdministrativeArea"/>
+				<xs:element ref="Locality"/>
+				<xs:element ref="Thoroughfare"/>
+			</xs:choice>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="AddressType">
+			<xs:annotation>
+				<xs:documentation>Type of address. Example: Postal, residential,business, primary, secondary, etc</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="CurrentStatus">
+			<xs:annotation>
+				<xs:documentation>Moved, Living, Investment, Deceased, etc..</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="ValidFromDate">
+			<xs:annotation>
+				<xs:documentation>Start Date of the validity of address</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="ValidToDate">
+			<xs:annotation>
+				<xs:documentation>End date of the validity of address</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="Usage">
+			<xs:annotation>
+				<xs:documentation>Communication, Contact, etc.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="grPostal"/>
+		<xs:attribute name="AddressDetailsKey">
+			<xs:annotation>
+				<xs:documentation>Key identifier for the element for not reinforced references from other elements. Not required to be unique for the document to be valid, but application may get confused if not unique. Extend this schema adding unique contraint if needed.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="AddressLinesType">
+		<xs:sequence>
+			<xs:element ref="AddressLine" maxOccurs="unbounded"/>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="BuildingNameType" mixed="true">
+		<xs:attribute name="Type"/>
+		<xs:attribute name="TypeOccurrence">
+			<xs:annotation>
+				<xs:documentation>Occurrence of the building name before/after the type. eg. EGIS BUILDING where name appears before type</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:NMTOKEN">
+					<xs:enumeration value="Before"/>
+					<xs:enumeration value="After"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attributeGroup ref="grPostal"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="DependentLocalityType">
+		<xs:sequence>
+			<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DependentLocalityName" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Name of the dependent locality</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="Type"/>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="DependentLocalityNumber" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Number of the dependent locality. Some areas are numbered. Eg. SECTOR 5 in a Suburb as in India or SOI SUKUMVIT 10 as in Thailand</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="NameNumberOccurrence">
+						<xs:annotation>
+							<xs:documentation>Eg. SECTOR occurs before 5 in SECTOR 5</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:NMTOKEN">
+								<xs:enumeration value="Before"/>
+								<xs:enumeration value="After"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element ref="PostBox"/>
+				<xs:element name="LargeMailUser" type="LargeMailUserType">
+					<xs:annotation>
+						<xs:documentation>Specification of a large mail user address. Examples of large mail users are postal companies, companies in France with a cedex number, hospitals and airports with their own post code. Large mail user addresses do not have a street name with premise name or premise number in countries like Netherlands. But they have a POBox and street also in countries like France</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="PostOffice"/>
+				<xs:element name="PostalRoute" type="PostalRouteType">
+					<xs:annotation>
+						<xs:documentation> A Postal van is specific for a route as in Is`rael, Rural route</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element ref="Thoroughfare" minOccurs="0"/>
+			<xs:element ref="Premise" minOccurs="0"/>
+			<xs:element name="DependentLocality" type="DependentLocalityType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Dependent localities are Districts within cities/towns, locality divisions, postal 
+divisions of cities, suburbs, etc. DependentLocality is a recursive element, but no nesting deeper than two exists (Locality-DependentLocality-DependentLocality).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="PostalCode" minOccurs="0"/>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Type">
+			<xs:annotation>
+				<xs:documentation>City or IndustrialEstate, etc</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="UsageType">
+			<xs:annotation>
+				<xs:documentation>Postal or Political - Sometimes locations must be distinguished between postal system, and physical locations as defined by a political system</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="Connector">
+			<xs:annotation>
+				<xs:documentation>"VIA" as in Hill Top VIA Parish where Parish is a locality and Hill Top is a dependent locality</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="Indicator">
+			<xs:annotation>
+				<xs:documentation>Eg. Erode (Dist) where (Dist) is the Indicator</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="FirmType">
+		<xs:sequence>
+			<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FirmName" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Name of the firm</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="Type"/>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="Department" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="MailStop" type="MailStopType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A MailStop is where the the mail is delivered to within a premise/subpremise/firm or a facility.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="PostalCode" minOccurs="0"/>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Type"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="LargeMailUserType">
+		<xs:sequence>
+			<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="LargeMailUserName" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Name of the large mail user. eg. Smith Ford International airport</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="Type" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>Airport, Hospital, etc</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Code" type="xs:string"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="LargeMailUserIdentifier" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Specification of the identification number of a large mail user. An example are the Cedex codes in France.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="Type" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>CEDEX Code</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Indicator">
+						<xs:annotation>
+							<xs:documentation>eg. Building 429 in which Building is the Indicator</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="BuildingName" type="BuildingNameType" minOccurs="0"
+                        maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Name of the building</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="Department" minOccurs="0"/>
+			<xs:element ref="PostBox" minOccurs="0"/>
+			<xs:element ref="Thoroughfare" minOccurs="0"/>
+			<xs:element ref="PostalCode" minOccurs="0"/>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Type" type="xs:string"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="MailStopType">
+		<xs:sequence>
+			<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="MailStopName" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Name of the the Mail Stop. eg. MSP, MS, etc</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="Type"/>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="MailStopNumber" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Number of the Mail stop. eg. 123 in MS 123</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="NameNumberSeparator">
+						<xs:annotation>
+							<xs:documentation>"-" in MS-123</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Type"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="PostalRouteType">
+		<xs:sequence>
+			<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:choice>
+				<xs:element name="PostalRouteName" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation> Name of the Postal Route</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type"/>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="PostalRouteNumber">
+					<xs:annotation>
+						<xs:documentation> Number of the Postal Route</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:choice>
+			<xs:element ref="PostBox" minOccurs="0"/>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Type"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="SubPremiseType">
+		<xs:sequence>
+			<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="SubPremiseName" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation> Name of the SubPremise</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="Type"/>
+					<xs:attribute name="TypeOccurrence">
+						<xs:annotation>
+							<xs:documentation>EGIS Building where EGIS occurs before Building</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:NMTOKEN">
+								<xs:enumeration value="Before"/>
+								<xs:enumeration value="After"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="SubPremiseLocation">
+					<xs:annotation>
+						<xs:documentation> Name of the SubPremise Location. eg. LOBBY, BASEMENT, GROUND FLOOR, etc...</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attributeGroup ref="grPostal"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="SubPremiseNumber" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation> Specification of the identifier of a sub-premise. Examples of sub-premises are apartments and suites. sub-premises in a building are often uniquely identified by means of consecutive
+identifiers. The identifier can be a number, a letter or any combination of the two. In the latter case, the identifier includes exactly one variable (range) part, which is either a 
+number or a single letter that is surrounded by fixed parts at the left (prefix) or the right (postfix).</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Indicator">
+							<xs:annotation>
+								<xs:documentation>"TH" in 12TH which is a floor number, "NO." in NO.1, "#" in APT #12, etc.</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="IndicatorOccurrence">
+							<xs:annotation>
+								<xs:documentation>"No." occurs before 1 in No.1, or TH occurs after 12 in 12TH</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:NMTOKEN">
+									<xs:enumeration value="Before"/>
+									<xs:enumeration value="After"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:attribute>
+						<xs:attribute name="NumberTypeOccurrence">
+							<xs:annotation>
+								<xs:documentation>12TH occurs "before" FLOOR (a type of subpremise) in 12TH FLOOR</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:NMTOKEN">
+									<xs:enumeration value="Before"/>
+									<xs:enumeration value="After"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:attribute>
+						<xs:attribute name="PremiseNumberSeparator">
+							<xs:annotation>
+								<xs:documentation>"/" in 12/14 Archer Street where 12 is sub-premise number and 14 is premise number</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="Type"/>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="SubPremiseNumberPrefix" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation> Prefix of the sub premise number. eg. A in A-12</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="NumberPrefixSeparator">
+						<xs:annotation>
+							<xs:documentation>A-12 where 12 is number and A is prefix and "-" is the separator</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Type"/>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SubPremiseNumberSuffix" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation> Suffix of the sub premise number. eg. A in 12A</xs:documentation>
+				</xs:annotation>
+				<xs:complexType mixed="true">
+					<xs:attribute name="NumberSuffixSeparator">
+						<xs:annotation>
+							<xs:documentation>12-A where 12 is number and A is suffix and "-" is the separator</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Type"/>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="BuildingName" type="BuildingNameType" minOccurs="0"
+                        maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Name of the building</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Firm" type="FirmType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Specification of a firm, company, organization, etc. It can be specified as part of an address that contains a street or a postbox. It is therefore different from a large mail user address, which contains no street.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MailStop" type="MailStopType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A MailStop is where the the mail is delivered to within a premise/subpremise/firm or a facility.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="PostalCode" minOccurs="0"/>
+			<xs:element name="SubPremise" type="SubPremiseType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Specification of a single sub-premise. Examples of sub-premises are apartments and suites. 
+Each sub-premise should be uniquely identifiable. SubPremiseType: Specification of the name of a sub-premise type. Possible values not limited to: Suite, Appartment, Floor, Unknown
+Multiple levels within a premise by recursively calling SubPremise Eg. Level 4, Suite 2, Block C</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Type"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="ThoroughfareLeadingTypeType" mixed="true">
+		<xs:attribute name="Type"/>
+		<xs:attributeGroup ref="grPostal"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="ThoroughfareNameType" mixed="true">
+		<xs:attribute name="Type"/>
+		<xs:attributeGroup ref="grPostal"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="ThoroughfarePostDirectionType" mixed="true">
+		<xs:attribute name="Type"/>
+		<xs:attributeGroup ref="grPostal"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="ThoroughfarePreDirectionType" mixed="true">
+		<xs:attribute name="Type"/>
+		<xs:attributeGroup ref="grPostal"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:complexType name="ThoroughfareTrailingTypeType" mixed="true">
+		<xs:attribute name="Type"/>
+		<xs:attributeGroup ref="grPostal"/>
+		<xs:anyAttribute namespace="##other"/>
+	</xs:complexType>
+	<xs:element name="AddressLine">
+		<xs:annotation>
+			<xs:documentation>Free format address representation. An address can have more than one line. The order of the AddressLine elements must be preserved.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>Defines the type of address line. eg. Street, Address Line 1, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="grPostal"/>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Locality">
+		<xs:annotation>
+			<xs:documentation>Locality is one level lower than adminisstrative area. Eg.: cities, reservations and any other built-up areas.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="LocalityName" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Name of the locality</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type"/>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:choice minOccurs="0">
+					<xs:element ref="PostBox"/>
+					<xs:element name="LargeMailUser" type="LargeMailUserType">
+						<xs:annotation>
+							<xs:documentation>Specification of a large mail user address. Examples of large mail users are postal companies, companies in France with a cedex number, hospitals and airports with their own post code. Large mail user addresses do not have a street name with premise name or premise number in countries like Netherlands. But they have a POBox and street also in countries like France</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="PostOffice"/>
+					<xs:element name="PostalRoute" type="PostalRouteType">
+						<xs:annotation>
+							<xs:documentation>A Postal van is specific for a route as in Is`rael, Rural route</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:choice>
+				<xs:element ref="Thoroughfare" minOccurs="0"/>
+				<xs:element ref="Premise" minOccurs="0"/>
+				<xs:element name="DependentLocality" type="DependentLocalityType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Dependent localities are Districts within cities/towns, locality divisions, postal 
+divisions of cities, suburbs, etc. DependentLocality is a recursive element, but no nesting deeper than two exists (Locality-DependentLocality-DependentLocality).</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="PostalCode" minOccurs="0"/>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>Possible values not limited to: City, IndustrialEstate, etc</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="UsageType">
+				<xs:annotation>
+					<xs:documentation>Postal or Political - Sometimes locations must be distinguished between postal system, and physical locations as defined by a political system</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="Indicator">
+				<xs:annotation>
+					<xs:documentation>Erode (Dist) where (Dist) is the Indicator</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Thoroughfare">
+		<xs:annotation>
+			<xs:documentation>Specification of a thoroughfare. A thoroughfare could be a rd, street, canal, river, etc.  Note dependentlocality in a street. For example, in some countries, a large street will 
+have many subdivisions with numbers. Normally the subdivision name is the same as the road name, but with a number to identifiy it. Eg. SOI SUKUMVIT 3, SUKUMVIT RD, BANGKOK</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:choice minOccurs="0" maxOccurs="unbounded">
+					<xs:element ref="ThoroughfareNumber"/>
+					<xs:element name="ThoroughfareNumberRange">
+						<xs:annotation>
+							<xs:documentation>A container to represent a range of numbers (from x thru y)for a thoroughfare. eg. 1-2 Albert Av</xs:documentation>
+						</xs:annotation>
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+								<xs:element name="ThoroughfareNumberFrom">
+									<xs:annotation>
+										<xs:documentation>Starting number in the range</xs:documentation>
+									</xs:annotation>
+									<xs:complexType mixed="true">
+										<xs:sequence>
+											<xs:element ref="AddressLine" minOccurs="0"
+                                                        maxOccurs="unbounded"/>
+											<xs:element ref="ThoroughfareNumberPrefix" minOccurs="0"
+                                                        maxOccurs="unbounded"/>
+											<xs:element ref="ThoroughfareNumber"
+                                                        maxOccurs="unbounded"/>
+											<xs:element ref="ThoroughfareNumberSuffix" minOccurs="0"
+                                                        maxOccurs="unbounded"/>
+										</xs:sequence>
+										<xs:attributeGroup ref="grPostal"/>
+										<xs:anyAttribute namespace="##other"/>
+									</xs:complexType>
+								</xs:element>
+								<xs:element name="ThoroughfareNumberTo">
+									<xs:annotation>
+										<xs:documentation>Ending number in the range</xs:documentation>
+									</xs:annotation>
+									<xs:complexType mixed="true">
+										<xs:sequence>
+											<xs:element ref="AddressLine" minOccurs="0"
+                                                        maxOccurs="unbounded"/>
+											<xs:element ref="ThoroughfareNumberPrefix" minOccurs="0"
+                                                        maxOccurs="unbounded"/>
+											<xs:element ref="ThoroughfareNumber"
+                                                        maxOccurs="unbounded"/>
+											<xs:element ref="ThoroughfareNumberSuffix" minOccurs="0"
+                                                        maxOccurs="unbounded"/>
+										</xs:sequence>
+										<xs:attributeGroup ref="grPostal"/>
+										<xs:anyAttribute namespace="##other"/>
+									</xs:complexType>
+								</xs:element>
+							</xs:sequence>
+							<xs:attribute name="RangeType">
+								<xs:annotation>
+									<xs:documentation>Thoroughfare number ranges are odd or even</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:NMTOKEN">
+										<xs:enumeration value="Odd"/>
+										<xs:enumeration value="Even"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+							<xs:attribute name="Indicator">
+								<xs:annotation>
+									<xs:documentation>"No." No.12-13</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+							<xs:attribute name="Separator">
+								<xs:annotation>
+									<xs:documentation>"-" in 12-14  or "Thru" in 12 Thru 14 etc.</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+							<xs:attribute name="IndicatorOccurrence">
+								<xs:annotation>
+									<xs:documentation>No.12-14 where "No." is before actual street number</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:NMTOKEN">
+										<xs:enumeration value="Before"/>
+										<xs:enumeration value="After"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+							<xs:attribute name="NumberRangeOccurrence">
+								<xs:annotation>
+									<xs:documentation>23-25 Archer St, where number appears before name</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:NMTOKEN">
+										<xs:enumeration value="BeforeName"/>
+										<xs:enumeration value="AfterName"/>
+										<xs:enumeration value="BeforeType"/>
+										<xs:enumeration value="AfterType"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+							<xs:attribute name="Type"/>
+							<xs:attributeGroup ref="grPostal"/>
+							<xs:anyAttribute namespace="##other"/>
+						</xs:complexType>
+					</xs:element>
+				</xs:choice>
+				<xs:element ref="ThoroughfareNumberPrefix" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="ThoroughfareNumberSuffix" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="ThoroughfarePreDirection" type="ThoroughfarePreDirectionType"
+                            minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>North Baker Street, where North is the pre-direction. The direction appears before the name.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ThoroughfareLeadingType" type="ThoroughfareLeadingTypeType"
+                            minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Appears before the thoroughfare name. Ed. Spanish: Avenida Aurora, where Avenida is the leading type / French: Rue Moliere, where Rue is the leading type.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ThoroughfareName" type="ThoroughfareNameType" minOccurs="0"
+                            maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specification of the name of a Thoroughfare (also dependant street name): street name, canal name, etc.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ThoroughfareTrailingType" type="ThoroughfareTrailingTypeType"
+                            minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Appears after the thoroughfare name. Ed. British: Baker Lane, where Lane is the trailing type.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ThoroughfarePostDirection" type="ThoroughfarePostDirectionType"
+                            minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>221-bis Baker Street North, where North is the post-direction. The post-direction appears after the name.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="DependentThoroughfare" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>DependentThroughfare is related to a street; occurs in GB, IE, ES, PT</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="ThoroughfarePreDirection"
+                                        type="ThoroughfarePreDirectionType" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>North Baker Street, where North is the pre-direction. The direction appears before the name.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="ThoroughfareLeadingType"
+                                        type="ThoroughfareLeadingTypeType" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Appears before the thoroughfare name. Ed. Spanish: Avenida Aurora, where Avenida is the leading type / French: Rue Moliere, where Rue is the leading type.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="ThoroughfareName" type="ThoroughfareNameType"
+                                        minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Specification of the name of a Thoroughfare (also dependant street name): street name, canal name, etc.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="ThoroughfareTrailingType"
+                                        type="ThoroughfareTrailingTypeType" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Appears after the thoroughfare name. Ed. British: Baker Lane, where Lane is the trailing type.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="ThoroughfarePostDirection"
+                                        type="ThoroughfarePostDirectionType" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>221-bis Baker Street North, where North is the post-direction. The post-direction appears after the name.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+						<xs:attribute name="Type"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:choice minOccurs="0">
+					<xs:element name="DependentLocality" type="DependentLocalityType">
+						<xs:annotation>
+							<xs:documentation>Dependent localities are Districts within cities/towns, locality divisions, postal 
+divisions of cities, suburbs, etc. DependentLocality is a recursive element, but no nesting deeper than two exists (Locality-DependentLocality-DependentLocality).</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="Premise"/>
+					<xs:element name="Firm" type="FirmType">
+						<xs:annotation>
+							<xs:documentation>Specification of a firm, company, organization, etc. It can be specified as part of an address that contains a street or a postbox. It is therefore different from 
+a large mail user address, which contains no street.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="PostalCode"/>
+				</xs:choice>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type"/>
+			<xs:attribute name="DependentThoroughfares">
+				<xs:annotation>
+					<xs:documentation>Does this thoroughfare have a a dependent thoroughfare? Corner of street X, etc</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="Yes"/>
+						<xs:enumeration value="No"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="DependentThoroughfaresIndicator">
+				<xs:annotation>
+					<xs:documentation>Corner of, Intersection of</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="DependentThoroughfaresConnector">
+				<xs:annotation>
+					<xs:documentation>Corner of Street1 AND Street 2 where AND is the Connector</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="DependentThoroughfaresType">
+				<xs:annotation>
+					<xs:documentation>STS in GEORGE and ADELAIDE STS, RDS IN A and B RDS, etc. Use only when both the street types are the same</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AdministrativeArea">
+		<xs:annotation>
+			<xs:documentation>Examples of administrative areas are provinces counties, special regions (such as "Rijnmond"), etc.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="AdministrativeAreaName" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation> Name of the administrative area. eg. MI in USA, NSW in Australia</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type"/>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="SubAdministrativeArea" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation> Specification of a sub-administrative area. An example of a sub-administrative areas is a county. There are two places where the name of an administrative 
+area can be specified and in this case, one becomes sub-administrative area.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="SubAdministrativeAreaName" minOccurs="0"
+                                        maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation> Name of the sub-administrative area</xs:documentation>
+								</xs:annotation>
+								<xs:complexType mixed="true">
+									<xs:attribute name="Type"/>
+									<xs:attributeGroup ref="grPostal"/>
+									<xs:anyAttribute namespace="##other"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:choice minOccurs="0">
+								<xs:element ref="Locality"/>
+								<xs:element ref="PostOffice"/>
+								<xs:element ref="PostalCode"/>
+							</xs:choice>
+							<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+						<xs:attribute name="Type">
+							<xs:annotation>
+								<xs:documentation>Province or State or County or Kanton, etc</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="UsageType">
+							<xs:annotation>
+								<xs:documentation>Postal or Political - Sometimes locations must be distinguished between postal system, and physical locations as defined by a political system</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="Indicator">
+							<xs:annotation>
+								<xs:documentation>Erode (Dist) where (Dist) is the Indicator</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:choice minOccurs="0">
+					<xs:element ref="Locality"/>
+					<xs:element ref="PostOffice"/>
+					<xs:element ref="PostalCode"/>
+				</xs:choice>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>Province or State or County or Kanton, etc</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="UsageType">
+				<xs:annotation>
+					<xs:documentation>Postal or Political - Sometimes locations must be distinguished between postal system, and physical locations as defined by a political system</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="Indicator">
+				<xs:annotation>
+					<xs:documentation>Erode (Dist) where (Dist) is the Indicator</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PostOffice">
+		<xs:annotation>
+			<xs:documentation>Specification of a post office. Examples are a rural post office where post is delivered and a post office containing post office boxes.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:choice>
+					<xs:element name="PostOfficeName" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>Specification of the name of the post office. This can be a rural postoffice where post is delivered or a post office containing post office boxes.</xs:documentation>
+						</xs:annotation>
+						<xs:complexType mixed="true">
+							<xs:attribute name="Type"/>
+							<xs:attributeGroup ref="grPostal"/>
+							<xs:anyAttribute namespace="##other"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="PostOfficeNumber" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Specification of the number of the postoffice. Common in rural postoffices</xs:documentation>
+						</xs:annotation>
+						<xs:complexType mixed="true">
+							<xs:attribute name="Indicator">
+								<xs:annotation>
+									<xs:documentation>MS in MS 62, # in MS # 12, etc.</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+							<xs:attribute name="IndicatorOccurrence">
+								<xs:annotation>
+									<xs:documentation>MS occurs before 62 in MS 62</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:NMTOKEN">
+										<xs:enumeration value="Before"/>
+										<xs:enumeration value="After"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+							<xs:attributeGroup ref="grPostal"/>
+							<xs:anyAttribute namespace="##other"/>
+						</xs:complexType>
+					</xs:element>
+				</xs:choice>
+				<xs:element name="PostalRoute" type="PostalRouteType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>A Postal van is specific for a route as in Is`rael, Rural route</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="PostBox" minOccurs="0"/>
+				<xs:element ref="PostalCode" minOccurs="0"/>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>Could be a Mobile Postoffice Van as in Isreal</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="Indicator">
+				<xs:annotation>
+					<xs:documentation>eg. Kottivakkam (P.O) here (P.O) is the Indicator</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PostalCode">
+		<xs:annotation>
+			<xs:documentation>PostalCode is the container element for either simple or complex (extended) postal codes. Type: Area Code, Postcode, etc.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="PostalCodeNumber" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specification of a postcode. The postcode is formatted according to country-specific rules. Example: SW3 0A8-1A, 600074, 2067</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type">
+							<xs:annotation>
+								<xs:documentation>Old Postal Code, new code, etc</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="PostalCodeNumberExtension" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Examples are: 1234 (USA), 1G (UK), etc.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type">
+							<xs:annotation>
+								<xs:documentation>Delivery Point Suffix, New Postal Code, etc..</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="NumberExtensionSeparator">
+							<xs:annotation>
+								<xs:documentation>The separator between postal code number and the extension. Eg. "-"</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="PostTown" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>A post town is not the same as a locality. A post town can encompass a collection of (small) localities. It can also be a subpart of a locality. An actual post town in Norway is "Bergen".</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="PostTownName" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Name of the post town</xs:documentation>
+								</xs:annotation>
+								<xs:complexType mixed="true">
+									<xs:attribute name="Type"/>
+									<xs:attributeGroup ref="grPostal"/>
+									<xs:anyAttribute namespace="##other"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="PostTownSuffix" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>GENERAL PO in MIAMI GENERAL PO</xs:documentation>
+								</xs:annotation>
+								<xs:complexType mixed="true">
+									<xs:attributeGroup ref="grPostal"/>
+									<xs:anyAttribute namespace="##other"/>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="Type">
+							<xs:annotation>
+								<xs:documentation>eg. village, town, suburb, etc</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>Area Code, Postcode, Delivery code as in NZ, etc</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PostBox">
+		<xs:annotation>
+			<xs:documentation>Specification of a postbox like mail delivery point. Only a single postbox number can be specified. Examples of postboxes are POBox, free mail numbers, etc.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="PostBoxNumber">
+					<xs:annotation>
+						<xs:documentation>Specification of the number of a postbox</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="PostBoxNumberPrefix" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Specification of the prefix of the post box number. eg. A in POBox:A-123</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="NumberPrefixSeparator">
+							<xs:annotation>
+								<xs:documentation>A-12 where 12 is number and A is prefix and "-" is the separator</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="PostBoxNumberSuffix" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Specification of the suffix of the post box number. eg. A in POBox:123A</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="NumberSuffixSeparator">
+							<xs:annotation>
+								<xs:documentation>12-A where 12 is number and A is suffix and "-" is the separator</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="PostBoxNumberExtension" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Some countries like USA have POBox as 12345-123</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="NumberExtensionSeparator">
+							<xs:annotation>
+								<xs:documentation>"-" is the NumberExtensionSeparator in POBOX:12345-123</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Firm" type="FirmType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Specification of a firm, company, organization, etc. It can be specified as part of an address that contains a street or a postbox. It is therefore different from 
+a large mail user address, which contains no street.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="PostalCode" minOccurs="0"/>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>Possible values are, not limited to: POBox and Freepost.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="Indicator">
+				<xs:annotation>
+					<xs:documentation>LOCKED BAG NO:1234 where the Indicator is NO: and Type is LOCKED BAG</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Department">
+		<xs:annotation>
+			<xs:documentation>Subdivision in the firm: School of Physics at Victoria University (School of Physics is the department)</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="DepartmentName" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specification of the name of a department.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type"/>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="MailStop" type="MailStopType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>A MailStop is where the the mail is delivered to within a premise/subpremise/firm or a facility.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="PostalCode" minOccurs="0"/>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>School in Physics School, Division in Radiology division of school of physics</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Premise">
+		<xs:annotation>
+			<xs:documentation>Specification of a single premise, for example a house or a building. The premise as a whole has a unique premise (house) number or a premise name.  There could be more than 
+one premise in a street referenced in an address. For example a building address near a major shopping centre or raiwlay station</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="PremiseName" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specification of the name of the premise (house, building, park, farm, etc). A premise name is specified when the premise cannot be addressed using a street name plus premise (house) number.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType mixed="true">
+						<xs:attribute name="Type"/>
+						<xs:attribute name="TypeOccurrence">
+							<xs:annotation>
+								<xs:documentation>EGIS Building where EGIS occurs before Building, DES JARDINS occurs after COMPLEXE DES JARDINS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:NMTOKEN">
+									<xs:enumeration value="Before"/>
+									<xs:enumeration value="After"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:attribute>
+						<xs:attributeGroup ref="grPostal"/>
+						<xs:anyAttribute namespace="##other"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:choice minOccurs="0">
+					<xs:element name="PremiseLocation">
+						<xs:annotation>
+							<xs:documentation>LOBBY, BASEMENT, GROUND FLOOR, etc...</xs:documentation>
+						</xs:annotation>
+						<xs:complexType mixed="true">
+							<xs:attributeGroup ref="grPostal"/>
+							<xs:anyAttribute namespace="##other"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:choice>
+						<xs:element ref="PremiseNumber" maxOccurs="unbounded"/>
+						<xs:element name="PremiseNumberRange">
+							<xs:annotation>
+								<xs:documentation>Specification for defining the premise number range. Some premises have number as Building C1-C7</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="PremiseNumberRangeFrom">
+										<xs:annotation>
+											<xs:documentation>Start number details of the premise number range</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element ref="AddressLine" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+												<xs:element ref="PremiseNumberPrefix" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+												<xs:element ref="PremiseNumber"
+                                                            maxOccurs="unbounded"/>
+												<xs:element ref="PremiseNumberSuffix" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="PremiseNumberRangeTo">
+										<xs:annotation>
+											<xs:documentation>End number details of the premise number range</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element ref="AddressLine" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+												<xs:element ref="PremiseNumberPrefix" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+												<xs:element ref="PremiseNumber"
+                                                            maxOccurs="unbounded"/>
+												<xs:element ref="PremiseNumberSuffix" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="RangeType">
+									<xs:annotation>
+										<xs:documentation>Eg. Odd or even number range</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="Indicator">
+									<xs:annotation>
+										<xs:documentation>Eg. No. in Building No:C1-C5</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="Separator">
+									<xs:annotation>
+										<xs:documentation>"-" in 12-14  or "Thru" in 12 Thru 14 etc.</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="Type"/>
+								<xs:attribute name="IndicatorOccurence">
+									<xs:annotation>
+										<xs:documentation>No.12-14 where "No." is before actual street number</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:NMTOKEN">
+											<xs:enumeration value="Before"/>
+											<xs:enumeration value="After"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="NumberRangeOccurence">
+									<xs:annotation>
+										<xs:documentation>Building 23-25 where the number occurs after building name</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:NMTOKEN">
+											<xs:enumeration value="BeforeName"/>
+											<xs:enumeration value="AfterName"/>
+											<xs:enumeration value="BeforeType"/>
+											<xs:enumeration value="AfterType"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+				</xs:choice>
+				<xs:element ref="PremiseNumberPrefix" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="PremiseNumberSuffix" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="BuildingName" type="BuildingNameType" minOccurs="0"
+                            maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specification of the name of a building.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:choice>
+					<xs:element name="SubPremise" type="SubPremiseType" minOccurs="0"
+                                maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>Specification of a single sub-premise. Examples of sub-premises are apartments and suites. Each sub-premise should be uniquely identifiable.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Firm" type="FirmType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Specification of a firm, company, organization, etc. It can be specified as part of an address that contains a street or a postbox. It is therefore different from a large mail user address, which contains no street.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:choice>
+				<xs:element name="MailStop" type="MailStopType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>A MailStop is where the the mail is delivered to within a premise/subpremise/firm or a facility.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="PostalCode" minOccurs="0"/>
+				<xs:element ref="Premise" minOccurs="0"/>
+				<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>COMPLEXE in COMPLEX DES JARDINS, A building, station, etc</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="PremiseDependency">
+				<xs:annotation>
+					<xs:documentation>STREET, PREMISE, SUBPREMISE, PARK, FARM, etc</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="PremiseDependencyType">
+				<xs:annotation>
+					<xs:documentation>NEAR, ADJACENT TO, etc</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="PremiseThoroughfareConnector">
+				<xs:annotation>
+					<xs:documentation>DES, DE, LA, LA, DU in RUE DU BOIS. These terms connect a premise/thoroughfare type and premise/thoroughfare name. Terms may appear with names AVE DU BOIS</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ThoroughfareNumberPrefix">
+		<xs:annotation>
+			<xs:documentation>Prefix before the number. A in A12 Archer Street</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:annotation>
+				<xs:documentation>A-12 where 12 is number and A is prefix and "-" is the separator</xs:documentation>
+			</xs:annotation>
+			<xs:attribute name="NumberPrefixSeparator"/>
+			<xs:attribute name="Type"/>
+			<xs:attributeGroup ref="grPostal"/>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ThoroughfareNumberSuffix">
+		<xs:annotation>
+			<xs:documentation>Suffix after the number. A in 12A Archer Street</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:attribute name="NumberSuffixSeparator">
+				<xs:annotation>
+					<xs:documentation>NEAR, ADJACENT TO, etc</xs:documentation>
+					<xs:documentation>12-A where 12 is number and A is suffix and "-" is the separator</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="Type"/>
+			<xs:attributeGroup ref="grPostal"/>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ThoroughfareNumber">
+		<xs:annotation>
+			<xs:documentation>Eg.: 23 Archer street or 25/15 Zero Avenue, etc</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:attribute name="NumberType">
+				<xs:annotation>
+					<xs:documentation>12 Archer Street is "Single" and 12-14 Archer Street is "Range"</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="Single"/>
+						<xs:enumeration value="Range"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="Type"/>
+			<xs:attribute name="Indicator">
+				<xs:annotation>
+					<xs:documentation>No. in Street No.12 or "#" in Street # 12, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="IndicatorOccurrence">
+				<xs:annotation>
+					<xs:documentation>No.12 where "No." is before actual street number</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="Before"/>
+						<xs:enumeration value="After"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="NumberOccurrence">
+				<xs:annotation>
+					<xs:documentation>23 Archer St, Archer Street 23, St Archer 23</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="BeforeName"/>
+						<xs:enumeration value="AfterName"/>
+						<xs:enumeration value="BeforeType"/>
+						<xs:enumeration value="AfterType"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="grPostal"/>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PremiseNumber">
+		<xs:annotation>
+			<xs:documentation>Specification of the identifier of the premise (house, building, etc). Premises in a street are often uniquely identified by means of consecutive identifiers. The identifier can be a number, a letter or any combination of the two.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:attribute name="NumberType">
+				<xs:annotation>
+					<xs:documentation>Building 12-14 is "Range" and Building 12 is "Single"</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="Single"/>
+						<xs:enumeration value="Range"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="Type"/>
+			<xs:attribute name="Indicator">
+				<xs:annotation>
+					<xs:documentation>No. in House No.12, # in #12, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="IndicatorOccurrence">
+				<xs:annotation>
+					<xs:documentation>No. occurs before 12 No.12</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="Before"/>
+						<xs:enumeration value="After"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="NumberTypeOccurrence">
+				<xs:annotation>
+					<xs:documentation>12 in BUILDING 12 occurs "after" premise type BUILDING</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="Before"/>
+						<xs:enumeration value="After"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="grPostal"/>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PremiseNumberPrefix">
+		<xs:annotation>
+			<xs:documentation>A in A12</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attribute name="NumberPrefixSeparator">
+						<xs:annotation>
+							<xs:documentation>A-12 where 12 is number and A is prefix and "-" is the separator</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Type"/>
+					<xs:attributeGroup ref="grPostal"/>
+					<xs:anyAttribute namespace="##other"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PremiseNumberSuffix">
+		<xs:annotation>
+			<xs:documentation>A in 12A</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:attribute name="NumberSuffixSeparator">
+				<xs:annotation>
+					<xs:documentation>12-A where 12 is number and A is suffix and "-" is the separator</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="Type"/>
+			<xs:attributeGroup ref="grPostal"/>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="CountryName">
+		<xs:annotation>
+			<xs:documentation>Specification of the name of a country.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:attribute name="Type">
+				<xs:annotation>
+					<xs:documentation>Old name, new name, etc</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="grPostal"/>
+			<xs:anyAttribute namespace="##other"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>


### PR DESCRIPTION
If not online, this happens:

```
Tests in error: 
  testValidKML(org.geoserver.kml.KMLReflectorTest): src-resolve: Cannot resolve the name 'xal:AddressDetails' to a(n) 'element declaration' component.

```
This adds the xAL.xsd file. The alternative would be to change this Reflector test to be an Online one.