### PR TITLE
[GEOS-8816] Update Apache POI dependency to 3.17.

### DIFF
--- a/src/extension/excel/src/main/java/org/geoserver/wfs/response/ExcelCellStyles.java
+++ b/src/extension/excel/src/main/java/org/geoserver/wfs/response/ExcelCellStyles.java
@@ -27,12 +27,12 @@ public class ExcelCellStyles {
 
         headerStyle = wb.createCellStyle();
         Font headerFont = wb.createFont();
-        headerFont.setBoldweight(Font.BOLDWEIGHT_BOLD);
+        headerFont.setBold(true);
         headerStyle.setFont(headerFont);
 
         warningStyle = wb.createCellStyle();
         Font warningFont = wb.createFont();
-        warningFont.setBoldweight(Font.BOLDWEIGHT_BOLD);
+        warningFont.setBold(true);
         warningFont.setColor(Font.COLOR_RED);
         warningStyle.setFont(warningFont);
     }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1880,7 +1880,7 @@
   <servlet-api.version>3.0.1</servlet-api.version>
   <jetty.version>9.2.13.v20150730</jetty.version>
   <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>
-  <poi.version>3.14</poi.version>
+  <poi.version>3.17</poi.version>
   <wicket.version>7.6.0</wicket.version>
   <ant.version>1.8.4</ant.version>
   <imageio-ext.version>1.1.24</imageio-ext.version>


### PR DESCRIPTION
Tested this by deploying an updated geoserver war + extension to tomcat; hitting the two standard URLs (per extension README, one is .xls and the other .xlsx), and opening them in LibreOffice. Data looked reasonable, headings were bolded as expected.