### PR TITLE
[GEOS-8799] NULL namespace prefixes used in AppSchema WFS GetFeature responses

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
@@ -602,5 +604,21 @@ public abstract class AbstractAppSchemaTestSupport extends GeoServerSystemTestSu
         NestedFilterToSQL nestedFilterToSQL = new NestedFilterToSQL(mapping, original);
         nestedFilterToSQL.setInline(true);
         return nestedFilterToSQL;
+    }
+
+    /**
+     * Returns xml String from Document Object
+     *
+     * @param document
+     * @return
+     * @throws TransformerException
+     */
+    protected String toString(Document document) throws TransformerException {
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        StringWriter writer = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(writer));
+        return writer.getBuffer().toString();
     }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NamespacesWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NamespacesWfsTest.java
@@ -15,7 +15,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.opengis.wfs20.StoredQueryDescriptionType;
+import org.apache.commons.io.IOUtils;
 import org.custommonkey.xmlunit.XpathEngine;
+import org.geoserver.catalog.impl.NamespaceInfoImpl;
+import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.StoredQuery;
 import org.geoserver.wfs.StoredQueryProvider;
 import org.geotools.wfs.v2_0.WFS;
@@ -103,6 +106,13 @@ public final class NamespacesWfsTest extends AbstractAppSchemaTestSupport {
                         "http://www.opengis.net/wfs/2.0",
                         "gml",
                         "http://www.opengis.net/gml/3.2");
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        // inject a test namespace to check on responses
+        addTestNamespaceToCatalog();
     }
 
     /** * GetFeature tests ** */
@@ -335,5 +345,81 @@ public final class NamespacesWfsTest extends AbstractAppSchemaTestSupport {
         } catch (Exception exception) {
             throw new RuntimeException("Error evaluating xpath.", exception);
         }
+    }
+
+    /**
+     * Test a request with two queries (to different featureTypes and namespaces) Checks null
+     * prefixes issue on multiple query WFS 2.0.0 GML 3.2 versions
+     */
+    @Test
+    public void testTwoQueriesNamespacesGml32() throws Exception {
+        String wfsQuery =
+                IOUtils.toString(
+                        getClass()
+                                .getClassLoader()
+                                .getResourceAsStream(
+                                        "test-data/stations/stations_two_queries.xml"));
+        Document document = postAsDOM("wfs", wfsQuery);
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                1,
+                "//wfs:FeatureCollection/wfs:member/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32");
+
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                1,
+                "/wfs:FeatureCollection/wfs:member/wfs:FeatureCollection/wfs:member/"
+                        + "ms_gml32:Measurement_gml32");
+        // check prefixes:
+        String output = toString(document);
+        assertTrue(output.indexOf("null:Measurement_gml32") < 0);
+        assertTrue(output.indexOf("null:Station_gml32") < 0);
+        assertTrue(output.indexOf("ms_gml32:Measurement_gml32") > -1);
+        assertTrue(output.indexOf("st_gml32:Station_gml32") > -1);
+        // check test1 namespace injected:
+        assertTrue(output.indexOf("xmlns:test1=\"http://www.test1.org/test1\"") >= 0);
+    }
+
+    /**
+     * Test a request with two queries (to different featureTypes and namespaces) Checks null
+     * prefixes issue on multiple query WFS 1.1.0 GML 3.1 version
+     */
+    @Test
+    public void testTwoQueriesNamespacesGml31() throws Exception {
+        String wfsQuery =
+                IOUtils.toString(
+                        getClass()
+                                .getClassLoader()
+                                .getResourceAsStream(
+                                        "test-data/stations/stations_two_queries_1.1.xml"));
+        Document document = postAsDOM("wfs", wfsQuery);
+        String output = toString(document);
+        checkCount(
+                WFS11_XPATH_ENGINE,
+                document,
+                1,
+                "//wfs:FeatureCollection/gml:featureMember/st_gml31:Station_gml31");
+
+        checkCount(
+                WFS11_XPATH_ENGINE,
+                document,
+                1,
+                "/wfs:FeatureCollection/gml:featureMember/" + "ms_gml31:Measurement_gml31");
+        // check prefixes:
+        assertTrue(output.indexOf("null:Measurement_gml31") < 0);
+        assertTrue(output.indexOf("null:Station_gml31") < 0);
+        assertTrue(output.indexOf("ms_gml31:Measurement_gml31") > -1);
+        assertTrue(output.indexOf("st_gml31:Station_gml31") > -1);
+        // check test1 namespace injected:
+        assertTrue(output.indexOf("xmlns:test1=\"http://www.test1.org/test1\"") >= 0);
+    }
+
+    private void addTestNamespaceToCatalog() {
+        NamespaceInfoImpl ns1 = new NamespaceInfoImpl();
+        ns1.setURI("http://www.test1.org/test1");
+        ns1.setPrefix("test1");
+        getCatalog().add(ns1);
     }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/stations_two_queries.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/stations_two_queries.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GetFeature version="2.0.0" service="WFS" handle="Filter on element test with PropertyIsNull deegree"
