### PR TITLE
[GEOS-8305] Fix module status version lookup

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/RenderingEngineStatus.java
+++ b/src/platform/src/main/java/org/geoserver/platform/RenderingEngineStatus.java
@@ -60,11 +60,7 @@ public class RenderingEngineStatus implements ModuleStatus {
 
     @Override
     public Optional<String> getVersion() {
-        if (provider.contains("OracleJDK")) {
-            return Optional.ofNullable(System.getProperty("java.version"));
-        } else {
-            return Optional.empty();
-        }
+        return Optional.ofNullable(System.getProperty("java.version"));
     }
 
     @Override

--- a/src/platform/src/test/java/org/geoserver/platform/RenderingEngineStatusTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/RenderingEngineStatusTest.java
@@ -59,8 +59,10 @@ public class RenderingEngineStatusTest {
         if (provider.equals("Marlin") || provider.equals("OracleJDK") || provider.equals("OpenJDK")) {
             assertEquals(msg, statusMessage.get());
         } else {
-            LOGGER.log(Level.WARNING, "Unkown Java Provider");
+            LOGGER.log(Level.WARNING, "Unknown Java Provider");
         }
+
+        assertEquals(System.getProperty("java.version"), res.getVersion().orElse(null));
     }
 
 }

--- a/src/web/core/src/test/java/org/geoserver/web/admin/StatusPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/admin/StatusPageTest.java
@@ -10,16 +10,18 @@ import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.ModuleStatusImpl;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class StatusPageTest extends GeoServerWicketTestSupport {
     @Override
@@ -97,6 +99,20 @@ public class StatusPageTest extends GeoServerWicketTestSupport {
         tester.assertRenderedPage(StatusPage.class);
         tester.clickLink("tabs:tabs-container:tabs:1:link", true);
         tester.assertContains("gs-main");
+    }
+
+    @Test
+    public void testModuleStatusPanelVersion() {
+        //Skip this test if we are excecuting from an IDE; the version is extracted from the compiled jar
+        Assume.assumeFalse(ModuleStatusImpl.class.getResource("ModuleStatusImpl.class").getProtocol().equals("file"));
+
+        tester.assertRenderedPage(StatusPage.class);
+        tester.clickLink("tabs:tabs-container:tabs:1:link", true);
+        tester.assertContains("gs-main");
+        Component component = tester.getComponentFromLastRenderedPage("tabs:panel:listViewContainer:modules:1:version");
+        assertTrue(component instanceof Label);
+        assertNotNull(component.getDefaultModelObjectAsString());
+        assertNotEquals("", component.getDefaultModelObjectAsString().trim());
     }
 
     @Test


### PR DESCRIPTION
See: https://osgeo-org.atlassian.net/browse/GEOS-8305

Adds a version lookup that searches the pom.properties for a matching artifactId and retrieves the version.

This lookup requires reading every pom.properties on the classpath, and as such is done on demand so as to not impact startup time (it takes somewhere on the order of 1 second on a default install, but even so).

I'm not particularly happy with this solution, but the current implementation of ModuleStatus does not include any information that can be used to associate it with a class or package from the module it describes. Consequently, any better solutions I can think of would require an API change.

The test was added in StatusPageTest.java so that the gs-main module will actually be compiled as a jar when the test runs (an `assume` has been included to skip this test if this is not the case, such as when you are running in an IDE).

I have also manually verified the expected behaviour, using differing core and extension jars - the different version show up correctly under there respective modules.

While fixing the main lookup, I also noticed that the Renderer version lookup was unnecessarily restricting its version lookup to Oracle JDK, and fixed that.