### PR TITLE
Set the EntityResolver in MapXMLConverter before parsing XML.

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/MapXMLConverter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/MapXMLConverter.java
@@ -44,6 +44,7 @@ public class MapXMLConverter extends BaseMessageConverter<Map<?, ?>> {
             throws IOException, HttpMessageNotReadableException {
         Object result;
         SAXBuilder builder = new SAXBuilder();
+        builder.setEntityResolver(catalog.getResourcePool().getEntityResolver());
         Document doc;
         try {
             doc = builder.build(inputMessage.getBody());

--- a/src/restconfig/src/test/resources/org/geoserver/rest/security/secret.txt
+++ b/src/restconfig/src/test/resources/org/geoserver/rest/security/secret.txt
@@ -1,0 +1,1 @@
+HELLO WORLD


### PR DESCRIPTION
This pull request updates MapXMLConverter to set the EntityResolver on the SAXBuilder before using it to parse the input XML.