### PR TITLE
[GEOS-8636] JDBC Configuration: Ensure that the JDBC Configuration service cache does not retain old service info when the database is updated.

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
@@ -694,6 +693,9 @@ public class ConfigDatabase {
             return;
         }
         
+        if (info instanceof ServiceInfo) {
+            disposeServiceCache();
+        }
         identityCache.invalidateAll(InfoIdentities.get().getIdentities(info));
         cache.invalidate(info.getId());
 
@@ -731,6 +733,9 @@ public class ConfigDatabase {
 
         final Info oldObject = (Info) modificationProxy.getProxyObject();
 
+        if (info instanceof ServiceInfo) {
+            disposeServiceCache();
+        }
         identityCache.invalidateAll(InfoIdentities.get().getIdentities(oldObject));
         cache.invalidate(id);
 
@@ -1130,6 +1135,12 @@ public class ConfigDatabase {
         cache.cleanUp();
         identityCache.invalidateAll();
         identityCache.cleanUp();
+        disposeServiceCache();
+    }
+
+    private void disposeServiceCache() {
+        serviceCache.invalidateAll();
+        serviceCache.cleanUp();
     }
 
     private final class CatalogLoader implements Callable<CatalogInfo> {
@@ -1340,6 +1351,12 @@ public class ConfigDatabase {
     }
 
     void clear(Info info) {
+        if (info instanceof ServiceInfo) {
+            // need to figure out how to remove only the relevant cache
+            // entries for the service info, like with InfoIdenties below,
+            // that will be able to handle new service types.
+            disposeServiceCache();
+        }
         identityCache.invalidateAll(InfoIdentities.get().getIdentities(info));
         cache.invalidate(info.getId());
     }

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/config/JDBCGeoServerImplTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/config/JDBCGeoServerImplTest.java
@@ -12,19 +12,15 @@ import java.util.Collection;
 
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
-import org.geoserver.config.GeoServerFacade;
 import org.geoserver.config.GeoServerImplTest;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.impl.GeoServerImpl;
 import org.geoserver.config.impl.ServiceInfoImpl;
 import org.geoserver.config.impl.SettingsInfoImpl;
-import org.geoserver.config.util.XStreamPersisterInitializer;
 import org.geoserver.jdbcconfig.JDBCConfigTestSupport;
 import org.geoserver.jdbcconfig.catalog.JDBCCatalogFacade;
 import org.geoserver.jdbcconfig.internal.ConfigDatabase;
-import org.geoserver.jdbcconfig.internal.JDBCConfigXStreamPersisterInitializer;
-import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -95,6 +91,7 @@ public class JDBCGeoServerImplTest extends GeoServerImplTest {
         assertEquals( global, geoServer.getGlobal() );
     }
     
+    @Override
     @Test
     public void testModifyService() throws Exception {
         ServiceInfo service = geoServer.getFactory().createService();
@@ -111,9 +108,22 @@ public class JDBCGeoServerImplTest extends GeoServerImplTest {
         ServiceInfo s2 = geoServer.getServiceByName( "foo", ServiceInfo.class );
         assertEquals( "quux", s2.getMaintainer() );
         
+        ServiceInfo s3 = geoServer.getService(ServiceInfo.class);
+        assertEquals( "quux", s3.getMaintainer() );
+        
         geoServer.save( s1 );
         s2 = geoServer.getServiceByName( "foo", ServiceInfo.class );
         assertEquals( "quam", s2.getMaintainer() );
+        
+        s3 = geoServer.getService(ServiceInfo.class);
+        assertEquals( "quam", s3.getMaintainer() );
+        
+        geoServer.remove( s1 );
+        s2 = geoServer.getServiceByName( "foo", ServiceInfo.class );
+        assertNull(s2);
+        
+        s3 = geoServer.getService(ServiceInfo.class);
+        assertNull(s3);
     }
     
     // Would have put this on GeoServerImplTest, but it depends on WMS and WFS InfoImpl classes


### PR DESCRIPTION
Pull request for https://osgeo-org.atlassian.net/browse/GEOS-8636 that fixes the service cache not being updated when service info is saved to or removed from the database.  Several unused imports were also removed.

Contains unit test and can be backported to 2.13.x.