### PR TITLE
[GEOT-6066] Remove junit and xmlunit from binary product

### DIFF
--- a/src/community/backup-restore/core/pom.xml
+++ b/src/community/backup-restore/core/pom.xml
@@ -84,7 +84,14 @@
 			<groupId>org.apache.commons</groupId>
 	    	<artifactId>commons-vfs2</artifactId>
 	    </dependency>
-	    
+
+		<!-- Test Dependencies -->
+		<dependency>
+			<groupId>xmlunit</groupId>
+			<artifactId>xmlunit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/src/community/geogig/pom.xml
+++ b/src/community/geogig/pom.xml
@@ -192,6 +192,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>info.cukes</groupId>
       <artifactId>cucumber-java</artifactId>
       <version>${cucumber-java.version}</version>

--- a/src/community/nsg-profiles/nsg-wfs-profile/pom.xml
+++ b/src/community/nsg-profiles/nsg-wfs-profile/pom.xml
@@ -72,6 +72,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/src/community/wmts-multi-dimensional/pom.xml
+++ b/src/community/wmts-multi-dimensional/pom.xml
@@ -56,6 +56,11 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/extension/vectortiles/pom.xml
+++ b/src/extension/vectortiles/pom.xml
@@ -57,13 +57,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.geoserver</groupId>
-      <artifactId>gs-wms</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-spring</artifactId>
       <scope>test</scope>
@@ -76,6 +69,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/extension/ysld/pom.xml
+++ b/src/extension/ysld/pom.xml
@@ -43,6 +43,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>

--- a/src/ows/pom.xml
+++ b/src/ows/pom.xml
@@ -52,6 +52,12 @@
    <artifactId>gt-xsd-core</artifactId>
   </dependency>
   <dependency>
+   <groupId>org.geotools.xsd</groupId>
+   <artifactId>gt-xsd-core</artifactId>
+   <classifier>tests</classifier>
+   <scope>test</scope>
+  </dependency>
+  <dependency>
    <groupId>javax.servlet</groupId>
    <artifactId>javax.servlet-api</artifactId>
    <scope>provided</scope>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -278,7 +278,13 @@
     <artifactId>gt-xsd-core</artifactId>
     <version>${gt.version}</version>
    </dependency>
-    <dependency>
+   <dependency>
+    <groupId>org.geotools.xsd</groupId>
+    <artifactId>gt-xsd-core</artifactId>
+    <version>${gt.version}</version>
+    <classifier>tests</classifier>
+   </dependency>
+   <dependency>
     <groupId>org.geotools.xsd</groupId>
     <artifactId>gt-xsd-ows</artifactId>
     <version>${gt.version}</version>


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-6066

GeoServer changes required to build with https://github.com/geotools/geotools/pull/1986 . Expected to fail until https://github.com/geotools/geotools/pull/1986 is merged.