### PR TITLE
[GEOS-8598] WMTS n-dimensional DescribeDomain loads the entire domain of a dimension when min/max would suffice

### DIFF
--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/DomainSummary.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/DomainSummary.java
@@ -1,0 +1,48 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.wmts.dimensions;
+
+import org.geotools.geometry.jts.ReferencedEnvelope;
+
+
+/**
+ * Simple containers of statistics about a domain
+ */
+class DomainSummary {
+    
+    private ReferencedEnvelope envelope;
+    private Object min;
+    private Object max;
+    private long count = -1;
+
+    public DomainSummary(ReferencedEnvelope envelope, Object min, Object max) {
+        this.envelope = envelope;
+        this.min = min;
+        this.max = max;
+    }
+
+    public DomainSummary(ReferencedEnvelope envelope, Object min, Object max, long count) {
+        this.envelope = envelope;
+        this.min = min;
+        this.max = max;
+        this.count = count;
+    }
+
+    public ReferencedEnvelope getEnvelope() {
+        return envelope;
+    }
+
+    public Object getMin() {
+        return min;
+    }
+
+    public Object getMax() {
+        return max;
+    }
+
+    public long getCount() {
+        return count;
+    }
+}

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterCustomDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterCustomDimension.java
@@ -6,21 +6,16 @@ package org.geoserver.gwc.wmts.dimensions;
 
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
-import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.gwc.wmts.dimensions.CoverageDimensionsReader.DataType;
 import org.geoserver.wms.WMS;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.opengis.filter.Filter;
-
-import java.util.List;
 
 /**
  * Represents a custom dimension of a raster.
  */
-public class RasterCustomDimension extends Dimension {
+public class RasterCustomDimension extends RasterDimension {
 
     public RasterCustomDimension(WMS wms, LayerInfo layerInfo, String name, DimensionInfo dimensionInfo) {
-        super(wms, name, layerInfo, dimensionInfo);
+        super(wms, name, layerInfo, dimensionInfo, DataType.CUSTOM, DimensionsUtils.CUSTOM_COMPARATOR);
     }
 
     @Override
@@ -33,13 +28,4 @@ public class RasterCustomDimension extends Dimension {
         return getWms().getDefaultCustomDimensionValue(getDimensionName(), getResourceInfo(), String.class);
     }
 
-    @Override
-    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
-        return getRasterDomainValues(filter, noDuplicates, DataType.CUSTOM, DimensionsUtils.CUSTOM_COMPARATOR);
-    }
-
-    @Override
-    public Filter getFilter() {
-        return buildRasterFilter();
-    }
 }

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterDimension.java
@@ -1,0 +1,82 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.wmts.dimensions;
+
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.gwc.wmts.Tuple;
+import org.geoserver.wms.WMS;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.filter.Filter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Base class for raster based dimensions
+ */
+public abstract class RasterDimension extends Dimension {
+
+    private final CoverageDimensionsReader.DataType dataType;
+    private final Comparator comparator;
+
+    public RasterDimension(WMS wms, String dimensionName, LayerInfo layerInfo, DimensionInfo dimensionInfo, CoverageDimensionsReader.DataType dataType, Comparator comparator) {
+        super(wms, dimensionName, layerInfo, dimensionInfo);
+        this.dataType = dataType;
+        this.comparator = comparator;
+    }
+
+    @Override
+    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
+        CoverageDimensionsReader reader = CoverageDimensionsReader.instantiateFrom((CoverageInfo) resourceInfo);
+        if (noDuplicates) {
+            // no duplicate values should be included
+            Tuple<ReferencedEnvelope, Set<Object>> values = reader.readWithoutDuplicates(getDimensionName(), filter, dataType, comparator);
+            List<Object> list = new ArrayList<>(values.second.size());
+            list.addAll(values.second);
+            return Tuple.tuple(values.first, list);
+        }
+        // we need the duplicate values (this is useful for some operations like get histogram operation)
+        return reader.readWithDuplicates(getDimensionName(), filter, dataType, comparator);
+    }
+
+    protected DomainSummary getDomainSummary(Filter filter, boolean includeCount) {
+        CoverageDimensionsReader reader = CoverageDimensionsReader.instantiateFrom((CoverageInfo) resourceInfo);
+
+        Tuple<String, FeatureCollection> values = reader.getValues(getDimensionName(), filter, dataType);
+        return getDomainSummary(values.second, values.first, includeCount);
+    }
+
+    @Override
+    public Filter getFilter() {
+        CoverageInfo typeInfo = (CoverageInfo) getResourceInfo();
+        Filter filter = Filter.INCLUDE;
+        if (boundingBox != null) {
+            // we have a bounding box so lets build a filter for it
+            try {
+                filter = appendBoundingBoxFilter(filter, typeInfo);
+            } catch (IOException exception) {
+                throw new RuntimeException(String.format("Exception accessing feature source of raster type '%s'.",
+                        typeInfo.getName()), exception);
+            }
+        }
+        if (domainRestrictions != null) {
+            CoverageDimensionsReader reader = CoverageDimensionsReader.instantiateFrom(typeInfo);
+            Tuple<String, String> attributes = reader.getDimensionAttributesNames(getDimensionName());
+            if (attributes.first == null) {
+                throw new RuntimeException(String.format(
+                        "Could not found start attribute name for dimension '%s' in raster '%s'.", getDimensionName(), typeInfo.getName()));
+            }
+            // ok time to build the domain values filter
+            filter = appendDomainRestrictionsFilter(filter, attributes.first, attributes.second);
+        }
+        return filter;
+    }
+}

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterElevationDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterElevationDimension.java
@@ -8,34 +8,21 @@ import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.opengis.filter.Filter;
-
-import java.util.List;
 
 /**
  * Represents an elevation dimension of a raster.
  */
