### PR TITLE
[GEOS-8108] fix for null namespaces with GetPropertyValue and stored queries requests

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSWorkspaceQualifier.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSWorkspaceQualifier.java
@@ -190,9 +190,11 @@ public class WFSWorkspaceQualifier extends WorkspaceQualifyingCallback {
     }
     
     void qualifyTypeNames(List names, WorkspaceInfo ws, NamespaceInfo ns) {
-        for (int i = 0; i < names.size(); i++) {
-            QName name = (QName) names.get(i);
-            names.set(i, qualifyTypeName(name, ws, ns));
+        if (names != null) {
+            for (int i = 0; i < names.size(); i++) {
+                QName name = (QName) names.get(i);
+                names.set(i, qualifyTypeName(name, ws, ns));
+            }
         }
     }
     


### PR DESCRIPTION
The trick of adding all the namespaces in the catalog before encoding, taking care of temporarily disabling local workspace filtering if needed, was applied also to `GetPropertyValueResponse` .

Test cases for GetPropertyValue requests and GetFeature requests making use of a StoredQuery were added to the test class `NamespacesWfsTest`, which provides a sample mapping involving two nested complex feature types in two GML flavors, 3.1 and 3.2: this allows to test both GML 3.1 and GML 3.2 output formats (where applicable).

