### PR TITLE
[GEOS-8460] Make importer share the request context when initializing a job asynchronously

### DIFF
--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RequestContextListener.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/RequestContextListener.java
@@ -4,9 +4,13 @@
  */
 package org.geoserver.importer.rest;
 
+import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.security.AbstractResourceAccessManager;
 import org.geoserver.security.DataAccessLimits;
+import org.geoserver.security.WorkspaceAccessLimits;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -22,7 +26,7 @@ public final class RequestContextListener extends AbstractResourceAccessManager 
     private CallBack callBack;
 
     public interface CallBack {
-        void invoked(HttpServletRequest request, Authentication user, ResourceInfo resource);
+        void invoked(HttpServletRequest request, Authentication user, CatalogInfo info);
     }
 
     public void setCallBack(CallBack callBack) {
@@ -41,5 +45,19 @@ public final class RequestContextListener extends AbstractResourceAccessManager 
             }
         }
         return super.getAccessLimits(user, resource);
+    }
+
+    @Override
+    public WorkspaceAccessLimits getAccessLimits(Authentication user, WorkspaceInfo workspace) {
+        if (callBack != null) {
+            // let's see if we can access this request context
+            try {
+                HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+                callBack.invoked(request, user, workspace);
+            } catch (Exception exception) {
+                // the call back should have test if the request context was properly obtained
+            }
+        }
+        return super.getAccessLimits(user, workspace);
     }
 }


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8460

See also https://github.com/geoserver/geoserver/pull/1762 ; this is effectivly a continuation of that PR, making the same logic apply to `initAsync` and `createContextAsync` in addition to `runAsync`.