### PR TITLE
[GEOS-8108] fix for null namespaces with GetPropertyValue and stored queries requests

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSWorkspaceQualifier.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSWorkspaceQualifier.java
@@ -190,9 +190,11 @@ public class WFSWorkspaceQualifier extends WorkspaceQualifyingCallback {
     }
     
     void qualifyTypeNames(List names, WorkspaceInfo ws, NamespaceInfo ns) {
-        for (int i = 0; i < names.size(); i++) {
-            QName name = (QName) names.get(i);
-            names.set(i, qualifyTypeName(name, ws, ns));
+        if (names != null) {
+            for (int i = 0; i < names.size(); i++) {
+                QName name = (QName) names.get(i);
+                names.set(i, qualifyTypeName(name, ws, ns));
+            }
         }
     }
     


### PR DESCRIPTION
Link to related JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-8108

This is the backport of the fix to GeoServer 2.12.x (stable).