### PR TITLE
[GEOS-8543] [GEOS-8544] Demo page fixes

### DIFF
--- a/src/web/demo/src/main/java/org/geoserver/web/demo/DemoRequestResponse.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/DemoRequestResponse.java
@@ -11,6 +11,7 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.HiddenField;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.geoserver.web.GeoServerBasePage;
 import org.vfny.geoserver.wfs.servlets.TestWfsPost;
@@ -48,10 +49,24 @@ public class DemoRequestResponse extends WebPage {
 
         Form form = new Form("form");
         add(form);
-        form.add(new HiddenField("url", new PropertyModel(model, "requestUrl")));
-        form.add(new TextArea("body", new PropertyModel(model, "requestBody")));
-        form.add(new HiddenField("username", new PropertyModel(model, "userName")));
-        form.add(new HiddenField("password", new PropertyModel(model, "password")));
+        form.add(new HiddenField<String>("url", new PropertyModel<>(model, "requestUrl")));
+        form.add(new TextArea<>("body", new PropertyModel<>(model, "requestBody")));
+        form.add(new HiddenField<String>("username", new PropertyModel<>(model, "userName")));
+        //[WICKET-6211] Wicket clears the password after submission, so we need to save as a string now.
+        HiddenField<String> passwordField = new HiddenField<String>("password", new Model<>(((DemoRequest)model.getObject()).getPassword())) {
+            @Override
+            protected void onDetach() {
+                //clear the password after we are done with it
+                clearInput();
+                if (getModel() != null) {
+                    setModelObject(null);
+                }
+                super.onDetach();
+            }
+        };
+
+        form.add(passwordField);
+
 
         // override the action property of the form to submit to the TestWfsPost
         // servlet

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/DemoRequestsPageTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/DemoRequestsPageTest.java
@@ -233,6 +233,37 @@ public class DemoRequestsPageTest extends GeoServerWicketTestSupport {
             getGeoServer().save(global);
         }
     }
