### PR TITLE
[GEOS-7622] Automatic relase scripts should copy PDF docs, shouldn't copy mac and win prebuild files

### DIFF
--- a/build/publish_release.sh
+++ b/build/publish_release.sh
@@ -77,7 +77,7 @@ popd > /dev/null
 pushd $DIST_PATH/$tag > /dev/null
 
 if [ -z $SKIP_DEPLOY ]; then
-  rsync -ave "ssh -i $SF_PK" *.zip $SF_USER@$SF_HOST:/home/pfs/project/g/ge/geoserver/GeoServer/$tag/
+  rsync -ave "ssh -i $SF_PK" *-bin.zip *-war.zip *doc.zip *.pdf $SF_USER@$SF_HOST:/home/pfs/project/g/ge/geoserver/GeoServer/$tag/
   
   # don't fail if exe or dmg is not around
   set +e


### PR DESCRIPTION
See here: https://osgeo-org.atlassian.net/browse/GEOS-7622