### PR TITLE
[GEOS-8242] Use separate keys when caching different queries

### DIFF
--- a/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayerProvider.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayerProvider.java
@@ -129,6 +129,10 @@ public class PreviewLayerProvider extends GeoServerDataProvider<PreviewLayer> {
     @Override
     public long size() {
         try {
+            if (getKeywords() != null && getKeywords().length > 0) {
+                // Use a unique key for different queries
+                return cache.get(KEY_SIZE+"."+String.join(",", getKeywords()), sizeCaller);
+            }
             return cache.get(KEY_SIZE, sizeCaller);
         } catch (ExecutionException e) {
             throw new RuntimeException(e);

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderTest.java
@@ -151,7 +151,16 @@ public class PreviewLayerProviderTest extends GeoServerWicketTestSupport {
             getCatalog().remove(singleGroup);
             getCatalog().remove(containerGroup);
         }        
-    }    
+    }
+
+    @Test
+    public void testKewordsFilterSizeCache() {
+        PreviewLayerProvider provider = new PreviewLayerProvider();
+        assertEquals(29, provider.size());
+
+        provider.setKeywords(new String[] {"cite"});
+        assertEquals(12, provider.size());
+    }
 
     @Test(expected=UnsupportedOperationException.class)
     public void testGetItems() throws Exception {


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8242

The size of the results when there was no filter was being cached, and that value was getting used in place of the actual number of results returned by the filter.

An alternative fix would be to just not cache the size value.

This behaviour seems to have been introduced by https://github.com/geoserver/geoserver/pull/836 
