### PR TITLE
[GEOS-7210] JDBC Configuration: Fixed incorrect encoding of special characters when adding catalog objects with JDBC Configuration.

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -466,8 +467,7 @@ public class ConfigDatabase {
         final String id = info.getId();
 
         byte[] value = binding.objectToEntry(info);
-
-        final String blob = new String(value);
+        final String blob = new String(value, StandardCharsets.UTF_8);
         final Class<T> interf = ClassMappings.fromImpl(info.getClass()).getInterface();
         final Integer typeId = dbMappings.getTypeId(interf);
 
@@ -755,13 +755,8 @@ public class ConfigDatabase {
 
         // get the object's internal id
         final Integer objectId = findObjectId(info);
-        final String blob;
-        try {
-            byte[] value = binding.objectToEntry(info);
-            blob = new String(value, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw Throwables.propagate(e);
-        }
+        byte[] value = binding.objectToEntry(info);
+        final String blob = new String(value, StandardCharsets.UTF_8);
         String updateStatement = "update object set blob = :blob where oid = :oid";
         params = params("blob", blob, "oid", objectId);
         logStatement(updateStatement, params);

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
@@ -73,6 +73,29 @@ public class CatalogImplWithJDBCFacadeTest extends org.geoserver.catalog.impl.Ca
     }
 
     @Test
+    public void testCharacterEncoding() {
+        addDataStore();
+        addNamespace();
+        String name = "testFT";
+        FeatureTypeInfo ft = newFeatureType(name, ds);
+
+        String degC = "Air Temperature in \u00b0C";
+        ft.setAbstract(degC);
+        catalog.add(ft);
+        // clear cache to force retrieval from database.
+        facade.getConfigDatabase().dispose();
+        FeatureTypeInfo added = catalog.getFeatureTypeByName(name);
+        assertEquals(degC, added.getAbstract());
+
+        String degF = "Air Temperature in \u00b0F";
+        added.setAbstract(degF);
+        catalog.save(added);
+        facade.getConfigDatabase().dispose();
+        FeatureTypeInfo saved = catalog.getFeatureTypeByName(name);
+        assertEquals(degF, saved.getAbstract());
+    }
+
+    @Test
     public void testOrderByMultiple() {
         addDataStore();
         addNamespace();


### PR DESCRIPTION
Pull request for https://osgeo-org.atlassian.net/browse/GEOS-7210 that fixes incorrect character encoding when saving new catalog objects to the database.

Contains unit test and can be backported to 2.13.x.