### PR TITLE
Reduce non-warning message to FINER and fix typo

### DIFF
--- a/src/community/geofence-server/src/main/java/org/geoserver/geofence/internal/InternalUserResolver.java
+++ b/src/community/geofence-server/src/main/java/org/geoserver/geofence/internal/InternalUserResolver.java
@@ -150,8 +150,8 @@ public class InternalUserResolver implements UserResolver {
             logger.log(Level.WARNING, e.getMessage(), e);
         }
 
-        logger.log(Level.WARNING,
-                "GeoFence was not able to find any matching user on Security Context amd Services.");
+        logger.log(Level.FINER,
+                "GeoFence was not able to find any matching user on Security Context or Services.");
 
         return false;
     }


### PR DESCRIPTION
Not finding a matching user is an expected case, not worth a WARNING log message.
Also fixed a typo