### PR TITLE
Fix compile failure in gs-platform caused by GeoTools Java 9 compatibility changes [GEOT-5289]

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerExtensions.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerExtensions.java
@@ -11,9 +11,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Properties;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -21,7 +20,6 @@ import java.util.logging.Logger;
 import javax.servlet.ServletContext;
 
 import org.geoserver.platform.resource.Paths;
-import org.geotools.factory.FactoryRegistry;
 import org.geotools.util.SoftValueHashMap;
 import org.geotools.util.logging.Logging;
 import org.springframework.beans.BeansException;
@@ -161,12 +159,9 @@ public class GeoServerExtensions implements ApplicationContextAware, Application
         
         // load from factory spi
         List<Object> spiExtensions = spiCache.get(extensionPoint);
-        if(spiExtensions == null) {
+        if (spiExtensions == null) {
             spiExtensions = new ArrayList<Object>();
-            Iterator i = FactoryRegistry.lookupProviders(extensionPoint);
-            while( i.hasNext() ) {
-                spiExtensions.add( i.next() );
-            }
+            ServiceLoader.load(extensionPoint).iterator().forEachRemaining(spiExtensions::add);
             spiCache.put(extensionPoint, spiExtensions);
         }
         // filter the beans coming from SPI (we don't cache the results


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5289
https://github.com/geotools/geotools/pull/1670

Failure was:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project gs-platform: Compilation failure
[ERROR] /home/ben/geoserver/src with spaces/geoserver/src/platform/src/main/java/org/geoserver/platform/GeoServerExtensions.java:[166,40] error: cannot find symbol
```

Fix follows change to `PropertyAccessors.java` in https://github.com/geotools/geotools/pull/1670 .