### PR TITLE
Fixes for GEOS-8427: rename scriptMgr to scriptManager, fix ruby test  and upgrade groovy

### DIFF
--- a/src/community/script/groovy/pom.xml
+++ b/src/community/script/groovy/pom.xml
@@ -24,7 +24,7 @@
   <dependency>
    <groupId>org.geoscript</groupId>
    <artifactId>geoscript-groovy</artifactId>
-   <version>1.7-SNAPSHOT</version>
+   <version>1.11-SNAPSHOT</version>
   </dependency>
   <dependency>
     <!-- this dependency taken from geoscript-groovy pom but upgraded to 1.0.9 -->

--- a/src/community/script/rb/src/test/resources/org/geoserver/script/rb/main-helloWorld.rb
+++ b/src/community/script/rb/src/test/resources/org/geoserver/script/rb/main-helloWorld.rb
@@ -1,3 +1,4 @@
 def run(request, response)
-  response.setEntity("Hello World!", org.restlet.data.MediaType::TEXT_PLAIN)
+    response.getWriter().write("Hello World!")
+    response.setContentType("text/plain")
 end

--- a/src/community/script/web/src/main/java/org/geoserver/script/web/Script.java
+++ b/src/community/script/web/src/main/java/org/geoserver/script/web/Script.java
@@ -70,7 +70,7 @@ public class Script implements Serializable {
     }
 
     private Resource findFile(String name, String type, String extension) {
-        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptMgr");
+        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptManager");
         try {
             if (name.contains(":")) {
                 name = name.replace(":",File.separator);
@@ -100,7 +100,7 @@ public class Script implements Serializable {
     }
 
     private String findType(Resource file) {
-        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptMgr");
+        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptManager");
         return scriptManager.getScriptType(file).getLabel();
     }
 

--- a/src/community/script/web/src/main/java/org/geoserver/script/web/ScriptEditPage.java
+++ b/src/community/script/web/src/main/java/org/geoserver/script/web/ScriptEditPage.java
@@ -94,7 +94,7 @@ public class ScriptEditPage extends GeoServerSecuredPage {
         form.add(extension);
 
         // Content
-        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptMgr");
+        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptManager");
         String mode = scriptManager.lookupPluginEditorMode(script.getResource());
         CodeMirrorEditor content = new CodeMirrorEditor("contents", mode, new PropertyModel<String>(scriptModel, "contents"));
         content.setRequired(true);

--- a/src/community/script/web/src/main/java/org/geoserver/script/web/ScriptNewPage.java
+++ b/src/community/script/web/src/main/java/org/geoserver/script/web/ScriptNewPage.java
@@ -119,7 +119,7 @@ public class ScriptNewPage extends GeoServerSecuredPage {
 
     private List<String> getExtensions() {
         List<String> extensions = Lists.newArrayList();
-        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptMgr");
+        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptManager");
         for (ScriptPlugin plugin : scriptManager.getPlugins()) {
             extensions.add(plugin.getExtension());
         }
@@ -127,7 +127,7 @@ public class ScriptNewPage extends GeoServerSecuredPage {
     }
 
     private String getModeFromExtension(String ext) {
-        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptMgr");
+        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptManager");
         String mode = scriptManager.lookupEditorModeByExtension(ext);
         return mode;
     }

--- a/src/community/script/web/src/main/java/org/geoserver/script/web/ScriptsModel.java
+++ b/src/community/script/web/src/main/java/org/geoserver/script/web/ScriptsModel.java
@@ -45,7 +45,7 @@ public class ScriptsModel extends LoadableDetachableModel<List<Script>> {
 
     protected List<Script> getScripts() {
         List<Script> scripts = new ArrayList<Script>();
-        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptMgr");
+        ScriptManager scriptManager = (ScriptManager) GeoServerExtensions.bean("scriptManager");
         try {
             Resource[] dirs = { scriptManager.wps(), scriptManager.wfsTx(),
                     scriptManager.function(), scriptManager.app() };


### PR DESCRIPTION
The script community module can't find the scriptMgr bean because it was renamed scriptManager. Also there is a failing ruby application test because of the restlet to spring migration.

JIRA:
https://osgeo-org.atlassian.net/browse/GEOS-8427
