### PR TITLE
[Backport on 2.12.x][GEOS-8485] Fix GetLegendGraphic to work on layergroup in workspace

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
@@ -160,11 +160,27 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
     @Override
     public LayerGroupInfo getLayerGroupByName(String name) {
         if (LocalWorkspace.get() != null) {
-            LayerGroupInfo layerGroup = super.getLayerGroupByName(LocalWorkspace.get(), name);
+            String wsName = LocalWorkspace.get().getName();
+
+            //prefix the unqualified name
+            if (name.contains(":")) {
+                //name already prefixed, ensure it is prefixed with the correct one
+                if (name.startsWith(wsName + ":")) {
+                    //good to go, just pass call through
+                    LayerGroupInfo layerGroup = super.getLayerGroupByName(name);
+                    if (layerGroup != null) {
+                        return wrap(layerGroup);
+                    }
+                    // else fall back on unqualified lookup
+                } else {
+                    //JD: perhaps strip of existing prefix?
+                }
+            }
+            //prefix it explicitly
+            LayerGroupInfo layerGroup = super.getLayerGroupByName(LocalWorkspace.get().getName(), name);
             if (layerGroup != null) {
                 return wrap(layerGroup);
             }
-            // else fall back on unqualified lookup
         }
 
         return wrap(super.getLayerGroupByName(name));

--- a/src/main/src/test/java/org/geoserver/catalog/impl/LocalWorkspaceCatalogTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/LocalWorkspaceCatalogTest.java
@@ -129,10 +129,12 @@ public class LocalWorkspaceCatalogTest {
         
         expect(cat.getLayerGroupByName("ws1", "lg1")).andReturn(lg1).anyTimes();
         expect(cat.getLayerGroupByName(ws1, "lg1")).andReturn(lg1).anyTimes();
+        expect(cat.getLayerGroupByName("ws1:lg1")).andReturn(lg1).anyTimes();
         expect(cat.getLayerGroupByName("lg1")).andReturn(null).anyTimes();
         
         expect(cat.getLayerGroupByName("ws2", "lg2")).andReturn(lg2).anyTimes();
         expect(cat.getLayerGroupByName(ws2, "lg2")).andReturn(lg2).anyTimes();
+        expect(cat.getLayerGroupByName("ws2:lg2")).andReturn(lg2).anyTimes();
         expect(cat.getLayerGroupByName("lg2")).andReturn(null).anyTimes();
 
         //expect(cat.getLayerByName("ws1", "l1")).andReturn(l1).anyTimes();
@@ -204,6 +206,7 @@ public class LocalWorkspaceCatalogTest {
         
         LocalWorkspace.set(ws1);
         assertNotNull(catalog.getLayerGroupByName("lg1"));
+        assertNotNull(catalog.getLayerGroupByName("ws1:lg1"));
         assertNull(catalog.getLayerGroupByName("lg2"));
 
         LocalWorkspace.remove();
@@ -212,6 +215,7 @@ public class LocalWorkspaceCatalogTest {
 
         LocalWorkspace.set(ws2);
         assertNull(catalog.getLayerGroupByName("lg1"));
+        assertNotNull(catalog.getLayerGroupByName("ws2:lg2"));
         assertNotNull(catalog.getLayerGroupByName("lg2"));
 
         LocalWorkspace.remove();


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8485

Backport from MR #2681 to branch 2.12.x