### PR TITLE
[GEOS-8459] Handle case where principal is instance of String

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/Transaction.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/Transaction.java
@@ -572,7 +572,7 @@ public class Transaction {
             Object principal = authentication.getPrincipal();
             if(principal instanceof UserDetails) {
                 username = ((UserDetails) principal).getUsername(); 
-            } else if(principal instanceof String) {
+            } else if(principal instanceof String) { // OAuth
             	username = principal.toString();
             }
         }

--- a/src/wfs/src/main/java/org/geoserver/wfs/Transaction.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/Transaction.java
@@ -572,6 +572,8 @@ public class Transaction {
             Object principal = authentication.getPrincipal();
             if(principal instanceof UserDetails) {
                 username = ((UserDetails) principal).getUsername(); 
+            } else if(principal instanceof String) {
+            	username = principal.toString();
             }
         }
         


### PR DESCRIPTION
This PR adds a condition to account for the principal being an instance of String. This occurs when sending wfs transactions while supplying the oauth access token, anonymous is stored as the VersioningCommitAuthor.

https://osgeo-org.atlassian.net/browse/GEOS-8459