### PR TITLE
[GEOS-8800] Reverting style changes to legend span. No longer blocks …

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -376,9 +376,8 @@ border: 0 none transparent;
 legend span { 
 position: absolute;
 width: 29.2em;
-top: -3em;
+top: -1.5em;
 left: 0;
-padding-top: 1.5em;
 }
 
 legend a {


### PR DESCRIPTION
…certain menu items.

Resolves [GEOS-8800](https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-8800)

This change reverts a previous change introduced in tbarsballe#6, which was to resolve [GEOS-8746](https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-8746). As far as I can tell, the change to the `legend span` element's CSS did not contribute to fixing the fullscreen style editor UI, only the `fieldset` element's CSS was needed. Please correct me if I'm wrong, @aaime .