### PR TITLE
Updated WFS CreateStoredQuery to set EntityResolver before validating XML.

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/StoredQuery.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/StoredQuery.java
@@ -131,7 +131,7 @@ public class StoredQuery {
         DocumentBuilder db;
         try {
             db = dbf.newDocumentBuilder();
-
+            db.setEntityResolver(catalog.getResourcePool().getEntityResolver());
         } catch (ParserConfigurationException e) {
             throw new IOException(e);
         }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/StoredQueryTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/StoredQueryTest.java
@@ -5,7 +5,9 @@
  */
 package org.geoserver.wfs.v2_0;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayInputStream;
 import org.custommonkey.xmlunit.XMLAssert;
@@ -552,5 +554,42 @@ public class StoredQueryTest extends WFS20TestSupport {
         assertGML32(dom);
         XMLAssert.assertXpathEvaluatesTo("1", "count(//sf:PrimitiveGeoFeature)", dom);
         XMLAssert.assertXpathExists("//sf:PrimitiveGeoFeature/gml:name[text() = 'name-f002']", dom);
+    }
+
+    @Test
+    public void testCreateStoredQueryXXE() throws Exception {
+        String xml =
+                "<wfs:CreateStoredQuery service='WFS' version='2.0.0' "
+                        + "   xmlns:wfs='http://www.opengis.net/wfs/2.0' "
+                        + "   xmlns:fes='http://www.opengis.net/fes/2.0' "
+                        + "   xmlns:gml='http://www.opengis.net/gml/3.2' "
+                        + "   xmlns:myns='http://www.someserver.com/myns' "
+                        + "   xmlns:sf='"
+                        + MockData.SF_URI
+                        + "'>"
+                        + "   <wfs:StoredQueryDefinition id='testXXE'> "
+                        + "      <wfs:Parameter name='AreaOfInterest' type='gml:Polygon'/> "
+                        + "      <wfs:QueryExpressionText "
+                        + "           returnFeatureTypes='sf:PrimitiveGeoFeature' "
+                        + "           language='urn:ogc:def:queryLanguage:OGC-WFS::WFS_QueryExpression' "
+                        + "           isPrivate='false'><![CDATA[<?xml version='1.0' encoding='UTF-8'?> "
+                        + "         <!DOCTYPE Query [ "
+                        + "         <!ELEMENT Query ANY> "
+                        + "         <!ENTITY xxe SYSTEM \"file:///this/file/does/not/exist\">]> "
+                        + "         <wfs:Query typeNames='sf:PrimitiveGeoFeature'> "
+                        + "            <fes:Filter> "
+                        + "               <fes:Within> "
+                        + "                  <fes:ValueReference>&xxe;</fes:ValueReference> "
+                        + "                  ${AreaOfInterest} "
+                        + "               </fes:Within> "
+                        + "            </fes:Filter> "
+                        + "         </wfs:Query>]]> "
+                        + "      </wfs:QueryExpressionText> "
+                        + "   </wfs:StoredQueryDefinition> "
+                        + "</wfs:CreateStoredQuery>";
+        Document dom = postAsDOM("wfs", xml);
+        String message =
+                checkOws11Exception(dom, "2.0.0", "OperationProcessingFailed", "CreateStoredQuery");
+        assertThat(message, containsString("Entity resolution disallowed"));
     }
 }


### PR DESCRIPTION
This pull request ensures that the EntityResolver is set on the DocumentBuilder before using it to validate the XML sent in WFS CreateStoredQuery requests.

This pull request can be backported to 2.13.x and 2.12.x.