### PR TITLE
[GEOS-8535] Using Apache Solr data store from GeoServer UI may result in a class not found exception

### DIFF
--- a/src/community/solr/pom.xml
+++ b/src/community/solr/pom.xml
@@ -38,17 +38,6 @@
       <version>${gt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.solr</groupId>
-      <artifactId>solr-solrj</artifactId>
-      <version>4.9.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1265,6 +1265,17 @@
       <artifactId>postgresql</artifactId>
       <version>${postgresql.jdbc.version}</version>
     </dependency>
+   <dependency>
+    <groupId>org.apache.solr</groupId>
+    <artifactId>solr-solrj</artifactId>
+    <version>${solrj.version}</version>
+    <exclusions>
+     <exclusion>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+     </exclusion>
+    </exclusions>
+   </dependency>
   </dependencies>
  </dependencyManagement>
 
@@ -1871,6 +1882,7 @@
   <compress-lzf.version>1.0.3</compress-lzf.version>
   <marlin.version>0.7.5-Unsafe</marlin.version>
   <postgresql.jdbc.version>42.1.1</postgresql.jdbc.version>
+  <solrj.version>7.2.1</solrj.version>
   <argLine>-Xmx${test.maxHeapSize} -enableassertions ${jvm.opts} -Djava.awt.headless=${java.awt.headless} -Dsun.java2d.d3d=${sun.java2d.d3d} -DremoteOwsTests=${remoteOwsTests} -DquietTests=${quietTests} -Dorg.geotools.image.test.enabled=${image.tests} -Dorg.geotools.image.test.interactive=${interactive.image} -Duser.timezone=${user.timezone} -Dwindows.leniency=${windows.leniency} -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
  </properties>
 


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-8535

Note that the necessary fixes have already be done in GeoTools:
https://github.com/geotools/geotools/pull/1792

The exception we get when creating a Solr store in GeoServer::

![image](https://user-images.githubusercontent.com/1590542/36043448-445bcd6a-0dc7-11e8-8536-729651bdb50c.png)
