### PR TITLE
[GEOS-8545] Fixed incorrect GetFeatureInfo for coverage using reproject to declared

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
@@ -103,7 +103,8 @@ public class RasterLayerIdentifier implements LayerIdentifier {
         CoordinateReferenceSystem requestedCRS = params.getRequestedCRS();
 
         CoordinateReferenceSystem targetCRS;
-        if (cinfo.getProjectionPolicy() == ProjectionPolicy.NONE) {
+        if ((cinfo.getProjectionPolicy() == ProjectionPolicy.NONE) ||
+                (cinfo.getProjectionPolicy() == ProjectionPolicy.REPROJECT_TO_DECLARED)) {
             targetCRS = cinfo.getNativeCRS();
         } else {
             targetCRS = cinfo.getCRS();

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -842,6 +842,29 @@ public class GetFeatureInfoTest extends WMSTestSupport {
        assertTrue(result.contains("2.0"));
    }
 
+   @Test
+   public void testRasterReprojectToDeclared() throws Exception {
+       // force it to "reproject to declared"
+       CoverageInfo ci = getCatalog().getCoverageByName(getLayerId(CUSTOM));
+       ci.setProjectionPolicy(ProjectionPolicy.REPROJECT_TO_DECLARED);
+       ci.setSRS("EPSG:900913");
+       getCatalog().save(ci);
+
+       // make a first reprojected request on a pixel that's black (0)
+       String result = getAsString("wms?REQUEST=GetFeatureInfo&EXCEPTIONS=application%2Fvnd.ogc.se_xml" +
+           "&BBOX=-887430.34934%2C4467316.30601%2C-885862.361705%2C4468893.535223&SERVICE=WMS" +
+           "&INFO_FORMAT=text%2Fplain&QUERY_LAYERS=cite%3Acustom&FEATURE_COUNT=50&Layers=custom" +
+           "&WIDTH=509&HEIGHT=512&format=image%2Fjpeg&styles=&srs=epsg%3A900913&version=1.1.1&x=177&y=225");
+       assertTrue(result.contains("0.0"));
+
+       // and now one with actual data, 2
+       result = getAsString("wms?REQUEST=GetFeatureInfo&EXCEPTIONS=application%2Fvnd.ogc.se_xml" +
+           "&BBOX=-887430.34934%2C4467316.30601%2C-885862.361705%2C4468893.535223&SERVICE=WMS" +
+           "&INFO_FORMAT=text%2Fplain&QUERY_LAYERS=cite%3Acustom&FEATURE_COUNT=50&Layers=custom" +
+           "&WIDTH=509&HEIGHT=512&format=image%2Fjpeg&styles=&srs=epsg%3A900913&version=1.1.1&x=135&y=223");
+       assertTrue(result.contains("2.0"));
+   }
+
    @Test 
    public void testGMLWithPostFilter() throws Exception {
        //we need to create a situation where a post filter is setup, simple way is to change the 


### PR DESCRIPTION
This pull request fixes incorrect WMS GetFeatureInfo responses for raster layers using "Reproject native to declared" with a different native and declared CRS.  RasterLayerIdentifier.identify makes multiple calls to the GridCoverage2DReader getOriginalEnvelope, getOriginalGridToWorld and getCoordinateReferenceSystem methods which should all be returning responses using the native CRS instead of the declared CRS when the projection policy is reproject to declared.

This pull request can be backported to 2.12.x and 2.11.x.