### PR TITLE
[GEOS-8631] JDBC Configuration: Fixed JDBC Configuration not upgrading to write locks before modifying the catalog.

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/catalog/JDBCCatalogFacade.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/catalog/JDBCCatalogFacade.java
@@ -26,6 +26,7 @@ import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.LockingCatalogFacade;
 import org.geoserver.catalog.MapInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourceInfo;
@@ -35,6 +36,7 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.ClassMappings;
 import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ProxyUtils;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.jdbcconfig.internal.ConfigDatabase;
 import org.geoserver.ows.util.OwsUtils;
@@ -844,7 +846,7 @@ public class JDBCCatalogFacade implements CatalogFacade {
      */
     @Override
     public void syncTo(CatalogFacade other) {
-
+        other = ProxyUtils.unwrap(other, LockingCatalogFacade.class);
         for (WorkspaceInfo w : getWorkspaces()) {
             other.add(w);
         }

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/JDBCConfigTestSupport.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/JDBCConfigTestSupport.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletContext;
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp.BasicDataSource;
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.config.util.XStreamPersisterInitializer;
@@ -220,6 +221,7 @@ public class JDBCConfigTestSupport {
         replay(appContext);
 
         GeoServerExtensionsHelper.init(appContext);
+        GeoServerExtensionsHelper.singleton("configurationLock", new GeoServerConfigurationLock(), GeoServerConfigurationLock.class);
         GeoServerExtensionsHelper.singleton("JDBCConfigXStreamPersisterInitializer", new JDBCConfigXStreamPersisterInitializer(), XStreamPersisterInitializer.class);
         
 //        final File testDbDir = new File("target", "jdbcconfig");

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.GeoServerConfigurationLock.LockType;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -20,6 +22,7 @@ import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.jdbcconfig.JDBCConfigTestSupport;
 import org.geoserver.jdbcconfig.internal.ConfigDatabase;
+import org.geoserver.platform.GeoServerExtensions;
 import org.junit.After;
 import org.junit.Test;
 import org.opengis.filter.Filter;
@@ -162,18 +165,15 @@ public class CatalogImplWithJDBCFacadeTest extends org.geoserver.catalog.impl.Ca
         }
     }
 
-    
-//    @Override
-//    public void testGetLayerGroupByNameWithWorkspace() {
-//        try {
-//            super.testGetLayerGroupByNameWithWorkspace();
-//        } catch (AssertionFailedError e) {
-//            // ignoring failure, we need to fix this as we did for styles by workspace. Check the
-//            // comment in the original test case:
-//            // "//will randomly return one... we should probably return null with multiple matches"
-//            e.printStackTrace();
-//        }
-//    }
+    @Test
+    public void testUpgradeLock() {
+        GeoServerConfigurationLock configurationLock = GeoServerExtensions.bean(GeoServerConfigurationLock.class);
+        configurationLock.lock(LockType.READ);
+        catalog.getNamespaces();
+        assertEquals(LockType.READ, configurationLock.getCurrentLock());
+        addNamespace();
+        assertEquals(LockType.WRITE, configurationLock.getCurrentLock());
+    }
 
     /**
      * Allow execution of a single test method with a hard-coded DBConfig. Due

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -116,10 +116,7 @@ public class CatalogImpl implements Catalog {
         facade = new DefaultCatalogFacade(this);
         // wrap the default catalog facade with the facade capable of handling isolated workspaces behavior
         facade = new IsolatedCatalogFacade(facade);
-        final GeoServerConfigurationLock configurationLock = GeoServerExtensions.bean(GeoServerConfigurationLock.class);
-        if(configurationLock != null) {
-            facade =  LockingCatalogFacade.create(facade, configurationLock);
-        }
+        setFacade(facade);
         resourcePool = ResourcePool.create(this);
     }
     
@@ -147,6 +144,10 @@ public class CatalogImpl implements Catalog {
     }
     
     public void setFacade(CatalogFacade facade) {
+        final GeoServerConfigurationLock configurationLock = GeoServerExtensions.bean(GeoServerConfigurationLock.class);
+        if (configurationLock != null) {
+            facade = LockingCatalogFacade.create(facade, configurationLock);
+        }
         this.facade = facade;
         facade.setCatalog(this);
     }


### PR DESCRIPTION
Pull request for https://osgeo-org.atlassian.net/browse/GEOS-8631 that fixes READ locks not being upgraded to WRITE locks before modifying the catalog when using JDBC Configuration.  Ideally, IsolatedCatalogFacade would have been moved to setFacade() at the same time but this causes ModificationProxy issues in JDBC Configuration so it will have to be done separately.

A commented out unit test that ignored an assertion error was removed since that unit test has been passing for a while now.

Contains unit test and can be backported to 2.13.x.