-public class RasterElevationDimension extends Dimension {
+public class RasterElevationDimension extends RasterDimension {
 
     public RasterElevationDimension(WMS wms, LayerInfo layerInfo, DimensionInfo dimensionInfo) {
-        super(wms, ResourceInfo.ELEVATION, layerInfo, dimensionInfo);
+        super(wms, ResourceInfo.ELEVATION, layerInfo, dimensionInfo, CoverageDimensionsReader.DataType.NUMERIC, 
+                DimensionsUtils.NUMERICAL_COMPARATOR);
     }
 
     @Override
     protected String getDefaultValueFallbackAsString() {
-        return DimensionDefaultValueSetting.TIME_CURRENT;
+        return "0";
     }
 
-    @Override
-    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
-        return getRasterDomainValues(filter, noDuplicates, CoverageDimensionsReader.DataType.NUMERIC, DimensionsUtils.NUMERICAL_COMPARATOR);
-    }
-
-    @Override
-    public Filter getFilter() {
-        return buildRasterFilter();
-    }
 }

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterTimeDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/RasterTimeDimension.java
@@ -8,20 +8,16 @@ import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.opengis.filter.Filter;
-
-import java.util.List;
 
 /**
  * Represents a time dimension of a raster.
  */
-public class RasterTimeDimension extends Dimension {
+public class RasterTimeDimension extends RasterDimension {
 
     public RasterTimeDimension(WMS wms, LayerInfo layerInfo, DimensionInfo dimensionInfo) {
-        super(wms, ResourceInfo.TIME, layerInfo, dimensionInfo);
+        super(wms, ResourceInfo.TIME, layerInfo, dimensionInfo, CoverageDimensionsReader.DataType.TEMPORAL, 
+                DimensionsUtils.TEMPORAL_COMPARATOR);
     }
 
     @Override
@@ -29,13 +25,4 @@ public class RasterTimeDimension extends Dimension {
         return DimensionDefaultValueSetting.TIME_CURRENT;
     }
 
-    @Override
-    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
-        return getRasterDomainValues(filter, noDuplicates, CoverageDimensionsReader.DataType.TEMPORAL, DimensionsUtils.TEMPORAL_COMPARATOR);
-    }
-
-    @Override
-    public Filter getFilter() {
-        return buildRasterFilter();
-    }
 }

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorDimension.java
@@ -1,0 +1,124 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.wmts.dimensions;
+
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.gwc.wmts.Tuple;
+import org.geoserver.wms.WMS;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.Query;
+import org.geotools.factory.GeoTools;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.filter.Filter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Base class for vector based dimension
+ */
+public abstract class VectorDimension extends Dimension {
+
+    private final Comparator comparator;
+
+    public VectorDimension(WMS wms, String dimensionName, LayerInfo layerInfo, DimensionInfo dimensionInfo, 
+                           Comparator comparator) {
+        super(wms, dimensionName, layerInfo, dimensionInfo);
+        this.comparator = comparator;
+    }
+
+    /**
+     * Helper method used to get domain values from a vector type in the form of a feature collection.
+     */
+    protected FeatureCollection getDomain(Filter filter) {
+        FeatureTypeInfo typeInfo = (FeatureTypeInfo) getResourceInfo();
+        FeatureSource source;
+        try {
+            source = typeInfo.getFeatureSource(null, GeoTools.getDefaultHints());
+        } catch (Exception exception) {
+            throw new RuntimeException(String.format(
+                    "Error getting feature source of vector '%s'.", resourceInfo.getName()), exception);
+        }
+        Query query = new Query(source.getSchema().getName().getLocalPart(), filter == null ? Filter.INCLUDE : filter);
+        try {
+            return source.getFeatures(query);
+        } catch (Exception exception) {
+            throw new RuntimeException(String.format(
+                    "Error reading feature from layer '%s' for dimension '%s'.",
+                    resourceInfo.getName(), getDimensionName()), exception);
+        }
+    }
+
+    /**
+     * Helper method used to get domain values from a vector type.
+     */
+    Tuple<ReferencedEnvelope, List<Object>> getVectorDomainValues(Filter filter, boolean noDuplicates, Comparator<Object> comparator) {
+        FeatureCollection featureCollection = getDomain(filter);
+        if (noDuplicates) {
+            // no duplicate values should be included
+            Set<Object> values = DimensionsUtils.
+                    getValuesWithoutDuplicates(dimensionInfo.getAttribute(), featureCollection, comparator);
+            List<Object> list = new ArrayList<>(values.size());
+            list.addAll(values);
+            return Tuple.tuple(featureCollection.getBounds(), list);
+        }
+        // we need the duplicate values (this is useful for some operations like get histogram operation)
+        return Tuple.tuple(featureCollection.getBounds(),
+                DimensionsUtils.getValuesWithDuplicates(dimensionInfo.getAttribute(), featureCollection, comparator));
+    }
+
+    @Override
+    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
+        FeatureCollection featureCollection = getDomain(filter);
+        if (noDuplicates) {
+            // no duplicate values should be included
+            Set<Object> values = DimensionsUtils.
+                    getValuesWithoutDuplicates(dimensionInfo.getAttribute(), featureCollection, comparator);
+            List<Object> list = new ArrayList<>(values.size());
+            list.addAll(values);
+            return Tuple.tuple(featureCollection.getBounds(), list);
+        }
+        // we need the duplicate values (this is useful for some operations like get histogram operation)
+        return Tuple.tuple(featureCollection.getBounds(),
+                DimensionsUtils.getValuesWithDuplicates(dimensionInfo.getAttribute(), featureCollection, comparator));
+    }
+
+    protected DomainSummary getDomainSummary(Filter filter, boolean includeCount) {
+        FeatureCollection features = getDomain(filter);
+        String attribute = dimensionInfo.getAttribute();
+
+        return getDomainSummary(features, attribute, includeCount);
+    }
+
+    @Override
+    public Filter getFilter() {
+        FeatureTypeInfo typeInfo = (FeatureTypeInfo) getResourceInfo();
+        Filter filter = Filter.INCLUDE;
+        if (boundingBox != null) {
+            // we have a bounding box so lets build a filter for it
+            String geometryAttributeName;
+            try {
+                // let's find out the geometry attribute
+                geometryAttributeName = typeInfo.getFeatureSource(null, null).getSchema().getGeometryDescriptor().getLocalName();
+            } catch (IOException exception) {
+                throw new RuntimeException(String.format("Exception accessing feature source of vector type '%s'.",
+                        typeInfo.getName()), exception);
+            }
+            // creating the bounding box filter and append it to our filter
+            filter = appendBoundingBoxFilter(filter, geometryAttributeName);
+        }
+        if (domainRestrictions != null) {
+            // we have a domain filter
+            filter = appendDomainRestrictionsFilter(filter, dimensionInfo.getAttribute(), dimensionInfo.getEndAttribute());
+        }
+        return filter;
+    }
+}

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorElevationDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorElevationDimension.java
@@ -7,34 +7,20 @@ package org.geoserver.gwc.wmts.dimensions;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.opengis.filter.Filter;
-
-import java.util.List;
 
 /**
  * Represents an elevation dimension of a vector (feature type).
  */
