### PR TITLE
[GEOS-8814] Fix loop failure condition off-by-one error

### DIFF
--- a/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
@@ -1063,12 +1063,12 @@ public class SystemTestData extends CiteTestData {
     @Override
     public void tearDown() throws Exception {
         int MAX_ATTEMPTS = 100;
-        for (int i = 0; i < MAX_ATTEMPTS; i++) {
+        for (int i = 1; i <= MAX_ATTEMPTS; i++) {
             try {
                 deleteFilesOnExit(data);
                 break;
             } catch (IOException e) {
-                if (i >= MAX_ATTEMPTS && data.exists()) {
+                if (i == MAX_ATTEMPTS && data.exists()) {
                     throw new IOException(
                             "Failed to clean up test data dir after " + MAX_ATTEMPTS + " attempts",
                             e);


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8814

Fix for a pre-existing loop failure condition off-by-one error found while backporting.