### PR TITLE
Broken nodata handling of native JAI

### DIFF
--- a/doc/en/user/source/production/java.rst
+++ b/doc/en/user/source/production/java.rst
@@ -34,6 +34,8 @@ The `Java Image I/O Technology <http://docs.oracle.com/javase/6/docs/technotes/g
 
 By default, GeoServer ships with the "pure java" version of JAI, but **for better performance JAI and ImageIO are available as "java extensions" to be installed into your JDK/JRE**.
 
+Native version of JAI has **issues handling "nodata" (transparency) for overlapping granules**. Consider sticking with default version if this feature is going to be used.
+
 Native JAI and ImageIO extensions are available for:
 
 +----------+-----------+-----------+


### PR DESCRIPTION
Hello,

Native JAI has some serious issues handling nodata when granule are overlapping. For instance, I haven't been able to get it considering FFFFFFF has nodata color.
It has been confirmed by GeoSolutions.it people that it's kinda broken:
https://sourceforge.net/p/geoserver/mailman/message/36372215/

Regards, Adam.