### PR TITLE
[GEOS-8250] WFS 2.0 DescribeFeatureType responses for app-schema types contain a spurious WFS 2.0 jar import

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -6,6 +6,9 @@
 
 package org.geoserver.test;
 
+import static org.geoserver.test.AbstractAppSchemaMockData.GSML_SCHEMA_LOCATION_URL;
+import static org.geoserver.test.AbstractAppSchemaMockData.GSML_URI;
+import static org.geoserver.test.FeatureChainingMockData.EX_URI;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -26,8 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import net.sf.json.JSON;
-import net.sf.json.JSONObject;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.util.IOUtils;
 import org.geoserver.wfs.WFSInfo;
@@ -50,6 +51,9 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.PropertyIsLike;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
 
 /**
  * WFS GetFeature to test integration of {@link AppSchemaDataAccess} with GeoServer.
@@ -406,6 +410,61 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         // nothing else
         assertXpathCount(0, "//xsd:complexType", doc);
         assertXpathCount(0, "//xsd:element", doc);
+    }
+
+    /**
+     * Tests that WFS schema is never imported in a DescribeFeatureType response.
+     *
+     * <p>
+     * <strong>Remarks:</strong> this test only targets WFS 2.0, as 1.1.0 is sufficiently covered
+     * by other tests. 
+     * </p>
+     */
+    @Test
+    public void testDescribeFeatureTypeNoWfsSchemaImport() {
+        // one feature type --> schema is included, no imports
+        Document doc = getAsDOM(
+                "wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typename=gsml:GeologicUnit");
+        assertXpathCount(0, "//xsd:import", doc);
+        assertXpathCount(1, "//xsd:include", doc);
+        assertImportNotExists(doc, WFS.NAMESPACE);
+        assertIncludeExists(doc, GSML_SCHEMA_LOCATION_URL);
+
+        // two feature types, same schema / namespace --> schema is included once, no imports
+        doc = getAsDOM(
+                "wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typename=gsml:GeologicUnit,gsml:MappedFeature");
+        assertXpathCount(0, "//xsd:import", doc);
+        assertXpathCount(0, "//xsd:import[@namespace='" + WFS.NAMESPACE + "']", doc);
+        assertImportNotExists(doc, WFS.NAMESPACE);
+        assertIncludeExists(doc, GSML_SCHEMA_LOCATION_URL);
+
+        // two feature types, different schemas / namespaces --> first schema is included, second is imported
+        doc = getAsDOM(
+                "wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typename=gsml:GeologicUnit,ex:FirstParentFeature");
+        // target namespace is set to the namespace of the first requested feature type
+        assertXpathEvaluatesTo(GSML_URI, "//@targetNamespace", doc);
+        assertXpathCount(1, "//xsd:import", doc);
+        assertXpathCount(1, "//xsd:include", doc);
+        assertImportNotExists(doc, WFS.NAMESPACE);
+        // the schema of the feature type whose namespace is equal to the target namespace is included
+        assertIncludeExists(doc, GSML_SCHEMA_LOCATION_URL);
+        // the other schema is imported
+        assertImportExists(doc, EX_URI);
+        assertXpathEvaluatesTo(getExSchemaOneLocation(), "//xsd:import/@schemaLocation", doc);
+
+        // same thing, reverse order of the requested types
+        doc = getAsDOM(
+                "wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typename=ex:FirstParentFeature,gsml:GeologicUnit");
+        // target namespace is set to the namespace of the first requested feature type
+        assertXpathEvaluatesTo(EX_URI, "//@targetNamespace", doc);
+        assertXpathCount(1, "//xsd:import", doc);
+        assertXpathCount(1, "//xsd:include", doc);
+        assertImportNotExists(doc, WFS.NAMESPACE);
+        // the schema of the feature type whose namespace is equal to the target namespace is included
+        assertIncludeExists(doc, getExSchemaOneLocation());
+        // the other schema is imported
+        assertImportExists(doc, GSML_URI);
+        assertXpathEvaluatesTo(GSML_SCHEMA_LOCATION_URL, "//xsd:import/@schemaLocation", doc);
     }
 
     /**
@@ -1640,4 +1699,17 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         String jsonText = new String(output.toByteArray());
         return JSONObject.fromObject(jsonText);
     }
+
+    private void assertImportExists(Document doc, String ns) {
+        assertXpathCount(1, "//xsd:import[@namespace='" + ns + "']", doc);
+    }
+
+    private void assertImportNotExists(Document doc, String ns) {
+        assertXpathCount(0, "//xsd:import[@namespace='" + ns + "']", doc);
+    }
+
+    private void assertIncludeExists(Document doc, String schemaLocation) {
+        assertXpathCount(1, "//xsd:include[@schemaLocation='" + schemaLocation + "']", doc);
+    }
+
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
@@ -980,7 +980,7 @@ public abstract class FeatureTypeSchemaBuilder {
         }
     }
     
-    public static final class GML32 extends GML3 {
+    public static class GML32 extends GML3 {
         /**
          * Cached gml32 schema
          */
