### PR TITLE
[GEOS-8487] Quickfix for BruteForce

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/BruteForceListener.java
+++ b/src/main/src/main/java/org/geoserver/security/BruteForceListener.java
@@ -117,7 +117,9 @@ public class BruteForceListener
         if (config.getWhitelistAddressMatchers() == null) {
             return false;
         }
-
+        if(request==null) {
+            return true;
+        }
         return config.getWhitelistAddressMatchers().stream()
                 .anyMatch(matcher -> matcher.matches(request));
     }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8487

BruteForce can't work when Request is null.