### PR TITLE
Fix serialization issue with tile layers with empty style parameter filter

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
@@ -15,10 +15,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
@@ -82,7 +79,8 @@ public class DefaultTileLayerCatalog implements TileLayerCatalog {
         // setup xstream security for local classes
         this.serializer = configuredXstream;
         this.serializer.allowTypeHierarchy(GeoServerTileLayerInfo.class);
-        this.serializer.allowTypeHierarchy(SortedSet.class);
+        //have to use a string here because UnmodifiableSet is private
+        this.serializer.allowTypes(new String[]{"java.util.Collections$UnmodifiableSet"});
 
     }
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/DefaultTileLayerCatalogTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/DefaultTileLayerCatalogTest.java
@@ -10,6 +10,7 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 
 import java.io.File;
+import java.util.Collections;
 
 import org.apache.commons.io.FileUtils;
 import org.geoserver.catalog.impl.ModificationProxy;
@@ -93,6 +94,44 @@ public class DefaultTileLayerCatalogTest {
             info.setName("name1");
             info.getMimeFormats().add("image/png");
             info.getMimeFormats().add("image/jpeg");
+
+            assertNull(catalog.save(info));
+
+            original = catalog.getLayerById("id1");
+            assertEquals(info.getMimeFormats(), original.getMimeFormats());
+        }
+
+        original.getMimeFormats().clear();
+        original.getMimeFormats().add("image/gif");
+        original.setName("name2");
+
+        final GeoServerTileLayerInfo oldValue = catalog.save(original);
+
+        assertNotNull(oldValue);
+        assertEquals(ImmutableSet.of("image/png", "image/jpeg"), oldValue.getMimeFormats());
+        assertEquals("name1", oldValue.getName());
+
+        assertNull(catalog.getLayerByName("name1"));
+        assertNotNull(catalog.getLayerByName("name2"));
+
+        GeoServerTileLayerInfo modified = catalog.getLayerById("id1");
+        assertEquals(ImmutableSet.of("image/gif"), modified.getMimeFormats());
+    }
+
+    @Test
+    public void testSaveWithEmptyStyleParamFilter() {
+        final GeoServerTileLayerInfo original;
+        {
+            final GeoServerTileLayerInfo info = new GeoServerTileLayerInfoImpl();
+            info.setId("id1");
+            info.setName("name1");
+            info.getMimeFormats().add("image/png");
+            info.getMimeFormats().add("image/jpeg");
+
+            StyleParameterFilter parameterFilter = new StyleParameterFilter();
+            parameterFilter.setStyles(Collections.emptySet());
+            info.addParameterFilter(parameterFilter);
+
             assertNull(catalog.save(info));
 
             original = catalog.getLayerById("id1");


### PR DESCRIPTION
This fixes an issue with tile layers that have an empty "Allowed Styles" parameter filter when saving. The issue has to do with Collections.unmodifiableSet not being serializable after the tile layer catalog switched to the SecureXstream implementation.

The issue mainly affected the backup/restore community module, which was failing when a tile layer had now styles selected except for the default.