@@ -1075,5 +1075,25 @@ public abstract class FeatureTypeSchemaBuilder {
         
     }
     
+    /**
+     * Derived from {@link GML32}, the only difference is that {@link #getWfsSchema()} is overridden
+     * to make it always return {@code null}.
+     *
+     * Useful when encoding DescribeFeatureType responses, as they don't need to import the WFS schema.
+     */
+    public static final class GML32NoWfsSchemaImport extends GML32 {
+
+        public GML32NoWfsSchemaImport(GeoServer gs) {
+            super(gs);
+        }
+
+        /**
+         * @return always {@code null}, i.e. there is no need to import the WFS schema
+         */
+        @Override
+        protected XSDSchema getWfsSchema() {
+            return null;
+        }
+    }
     
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/XmlSchemaEncoder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/XmlSchemaEncoder.java
@@ -119,7 +119,7 @@ public class XmlSchemaEncoder extends WFSDescribeFeatureTypeOutputFormat {
             MIME_TYPES.add("text/xml; subtype=gml/3.2");
         }
         public V20(GeoServer gs) {
-            super(MIME_TYPES, gs, new FeatureTypeSchemaBuilder.GML32(gs));
+            super(MIME_TYPES, gs, new FeatureTypeSchemaBuilder.GML32NoWfsSchemaImport(gs));
         }
         
         @Override

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/DescribeFeatureTypeTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/DescribeFeatureTypeTest.java
@@ -5,13 +5,17 @@
  */
 package org.geoserver.wfs.v1_1;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URLEncoder;
+
 import javax.xml.namespace.QName;
+
 import org.custommonkey.xmlunit.XMLAssert;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
@@ -24,6 +28,8 @@ import org.geoserver.util.IOUtils;
 import org.geoserver.wfs.GMLInfo;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.WFSTestSupport;
+import org.geotools.gml3.GML;
+import org.geotools.wfs.v1_1.WFS;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -299,4 +305,22 @@ public class DescribeFeatureTypeTest extends WFSTestSupport {
 //            future.get();
 //        }
 //    }
+
+    /**
+     * Tests that WFS schema is not imported in a DescribeFeatureType response.
+     */
+    @Test
+    public void testNoWfsSchemaImport() throws Exception {
+        final String typeName = CiteTestData.POLYGONS.getLocalPart();
+        String path = "ows?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName="
+            + typeName;
+        Document doc = getAsDOM(path);
+
+        assertEquals("xsd:schema", doc.getDocumentElement().getNodeName());
+        assertXpathExists("//xsd:complexType[@name='" + typeName + "Type']", doc);
+        assertXpathExists("//xsd:element[@name='" + typeName + "']", doc);
+        assertXpathExists("//xsd:import[@namespace='" + GML.NAMESPACE + "']", doc);
+        assertXpathNotExists("//xsd:import[@namespace='" + WFS.NAMESPACE + "']", doc);
+    }
+
 }


### PR DESCRIPTION
Link to related JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-8250

This is the backport of #2676 to GeoServer 2.12.x (stable).