### PR TITLE
[GEOS-8768] OpenLayers preview do not report exceptions 'in image' anymore

### DIFF
--- a/src/web/wms/src/main/resources/org/geoserver/wms/web/data/ol-load.ftl
+++ b/src/web/wms/src/main/resources/org/geoserver/wms/web/data/ol-load.ftl
@@ -15,7 +15,8 @@ var source = new ol.source.ImageWMS({
     'FORMAT': 'image/png',
     'FORMAT_OPTIONS': "layout:style-editor-legend;fontAntiAliasing:true",
     'RANDOM': ${cachebuster?c},
-    'LEGEND_OPTIONS': 'forceLabels:on'
+    'LEGEND_OPTIONS': 'forceLabels:on;fontAntiAliasing:true',
+    'EXCEPTIONS': 'application/vnd.ogc.se_inimage'
   },
   serverType: 'geoserver',
   ratio: 1

--- a/src/wms/src/main/java/org/geoserver/wms/WMSServiceExceptionHandler.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSServiceExceptionHandler.java
@@ -8,10 +8,7 @@ package org.geoserver.wms;
 import static org.geoserver.ows.util.ResponseUtils.baseURL;
 import static org.geoserver.ows.util.ResponseUtils.buildSchemaURL;
 
-import java.awt.Color;
-import java.awt.FontMetrics;
-import java.awt.Graphics2D;
-import java.awt.Point;
+import java.awt.*;
 import java.awt.font.FontRenderContext;
 import java.awt.font.LineBreakMeasurer;
 import java.awt.font.TextLayout;
@@ -21,6 +18,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.text.AttributedString;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -196,6 +194,7 @@ public class WMSServiceExceptionHandler extends ServiceExceptionHandler {
         Graphics2D g = (Graphics2D) img.getGraphics();
         
         g.setColor(bgcolor);
+        g.addRenderingHints(Collections.singletonMap(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON));
         g.fillRect(0, 0, img.getWidth(), img.getHeight());
         
         if (!("BLANK".equals(exceptionFormat) || "application/vnd.ogc.se_blank".equals(exceptionFormat))) { //wms 1.3 only

--- a/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
@@ -281,10 +281,11 @@ public abstract class AbstractOpenLayersMapOutputFormat implements GetMapOutputF
      *
      */
     private List<Map<String, String>> getLayerParameter(Map<String, String> rawKvp) {
-        List<Map<String, String>> result = new ArrayList<Map<String, String>>(rawKvp.size());
-
+        List<Map<String, String>> result = new ArrayList<>(rawKvp.size());
+        boolean exceptionsFound = false;
         for (Map.Entry<String, String> en : rawKvp.entrySet()) {
             String paramName = en.getKey();
+            exceptionsFound |= paramName.equalsIgnoreCase("exceptions");
 
             if (ignoredParameters.contains(paramName.toUpperCase())) {
                 continue;
@@ -292,9 +293,16 @@ public abstract class AbstractOpenLayersMapOutputFormat implements GetMapOutputF
 
             // this won't work for multi-valued parameters, but we have none so
             // far (they are common just in HTML forms...)
-            Map<String, String> map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
+            
             map.put("name", paramName);
             map.put("value", en.getValue());
+            result.add(map);
+        }
+        if (!exceptionsFound) {
+            Map<String, String> map = new HashMap<>();
+            map.put("name", "exceptions");
+            map.put("value", "application/vnd.ogc.se_inimage");
             result.add(map);
         }
 

--- a/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapOutputFormatTest.java
@@ -7,6 +7,7 @@ package org.geoserver.wms.map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -355,6 +356,30 @@ public class OpenLayersMapOutputFormatTest extends WMSTestSupport {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         rawMap.writeTo(bos);
         return new String(bos.toByteArray(), "UTF-8");
+    }
+    
+    @Test
+    public void testExceptionsInImage() throws Exception {
+        // the base request
+        String path = "wms?service=WMS&version=1.1.0&request=GetMap&layers=" + getLayerId(MockData.BASIC_POLYGONS) +
+                "&styles=&bbox=-180,-90,180,90&width=768&height=330" +
+                "&srs=EPSG:4326&format=application/openlayers";
+
+        String html = getAsString(path);
+        assertThat(html, containsString("\"exceptions\": 'application/vnd.ogc.se_inimage'"));
+    }
+
+    @Test
+    public void testExceptionsXML() throws Exception {
+        // the base request
+        String path = "wms?service=WMS&version=1.1.0&request=GetMap&layers=" + getLayerId(MockData.BASIC_POLYGONS) +
+                "&styles=&bbox=-180,-90,180,90&width=768&height=330" +
+                "&srs=EPSG:4326&format=application/openlayers" +
+                "&exceptions=application/vnd.ogc.se_xml";
+
+        String html = getAsString(path);
+        assertThat(html, containsString("\"EXCEPTIONS\": 'application/vnd.ogc.se_xml'"));
+        assertThat(html, not(containsString("\"exceptions\": 'application/vnd.ogc.se_inimage'")));
     }
 
 }


### PR DESCRIPTION
We can get at least this, it's not much, but better than a blank:

![selezione_221](https://user-images.githubusercontent.com/325433/40887321-778b4bf0-6747-11e8-96f0-df7cbd7badbc.png)

![selezione_223](https://user-images.githubusercontent.com/325433/40887331-976e0a02-6747-11e8-9437-93be31c57ff9.png)
