### PR TITLE
Remove duplicate dependency gs-wps-core (en)

### DIFF
--- a/doc/en/developer/source/programming-guide/wps-services/implementing.rst
+++ b/doc/en/developer/source/programming-guide/wps-services/implementing.rst
@@ -73,11 +73,6 @@ For this example the project will be called "hello_wps".
            <scope>test</scope>
          </dependency>
          <dependency>
-           <groupId>org.geoserver.extension</groupId>
-           <artifactId>gs-wps-core</artifactId>
-           <version>${gs.version}</version>
-         </dependency>
-         <dependency>
            <groupId>junit</groupId>
            <artifactId>junit</artifactId>
            <version>4.11</version>


### PR DESCRIPTION
This removes the duplicate dependency ``gs-wps-core`` in the English WPS-implementation documentation. Otherwise the duplicate leads to an error when building the WPS with Maven:

``duplicate declaration of version ${gs.version}``

