### PR TITLE
[GEOS-8550] Fix GWC Secrutiy NPE for layer group request

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -2278,7 +2278,15 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             if (group != null) {
                 // use the prefixed name to avoid clashes because the raw catalog is not
                 // workspace-filtered
-                LayerGroupInfo rawGroup = rawCatalog.getLayerGroupByName(group.prefixedName());
+                LayerGroupInfo rawGroup;
+                if (group.getWorkspace() != null) {
+                    // LocalWorkspace has a NameDequalifyingProxy which will strip off the workspace
+                    // if we just call prefixedName
+                    rawGroup =
+                            rawCatalog.getLayerGroupByName(group.getWorkspace(), group.getName());
+                } else {
+                    rawGroup = rawCatalog.getLayerGroupByName(group.getName());
+                }
                 if (rawGroup.layers().size() == group.layers().size()) {
                     layerInfos = group.layers();
                 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCDataSecurityTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCDataSecurityTest.java
@@ -24,9 +24,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
-import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.CoverageInfo;
-import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.*;
 import org.geoserver.data.test.CiteTestData;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
@@ -667,6 +665,32 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         // but this can access it all
         setRequestAuth("cite", "cite");
         response = getAsServletResponse(path);
+        assertEquals("image/png", response.getContentType());
+    }
+
+    @Test
+    public void testWorkspacedLayerGroup() throws Exception {
+        Catalog catalog = getCatalog();
+        LayerInfo lakes = catalog.getLayerByName(getLayerId(MockData.LAKES));
+        WorkspaceInfo ws = lakes.getResource().getStore().getWorkspace();
+        LayerGroupInfo workspacedLayerGroup = getCatalog().getFactory().createLayerGroup();
+        workspacedLayerGroup.setWorkspace(ws);
+        workspacedLayerGroup.setName("citeGroup");
+        workspacedLayerGroup.getLayers().add(lakes);
+        workspacedLayerGroup.getStyles().add(null);
+        catalog.add(workspacedLayerGroup);
+        // enable direct WMS integration
+        GWC.get().getConfig().setDirectWMSIntegrationEnabled(true);
+
+        // no auth, it should work
+        setRequestAuth(null, null);
+        String path =
+                ws.getName()
+                        + "/wms?bgcolor=0x000000&LAYERS="
+                        + workspacedLayerGroup.prefixedName()
+                        + "&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
+                        + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=0,-90,180,90&WIDTH=256&HEIGHT=256&transparent=false&tiled=true";
+        MockHttpServletResponse response = getAsServletResponse(path);
         assertEquals("image/png", response.getContentType());
     }
 }


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8550

NPE only occurs when you make a workspace-virtual WMS request against a workspaced layer group and all of the following are true:
- Caching is enabled
- GWC Data Security is enabled
- Direct WMS integration is enabled

Caused because LocalWorkspace has a NameDequalifyingProxy which will strip off the workspace if we just call prefixedName