### PR TITLE
[GEOS-8430] Cache small amount of features in memory to avoid repeated data scans in GetFeature requests

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/FeatureSizeFeatureCollection.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/FeatureSizeFeatureCollection.java
@@ -1,0 +1,157 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.geotools.data.FeatureSource;
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.feature.collection.DecoratingSimpleFeatureCollection;
+
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.type.FeatureType;
+
+
+/**
+ * A feature collection which caches a configurable (and small) amount of features.
+ * 
+ * @author Alvaro Huarte
+ */
+class FeatureSizeFeatureCollection extends DecoratingSimpleFeatureCollection {
+    
+    /**
+     * The original feature source.
+     */
+    protected FeatureSource<? extends FeatureType, ? extends Feature> featureSource;
+    
+    /**
+     * The feature cache to manage.
+     */
+    protected List<SimpleFeature> featureCache;
+    
+    /**
+     * The original query.
+     */
+    protected Query query;
+    
+    /**
+     * Defines the maximum number of cacheable features to avoid successive readings 
+     * of the data source.
+     * <p>
+     * With a minimum overload of memory, it takes advantage of a previous reading 
+     * of features when the feature source does not support direct count of the 
+     * collection managed (e.g. shapefile stores).
+     * </p>
+     * <p>
+     * It is very useful when the feature store needs to execute costly queries 
+     * and the filter returns empty or low-count feature results. 
+     * In some contexts, WFS-GetFeature requests need to precalculate the size 
+     * of the results, and (e.g. shapefile stores) the query is executed at 
+     * least twice causing two readings of the data source.
+     * </p>
+     */
+    static int FEATURE_CACHE_LIMIT = 
+        Integer.valueOf(System.getProperty("org.geoserver.wfs.getfeature.cachelimit", "16"));
+    
+    /**
+     * Allows to programmatically set the maximum number of cacheable features.
+     */
+    public static void setFeatureCacheLimit(int featureCacheLimit) {
+        FEATURE_CACHE_LIMIT = featureCacheLimit;
+    }
+
+    public FeatureSizeFeatureCollection(SimpleFeatureCollection delegate, FeatureSource<? extends FeatureType, ? extends Feature> source, Query query) {
+        super(delegate);
+        this.featureSource = source;
+        this.query = query;
+    }
+
+    class CachedWrappingFeatureIterator implements SimpleFeatureIterator {
+        
+        private List<SimpleFeature> featureCache;
+        private int featureIndex = 0;
+        
+        public CachedWrappingFeatureIterator(List<SimpleFeature> featureCache) {
+            this.featureCache = featureCache;
+        }
+        
+        @Override
+        public boolean hasNext() {
+            return featureIndex < featureCache.size();
+        }
+        
+        @Override
+        public SimpleFeature next() {
+            return featureCache.get(featureIndex++);
+        }
+        
+        @Override
+        public void close() {
+            featureIndex = 0;
+        }
+    }
+    
+    @Override
+    public SimpleFeatureIterator features() {
+        if (featureCache != null) {
+            return new CachedWrappingFeatureIterator( featureCache );
+        }
+        return super.features();
+    }
+    
+    @Override
+    public int size() {
+        if (featureCache != null) {
+            return featureCache.size();
+        }
+        if (FEATURE_CACHE_LIMIT > 0) {
+            FeatureIterator<? extends Feature> it = null;
+            
+            try {
+                int count = featureSource.getCount(query);
+                
+                if (count == 0) {
+                    featureCache = new ArrayList<SimpleFeature>();
+                    return count;
+                }
+                if (count > 0) {
+                    return count;
+                }
+                
+                // we have to iterate, save to cache to avoid later successive readings of data.
+                List<SimpleFeature> tempFeatureCache = new ArrayList<SimpleFeature>();
+                
+                // bean counting...
+                it = featureSource.getFeatures(query).features();
+                count = 0;
+                while (it.hasNext()) {
+                    SimpleFeature feature = (SimpleFeature) it.next();
+                    if (tempFeatureCache.size() < FEATURE_CACHE_LIMIT) tempFeatureCache.add(feature);
+                    count++;
+                }
+                if (count <= FEATURE_CACHE_LIMIT) {
+                    featureCache = tempFeatureCache;
+                } else {
+                    tempFeatureCache.clear();
+                }
+                return count;
+                
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } finally {
+                if (it != null) {
+                    it.close();
+                }
+            }
+        }
+        return super.size();
+    }
+}

--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -31,6 +31,7 @@ import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Join;
 import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.factory.Hints;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.NameImpl;
@@ -930,7 +931,8 @@ public class GetFeature {
     }
 
     /**
-     * Allows subclasses to poke with the feature collection extraction
+     * Allows subclasses to poke with the feature collection extraction. The default behavior attempts to
+     * wrap the feature collectio into a {@link FeatureSizeFeatureCollection}.
      * @param source
      * @param gtQuery
      *
@@ -942,9 +944,7 @@ public class GetFeature {
             throws IOException {
         FeatureCollection<? extends FeatureType, ? extends Feature> features = source.getFeatures(gtQuery);
         
-        if (features.getSchema() instanceof SimpleFeatureType) {
-            features = new FeatureSizeFeatureCollection((SimpleFeatureCollection)features, source, gtQuery);
-        }
+        features = FeatureSizeFeatureCollection.wrap(features, source, gtQuery);
         return features;
     }
 

--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -940,7 +940,12 @@ public class GetFeature {
             Object request, FeatureSource<? extends FeatureType, ? extends Feature> source,
             org.geotools.data.Query gtQuery)
             throws IOException {
-        return source.getFeatures(gtQuery);
+        FeatureCollection<? extends FeatureType, ? extends Feature> features = source.getFeatures(gtQuery);
+        
+        if (features.getSchema() instanceof SimpleFeatureType) {
+            features = new FeatureSizeFeatureCollection((SimpleFeatureCollection)features, source, gtQuery);
+        }
+        return features;
     }
 
     /**

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureNoCachingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureNoCachingTest.java
@@ -1,0 +1,26 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs;
+
+import org.geoserver.wfs.v2_0.GetFeatureTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Test making sure GetFeature still works when the caching machinery is off (since most test datasets
+ * will actually be cached in memory)
+ */
+public class GetFeatureNoCachingTest extends GetFeatureTest {
+    
+    @BeforeClass
+    public static void disableCaching() {
+        FeatureSizeFeatureCollection.setFeatureCacheLimit(0);
+    }
+    
+    @AfterClass
+    public static void enableCaching() {
+        FeatureSizeFeatureCollection.setFeatureCacheLimit(FeatureSizeFeatureCollection.DEFAULT_CACHE_SIZE);
+    }
+}


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8430

Replaces #1355
Rebased the pull request on current master to make sure everything builds against today's code, and:

- Improve use of generic and use try with resources when possible
- Some fixes to docs, cut down on advertisement and augment code behavior description
- Made the class public (sigh) because subclasses of GetFeature in GeoServer extensions might actually need it (since the code is right in the middle of an extension point)
- Added test to make sure GetFeature works with both caching on and off
- Created a GeoServer ticket and made the commits refer to it