### PR TITLE
Exclude App-Schema default geometry tests from the online tests

### DIFF
--- a/src/extension/app-schema/app-schema-oracle-test/pom.xml
+++ b/src/extension/app-schema/app-schema-oracle-test/pom.xml
@@ -195,6 +195,7 @@
                     <!-- These tests are already run on the parent module -->
                     <excludes>
                         <exclude>**/onlineTest/*.java</exclude>
+                        <exclude>**/DefaultGeometryTest.java</exclude>
                         <exclude>${test.exclude.pattern}</exclude>
                     </excludes>
                     <argLine>-Xmx${test.maxHeapSize} -enableassertions ${jvm.opts}

--- a/src/extension/app-schema/app-schema-postgis-test/pom.xml
+++ b/src/extension/app-schema/app-schema-postgis-test/pom.xml
@@ -190,6 +190,7 @@
                     <!-- These tests are already run on the parent module -->
                     <excludes>
                         <exclude>**/onlineTest/*.java</exclude>
+                        <exclude>**/DefaultGeometryTest.java</exclude>
                         <exclude>${test.exclude.pattern}</exclude>
                     </excludes>
                     <argLine>-Xmx${test.maxHeapSize} -enableassertions ${jvm.opts}

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -202,6 +202,7 @@
                                 <exclude>**/IdFunctionWfsWithJoiningTest.java</exclude>
                                 <exclude>**/XPathPredicateTest.java</exclude>
                                 <exclude>**/PagingTest.java</exclude>
+                                <exclude>**/DefaultGeometryTest.java</exclude>
                                 <exclude>${test.exclude.pattern}</exclude>
                             </excludes>
                         </configuration>


### PR DESCRIPTION
`DefaultGeometryTest` seems to cause Jenkins geoserver-master-app-schema-online to hang. See: https://sourceforge.net/p/geoserver/mailman/message/36277267/