### PR TITLE
[GEOS-8821] Upgrade spring-security to 4.2.7-RELEASE.

### DIFF
--- a/src/extension/security/cas/pom.xml
+++ b/src/extension/security/cas/pom.xml
@@ -47,5 +47,11 @@
       <artifactId>easymockclassextension</artifactId>
       <scope>test</scope>
     </dependency>
-   </dependencies>
+    <dependency>
+      <groupId>org.jasig.cas.client</groupId>
+      <artifactId>cas-client-core</artifactId>
+      <version>3.4.1</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/extension/security/cas/src/main/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilter.java
+++ b/src/extension/security/cas/src/main/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilter.java
@@ -21,6 +21,7 @@ import org.geoserver.security.LogoutFilterChain;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.filter.GeoServerLogoutFilter;
 import org.geoserver.security.filter.GeoServerPreAuthenticatedUserNameFilter;
+import org.jasig.cas.client.configuration.ConfigurationKeys;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.session.SingleSignOutHandler;
 import org.jasig.cas.client.util.CommonUtils;
@@ -246,7 +247,8 @@ public class GeoServerCasAuthenticationFilter extends GeoServerPreAuthenticatedU
         return "POST".equals(request.getMethod())
                 && CommonUtils.isNotBlank(
                         CommonUtils.safeGetParameter(
-                                request, SingleSignOutHandler.DEFAULT_LOGOUT_PARAMETER_NAME));
+                                request,
+                                ConfigurationKeys.LOGOUT_PARAMETER_NAME.getDefaultValue()));
     }
 
     @Override

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1881,7 +1881,7 @@
   <gt.version>20-SNAPSHOT</gt.version>
   <gwc.version>1.14-SNAPSHOT</gwc.version>
   <spring.version>4.3.18.RELEASE</spring.version>
-  <spring.security.version>4.0.4.RELEASE</spring.security.version> 
+  <spring.security.version>4.2.7.RELEASE</spring.security.version>
   <servlet-api.version>3.0.1</servlet-api.version>
   <jetty.version>9.2.13.v20150730</jetty.version>
   <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>

--- a/src/security/security-tests/src/test/java/org/geoserver/security/BruteForceAttackTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/BruteForceAttackTest.java
@@ -28,7 +28,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 public class BruteForceAttackTest extends GeoServerSystemTestSupport {
 
     private static final String HELLO_GET_REQUEST =
-            "ows?service=hello&request=hello&message=Hello%20World";
+            "ows?service=hello&request=hello&message=Hello_World";
 
     @Override
     protected void setUpSpring(List<String> springContextLocations) {


### PR DESCRIPTION
Tested by booting on tomcat8, logged in OK.

Made sure the CAS extension unpacked OK, tomcat8 restarted afterwards, and that the CAS authentication filter showed up - couldn't test whether it worked correctly, since I don't have a CAS server.

I did see one problem where  geoserver (presumably spring-security) complained about a URL with a ";" character being potentially malicious, but couldn't reproduce and nothing in the logs. More testing would be appreciated.