### PR TITLE
[GEOS-8707] WMTS REST API is not compatible with local workspaces

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/controller/GwcWmtsRestUrlHandlerMapping.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/controller/GwcWmtsRestUrlHandlerMapping.java
@@ -1,0 +1,146 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.controller;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.gwc.layer.CatalogConfiguration;
+import org.geoserver.ows.LocalWorkspace;
+import org.geotools.util.logging.Logging;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Specific URL mapping handler for GWC WMTS REST API. The main goal of this handler id to handle
+ * virtual services, it makes sure URLs with an workspace are correctly mapped and that a local
+ * workspace is set and removed when needed.
+ */
+public final class GwcWmtsRestUrlHandlerMapping extends RequestMappingHandlerMapping
+    implements HandlerInterceptor {
+
+  private static final Logger LOGGER = Logging.getLogger(GwcWmtsRestUrlHandlerMapping.class);
+
+  private final Catalog catalog;
+
+  public GwcWmtsRestUrlHandlerMapping(Catalog catalog) {
+    this.catalog = catalog;
+  }
+
+  @Override
+  protected void registerHandlerMethod(Object handler, Method method, RequestMappingInfo mapping) {
+    // this handler is only interested on GWC WMTS REST API URLs
+    for (String pattern : mapping.getPatternsCondition().getPatterns()) {
+      if (pattern.contains("/gwc/rest/wmts")) {
+        // this is an handler for GWC WMTS REST API
+        super.registerHandlerMethod(handler, method, mapping);
+        break;
+      }
+    }
+  }
+
+  @Override
+  protected HandlerMethod lookupHandlerMethod(String lookupPath, HttpServletRequest request)
+      throws Exception {
+    int gwcRestBaseIndex = lookupPath.indexOf("/gwc/rest/wmts");
+    if (gwcRestBaseIndex == -1 || gwcRestBaseIndex == 0) {
+      // not a GWC REST URL or not in the context of a virtual service
+      return null;
+    }
+    int startIndex = lookupPath.charAt(0) == '/' ? 1 : 0;
+    String workspaceName = lookupPath.substring(startIndex, gwcRestBaseIndex);
+    WorkspaceInfo workspace = catalog.getWorkspaceByName(workspaceName);
+    if (workspace == null) {
+      // not a valid workspace,we are done
+      return null;
+    }
+    // we are in the context of a virtual service
+    HandlerMethod handler =
+        super.lookupHandlerMethod(
+            lookupPath.substring(gwcRestBaseIndex), new Wrapper(request, catalog, workspaceName));
+    if (handler == null) {
+      // no handler found
+      return null;
+    }
+    // setup the thread local workspace
+    LocalWorkspace.set(workspace);
+    return handler;
+  }
+
+  /**
+   * Utility wrapper aground the HTTP servlet request that allow us to replace the original virtual
+   * service URL with the global URL, i.e. no workspace in the URL. Note, this is only used by
+   * Spring to match against the correct handler, GeoServer will use \ see the original request.
+   */
+  private static final class Wrapper extends HttpServletRequestWrapper {
+
+    // regex expression that matches a layer name in a WMTS REST URI
+    private final Pattern URI_LAYER_PATTERN = Pattern.compile("rest/wmts/([^/]+)/]");
+
+    private final String requestUri;
+
+    Wrapper(HttpServletRequest request, Catalog catalog, String workspaceName) {
+      super(request);
+      // remove the virtual service workspace from the URL
+      requestUri = request.getRequestURI().replace(workspaceName + "/", "");
+      // prefix layers in the URI with the local workspace prefix
+      Matcher matcher = URI_LAYER_PATTERN.matcher(requestUri);
+    }
+
+    @Override
+    public String getRequestURI() {
+      // return the global request URL, i.e. no workspace on it
+      return requestUri;
+    }
+
+    private String adaptQueryUri(Catalog catalog, String queryUri, String workspaceName) {
+      // remove the virtual service workspace from the URL
+      queryUri = queryUri.replace(workspaceName + "/", "");
+      // prefix layers in the URI with the local workspace prefix
+      Matcher matcher = URI_LAYER_PATTERN.matcher(requestUri);
+      if (!matcher.find()) {
+        // no layers in the URI, we are done
+        return queryUri;
+      }
+      // we have layers in the URI let's adapt them
+      String layerName = matcher.group(0);
+      layerName = CatalogConfiguration.removeWorkspacePrefix(layerName, catalog);
+      return matcher.replaceFirst("rest/wmts/" + workspaceName + ":" + layerName);
+    }
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    // nothing to do here
+    return true;
+  }
+
+  @Override
+  public void postHandle(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      Object handler,
+      ModelAndView modelAndView) {
+    // nothing to do here
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    // make sure that local workspace is properly cleaned
+    LocalWorkspace.remove();
+  }
+}

