### PR TITLE
[GEOS-8366] fix bug adding a new GeoPackage datastore from within the data directory

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -579,7 +579,7 @@ public class ResourcePool {
                         // call this method to execute the hack which recognizes 
                         // urls which are relative to the data directory
                         // TODO: find a better way to do this
-                        connectionParameters = ResourcePool.getParams(connectionParameters, catalog.getResourceLoader() );
+                        connectionParameters = ResourcePool.getParams(connectionParameters, catalog.getResourceLoader());
                         
                         // obtain the factory
                         DataAccessFactory factory = null;
@@ -692,12 +692,12 @@ public class ResourcePool {
     }
         
     /**
-     * Process conneciton parameters into a synchronized map.
+     * Process connection parameters into a synchronized map.
      *
      * <p>
      * This is used to smooth any relative path kind of issues for any file
      * URLS or directory. This code should be expanded to deal with any other context
-     * sensitve isses data stores tend to have.
+     * sensitive issues data stores tend to have.
      * </p>
      * <ul>
      * <li>key ends in URL, and value is a string</li>
@@ -706,8 +706,8 @@ public class ResourcePool {
      * </ul>
      * 
      * @return Processed parameters with relative file URLs resolved
-     * @param m
-     * @param baseDir Base directory used to resolve relative file URLs
+     * @param m a map of data store connection parameters
+     * @parm loader
      * @task REVISIT: cache these?
      */
     public static <K,V> Map<K,V> getParams(Map<K,V> m, GeoServerResourceLoader loader) {
@@ -739,7 +739,7 @@ public class ResourcePool {
                 URL url = (URL) value;
                 File fixedPath = loader.url( url.toString() );
                 entry.setValue( (V) DataUtilities.fileToURL(fixedPath));
-            } else if ((key != null) && key.equals("directory") && value instanceof String) {
+            } else if ((key != null) && (key.equals("directory")|| key.equals("database")) && value instanceof String) {
                 String path = (String) value;
                 //if a url is used for a directory (for example property store), convert it to path
                 

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -671,4 +671,17 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
         assertThat(hints2, hasEntry(Hints.REPOSITORY, pool.repository));
         assertThat(hints2, hasEntry(Hints.KEY_ANTIALIASING, Hints.VALUE_ANTIALIAS_ON));
     }
+
+    @Test
+    public void testGetParamsFixesDatabaseFilePath() {
+        Catalog catalog = getCatalog();
+        ResourcePool pool = new ResourcePool(catalog);
+        DataStoreInfo ds = getCatalog().getFactory().createDataStore();
+        ds.getConnectionParameters().put("database", "file:data/test.gpkg");
+        Map newParams = pool.getParams(ds.getConnectionParameters(), getResourceLoader());
+        GeoServerDataDirectory dataDir = new GeoServerDataDirectory(getResourceLoader());
+        String absolutePath = dataDir.get("data/test.gpkg").dir().getAbsolutePath();
+        assertNotEquals(newParams.get("database"), "file:data/test.gpkg");
+        assertTrue(((String)newParams.get("database")).contains(absolutePath));
+    }
 }


### PR DESCRIPTION
Fixes [GEOS-8366](https://osgeo-org.atlassian.net/browse/GEOS-8366) by changing the relative path to an absolute path.