### PR TITLE
ImageMosaic GetCapabilities performance

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/DimensionHelper.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/DimensionHelper.java
@@ -264,7 +264,26 @@ abstract class DimensionHelper {
     private void handleElevationDimensionRaster(
             CoverageInfo cvInfo, DimensionInfo elevInfo, ReaderDimensionsAccessor dimensions)
             throws IOException {
-        TreeSet<Object> elevations = dimensions.getElevationDomain();
+        TreeSet<Object> elevations = null;
+        try {
+            if (elevInfo.getPresentation() != DimensionPresentation.LIST) {
+                Double minValue = dimensions.getMinElevation();
+                if (minValue != null) {
+                    elevations = new TreeSet<>();
+                    elevations.add(minValue);
+                    elevations.add(dimensions.getMaxElevation());
+                }
+            }
+            if (elevations == null) {
+                throw new Exception(
+                        "The \"List\" presentation of the elevation dimension has been selected");
+            }
+        } catch (Exception ex) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Dimension has not been extracted. The reason: ", ex);
+            }
+            elevations = dimensions.getElevationDomain();
+        }
         String elevationMetadata = getZDomainRepresentation(elevInfo, elevations);
         String defaultValue = getDefaultValueRepresentation(cvInfo, ResourceInfo.ELEVATION, "0");
         writeElevationDimension(
@@ -291,7 +310,26 @@ abstract class DimensionHelper {
     private void handleTimeDimensionRaster(
             CoverageInfo cvInfo, DimensionInfo timeInfo, ReaderDimensionsAccessor dimension)
             throws IOException {
-        TreeSet<Object> temporalDomain = dimension.getTimeDomain();
+        TreeSet<Object> temporalDomain = null;
+        try {
+            if (timeInfo.getPresentation() != DimensionPresentation.LIST) {
+                Date minValue = dimension.getMinTime();
+                if (minValue != null) {
+                    temporalDomain = new TreeSet<>();
+                    temporalDomain.add(minValue);
+                    temporalDomain.add(dimension.getMaxTime());
+                }
+            }
+            if (temporalDomain == null) {
+                throw new Exception(
+                        "The \"List\" presentation of the temporal dimension has been selected");
+            }
+        } catch (Exception ex) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Dimension has not been extracted. The reason: ", ex);
+            }
+            temporalDomain = dimension.getTimeDomain();
+        }
         String timeMetadata = getTemporalDomainRepresentation(timeInfo, temporalDomain);
         String defaultValue =
                 getDefaultValueRepresentation(


### PR DESCRIPTION
We are using GeoServer to display a large number of GeoTIFFs using ImageMosaic data stores. The data has several dimensions (time and custom). We are adding new data to these stores periodically and the goal is to be able to display years of data (millions of granules). We have encountered performance problems with the WMS GetCapabilities operation. It is most noticeable when using Oracle database (or PostGIS with parameter WrapStore=true). We implemented changes which improved the performance for our use case significantly. We would like to publish these changes and hopefully merge them into the official repo.

Details:
our performance problems are caused by the queries for values and defaults for dimensions. The currently used queries vary depending on the selected presentation for the dimension:

1. query for values:
  "List":
    * PostGIS (with WrapStore=false): `SELECT distinct("<dim_name>") FROM "<table_name>"`
    * Oracle: `SELECT FID, <DIM_NAME> FROM <table_name>`
    * PostGIS (with WrapStore=true): `SELECT "fid","<dim_name>" FROM "<table_name>"`
    First version is clearly the fastest, because it loads only distinct values.

"Interval and resolution":
  The queries are the same as for "List", but in this case we only really need the min/max values, which could be calculated much faster in the database.

2. query for defaults (when using smallest/biggest domain value):
  * PostGIS (with WrapStore=false): `SELECT <min | max> ("<dim_name>") FROM "<table_name>"`
  * Oracle: `SELECT FID, <DIM_NAME> FROM <table_name>`
  * PostGIS (with WrapStore=true): `SELECT "fid","<dim_name>" FROM "<table_name>"`
  Again the first PostGIS variant is clearly the fastest. Others load all the values to the application where the min/max values are calculated.

Our proposed solution creates optimized queries depending on which presentation and default setting is used for the dimension. The needed additional information from the settings is sent to the lower level functions using new RenderingHints. The goal of the optimized queries is to load only the needed values from the database (usually what the current PostGIS query does). Unit tests were also added.

We would like to get some feedback on this.