### PR TITLE
Multiple Windows Installer issues + developer documentation

### DIFF
--- a/doc/en/developer/source/policies/committing.rst
+++ b/doc/en/developer/source/policies/committing.rst
@@ -36,8 +36,8 @@ The process of getting community commit access is as follows:
 
 #. **Print, sign, scan and send the contributor agreement**
    
-   * `corporate_contributor.txt <http://www.osgeo.org/sites/osgeo.org/files/Page/corporate_contributor.txt>`_
-   * `individual_contributor.txt <http://www.osgeo.org/sites/osgeo.org/files/Page/individual_contributor.txt>`__
+   * `corporate_contributor <https://www.osgeo.org/resources/corporate-contributor-license/>`_
+   * `individual_contributor <https://www.osgeo.org/resources/individual-contributor-license/>`__
    
    Scanned assignment agreement can be emailed `info@osgeo.org <mailto:info@osgeo.org>`_ at OSGeo.
 

--- a/doc/en/developer/source/policies/committing.rst
+++ b/doc/en/developer/source/policies/committing.rst
@@ -8,8 +8,8 @@ Getting commit access
 
 All contributors are asked to provide an assignment agreement for working on the project:
 
-* `corporate_contributor.txt <http://www.osgeo.org/sites/osgeo.org/files/Page/corporate_contributor.txt>`__
-* `individual_contributor.txt <http://www.osgeo.org/sites/osgeo.org/files/Page/individual_contributor.txt>`__
+* `corporate_contributor <https://www.osgeo.org/resources/corporate-contributor-license/>`__
+* `individual_contributor <https://www.osgeo.org/resources/individual-contributor-license/>`__
 
 This agreement can be printed, signed, scanned and emailed to `info@osgeo.org <mailto:info@osgeo.org>`_ at Open Source Geospatial Foundation (OSGeo). `OSGeo <http://www.osgeo.org/content/foundation/about.html>`_ is the  non-profit which holds the GeoServer codebase for the community.
 

--- a/src/release/installer/win/GeoServerEXE.nsi
+++ b/src/release/installer/win/GeoServerEXE.nsi
@@ -65,20 +65,6 @@ Var PortHWND
 ;VIAddVersionKey FileVersion "${VERSION}"
 ;VIAddVersionKey Comments "http://geoserver.org"
 
-; Install options page headers
-LangString TEXT_JRE_TITLE ${LANG_ENGLISH} "Java Runtime Environment"
-LangString TEXT_JRE_SUBTITLE ${LANG_ENGLISH} "Java Runtime Environment path selection"
-LangString TEXT_DATADIR_TITLE ${LANG_ENGLISH} "GeoServer Data Directory"
-LangString TEXT_DATADIR_SUBTITLE ${LANG_ENGLISH} "GeoServer Data Directory path selection"
-LangString TEXT_TYPE_TITLE ${LANG_ENGLISH} "Type of Installation"
-LangString TEXT_TYPE_SUBTITLE ${LANG_ENGLISH} "Select the type of installation"
-LangString TEXT_READY_TITLE ${LANG_ENGLISH} "Ready to Install"
-LangString TEXT_READY_SUBTITLE ${LANG_ENGLISH} "GeoServer is ready to be installed"
-LangString TEXT_CREDS_TITLE ${LANG_ENGLISH} "GeoServer Administrator"
-LangString TEXT_CREDS_SUBTITLE ${LANG_ENGLISH} "Set administrator credentials"
-LangString TEXT_PORT_TITLE ${LANG_ENGLISH} "GeoServer Web Server Port"
-LangString TEXT_PORT_SUBTITLE ${LANG_ENGLISH} "Set the port that GeoServer will respond on"
-
 ;Interface Settings
 !define MUI_ICON "gs.ico"
 !define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\win-uninstall.ico"
