### PR TITLE
Change to factory registry

### DIFF
--- a/src/extension/dxf/core/src/main/java/org/geoserver/wfs/response/dxf/DXFWriterFinder.java
+++ b/src/extension/dxf/core/src/main/java/org/geoserver/wfs/response/dxf/DXFWriterFinder.java
@@ -55,7 +55,7 @@ public final class DXFWriterFinder {
      */
     public static DXFWriter getWriter(String version, Writer writer) {
         FactoryRegistry writerRegistry = getServiceRegistry();
-        Iterator<DXFWriter> it = writerRegistry.getServiceProviders(DXFWriter.class, null, null);
+        Iterator<DXFWriter> it = writerRegistry.getFactories(DXFWriter.class, null, null).iterator();
         DXFWriter candidate;
         while (it.hasNext()) {
             candidate = it.next();


### PR DESCRIPTION
GeoTools plugin system has changed in response to Java 9 restrictions (changing API to use factory rather than service provider).

Follow API change to geotools covered here:

- https://github.com/geotools/geotools/wiki/FactoryRegistry-Refactoring-for-Java-9-Compatibility
- https://github.com/geotools/geotools/pull/1670