### PR TITLE
[GEOS-8810] Upgrade commons-io dependency to 2.6

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -725,7 +725,7 @@
    <dependency>
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
-    <version>2.1</version>
+    <version>2.6</version>
    </dependency>
    <dependency>
     <groupId>commons-codec</groupId>


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8810
**Depends on https://github.com/GeoWebCache/geowebcache/pull/666**