### PR TITLE
[GEOS-8389] Support forceTitles:off for layer group legends

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
@@ -434,7 +434,7 @@ public class BufferedImageLegendGraphicBuilder {
                 if(!StringUtils.isEmpty(request.getLegendOptions().get("labelMargin"))) {
                     labelMargin = Integer.parseInt(request.getLegendOptions().get("labelMargin").toString());
                 }
-                LegendMerger.MergeOptions options = LegendMerger.MergeOptions.createFromRequest(legendsStack, 0, 0, 0, labelMargin, request, forceLabelsOn, forceLabelsOff);
+                LegendMerger.MergeOptions options = LegendMerger.MergeOptions.createFromRequest(legendsStack, 0, 0, 0, labelMargin, request, forceLabelsOn, forceLabelsOff, forceTitlesOff);
                 if(ruleCount > 0) {
                     BufferedImage image = LegendMerger.mergeLegends(applicableRules, request, options); 
                             
@@ -446,7 +446,7 @@ public class BufferedImageLegendGraphicBuilder {
             
         }
         // all legend graphics are merged if we have a layer group
-        BufferedImage finalLegend = mergeGroups(layersImages,null,request, forceLabelsOn, forceLabelsOff);
+        BufferedImage finalLegend = mergeGroups(layersImages,null,request, forceLabelsOn, forceLabelsOff, forceTitlesOff);
         if(finalLegend == null) {
             throw new IllegalArgumentException("no legend passed");
         }
@@ -679,8 +679,8 @@ public class BufferedImageLegendGraphicBuilder {
      *             if the list is empty
      */
     private BufferedImage mergeGroups(List<RenderedImage> imageStack, Rule[] rules, GetLegendGraphicRequest req,
-            boolean forceLabelsOn, boolean forceLabelsOff) {
-        LegendMerger.MergeOptions options = LegendMerger.MergeOptions.createFromRequest(imageStack, 0, 0, 0, 0, req, forceLabelsOn, forceLabelsOff);
+            boolean forceLabelsOn, boolean forceLabelsOff, boolean forceTitlesOff) {
+        LegendMerger.MergeOptions options = LegendMerger.MergeOptions.createFromRequest(imageStack, 0, 0, 0, 0, req, forceLabelsOn, forceLabelsOff, forceTitlesOff);
         options.setLayout(LegendUtils.getGroupLayout(req));
         return LegendMerger.mergeGroups(rules, options);
 

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/ColorMapLegendCreator.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/ColorMapLegendCreator.java
@@ -935,7 +935,7 @@ public class ColorMapLegendCreator {
             List<RenderedImage> imgs = new ArrayList<RenderedImage>(legendsQueue);
             
             LegendMerger.MergeOptions options = new LegendMerger.MergeOptions(imgs, (int) dx, (int) dy, (int) margin, 0, backgroundColor, transparent, true, layout, rowWidth, 
-                    rows, columnHeight, columns, null ,false, false);
+                    rows, columnHeight, columns, null ,false, false, false);
             finalLegend = LegendMerger.mergeRasterLegends(options);
         }
 


### PR DESCRIPTION
See: https://osgeo-org.atlassian.net/browse/GEOS-8389

Turns out the LegendMerger was always assuming a title would be present, and with `forceTitles:off` would try merging layer group images with each other in place of the titles.

* Added `forceTitlesOff` property to `MergeOptions`
* If `forceTitlesOff=true`, LegendMerger doesn't try to merge images with the (nonexistant) titles
* Added a full set of tests for LayerGroup legend generation