### PR TITLE
[GEOS-8765] Undocumented GDAL 2.3.0 CSV output geometry column name change breaks WPSOgrTest

### DIFF
--- a/src/extension/ogr/ogr-wps/src/test/java/org/geoserver/wps/ogr/WPSOgrTest.java
+++ b/src/extension/ogr/ogr-wps/src/test/java/org/geoserver/wps/ogr/WPSOgrTest.java
@@ -166,7 +166,8 @@ public class WPSOgrTest extends WPSTestSupport {
                     getWpsRawXML("text/csv; subtype=OGR-CSV"));
             assertEquals("text/csv; subtype=OGR-CSV", r.getContentType());
             assertTrue(r.getContentAsString().length() > 0);
-            assertTrue(r.getContentAsString().contains("WKT,gml_id,STATE_NAME"));
+            assertTrue(r.getContentAsString().contains("WKT,gml_id,STATE_NAME")
+                    || r.getContentAsString().contains("geometry,gml_id,STATE_NAME"));
         } catch (IOException e) {
             System.err.println(e.getStackTrace());
         } finally {


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8765

Fix is to accept either column name in the failing `assertTrue`.