### PR TITLE
GEOS-8870 error trying to rename workspace through rest api

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
@@ -175,7 +175,7 @@ public class WorkspaceController extends AbstractCatalogController {
             }
 
             String infoName = workspace.getName();
-            if (infoName != null && workspaceName.equals(infoName)) {
+            if (infoName != null && infoName.isEmpty()) {
                 throw new RestException("Can't change name of workspace", HttpStatus.FORBIDDEN);
             }
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
@@ -176,7 +176,7 @@ public class WorkspaceController extends AbstractCatalogController {
 
             String infoName = workspace.getName();
             if (infoName != null && infoName.isEmpty()) {
-                throw new RestException("Can't change name of workspace", HttpStatus.FORBIDDEN);
+                throw new RestException("The workspace name cannot be empty", HttpStatus.FORBIDDEN);
             }
 
             new CatalogBuilder(catalog).updateWorkspace(wks, workspace);

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
@@ -175,7 +175,7 @@ public class WorkspaceController extends AbstractCatalogController {
             }
 
             String infoName = workspace.getName();
-            if (infoName != null && !workspaceName.equals(infoName)) {
+            if (infoName != null && workspaceName.equals(infoName)) {
                 throw new RestException("Can't change name of workspace", HttpStatus.FORBIDDEN);
             }
 

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
@@ -304,7 +304,7 @@ public class WorkspaceTest extends CatalogRESTTestSupport {
 
     @Test
     public void testPutNameChangeForbidden() throws Exception {
-        String xml = "<workspace>" + "<name>changed</name>" + "</workspace>";
+        String xml = "<workspace>" + "<name></name>" + "</workspace>";
 
         MockHttpServletResponse response =
                 putAsServletResponse(

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
@@ -310,6 +310,41 @@ public class WorkspaceTest extends CatalogRESTTestSupport {
                 putAsServletResponse(
                         RestBaseController.ROOT_PATH + "/workspaces/gs", xml, "text/xml");
         assertEquals(403, response.getStatus());
+
+        String json = "{'workspace':{ 'name': '' }}";
+        response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/workspaces/gs", json, "application/json");
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testPutNameChange() throws Exception {
+        String xml = "<workspace>" + "<name>changed</name>" + "</workspace>";
+
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/workspaces/gs", xml, "text/xml");
+        assertEquals(200, response.getStatus());
+
+        // verify if changed
+        JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/workspaces/changed.json");
+        JSONObject workspace = ((JSONObject) json).getJSONObject("workspace");
+        assertEquals("changed", workspace.get("name"));
+
+        // undo name change -- this workspace is needed by other tests
+
+        xml = "<workspace>" + "<name>gs</name>" + "</workspace>";
+
+        response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/workspaces/changed", xml, "text/xml");
+        assertEquals(200, response.getStatus());
+
+        // verify if changed
+        json = getAsJSON(RestBaseController.ROOT_PATH + "/workspaces/gs.json");
+        workspace = ((JSONObject) json).getJSONObject("workspace");
+        assertEquals("gs", workspace.get("name"));
     }
 
     @Test


### PR DESCRIPTION
[https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-8870](https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-8870)

Fixed bug  error trying to rename workspace through rest api.

For tests:

curl -v --user admin:geoserver -X put -H "Content-Type: application/json" -d '{"workspace": {"name":"toppNew"}}' http://localhost:8080/geoserver/rest/workspaces/topp 

Before
< HTTP/1.1 403 Can't change name of workspace

After:
< HTTP/1.1 200 OK



