### PR TITLE
GEOS-8779 Disable FeatureSizeFeatureCollection by default to avoid un…

### DIFF
--- a/doc/en/user/source/production/config.rst
+++ b/doc/en/user/source/production/config.rst
@@ -66,6 +66,8 @@ Cache your data
 
 Server-side caching of WMS tiles is the best way to increase performance.  In caching, pre-rendered tiles will be saved, eliminating the need for redundant WMS calls.  There are several ways to set up WMS caching for GeoServer.  GeoWebCache is the simplest method, as it comes bundled with GeoServer.  (See the section on :ref:`gwc` for more details.)  Another option is `TileCache <http://tilecache.org>`_.  You can also use a more generic caching system, such as `OSCache <http://www.opensymphony.com/oscache/>`_ (an embedded cache service) or `Squid <http://www.squid-cache.org>`_ (a web cache proxy).
 
+Caching is also possible for WFS layers, in a very limited fashion. For DataStores that don't have a quick way to determine feature counts (i.e. shapefiles), enabling caching can prevent querying a store twice during a single request. To enable caching, set the Java system property ``org.geoserver.wfs.getfeature.cachelimit`` to a positive integer. Any data sets that are smaller than the cache limit will be cached for the duration of a request, which will prevent them from being queried a second time for the feature count. Note that this may adversely affect some types of DataStores, as it bypasses any feature count optimizations that may exist.
+
 Disable the GeoServer web administration interface
 --------------------------------------------------
 

--- a/src/wfs/src/main/java/org/geoserver/wfs/FeatureSizeFeatureCollection.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/FeatureSizeFeatureCollection.java
@@ -30,8 +30,8 @@ import org.opengis.feature.type.FeatureType;
  */
 public class FeatureSizeFeatureCollection extends DecoratingSimpleFeatureCollection {
 
-    /** The default feature cache size */
-    public static final int DEFAULT_CACHE_SIZE = 16;
+    /** The default feature cache size - disabled by default */
+    public static final int DEFAULT_CACHE_SIZE = 0;
 
     /** The original feature source. */
     protected SimpleFeatureSource featureSource;

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureCachingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureCachingTest.java
@@ -6,21 +6,23 @@ package org.geoserver.wfs;
 
 import org.geoserver.wfs.v2_0.GetFeatureTest;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 
 /**
  * Test making sure GetFeature still works when the caching machinery is off (since most test
  * datasets will actually be cached in memory)
  */
-public class GetFeatureNoCachingTest extends GetFeatureTest {
+public class GetFeatureCachingTest extends GetFeatureTest {
 
     @BeforeClass
-    public static void disableCaching() {
-        FeatureSizeFeatureCollection.setFeatureCacheLimit(0);
+    public static void enableCaching() {
+        Assert.assertEquals(0, FeatureSizeFeatureCollection.DEFAULT_CACHE_SIZE);
+        FeatureSizeFeatureCollection.setFeatureCacheLimit(16);
     }
 
     @AfterClass
-    public static void enableCaching() {
+    public static void disableCaching() {
         FeatureSizeFeatureCollection.setFeatureCacheLimit(
                 FeatureSizeFeatureCollection.DEFAULT_CACHE_SIZE);
     }


### PR DESCRIPTION
…optimized counts

* FeatureSizeFeatureCollection is disabled by default, to prevent unoptimized counts when a feature collection returns -1 for size()

https://osgeo-org.atlassian.net/browse/GEOS-8790

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>