### PR TITLE
[GEOS-7343] Add jetty-servlets to system-independent binary to support CORS filter

### DIFF
--- a/src/release/jetty/modules/servlets.mod
+++ b/src/release/jetty/modules/servlets.mod
@@ -1,0 +1,9 @@
+#
+# Jetty Servlets Module
+#
+
+[depend]
+server
+
+[lib]
+lib/jetty-servlets-${jetty.version}.jar

--- a/src/release/jetty/start.ini
+++ b/src/release/jetty/start.ini
@@ -32,6 +32,10 @@ jetty.dump.stop=false
 jetty.delayDispatchUntilContent=false
 
 # --------------------------------------- 
+# Module: servlets
+--module=servlets
+
+# --------------------------------------- 
 # Module: deploy
 --module=deploy
 

--- a/src/release/pom.xml
+++ b/src/release/pom.xml
@@ -28,6 +28,11 @@
   </dependency>
   <dependency>
    <groupId>org.eclipse.jetty</groupId>
+   <artifactId>jetty-servlets</artifactId>
+   <version>${jetty.version}</version>
+  </dependency>
+  <dependency>
+   <groupId>org.eclipse.jetty</groupId>
    <artifactId>jetty-webapp</artifactId>
    <version>${jetty.version}</version>
   </dependency>


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-7343

Tested locally by building the bin.zip and uncommenting the CORS filter, seems to work. Should try and confirm with the next release artifacts.