### PR TITLE
[GEOS-8724] Intermittent build failure in NamespacesWfsTest

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/StationsMockData.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/StationsMockData.java
@@ -20,12 +20,15 @@ import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.util.IOUtils;
+import org.geotools.util.logging.Logging;
 
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Helper class that will setup custom complex feature types using the stations data set.
@@ -33,7 +36,9 @@ import java.util.Map;
  * on the same mappings files and schemas.
  */
 public class StationsMockData extends AbstractAppSchemaMockData {
-
+    
+    private static final Logger LOGGER = Logging.getLogger(StationsMockData.class);
+    
     // stations GML 3.1 namespaces
     protected static final String STATIONS_PREFIX_GML31 = "st_gml31";
     protected static final String STATIONS_URI_GML31 = "http://www.stations_gml31.org/1.0";
@@ -47,12 +52,16 @@ public class StationsMockData extends AbstractAppSchemaMockData {
     protected static final String MEASUREMENTS_URI_GML32 = "http://www.measurements_gml32.org/1.0";
 
     // directory that should contain all the new files created during the setup of this data set
-    protected static final File TEST_ROOT_DIRECTORY;
+    protected final File TEST_ROOT_DIRECTORY = createTestRootDirectory();
 
-    static {
+
+    /**
+     * Helper method that just quietly creates a temporary directory,
+     */
+    private static File createTestRootDirectory() {
         try {
             // create the tests root directory
-            TEST_ROOT_DIRECTORY = IOUtils.createTempDirectory("app-schema-stations");
+            return IOUtils.createTempDirectory("app-schema-stations");
         } catch (Exception exception) {
             throw new RuntimeException("Error creating temporary directory.", exception);
         }
@@ -232,8 +241,9 @@ public class StationsMockData extends AbstractAppSchemaMockData {
             // remove tests root directory
             IOUtils.delete(TEST_ROOT_DIRECTORY);
         } catch (Exception exception) {
-            throw new RuntimeException(String.format(
-                    "Error removing tests root directory '%s'.", TEST_ROOT_DIRECTORY.getAbsolutePath()));
+            // something bad happen, just log the exception and move on
+            LOGGER.log(Level.WARNING, String.format(
+                    "Error removing tests root directory '%s'.", TEST_ROOT_DIRECTORY.getAbsolutePath()), exception);
         }
     }
 }


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-8724

I could not reproduce the original issue locally, this PR does two things:

- if an something bad happens when removing the tests temp directory, the exception is logged and no exception is throw
- the tests root directory is not shared anymore between instances