### PR TITLE
[GEOS-8587] Finalize backup as part of backup job

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/BackupJobExecutionListener.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/BackupJobExecutionListener.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.backuprestore.listener;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
@@ -13,7 +12,6 @@ import java.util.logging.Logger;
 
 import org.geoserver.backuprestore.Backup;
 import org.geoserver.backuprestore.BackupExecutionAdapter;
-import org.geoserver.backuprestore.utils.BackupUtils;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
 import org.geotools.util.logging.Logging;
@@ -115,7 +113,6 @@ public class BackupJobExecutionListener implements JobExecutionListener {
                     JobParameters jobParameters = backupExecution.getJobParameters();
                     Resource sourceFolder = Resources
                             .fromURL(jobParameters.getString(Backup.PARAM_OUTPUT_FILE_PATH));
-                    BackupUtils.compressTo(sourceFolder, backupExecution.getArchiveFile());
                     
                     // Cleanup Temporary Resources
                     String cleanUpTempFolders = jobParameters.getString(Backup.PARAM_CLEANUP_TEMP);
@@ -132,7 +129,7 @@ public class BackupJobExecutionListener implements JobExecutionListener {
                     }
                 }
             }
-        } catch (NoSuchJobExecutionException | IOException e) {
+        } catch (NoSuchJobExecutionException e) {
             if (!bestEffort) {
                 this.backupExecution.addFailureExceptions(Arrays.asList(e));
                 throw new RuntimeException(e);

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/FinalizeBackupTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/FinalizeBackupTasklet.java
@@ -1,0 +1,65 @@
+package org.geoserver.backuprestore.tasklet;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.geoserver.backuprestore.Backup;
+import org.geoserver.backuprestore.BackupExecutionAdapter;
+import org.geoserver.backuprestore.utils.BackupUtils;
+import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * Final step of the backup: creating the final zip file
+ */
+public class FinalizeBackupTasklet extends AbstractCatalogBackupRestoreTasklet {
+
+    public FinalizeBackupTasklet(Backup backupFacade, XStreamPersisterFactory xStreamPersisterFactory) {
+        super(backupFacade, xStreamPersisterFactory);
+    }
+
+    @Override
+    protected void initialize(StepExecution stepExecution) {
+
+    }
+
+    @Override
+    RepeatStatus doExecute(StepContribution contribution, ChunkContext chunkContext, JobExecution jobExecution)
+        throws Exception {
+
+        BackupExecutionAdapter backupExecution = backupFacade.getBackupExecutions().get(jobExecution.getId());
+        boolean bestEffort = Boolean.parseBoolean(
+            jobExecution.getJobParameters().getString(Backup.PARAM_BEST_EFFORT_MODE, "false"));
+
+        final Long executionId = jobExecution.getId();
+
+        LOGGER.fine("Running Executions IDs : " + executionId);
+
+        if (jobExecution.getStatus() != BatchStatus.STOPPED) {
+            try {
+                JobParameters jobParameters = backupExecution.getJobParameters();
+                Resource sourceFolder = Resources.fromURL(jobParameters.getString(Backup.PARAM_OUTPUT_FILE_PATH));
+                BackupUtils.compressTo(sourceFolder, backupExecution.getArchiveFile());
+            } catch (IOException e) {
+                LOGGER.severe("Backup failed while creating final ");
+                if (!bestEffort) {
+                    backupExecution.addFailureExceptions(Arrays.asList(e));
+                    throw new RuntimeException(e);
+                } else {
+                    backupExecution.addWarningExceptions(Arrays.asList(e));
+                }
+
+            }
+        }
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/community/backup-restore/core/src/main/resources/applicationContext.xml
+++ b/src/community/backup-restore/core/src/main/resources/applicationContext.xml
@@ -59,9 +59,9 @@
 	<!-- ********************** -->
 	
 	<!-- The main Job Listener: This is responsible of both pre/post-processing before/afer the Job execution and managing configuration locks -->
-		<bean id="backupJobExecutionListener" class="org.geoserver.backuprestore.listener.BackupJobExecutionListener">
-			<constructor-arg ref="backupFacade"/>
-		</bean>
+	<bean id="backupJobExecutionListener" class="org.geoserver.backuprestore.listener.BackupJobExecutionListener">
+		<constructor-arg ref="backupFacade"/>
+	</bean>
 
 	<!-- Extension point for backup jobs listeners -->
 	<bean id="genericBackupJobExecutionListener" class="org.geoserver.backuprestore.listener.GenericListenersExecutor">
@@ -69,9 +69,13 @@
 	</bean>
 
 	<!-- CatalogAdditionalResourcesWriter extensions: those can be triggered by the CatalogWriter -->
-		<bean id="styleInfoAdditionalResourceWriter" class="org.geoserver.backuprestore.writer.StyleInfoAdditionalResourceWriter" />
-	
-		<bean id="resourceInfoAdditionalResourceWriter" class="org.geoserver.backuprestore.writer.ResourceInfoAdditionalResourceWriter" />
+	<bean id="styleInfoAdditionalResourceWriter" class="org.geoserver.backuprestore.writer.StyleInfoAdditionalResourceWriter" />
+	<bean id="resourceInfoAdditionalResourceWriter" class="org.geoserver.backuprestore.writer.ResourceInfoAdditionalResourceWriter" />
+	<bean id="finalizeBackupTasklet" class="org.geoserver.backuprestore.tasklet.FinalizeBackupTasklet">
+		<constructor-arg ref="backupFacade" />
+		<constructor-arg ref="xstreamPersisterFactory" />
+		<property name="timeout" value="600000"/>
+	</bean>
 	
 	<!-- The BACKUP Job definition START here -->
 	<batch:job id="backupJob" restartable="true">
@@ -420,6 +424,13 @@
 					</batch:writer>
 				</batch:chunk>
 			</batch:tasklet>
+			<batch:fail on="FAILED"/>
+			<batch:stop on="STOPPED" restart="finalizeBackup"/>
+			<batch:next on="*" to="finalizeBackup"/>
+		</batch:step>
+
+		<batch:step id="finalizeBackup">
+			<batch:tasklet ref="finalizeBackupTasklet"/>
 		</batch:step>
 
 	</batch:job>
@@ -431,9 +442,9 @@
 	<!-- *********************** -->
 	
 	<!-- The main Job Listener: This is responsible of both pre/post-processing before/afer the Job execution and managing configuration locks -->
-		<bean id="restoreJobExecutionListener" class="org.geoserver.backuprestore.listener.RestoreJobExecutionListener">
-			<constructor-arg ref="backupFacade"/>
-		</bean>
+	<bean id="restoreJobExecutionListener" class="org.geoserver.backuprestore.listener.RestoreJobExecutionListener">
+		<constructor-arg ref="backupFacade"/>
+	</bean>
 
 	<!-- Extensions point for restore jobs listeners -->
 	<bean id="genericRestoreJobExecutionListener" class="org.geoserver.backuprestore.listener.GenericListenersExecutor">
@@ -441,10 +452,10 @@
 	</bean>
 
 		<!-- This specific Listener allows to promote properties setted on Steps to Job Context Scope -->
-		<bean id="restoreExecutionPromotionListener" 
-				class="org.springframework.batch.core.listener.ExecutionContextPromotionListener">
-	    	<property name="keys" value="restore.catalog"/>
-		</bean>
+	<bean id="restoreExecutionPromotionListener"
+			class="org.springframework.batch.core.listener.ExecutionContextPromotionListener">
+		<property name="keys" value="restore.catalog"/>
+	</bean>
 
 	<!-- CatalogAdditionalResourcesReader extensions: those can be triggered by the CatalogReader -->
 		

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
@@ -5,10 +5,7 @@
 package org.geoserver.backuprestore;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -311,11 +308,8 @@ public class BackupTest extends BackupRestoreTestSupport {
         } catch (Exception exception) {
             throw new RuntimeException("Error reading extra properties file.", exception);
         }
-        // check that the expected properties are present
-        // AF: Currently this file exists but is empty
-        assertThat(extraProperties.size(), is(0));
-        // assertThat(extraProperties.size(), is(2));
-        // assertThat(extraProperties.getProperty("property.a"), is("1"));
-        // assertThat(extraProperties.getProperty("property.b"), is("2"));
+        assertThat(extraProperties.size(), is(2));
+        assertThat(extraProperties.getProperty("property.a"), is("1"));
+        assertThat(extraProperties.getProperty("property.b"), is("2"));
     }
 }


### PR DESCRIPTION
This moves the final step of the backup process from the afterJob call to its own discrete Spring Batch step. This prevents the job from being marked as COMPLETED before the entire process is finished.

We ran into this issue when trying to script backups, because the job gets marked as completed but the zip file does not exist yet.