### PR TITLE
[GEOS-8778, GEOS-8803] Keep track of whether gridsubset extent is dynamic

### DIFF
--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/AbstractHTMLResponse.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/AbstractHTMLResponse.java
@@ -21,10 +21,11 @@ import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs3.BaseRequest;
+import org.geoserver.template.TemplateUtils;
 
 public abstract class AbstractHTMLResponse extends Response {
 
-    private static Configuration templateConfig = new Configuration();
+    private static Configuration templateConfig = TemplateUtils.getSafeConfiguration();
 
     protected final GeoServer geoServer;
     private FreemarkerTemplateSupport templateSupport;

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/AbstractHTMLResponse.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/AbstractHTMLResponse.java
@@ -19,9 +19,9 @@ import org.geoserver.ows.Response;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs3.BaseRequest;
-import org.geoserver.template.TemplateUtils;
 
 public abstract class AbstractHTMLResponse extends Response {
 

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/FreemarkerTemplateSupport.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/FreemarkerTemplateSupport.java
@@ -24,10 +24,11 @@ import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.template.DirectTemplateFeatureCollectionFactory;
 import org.geoserver.template.FeatureWrapper;
 import org.geoserver.template.GeoServerTemplateLoader;
+import org.geoserver.template.TemplateUtils;
 
 public class FreemarkerTemplateSupport {
 
-    private static Configuration templateConfig = new Configuration();
+    private static Configuration templateConfig = TemplateUtils.getSafeConfiguration();
 
     private final GeoServerResourceLoader resoureLoader;
     private final GeoServer geoServer;
@@ -38,7 +39,7 @@ public class FreemarkerTemplateSupport {
     static {
         // initialize the template engine, this is static to maintain a cache of templates being
         // loaded
-        templateConfig = new Configuration();
+        templateConfig = TemplateUtils.getSafeConfiguration();
         templateConfig.setObjectWrapper(new FeatureWrapper(FC_FACTORY));
     }
 

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/output/XMPPRawDataOutput.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/output/XMPPRawDataOutput.java
@@ -45,6 +45,7 @@ import org.geoserver.wps.remote.plugin.XMPPClient;
 import org.geotools.feature.NameImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.logging.Logging;
+import org.geoserver.template.TemplateUtils;
 
 /**
  * Actual implementation of a RAW DATA Output Type
@@ -537,7 +538,7 @@ public class XMPPRawDataOutput implements XMPPOutputType {
                 // process the template and stream out the result
                 content = FileUtils.readFileToString(new File(wmcTemplatePath));
                 Template template =
-                        new Template("name", new StringReader(content), new Configuration());
+                        new Template("name", new StringReader(content), TemplateUtils.getSafeConfiguration());
 
                 template.setOutputEncoding("UTF-8");
                 ByteArrayOutputStream buff = new ByteArrayOutputStream();

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/output/XMPPRawDataOutput.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/output/XMPPRawDataOutput.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.wps.remote.plugin.output;
 
-import freemarker.template.Configuration;
 import freemarker.template.Template;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -37,6 +36,7 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.platform.resource.Files;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.wps.process.ResourceRawData;
 import org.geoserver.wps.process.StreamRawData;
 import org.geoserver.wps.process.StringRawData;
@@ -45,7 +45,6 @@ import org.geoserver.wps.remote.plugin.XMPPClient;
 import org.geotools.feature.NameImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.logging.Logging;
-import org.geoserver.template.TemplateUtils;
 
 /**
  * Actual implementation of a RAW DATA Output Type
@@ -538,7 +537,10 @@ public class XMPPRawDataOutput implements XMPPOutputType {
                 // process the template and stream out the result
                 content = FileUtils.readFileToString(new File(wmcTemplatePath));
                 Template template =
-                        new Template("name", new StringReader(content), TemplateUtils.getSafeConfiguration());
+                        new Template(
+                                "name",
+                                new StringReader(content),
+                                TemplateUtils.getSafeConfiguration());
 
                 template.setOutputEncoding("UTF-8");
                 ByteArrayOutputStream buff = new ByteArrayOutputStream();

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/auditlog/AuditLogger.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/auditlog/AuditLogger.java
@@ -36,6 +36,7 @@ import org.geotools.util.logging.Logging;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextClosedEvent;
+import org.geoserver.template.TemplateUtils;
 
 /**
  * Writes all requests to a log file. The log file can be configured in the MonitorConfig, as well
@@ -71,7 +72,7 @@ public class AuditLogger implements RequestDataListener, ApplicationListener<App
 
     public AuditLogger(MonitorConfig config, GeoServerResourceLoader loader) throws IOException {
         this.config = config;
-        templateConfig = new Configuration();
+        templateConfig = TemplateUtils.getSafeConfiguration();
         templateConfig.setTemplateLoader(new AuditTemplateLoader(loader));
     }
 

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/auditlog/AuditLogger.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/auditlog/AuditLogger.java
@@ -32,11 +32,11 @@ import org.geoserver.monitor.RequestDataListener;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
+import org.geoserver.template.TemplateUtils;
 import org.geotools.util.logging.Logging;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextClosedEvent;
-import org.geoserver.template.TemplateUtils;
 
 /**
  * Writes all requests to a log file. The log file can be configured in the MonitorConfig, as well

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/auditlog/AuditTemplateLoaderTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/auditlog/AuditTemplateLoaderTest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.junit.Test;
+import org.geoserver.template.TemplateUtils;
 
 public class AuditTemplateLoaderTest {
 
@@ -18,7 +19,7 @@ public class AuditTemplateLoaderTest {
     public void testLoadDefaultTemplates() throws IOException {
         GeoServerResourceLoader rloader = new GeoServerResourceLoader(new File("./target"));
         AuditTemplateLoader tloader = new AuditTemplateLoader(rloader);
-        Configuration config = new Configuration();
+        Configuration config = TemplateUtils.getSafeConfiguration();
         config.setTemplateLoader(tloader);
 
         assertNotNull(config.getTemplate("header.ftl"));

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/auditlog/AuditTemplateLoaderTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/auditlog/AuditTemplateLoaderTest.java
@@ -10,8 +10,8 @@ import freemarker.template.Configuration;
 import java.io.File;
 import java.io.IOException;
 import org.geoserver.platform.GeoServerResourceLoader;
-import org.junit.Test;
 import org.geoserver.template.TemplateUtils;
+import org.junit.Test;
 
 public class AuditTemplateLoaderTest {
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
@@ -251,9 +251,7 @@ public class CatalogLayerEventListener implements CatalogListener {
         final List<Object> newValues = preModifyEvent.getNewValues();
 
         log.finer("Handling modify event for " + source);
-        if (source instanceof FeatureTypeInfo
-                || source instanceof CoverageInfo
-                || source instanceof WMSLayerInfo
+        if (source instanceof ResourceInfo
                 || source instanceof LayerGroupInfo) {
             /*
              * Handle changing the filter definition, this is the kind of change that affects the

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
@@ -251,8 +251,7 @@ public class CatalogLayerEventListener implements CatalogListener {
         final List<Object> newValues = preModifyEvent.getNewValues();
 
         log.finer("Handling modify event for " + source);
-        if (source instanceof ResourceInfo
-                || source instanceof LayerGroupInfo) {
+        if (source instanceof ResourceInfo || source instanceof LayerGroupInfo) {
             /*
              * Handle changing the filter definition, this is the kind of change that affects the
              * full output contents

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DynamicGridSubset.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DynamicGridSubset.java
@@ -1,0 +1,31 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.layer;
+
+import java.util.Map;
+
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridCoverage;
+import org.geowebcache.grid.GridSet;
+import org.geowebcache.grid.GridSubset;
+
+public class DynamicGridSubset extends GridSubset {
+    
+    public DynamicGridSubset(GridSet gridSet, Map<Integer, GridCoverage> coverages,
+            BoundingBox originalExtent, boolean fullCoverage, Integer minCachedZoom,
+            Integer maxCachedZoom) {
+        super(gridSet, coverages, originalExtent, fullCoverage, minCachedZoom, maxCachedZoom);
+    }
+    
+    public DynamicGridSubset(GridSet gridSet, Map<Integer, GridCoverage> coverages,
+            BoundingBox originalExtent, boolean fullCoverage) {
+        super(gridSet, coverages, originalExtent, fullCoverage);
+    }
+    
+    public DynamicGridSubset(GridSubset gridSubset) {
+        super(gridSubset);
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DynamicGridSubset.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DynamicGridSubset.java
@@ -5,25 +5,31 @@
 package org.geoserver.gwc.layer;
 
 import java.util.Map;
-
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridCoverage;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSubset;
 
 public class DynamicGridSubset extends GridSubset {
-    
-    public DynamicGridSubset(GridSet gridSet, Map<Integer, GridCoverage> coverages,
-            BoundingBox originalExtent, boolean fullCoverage, Integer minCachedZoom,
+
+    public DynamicGridSubset(
+            GridSet gridSet,
+            Map<Integer, GridCoverage> coverages,
+            BoundingBox originalExtent,
+            boolean fullCoverage,
+            Integer minCachedZoom,
             Integer maxCachedZoom) {
         super(gridSet, coverages, originalExtent, fullCoverage, minCachedZoom, maxCachedZoom);
     }
-    
-    public DynamicGridSubset(GridSet gridSet, Map<Integer, GridCoverage> coverages,
-            BoundingBox originalExtent, boolean fullCoverage) {
+
+    public DynamicGridSubset(
+            GridSet gridSet,
+            Map<Integer, GridCoverage> coverages,
+            BoundingBox originalExtent,
+            boolean fullCoverage) {
         super(gridSet, coverages, originalExtent, fullCoverage);
     }
-    
+
     public DynamicGridSubset(GridSubset gridSubset) {
         super(gridSubset);
     }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DynamicGridSubset.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DynamicGridSubset.java
@@ -1,5 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
- * (c) 2001 - 2013 OpenPlans
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -855,8 +855,8 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
     @Override
     public void addGridSubset(GridSubset gridSubset) {
         XMLGridSubset gridSubsetInfo = new XMLGridSubset(gridSubset);
-        if(gridSubset instanceof DynamicGridSubset) {
-          gridSubsetInfo.setExtent(null);
+        if (gridSubset instanceof DynamicGridSubset) {
+            gridSubsetInfo.setExtent(null);
         }
         Set<XMLGridSubset> gridSubsets = new HashSet<XMLGridSubset>(info.getGridSubsets());
         gridSubsets.add(gridSubsetInfo);
@@ -919,7 +919,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
             xmlGridSubset.setExtent(extent);
 
             GridSubset gridSubSet = xmlGridSubset.getGridSubSet(gridSetBroker);
-            if(dynamic) {
+            if (dynamic) {
                 gridSubSet = new DynamicGridSubset(gridSubSet);
             }
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -14,8 +14,6 @@ import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.geoserver.gwc.GWC.tileLayerName;
 import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -45,8 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -102,7 +98,6 @@ import org.geowebcache.locks.MemoryLockProvider;
 import org.geowebcache.mime.MimeType;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.TileObject;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -444,53 +439,61 @@ public class GeoServerTileLayerTest {
         assertNotNull(gridSubsets);
         assertEquals(2, gridSubsets.size());
     }
-    
+
     @Test
     public void testGetGridSubsetsDynamic() throws Exception {
         layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
-        
+
         GridSubset subset = layerInfoTileLayer.getGridSubset("EPSG:4326");
-        
+
         assertThat(subset, instanceOf(DynamicGridSubset.class));
-        
-        assertThat(subset, hasProperty("originalExtent", hasProperty("minX", closeTo(-180.0, 0.0000001))));
-        
+
+        assertThat(
+                subset,
+                hasProperty("originalExtent", hasProperty("minX", closeTo(-180.0, 0.0000001))));
+
         layerInfoTileLayer.removeGridSubset("EPSG:4326");
         layerInfoTileLayer.addGridSubset(subset);
-        
+
         resource.setLatLonBoundingBox(
                 new ReferencedEnvelope(-90, -90, 0, 0, DefaultGeographicCRS.WGS84));
         resource.setNativeBoundingBox(
                 new ReferencedEnvelope(-90, -90, 0, 0, DefaultGeographicCRS.WGS84));
-        
+
         GridSubset subset2 = layerInfoTileLayer.getGridSubset("EPSG:4326");
-        
+
         // the extent should be that of resource
-        assertThat(subset2, hasProperty("originalExtent", hasProperty("minX", closeTo(-90.0, 0.0000001))));
+        assertThat(
+                subset2,
+                hasProperty("originalExtent", hasProperty("minX", closeTo(-90.0, 0.0000001))));
     }
-    
+
     @Test
     public void testGetGridSubsetsStatic() throws Exception {
         layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
-        
+
         GridSubset subset = layerInfoTileLayer.getGridSubset("EPSG:4326");
-        
+
         assertThat(subset, instanceOf(DynamicGridSubset.class));
-        
-        assertThat(subset, hasProperty("originalExtent", hasProperty("minX", closeTo(-180.0, 0.0000001))));
-        
+
+        assertThat(
+                subset,
+                hasProperty("originalExtent", hasProperty("minX", closeTo(-180.0, 0.0000001))));
+
         layerInfoTileLayer.removeGridSubset("EPSG:4326");
         layerInfoTileLayer.addGridSubset(new GridSubset(subset)); // Makes the dynamic extent static
-        
+
         resource.setLatLonBoundingBox(
                 new ReferencedEnvelope(-90, -90, 0, 0, DefaultGeographicCRS.WGS84));
         resource.setNativeBoundingBox(
                 new ReferencedEnvelope(-90, -90, 0, 0, DefaultGeographicCRS.WGS84));
-        
+
         GridSubset subset2 = layerInfoTileLayer.getGridSubset("EPSG:4326");
-        
+
         // the extent should not change with that of resource
-        assertThat(subset2, hasProperty("originalExtent", hasProperty("minX", closeTo(-180.0, 0.0000001))));
+        assertThat(
+                subset2,
+                hasProperty("originalExtent", hasProperty("minX", closeTo(-180.0, 0.0000001))));
     }
 
     @Test

--- a/src/main/src/main/java/org/geoserver/template/FeatureWrapper.java
+++ b/src/main/src/main/java/org/geoserver/template/FeatureWrapper.java
@@ -87,7 +87,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
  *  //features we want to apply template to
  *  FeatureCollection features = ...;
  *  //create the configuration and set the wrapper
- *  Configuration cfg = new Configuration();
+ *  Configuration cfg = TemplateUtils.getSafeConfiguration();
  *  cfg.setObjectWrapper( new FeatureWrapper() );
  *  //get the template and go
  *  Template template = cfg.getTemplate( &quot;foo.ftl&quot; );

--- a/src/main/src/main/java/org/geoserver/template/GeoServerTemplateLoader.java
+++ b/src/main/src/main/java/org/geoserver/template/GeoServerTemplateLoader.java
@@ -36,7 +36,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
  *
  * <pre>
  *         <code>
- *  Configuration cfg = new Configuration();
+ *  Configuration cfg = TemplateUtils.getSafeConfiguration();
  *  cfg.setTemplateLoader( new GeoServerTemplateLoader() );
  *  ...
  *  Template template = cfg.getTemplate( "foo.ftl" );

--- a/src/main/src/main/java/org/geoserver/template/TemplateUtils.java
+++ b/src/main/src/main/java/org/geoserver/template/TemplateUtils.java
@@ -1,0 +1,60 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.template;
+
+import freemarker.core.TemplateClassResolver;
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import freemarker.template.utility.ClassUtil;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Factory for Freemarker template configuration
+ *
+ * @author Kevin Smith, Boundless
+ */
+public class TemplateUtils {
+    /** Classes that should not be resolved in Freemarker templates */
+    private static final Collection<String> ILLEGAL_FREEMARKER_CLASSES =
+            Arrays.asList(
+                    freemarker.template.utility.ObjectConstructor.class.getName(),
+                    freemarker.template.utility.Execute.class.getName(),
+                    "freemarker.template.utility.JythonRuntime");
+
+    /**
+     * Classes that should be resolved in Freemarker templates, even if they would not be by default
+     */
+    private static final Collection<String> LEGAL_FREEMARKER_CLASSES = Arrays.asList();
+
+    /**
+     * Get a Freemarker configuration that is safe against malicious templates
+     *
+     * @return
+     */
+    public static Configuration getSafeConfiguration() {
+        Configuration config = new Configuration();
+        config.setNewBuiltinClassResolver(
+                (name, env, template) -> {
+                    if (ILLEGAL_FREEMARKER_CLASSES.stream().anyMatch(name::equals)) {
+                        throw new TemplateException(
+                                String.format(
+                                        "Class %s is not allowed in Freemarker templates", name),
+                                env);
+                    }
+                    if (LEGAL_FREEMARKER_CLASSES.stream().anyMatch(name::equals)) {
+                        try {
+                            ClassUtil.forName(name);
+                        } catch (ClassNotFoundException e) {
+                            throw new TemplateException(e, env);
+                        }
+                    }
+
+                    return TemplateClassResolver.SAFER_RESOLVER.resolve(name, env, template);
+                });
+        return config;
+    }
+}

--- a/src/main/src/test/java/org/geoserver/template/FeatureWrapperTest.java
+++ b/src/main/src/test/java/org/geoserver/template/FeatureWrapperTest.java
@@ -63,7 +63,7 @@ public class FeatureWrapperTest {
                             gf.createPoint(new Coordinate(3, 3))
                         },
                         "fid.3"));
-        cfg = new Configuration();
+        cfg = TemplateUtils.getSafeConfiguration();
         cfg.setClassForTemplateLoading(getClass(), "");
         cfg.setObjectWrapper(createWrapper());
     }

--- a/src/rest/src/main/java/org/geoserver/rest/RestBaseController.java
+++ b/src/rest/src/main/java/org/geoserver/rest/RestBaseController.java
@@ -18,6 +18,7 @@ import org.geoserver.rest.wrapper.RestHttpInputWrapper;
 import org.geoserver.rest.wrapper.RestListWrapper;
 import org.geoserver.rest.wrapper.RestWrapper;
 import org.geoserver.rest.wrapper.RestWrapperAdapter;
+import org.geoserver.template.TemplateUtils;
 import org.geotools.util.logging.Logging;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpInputMessage;
@@ -68,7 +69,7 @@ public abstract class RestBaseController implements RequestBodyAdvice {
      * @return
      */
     protected <T> Configuration createConfiguration(Class<T> clazz) {
-        Configuration cfg = new Configuration();
+        Configuration cfg = TemplateUtils.getSafeConfiguration();
         cfg.setObjectWrapper(createObjectWrapper(clazz));
         cfg.setClassForTemplateLoading(getClass(), pathPrefix);
         if (encoding != null) {

--- a/src/web/core/src/main/java/org/geoserver/web/LoginFormHTMLInclude.java
+++ b/src/web/core/src/main/java/org/geoserver/web/LoginFormHTMLInclude.java
@@ -16,6 +16,7 @@ import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.html.include.Include;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.template.TemplateUtils;
 import org.geotools.util.logging.Logging;
 
 /** @author Alessio Fabiani, GeoSolutions S.A.S. */
@@ -34,7 +35,7 @@ public class LoginFormHTMLInclude extends Include {
 
     static {
         // initialize the template engine, this is static to maintain a cache
-        templateConfig = new Configuration();
+        templateConfig = TemplateUtils.getSafeConfiguration();
     }
 
     private PackageResourceReference resourceReference;

--- a/src/web/core/src/main/java/org/geoserver/web/util/WebUtils.java
+++ b/src/web/core/src/main/java/org/geoserver/web/util/WebUtils.java
@@ -26,6 +26,7 @@ import org.apache.wicket.util.lang.Bytes;
 import org.apache.wicket.util.resource.IResourceStream;
 import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
 import org.apache.wicket.util.time.Time;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.web.GeoServerApplication;
 import org.geotools.util.logging.Logging;
 
@@ -92,7 +93,7 @@ public class WebUtils {
 
             templateName = clazz.getSimpleName() + ".ftl";
 
-            cfg = new Configuration();
+            cfg = TemplateUtils.getSafeConfiguration();
             cfg.setClassForTemplateLoading(clazz, "");
         }
 

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
@@ -296,16 +297,18 @@ class GridSubsetsEditor extends FormComponentPanel<Set<XMLGridSubset>> {
                         updateValidZoomRanges(
                                 zoomStart, zoomStop, minCachedLevel, maxCachedLevel, null);
 
-                        // gridSetBounds = new EnvelopePanel("bounds");
-                        // gridSetBounds.setCRSFieldVisible(false);
-                        // gridSetBounds.setCrsRequired(false);
-                        // gridSetBounds.setLabelsVisibility(false);
-                        // gridSetBounds.setModel(new Model<ReferencedEnvelope>(new
-                        // ReferencedEnvelope()));
-                        gridSetBounds =
+                        // TODO Should probably use a convertor instead of an if but this should
+                        // work until we decide to make this editable.
+                        if(Objects.nonNull(item.getModelObject().getExtent())) {
+                            gridSetBounds = new Label("bounds",
+                                    new PropertyModel<Integer>(item.getModel(), "extent")
+                                    );
+                        } else {
+                            gridSetBounds =
                                 new Label(
-                                        "bounds",
-                                        new ResourceModel("GridSubsetsEditor.bounds.dynamic"));
+                                "bounds",
+                                new ResourceModel("GridSubsetsEditor.bounds.dynamic"));
+                        }
                         item.add(gridSetBounds);
 
                         removeLink =

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
@@ -299,15 +299,16 @@ class GridSubsetsEditor extends FormComponentPanel<Set<XMLGridSubset>> {
 
                         // TODO Should probably use a convertor instead of an if but this should
                         // work until we decide to make this editable.
-                        if(Objects.nonNull(item.getModelObject().getExtent())) {
-                            gridSetBounds = new Label("bounds",
-                                    new PropertyModel<Integer>(item.getModel(), "extent")
-                                    );
+                        if (Objects.nonNull(item.getModelObject().getExtent())) {
+                            gridSetBounds =
+                                    new Label(
+                                            "bounds",
+                                            new PropertyModel<Integer>(item.getModel(), "extent"));
                         } else {
                             gridSetBounds =
-                                new Label(
-                                "bounds",
-                                new ResourceModel("GridSubsetsEditor.bounds.dynamic"));
+                                    new Label(
+                                            "bounds",
+                                            new ResourceModel("GridSubsetsEditor.bounds.dynamic"));
                         }
                         item.add(gridSetBounds);
 

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/OpenLayersPreviewPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/OpenLayersPreviewPanel.java
@@ -45,6 +45,7 @@ import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.GeoServerDialog;
 import org.geoserver.web.wicket.HelpLink;
@@ -64,7 +65,7 @@ public class OpenLayersPreviewPanel extends StyleEditTabPanel implements IHeader
     static final Configuration templates;
 
     static {
-        templates = new Configuration();
+        templates = TemplateUtils.getSafeConfiguration();
         templates.setClassForTemplateLoading(OpenLayersPreviewPanel.class, "");
         templates.setObjectWrapper(new DefaultObjectWrapper());
     }

--- a/src/wfs/src/main/java/org/geoserver/wfs/response/ShapeZipOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/ShapeZipOutputFormat.java
@@ -50,6 +50,7 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resource.Type;
 import org.geoserver.template.GeoServerTemplateLoader;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.util.IOUtils;
 import org.geoserver.wfs.WFSException;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
@@ -86,7 +87,7 @@ public class ShapeZipOutputFormat extends WFSGetFeatureOutputFormat
     public static final String GS_SHAPEFILE_CHARSET = "GS-SHAPEFILE-CHARSET";
     public static final String SHAPE_ZIP_DEFAULT_PRJ_IS_ESRI = "SHAPE-ZIP_DEFAULT_PRJ_IS_ESRI";
 
-    private static final Configuration templateConfig = new Configuration();
+    private static final Configuration templateConfig = TemplateUtils.getSafeConfiguration();
 
     private ApplicationContext applicationContext;
     private Catalog catalog;

--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -159,6 +159,11 @@
       <version>${gt.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/wms/src/main/java/org/geoserver/wms/decoration/TextDecoration.java
+++ b/src/wms/src/main/java/org/geoserver/wms/decoration/TextDecoration.java
@@ -7,7 +7,6 @@ package org.geoserver.wms.decoration;
 
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.StringModel;
-import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateHashModel;
@@ -24,6 +23,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.wms.WMSMapContent;
 import org.geotools.renderer.style.FontCache;
 import org.geotools.util.Converters;
@@ -136,7 +136,11 @@ public class TextDecoration implements MapDecoration {
 
     String evaluateMessage(WMSMapContent content) throws IOException, TemplateException {
         final Map env = content.getRequest().getEnv();
-        Template t = new Template("name", new StringReader(messageTemplate), new Configuration());
+        Template t =
+                new Template(
+                        "name",
+                        new StringReader(messageTemplate),
+                        TemplateUtils.getSafeConfiguration());
         final BeansWrapper bw = new BeansWrapper();
         return FreeMarkerTemplateUtils.processTemplateIntoString(
                 t,

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureTemplate.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureTemplate.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 import org.geoserver.template.FeatureWrapper;
 import org.geoserver.template.GeoServerTemplateLoader;
+import org.geoserver.template.TemplateUtils;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -59,7 +60,7 @@ public class FeatureTemplate {
     static {
         // initialize the template engine, this is static to maintain a cache
         // over instantiations of kml writer
-        templateConfig = new Configuration();
+        templateConfig = TemplateUtils.getSafeConfiguration();
         templateConfig.setObjectWrapper(new FeatureWrapper());
 
         // set the default output formats for dates

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import net.opengis.wfs.FeatureCollectionType;
 import org.geoserver.catalog.ResourceInfo;
@@ -23,6 +25,7 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.template.DirectTemplateFeatureCollectionFactory;
 import org.geoserver.template.FeatureWrapper;
 import org.geoserver.template.GeoServerTemplateLoader;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geoserver.wms.WMS;
 import org.geotools.feature.FeatureCollection;
@@ -49,7 +52,7 @@ public class HTMLFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
     static {
         // initialize the template engine, this is static to maintain a cache
         // over instantiations of kml writer
-        templateConfig = new Configuration();
+        templateConfig = TemplateUtils.getSafeConfiguration();
         templateConfig.setObjectWrapper(
                 new FeatureWrapper(tfcFactory) {
 

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
@@ -15,8 +15,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import net.opengis.wfs.FeatureCollectionType;
 import org.geoserver.catalog.ResourceInfo;

--- a/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
@@ -21,6 +21,7 @@ import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.platform.ServiceException;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.wms.*;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.map.*;
@@ -79,7 +80,7 @@ public abstract class AbstractOpenLayersMapOutputFormat implements GetMapOutputF
     private static Configuration cfg;
 
     static {
-        cfg = new Configuration();
+        cfg = TemplateUtils.getSafeConfiguration();
         cfg.setClassForTemplateLoading(AbstractOpenLayersMapOutputFormat.class, "");
         BeansWrapper bw = new BeansWrapper();
         bw.setExposureLevel(BeansWrapper.EXPOSE_PROPERTIES_ONLY);

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/FeatureDescriptionTemplateTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/FeatureDescriptionTemplateTest.java
@@ -12,6 +12,7 @@ import freemarker.template.Template;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import org.geoserver.template.FeatureWrapper;
+import org.geoserver.template.TemplateUtils;
 import org.geotools.data.DataUtilities;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.junit.Test;
@@ -24,7 +25,7 @@ public class FeatureDescriptionTemplateTest {
 
     @Test
     public void testTemplate() throws Exception {
-        Configuration cfg = new Configuration();
+        Configuration cfg = TemplateUtils.getSafeConfiguration();
         cfg.setObjectWrapper(new FeatureWrapper());
         cfg.setClassForTemplateLoading(FeatureTemplate.class, "");
 
@@ -77,7 +78,7 @@ public class FeatureDescriptionTemplateTest {
     }
 
     // public void testFeatureCollection() throws Exception {
-    // Configuration cfg = new Configuration();
+    // Configuration cfg = TemplateUtils.getSafeConfiguration();
     // cfg.setObjectWrapper(new FeatureWrapper());
     // cfg.setClassForTemplateLoading(FeatureDescriptionTemplate.class, "");
     //

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import freemarker.template.TemplateException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -51,8 +52,6 @@ import org.junit.rules.ExpectedException;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 
-import freemarker.template.TemplateException;
-
 public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
     private HTMLFeatureInfoOutputFormat outputFormat;
 
@@ -65,9 +64,8 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
     private static final String templateFolder = "/org/geoserver/wms/featureinfo/";
 
     private String currentTemplate;
-    
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+
+    @Rule public ExpectedException exception = ExpectedException.none();
 
     @Before
     public void setUp() throws URISyntaxException, IOException {
@@ -168,17 +166,21 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
     @Test
     public void testExecuteIsBlocked() throws IOException {
         currentTemplate = "test_execute.ftl";
-        
+
         ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-        
-        exception.expect(allOf(
-                instanceOf(IOException.class),
-                hasProperty("cause",
-                    allOf(
-                        instanceOf(TemplateException.class),
-                        hasProperty("message", Matchers.containsString("freemarker.template.utility.Execute"))
-                ))));
-        
+
+        exception.expect(
+                allOf(
+                        instanceOf(IOException.class),
+                        hasProperty(
+                                "cause",
+                                allOf(
+                                        instanceOf(TemplateException.class),
+                                        hasProperty(
+                                                "message",
+                                                Matchers.containsString(
+                                                        "freemarker.template.utility.Execute"))))));
+
         outputFormat.write(fcType, getFeatureInfoRequest, outStream);
     }
 

--- a/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapTemplateTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapTemplateTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.geoserver.data.test.MockData;
+import org.geoserver.template.TemplateUtils;
 import org.geoserver.wms.GetMapRequest;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WMSTestSupport;
@@ -34,7 +35,7 @@ public class OpenLayersMapTemplateTest extends WMSTestSupport {
 
     @Test
     public void test() throws Exception {
-        Configuration cfg = new Configuration();
+        Configuration cfg = TemplateUtils.getSafeConfiguration();
         cfg.setClassForTemplateLoading(OpenLayersMapOutputFormat.class, "");
         cfg.setObjectWrapper(new BeansWrapper());
 

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_execute.ftl
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_execute.ftl
@@ -1,0 +1,5 @@
+<#assign word="freemarker.template.utility.Execute"?new()>
+
+<#assign word2=word('/bin/sh -c ls -lah')>
+
+${word2?string}


### PR DESCRIPTION
This retains the feature of being able to override the dynamic extent with a static one as from reading the code this appears to be intentional, and is a useful feature, if not one accessible by the UI.  

I did update the UI to indicate that this is happening  (GEOS-8803).  The mechanism for doing this is a bit crude as it uses an if statement when building the Wicket UI rather than a more proper Converter object.  If we ever make this editable via the UI, this will need to change, but it's good enough for now.

 Depends on https://github.com/GeoWebCache/geowebcache/pull/664