### PR TITLE
Support non-amazon s3 compatible servers in GWC S3 blobstore

### DIFF
--- a/src/community/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.html
+++ b/src/community/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.html
@@ -16,6 +16,9 @@
 			<label for="prefix"><wicket:message key="prefix"/></label>
 			<input id="prefix" wicket:id="prefix" type="text" class="text" />
 			
+			<label for="endpoint"><wicket:message key="endpoint"/></label>
+			<input id="endpoint" wicket:id="endpoint" type="text" class="text" />
+			
 			<label for="maxConnections"><wicket:message key="maxConnections"/></label>
 			<input id="maxConnections" wicket:id="maxConnections" type="text" class="text" />
 						

--- a/src/community/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.java
+++ b/src/community/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.java
@@ -44,6 +44,9 @@ public class S3BlobStorePanel extends Panel {
                 new TextField<String>("prefix")
                         .add(new AttributeModifier("title", new ResourceModel("prefix.title"))));
         add(
+                new TextField<String>("endpoint")
+                        .add(new AttributeModifier("title", new ResourceModel("endpoint.title"))));
+        add(
                 new TextField<Integer>("maxConnections")
                         .setRequired(true)
                         .add(

--- a/src/web/gwc/src/main/resources/GeoServerApplication.properties
+++ b/src/web/gwc/src/main/resources/GeoServerApplication.properties
@@ -358,6 +358,8 @@ S3BlobStorePanel.proxyPassword = Proxy Password
 S3BlobStorePanel.proxyPassword.title = Password the client will use if connecting through a proxy (optional).
 S3BlobStorePanel.useGzip = Use Gzip
 S3BlobStorePanel.useGzip.title = When enabled, the stored tiles will be GZIP compressed.
+S3BlobStorePanel.endpoint.title = Endpoint for alternative S3-compatible server.
+S3BlobStorePanel.endpoint = Endpoint
 
 FileBlobStorePanel.baseDirectory = Base Directory
 FileBlobStorePanel.baseDirectory.title = The directory where the tiles will be stored.


### PR DESCRIPTION
Depends on https://github.com/GeoWebCache/geowebcache/pull/674