### PR TITLE
[GEOS-8780] Fix CatalogLayerEventListener handling of tile truncation

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -410,6 +410,37 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         truncate(layerName, styleName, gridSetId, bounds, format);
     }
 
+    /**
+     * Truncates the cache for the default style of the given layer
+     *
+     * @param layerName
+     */
+    public void truncateByLayerDefaultStyle(final String layerName) {
+        checkNotNull(layerName, "layerName can't be null");
+        log.fine("truncating '" + layerName + "' for default style");
+
+        final TileLayer layer = getTileLayerByName(layerName);
+        final Set<String> gridSetIds = layer.getGridSubsets(); // all of them
+        final List<MimeType> mimeTypes = layer.getMimeTypes(); // all of them
+        final BoundingBox bounds = null; // all of them
+        final Map<String, String> parameters = null; // only default style
+
+        for (String gridSetId : gridSetIds) {
+            GridSubset gridSubset = layer.getGridSubset(gridSetId);
+            if (gridSubset == null) {
+                // layer may no longer have this gridsubset, but we want to truncate any remaining
+                // tiles
+                GridSet gridSet = gridSetBroker.get(gridSetId);
+                gridSubset = GridSubsetFactory.createGridSubSet(gridSet);
+            }
+
+            for (MimeType mime : mimeTypes) {
+                String formatName = mime.getFormat();
+                truncate(layer, bounds, gridSubset, formatName, parameters);
+            }
+        }
+    }
+
     public void truncate(final String layerName, final ReferencedEnvelope bounds)
             throws GeoWebCacheException {
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
@@ -380,7 +380,7 @@ public class CatalogLayerEventListener implements CatalogListener {
                                 + oldStyleName
                                 + " to "
                                 + defaultStyle);
-                mediator.truncateByLayerAndStyle(layerName, oldStyleName);
+                mediator.truncateByLayerDefaultStyle(layerName);
             }
         } else {
             StyleInfo styleInfo = li.getDefaultStyle();
@@ -392,6 +392,7 @@ public class CatalogLayerEventListener implements CatalogListener {
             for (StyleInfo s : li.getStyles()) {
                 styles.add(s.prefixedName());
             }
+            styles.add(defaultStyle);
             ImmutableSet<String> cachedStyles = tileLayerInfo.cachedStyles();
             if (!styles.equals(cachedStyles)) {
                 // truncate no longer existing cached styles
@@ -406,9 +407,7 @@ public class CatalogLayerEventListener implements CatalogListener {
                     mediator.truncateByLayerAndStyle(layerName, oldCachedStyle);
                 }
                 // reset STYLES parameter filter
-                final boolean createParamIfNotExists = true;
-                TileLayerInfoUtil.updateStringParameterFilter(
-                        tileLayerInfo, "STYLES", createParamIfNotExists, defaultStyle, styles);
+                TileLayerInfoUtil.checkAutomaticStyles(li, tileLayerInfo);
                 save = true;
             }
         }

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogLayerEventListenerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogLayerEventListenerTest.java
@@ -481,7 +481,7 @@ public class CatalogLayerEventListenerTest {
 
         listener.handlePostModifyEvent(postModifyEvent);
 
-        verify(mockMediator).truncateByLayerAndStyle(eq(PREFIXED_RESOURCE_NAME), eq(oldName));
+        verify(mockMediator).truncateByLayerDefaultStyle(eq(PREFIXED_RESOURCE_NAME));
         // both the layer group and the layer got saved
         verify(mockMediator, times(2)).save(any(GeoServerTileLayer.class));
 


### PR DESCRIPTION
Fix CatalogLayerEventListener behavior:
 - truncate layer tiles whe styles change
 - don't remove the style parameter filter if it is empty
 - simplify default style tile truncation

Add integration tests for tile truncation on style changes

https://osgeo-org.atlassian.net/browse/GEOS-8780