### PR TITLE
[GEOS-8493] Support POST for non-SLD styles

### DIFF
--- a/src/community/mbstyle/src/test/java/org/geoserver/rest/catalog/MBStyleControllerTest.java
+++ b/src/community/mbstyle/src/test/java/org/geoserver/rest/catalog/MBStyleControllerTest.java
@@ -164,4 +164,29 @@ public class MBStyleControllerTest extends GeoServerSystemTestSupport {
         catalog.remove(styleInfo);
     }
 
+    @Test
+    public void testPostJson() throws Exception {
+        String jsonBody = newMbStyle();
+        Catalog cat = getCatalog();
+        assertNull("foo not available", cat.getStyleByName("foo"));
+
+        MockHttpServletResponse response = postAsServletResponse("/rest/styles?name=foo",jsonBody, MBStyleHandler.MIME_TYPE);
+        assertEquals(201, response.getStatus());
+
+        GeoServerResourceLoader resources = catalog.getResourceLoader();
+        Resource resource = resources.get("/styles/foo.json");
+        String definition = new String(resource.getContents());
+        assertTrue("is json", definition.contains("\"circle-color\": \"#FFFFFF\""));
+
+        StyleInfo styleInfo = catalog.getStyleByName("foo");
+        Style s = styleInfo.getStyle();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        SLDHandler handler = new SLDHandler();
+        handler.encode(Styles.sld(s), SLDHandler.VERSION_10, false, out);
+        String contentOut = new String(out.toByteArray());
+        assertTrue(contentOut.contains("<sld:Name>foo</sld:Name>"));
+        catalog.remove(styleInfo);
+    }
+
 }

--- a/src/extension/ysld/src/test/java/org/geoserver/rest/catalog/YsldStyleControllerTest.java
+++ b/src/extension/ysld/src/test/java/org/geoserver/rest/catalog/YsldStyleControllerTest.java
@@ -99,6 +99,34 @@ public class YsldStyleControllerTest extends GeoServerSystemTestSupport {
         assertTrue(content.contains("<sld:Name>foo</sld:Name>"));
         catalog.remove(styleInfo);
     }
+
+    @Test
+    public void testPostYSLD() throws Exception {
+        // step 1 create style info with correct format
+        Catalog cat = getCatalog();
+        assertNull("foo not available",cat.getStyleByName("foo"));
+
+        String content = newYSLD();
+        MockHttpServletResponse response = postAsServletResponse( "/rest/styles?name=foo", content, YsldHandler.MIMETYPE);
+        assertEquals( 201, response.getStatus() );
+
+        GeoServerResourceLoader resources = catalog.getResourceLoader();
+
+        Resource resource = resources.get("/styles/foo.yaml");
+
+        String definition = new String(resource.getContents());
+        assertTrue("is yaml",definition.contains("stroke-color: '#FF0000'"));
+
+        StyleInfo styleInfo = catalog.getStyleByName( "foo" );
+        Style s = styleInfo.getStyle();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        SLDHandler handler = new SLDHandler();
+        handler.encode(Styles.sld(s), SLDHandler.VERSION_10, false, out);
+        content = new String(out.toByteArray());
+        assertTrue(content.contains("<sld:Name>foo</sld:Name>"));
+        catalog.remove(styleInfo);
+    }
     
     @Test
     public void testPutYSLD() throws Exception {


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8493

In order to make this fix a bit more sane, this PR also includes heavy refactoring on the StyleController class, moving most common code snippets into methods, and making each endpoint implementation more consistent with respect to behaviour, error messages, and variable names. As part of this, some methods were moved to different places in the file, so it might be a little difficult to follow the changes (the file structure was a mess before, it should be more organized now).

Functionality-wise, the only change should be the Support for POSTing non-SLD files (StyleController has pretty good test cases, and they are all happy, so I am reasonably confident in this). Some error messages _may_ have changed to be more consistent between different methods.