### PR TITLE
[GEOS-7233] Fix `totalFeatures` count for WFS 2.0 GetFeature requests

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -251,8 +251,7 @@ public class GetFeature {
         }
         
         // WFS 2.0 validation, with locks "hits" is not allowed
-        if (WFSInfo.Version.V_20.compareTo(request.getVersion()) >= 0
-                && request.isLockRequest() && request.isResultTypeHits()) {
+        if (WFSInfo.Version.V_20.compareTo(request.getVersion()) >= 0 && request.isLockRequest() && request.isResultTypeHits()) {
             throw new WFSException("GetFeatureWithLock cannot be used with result type 'hits'", 
                     ServiceException.INVALID_PARAMETER_VALUE, "resultType");
         }
@@ -608,6 +607,23 @@ public class GetFeature {
                 
                 //update the count
                 count += size;
+
+                // collect queries required to return numberMatched/totalSize
+                // check maxFeatures and offset, if they are unset we can use the size we 
+                // calculated above
+                isNumberMatchedSkipped = meta.getSkipNumberMatched() && !request.isResultTypeHits();
+                if (!isNumberMatchedSkipped) {
+                    if (calculateSize
+                            && (queryMaxFeatures == Integer.MAX_VALUE || size < queryMaxFeatures)
+                            && offset <= 0) {
+                        totalCountExecutors.add(new CountExecutor(size));
+                    } else {
+                        org.geotools.data.Query qTotal = toDataQuery(query, filter, 0,
+                                Integer.MAX_VALUE, source, request, allPropNames.get(0), viewParam,
+                                joins, primaryTypeName, primaryAlias);
+                        totalCountExecutors.add(new CountExecutor(source, qTotal));
+                    }
+                }
                 
                 //if offset is present we need to check the size of this returned feature collection
                 // and adjust the offset for the next feature collection accordingly
@@ -629,24 +645,6 @@ public class GetFeature {
                             //adjust the offset for the next query
                             offset = Math.max(0, offset - size2);
                         }
-                    }
-                }
-
-                // collect queries required to return numberMatched/totalSize
-                // check maxFeatures and offset, if they are unset we can use the size we 
-                // calculated above
-                isNumberMatchedSkipped = meta.getSkipNumberMatched()
-                        && !request.isResultTypeHits();
-                if (!isNumberMatchedSkipped) {
-                        if (calculateSize
-                                && (queryMaxFeatures == Integer.MAX_VALUE || size < queryMaxFeatures)
-                                && offset <= 0) {
-                        totalCountExecutors.add(new CountExecutor(size));
-                    } else {
-                        org.geotools.data.Query qTotal = toDataQuery(query, filter, 0,
-                                Integer.MAX_VALUE, source, request, allPropNames.get(0), viewParam,
-                                joins, primaryTypeName, primaryAlias);
-                        totalCountExecutors.add(new CountExecutor(source, qTotal));
                     }
                 }
 
@@ -693,8 +691,9 @@ public class GetFeature {
             // where the client has limited the result set size, so we compute it lazily
             if (isNumberMatchedSkipped) {
                 totalCount = BigInteger.valueOf(-1);
-            } else if(count < maxFeatures && calculateSize) {
+            } else if(count < maxFeatures && calculateSize && totalOffset == 0) {
                  // optimization: if count < max features then total count == count
+                 // can't use this optimization for v2
                  totalCount = BigInteger.valueOf(count);
             } else {
                 // ok, in this case we're forced to run the queries to discover the actual total count

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Future;
 
 import javax.xml.namespace.QName;
 
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
@@ -741,5 +743,30 @@ public class GetFeatureTest extends WFSTestSupport {
             executorService.shutdown();
         }
     }
+
+    @Test
+    public void testGetWithCountAndStartIndex0() throws Exception {
+        JSONObject json = (JSONObject) getAsJSON(
+                "wfs?request=GetFeature&typenames=cdf:Fifteen&version=1.1.0&service=wfs&maxFeatures=5&startIndex=0&outputFormat=JSON");
+        assertEquals(5, json.getJSONArray("features").size());
+        assertEquals(15, json.getInt("totalFeatures"));
+    }
+
+    @Test
+    public void testGetWithCountAndStartIndexMiddle() throws Exception {
+        JSONObject json = (JSONObject) getAsJSON(
+                "wfs?request=GetFeature&typenames=cdf:Fifteen&version=1.1.0&service=wfs&maxFeatures=5&startIndex=7&outputFormat=JSON");
+        assertEquals(5, json.getJSONArray("features").size());
+        assertEquals(15, json.getInt("totalFeatures"));
+    }
     
+    @Test
+    public void testGetWithCountAndStartIndexEnd() throws Exception {
+        JSONObject json = (JSONObject) getAsJSON(
+                "wfs?request=GetFeature&typenames=cdf:Fifteen&version=1.1.0&service=wfs&maxFeatures=5&startIndex=11&outputFormat=JSON");
+        assertEquals(4, json.getJSONArray("features").size());
+        assertEquals(15, json.getInt("totalFeatures"));
+    }
+
+
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
@@ -158,6 +158,33 @@ public class GetFeatureTest extends WFS20TestSupport {
     }
 
     @Test
+    public void testGetWithCountAndStartIndex0() throws Exception {
+        Document dom = getAsDOM(
+            "wfs?request=GetFeature&typenames=cdf:Fifteen&version=2.0.0&service=wfs&count=5&startIndex=0");
+        XMLAssert.assertXpathEvaluatesTo("5", "count(//cdf:Fifteen)", dom);
+        assertEquals("5", dom.getDocumentElement().getAttribute("numberReturned"));
+        assertEquals("15", dom.getDocumentElement().getAttribute("numberMatched"));
+    }
+
+    @Test
+    public void testGetWithCountAndStartIndexMiddle() throws Exception {
+        Document dom = getAsDOM(
+            "wfs?request=GetFeature&typenames=cdf:Fifteen&version=2.0.0&service=wfs&count=5&startIndex=7");
+        XMLAssert.assertXpathEvaluatesTo("5", "count(//cdf:Fifteen)", dom);
+        assertEquals("5", dom.getDocumentElement().getAttribute("numberReturned"));
+        assertEquals("15", dom.getDocumentElement().getAttribute("numberMatched"));
+    }
+
+    @Test
+    public void testGetWithCountAndStartIndexEnd() throws Exception {
+        Document dom = getAsDOM(
+            "wfs?request=GetFeature&typenames=cdf:Fifteen&version=2.0.0&service=wfs&count=5&startIndex=11");
+        XMLAssert.assertXpathEvaluatesTo("4", "count(//cdf:Fifteen)", dom);
+        assertEquals("4", dom.getDocumentElement().getAttribute("numberReturned"));
+        assertEquals("15", dom.getDocumentElement().getAttribute("numberMatched"));
+    }
+
+    @Test
     public void testGetPropertyNameEmpty() throws Exception {
     	testGetFifteenAll("wfs?request=GetFeature&typename=cdf:Fifteen&version=2.0.0&service=wfs&propertyname=");
     }


### PR DESCRIPTION
Prevent optimizations when the combination of `count` and `startIndex` result in fewer than `count` features matching the request.