### PR TITLE
[GEOS-6540] Fix problem in ArcGrid WCS format (advertised as ARCGRID, supported ArcGrid)

### DIFF
--- a/src/wcs/src/main/java/org/geoserver/wcs/responses/AscCoverageResponseDelegate.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/responses/AscCoverageResponseDelegate.java
@@ -26,35 +26,48 @@ import org.geotools.gce.arcgrid.ArcGridWriter;
  */
 public class AscCoverageResponseDelegate extends BaseCoverageResponseDelegate implements CoverageResponseDelegate {
 
+    public static final String ARCGRID_COVERAGE_FORMAT = "ARCGRID";
+    public static final String ARCGRID_COMPRESSED_COVERAGE_FORMAT = ARCGRID_COVERAGE_FORMAT + "-GZIP";
+    private static final String ARCGRID_MIME_TYPE = "text/plain";
+    private static final String ARCGRID_COMPRESSED_MIME_TYPE = "application/x-gzip";
+    private static final String ARCGRID_FILE_EXTENSION = "asc";
+    private static final String ARCGRID_COMPRESSED_FILE_EXTENSION = "asc.gz";
+
     @SuppressWarnings("serial")
     public AscCoverageResponseDelegate(GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList("ArcGrid","ArcGrid-GZIP"), //output formats
+                Arrays.asList(ARCGRID_COVERAGE_FORMAT, ARCGRID_COMPRESSED_COVERAGE_FORMAT, "ArcGrid","ArcGrid-GZIP"), //output formats
                 new HashMap<String, String>(){ // file extensions
                     {
-                        put("ArcGrid", "asc");
-                        put("ArcGrid-GZIP", "asc.gz");
-                        put("text/plain", "asc");
-                        put("application/x-gzip", "ArcGrid-GZIP");
+                        put("ArcGrid", ARCGRID_FILE_EXTENSION);
+                        put("ArcGrid-GZIP", ARCGRID_COMPRESSED_FILE_EXTENSION);
+                        put(ARCGRID_MIME_TYPE, ARCGRID_FILE_EXTENSION);
+                        put(ARCGRID_COMPRESSED_MIME_TYPE, ARCGRID_COMPRESSED_FILE_EXTENSION);
+                        put(ARCGRID_COVERAGE_FORMAT, ARCGRID_FILE_EXTENSION);
+                        put(ARCGRID_COMPRESSED_COVERAGE_FORMAT, ARCGRID_COMPRESSED_FILE_EXTENSION);
                     }
                 },
                 new HashMap<String, String>(){ //mime types
                     {
-                        put("ArcGrid", "text/plain");
-                        put("ArcGrid-GZIP", "application/x-gzip");
+                        put("ArcGrid", ARCGRID_MIME_TYPE);
+                        put("ArcGrid-GZIP", ARCGRID_COMPRESSED_MIME_TYPE);
+                        put(ARCGRID_COVERAGE_FORMAT, ARCGRID_MIME_TYPE);
+                        put(ARCGRID_COMPRESSED_COVERAGE_FORMAT, ARCGRID_COMPRESSED_MIME_TYPE);
                     }
                 });
     }
 
     private boolean isOutputCompressed(String outputFormat) {
-        return "ArcGrid-GZIP".equalsIgnoreCase(outputFormat) || "application/arcgrid;gzipped=\"true\"".equals(outputFormat);
+        return ARCGRID_COMPRESSED_COVERAGE_FORMAT.equalsIgnoreCase(outputFormat)
+                || "application/arcgrid;gzipped=\"true\"".equals(outputFormat)
+                || ARCGRID_COMPRESSED_MIME_TYPE.equals(outputFormat);
     }
 
     public void encode(GridCoverage2D sourceCoverage, String outputFormat,  Map<String,String> econdingParameters,OutputStream output) throws ServiceException, IOException {
         if (sourceCoverage == null) {
             throw new IllegalStateException(new StringBuffer(
-                    "It seems prepare() has not been called").append(" or has not succeed")
+                    "It seems prepare() has not been called").append(" or has not succeeded")
                     .toString());
         }
 

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -193,6 +193,64 @@ public class GetCoverageTest extends WCSTestSupport {
     }
     
     @Test
