### PR TITLE
Add osgeo dependency to implementing wps tutorial

### DIFF
--- a/doc/en/developer/source/programming-guide/wps-services/implementing.rst
+++ b/doc/en/developer/source/programming-guide/wps-services/implementing.rst
@@ -102,12 +102,12 @@ For this example the project will be called "hello_wps".
             <repository>
                 <id>boundless</id>
                 <name>Boundless Maven Repository</name>
-                <url>http://repo.boundlessgeo.com/main</url>
+                <url>https://repo.boundlessgeo.com/main</url>
             </repository>
 	    <repository>
                 <id>osgeo</id>
                 <name>Open Source Geospatial Foundation Repository</name>
-                <url>http://download.osgeo.org/webdav/geotools</url>
+                <url>https://download.osgeo.org/webdav/geotools</url>
             </repository>
         </repositories>
 

--- a/doc/en/developer/source/programming-guide/wps-services/implementing.rst
+++ b/doc/en/developer/source/programming-guide/wps-services/implementing.rst
@@ -103,17 +103,11 @@ For this example the project will be called "hello_wps".
                 <id>boundless</id>
                 <name>Boundless Maven Repository</name>
                 <url>http://repo.boundlessgeo.com/main</url>
-                <snapshots>
-                    <enabled>true</enabled>
-                </snapshots>
             </repository>
 	    <repository>
                 <id>osgeo</id>
                 <name>Open Source Geospatial Foundation Repository</name>
                 <url>http://download.osgeo.org/webdav/geotools</url>
-                <snapshots>
-                    <enabled>true</enabled>
-                </snapshots>
             </repository>
         </repositories>
 

--- a/doc/en/developer/source/programming-guide/wps-services/implementing.rst
+++ b/doc/en/developer/source/programming-guide/wps-services/implementing.rst
@@ -107,6 +107,14 @@ For this example the project will be called "hello_wps".
                     <enabled>true</enabled>
                 </snapshots>
             </repository>
+	    <repository>
+                <id>osgeo</id>
+                <name>Open Source Geospatial Foundation Repository</name>
+                <url>http://download.osgeo.org/webdav/geotools</url>
+                <snapshots>
+                    <enabled>true</enabled>
+                </snapshots>
+            </repository>
         </repositories>
 
     </project>  


### PR DESCRIPTION
Added osgeo dependency to fix Maven build. 
These were not downloaded before: 
*The following artifacts could not be resolved: jgridshift:jgridshift:jar:1.0, javax.media:jai_imageio:jar:1.1, javax.media:jai_codec:jar:1.1.3, javax.media:jai_core:jar:1.1.3: Could not find artifact jgridshift:jgridshift:jar:1.0 in boundless*

geoserver-users mail list message linked to this:
https://sourceforge.net/p/geoserver/mailman/message/36360921/