### PR TITLE
[GEOS-8563] Importer should correctly report INIT_ERROR state

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/ImportContext.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/ImportContext.java
@@ -223,6 +223,8 @@ public class ImportContext implements Serializable {
         if (tasks.isEmpty()) {
             if (state == State.INIT) {
                 newState = State.INIT;
+            } else if (state == State.INIT_ERROR) {
+                newState = State.INIT_ERROR;
             } else {
                 newState = State.PENDING;
             }


### PR DESCRIPTION
When an error occurs during import initialization, the error is caught and the context state is set to INIT_ERROR.
However, later in initialization, Importer.changed() is called, which resets the state, overwriting this value with PENDING. This has been fixed, and Importer will now correctly report the INIT_ERROR state.

For some background info, see https://osgeo-org.atlassian.net/browse/GEOS-8563
Note - This doesn't really fix GEOS-8563, but does make it more clear that importer is in an error state when the issue occurs.