### PR TITLE
[GEOS-4339][GEOS-5356][GEOS-6227][GEOS-7682] REST API - Use prefixed layer names in lists and links

### DIFF
--- a/doc/en/api/1.0.0/layergroups.yaml
+++ b/doc/en/api/1.0.0/layergroups.yaml
@@ -101,11 +101,11 @@ paths:
                 <publishables>
                   <published type="layer">
                     <name>sfdem</name>
-                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/sfdem.xml" type="application/xml"/>
+                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/sf/layers/sfdem.xml" type="application/xml"/>
                   </published>
                   <published type="layer">
                     <name>streams</name>
-                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/streams.xml" type="application/xml"/>
+                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/sf/layers/streams.xml" type="application/xml"/>
                   </published>
                 </publishables>
                 <styles>
@@ -139,10 +139,10 @@ paths:
                 "publishables":{"published":[
                     {"@type":"layer",
                     "name":"sfdem",
-                    "href":"http://localhost:8080/geoserver/rest/layers/sfdem.json"},
+                    "href":"http://localhost:8080/geoserver/rest/workspaces/sf/layers/sfdem.json"},
                     {"@type":"layer",
                     "name":"streams",
-                    "href":"http://localhost:8080/geoserver/rest/layers/streams.json"}]},
+                    "href":"http://localhost:8080/geoserver/rest/workspaces/sf/layers/streams.json"}]},
                 "styles": {"style":[
                     {"name":"dem",
                     "href":"http://localhost:8080/geoserver/rest/styles/dem.json"},
@@ -292,7 +292,7 @@ paths:
             $ref: "#/definitions/Layergroup"
           examples:
             application/json: |
-              {"layerGroup":{"name":"spearfish","mode":"SINGLE","title":"Spearfish","abstractTxt":"Spearfish City in Lawrence County, South Dakota","workspace":{"name":"sf"},"publishables":{"published":[{"@type":"layer","name":"sfdem","href":"http://localhost:8080/geoserver/rest/layers/sfdem.json"},{"@type":"layer","name":"streams","href":"http://localhost:8080/geoserver/rest/layers/streams.json"}]},"styles":{"style":[{"name":"dem","href":"http://localhost:8080/geoserver/rest/styles/dem.json"},"null"]},"bounds":{"minx":589425.9342365642,"maxx":609518.6719560538,"miny":4913959.224611808,"maxy":4928082.949945881,"crs":{"@class":"projected","$":"EPSG:26713"}},"metadata":{"entry":{"@key":"rawStyleList","$":""}}}}
+              {"layerGroup":{"name":"spearfish","mode":"SINGLE","title":"Spearfish","abstractTxt":"Spearfish City in Lawrence County, South Dakota","workspace":{"name":"sf"},"publishables":{"published":[{"@type":"layer","name":"sfdem","href":"http://localhost:8080/geoserver/rest/workspaces/sf/layers/sfdem.json"},{"@type":"layer","name":"streams","href":"http://localhost:8080/geoserver/rest/workspaces/sf/layers/streams.json"}]},"styles":{"style":[{"name":"dem","href":"http://localhost:8080/geoserver/rest/styles/dem.json"},"null"]},"bounds":{"minx":589425.9342365642,"maxx":609518.6719560538,"miny":4913959.224611808,"maxy":4928082.949945881,"crs":{"@class":"projected","$":"EPSG:26713"}},"metadata":{"entry":{"@key":"rawStyleList","$":""}}}}
               
             application/xml: |
               <layerGroup>
@@ -306,11 +306,11 @@ paths:
                 <publishables>
                   <published type="layer">
                     <name>sfdem</name>
-                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/sfdem.xml" type="application/xml"/>
+                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/sf/layers/sfdem.xml" type="application/xml"/>
                   </published>
                   <published type="layer">
                     <name>streams</name>
-                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/streams.xml" type="application/xml"/>
+                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/sf/layers/streams.xml" type="application/xml"/>
                   </published>
                 </publishables>
                 <styles>

--- a/doc/en/api/1.0.0/layers.yaml
+++ b/doc/en/api/1.0.0/layers.yaml
@@ -24,15 +24,15 @@ paths:
             application/xml: |
               <layers>
                  <layer>
-                   <name>giant_polygon</name>
+                   <name>tiger:giant_polygon</name>
                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate"
-                     href="http://localhost:8080/geoserver/rest/layers/giant_polygon.xml"
+                     href="http://localhost:8080/geoserver/rest/layers/tiger%3Agiant_polygon.xml"
                      type="application/xml"/>
                  </layer>
                  <layer>
-                   <name>bugsites</name>
+                   <name>sf:bugsites</name>
                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate"
-                     href="http://localhost:8080/geoserver/rest/layers/bugsites.xml"
+                     href="http://localhost:8080/geoserver/rest/layers/sf%3Abugsites.xml"
                      type="application/xml"/>
                  </layer>
                </layers>
@@ -42,12 +42,12 @@ paths:
                  "layers": {
                    "layer": [
                      {
-                       "name": "giant_polygon",
-                       "href": "http:\/\/localhost:8080\/geoserver\/rest\/layers\/giant_polygon.json"
+                       "name": "tiger:giant_polygon",
+                       "href": "http:\/\/localhost:8080\/geoserver\/rest\/layers\/tiger%3Agiant_polygon.json"
                      },
                      {
-                       "name": "bugsites",
-                       "href": "http:\/\/localhost:8080\/geoserver\/rest\/layers\/bugsites.json"
+                       "name": "sf:bugsites",
+                       "href": "http:\/\/localhost:8080\/geoserver\/rest\/layers\/sf%3Abugsites.json"
                      },
                    ]
                  }
@@ -205,7 +205,214 @@ paths:
       responses:
         200:
           description: OK
-          
+  /workspaces/{workspaceName}/layers:
+    get:
+      operationId: layersWorkspaceGet
+      summary: Get a list of layers in a workspace.
+      description: Displays a list of all layers in the provided workspace. You must use the "Accept:" header to specify format or append an extension to the endpoint (example "/layers.xml" for XML)
+      parameters:
+        - name: workspaceName
+          in: path
+          required: true
+          description: The name of the workspace to list layers in
+          type: string
+      produces:
+        - text/html
+        - application/xml
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Layers"
+          examples:
+            application/xml: |
+               <layers>
+                 <layer>
+                   <name>bugsites</name>
+                   <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate"
+                     href="http://localhost:8080/geoserver/rest/workspaces/sf/layers/bugsites.xml"
+                     type="application/xml"/>
+                 </layer>
+               </layers>
+            
+            application/json: |
+               {
+                 "layers": {
+                   "layer": [
+                     {
+                       "name": "bugsites",
+                       "href": "http:\/\/localhost:8080\/geoserver\/rest\/workspaces\/sf\/layers\/bugsites.json"
+                     },
+                   ]
+                 }
+               }
+    post:
+      operationId: layersWorkspacePost
+      description: Invalid. To create a new layer, instead POST to one of `/workspaces/{workspaceName}/coveragestores/{coveragestoreName}/coverages`, `/workspaces/{workspaceName}/datastores/{datastoreName}/featuretypes`, `/workspaces/{workspaceName}/wmsstores/{wmsstoreName}/wmslayers`, or `/workspaces/{workspaceName}/wmtsstores/{wmststoreName}/wmtslayers`
+      responses:
+        405:
+          description: Method not allowed.
+    put:
+      operationId: layersWorkspacePut
+      description: Invalid. To edit a layer, use PUT on an individual layer instead.
+      responses:
+        405:
+          description: Method not allowed.
+    delete:
+      operationId: layersWorkspaceDelete
+      description: Invalid.
+      responses:
+        405:
+          description: Method not allowed. 
+  /workspaces/{workspaceName}/layers/{layerName}:
+    get:
+      operationId: layersNameWorkspaceGet
+      summary: Retrieve a layer 
+      description: Retrieves a single layer definition. Use the "Accept:" header to specify format or append an extension to the endpoint (example "/layers/{layer}.xml" for XML).
+      produces:
+        - application/xml
+        - application/json
+        - text/html
+      parameters:
+        - name: workspaceName
+          in: path
+          required: true
+          description: The name of the workspace the layer is in.
+          type: string
+        - name: layerName
+          in: path
+          required: true
+          description: The name of the layer to retrieve.
+          type: string
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Layer"
+          examples:
+            application/xml: |
+              <layer>
+                <name>poi</name>
+                <path>/</path>
+                <type>VECTOR</type>
+                <defaultStyle>
+                  <name>poi</name>
+                  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/poi.xml" type="application/xml"/>
+                </defaultStyle>
+                <styles class="linked-hash-set">
+                  <style>
+                    <name>burg</name>
+                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/burg.xml" type="application/xml"/>
+                  </style>
+                  <style>
+                    <name>point</name>
+                    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/point.xml" type="application/xml"/>
+                  </style>
+                </styles>
+                <resource class="featureType">
+                  <name>poi</name>
+                  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/tiger/datastores/nyc/featuretypes/poi.xml" type="application/xml"/>
+                </resource>
+                <attribution>
+                  <logoWidth>0</logoWidth>
+                  <logoHeight>0</logoHeight>
+                </attribution>
+              </layer>
+              
+            application/json: |
+              {
+              
+                  "layer": {
+                      "name": "poi",
+                      "path": "/",
+                      "type": "VECTOR",
+                      "defaultStyle": {
+                          "name": "poi",
+                          "href": "http://localhost:8080/geoserver/rest/styles/poi.json"
+                      },
+                      "styles": {
+                          "@class": "linked-hash-set",
+                          "style": [
+                              {
+                                  "name": "burg",
+                                  "href": "http://localhost:8080/geoserver/rest/styles/burg.json"
+                              },
+                              {
+                                  "name": "point",
+                                  "href": "http://localhost:8080/geoserver/rest/styles/point.json"
+                              }
+                          ]
+                      },
+                      "resource": {
+                          "@class": "featureType",
+                          "name": "poi",
+                          "href": "http://localhost:8080/geoserver/rest/workspaces/tiger/datastores/nyc/featuretypes/poi.json"
+                      },
+                      "attribution": {
+                          "logoWidth": 0,
+                          "logoHeight": 0
+                      }
+                  }
+              
+              }
+    post:
+      operationId: layersNameWorkspacePost
+      description: Invalid. To create a new layer, instead POST to one of `/workspaces/{workspaceName}/coveragestores/{coveragestoreName}/coverages`, `/workspaces/{workspaceName}/datastores/{datastoreName}/featuretypes`, `/workspaces/{workspaceName}/wmsstores/{wmsstoreName}/wmslayers`, or `/workspaces/{workspaceName}/wmtsstores/{wmststoreName}/wmtslayers`
+      responses:
+        405:
+          description: Method not allowed.
+    put:
+      operationId: layersNameWorkspacePut
+      summary: Modify a layer.
+      description: Modifies an existing layer on the server. Use the "Accept:" header to specify format or append an extension to the endpoint (example "/layers/{layer}.xml" for XML).
+      parameters:
+        - name: workspaceName
+          in: path
+          required: true
+          description: The name of the workspace the layer is in.
+        - name: layerName
+          in: path
+          required: true
+          description: The name of the layer to modify.
+          type: string
+        - name: layerBody
+          in: body
+          description: The updated layer definition.
+          required: true
+          schema:
+            $ref: "#/definitions/Layer"
+      consumes:
+        - application/xml
+        - application/json
+      responses:
+        200:
+          description: The layer was successfully updated.
+
+    delete:
+      operationId: layersNameWorkspaceDelete
+      summary: Delete layer
+      description: Deletes a layer from the server.
+      parameters:
+        - name: workspaceName
+          in: path
+          required: true
+          description: The name of the workspace the layer is in.
+        - name: layerName
+          in: path
+          required: true
+          description: The name of the layer to delete.
+          type: string
+        - name: recurse
+          in: query
+          description: Recursively removes the layer from all layer groups which reference it. If this results in an empty layer group, also delete the layer group. Allowed values for this parameter are true or false. The default value is false. A request with 'recurse=false' will fail if any layer groups reference the layer.
+          required: false
+          type: boolean
+          default: false
+      responses:
+        200:
+          description: OK
+
 definitions:
   Layers:
     title: layers

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -839,7 +839,7 @@ public class CatalogImpl implements Catalog {
         List<PublishedInfo> layers = layerGroup.getLayers();
         List<StyleInfo> styles = layerGroup.getStyles();
         for (int i = 0; i < layers.size(); ) {
-            if(layers.get(i) == null && styles.get(i) == null) {
+            if(layers != null && styles != null && layers.get(i) == null && styles.get(i) == null) {
                 layers.remove(i);
                 styles.remove(i);
             } else {

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -1078,6 +1078,15 @@ public class XStreamPersister {
                         wsName = workspace.getName();
                     }
                 }
+
+                //use prefixed name to get wsName if available
+                String prefixedName;
+                if (wsName == null && OwsUtils.has(source, "prefixedName")) {
+                    prefixedName = (String) OwsUtils.get(source, "prefixedName");
+                    if (prefixedName != null  && prefixedName.indexOf(":") > 0) {
+                        wsName = prefixedName.substring(0, prefixedName.indexOf(":"));
+                    }
+                }
                 
                 if ( name != null ) {
                     writer.startNode("name");

--- a/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
+++ b/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
@@ -16,6 +16,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.config.util.SecureXStream;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.ows.util.OwsUtils;
+import org.geoserver.rest.RequestInfo;
 import org.geoserver.rest.wrapper.RestListWrapper;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
@@ -102,8 +103,10 @@ public abstract class XStreamCatalogListConverter
                     MarshallingContext context) {
 
                 String ref;
-                //Special case for layer list, since there is no workspace-specific endpoint for layers
-                if (clazz.equals(LayerInfo.class) && OwsUtils.getter(clazz, "prefixedName", String.class) != null) {
+                //Special case for layer list, to handle the non-workspace-specific endpoint for layers
+                if (clazz.equals(LayerInfo.class) && OwsUtils.getter(clazz, "prefixedName", String.class) != null
+                        && RequestInfo.get() != null && !RequestInfo.get().getPagePath().contains("/workspaces/")) {
+
                     ref = (String) OwsUtils.get(source, "prefixedName");
                 } else if (OwsUtils.getter(clazz, "name", String.class) != null) {
                     ref = (String) OwsUtils.get(source, "name");

--- a/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
+++ b/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
@@ -12,6 +12,7 @@ import com.thoughtworks.xstream.converters.collections.CollectionConverter;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.io.json.JettisonMappedXmlDriver;
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.config.util.SecureXStream;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.ows.util.OwsUtils;
@@ -101,7 +102,10 @@ public abstract class XStreamCatalogListConverter
                     MarshallingContext context) {
 
                 String ref;
-                if (OwsUtils.getter(clazz, "name", String.class) != null) {
+                //Special case for layer list, since there is no workspace-specific endpoint for layers
+                if (clazz.equals(LayerInfo.class) && OwsUtils.getter(clazz, "prefixedName", String.class) != null) {
+                    ref = (String) OwsUtils.get(source, "prefixedName");
+                } else if (OwsUtils.getter(clazz, "name", String.class) != null) {
                     ref = (String) OwsUtils.get(source, "name");
                 } else if (OwsUtils.getter(clazz, "id", String.class) != null) {
                     ref = (String) OwsUtils.get(source, "id");

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/LayerGroupController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/LayerGroupController.java
@@ -239,7 +239,7 @@ public class LayerGroupController extends AbstractCatalogController {
                     converter.encodeLink(link.toString(), writer);
                 }
                 if ( obj instanceof LayerInfo ) {
-                    converter.encodeLink("/layers/" + converter.encode(prefix +":"+ref), writer);
+                    converter.encodeLink("/workspaces/"+prefix+"/layers/" + converter.encode(ref), writer);
                 } else if ( obj instanceof LayerGroupInfo) {
                     LayerGroupInfo lg = (LayerGroupInfo) obj;
                     if (lg.getWorkspace() != null) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/LayerGroupController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/LayerGroupController.java
@@ -5,14 +5,19 @@
  */
 package org.geoserver.rest.catalog;
 
+import freemarker.template.ObjectWrapper;
+import freemarker.template.SimpleHash;
+import freemarker.template.TemplateModelException;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.rest.ObjectToMapWrapper;
 import org.geoserver.rest.ResourceNotFoundException;
 import org.geoserver.rest.RestBaseController;
 import org.geoserver.rest.RestException;
@@ -39,8 +44,13 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -229,7 +239,7 @@ public class LayerGroupController extends AbstractCatalogController {
                     converter.encodeLink(link.toString(), writer);
                 }
                 if ( obj instanceof LayerInfo ) {
-                    converter.encodeLink("/layers/" + converter.encode(ref), writer);
+                    converter.encodeLink("/layers/" + converter.encode(prefix +":"+ref), writer);
                 } else if ( obj instanceof LayerGroupInfo) {
                     LayerGroupInfo lg = (LayerGroupInfo) obj;
                     if (lg.getWorkspace() != null) {
@@ -240,5 +250,54 @@ public class LayerGroupController extends AbstractCatalogController {
                 }
             }
         });
+    }
+
+    @Override
+    protected <T> ObjectWrapper createObjectWrapper(Class<T> clazz) {
+        return new ObjectToMapWrapper<LayerGroupInfo>(LayerGroupInfo.class) {
+            @Override
+            protected void wrapInternal(Map<String, Object> properties, SimpleHash model, LayerGroupInfo layerGroup) {
+                if (properties == null) {
+                    try {
+                        properties = model.toMap();
+                    } catch (TemplateModelException e) {
+                        LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                        return;
+                    }
+                }
+                List<Map<String, Map<String, String>>> layerProps = new ArrayList<>();
+                for (PublishedInfo info : layerGroup.getLayers()) {
+                    Map<String, String> props = new HashMap<>();
+                    if (info != null) {
+                        props.put("name", info.getName());
+                        props.put("prefixedName", info.prefixedName());
+                    }
+                    layerProps.add(Collections.singletonMap("properties", props));
+                }
+                properties.put("layers", layerProps);
+
+                List<Map<String, Map<String, String>>> styleProps = new ArrayList<>();
+                for (StyleInfo info : layerGroup.getStyles()) {
+                    Map<String, String> props = new HashMap<>();
+                    if (info != null) {
+                        props.put("name", info.getName());
+                        if (info.getWorkspace() != null) {
+                            props.put("workspace", info.getWorkspace().getName());
+                        }
+                    }
+                    styleProps.add(Collections.singletonMap("properties", props));
+                }
+                properties.put("styles", styleProps);
+            }
+
+            @Override
+            protected void wrapInternal(SimpleHash model, @SuppressWarnings("rawtypes") Collection object) {
+                for (Object l : object) {
+                    LayerGroupInfo lg = (LayerGroupInfo) l;
+                    wrapInternal(null, model, lg);
+                }
+
+            }
+        };
     }
 }

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/ftl-templates/LayerGroupInfo.ftl
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/ftl-templates/LayerGroupInfo.ftl
@@ -2,9 +2,18 @@
 Layer group "${properties.name}"
 
 <ul>
-  <li>Name: ${properties.name}</li>
-  <li>Layers: ${properties.layers}</li>
-  <li>Styles: ${properties.styles}</li>
+<h2>Layers</h2>
+<#list properties.layers as l>
+  <li><#if l.properties.prefixedName??><a href="${page.servletURI('/layers/' + l.properties.prefixedName + '.html')}">${l.properties.prefixedName}</a></#if></li>
+</#list>
+<h2>Styles</h2>
+<#list properties.styles as s>
+  <#if s.properties.workspace??>
+    <li><a href="${page.servletURI('/workspaces/'+ s.properties.workspace +'/styles/' + s.properties.name + '.html')}">${s.properties.workspace}:${s.properties.name}</a></li>
+  <#else>
+    <li><#if s.properties.name??><a href="${page.servletURI('/styles/' + s.properties.name + '.html')}">${s.properties.name}</a></#if></li>
+  </#if>
+</#list>
 </ul>
-  
+
 <#include "tail.ftl">

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/ftl-templates/layergroups.ftl
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/ftl-templates/layergroups.ftl
@@ -1,5 +1,5 @@
 <#include "head.ftl">
-Layers:
+Layer Groups:
 <ul>
 <#list values as lg>
   <li><a href="${page.pageURI(lg.properties.name + '.html')}">${lg.properties.name}</a></li>

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/ftl-templates/layers.ftl
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/ftl-templates/layers.ftl
@@ -2,7 +2,7 @@
 Layers:
 <ul>
 <#list values as l>
-  <li><a href="${page.pageURI(l.properties.name + '.html')}">${l.properties.name}</a></li>
+  <li><a href="${page.pageURI(l.properties.prefixedName + '.html')}">${l.properties.prefixedName}</a></li>
 </#list>
 </ul>
 <#include "tail.ftl">

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerControllerTest.java
@@ -8,6 +8,8 @@ package org.geoserver.rest.catalog;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -18,6 +20,7 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.rest.RestBaseController;
 import org.junit.After;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -40,6 +43,17 @@ public class LayerControllerTest extends CatalogRESTTestSupport {
     @Override
     protected void onTearDown(SystemTestData testData) throws Exception {
         super.onTearDown(testData);
+    }
+
+    @Test
+    public void testGetListAsXML() throws Exception {
+        Document dom = getAsDOM( ROOT_PATH + "/layers.xml",200);
+        assertEquals( "layers", dom.getDocumentElement().getNodeName() );
+
+        // verify layer name and links for cite:Buildings
+        assertXpathExists("//layer[name='cite:Buildings']", dom);
+        assertThat(xp.evaluate("//layer[name='cite:Buildings']/atom:link/@href", dom),
+                endsWith(RestBaseController.ROOT_PATH + "/layers/cite%3ABuildings.xml"));
     }
 
     @Test

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerControllerTest.java
@@ -18,6 +18,7 @@ import net.sf.json.JSONObject;
 
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.rest.RestBaseController;
@@ -57,8 +58,31 @@ public class LayerControllerTest extends CatalogRESTTestSupport {
     }
 
     @Test
+    public void testGetListInWorkspaceAsXML() throws Exception {
+        Document dom = getAsDOM( ROOT_PATH + "/workspaces/cite/layers.xml",200);
+        assertEquals( "layers", dom.getDocumentElement().getNodeName() );
+        print(dom);
+        // verify layer name and links for cite:Buildings
+        assertXpathExists("//layer[name='Buildings']", dom);
+        assertThat(xp.evaluate("//layer[name='Buildings']/atom:link/@href", dom),
+                endsWith(RestBaseController.ROOT_PATH + "/workspaces/cite/layers/Buildings.xml"));
+    }
+
+    @Test
     public void testGetAsXML() throws Exception {
         Document dom = getAsDOM( ROOT_PATH + "/layers/cite:Buildings.xml",200);
+        assertEquals( "layer", dom.getDocumentElement().getNodeName() );
+        assertXpathEvaluatesTo("Buildings", "/layer/name", dom );
+        // check the layer name is actually the first child (GEOS-3336 risked modifying
+        // the order)
+        assertXpathEvaluatesTo("Buildings", "/layer/*[1]", dom );
+        assertXpathEvaluatesTo("http://localhost:8080/geoserver"+ROOT_PATH+"/styles/Buildings.xml",
+                "/layer/defaultStyle/atom:link/attribute::href", dom);
+    }
+
+    @Test
+    public void testGetInWorkspaceAsXML() throws Exception {
+        Document dom = getAsDOM( ROOT_PATH + "/workspaces/cite/layers/Buildings.xml",200);
         assertEquals( "layer", dom.getDocumentElement().getNodeName() );
         assertXpathEvaluatesTo("Buildings", "/layer/name", dom );
         // check the layer name is actually the first child (GEOS-3336 risked modifying
@@ -100,6 +124,13 @@ public class LayerControllerTest extends CatalogRESTTestSupport {
         Document dom = getAsDOM( ROOT_PATH + "/layers.xml",200);
         assertXpathEvaluatesTo(catalog.getLayers().size()+"", "count(//layer)", dom );
     }
+
+    @Test
+    public void testGetAllInWorkspaceAsXML() throws Exception {
+        Document dom = getAsDOM( ROOT_PATH + "/workspaces/cite/layers.xml",200);
+        int count = catalog.getResourcesByNamespace("cite", ResourceInfo.class).stream().mapToInt(info -> catalog.getLayers(info).size()).sum();
+        assertXpathEvaluatesTo(count+"", "count(//layer)", dom );
+    }
     
     @Test
     public void testGetAllAsHTML() throws Exception {
@@ -124,6 +155,26 @@ public class LayerControllerTest extends CatalogRESTTestSupport {
         l = catalog.getLayerByName("cite:Buildings");
         assertEquals( "Forests", l.getDefaultStyle().getName() );
     }
+
+    @Test
+    public void testPutInWorkspace() throws Exception {
+        LayerInfo l = catalog.getLayerByName( "cite:Buildings" );
+        assertEquals( "Buildings", l.getDefaultStyle().getName() );
+        String xml =
+                "<layer>" +
+                        "<defaultStyle>Forests</defaultStyle>" +
+                        "<styles>" +
+                        "<style>Ponds</style>" +
+                        "</styles>" +
+                        "</layer>";
+        MockHttpServletResponse response =
+                putAsServletResponse(ROOT_PATH + "/workspaces/cite/layers/Buildings", xml, "text/xml");
+        assertEquals( 200, response.getStatus() );
+
+        l = catalog.getLayerByName("cite:Buildings");
+        assertEquals( "Forests", l.getDefaultStyle().getName() );
+    }
+
     @Test
     public void testPutNonDestructive() throws Exception {
         LayerInfo l = catalog.getLayerByName( "cite:Buildings" );
@@ -175,6 +226,13 @@ public class LayerControllerTest extends CatalogRESTTestSupport {
     public void testDelete() throws Exception {
         assertNotNull(catalog.getLayerByName( "cite:Buildings" ));
         assertEquals(200, deleteAsServletResponse(ROOT_PATH + "/layers/cite:Buildings").getStatus());
+        assertNull(catalog.getLayerByName( "cite:Buildings" ));
+    }
+
+    @Test
+    public void testDeleteInWorkspace() throws Exception {
+        assertNotNull(catalog.getLayerByName( "cite:Buildings" ));
+        assertEquals(200, deleteAsServletResponse(ROOT_PATH + "/workspaces/cite/layers/Buildings").getStatus());
         assertNull(catalog.getLayerByName( "cite:Buildings" ));
     }
     

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerGroupControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerGroupControllerTest.java
@@ -144,7 +144,7 @@ public class LayerGroupControllerTest extends CatalogRESTTestSupport {
         assertXpathEvaluatesTo( "2", "count(//style)", dom );
         // check layer link
         assertThat(xp.evaluate("//published[name='sf:PrimitiveGeoFeature']/atom:link/@href", dom),
-                endsWith(RestBaseController.ROOT_PATH + "/layers/sf%3APrimitiveGeoFeature.xml"));
+                endsWith(RestBaseController.ROOT_PATH + "/workspaces/sf/layers/PrimitiveGeoFeature.xml"));
         assertThat(xp.evaluate("//published[name='sf:PrimitiveGeoFeature']/atom:link/@type", dom),
                 equalTo("application/xml"));
         // check style link
@@ -764,11 +764,11 @@ public class LayerGroupControllerTest extends CatalogRESTTestSupport {
         assertXpathEvaluatesTo( "cite:Lakes", "//publishables/published[2]/name", dom );
         // verify layer links
         assertThat(xp.evaluate("//published[name='sf:Lakes']/atom:link/@href", dom),
-                endsWith(RestBaseController.ROOT_PATH + "/layers/sf%3ALakes.xml"));
+                endsWith(RestBaseController.ROOT_PATH + "/workspaces/sf/layers/Lakes.xml"));
         assertThat(xp.evaluate("//published[name='sf:Lakes']/atom:link/@type", dom),
                 equalTo("application/xml"));
         assertThat(xp.evaluate("//published[name='cite:Lakes']/atom:link/@href", dom),
-                endsWith(RestBaseController.ROOT_PATH + "/layers/cite%3ALakes.xml"));
+                endsWith(RestBaseController.ROOT_PATH + "/workspaces/cite/layers/Lakes.xml"));
         assertThat(xp.evaluate("//published[name='cite:Lakes']/atom:link/@type", dom),
                 equalTo("application/xml"));
 

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerGroupControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerGroupControllerTest.java
@@ -26,6 +26,7 @@ import org.geoserver.data.test.SystemTestData;
 import org.geoserver.rest.RestBaseController;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -45,6 +46,7 @@ public class LayerGroupControllerTest extends CatalogRESTTestSupport {
 
     @Before
     public void revertChanges() throws Exception {
+        removeLayer("sf", "Lakes");
         removeLayerGroup(null, "nestedLayerGroupTest");
         removeLayerGroup(null, "citeLayerGroup");
         removeLayerGroup(null, "sfLayerGroup");
@@ -53,6 +55,7 @@ public class LayerGroupControllerTest extends CatalogRESTTestSupport {
         removeLayerGroup(null, "newLayerGroupWithTypeCONTAINER");
         removeLayerGroup(null, "newLayerGroupWithTypeEO");
         removeLayerGroup(null, "newLayerGroupWithStyleGroup");
+        removeLayerGroup(null, "doubleLayerGroup");
 
         LayerGroupInfo lg = catalog.getFactory().createLayerGroup();
         lg.setName("sfLayerGroup");
@@ -140,9 +143,9 @@ public class LayerGroupControllerTest extends CatalogRESTTestSupport {
         assertXpathEvaluatesTo( "2", "count(//published)", dom );
         assertXpathEvaluatesTo( "2", "count(//style)", dom );
         // check layer link
-        assertThat(xp.evaluate("//published[name='PrimitiveGeoFeature']/atom:link/@href", dom), 
-                endsWith(RestBaseController.ROOT_PATH + "/layers/PrimitiveGeoFeature.xml"));
-        assertThat(xp.evaluate("//published[name='PrimitiveGeoFeature']/atom:link/@type", dom), 
+        assertThat(xp.evaluate("//published[name='sf:PrimitiveGeoFeature']/atom:link/@href", dom),
+                endsWith(RestBaseController.ROOT_PATH + "/layers/sf%3APrimitiveGeoFeature.xml"));
+        assertThat(xp.evaluate("//published[name='sf:PrimitiveGeoFeature']/atom:link/@type", dom),
                 equalTo("application/xml"));
         // check style link
         assertThat(xp.evaluate("//style[1]/atom:link/@href", dom), 
@@ -701,6 +704,74 @@ public class LayerGroupControllerTest extends CatalogRESTTestSupport {
         assertEquals(200, response.getStatus());
 
         assertNull(cat.getLayerGroupByName("sf", "workspaceLayerGroup"));
+    }
+
+    @Test
+    public void testLayerGroupDuplicateLayerNames() throws Exception {
+        //Create a Lakes layer in the sf workspace
+        Catalog catalog = getCatalog();
+        FeatureTypeInfo lakesFt = catalog.getFactory().createFeatureType();
+        lakesFt.setName("Lakes");
+        lakesFt.setNamespace(catalog.getNamespaceByPrefix("sf"));
+        lakesFt.setStore(catalog.getDefaultDataStore(catalog.getWorkspaceByName("sf")));
+        lakesFt.setNativeBoundingBox(new ReferencedEnvelope(-10, 10, -10, 10, DefaultGeographicCRS.WGS84));
+
+        catalog.add(lakesFt);
+        lakesFt = catalog.getFeatureTypeByName("sf", "Lakes");
+
+        LayerInfo lakes = catalog.getFactory().createLayer();
+        lakes.setResource(lakesFt);
+
+        catalog.add(lakes);
+
+        assertNotNull(catalog.getLayerByName("sf:Lakes"));
+        assertNotNull(catalog.getLayerByName("cite:Lakes"));
+
+        //POST a new layer group consisting of sf:Lakes and cite:Lakes
+        String xml =
+                "<layerGroup>" +
+                "<name>doubleLayerGroup</name>" +
+                "<layers>" +
+                "<layer>sf:Lakes</layer>" +
+                "<layer>cite:Lakes</layer>" +
+                "</layers>" +
+                "</layerGroup>";
+
+        MockHttpServletResponse response = postAsServletResponse(RestBaseController.ROOT_PATH + "/layergroups", xml );
+        assertEquals( 201, response.getStatus() );
+
+        //Verify the new layer group in the catalog
+        LayerGroupInfo lg = catalog.getLayerGroupByName( "doubleLayerGroup");
+        assertNotNull( lg );
+
+        assertEquals( 2, lg.getLayers().size() );
+        assertEquals( "Lakes", lg.getLayers().get( 0 ).getName() );
+        assertEquals( "sf:Lakes", lg.getLayers().get( 0 ).prefixedName() );
+        assertEquals( "Lakes", lg.getLayers().get( 1 ).getName() );
+        assertEquals( "cite:Lakes", lg.getLayers().get( 1 ).prefixedName() );
+
+        //GET layer group and verify layer names
+        Document dom = getAsDOM( RestBaseController.ROOT_PATH + "/layergroups/doubleLayerGroup.xml");
+        print(dom);
+
+        assertEquals( "layerGroup", dom.getDocumentElement().getNodeName() );
+        assertXpathEvaluatesTo("doubleLayerGroup", "/layerGroup/name", dom );
+        assertXpathEvaluatesTo( "2", "count(//published)", dom );
+        assertXpathEvaluatesTo( "2", "count(//style)", dom );
+
+        // verify layer order
+        assertXpathEvaluatesTo( "sf:Lakes", "//publishables/published[1]/name", dom );
+        assertXpathEvaluatesTo( "cite:Lakes", "//publishables/published[2]/name", dom );
+        // verify layer links
+        assertThat(xp.evaluate("//published[name='sf:Lakes']/atom:link/@href", dom),
+                endsWith(RestBaseController.ROOT_PATH + "/layers/sf%3ALakes.xml"));
+        assertThat(xp.evaluate("//published[name='sf:Lakes']/atom:link/@type", dom),
+                equalTo("application/xml"));
+        assertThat(xp.evaluate("//published[name='cite:Lakes']/atom:link/@href", dom),
+                endsWith(RestBaseController.ROOT_PATH + "/layers/cite%3ALakes.xml"));
+        assertThat(xp.evaluate("//published[name='cite:Lakes']/atom:link/@type", dom),
+                equalTo("application/xml"));
+
     }
 
     public void testLayersStylesInWorkspace() throws Exception {


### PR DESCRIPTION
This has been an ongoing issue, and has a number of associated JIRA tickets:
* https://osgeo-org.atlassian.net/browse/GEOS-4339
* https://osgeo-org.atlassian.net/browse/GEOS-5356
* https://osgeo-org.atlassian.net/browse/GEOS-6227
* https://osgeo-org.atlassian.net/browse/GEOS-7682

The issue is that layers of the same name in different workspaces show up identically when listing layers using the rest API (not noted in most of these issues is that this also affects the layer list shown when viewing a layer group).
This also presents as a legitimate error for links to layers, as links also use the unprefixed name and therefore always go to the default / first layer with that name.

There has been a bunch of ongoing discussion, which ultimately boils down to we should probably use prefixed layer names. However, this is a little bit of an API change.

The results of this change are as follows (I am using layer groups as an example, but the layers list endpoint has been changed in the same way): 

Before

```
<layerGroup>
  <name>double</name>
  <mode>SINGLE</mode>
  <publishables>
    <published type="layer">
      <name>roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/roads.xml" type="application/xml"/>
    </published>
    <published type="layer">
      <name>roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/roads.xml" type="application/xml"/>
    </published>
  </publishables>
  <styles>
    <style>
      <name>simple_roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/simple_roads.xml" type="application/xml"/>
    </style>
    <style>
      <name>simple_roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/simple_roads.xml" type="application/xml"/>
    </style>
  </styles>
  <bounds>
    <minx>-4130652.2521738065</minx>
    <maxx>609527.2102150217</maxx>
    <miny>-1.4272116226768898E7</miny>
    <maxy>4928063.398014731</maxy>
    <crs class="projected">EPSG:26713</crs>
  </bounds>
</layerGroup>
```

After: 

```
<layerGroup>
  <name>double</name>
  <mode>SINGLE</mode>
  <publishables>
    <published type="layer">
      <name>sf:roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/sf%3Aroads.xml" type="application/xml"/>
    </published>
    <published type="layer">
      <name>topp:roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/layers/topp%3Aroads.xml" type="application/xml"/>
    </published>
  </publishables>
  <styles>
    <style>
      <name>simple_roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/simple_roads.xml" type="application/xml"/>
    </style>
    <style>
      <name>simple_roads</name>
      <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/simple_roads.xml" type="application/xml"/>
    </style>
  </styles>
  <bounds>
    <minx>-4130652.2521738065</minx>
    <maxx>609527.2102150217</maxx>
    <miny>-1.4272116226768898E7</miny>
    <maxy>4928063.398014731</maxy>
    <crs class="projected">EPSG:26713</crs>
  </bounds>
</layerGroup>
```

This is consistent with how we already treat references to stores or resources, for example:

```
<layer>
  <name>roads</name>
  <path>/</path>
  <type>VECTOR</type>
  <defaultStyle>
    <name>simple_roads</name>
    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/simple_roads.xml" type="application/xml"/>
  </defaultStyle>
  <resource class="featureType">
    <name>sf:roads</name>
    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/sf/datastores/sf/featuretypes/roads.xml" type="application/xml"/>
  </resource>
  <attribution>
    <logoWidth>0</logoWidth>
    <logoHeight>0</logoHeight>
  </attribution>
</layer>
```

See `//resource/name`=`sf:roads`.
Also notice that for the actual layer entry, name remains unprefixed. Again, this is consistent with how we treat entries for stores or resources.

This does not affect catalog persistence in any way, only the REST API.