### PR TITLE
[GEOS-8369] Style preview - Update window.onload when ol source (preview layer) changes

### DIFF
--- a/src/web/wms/src/main/resources/org/geoserver/wms/web/data/ol-load.ftl
+++ b/src/web/wms/src/main/resources/org/geoserver/wms/web/data/ol-load.ftl
@@ -48,8 +48,6 @@ map.getView().on('change:resolution', function(evt) {
 
 map.getView().fit(extent, map.getSize());
 
-if (!window.olUpdate) {
-  window.olUpdate = function(id, params) {
-    source.updateParams(params);
-  };
-}
+window.olUpdate = function(id, params) {
+  source.updateParams(params);
+};


### PR DESCRIPTION
Fix for https://osgeo-org.atlassian.net/browse/GEOS-8369

Turns out the window.onload function was holding on to the old source referencing the initial preview layer, and not getting updated when the preview layer was changed. This has been fixed.

No test case, since this involves JS nested in Ajax updated nested in Wicket; and is therefore likely untestable within the wicket test framework.