### PR TITLE
ysld generate styles break kml output formats [GEOS-8885]

### DIFF
--- a/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkNameDecoratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkNameDecoratorFactory.java
@@ -63,10 +63,12 @@ public class PlacemarkNameDecoratorFactory implements KmlDecoratorFactory {
                     for (Symbolizer sym : context.getCurrentSymbolizers()) {
                         if (sym instanceof TextSymbolizer) {
                             Expression e = SLD.textLabel((TextSymbolizer) sym);
-                            String value = e.evaluate(sf, String.class);
+                            if (e != null) {
+                                String value = e.evaluate(sf, String.class);
 
-                            if ((value != null) && !"".equals(value.trim())) {
-                                label.append(value);
+                                if ((value != null) && !"".equals(value.trim())) {
+                                    label.append(value);
+                                }
                             }
                         }
                     }

--- a/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
@@ -301,12 +301,27 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
 
             Fill fill = symbolizer.getFill();
             if (fill != null) {
-                Double opacity = fill.getOpacity().evaluate(feature, Double.class);
+              Double opacity;
+              Expression opacityExpr = fill.getOpacity();
+              if (opacityExpr == null) {
+                opacity = 1.0; // default
+              } else {
+                opacity = opacityExpr.evaluate(feature, Double.class);
                 if (opacity == null || Double.isNaN(opacity)) {
-                    opacity = 1.0;
+                  opacity = 1.0;
                 }
-                Color color = fill.getColor().evaluate(feature, Color.class);
-                ls.setColor(colorToHex(color, opacity));
+              }
+              Color color;
+              Expression colorExpr = fill.getColor();
+              if (colorExpr == null) {
+                color = Color.WHITE;
+              } else {
+                color = colorExpr.evaluate(feature, Color.class);
+                if (color == null) {
+                  color = Color.WHITE;
+                }
+              }
+              ls.setColor(colorToHex(color, opacity));
             } else {
                 ls.setColor("ffffffff");
             }

--- a/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
@@ -292,7 +292,7 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
             Font font = symbolizer.getFont();
             if (font != null && font.getSize() != null) {
                 // we make the scale proportional to the normal font size
-                double size = evaluate( font.getSize(), feature, Font.DEFAULT_FONTSIZE);
+                double size = evaluate(font.getSize(), feature, Font.DEFAULT_FONTSIZE);
                 scale = Math.round(size / Font.DEFAULT_FONTSIZE * 100) / 100.0;
             }
             ls.setScale(scale);
@@ -336,10 +336,10 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
                 ps.setOutline(true);
             }
         }
