### PR TITLE
[GEOS-8240] Fix "Forwarded" header name, add user docs

### DIFF
--- a/doc/en/user/source/configuration/globalsettings.rst
+++ b/doc/en/user/source/configuration/globalsettings.rst
@@ -61,7 +61,7 @@ Specifies the global character encoding that will be used in XML responses. Defa
 Proxy Base URL
 --------------
 
-GeoServer can have the capabilities documents report a proxy properly. The Proxy Base URL field is the base URL seen beyond a reverse proxy.
+GeoServer can have the capabilities documents report a proxy properly. "The Proxy Base URL" field is the base URL seen beyond a reverse proxy.
 
 Use headers for Proxy URL
 -------------------------
@@ -73,9 +73,16 @@ The supported proxy headers are:
 #. **X-Forwarded-For** The client IP address
 #. **X-Forwarded-Path** The path of the proxy URL (this is not an official HTTP header, although it is supported by some web-servers)
 #. **Forwarded** Header that supersedes the "X-Forwarded-*" headers above. It has these components: "by", "for", "host", "proto", "path" (this component is not official, but added for consistency with ``X-Forwarded-Path``)
+#. **Host** Same as ``X-Forwarded
 
 For instance, to allow different protocols (``http`` and ``https``) and different hostnames, the proxy base URL field may be changed to: ``${X-Forwarded-Proto}://${X-Forwarded-Host}/geoserver``
-The use of the ``Forwarded`` header is a tad more complex, as its components have to be referenced in templates with the dot-notation, as in: ``{Forwarded.proto}://${Forwarded.host}/geoserver``
+The use of the ``Forwarded`` header is a tad more complex, as its components have to be referenced in templates with the dot-notation, as in: ``{Forwarded.proto}://${Forwarded.host}/geoserver``.
+
+Multiple templates can be put into the "Proxy Base URL". These templates provide fall-backs, since only the first one that is fully matched is used. 
+For instance, a Proxy Base URL of ``http://${X-Forwarded-Host}/geoserver http://www.foo.org/geoserver`` (Templates are space-separated.) can result in either: ``http://www.example.com/geoserver`` (if ``X-Forwarded-Host`` is set to ``www.example.com``.)  or ``http://www.foo.org/geoserver``  (if ``X-Forwarded-Host`` is not set.)
+
+Header names in templates are case-insentive.
+
 
 Logging Profile
 ---------------

--- a/doc/en/user/source/configuration/globalsettings.rst
+++ b/doc/en/user/source/configuration/globalsettings.rst
@@ -63,6 +63,20 @@ Proxy Base URL
 
 GeoServer can have the capabilities documents report a proxy properly. The Proxy Base URL field is the base URL seen beyond a reverse proxy.
 