+    public void testGEOS6540_1() throws Exception {
+        String queryString = "wcs?sourcecoverage=" + getLayerId(MOSAIC) + "&request=getcoverage" +
+                "&service=wcs&version=1.0.0&format=ArcGrid&crs=EPSG:4326" +
+                "&bbox=0,0,1,1&width=50&height=60";
+
+        MockHttpServletResponse response = getAsServletResponse(queryString);
+        assertEquals("text/plain", response.getContentType());
+        String content = response.getContentAsString();
+        assertTrue(content.startsWith("NCOLS 50\nNROWS 60\n"));
+        assertEquals("inline; filename=sf:rasterFilter.asc", response.getHeader("Content-Disposition"));
+    }
+
+    @Test
+    public void testGEOS6540_2() throws Exception {
+        String queryString = "wcs?sourcecoverage=" + getLayerId(MOSAIC) + "&request=getcoverage" +
+                "&service=wcs&version=1.0.0&format=ARCGRID&crs=EPSG:4326" +
+                "&bbox=0,0,1,1&width=50&height=60";
+
+        MockHttpServletResponse response = getAsServletResponse(queryString);
+        String content = response.getContentAsString();
+        assertEquals("text/plain", response.getContentType());
+        assertTrue(content.startsWith("NCOLS 50\nNROWS 60\n"));
+        assertEquals("inline; filename=sf:rasterFilter.asc", response.getHeader("Content-Disposition"));
+    }
+
+    @Test
+    public void testGEOS6540_3() throws Exception {
+        String queryString = "wcs?sourcecoverage=" + getLayerId(MOSAIC) + "&request=getcoverage" +
+                "&service=wcs&version=1.0.0&format=ARCGRID-GZIP&crs=EPSG:4326" +
+                "&bbox=0,0,1,1&width=50&height=60";
+
+        MockHttpServletResponse response = getAsServletResponse(queryString);
+        byte[] content = response.getContentAsByteArray();
+        assertEquals("application/x-gzip", response.getContentType());
+        assertEquals((byte)0x1f, content[0]);
+        assertEquals((byte)0x8b, content[1]);
+        assertEquals((byte)0x08, content[2]);
+        assertEquals((byte)0x00, content[3]);
+        assertEquals("inline; filename=sf:rasterFilter.asc.gz", response.getHeader("Content-Disposition"));
+    }
+
+    @Test
+    public void testGEOS6540_4() throws Exception {
+        String queryString = "wcs?sourcecoverage=" + getLayerId(MOSAIC) + "&request=getcoverage" +
+                "&service=wcs&version=1.0.0&format=application/x-gzip&crs=EPSG:4326" +
+                "&bbox=0,0,1,1&width=50&height=60";
+
+        MockHttpServletResponse response = getAsServletResponse(queryString);
+        byte[] content = response.getContentAsByteArray();
+        assertEquals("application/x-gzip", response.getContentType());
+        assertEquals((byte)0x1f, content[0]);
+        assertEquals((byte)0x8b, content[1]);
+        assertEquals((byte)0x08, content[2]);
+        assertEquals((byte)0x00, content[3]);
+        assertEquals("inline; filename=sf:rasterFilter.asc.gz", response.getHeader("Content-Disposition"));
+    }
+
+    @Test
     public void testNonExistentCoverage() throws Exception {
         String queryString ="&request=getcoverage&service=wcs&version=1.0.0&format=image/geotiff&bbox=146,-45,147,-42"+
             "&crs=EPSG:4326&width=150&height=150";

--- a/src/web/wcs/src/main/java/org/geoserver/wcs/web/publish/WCSLayerConfig.java
+++ b/src/web/wcs/src/main/java/org/geoserver/wcs/web/publish/WCSLayerConfig.java
@@ -23,6 +23,7 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.LayerInfo;
+import static org.geoserver.wcs.responses.AscCoverageResponseDelegate.ARCGRID_COVERAGE_FORMAT;
 import org.geoserver.web.publish.PublishedConfigurationPanel;
 import org.geoserver.web.wicket.LiveCollectionModel;
 import org.geoserver.web.wicket.SimpleChoiceRenderer;
@@ -34,7 +35,7 @@ public class WCSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
 
     private static final long serialVersionUID = 6120092654147588736L;
     
-    private static final List<String> WCS_FORMATS = Arrays.asList("GIF","PNG","JPEG","TIFF","GTOPO30","GEOTIFF","IMAGEMOSAIC","ARCGRID");
+    private static final List<String> WCS_FORMATS = Arrays.asList("GIF","PNG","JPEG","TIFF","GTOPO30","GEOTIFF","IMAGEMOSAIC", ARCGRID_COVERAGE_FORMAT);
     private static final List<String> INTERPOLATIONS = Arrays.asList("nearest neighbor","bilinear","bicubic");
     
     private List<String> selectedRequestSRSs;


### PR DESCRIPTION
This change just allows both, because we advertise it as ARCGRID in some places (including as
default publish format) and that is used in the default resource directory. So changing it everywhere still seemed likely to cause breakage (e.g. for upgrades in place).

Also fixes case where requesting compressed mime-type doesn't return compressed.

Also fixes case where requesting compressed mime-type returns an unusual file extension
("ArcGrid-GZIP" instead of "asc.gz").