### PR TITLE
Set the EntityResolver in the WPS Request Builder when building the Execute XML.

### DIFF
--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/ComplexInputPanel.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/ComplexInputPanel.java
@@ -254,6 +254,8 @@ public class ComplexInputPanel extends Panel {
 
     String getExecuteXML() {
         WPSExecuteTransformer tx = new WPSExecuteTransformer();
+        tx.setEntityResolver(
+                GeoServerApplication.get().getCatalog().getResourcePool().getEntityResolver());
         tx.setIndentation(2);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSExecuteTransformer.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSExecuteTransformer.java
@@ -31,7 +31,9 @@ import org.hsqldb.lib.StringInputStream;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.w3c.dom.Document;
 import org.xml.sax.ContentHandler;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
@@ -43,6 +45,9 @@ import org.xml.sax.helpers.AttributesImpl;
 class WPSExecuteTransformer extends TransformerBase {
 
     static final Logger LOGGER = Logging.getLogger(WPSExecuteTransformer.class);
+
+    /** entity resolver */
+    private EntityResolver2 entityResolver;
 
     public WPSExecuteTransformer() {
         this(null);
@@ -57,6 +62,14 @@ class WPSExecuteTransformer extends TransformerBase {
     @Override
     public Translator createTranslator(ContentHandler handler) {
         return new ExecuteRequestTranslator(handler);
+    }
+
+    public void setEntityResolver(EntityResolver entityResolver) {
+        this.entityResolver = (EntityResolver2) entityResolver;
+    }
+
+    public EntityResolver getEntityResolver() {
+        return entityResolver;
     }
 
     public class ExecuteRequestTranslator extends TranslatorSupport {
@@ -378,6 +391,7 @@ class WPSExecuteTransformer extends TransformerBase {
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                 factory.setNamespaceAware(true);
                 DocumentBuilder builder = factory.newDocumentBuilder();
+                builder.setEntityResolver(entityResolver);
                 if (!data.startsWith("<?xml")) {
                     data = "<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n" + data;
                 }

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSRequestBuilder.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSRequestBuilder.java
@@ -147,6 +147,7 @@ public class WPSRequestBuilder extends GeoServerBasePage {
     String getRequestXML() {
         // turn the GUI request into an actual WPS request
         WPSExecuteTransformer tx = new WPSExecuteTransformer(getCatalog());
+        tx.setEntityResolver(getCatalog().getResourcePool().getEntityResolver());
         tx.setIndentation(2);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSRequestBuilderPanel.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSRequestBuilderPanel.java
@@ -5,16 +5,13 @@
  */
 package org.geoserver.wps.web;
 
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
-import javax.xml.transform.TransformerException;
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -388,21 +385,6 @@ public class WPSRequestBuilderPanel extends Panel {
         Collections.sort(result);
 
         return result;
-    }
-
-    String getRequestXML() {
-        // turn the GUI request into an actual WPS request
-        WPSExecuteTransformer tx = new WPSExecuteTransformer();
-        tx.setIndentation(2);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-        try {
-            tx.transform(execute, out);
-        } catch (TransformerException e) {
-            LOGGER.log(Level.SEVERE, "Error generating xml request", e);
-            error(e);
-        }
-        return out.toString();
     }
 
     public Component getFeedbackPanel() {

--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/secret.txt
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/secret.txt
@@ -1,0 +1,1 @@
+HELLO WORLD


### PR DESCRIPTION
This pull request ensures that the EntityResolver is set on the WPSExecuteTransformer object before using the transformer to builder the Execute XML and updates WPSExecuteTransformer to use the EntityResolver when internally parsing text as XML.  WPSRequestBuilderPanel contained unused code to build the Execute XML that was removed.

This pull request can be backported to 2.13.x and probably 2.12.x.