### PR TITLE
[GEOS-8751] Missing gs-nsg-profiles pom in maven repository (backport 2.13.x)

### DIFF
--- a/src/community/nsg-profiles/pom.xml
+++ b/src/community/nsg-profiles/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -12,8 +12,24 @@
   <packaging>pom</packaging>
   <version>2.13-SNAPSHOT</version>
   <name>NSG Profiles</name>
-  <modules>
-  	<module>nsg-wfs-profile</module>
-  	<module>nsg-wmts-profile</module>
-  </modules>
+  <profiles>
+    <profile>
+      <id>nsg-wfs-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>nsg-wfs-profile</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>nsg-wmts-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>nsg-wmts-profile</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -252,8 +252,7 @@
         <module>mbstyle</module>
         <module>s3-geotiff</module>
         <module>status-monitoring</module>
-        <module>nsg-profiles/nsg-wfs-profile</module>
-        <module>nsg-profiles/nsg-wmts-profile</module>
+        <module>nsg-profiles</module>
         <module>netcdf-ghrsst</module>
         <module>monitor-hibernate</module>
       </modules>
@@ -560,13 +559,13 @@
     <profile>
       <id>nsg-wfs-profile</id>
       <modules>
-        <module>nsg-profiles/nsg-wfs-profile</module>
+        <module>nsg-profiles</module>
       </modules>
     </profile>
     <profile>
       <id>nsg-wmts-profile</id>
       <modules>
-        <module>nsg-profiles/nsg-wmts-profile</module>
+        <module>nsg-profiles</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
Backport of PR https://github.com/geoserver/geoserver/pull/2919.