### PR TITLE
[GEOS-8603] Backport 2.12.x - Include missing types in `canSecure` list

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/decorators/DefaultSecureCatalogFactory.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DefaultSecureCatalogFactory.java
@@ -35,7 +35,9 @@ public class DefaultSecureCatalogFactory implements SecuredObjectFactory {
                 || CoverageStoreInfo.class.isAssignableFrom(clazz)
                 || DataStoreInfo.class.isAssignableFrom(clazz)
                 || FeatureTypeInfo.class.isAssignableFrom(clazz)
-                || LayerInfo.class.isAssignableFrom(clazz);
+                || LayerInfo.class.isAssignableFrom(clazz)
+                || WMSLayerInfo.class.isAssignableFrom(clazz)
+                || WMTSLayerInfo.class.isAssignableFrom(clazz);
     }
 
     @Override

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredObjects.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredObjects.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.security.decorators;
 
+import org.geoserver.catalog.impl.ModificationProxy;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,9 +17,9 @@ import org.geoserver.security.WrapperPolicy;
 /**
  * Utility class that provides easy and fast access to the registered
  * {@link SecuredObjectFactory} implementations
- * 
+ *
  * @author Andrea Aime - TOPP
- * 
+ *
  */
 public class SecuredObjects {
     /**
@@ -30,8 +32,7 @@ public class SecuredObjects {
      * points for a factory that can do the proper wrapping and invokes it, or
      * simply gives up and throws an {@link IllegalArgumentException} if no
      * factory can deal with securing the specified object.
-     * 
-     * @param <T>
+     *
      * @param object
      *            the raw object to be secured
      * @param policy
@@ -45,9 +46,13 @@ public class SecuredObjects {
         if (object == null)
             return null;
 
+        // In case the object to be secured is wrapped in a ModificationProxy, get the proxied Object class
+        // if the object is not wrapped, ModificationProxy.unwrap() will just return the object reference.
+        final Object unwrappedObject = ModificationProxy.unwrap(object);
+
         // if we already know what can handle the wrapping, just do it, don't
         // scan the extension points once more
-        Class<?> clazz = object.getClass();
+        Class<?> clazz = unwrappedObject.getClass();
         SecuredObjectFactory candidate = FACTORY_CACHE.get(clazz);
 
         // otherwise scan and store (or complain)

--- a/src/main/src/test/java/org/geoserver/security/decorators/SecuredResourceInfoTest.java
+++ b/src/main/src/test/java/org/geoserver/security/decorators/SecuredResourceInfoTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.fail;
 
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
 import org.junit.Test;
 
 import org.geoserver.security.AccessLimits;
@@ -90,6 +91,26 @@ public abstract class SecuredResourceInfoTest<D extends ResourceInfo, S extends 
         // this may not fail on all platforms if set/get is broken however, as some platforms may
         // ignore the stack size in the Thread constructor.
         return new Thread(Thread.currentThread().getThreadGroup(), runnable, "RoundTripThread", 5);
+    }
+
+    @Test
+    public void testCanSecure() throws Exception {
+        // get a delegate
+        final D delegate = createDelegate();
+        // secure it
+        Object secure = SecuredObjects.secure(delegate, policy);
+        assertTrue("Unable to secure ResourceInfo", getSecuredDecoratorClass().isAssignableFrom(secure.getClass()));
+    }
+
+    @Test
+    public void testCanSecureProxied() throws Exception {
+        // get a delegate
+        final D delegate = createDelegate();
+        // wrap the delegate in a ModificationProxy
+        ResourceInfo proxy = ModificationProxy.create(delegate, getDelegateClass());
+        // secure it
+        Object secure = SecuredObjects.secure(proxy, policy);
+        assertTrue("Unable to secure proxied Resourceinfo", getSecuredDecoratorClass().isAssignableFrom(secure.getClass()));
     }
 
     @Test


### PR DESCRIPTION
The original GEOS-8603 fix added WMSLayerInfo and WMTSLayerInfo types to the `secure` method of the default factory, but forgot to add them to the list of supported types. Tests added as well.