+    xmlns="http://www.opengis.net/wfs/2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:wfs="http://www.opengis.net/wfs/2.0"
+    xmlns:ms_gml32="http://www.measurements_gml32.org/1.0"
+    xmlns:st_gml32="http://www.stations_gml32.org/1.0"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd">
+    <Query typeNames="ms_gml32:Measurement_gml32">
+         <Filter xmlns="http://www.opengis.net/fes/2.0">
+              <PropertyIsEqualTo>
+                <ValueReference>Measurement_gml32/@gml:id</ValueReference>
+                <Literal>ms.1</Literal>
+              </PropertyIsEqualTo>
+          </Filter>
+    </Query>
+    <Query typeNames="st_gml32:Station_gml32">
+         <Filter xmlns="http://www.opengis.net/fes/2.0">
+              <PropertyIsEqualTo>
+                <ValueReference>Station_gml32/@gml:id</ValueReference>
+                <Literal>st.1</Literal>
+              </PropertyIsEqualTo>
+          </Filter>
+    </Query>
+ </GetFeature>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/stations_two_queries_1.1.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/stations_two_queries_1.1.xml
@@ -1,0 +1,24 @@
+<wfs:GetFeature service="WFS" version="1.1.0"
+                xmlns:wfs="http://www.opengis.net/wfs"
+                xmlns:ogc="http://www.opengis.net/ogc"
+                xmlns:ms_gml31="http://www.measurements_gml31.org/1.0"
+    			xmlns:st_gml31="http://www.stations_gml31.org/1.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+      <wfs:Query typeName="ms_gml31:Measurement_gml31">
+      	<ogc:Filter>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>Measurement_gml31/@gml:id</ogc:PropertyName>
+                <ogc:Literal>ms.1</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+          </ogc:Filter>  
+      </wfs:Query>
+      <wfs:Query typeName="st_gml31:Station_gml31">
+        <ogc:Filter>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>Station_gml31/@gml:id</ogc:PropertyName>
+                <ogc:Literal>st.1</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+          </ogc:Filter>  
+      </wfs:Query>
+    </wfs:GetFeature>

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/FeatureTypeSchemaBuilder.java
@@ -192,36 +192,11 @@ public abstract class FeatureTypeSchemaBuilder {
             schema.setTargetNamespace(targetNamespace);
             schema.getQNamePrefixToNamespaceMap().put(targetPrefix, targetNamespace);
 
-            boolean simple = true;
-            for (int i = 0; i < featureTypeInfos.length && simple; i++) {
-                try {
-                    simple = featureTypeInfos[i].getFeatureType() instanceof SimpleFeatureType;
-                } catch (IOException e) {
-                    // ignore so that broken feature types don't prevent others from continuing to
-                    // work
-                }
-            }
+            boolean simple = isSimpleFeature(featureTypeInfos);
 
             if (!simple) {
                 // complex features may belong to different workspaces
-                WorkspaceInfo localWorkspace = LocalWorkspace.get();
-                if (localWorkspace != null) {
-                    // deactivate workspace filtering
-                    LocalWorkspace.remove();
-                }
-                // add secondary namespaces from the full catalog
-                try {
-                    for (NamespaceInfo nameSpaceinfo : catalog.getNamespaces()) {
-                        if (!schema.getQNamePrefixToNamespaceMap()
-                                .containsKey(nameSpaceinfo.getPrefix())) {
-                            schema.getQNamePrefixToNamespaceMap()
-                                    .put(nameSpaceinfo.getPrefix(), nameSpaceinfo.getURI());
-                        }
-                    }
-                } finally {
-                    // make sure local workspace filtering is repositioned
-                    LocalWorkspace.set(localWorkspace);
-                }
+                addAllNamespacesFromCatalog(schema);
             }
 
             // would result in some xsd:include or xsd:import if schema location is specified
@@ -280,6 +255,11 @@ public abstract class FeatureTypeSchemaBuilder {
                 }
             }
         } else {
+            // if complex features, add all namespaces
+            if (!isSimpleFeature(featureTypeInfos)) {
+                addAllNamespacesFromCatalog(schema);
+            }
+
             // different namespaces, write out import statements
 
             // set the first namespace as the target one
@@ -382,6 +362,39 @@ public abstract class FeatureTypeSchemaBuilder {
             }
         }
         return schema;
+    }
+
+    private void addAllNamespacesFromCatalog(XSDSchema schema) {
+        WorkspaceInfo localWorkspace = LocalWorkspace.get();
+        if (localWorkspace != null) {
+            // deactivate workspace filtering
+            LocalWorkspace.remove();
+        }
+        // add secondary namespaces from the full catalog
+        try {
+            for (NamespaceInfo nameSpaceinfo : catalog.getNamespaces()) {
+                if (!schema.getQNamePrefixToNamespaceMap().containsKey(nameSpaceinfo.getPrefix())) {
+                    schema.getQNamePrefixToNamespaceMap()
+                            .put(nameSpaceinfo.getPrefix(), nameSpaceinfo.getURI());
+                }
+            }
+        } finally {
+            // make sure local workspace filtering is repositioned
+            LocalWorkspace.set(localWorkspace);
+        }
+    }
+
+    private boolean isSimpleFeature(FeatureTypeInfo[] featureTypeInfos) {
+        boolean simple = true;
+        for (int i = 0; i < featureTypeInfos.length && simple; i++) {
+            try {
+                simple = featureTypeInfos[i].getFeatureType() instanceof SimpleFeatureType;
+            } catch (IOException e) {
+                // ignore so that broken feature types don't prevent others from continuing to
+                // work
+            }
+        }
+        return simple;
     }
 
     protected void importGMLSchema(XSDSchema schema, XSDFactory factory, String baseUrl) {


### PR DESCRIPTION
Fix and tests for [GEOS-8799] "WFS GetFeature response contains NULL namespaces for App-Schema complex features when multiple queries are used".

https://osgeo-org.atlassian.net/browse/GEOS-8799