-public class VectorElevationDimension extends Dimension {
+public class VectorElevationDimension extends VectorDimension {
 
     public VectorElevationDimension(WMS wms, LayerInfo layerInfo, DimensionInfo dimensionInfo) {
-        super(wms, ResourceInfo.ELEVATION, layerInfo, dimensionInfo);
+        super(wms, ResourceInfo.ELEVATION, layerInfo, dimensionInfo, DimensionsUtils.NUMERICAL_COMPARATOR);
     }
 
     @Override
     protected String getDefaultValueFallbackAsString() {
         return "0";
     }
-
-    @Override
-    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
-        return getVectorDomainValues(filter, noDuplicates, DimensionsUtils.NUMERICAL_COMPARATOR);
-    }
-
-    @Override
-    public Filter getFilter() {
-        return buildVectorFilter();
-    }
+   
 }

--- a/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorTimeDimension.java
+++ b/src/community/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/VectorTimeDimension.java
@@ -8,20 +8,15 @@ import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.gwc.wmts.Tuple;
 import org.geoserver.wms.WMS;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.opengis.filter.Filter;
-
-import java.util.List;
 
 /**
  * Represents a time dimension of a vector (feature type).
  */
-public class VectorTimeDimension extends Dimension {
+public class VectorTimeDimension extends VectorDimension {
 
     public VectorTimeDimension(WMS wms, LayerInfo layerInfo, DimensionInfo dimensionInfo) {
-        super(wms, ResourceInfo.TIME, layerInfo, dimensionInfo);
+        super(wms, ResourceInfo.TIME, layerInfo, dimensionInfo, DimensionsUtils.TEMPORAL_COMPARATOR);
     }
 
     @Override
@@ -29,13 +24,4 @@ public class VectorTimeDimension extends Dimension {
         return DimensionDefaultValueSetting.TIME_CURRENT;
     }
 
-    @Override
-    public Tuple<ReferencedEnvelope, List<Object>> getDomainValues(Filter filter, boolean noDuplicates) {
-        return getVectorDomainValues(filter, noDuplicates, DimensionsUtils.TEMPORAL_COMPARATOR);
-    }
-
-    @Override
-    public Filter getFilter() {
-        return buildVectorFilter();
-    }
 }


### PR DESCRIPTION
The changes in this pull request:

- The optimization reported in the title
- Taking apart the Dimension class, which was a "method collector" mixing vector and raster stuff, and creating two subclasses better separating the vector and raster bits
- Making the other subclasses extend one of the above, reducing the amount of code duplication (they could have been parameterized away by just using VectorDimension and RasterDimension, but then I would have had to change all creation points... probably enough changes for a first round)