-        
+
         /**
          * Safe expression execution with default fallback.
-         * 
+         *
          * @param expression
          * @param feature
          * @param defaultValue
@@ -357,7 +357,7 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
         }
         /**
          * Safe expression execution with default fallback.
-         * 
+         *
          * @param expression
          * @param feature
          * @param defaultColor
@@ -380,8 +380,8 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
 
             if (stroke != null) {
                 // opacity
-                Double opacity = evaluate( stroke.getOpacity(),  feature,  1.0);
-                
+                Double opacity = evaluate(stroke.getOpacity(), feature, 1.0);
+
                 Color color = null;
                 Expression sc = stroke.getColor();
                 if (sc != null) {
@@ -394,7 +394,8 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
                 ls.setColor(colorToHex(color, opacity));
 
                 // width
-                Double width = evaluate( stroke.getWidth(), feature, 1d ); // from Stroke.DEFAULT.getWidth()
+                Double width =
+                        evaluate(stroke.getWidth(), feature, 1d); // from Stroke.DEFAULT.getWidth()
                 ls.setWidth(width);
             } else {
                 // default

--- a/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
@@ -28,7 +28,6 @@ import org.geoserver.kml.icons.IconPropertyInjector;
 import org.geoserver.wms.WMSInfo;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.renderer.style.ExpressionExtractor;
-import org.geotools.styling.ExternalGraphic;
 import org.geotools.styling.Fill;
 import org.geotools.styling.Font;
 import org.geotools.styling.LineSymbolizer;
@@ -45,7 +44,6 @@ import org.locationtech.jts.geom.Polygon;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
-import org.opengis.style.GraphicalSymbol;
 
 /**
  * Encodes the SLD styles into KML corresponding styles and adds them to the Placemark
@@ -290,38 +288,20 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
         protected void setLabelStyle(
                 Style style, SimpleFeature feature, TextSymbolizer symbolizer) {
             LabelStyle ls = style.createAndSetLabelStyle();
-            double scale = 1;
+            double scale = 1.0;
             Font font = symbolizer.getFont();
             if (font != null && font.getSize() != null) {
                 // we make the scale proportional to the normal font size
-                double size = font.getSize().evaluate(feature, Double.class);
+                double size = evaluate( font.getSize(), feature, Font.DEFAULT_FONTSIZE);
                 scale = Math.round(size / Font.DEFAULT_FONTSIZE * 100) / 100.0;
             }
             ls.setScale(scale);
 
             Fill fill = symbolizer.getFill();
             if (fill != null) {
-              Double opacity;
-              Expression opacityExpr = fill.getOpacity();
-              if (opacityExpr == null) {
-                opacity = 1.0; // default
-              } else {
-                opacity = opacityExpr.evaluate(feature, Double.class);
-                if (opacity == null || Double.isNaN(opacity)) {
-                  opacity = 1.0;
-                }
-              }
-              Color color;
-              Expression colorExpr = fill.getColor();
-              if (colorExpr == null) {
-                color = Color.WHITE;
-              } else {
-                color = colorExpr.evaluate(feature, Color.class);
-                if (color == null) {
-                  color = Color.WHITE;
-                }
-              }
-              ls.setColor(colorToHex(color, opacity));
+                Double opacity = evaluate(fill.getOpacity(), feature, 1.0);
+                Color color = evaluate(fill.getColor(), feature, Color.WHITE);
+                ls.setColor(colorToHex(color, opacity));
             } else {
                 ls.setColor("ffffffff");
             }
@@ -343,13 +323,8 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
             PolyStyle ps = style.createAndSetPolyStyle();
             Fill fill = symbolizer.getFill();
             if (fill != null) {
-                // get opacity
-                Double opacity = fill.getOpacity().evaluate(feature, Double.class);
-                if (opacity == null || Double.isNaN(opacity)) {
-                    opacity = 1.0;
-                }
-
-                Color color = (Color) fill.getColor().evaluate(feature, Color.class);
+                Double opacity = evaluate(fill.getOpacity(), feature, 1.0);
+                Color color = evaluate(fill.getColor(), feature, new Color(0xAAAAAA));
                 ps.setColor(colorToHex(color, opacity));
             } else {
                 // make it transparent
@@ -361,6 +336,43 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
                 ps.setOutline(true);
             }
         }
+        
+        /**
+         * Safe expression execution with default fallback.
+         * 
+         * @param expression
+         * @param feature
+         * @param defaultValue
+         * @return evaluated value or defaultValue if unavailable
+         */
+        private Double evaluate(Expression expression, SimpleFeature feature, double defaultValue) {
+            if (expression == null) {
+                return defaultValue;
+            }
+            Double value = expression.evaluate(feature, Double.class);
+            if (value == null || Double.isNaN(value)) {
+                return defaultValue;
+            }
+            return value;
+        }
+        /**
+         * Safe expression execution with default fallback.
+         * 
+         * @param expression
+         * @param feature
+         * @param defaultColor
+         * @return evaluated value or defaultColor if unavailable
+         */
+        private Color evaluate(Expression expression, SimpleFeature feature, Color defaultColor) {
+            if (expression == null) {
+                return defaultColor;
+            }
+            Color color = expression.evaluate(feature, Color.class);
+            if (color == null) {
+                return defaultColor;
+            }
+            return color;
+        }
 
         /** Encodes a KML IconStyle + LineStyle from a polygon style and symbolizer. */
         protected void setLineStyle(Style style, SimpleFeature feature, Stroke stroke) {
@@ -368,46 +380,27 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
 
             if (stroke != null) {
                 // opacity
-                Double opacity = stroke.getOpacity().evaluate(feature, Double.class);
-                if (opacity == null || Double.isNaN(opacity)) {
-                    opacity = 1.0;
-                }
-
+                Double opacity = evaluate( stroke.getOpacity(),  feature,  1.0);
+                
                 Color color = null;
                 Expression sc = stroke.getColor();
                 if (sc != null) {
                     color = (Color) sc.evaluate(feature, Color.class);
                 }
                 if (color == null) {
+                    // Different from BLACK provided by Stroke.DEFAULT.getColor()
                     color = Color.DARK_GRAY;
                 }
                 ls.setColor(colorToHex(color, opacity));
 
                 // width
-                Double width = null;
-                Expression sw = stroke.getWidth();
-                if (sw != null) {
-                    width = sw.evaluate(feature, Double.class);
-                }
-                if (width == null) {
-                    width = 1d;
-                }
+                Double width = evaluate( stroke.getWidth(), feature, 1d ); // from Stroke.DEFAULT.getWidth()
                 ls.setWidth(width);
             } else {
                 // default
                 ls.setColor("ffaaaaaa");
                 ls.setWidth(1);
             }
-        }
-
-        private ExternalGraphic getExternalGraphic(PointSymbolizer symbolizer) {
-            for (GraphicalSymbol s : symbolizer.getGraphic().graphicalSymbols()) {
-                if (s instanceof ExternalGraphic) {
-                    return (ExternalGraphic) s;
-                }
-            }
-
-            return null;
         }
 
         /**
@@ -446,7 +439,10 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
          * @param opacity Opacity / alpha, double from 0 to 1.0.
          * @return A String of the form "AABBGGRR".
          */
