### PR TITLE
[GEOS-8751] Missing gs-nsg-profiles pom in maven repository

### DIFF
--- a/src/community/nsg-profiles/pom.xml
+++ b/src/community/nsg-profiles/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -12,8 +12,24 @@
   <packaging>pom</packaging>
   <version>2.14-SNAPSHOT</version>
   <name>NSG Profiles</name>
-  <modules>
-  	<module>nsg-wfs-profile</module>
-  	<module>nsg-wmts-profile</module>
-  </modules>
+  <profiles>
+    <profile>
+      <id>nsg-wfs-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>nsg-wfs-profile</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>nsg-wmts-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>nsg-wmts-profile</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -255,8 +255,7 @@
         <module>mbstyle</module>
         <module>s3-geotiff</module>
         <module>status-monitoring</module>
-        <module>nsg-profiles/nsg-wfs-profile</module>
-        <module>nsg-profiles/nsg-wmts-profile</module>
+        <module>nsg-profiles</module>
         <module>netcdf-ghrsst</module>
         <!--<module>taskmanager</module>-->
         <module>wfs3</module>
@@ -565,13 +564,13 @@
     <profile>
       <id>nsg-wfs-profile</id>
       <modules>
-        <module>nsg-profiles/nsg-wfs-profile</module>
+        <module>nsg-profiles</module>
       </modules>
     </profile>
     <profile>
       <id>nsg-wmts-profile</id>
       <modules>
-        <module>nsg-profiles/nsg-wmts-profile</module>
+        <module>nsg-profiles</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOS-8751

This PR changes will make ``nsg-profiles`` ``pom.xml`` file to be also published. 

When a maven command is issued inside the NSG profiles module directory both the WMTS and WFS profiles will be activated. Outside NSG profiles module directory each profile needs to be explicitly activated.