### PR TITLE
[GEOS-8409] GZIPResponseStream should not throw Exception on flushing

### DIFF
--- a/src/main/src/main/java/org/geoserver/filters/GZIPResponseStream.java
+++ b/src/main/src/main/java/org/geoserver/filters/GZIPResponseStream.java
@@ -35,10 +35,9 @@ public class GZIPResponseStream extends ServletOutputStream {
     }
 
     public void flush() throws IOException {
-        if (closed) {
-            throw new IOException("Cannot flush a closed output stream");
+        if (!closed) {
+            gzipstream.flush();
         }
-        gzipstream.flush();
     }
 
     public void write(int b) throws IOException {


### PR DESCRIPTION
Fixes JIRA GEOS-8409