+Use headers for Proxy URL
+-------------------------
+
+Checking this box allows a by-request modification of the proxy URL using templates (templates based on HTTP proxy headers).
+The supported proxy headers are:
+#. **X-Forwarded-Proto** The protocol used by the request
+#. **X-Forwarded-Host** The hostname and port of the proxy URL
+#. **X-Forwarded-For** The client IP address
+#. **X-Forwarded-Path** The path of the proxy URL (this is not an official HTTP header, although it is supported by some web-servers)
+#. **Forwarded** Header that supersedes the "X-Forwarded-*" headers above. It has these components: "by", "for", "host", "proto", "path" (this component is not official, but added for consistency with ``X-Forwarded-Path``)
+
+For instance, to allow different protocols (``http`` and ``https``) and different hostnames, the proxy base URL field may be changed to: ``${X-Forwarded-Proto}://${X-Forwarded-Host}/geoserver``
+The use of the ``Forwarded`` header is a tad more complex, as its components have to be referenced in templates with the dot-notation, as in: ``{Forwarded.proto}://${Forwarded.host}/geoserver``
+
 Logging Profile
 ---------------
 

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
@@ -222,7 +222,7 @@ public class GeoServerInfoImpl implements GeoServerInfo {
     }
 
     public Boolean isUseHeadersProxyURL() {
-        return useHeadersProxyURL;
+        return useHeadersProxyURL == null ? false : useHeadersProxyURL;
     }
 
     public void setUseHeadersProxyURL(Boolean useHeadersProxyURL) {

--- a/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
@@ -17,7 +17,7 @@ import org.vfny.geoserver.util.Requests;
 public class ProxifyingURLMangler implements URLMangler {
 
     public enum Headers {
-        FORWARDED("X-Forwarded"),
+        FORWARDED("Forwarded"),
         FORWARDED_PROTO("X-Forwarded-Proto"),
         FORWARDED_HOST("X-Forwarded-Host"),
         FORWARDED_PATH("X-Forwarded-Path"),
@@ -169,7 +169,7 @@ public class ProxifyingURLMangler implements URLMangler {
                                                             String.format(
                                                                     "%s%s%s",
                                                                     TEMPLATE_PREFIX,
-                                                                    Headers.FORWARDED.toString()
+                                                                    Headers.FORWARDED.asString()
                                                                             + "."
                                                                             + comp,
                                                                     TEMPLATE_POSTFIX),

--- a/src/main/src/main/java/org/geoserver/ows/QuickTemplate.java
+++ b/src/main/src/main/java/org/geoserver/ows/QuickTemplate.java
@@ -16,7 +16,8 @@ import java.util.Map;
 class QuickTemplate {
 
     /**
-     * Simple replacement of a set of variables in a string with their values
+     * Simple replacement of a set of variables in a string with their values. The variable names to
+     * expand are case-insensitive.
      *
      * @param template
      * @param variables

--- a/src/main/src/test/java/org/vfny/geoserver/util/URLProxifyingTest.java
+++ b/src/main/src/test/java/org/vfny/geoserver/util/URLProxifyingTest.java
@@ -258,7 +258,7 @@ public class URLProxifyingTest {
                 null,
                 null,
                 "for=192.0.2.60; proto=http; by=203.0.113.43; host=example.com:8080");
-        StringBuilder baseURL = new StringBuilder();
+       StringBuilder baseURL = new StringBuilder();
         this.mangler.mangleURL(
                 baseURL,
                 new StringBuilder(),

--- a/src/main/src/test/java/org/vfny/geoserver/util/URLProxifyingTest.java
+++ b/src/main/src/test/java/org/vfny/geoserver/util/URLProxifyingTest.java
@@ -71,7 +71,7 @@ public class URLProxifyingTest {
                         new GeoServerInfoImpl() {
                             @Override
                             public Boolean isUseHeadersProxyURL() {
-                                return useHeadersProxyURLIn;
+                                return useHeadersProxyURLIn == null ? false : useHeadersProxyURLIn;
                             }
                         })
                 .anyTimes();
@@ -97,6 +97,18 @@ public class URLProxifyingTest {
     @After
     public void clearAppContext() {
         GeoServerExtensionsHelper.init(null);
+    }
+
+    @Test
+    public void testNullFlag() throws Exception {
+        createAppContext(null, null, null, null, null, null, null, null);
+        StringBuilder baseURL = new StringBuilder();
+        this.mangler.mangleURL(
+                baseURL,
+                new StringBuilder(),
+                new HashMap<String, String>(),
+                URLMangler.URLType.SERVICE);
+        assertEquals("", baseURL.toString());
     }
 
     @Test
@@ -258,7 +270,7 @@ public class URLProxifyingTest {
                 null,
                 null,
                 "for=192.0.2.60; proto=http; by=203.0.113.43; host=example.com:8080");
-       StringBuilder baseURL = new StringBuilder();
+        StringBuilder baseURL = new StringBuilder();
         this.mangler.mangleURL(
                 baseURL,
                 new StringBuilder(),


### PR DESCRIPTION
- Fixed the name of the "Forwarded" header
- Added user documentation (English only)

Dee discussion: https://github.com/geoserver/geoserver/commit/3c05cfb84151fbcdf5bde6d4d42faa4d743673e9#commitcomment-29588575