### PR TITLE
[GEOS-6745] Copy style needs to copy content and format

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
@@ -435,6 +435,7 @@ public class StyleAdminPanel extends StyleEditTabPanel {
                         // same here, force validation or the field won't be updated
                         stylePage.editor.reset();
                         stylePage.setRawStyle(stylePage.readFile(style));
+                        stylePage.getStyleInfo().setFormat(style.getFormat());
                         target.appendJavaScript(String.format(
                                 "if (document.gsEditors) { document.gsEditors.editor.setOption('mode', '%s'); }", 
                                 stylePage.styleHandler().getCodeMirrorEditMode()));


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-6745 seems to have reoccured after the Style Editor update in 2.11.x

I have fixed it. I attempted to construct a viable test case, but was unsuccessful (given this functionality involves Wicket + Ajax, this is unsurprising).