### PR TITLE
[GEOS-8352] Number of decimals ignored for GML 3.2 output

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/BBox3DTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/BBox3DTest.java
@@ -36,7 +36,7 @@ public class BBox3DTest extends AbstractAppSchemaTestSupport {
         assertXpathCount( 1,"//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf3']", doc);
         assertXpathCount( 0,"//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf4']", doc);
         
-        assertXpathEvaluatesTo("167.9388 -29.0434 7.0", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf2']/gsml:shape/gml:Point/gml:pos", doc);
+        assertXpathEvaluatesTo("167.9388 -29.0434 7", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf2']/gsml:shape/gml:Point/gml:pos", doc);
         assertXpathEvaluatesTo("3", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf2']/gsml:shape/gml:Point/@srsDimension", doc);
         assertXpathEvaluatesTo("http://www.opengis.net/gml/srs/epsg.xml#4979", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf2']/gsml:shape/gml:Point/@srsName", doc);
     }
@@ -56,7 +56,7 @@ public class BBox3DTest extends AbstractAppSchemaTestSupport {
         assertXpathCount( 0,"//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf3']", doc);
         assertXpathCount( 1,"//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf4']", doc);
         
-        assertXpathEvaluatesTo("133.8855 -23.6701 112.0", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf1']/gsml:shape/gml:Point/gml:pos", doc);
+        assertXpathEvaluatesTo("133.8855 -23.6701 112", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf1']/gsml:shape/gml:Point/gml:pos", doc);
         assertXpathEvaluatesTo("3", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf1']/gsml:shape/gml:Point/@srsDimension", doc);
         assertXpathEvaluatesTo("http://www.opengis.net/gml/srs/epsg.xml#4979", "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf1']/gsml:shape/gml:Point/@srsName", doc);
 

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/BBoxFilterTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/BBoxFilterTest.java
@@ -7,6 +7,8 @@
 package org.geoserver.test;
 
 import org.geotools.geometry.jts.JTS;
+import org.geotools.gml.producer.CoordinateFormatter;
+import org.geotools.measure.CoordinateFormat;
 import org.geotools.referencing.CRS;
 import org.junit.Test;
 import org.opengis.geometry.MismatchedDimensionException;
@@ -181,12 +183,13 @@ public class BBoxFilterTest extends AbstractAppSchemaTestSupport {
         GeometryFactory factory = new GeometryFactory();
         Point targetPoint = (Point) JTS.transform(factory
                 .createPoint(new Coordinate(132.61, -26.98)), transform);
-        String targetPointCoord1 = targetPoint.getCoordinate().x + " "
-                + targetPoint.getCoordinate().y;
+        CoordinateFormatter format = new CoordinateFormatter(8);
+        String targetPointCoord1 = format.format(targetPoint.getCoordinate().x) + " "
+                + format.format(targetPoint.getCoordinate().y);
         targetPoint = (Point) JTS.transform(factory.createPoint(new Coordinate(132.71, -26.46)),
                 transform);
-        String targetPointCoord2 = targetPoint.getCoordinate().x + " "
-                + targetPoint.getCoordinate().y;
+        String targetPointCoord2 = format.format(targetPoint.getCoordinate().x) + " "
+                + format.format(targetPoint.getCoordinate().y);
 
         assertXpathEvaluatesTo("urn:x-ogc:def:crs:EPSG:4283",
                 "//ex:geomContainer[@gml:id='1']/ex:geom/gml:Point/@srsName", doc);

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml32BoreholeIntervalWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml32BoreholeIntervalWfsTest.java
@@ -49,13 +49,13 @@ public class Gsml32BoreholeIntervalWfsTest extends AbstractAppSchemaTestSupport 
         assertXpathEvaluatesTo("#borehole.shape.GA.17322", "//gsmlbh:Borehole[@gml:id='borehole.GA.17322']/" + lineStringPath + "/@srsName", doc);
         assertXpathEvaluatesTo("1", "//gsmlbh:Borehole[@gml:id='borehole.GA.17322']/" + lineStringPath + "/@srsDimension", doc);
         assertXpathEvaluatesTo("m", "//gsmlbh:Borehole[@gml:id='borehole.GA.17322']/" + lineStringPath + "/@uomLabels", doc);
-        assertXpathEvaluatesTo("0.0 153.92", "//gsmlbh:Borehole[@gml:id='borehole.GA.17322']/" + lineStringPath + "/gml:posList", doc);   
+        assertXpathEvaluatesTo("0 153.92", "//gsmlbh:Borehole[@gml:id='borehole.GA.17322']/" + lineStringPath + "/gml:posList", doc);   
         // 2. Second borehole
         assertXpathEvaluatesTo("borehole.drillingDetails.interval.17338", "//gsmlbh:Borehole[@gml:id='borehole.GA.17338']/" + lineStringPath + "/@gml:id", doc);
         assertXpathEvaluatesTo("#borehole.shape.GA.17338", "//gsmlbh:Borehole[@gml:id='borehole.GA.17338']/" + lineStringPath + "/@srsName", doc);
         assertXpathEvaluatesTo("1", "//gsmlbh:Borehole[@gml:id='borehole.GA.17338']/" + lineStringPath + "/@srsDimension", doc);
         assertXpathEvaluatesTo("m", "//gsmlbh:Borehole[@gml:id='borehole.GA.17338']/" + lineStringPath + "/@uomLabels", doc);
-        assertXpathEvaluatesTo("0.0 91.55", "//gsmlbh:Borehole[@gml:id='borehole.GA.17338']/" + lineStringPath + "/gml:posList", doc);      
+        assertXpathEvaluatesTo("0 91.55", "//gsmlbh:Borehole[@gml:id='borehole.GA.17338']/" + lineStringPath + "/gml:posList", doc);      
         
         // #Second LineString
         // 1. First borehole
@@ -78,7 +78,6 @@ public class Gsml32BoreholeIntervalWfsTest extends AbstractAppSchemaTestSupport 
         assertXpathCount(0, "/gsmlbh:Borehole[@gml:id='borehole.GA.17322']/sams:shape/gml:Curve/@srsName", doc);
         assertXpathCount(0, "/gsmlbh:Borehole[@gml:id='borehole.GA.17322']/sams:shape/gml:Curve/@srsDimension", doc);  
         assertXpathEvaluatesTo("borehole.shape.GA.17338", "//gsmlbh:Borehole[@gml:id='borehole.GA.17338']/sams:shape/gml:Curve/@gml:id", doc);
-        assertXpathCount(0, "/gsmlbh:Borehole[@gml:id='borehole.GA.17338']/sams:shape/gml:Curve/@srsName", doc);
         assertXpathCount(0, "/gsmlbh:Borehole[@gml:id='borehole.GA.17338']/sams:shape/gml:Curve/@srsDimension", doc);
     }
 

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/IsolatedNamespacesWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/IsolatedNamespacesWfsTest.java
@@ -140,7 +140,7 @@ public final class IsolatedNamespacesWfsTest extends AbstractAppSchemaTestSuppor
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/gml:featureMember/" +
                 "st_1_gml31:Station_gml31[@gml:id='st.1']/st_1_gml31:measurements/ms_1_gml31:Measurement_gml31[ms_1_gml31:name='isolated_1_wind']");
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/gml:featureMember/" +
-                "st_1_gml31:Station_gml31[@gml:id='st.1']/st_1_gml31:location/gml:Point[gml:pos='1.0 -1.0']");
+                "st_1_gml31:Station_gml31[@gml:id='st.1']/st_1_gml31:location/gml:Point[gml:pos='1 -1']");
         // request isolated feature type using global service should fail with feature type unknown
         document = getAsDOM("wfs?request=GetFeature&version=1.1.0&typename=st_1_gml31:Station_gml31");
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/ows:ExceptionReport/ows:Exception[@exceptionCode='InvalidParameterValue']");
@@ -156,7 +156,7 @@ public final class IsolatedNamespacesWfsTest extends AbstractAppSchemaTestSuppor
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/wfs:member/" +
                 "st_1_gml32:Station_gml32[@gml:id='st.1']/st_1_gml32:measurements/ms_1_gml32:Measurement_gml32[ms_1_gml32:name='isolated_1_wind']");
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/wfs:member/" +
-                "st_1_gml32:Station_gml32[@gml:id='st.1']/st_1_gml32:location/gml:Point[gml:pos='1.0 -1.0']");
+                "st_1_gml32:Station_gml32[@gml:id='st.1']/st_1_gml32:location/gml:Point[gml:pos='1 -1']");
         // request isolated feature type using global service should fail with feature type unknown
         document = getAsDOM("wfs?request=GetFeature&version=2.0&typename=st_1_gml32:Station_gml32");
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/ows:ExceptionReport/ows:Exception[@exceptionCode='InvalidParameterValue']");
@@ -172,7 +172,7 @@ public final class IsolatedNamespacesWfsTest extends AbstractAppSchemaTestSuppor
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/gml:featureMember/" +
                 "st_2_gml31:Station_gml31[@gml:id='st.1']/st_2_gml31:measurements/ms_2_gml31:Measurement_gml31[ms_2_gml31:name='isolated_2_wind']");
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/gml:featureMember/" +
-                "st_2_gml31:Station_gml31[@gml:id='st.1']/st_2_gml31:location/gml:Point[gml:pos='1.0 -1.0']");
+                "st_2_gml31:Station_gml31[@gml:id='st.1']/st_2_gml31:location/gml:Point[gml:pos='1 -1']");
         // request isolated feature type using global service should fail with feature type unknown
         document = getAsDOM("wfs?request=GetFeature&version=1.1.0&typename=st_2_gml31:Station_gml31");
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/ows:ExceptionReport/ows:Exception[@exceptionCode='InvalidParameterValue']");
@@ -188,7 +188,7 @@ public final class IsolatedNamespacesWfsTest extends AbstractAppSchemaTestSuppor
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/wfs:member/" +
                 "st_2_gml32:Station_gml32[@gml:id='st.1']/st_2_gml32:measurements/ms_2_gml32:Measurement_gml32[ms_2_gml32:name='isolated_2_wind']");
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/wfs:member/" +
-                "st_2_gml32:Station_gml32[@gml:id='st.1']/st_2_gml32:location/gml:Point[gml:pos='1.0 -1.0']");
+                "st_2_gml32:Station_gml32[@gml:id='st.1']/st_2_gml32:location/gml:Point[gml:pos='1 -1']");
         // request isolated feature type using global service should fail with feature type unknown
         document = getAsDOM("wfs?request=GetFeature&version=2.0&typename=st_2_gml32:Station_gml32");
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/ows:ExceptionReport/ows:Exception[@exceptionCode='InvalidParameterValue']");

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NamespacesWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NamespacesWfsTest.java
@@ -366,7 +366,7 @@ public final class NamespacesWfsTest extends AbstractAppSchemaTestSupport {
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/gml:featureMember/" +
                 "st_gml31:Station_gml31[@gml:id='st.1']/st_gml31:measurements/ms_gml31:Measurement_gml31[ms_gml31:name='temperature']");
         checkCount(WFS11_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/gml:featureMember/" +
-                "st_gml31:Station_gml31[@gml:id='st.1']/st_gml31:location/gml:Point[gml:pos='1.0 -1.0']");
+                "st_gml31:Station_gml31[@gml:id='st.1']/st_gml31:location/gml:Point[gml:pos='1 -1']");
     }
 
     /**
@@ -376,7 +376,7 @@ public final class NamespacesWfsTest extends AbstractAppSchemaTestSupport {
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/wfs:member/" +
                 "st_gml32:Station_gml32[@gml:id='st.1']/st_gml32:measurements/ms_gml32:Measurement_gml32[ms_gml32:name='temperature']");
         checkCount(WFS20_XPATH_ENGINE, document, 1, "/wfs:FeatureCollection/wfs:member/" +
-                "st_gml32:Station_gml32[@gml:id='st.1']/st_gml32:location/gml:Point[gml:pos='1.0 -1.0']");
+                "st_gml32:Station_gml32[@gml:id='st.1']/st_gml32:location/gml:Point[gml:pos='1 -1']");
     }
 
     /**

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SRSReprojectionTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SRSReprojectionTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 
+import org.geotools.gml.producer.CoordinateFormatter;
 import org.junit.Test;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geotools.data.FeatureSource;
@@ -141,15 +142,16 @@ public class SRSReprojectionTest extends AbstractAppSchemaTestSupport {
                                 new Coordinate(-1.2, 52.5) })), null);
         Polygon targetPolygon = (Polygon) JTS.transform(srcPolygon, transform);
         StringBuffer polygonBuffer = new StringBuffer();
+        CoordinateFormatter formatter = new CoordinateFormatter(8);
         for (Coordinate coord : targetPolygon.getCoordinates()) {
-            polygonBuffer.append(coord.x).append(" ");
-            polygonBuffer.append(coord.y).append(" ");
+            formatter.format(coord.x, polygonBuffer).append(" ");
+            formatter.format(coord.y, polygonBuffer).append(" ");
         }
         String targetPolygonCoords = polygonBuffer.toString().trim();
         Point targetPoint = (Point) JTS.transform(
                 factory.createPoint(new Coordinate(42.58, 31.29)), transform);
-        String targetPointCoord = targetPoint.getCoordinate().x + " "
-                + targetPoint.getCoordinate().y;
+        String targetPointCoord = formatter.format(targetPoint.getCoordinate().x) + " "
+                + formatter.format(targetPoint.getCoordinate().y);
 
         assertXpathEvaluatesTo(
                 "52.5 -1.2 52.6 -1.2 52.6 -1.1 52.5 -1.1 52.5 -1.2",

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SRSWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SRSWfsTest.java
@@ -8,6 +8,8 @@ package org.geoserver.test;
 
 import static org.junit.Assert.*;
 
+import org.geotools.gml.producer.CoordinateFormatter;
+import org.geotools.measure.CoordinateFormat;
 import org.junit.Test;
 
 import org.geoserver.data.test.SystemTestData;
@@ -241,15 +243,16 @@ public class SRSWfsTest extends AbstractAppSchemaTestSupport {
                                 new Coordinate(-1.2, 52.5) })), null);
         Polygon targetPolygon = (Polygon) JTS.transform(srcPolygon, transform);
         StringBuffer polygonBuffer = new StringBuffer();
+        CoordinateFormatter formatter = new CoordinateFormatter(8);
         for (Coordinate coord : targetPolygon.getCoordinates()) {
-            polygonBuffer.append(coord.x).append(" ");
-            polygonBuffer.append(coord.y).append(" ");
+            formatter.format(coord.x, polygonBuffer).append(" ");
+            formatter.format(coord.y, polygonBuffer).append(" ");
         }
         String targetPolygonCoords = polygonBuffer.toString().trim();
         Point targetPoint = (Point) JTS.transform(
                 factory.createPoint(new Coordinate(42.58, 31.29)), transform);
-        String targetPointCoord = targetPoint.getCoordinate().x + " "
-                + targetPoint.getCoordinate().y;
+        String targetPointCoord = formatter.format(targetPoint.getCoordinate().x) + " "
+                + formatter.format(targetPoint.getCoordinate().y);
 
         Document doc = getAsDOM("wfs?request=GetFeature&version=1.1.0&typename=ex:geomContainer" +
             "&srsname=urn:x-ogc:def:crs:EPSG::4326");

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
@@ -166,7 +166,7 @@ public class SimpleAttributeFeatureChainWfsTest extends AbstractAppSchemaTestSup
         checkMf3(doc);
         // chaining geometry
         assertXpathEvaluatesTo(
-                "-1.2 53.50000003577337 -1.2000000000000002 53.60000003565695 -1.1 53.60000003565695 -1.1 53.50000003577337 -1.2 53.50000003577337",
+                "-1.2 53.50000004 -1.2 53.60000004 -1.1 53.60000004 -1.1 53.50000004 -1.2 53.50000004",
                 "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf3']/gsml:shape/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
                 doc);
         assertXpathEvaluatesTo(
@@ -182,7 +182,7 @@ public class SimpleAttributeFeatureChainWfsTest extends AbstractAppSchemaTestSup
         checkMf4(doc);
         // chaining geometry
         assertXpathEvaluatesTo(
-                "-1.2999999999999998 53.50000003577337 -1.3 53.60000003565695 -1.2000000000000002 53.60000003565695 -1.2 52.50000003687648 -1.2999999999999998 53.50000003577337",
+                "-1.3 53.50000004 -1.3 53.60000004 -1.2 53.60000004 -1.2 52.50000004 -1.3 53.50000004",
                 "//gsml:MappedFeature[@gml:id='gsml.mappedfeature.mf4']/gsml:shape/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
                 doc);
         assertXpathEvaluatesTo(

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML32OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML32OutputFormat.java
@@ -77,25 +77,31 @@ public class GML32OutputFormat extends GML3OutputFormat {
     public String getMimeType(Object value, Operation operation) {
         return MIME_TYPES[0];
     }
-
+    
     @Override
-    protected Encoder createEncoder(Configuration configuration, 
-        Map<String, Set<ResourceInfo>> resources, Object request) {
-        
+    protected Configuration customizeConfiguration(Configuration configuration, Map<String, Set<ResourceInfo>> resources, Object request) {
+
         FeatureTypeSchemaBuilder schemaBuilder = new FeatureTypeSchemaBuilder.GML32(geoServer);
-        
+
         ApplicationSchemaXSD2 xsd = new ApplicationSchemaXSD2(schemaBuilder);
         xsd.setBaseURL(GetFeatureRequest.adapt(request).getBaseURL());
         xsd.setResources(resources);
 
         org.geotools.wfs.v2_0.WFSConfiguration wfs = new org.geotools.wfs.v2_0.WFSConfiguration();
         wfs.getDependency(GMLConfiguration.class).setSrsSyntax(
-            getInfo().getGML().get(WFSInfo.Version.V_20).getSrsNameStyle().toSrsSyntax());
+                getInfo().getGML().get(WFSInfo.Version.V_20).getSrsNameStyle().toSrsSyntax());
         ApplicationSchemaConfiguration2 config = new ApplicationSchemaConfiguration2(xsd, wfs);
         // adding properties from original configuration to allow
         // hints handling
         config.getProperties().addAll(configuration.getProperties());
-        return new Encoder(config);
+        
+        return config;
+    }
+
+    @Override
+    protected Encoder createEncoder(Configuration configuration,
+                                    Map<String, Set<ResourceInfo>> resources, Object request) {
+        return new Encoder(configuration);
     }
 
     @Override
@@ -145,7 +151,7 @@ public class GML32OutputFormat extends GML3OutputFormat {
         return GML32OutputFormat.xslt;
     }
 
-    protected void setNumDecimals(int numDecimals) {
+    protected void setNumDecimals(Configuration configuration, int numDecimals) {
         GMLConfiguration gml = configuration.getDependency(GMLConfiguration.class);
         if (gml != null) {
             gml.setNumDecimals(numDecimals);

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
@@ -215,12 +215,13 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
             configuration.getProperties().remove(GMLConfiguration.ENCODE_FEATURE_MEMBER);
         }
         
-        setNumDecimals(numDecimals);
-
         //declare wfs schema location
         Object gft = getFeature.getParameters()[0];
-        
+
+        Configuration configuration = customizeConfiguration(this.configuration, ns2metas, gft);
+        setNumDecimals(configuration, numDecimals);
         Encoder encoder = createEncoder(configuration, ns2metas, gft);
+
         encoder.setEncoding(Charset.forName( geoServer.getSettings().getCharset() ));
         Request dispatcherRequest = Dispatcher.REQUEST.get();
         if (dispatcherRequest != null) {
@@ -279,7 +280,7 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
         }
 
         setAdditionalSchemaLocations(encoder, request, wfs);
-        if (this.isComplexFeature(results)) {
+        if (isComplexFeature(results)) {
             complexFeatureStreamIntercept(results, output, encoder);
         } else {
             encode(results, output, encoder);
@@ -287,11 +288,15 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
         
     }
     
-    protected void setNumDecimals(int numDecimals) {
+    protected void setNumDecimals(Configuration configuration, int numDecimals) {
         GMLConfiguration gml = configuration.getDependency(GMLConfiguration.class);
         if (gml != null) {
             gml.setNumDecimals(numDecimals);
         }
+    }
+
+    protected Configuration customizeConfiguration(Configuration configuration, Map<String, Set<ResourceInfo>> resources, Object request) {
+        return configuration;
     }
 
     protected Encoder createEncoder(Configuration configuration,


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8352

Follow up to https://github.com/geotools/geotools/pull/1824 
This one will not even compile until the geotools counterpart is merged (and the build will fail as soon as the GT is merged, if this is also not merged)

Same arrangement as the GT one, I'm asking @nmco for review but maybe @bencaradocdavies is interested too