### PR TITLE
[GEOS-8810] Upgrade commons-io dependency to 2.6 (backport 2.12.x)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -712,7 +712,7 @@
    <dependency>
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
-    <version>2.1</version>
+    <version>2.6</version>
    </dependency>
    <dependency>
     <groupId>commons-codec</groupId>


### PR DESCRIPTION
Backport of https://github.com/geoserver/geoserver/pull/2951