### PR TITLE
[GEOS-8434, GEOS-8436, GEOS-8439, GEOS-8438] Allow WMTS to use CITE compliance mode

### DIFF
--- a/src/community/nsg-profiles/nsg-wmts-profile/src/main/java/org/geoserver/nsg/wmts/GridSetsLoader.java
+++ b/src/community/nsg-profiles/nsg-wmts-profile/src/main/java/org/geoserver/nsg/wmts/GridSetsLoader.java
@@ -47,7 +47,7 @@ public class GridSetsLoader implements ApplicationListener<ContextLoadedEvent> {
         String description = "The World Mercator (EPSG::3395) well-known scale set is define in this " +
                 "NSG WMTS Implementation Interoperability Profile.";
         // world mercator 3395 grid set, add grid set
-        addGridSet(WORLD_MERCATOR_GRID_SET_NAME, EPSG_3395, resolutions, scaleNames, boundingBox, description, 10.0);
+        addGridSet(WORLD_MERCATOR_GRID_SET_NAME, EPSG_3395, resolutions, scaleNames, boundingBox, description, 1.0);
 
         // ups tiles EPSG::5041 grid set, resolutions
         resolutions = new double[]{
@@ -69,7 +69,7 @@ public class GridSetsLoader implements ApplicationListener<ContextLoadedEvent> {
                 "Stereographic (variant A)) as its projection. WGS 84 / UPS North (E,N) is a CRS for Military mapping by " +
                 "NATO. It was defined by information from US National Geospatial-Intelligence Agency (NGA).";
         // ups tiles EPSG::5041 grid set, add grid set
-        addGridSet(EPSG_5041_GRID_SET_NAME, EPSG_5041, resolutions, scaleNames, boundingBox, description, 10.0);
+        addGridSet(EPSG_5041_GRID_SET_NAME, EPSG_5041, resolutions, scaleNames, boundingBox, description, 1.0);
 
         // ups tiles EPSG::5042 grid set, resolutions
         resolutions = new double[]{
@@ -91,7 +91,7 @@ public class GridSetsLoader implements ApplicationListener<ContextLoadedEvent> {
                 "(variant A)) as its projection. WGS 84 / UPS South (E,N) is a CRS for Military mapping by NATO. It was " +
                 "defined by information from US National Geospatial-Intelligence Agency (NGA).";
         // ups tiles EPSG::5041 grid set, add grid set
-        addGridSet(EPSG_5042_GRID_SET_NAME, EPSG_5042, resolutions, scaleNames, boundingBox, description, 10.0);
+        addGridSet(EPSG_5042_GRID_SET_NAME, EPSG_5042, resolutions, scaleNames, boundingBox, description, 1.0);
     }
 
     /**

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wmts/WMTSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wmts/WMTSExtendedCapabilitiesProvider.java
@@ -9,6 +9,7 @@ import org.geoserver.catalog.MetadataMap;
 import org.geoserver.config.GeoServer;
 import org.geoserver.gwc.wmts.WMTSInfo;
 import org.geoserver.inspire.ViewServicesUtils;
+import org.geowebcache.config.meta.ServiceInformation;
 import org.geowebcache.io.XMLBuilder;
 import org.geowebcache.service.wmts.WMTSExtensionImpl;
 import org.xml.sax.Attributes;
@@ -99,5 +100,10 @@ public class WMTSExtendedCapabilitiesProvider extends WMTSExtensionImpl {
         String mediaType = (String) serviceMetadata.get(SERVICE_METADATA_TYPE.key);
         String language = (String) serviceMetadata.get(LANGUAGE.key);
         ViewServicesUtils.addScenario1Elements(translator, metadataURL, mediaType, language);
+    }
+
+    @Override
+    public ServiceInformation getServiceInformation() {
+        return new ServiceInformation();
     }
 }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -1321,7 +1321,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
                         .withFormat(finalFormat)
                         .withMinScale(scalesDenominator.getMinimum())
                         .withMaxScale(scalesDenominator.getMaximum())
-                        .withCompleteUrl(buildURL(baseUrl, "ows", params, URLMangler.URLType.SERVICE));
+                        .withCompleteUrl(buildURL(baseUrl, "ows", params, URLMangler.URLType.RESOURCE));
                 legends.put(styleInfo.prefixedName(), gwcLegendInfo.build());
             }
         }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
@@ -97,7 +97,8 @@ public class StyleParameterFilter extends ParameterFilter {
                 }
             }
             // no match so fail
-            throw new ParameterException(str);
+            throw new ParameterException(400, "InvalidParameterValue",
+                    "Style", String.format("Style '%s' is invalid.", str));
         }
     }
     

--- a/src/gwc/src/main/java/org/geoserver/gwc/wmts/WMTSCapabilitiesProvider.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/wmts/WMTSCapabilitiesProvider.java
@@ -55,6 +55,7 @@ public class WMTSCapabilitiesProvider extends WMTSExtensionImpl {
             serviceProvider.setServiceContact(gwcContactInfo);
         }
         gwcInfo.setServiceProvider(serviceProvider);
+        gwcInfo.setCiteCompliant(gsInfo.isCiteCompliant());
         return gwcInfo;
     }
 }

--- a/src/gwc/src/main/resources/geowebcache-wmtsservice-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-wmtsservice-context.xml
@@ -13,6 +13,7 @@
     <constructor-arg ref="gwcURLMangler"/>
     <constructor-arg ref="geowebcacheDispatcher"/>
     <property name="securityDispatcher" ref="gwcSecurityDispatcher"/>
+    <property name="mainConfiguration" ref="gwcXmlConfig"/>
   </bean>
   <bean id="gwcServiceWMTSProxy" class="org.springframework.aop.framework.ProxyFactoryBean">
     <property name="targetName">

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -11,7 +11,13 @@ import org.apache.commons.io.IOUtils;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
-import org.geoserver.catalog.*;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
@@ -60,13 +66,31 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.geoserver.data.test.MockData.BASIC_POLYGONS;
 import static org.geoserver.gwc.GWC.tileLayerName;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -1231,6 +1255,27 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
     }
 
+    /**
+     * Test that using an invalid \ non-existing style in a GetTile request will throw
+     * the correct OWS exception.
+     */
+    @Test
+    public void testCetTileWithInvalidStyle() throws Exception {
+        // using cite:BasicPolygons layer for testing
+        String layerName = getLayerId(MockData.BASIC_POLYGONS);
+        // get tile request with an invalid style, this should return an exception report
+        MockHttpServletResponse response = getAsServletResponse("gwc/service/wmts" +
+                "?request=GetTile&layer=" + layerName + "&style=invalid&format=image/png" +
+                "&tilematrixset=EPSG:4326&tilematrix=EPSG:4326:0&tilerow=0&tilecol=0");
+        assertEquals(400, response.getStatus());
+        assertEquals("text/xml", response.getContentType());
+        // parse XML response content
+        Document document = dom(response, false);
+        // let's check the content of the exception report
+        String result = WMTS_XPATH_10.evaluate("count(//ows:ExceptionReport/ows:Exception" +
+                "[@exceptionCode='InvalidParameterValue'][@locator='Style'])", document);
+        assertThat(Integer.parseInt(result), is(1));
+    }
 
     /**
      * Helper method that creates a layer group using the provided name and layers names.

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -1120,7 +1120,7 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
         // checking the service metadata URL
         assertEquals("1", WMTS_XPATH_10.evaluate(
                 "count(//wmts:ServiceMetadataURL[@xlink:href='http://localhost:8080/geoserver/gwc"
-                        + WMTSService.SERVICE_PATH + "?REQUEST=getcapabilities&VERSION=1.0.0'])",
+                        + WMTSService.SERVICE_PATH + "?SERVICE=wmts&REQUEST=getcapabilities&VERSION=1.0.0'])",
                 doc));
         assertEquals("1",
                 WMTS_XPATH_10.evaluate(

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/wmts/WMTSAdminPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/wmts/WMTSAdminPage.java
@@ -36,6 +36,5 @@ public class WMTSAdminPage extends BaseServiceAdminPage<WMTSInfo> {
 
     @Override
     protected void build(IModel info, Form form) {
-        form.get("citeCompliant").setEnabled(false);
     }
 }

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/wmts/WMTSAdminPageTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/wmts/WMTSAdminPageTest.java
@@ -6,10 +6,15 @@ package org.geoserver.gwc.web.wmts;
 
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.gwc.wmts.WMTSInfo;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.web.GeoServerHomePage;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.wms.WMSInfo;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class WMTSAdminPageTest extends GeoServerWicketTestSupport {
 
@@ -36,11 +41,20 @@ public class WMTSAdminPageTest extends GeoServerWicketTestSupport {
 
     @Test
     public void testFormSubmit() throws Exception {
+        // get WMTS service information
+        WMTSInfo wmtsInfo = getGeoServerApplication().getGeoServer().getService(WMTSInfo.class);
+        // start WMTS administration page
         tester.startPage(WMTSAdminPage.class);
         // let's submit the form
         FormTester formTester = tester.newFormTester("form");
+        // change cite compliance value
+        boolean citeCompliant = wmtsInfo.isCiteCompliant();
+        formTester.setValue("citeCompliant", !citeCompliant);
+        // submit form
         formTester.submit("submit");
         tester.assertNoErrorMessage();
         tester.assertRenderedPage(GeoServerHomePage.class);
+        // check the service info object was correctly updated
+        assertThat(wmtsInfo.isCiteCompliant(), is(!citeCompliant));
     }
 }


### PR DESCRIPTION
Associated issues:
- https://osgeo-org.atlassian.net/browse/GEOS-8434
- https://osgeo-org.atlassian.net/browse/GEOS-8436
- https://osgeo-org.atlassian.net/browse/GEOS-8439
- https://osgeo-org.atlassian.net/browse/GEOS-8438

**Depends on this PR https://github.com/GeoWebCache/geowebcache/pull/572**