### PR TITLE
[GEOS-8607] Fix warning when parsing rules on a non global group

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
@@ -24,6 +24,7 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.security.AccessMode;
 import org.geoserver.security.CatalogMode;
+import org.geotools.feature.NameImpl;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -163,7 +164,9 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         if(layerName != null) {
             if (!ANY.equals(root) && rawCatalog.getWorkspaceByName(root) == null)
                 LOGGER.warning("Namespace/Workspace " + root + " is unknown in rule " + rule);
-            if (!ANY.equals(layerName) && rawCatalog.getLayerByName(layerName) == null)
+            if (!ANY.equals(layerName) &&
+                    !(   rawCatalog.getLayerByName(new NameImpl(root, layerName)) != null
+                    || rawCatalog.getLayerGroupByName(root, layerName) != null ))
                 LOGGER.warning("Layer " + root + " is unknown in rule + " + rule);
         } else {
             if (!ANY.equals(root) && rawCatalog.getLayerGroupByName(root) == null)

--- a/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
@@ -164,9 +164,9 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         if(layerName != null) {
             if (!ANY.equals(root) && rawCatalog.getWorkspaceByName(root) == null)
                 LOGGER.warning("Namespace/Workspace " + root + " is unknown in rule " + rule);
-            if (!ANY.equals(layerName) &&
-                    !(   rawCatalog.getLayerByName(new NameImpl(root, layerName)) != null
-                    || rawCatalog.getLayerGroupByName(root, layerName) != null ))
+            if (!ANY.equals(layerName)
+                    && rawCatalog.getLayerByName(new NameImpl(root, layerName)) == null
+                    && rawCatalog.getLayerGroupByName(root, layerName) == null)
                 LOGGER.warning("Layer " + root + " is unknown in rule + " + rule);
         } else {
             if (!ANY.equals(root) && rawCatalog.getLayerGroupByName(root) == null)


### PR DESCRIPTION
When parsing security rules, class DataAccessRuleDao log a warn when a rule doesn't match an existing layer. This check doesn't handle layergroups in workspaces, only workspaces, layers with or without
workspaces and layergroups without workspace.
This fix adds a check on layergroups in workspace in order not to log a false warning.