### PR TITLE
Move the catalog reload/reset to a final Spring batch step. 

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
@@ -127,12 +127,6 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
                         + backupFacade.getJobOperator().getSummary(executionId));
 
                 if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
-                    // Reload GeoServer Catalog
-                    if (!dryRun) {
-                        backupFacade.getGeoServer().reload();
-                    }
-                    
-                    backupFacade.getGeoServer().reset();
                     
                     JobParameters jobParameters = restoreExecution.getJobParameters();
                     Resource tempFolder = Resources

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/FinalizeRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/FinalizeRestoreTasklet.java
@@ -1,0 +1,44 @@
+package org.geoserver.backuprestore.tasklet;
+
+import org.geoserver.backuprestore.Backup;
+import org.geoserver.config.util.XStreamPersisterFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * Spring batch tasklet responsible for performing final restore steps. In particular, reloaded the catalog
+ */
+public class FinalizeRestoreTasklet extends AbstractCatalogBackupRestoreTasklet {
+
+    private boolean dryRun;
+
+    public FinalizeRestoreTasklet(Backup backupFacade, XStreamPersisterFactory xStreamPersisterFactory) {
+        super(backupFacade, xStreamPersisterFactory);
+    }
+
+    @Override
+    RepeatStatus doExecute(StepContribution contribution, ChunkContext chunkContext, JobExecution jobExecution)
+        throws Exception {
+        // Reload GeoServer Catalog
+        if (jobExecution.getStatus() != BatchStatus.STOPPED) {
+            if (!dryRun) {
+                backupFacade.getGeoServer().reload();
+            }
+
+            backupFacade.getGeoServer().reset();
+        }
+
+
+        return RepeatStatus.FINISHED;
+    }
+
+    @Override
+    protected void initialize(StepExecution stepExecution) {
+        dryRun = Boolean.parseBoolean(
+            stepExecution.getJobParameters().getString(Backup.PARAM_DRY_RUN_MODE, "false"));
+    }
+}

--- a/src/community/backup-restore/core/src/main/resources/applicationContext.xml
+++ b/src/community/backup-restore/core/src/main/resources/applicationContext.xml
@@ -76,6 +76,12 @@
 		<constructor-arg ref="xstreamPersisterFactory" />
 		<property name="timeout" value="600000"/>
 	</bean>
+
+	<bean id="finalizeRestoreTasklet" class="org.geoserver.backuprestore.tasklet.FinalizeRestoreTasklet">
+		<constructor-arg ref="backupFacade" />
+		<constructor-arg ref="xstreamPersisterFactory" />
+		<property name="timeout" value="600000"/>
+	</bean>
 	
 	<!-- The BACKUP Job definition START here -->
 	<batch:job id="backupJob" restartable="true">
@@ -853,10 +859,18 @@
       </batch:listeners>
     </batch:step>
 
-    <!-- extension point for generic restore tasklets -->
-    <batch:step id="genericTaskletsRestore">
-      <batch:tasklet allow-start-if-complete="true" ref="genericTasklet"/>
-    </batch:step>
+      <!-- extension point for generic restore tasklets -->
+      <batch:step id="genericTaskletsRestore">
+        <batch:tasklet allow-start-if-complete="true" ref="genericTasklet"/>
+
+        <batch:fail on="FAILED"/>
+        <batch:stop on="STOPPED" restart="finalizeRestore"/>
+        <batch:next on="*" to="finalizeRestore"/>
+      </batch:step>
+
+      <batch:step id="finalizeRestore">
+        <batch:tasklet ref="finalizeRestoreTasklet"/>
+      </batch:step>
 
 	</batch:job>
 	<!-- The RESTORE Job definition ENDS here -->


### PR DESCRIPTION
Similar to #2770 this PR moves the final catalog reload/reset into a Spring batch tasklet instead of the afterJob call. This ensures that the restore job is fully finalized before reporting complete, which makes it easier for clients/scripts to do work after doing the restore.