### PR TITLE
[GEOS-8729] MongoDB extension descriptor missing in the main pom.xml (backport 2.12.x)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1479,6 +1479,7 @@
       <descriptor>release/ext-cas.xml</descriptor>
       <descriptor>release/ext-monitor.xml</descriptor>
       <descriptor>release/ext-monitor-hibernate.xml</descriptor>
+      <descriptor>release/ext-mongodb.xml</descriptor>
       <descriptor>release/ext-xslt.xml</descriptor>
       <descriptor>release/ext-inspire.xml</descriptor>
       <descriptor>release/ext-css.xml</descriptor>      


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-8729