### PR TITLE
Updated GeoPackage process to set EntityResolver before validating XML.

### DIFF
--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/wps/GeoPackageProcessRequestPPIO.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/wps/GeoPackageProcessRequestPPIO.java
@@ -32,8 +32,8 @@ public class GeoPackageProcessRequestPPIO extends ComplexPPIO {
     @Override
     public Object decode(InputStream input) throws Exception {
         Parser p = new Parser(config);
-        p.validate(input);
         p.setEntityResolver(resolverProvider.getEntityResolver());
+        p.validate(input);
 
         if (!p.getValidationErrors().isEmpty()) {
             throw new ServiceException(


### PR DESCRIPTION
This pull request updates GeoPackageProcessRequestPPIO to set the EntityResolver on the Parser before using it to validate the input XML and it is dependent on the GeoTools pull request https://github.com/geotools/geotools/pull/1965 which has already been merged.

This pull request can be backported to 2.12.x and 2.13.x.