### PR TITLE
[GEOS-8364] Fixed "Failed to resolve workspace" messages for non-workspaced styles.

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogFacade.java
@@ -177,13 +177,16 @@ public abstract class AbstractCatalogFacade implements CatalogFacade {
         setId(style);
 
         // resolve the workspace
-        WorkspaceInfo resolved = ResolvingProxy.resolve(getCatalog(), style.getWorkspace());
-        if (resolved != null) {
-            resolved = unwrap(resolved);
-            style.setWorkspace(resolved);
-        } else {
-            LOGGER.log(Level.INFO, "Failed to resolve workspace for style \""+style.getName()+
-                    "\". This means the workspace has not yet been added to the catalog, keep the proxy around");
+        WorkspaceInfo ws = style.getWorkspace();
+        if (ws != null) {
+            WorkspaceInfo resolved = ResolvingProxy.resolve(getCatalog(), ws);
+            if (resolved != null) {
+                resolved = unwrap(resolved);
+                style.setWorkspace(resolved);
+            } else {
+                LOGGER.log(Level.INFO, "Failed to resolve workspace for style \""+style.getName()+
+                        "\". This means the workspace has not yet been added to the catalog, keep the proxy around");
+            }
         }
     }
 

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -519,6 +519,9 @@ public class XStreamPersisterTest {
         
         Document dom = dom( in( out ) );
         assertEquals( "style", dom.getDocumentElement().getNodeName() );
+
+        catalog.add(s2);
+        assertNull(s2.getWorkspace());
     }
 
     @Test


### PR DESCRIPTION
This modifies the fix for https://osgeo-org.atlassian.net/browse/GEOS-8289 to only apply to styles that have a workspace.

This pull request can be backported to 2.12.x only.