### PR TITLE
[GEOS-8340] Upgrade JDom library to version 2.0.6

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/pom.xml
+++ b/src/community/jms-cluster/jms-geoserver/pom.xml
@@ -54,6 +54,10 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-rest</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.restlet</groupId>

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
@@ -12,7 +12,7 @@ import java.io.OutputStream;
 import org.apache.commons.io.IOUtils;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
-import org.jdom.JDOMException;
+import org.jdom2.JDOMException;
 
 /**
  * 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -473,7 +473,11 @@
     <artifactId>gt-geopkg</artifactId>
     <version>${gt.version}</version>
    </dependency>
-
+   <dependency>
+     <groupId>org.jdom</groupId>
+     <artifactId>jdom2</artifactId>
+     <version>2.0.6</version>
+   </dependency>
 
    <dependency>
      <groupId>com.google.code.gson</groupId>

--- a/src/restconfig/pom.xml
+++ b/src/restconfig/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>gt-geojson</artifactId>
       <version>${gt.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/AvailableResourcesConverter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/AvailableResourcesConverter.java
@@ -10,10 +10,10 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 
 import org.geoserver.rest.converters.BaseMessageConverter;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/MapXMLConverter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/MapXMLConverter.java
@@ -12,12 +12,12 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.geoserver.rest.converters.BaseMessageConverter;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/RuleMapXMLConverter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/RuleMapXMLConverter.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import org.geoserver.platform.ExtensionPriority;
 import org.geoserver.rest.catalog.MapXMLConverter;
-import org.jdom.Element;
+import org.jdom2.Element;
 import org.springframework.stereotype.Component;
 
 /**

--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -87,6 +87,10 @@
       <artifactId>pngj</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/src/wms/src/main/java/org/geoserver/wms/decoration/MapDecorationLayout.java
+++ b/src/wms/src/main/java/org/geoserver/wms/decoration/MapDecorationLayout.java
@@ -24,9 +24,9 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.wms.WMSMapContent;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.input.SAXBuilder;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
 
 /**
  * The MapDecorationLayout class describes a set of overlays to be used to enhance a WMS response.


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8340

Adds the JDom dependency in the pom files where required and changes the package names from `org.jdom` to `org.jdom2`

This follows up on geotools/geotools#1719