### PR TITLE
[GEOS-8877] Added test scope to gs-sec-jdbc test dependency.

### DIFF
--- a/src/security/jdbc/pom.xml
+++ b/src/security/jdbc/pom.xml
@@ -47,6 +47,7 @@
       <artifactId>gs-security-tests</artifactId>
       <version>${project.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/web/security/jdbc/pom.xml
+++ b/src/web/security/jdbc/pom.xml
@@ -46,6 +46,13 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.security</groupId>
+      <artifactId>gs-security-tests</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
 
 	</dependencies>
 


### PR DESCRIPTION
This pull request adds the test scope to a test dependency to prevent it and its transitive test dependencies from getting into the released GeoServer WAR file.

This pull request can be backported to 2.13.x.