### PR TITLE
GEOS-8779 Disable FeatureSizeFeatureCollection by default to avoid un…

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/FeatureSizeFeatureCollection.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/FeatureSizeFeatureCollection.java
@@ -30,8 +30,8 @@ import org.opengis.feature.type.FeatureType;
  */
 public class FeatureSizeFeatureCollection extends DecoratingSimpleFeatureCollection {
 
-    /** The default feature cache size */
-    public static final int DEFAULT_CACHE_SIZE = 16;
+    /** The default feature cache size - disabled by default */
+    public static final int DEFAULT_CACHE_SIZE = 0;
 
     /** The original feature source. */
     protected SimpleFeatureSource featureSource;

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureCachingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureCachingTest.java
@@ -6,21 +6,23 @@ package org.geoserver.wfs;
 
 import org.geoserver.wfs.v2_0.GetFeatureTest;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 
 /**
  * Test making sure GetFeature still works when the caching machinery is off (since most test
  * datasets will actually be cached in memory)
  */
-public class GetFeatureNoCachingTest extends GetFeatureTest {
+public class GetFeatureCachingTest extends GetFeatureTest {
 
     @BeforeClass
-    public static void disableCaching() {
-        FeatureSizeFeatureCollection.setFeatureCacheLimit(0);
+    public static void enableCaching() {
+        Assert.assertEquals(0, FeatureSizeFeatureCollection.DEFAULT_CACHE_SIZE);
+        FeatureSizeFeatureCollection.setFeatureCacheLimit(16);
     }
 
     @AfterClass
-    public static void enableCaching() {
+    public static void disableCaching() {
         FeatureSizeFeatureCollection.setFeatureCacheLimit(
                 FeatureSizeFeatureCollection.DEFAULT_CACHE_SIZE);
     }


### PR DESCRIPTION
…optimized counts

* FeatureSizeFeatureCollection is disabled by default, to prevent unoptimized counts when a feature collection returns -1 for size()

https://osgeo-org.atlassian.net/browse/GEOS-8790

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>