### PR TITLE
[GEOS-8250] WFS 2.0 DescribeFeatureType responses for app-schema type s contain a spurious WFS 2.0 jar import

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
@@ -980,7 +980,7 @@ public abstract class FeatureTypeSchemaBuilder {
         }
     }
     
-    public static final class GML32 extends GML3 {
+    public static class GML32 extends GML3 {
         /**
          * Cached gml32 schema
          */
@@ -1075,5 +1075,25 @@ public abstract class FeatureTypeSchemaBuilder {
         
     }
     
+    /**
+     * Derived from {@link GML32}, the only difference is that {@link #getWfsSchema()} is overridden
+     * to make it always return {@code null}.
+     *
+     * Useful when encoding DescribeFeatureType responses, as they don't need to import the WFS schema.
+     */
+    public static final class GML32NoWfsSchemaImport extends GML32 {
+
+        public GML32NoWfsSchemaImport(GeoServer gs) {
+            super(gs);
+        }
+
+        /**
+         * @return always {@code null}, i.e. there is no need to import the WFS schema
+         */
+        @Override
+        protected XSDSchema getWfsSchema() {
+            return null;
+        }
+    }
     
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/XmlSchemaEncoder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/XmlSchemaEncoder.java
@@ -119,7 +119,7 @@ public class XmlSchemaEncoder extends WFSDescribeFeatureTypeOutputFormat {
             MIME_TYPES.add("text/xml; subtype=gml/3.2");
         }
         public V20(GeoServer gs) {
-            super(MIME_TYPES, gs, new FeatureTypeSchemaBuilder.GML32(gs));
+            super(MIME_TYPES, gs, new FeatureTypeSchemaBuilder.GML32NoWfsSchemaImport(gs));
         }
         
         @Override

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/DescribeFeatureTypeTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/DescribeFeatureTypeTest.java
@@ -5,13 +5,17 @@
  */
 package org.geoserver.wfs.v1_1;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URLEncoder;
+
 import javax.xml.namespace.QName;
+
 import org.custommonkey.xmlunit.XMLAssert;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
@@ -24,6 +28,8 @@ import org.geoserver.util.IOUtils;
 import org.geoserver.wfs.GMLInfo;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.WFSTestSupport;
+import org.geotools.gml3.GML;
+import org.geotools.wfs.v1_1.WFS;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -299,4 +305,22 @@ public class DescribeFeatureTypeTest extends WFSTestSupport {
 //            future.get();
 //        }
 //    }
+
+    /**
+     * Tests that WFS schema is not imported in a DescribeFeatureType response.
+     */
+    @Test
+    public void testNoWfsSchemaImport() throws Exception {
+        final String typeName = CiteTestData.POLYGONS.getLocalPart();
+        String path = "ows?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName="
+            + typeName;
+        Document doc = getAsDOM(path);
+
+        assertEquals("xsd:schema", doc.getDocumentElement().getNodeName());
+        assertXpathExists("//xsd:complexType[@name='" + typeName + "Type']", doc);
+        assertXpathExists("//xsd:element[@name='" + typeName + "']", doc);
+        assertXpathExists("//xsd:import[@namespace='" + GML.NAMESPACE + "']", doc);
+        assertXpathNotExists("//xsd:import[@namespace='" + WFS.NAMESPACE + "']", doc);
+    }
+
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/DescribeFeatureTypeTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/DescribeFeatureTypeTest.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.wfs.v2_0;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -31,7 +32,7 @@ import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.GMLInfo;
 import org.geoserver.wfs.WFSInfo;
 import org.geotools.gml3.v3_2.GML;
-import org.junit.Before;
+import org.geotools.wfs.v2_0.WFS;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
@@ -413,4 +414,22 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
         dom = dom(new ByteArrayInputStream(decoded));
         assertEquals("xsd:schema", dom.getDocumentElement().getNodeName());
     }
+
+    /**
+     * Tests that WFS schema is not imported in a DescribeFeatureType response.
+     */
+    @Test
+    public void testNoWfsSchemaImport() throws Exception {
+        String typeName = getLayerId(CiteTestData.PRIMITIVEGEOFEATURE);
+
+        MockHttpServletResponse response = getAsServletResponse(
+                "wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typeNames=" + typeName);
+        assertThat(response.getContentType(), is("application/gml+xml; version=3.2"));
+
+        Document doc = dom(response, true);
+
+        assertSchema(doc, CiteTestData.PRIMITIVEGEOFEATURE);
+        assertXpathNotExists("//xsd:import[@namespace='" + WFS.NAMESPACE + "']", doc);
+    }
+
 }


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8250

Like in WFS 1.0, WFS 2.0 schema import is unnecessary when doing a describe feature type. According to WFS 2.0 standard the describe feature type should only describe the feature type not the full response:

> The DescribeFeatureType operation returns a schema description of feature types offered by a WFS instance. The schema descriptions define how a WFS expects feature instances to be encoded on input (via Insert, Update and Replace actions) and how feature instances shall be encoded on output (in response to a GetPropertyValue, GetFeature or GetFeatureWithLock operation).

This PR removes the uncessary and wrong import adn adds several tests cases for this, including app-schema integration tests.