+
+    @Test
+    public void testAuthentication() {
+        final FormTester requestFormTester = tester.newFormTester("demoRequestsForm");
+
+        final String requestName = "WMS_describeLayer.url";
+        requestFormTester.select("demoRequestsList", 1);
+
+        /*
+         * There's an AjaxFormSubmitBehavior attached to onchange so force it
+         */
+        tester.executeAjaxEvent("demoRequestsForm:demoRequestsList", "change");
+        tester.assertModelValue("demoRequestsForm:demoRequestsList", requestName);
+
+        String username = "admin";
+        String password = "geoserver";
+
+        requestFormTester.setValue("username", username);
+        requestFormTester.setValue("password", password);
+
+        final boolean isAjax = true;
+        tester.clickLink("demoRequestsForm:submit", isAjax);
+
+        tester.assertVisible("responseWindow");
+
+        IModel model = tester.getLastRenderedPage().getDefaultModel();
+        assertTrue(model.getObject() instanceof DemoRequest);
+
+        assertEquals(username, tester.getLastRequest().getPostParameters().getParameterValue("username").toString());
+        assertEquals(password, tester.getLastRequest().getPostParameters().getParameterValue("password").toString());
+    }
     
     @Test
     public void testSerializable() {

--- a/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostOnlineIntegrationTest.java
+++ b/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostOnlineIntegrationTest.java
@@ -1,0 +1,104 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.vfny.geoserver.wfs.servlets;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * Tests the functionality of the {@link TestWfsPost} servlet on a running geoserver.
+ *
+ * This test assumes a running GeoServer on port 8080 with the release data dir.
+ *
+ * @author Torben Barsballe
+ *
+ */
+public class TestWfsPostOnlineIntegrationTest {
+
+    public static final String WFS_REQUEST =
+            "<wfs:GetFeature service=\"WFS\" version=\"1.1.0\"\n" +
+            "  xmlns:ne=\"http://www.naturalearthdata.com\"\n" +
+            "  xmlns:wfs=\"http://www.opengis.net/wfs\"\n" +
+            "  xmlns:ogc=\"http://www.opengis.net/ogc\"\n" +
+            "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+            "  xsi:schemaLocation=\"http://www.opengis.net/wfs\n" +
+            "                      http://schemas.opengis.net/wfs/1.1.0/wfs.xsd\">\n" +
+            "  <wfs:Query typeName=\"states\">\n" +
+            "    <ogc:Filter>\n" +
+            "       <ogc:FeatureId fid=\"states.3\"/>\n" +
+            "    </ogc:Filter>\n" +
+            "    </wfs:Query>\n" +
+            "</wfs:GetFeature>";
+
+    protected MockHttpServletResponse doWfsPost() throws ServletException, IOException {
+        return doWfsPost(null, null);
+    }
+    protected MockHttpServletResponse doWfsPost(String username, String password) throws ServletException, IOException {
+        TestWfsPost servlet = new TestWfsPost();
+        MockHttpServletRequest request = TestWfsPostTest.buildMockRequest();
+        request.setParameter("url", "http://localhost:8080/geoserver/wfs");
+        request.setParameter("body", WFS_REQUEST);
+
+        if (username != null && password != null) {
+            request.setParameter("username", username);
+            request.setParameter("password", password);
+        }
+        request.setMethod("GET");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+
+        return response;
+    }
+
+    private boolean isOnline() {
+        try {
+            URL u = new URL("http://localhost:8080/geoserver");
+            HttpURLConnection huc =  (HttpURLConnection)  u.openConnection();
+            huc.setRequestMethod("HEAD");
+            huc.connect();
+            return huc.getResponseCode() == 200;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    @Test
+    public void testWfsPost() throws ServletException, IOException {
+        Assume.assumeTrue(isOnline());
+        MockHttpServletResponse response = doWfsPost();
+
+        assertTrue(response.getContentAsString().contains("wfs:FeatureCollection"));
+    }
+
+    @Test
+    public void testWfsPostAuthenticated() throws ServletException, IOException {
+        Assume.assumeTrue(isOnline());
+        MockHttpServletResponse response = doWfsPost("admin", "geoserver");
+
+        assertTrue(response.getContentAsString().contains("wfs:FeatureCollection"));
+    }
+
+    @Test
+    public void testWfsPostInvalidAuth() throws ServletException, IOException {
+        Assume.assumeTrue(isOnline());
+        MockHttpServletResponse response = doWfsPost("admin", "badpassword");
+
+        assertFalse(response.getContentAsString().contains("wfs:FeatureCollection"));
+        assertTrue(response.getContentAsString().contains("HTTP response: 401"));
+    }
+
+}

--- a/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
+++ b/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
@@ -81,7 +81,7 @@ public class TestWfsPostTest {
         }
     }
     
-    private MockHttpServletRequest buildMockRequest() {
+    protected static MockHttpServletRequest buildMockRequest() {
         
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setScheme("http");


### PR DESCRIPTION
This one wound up turning into two different bugs partway through fixing it. Still submitting as one PR, since the bugs are closely related, but included the fixes as separate commits.

[GEOS-8543](https://osgeo-org.atlassian.net/browse/GEOS-8543) - Error handling just used a PrintWriter for output, so if an error occurred during error handling, then everything already written would be included in the new error response, resulting in malformed output. Fixed, and added some (online) tests (not optimal, but there isn't really any other way to test the full servlet functionality)

[GEOS-8544](https://osgeo-org.atlassian.net/browse/GEOS-8544) - When sending a request, the demo page sends the form content to a new form in the modal window page, which then sends that to GeoServer and handled the response. Upgrading to Wicket 7.6 broke authentication for this, due to [WICKET-6211](https://issues.apache.org/jira/browse/WICKET-6211). Fixed, and added equivalent password-clearing behaviour to the fix.