### PR TITLE
Fix serialization of brute force whitelist mask

### DIFF
--- a/src/web/security/core/src/main/java/org/geoserver/security/web/auth/CommaSeparatedListConverter.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/auth/CommaSeparatedListConverter.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.security.web.auth;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -22,7 +22,14 @@ public class CommaSeparatedListConverter implements IConverter<List<String>> {
 
     @Override
     public List<String> convertToObject(String value, Locale locale) throws ConversionException {
-        return Arrays.asList(value.split("\\s*,\\s*"));
+        String[] split = value.split("\\s*,\\s*");
+        final ArrayList list = new ArrayList<>();
+        // Need to return an implementation of List<String> that isn't private.
+        // Arrays.asList returns a private inner class inside Arrays that can't be added to the allowed XStream types.
+        for (String val : split) {
+            list.add(val);
+        }
+        return list;
     }
 
     @Override


### PR DESCRIPTION
When using the UI to add IP addresses to the `Excluded network masks`, the serialized config that is written looks like this:
```xml
  <bruteForcePrevention>
    <enabled>true</enabled>
    <minDelaySeconds>1</minDelaySeconds>
    <maxDelaySeconds>5</maxDelaySeconds>
    <maxBlockedThreads>100</maxBlockedThreads>
    <whitelistedMasks  class="java.util.Arrays$ArrayList">
        <a class="string-array">
            <string>127.0.0.1</string>
            <string>192.168.0.1</string>
        </a>
    </whitelistedMasks>
  </bruteForcePrevention>
```

This is because the UI page (`AuthenticationPage`) that contains the brute force protection config uses `CommaSeparatedListConverter` to convert the user entered list of IPs into a `List<String>`. The problem is, the implementation uses `java.util.Arrays.asList()` which returns a private concrete class: `java.util.Arrays.ArrayList`.

There doesn't seem to be a way to use any of the `allowTypes` methods within `SecureXStream.java` to add this Class type to the allowed list, so when the config is deserialized on restarts, it throws `com.thoughtworks.xstream.security.ForbiddenClassException`.

Changing the UI implementation to create an `ArrayList<String>` changes how the config is serialized to this:
```xml
  <bruteForcePrevention>
    <enabled>true</enabled>
    <minDelaySeconds>1</minDelaySeconds>
    <maxDelaySeconds>5</maxDelaySeconds>
    <maxBlockedThreads>100</maxBlockedThreads>
    <whitelistedMasks>
        <string>127.0.0.1</string>
        <string>192.168.0.1</string>
    </whitelistedMasks>
  </bruteForcePrevention>
```
which can be deserialized correctly over restarts.