### PR TITLE
[GEOS-8819] Upgrade json-lib dependency to 2.4 (backport 2.13.x)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1062,8 +1062,8 @@
    <dependency> 
      <groupId>net.sf.json-lib</groupId> 
      <artifactId>json-lib</artifactId> 
-     <version>2.2.3</version> 
      <classifier>jdk15</classifier>
+     <version>2.4</version>
    </dependency>
    <dependency>
      <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
Backport of https://github.com/geoserver/geoserver/pull/2963