@@ -127,6 +113,20 @@ Page custom Ready                                             ; Summary page
 ; Set languages (first is default language)
 !insertmacro MUI_LANGUAGE "English"
 !insertmacro MUI_RESERVEFILE_LANGDLL
+
+; Install options page headers
+LangString TEXT_JRE_TITLE ${LANG_ENGLISH} "Java Runtime Environment"
+LangString TEXT_JRE_SUBTITLE ${LANG_ENGLISH} "Java Runtime Environment path selection"
+LangString TEXT_DATADIR_TITLE ${LANG_ENGLISH} "GeoServer Data Directory"
+LangString TEXT_DATADIR_SUBTITLE ${LANG_ENGLISH} "GeoServer Data Directory path selection"
+LangString TEXT_TYPE_TITLE ${LANG_ENGLISH} "Type of Installation"
+LangString TEXT_TYPE_SUBTITLE ${LANG_ENGLISH} "Select the type of installation"
+LangString TEXT_READY_TITLE ${LANG_ENGLISH} "Ready to Install"
+LangString TEXT_READY_SUBTITLE ${LANG_ENGLISH} "GeoServer is ready to be installed"
+LangString TEXT_CREDS_TITLE ${LANG_ENGLISH} "GeoServer Administrator"
+LangString TEXT_CREDS_SUBTITLE ${LANG_ENGLISH} "Set administrator credentials"
+LangString TEXT_PORT_TITLE ${LANG_ENGLISH} "GeoServer Web Server Port"
+LangString TEXT_PORT_SUBTITLE ${LANG_ENGLISH} "Set the port that GeoServer will respond on"
 
 ; Startup tasks
 Function .onInit

--- a/src/release/installer/win/GeoServerEXE.nsi
+++ b/src/release/installer/win/GeoServerEXE.nsi
@@ -983,6 +983,7 @@ Section Uninstall
   RMDir /r "$INSTDIR\lib"
   RMDir /r "$INSTDIR\logs"
   RMDir /r "$INSTDIR\resources"
+  RMDir /r "$INSTDIR\work" ; working data
   RMDir /r "$INSTDIR\webapps"
   RMDir /r "$INSTDIR\v*" ; EPSG DB
   Delete "$INSTDIR\*.*"

--- a/src/release/installer/win/GeoServerEXE.nsi
+++ b/src/release/installer/win/GeoServerEXE.nsi
@@ -1,3 +1,8 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
 ; GeoServer Windows installer creation file.
 
 ; Define your application name
@@ -786,7 +791,6 @@ Section "Main" SectionMain
   File /a LICENSE.txt
   File /a README.txt
   File /a RUNNING.txt
-  File /r data_dir
   File /r etc
   File /r modules
   File /r lib
@@ -794,6 +798,12 @@ Section "Main" SectionMain
   File /r resources
   File /r webapps
   File /r gs.ico
+
+  ; Special handling of the 'data_dir'
+  ${If} $IsExisting == 0 ; Only place files, when NOT using an existing folder
+  File /r data_dir
+  ${EndIf}
+
 
   ; Write environment variables
   Push "JAVA_HOME"
@@ -953,7 +963,7 @@ Section Uninstall
   RMDir /r "$SMPROGRAMS\${APPNAMEANDVERSION}"
 
   ; Delete files/folders
-  RMDir /r "$INSTDIR\data_dir"
+;  RMDir /r "$INSTDIR\data_dir" - do not remove this, as it might be the actual application 'data_dir'
   RMDir /r "$INSTDIR\bin"
   RMDir /r "$INSTDIR\etc"
   RMDir /r "$INSTDIR\modules"


### PR DESCRIPTION
Fixes regarding the following issue:

[GEOS-8683] Windows Installation issue - upgrading GeoServer results in corrupt data_dir
[GEOS-8697] Remove language warnings during Windows setup compilation
[GEOS-8698] Windows Installer: Remove 'work' folder when uninstalling
[GEOS-8712] GeoServer Developer documentation contains invalid links to contributor agreements