--- a/src/gwc/src/main/resources/applicationContext.xml
+++ b/src/gwc/src/main/resources/applicationContext.xml
@@ -144,4 +144,12 @@
     <constructor-arg ref="resourceLoader"/>
   </bean>
   <bean id="wmtsFactoryExtension" class="org.geoserver.gwc.wmts.WMTSFactoryExtension"/>
+
+  <!-- Specific URL mapping for GWC WMTS REST API -->
+  <bean id="gwcWmtsRestUrlHandlerMapping" class="org.geoserver.gwc.controller.GwcWmtsRestUrlHandlerMapping">
+    <constructor-arg ref="catalog" />
+    <property name="alwaysUseFullPath" value="true" />
+    <property name="order" value="10" />
+  </bean>
+
 </beans>

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -699,7 +699,7 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
         try {
             tld.getTileLayer("");
-        } catch (GeoWebCacheException gwce) {
+        } catch (Exception gwce) {
 
         }
 
@@ -1259,20 +1259,57 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
         assertThat(response.getStatus(), is(200));
         assertContentType("image/png", response);
     }
+
+    @Test
+    public void testGetTileWithRestEndpointsInVirtualService() throws Exception {
+        // get tile
+        MockHttpServletRequest request = createRequest(MockData.BASIC_POLYGONS.getPrefix()
+                + "/gwc" + WMTSService.REST_PATH + "/"
+                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
+                + "/EPSG:4326/EPSG:4326:0/0/0?format=image/png");
+        request.setMethod("GET");
+        request.setContent(new byte[] {});
+        // mock the request
+        Request mockRequest = mock(Request.class);
+        when(mockRequest.getHttpRequest()).thenReturn(request);
+        Dispatcher.REQUEST.set(mockRequest);
+        MockHttpServletResponse response = dispatch(request, null);
+        // check that the request was successful
+        assertThat(response.getStatus(), is(200));
+        assertContentType("image/png", response);
+    }
     
     @Test
     public void testFeatureInfoWithRestEndpoints() throws Exception {
-        // getting feature info
+        // get feature info
         MockHttpServletRequest request = createRequest("/gwc" + WMTSService.REST_PATH + "/"
                 + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
                 + "/EPSG:4326/EPSG:4326:0/0/0/0/0?format=text/plain");
         request.setMethod("GET");
         request.setContent(new byte[] {});
-
+        // mock the request
         Request mockRequest = mock(Request.class);
         when(mockRequest.getHttpRequest()).thenReturn(request);
         Dispatcher.REQUEST.set(mockRequest);
+        MockHttpServletResponse response = dispatch(request, null);
+        // check that the request was successful
+        assertThat(response.getStatus(), is(200));
+        assertContentType("text/plain", response);
+    }
 
+    @Test
+    public void testFeatureInfoWithRestEndpointsInVirtualService() throws Exception {
+        // getting feature info
+        MockHttpServletRequest request = createRequest(MockData.BASIC_POLYGONS.getPrefix() + 
+                "/gwc" + WMTSService.REST_PATH + "/"
+                + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart()
+                + "/EPSG:4326/EPSG:4326:0/0/0/0/0?format=text/plain");
+        request.setMethod("GET");
+        request.setContent(new byte[] {});
+        // mock the request
+        Request mockRequest = mock(Request.class);
+        when(mockRequest.getHttpRequest()).thenReturn(request);
+        Dispatcher.REQUEST.set(mockRequest);
         MockHttpServletResponse response = dispatch(request, null);
         // check that the request was successful
         assertThat(response.getStatus(), is(200));


### PR DESCRIPTION
*** Depends on this GWC PR https://github.com/GeoWebCache/geowebcache/pull/644 ***

Associated issue:
https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-8707?filter=myopenissues

GWS WMTS service can be invoked using a REST API, which means that this REST API should take into account virtual services logic.

To implement this, I basically end-up implementing a custom URL mapping that will take care of matching the correct controller when workspaces are involved. This will also take care of settling the correct local workspace and clean it.

Note, this PR adds this big function ``prefixWithWorkspaceName`` I tried to break it in several pieces but it just keep going more awkward and more complex to read ... handling layer groups, workspaces, virtual services dependent behavior is not easy. If someone has a better option I will take it.