-        String colorToHex(Color c, double opacity) {
+        String colorToHex(Color c, Double opacity) {
+            if (opacity == null || Double.isNaN(opacity)) {
+                opacity = 1.0;
+            }
             return new StringBuffer()
                     .append(intToHex(new Float(255 * opacity).intValue()))
                     .append(intToHex(c.getBlue()))

--- a/src/kml/src/main/java/org/geoserver/kml/icons/IconPropertyExtractor.java
+++ b/src/kml/src/main/java/org/geoserver/kml/icons/IconPropertyExtractor.java
@@ -64,6 +64,24 @@ public final class IconPropertyExtractor {
         public FeatureProperties(SimpleFeature feature) {
             this.feature = feature;
         }
+        /**
+         * Safe expression execution with default fallback.
+         *
+         * @param expression
+         * @param feature
+         * @param defaultValue
+         * @return evaluated value or defaultValue if unavailable
+         */
+        private Double evaluate(Expression expression, SimpleFeature feature, double defaultValue) {
+            if (expression == null) {
+                return defaultValue;
+            }
+            Double value = expression.evaluate(feature, Double.class);
+            if (value == null || Double.isNaN(value)) {
+                return defaultValue;
+            }
+            return value;
+        }
 
         public IconProperties properties() {
             IconProperties singleExternalGraphic = trySingleExternalGraphic();
@@ -116,10 +134,10 @@ public final class IconPropertyExtractor {
             }
             ExternalGraphic exGraphic = (ExternalGraphic) gSym;
             try {
-                Double opacity = g.getOpacity().evaluate(feature, Double.class);
+                Double opacity = evaluate(g.getOpacity(), feature, 1.0);
                 Double size = 1d * Icons.getExternalSize(exGraphic, feature);
                 if (size != null) size = size / Icons.DEFAULT_SYMBOL_SIZE;
-                Double rotation = g.getRotation().evaluate(feature, Double.class);
+                Double rotation = evaluate(g.getRotation(), feature, 0.0);
                 Expression urlExpression =
                         ExpressionExtractor.extractCqlExpressions(
                                 exGraphic.getLocation().toExternalForm());

--- a/src/kml/src/main/java/org/geoserver/kml/icons/Icons.java
+++ b/src/kml/src/main/java/org/geoserver/kml/icons/Icons.java
@@ -83,7 +83,11 @@ public class Icons {
      * @param f
      */
     public static @Nullable Double getRotation(Graphic g, @Nullable Feature f) {
-        return g.getRotation().evaluate(f, Double.class);
+        if (g.getRotation() != null) {
+            return g.getRotation().evaluate(f, Double.class);
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -93,7 +97,11 @@ public class Icons {
      * @param f
      */
     public static @Nullable Double getSpecifiedSize(Graphic g, @Nullable Feature f) {
-        return g.getSize().evaluate(f, Double.class);
+        if (g.getSize() != null) {
+            return g.getSize().evaluate(f, Double.class);
+        } else {
+            return null;
+        }
     }
 
     private static @Nullable Icon getIcon(ExternalGraphic eg, @Nullable Feature f) {
@@ -158,7 +166,7 @@ public class Icons {
 
         if (gs instanceof Mark) {
             Stroke stroke = ((Mark) gs).getStroke();
-            if (stroke != null) {
+            if (stroke != null && stroke.getWidth() != null) {
                 Double width = stroke.getWidth().evaluate(f, Double.class);
                 if (width != null) {
                     border = width;

--- a/src/kml/src/test/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ *
+ * This code is licensed under the GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.kml.decorator;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.geoserver.kml.KmlEncodingContext;
+import org.geoserver.kml.decorator.PlacemarkStyleDecoratorFactory.PlacemarkStyleDecorator;
+import org.geoserver.kml.icons.IconTestSupport;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.styling.TextSymbolizer;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
+
+public class PlacemarkStyleDecoratorTest extends IconTestSupport {
+
+  /**
+   * Test partial style transformation.
+   *
+   * <p>The YSLD parser is not supplying the same defaults as the SLD parser, producing styles that
+   * violate some of the (perfectly sensible SLD 1.0) assumptions made by PlacemarkStyleDecorator.
+   */
+  @Test
+  public void testYSLDTextSymbolizerEncoding() {
+    TextSymbolizer text =
+        text("text", "NAME", font("Arial Black", null, "bold", 8), fill(Color.white, null));
+    
+    PlacemarkStyleDecoratorFactory.PlacemarkStyleDecorator decorator =
+        new PlacemarkStyleDecorator();
+
+    KmlEncodingContext context = new FakeKmlEncodingContext(featureType);
+    SimpleFeatureCollection collection = DataUtilities.collection(fieldIs1);
+    context.setCurrentFeatureCollection(collection);
+    context.setCurrentFeature(fieldIs1);
+    context.setCurrentSymbolizers( Collections.singletonList(text));
+    
+    Placemark placemark = new Placemark();
+    decorator.decorate(placemark, context);
+  }
+
+  public static class FakeKmlEncodingContext extends KmlEncodingContext {
+    private SimpleFeatureType featureType;
+    public FakeKmlEncodingContext( SimpleFeatureType featureType ) {
+      this.featureType = featureType;
+    }
+    
+    public List<SimpleFeatureType> getFeatureTypes() {
+      List<SimpleFeatureType> results = new ArrayList<SimpleFeatureType>();
+      results.add(featureType);
+      return results;
+    }   
+    @Override
+    public SimpleFeatureType getCurrentFeatureType() {
+        return featureType;
+    }
+  }
+}

--- a/src/kml/src/test/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorTest.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.kml.decorator;
 
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,48 +18,50 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.styling.TextSymbolizer;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeatureType;
-import de.micromata.opengis.kml.v_2_2_0.Placemark;
 
 public class PlacemarkStyleDecoratorTest extends IconTestSupport {
 
-  /**
-   * Test partial style transformation.
-   *
-   * <p>The YSLD parser is not supplying the same defaults as the SLD parser, producing styles that
-   * violate some of the (perfectly sensible SLD 1.0) assumptions made by PlacemarkStyleDecorator.
-   */
-  @Test
-  public void testYSLDTextSymbolizerEncoding() {
-    TextSymbolizer text =
-        text("text", "NAME", font("Arial Black", null, "bold", 8), fill(Color.white, null));
-    
-    PlacemarkStyleDecoratorFactory.PlacemarkStyleDecorator decorator =
-        new PlacemarkStyleDecorator();
+    /**
+     * Test partial style transformation.
+     *
+     * <p>The YSLD parser is not supplying the same defaults as the SLD parser, producing styles
+     * that violate some of the (perfectly sensible SLD 1.0) assumptions made by
+     * PlacemarkStyleDecorator.
+     */
+    @Test
+    public void testYSLDTextSymbolizerEncoding() {
+        TextSymbolizer text =
+                text("text", "NAME", font("Arial Black", null, "bold", 8), fill(Color.white, null));
 
-    KmlEncodingContext context = new FakeKmlEncodingContext(featureType);
-    SimpleFeatureCollection collection = DataUtilities.collection(fieldIs1);
-    context.setCurrentFeatureCollection(collection);
-    context.setCurrentFeature(fieldIs1);
-    context.setCurrentSymbolizers( Collections.singletonList(text));
-    
-    Placemark placemark = new Placemark();
-    decorator.decorate(placemark, context);
-  }
+        PlacemarkStyleDecoratorFactory.PlacemarkStyleDecorator decorator =
+                new PlacemarkStyleDecorator();
 
-  public static class FakeKmlEncodingContext extends KmlEncodingContext {
-    private SimpleFeatureType featureType;
-    public FakeKmlEncodingContext( SimpleFeatureType featureType ) {
-      this.featureType = featureType;
+        KmlEncodingContext context = new FakeKmlEncodingContext(featureType);
+        SimpleFeatureCollection collection = DataUtilities.collection(fieldIs1);
+        context.setCurrentFeatureCollection(collection);
+        context.setCurrentFeature(fieldIs1);
+        context.setCurrentSymbolizers(Collections.singletonList(text));
+
+        Placemark placemark = new Placemark();
+        decorator.decorate(placemark, context);
     }
-    
-    public List<SimpleFeatureType> getFeatureTypes() {
-      List<SimpleFeatureType> results = new ArrayList<SimpleFeatureType>();
-      results.add(featureType);
-      return results;
-    }   
-    @Override
-    public SimpleFeatureType getCurrentFeatureType() {
-        return featureType;
+
+    public static class FakeKmlEncodingContext extends KmlEncodingContext {
+        private SimpleFeatureType featureType;
+
+        public FakeKmlEncodingContext(SimpleFeatureType featureType) {
+            this.featureType = featureType;
+        }
+
+        public List<SimpleFeatureType> getFeatureTypes() {
+            List<SimpleFeatureType> results = new ArrayList<SimpleFeatureType>();
+            results.add(featureType);
+            return results;
+        }
+
+        @Override
+        public SimpleFeatureType getCurrentFeatureType() {
+            return featureType;
+        }
     }
-  }
 }

--- a/src/kml/src/test/java/org/geoserver/kml/icons/IconPropertiesTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/icons/IconPropertiesTest.java
@@ -9,10 +9,11 @@ import static org.geotools.filter.text.ecql.ECQL.toExpression;
 import static org.geotools.filter.text.ecql.ECQL.toFilter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Collections;
 import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.styling.Fill;
 import org.geotools.styling.Graphic;
 import org.geotools.styling.Mark;
 import org.geotools.styling.PointSymbolizer;
@@ -21,6 +22,7 @@ import org.geotools.styling.Style;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.filter.expression.Expression;
+import org.opengis.style.Stroke;
 
 public class IconPropertiesTest extends IconTestSupport {
     @Test
@@ -82,6 +84,20 @@ public class IconPropertiesTest extends IconTestSupport {
         final Style s = styleFromRules(catchAllRule(symbolizer));
         assertEquals("0.0.0=&0.0.0.name=circle", encode(s, fieldIs1));
         assertEquals("0.0.0=&0.0.0.name=square", encode(s, fieldIs2));
+    }
+    
+    @Test
+    public void testDynamicColor() throws CQLException {
+        Expression color = toExpression("if_then_else(equalTo(field, 1), '#8080C0', '#CC8030')");
+        Stroke stroke = styleFactory.stroke(color,  null,  null, null, null, null, null);
+        Fill fill = styleFactory.fill(null, color, null );        
+        Mark mark = styleFactory.mark(toExpression("circle"), fill, stroke);
+        Graphic graphic = styleFactory.graphic( Collections.singletonList(mark),null, null, null, null, null);       
+        PointSymbolizer symbolizer = styleFactory.pointSymbolizer("symbolizer", toExpression("geom"),  null,  null, graphic );
+        
+        final Style s = styleFromRules(catchAllRule(symbolizer));
+        assertEquals("0.0.0=&0.0.0.fill.color=%238080C0&0.0.0.name=&0.0.0.stroke.color=%238080C0", encode(s, fieldIs1));
+        assertEquals("0.0.0=&0.0.0.fill.color=C08030&0.0.0.name=&0.0.0.stroke.color=C08030", encode(s, fieldIs2));
     }
 
     @Test

--- a/src/kml/src/test/java/org/geoserver/kml/icons/IconPropertiesTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/icons/IconPropertiesTest.java
@@ -9,6 +9,7 @@ import static org.geotools.filter.text.ecql.ECQL.toExpression;
 import static org.geotools.filter.text.ecql.ECQL.toFilter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collections;
@@ -85,19 +86,26 @@ public class IconPropertiesTest extends IconTestSupport {
         assertEquals("0.0.0=&0.0.0.name=circle", encode(s, fieldIs1));
         assertEquals("0.0.0=&0.0.0.name=square", encode(s, fieldIs2));
     }
-    
+
     @Test
     public void testDynamicColor() throws CQLException {
         Expression color = toExpression("if_then_else(equalTo(field, 1), '#8080C0', '#CC8030')");
-        Stroke stroke = styleFactory.stroke(color,  null,  null, null, null, null, null);
-        Fill fill = styleFactory.fill(null, color, null );        
+        Stroke stroke = styleFactory.stroke(color, null, null, null, null, null, null);
+        Fill fill = styleFactory.fill(null, color, null);
         Mark mark = styleFactory.mark(toExpression("circle"), fill, stroke);
-        Graphic graphic = styleFactory.graphic( Collections.singletonList(mark),null, null, null, null, null);       
-        PointSymbolizer symbolizer = styleFactory.pointSymbolizer("symbolizer", toExpression("geom"),  null,  null, graphic );
-        
+        Graphic graphic =
+                styleFactory.graphic(Collections.singletonList(mark), null, null, null, null, null);
+        PointSymbolizer symbolizer =
+                styleFactory.pointSymbolizer(
+                        "symbolizer", toExpression("geom"), null, null, graphic);
+
         final Style s = styleFromRules(catchAllRule(symbolizer));
-        assertEquals("0.0.0=&0.0.0.fill.color=%238080C0&0.0.0.name=&0.0.0.stroke.color=%238080C0", encode(s, fieldIs1));
-        assertEquals("0.0.0=&0.0.0.fill.color=C08030&0.0.0.name=&0.0.0.stroke.color=C08030", encode(s, fieldIs2));
+        assertEquals(
+                "0.0.0=&0.0.0.fill.color=%238080C0&0.0.0.name=&0.0.0.stroke.color=%238080C0",
+                encode(s, fieldIs1));
+        assertEquals(
+                "0.0.0=&0.0.0.fill.color=%23CC8030&0.0.0.name=&0.0.0.stroke.color=%23CC8030",
+                encode(s, fieldIs2));
     }
 
     @Test

--- a/src/kml/src/test/java/org/geoserver/kml/icons/IconTestSupport.java
+++ b/src/kml/src/test/java/org/geoserver/kml/icons/IconTestSupport.java
@@ -8,6 +8,8 @@ package org.geoserver.kml.icons;
 import java.awt.Color;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -21,11 +23,16 @@ import org.geotools.styling.SLD;
 import org.geotools.styling.Style;
 import org.geotools.styling.StyleFactory2;
 import org.geotools.styling.Symbolizer;
+import org.geotools.styling.TextSymbolizer;
 import org.junit.BeforeClass;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.Expression;
+import org.opengis.style.Fill;
+import org.opengis.style.Font;
+import org.opengis.style.GraphicFill;
 
 public class IconTestSupport {
 
@@ -33,6 +40,7 @@ public class IconTestSupport {
     protected static SimpleFeature fieldIs2;
     protected static StyleFactory2 styleFactory;
     protected static FilterFactory2 filterFactory;
+    protected static SimpleFeatureType featureType;
 
     @BeforeClass
     public static void classSetup() {
@@ -43,7 +51,7 @@ public class IconTestSupport {
         typeBuilder.setNamespaceURI("http://example.com/");
         typeBuilder.setSRS("EPSG:4326");
         typeBuilder.add("field", String.class);
-        SimpleFeatureType featureType = typeBuilder.buildFeatureType();
+        featureType = typeBuilder.buildFeatureType();
         SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureType);
         featureBuilder.set("field", "1");
         fieldIs1 = featureBuilder.buildFeature(null);
@@ -69,6 +77,27 @@ public class IconTestSupport {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected final Fill fill(Color color, Double opacity) {
+      Expression colorExpr = color == null ? null : filterFactory.literal(color);
+      Expression opacityExpr = opacity == null ? null : filterFactory.literal(opacity);
+      return styleFactory.fill(null, colorExpr, opacityExpr);
+    }
+  
+    protected final Font font(String fontFace, String style, String weight, Integer size) {
+      List<Expression> fontFaceList =
+          fontFace == null ? null : Collections.singletonList(filterFactory.literal(fontFace));
+      Expression styleExpr = style == null ? null : filterFactory.literal(style);
+      Expression weightExpr = weight == null ? null : filterFactory.literal(weight);
+      Expression sizeExpr = size == null ? null : filterFactory.literal(size);
+      return styleFactory.font(fontFaceList, styleExpr, weightExpr, sizeExpr);
+    }
+  
+    protected final TextSymbolizer text(String name, String label, Font font, Fill fill) {
+      Expression geometry = filterFactory.property("");
+      return styleFactory.textSymbolizer(
+          name, geometry, null, null, filterFactory.property(label), font, null, null, fill);
     }
 
     protected final PointSymbolizer mark(

--- a/src/kml/src/test/java/org/geoserver/kml/icons/IconTestSupport.java
+++ b/src/kml/src/test/java/org/geoserver/kml/icons/IconTestSupport.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.geometry.jts.JTSFactoryFinder;
 import org.geotools.styling.ExternalGraphic;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.Graphic;
@@ -25,6 +26,9 @@ import org.geotools.styling.StyleFactory2;
 import org.geotools.styling.Symbolizer;
 import org.geotools.styling.TextSymbolizer;
 import org.junit.BeforeClass;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
@@ -32,7 +36,6 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
 import org.opengis.style.Fill;
 import org.opengis.style.Font;
-import org.opengis.style.GraphicFill;
 
 public class IconTestSupport {
 
@@ -46,16 +49,20 @@ public class IconTestSupport {
     public static void classSetup() {
         styleFactory = (StyleFactory2) CommonFactoryFinder.getStyleFactory();
         filterFactory = (FilterFactory2) CommonFactoryFinder.getFilterFactory2();
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
         SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();
         typeBuilder.setName("example");
         typeBuilder.setNamespaceURI("http://example.com/");
         typeBuilder.setSRS("EPSG:4326");
         typeBuilder.add("field", String.class);
+        typeBuilder.add("geom", Point.class, "EPSG:4326");
         featureType = typeBuilder.buildFeatureType();
         SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureType);
         featureBuilder.set("field", "1");
+        featureBuilder.set("geom", geometryFactory.createPoint(new Coordinate(0, 0)));
         fieldIs1 = featureBuilder.buildFeature(null);
         featureBuilder.set("field", "2");
+        featureBuilder.set("geom", geometryFactory.createPoint(new Coordinate(0, 0)));
         fieldIs2 = featureBuilder.buildFeature(null);
     }
 
@@ -80,24 +87,26 @@ public class IconTestSupport {
     }
 
     protected final Fill fill(Color color, Double opacity) {
-      Expression colorExpr = color == null ? null : filterFactory.literal(color);
-      Expression opacityExpr = opacity == null ? null : filterFactory.literal(opacity);
-      return styleFactory.fill(null, colorExpr, opacityExpr);
+        Expression colorExpr = color == null ? null : filterFactory.literal(color);
+        Expression opacityExpr = opacity == null ? null : filterFactory.literal(opacity);
+        return styleFactory.fill(null, colorExpr, opacityExpr);
     }
-  
+
     protected final Font font(String fontFace, String style, String weight, Integer size) {
-      List<Expression> fontFaceList =
-          fontFace == null ? null : Collections.singletonList(filterFactory.literal(fontFace));
-      Expression styleExpr = style == null ? null : filterFactory.literal(style);
-      Expression weightExpr = weight == null ? null : filterFactory.literal(weight);
-      Expression sizeExpr = size == null ? null : filterFactory.literal(size);
-      return styleFactory.font(fontFaceList, styleExpr, weightExpr, sizeExpr);
+        List<Expression> fontFaceList =
+                fontFace == null
+                        ? null
+                        : Collections.singletonList(filterFactory.literal(fontFace));
+        Expression styleExpr = style == null ? null : filterFactory.literal(style);
+        Expression weightExpr = weight == null ? null : filterFactory.literal(weight);
+        Expression sizeExpr = size == null ? null : filterFactory.literal(size);
+        return styleFactory.font(fontFaceList, styleExpr, weightExpr, sizeExpr);
     }
-  
+
     protected final TextSymbolizer text(String name, String label, Font font, Fill fill) {
-      Expression geometry = filterFactory.property("");
-      return styleFactory.textSymbolizer(
-          name, geometry, null, null, filterFactory.property(label), font, null, null, fill);
+        Expression geometry = filterFactory.property("");
+        return styleFactory.textSymbolizer(
+                name, geometry, null, null, filterFactory.property(label), font, null, null, fill);
     }
 
     protected final PointSymbolizer mark(


### PR DESCRIPTION
See [GEOS-8885](https://osgeo-org.atlassian.net/browse/GEOS-8885) for details.

Will need to check for code that assumes expressions are provided:

* [x] PlacemarkNameDecoratorFactory: label used if available
* [x] PlacemarkStyleDecorator PolygonSymbolizer fill-color, fill-opacity
* [x] PlacemarkStyleDecorator LineSymbolizer: stroke-opacity, stroke-color, stroke-width
* [x] PlacemarkStyleDecorator TextSymbolizer:  fill-opacity, fill-color, font-size
* [x] IconPropertyExtractor: mostly has null checks in place