### PR TITLE
[GEOS-7653] tiled layers preview does not use Proxy Base URL

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayersPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayersPage.java
@@ -294,16 +294,18 @@ public class CachedLayersPage extends GeoServerSecuredPage {
         menu.add(previewLinks);
 
         // build the wms request, redirect to it in a new window, reset the selection
-        String demoUrl =
+        final String baseURL = ResponseUtils.baseURL(getGeoServerApplication().servletRequest());
+        // Since we're working with an absolute URL, build the URL this way to ensure proxy
+        // mangling is applied.
+        final String demoURL =
                 "'"
-                        + ResponseUtils.baseURL(getGeoServerApplication().servletRequest())
-                        + "gwc/demo/"
-                        + layer.getName()
+                        + ResponseUtils.buildURL(
+                                baseURL, "gwc/demo/" + layer.getName(), null, URLType.EXTERNAL)
                         + "?' + this.options[this.selectedIndex].value";
         menu.add(
                 new AttributeAppender(
                         "onchange",
-                        new Model<String>("window.open(" + demoUrl + ");this.selectedIndex=0"),
+                        new Model<String>("window.open(" + demoURL + ");this.selectedIndex=0"),
                         ";"));
 
         f.add(menu);

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 import java.util.List;
-
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
@@ -30,21 +29,22 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class CachedLayersPageTest extends GeoServerWicketTestSupport {
-    private final static Method getReplaceModelMethod;
+    private static final Method getReplaceModelMethod;
     /*
      * Yes, we do need to use reflection here as the stupid wicket model is private and has no setter which
      * makes it hard to test!
-     * See https://cwiki.apache.org/confluence/display/WICKET/Testing+Pages 
+     * See https://cwiki.apache.org/confluence/display/WICKET/Testing+Pages
      */
     static {
-      try {
-        getReplaceModelMethod = AttributeModifier.class.getDeclaredMethod("getReplaceModel");
-        getReplaceModelMethod.setAccessible(true);
-      } catch (Exception e) {
-        e.printStackTrace();
-        throw new RuntimeException(e);
-      }
+        try {
+            getReplaceModelMethod = AttributeModifier.class.getDeclaredMethod("getReplaceModel");
+            getReplaceModelMethod.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
+
     @Rule
     public GeoServerExtensionsHelper.ExtensionsHelperRule extensions =
             new GeoServerExtensionsHelper.ExtensionsHelperRule();
@@ -111,7 +111,7 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
                 "table:listContainer:items:1:itemProperties:7:component:seedLink",
                 "http://localhost:80/context/gwc/rest/seed/cgf:Polygons");
     }
-   
+
     @Test
     public void testMangleSeedLink() {
         // Mimic a Proxy URL mangler
@@ -129,7 +129,7 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
                 "table:listContainer:items:1:itemProperties:7:component:seedLink",
                 "http://rewrite/gwc/rest/seed/cgf:Polygons");
     }
-    
+
     @Test
     public void testNoManglePreviewLink() {
 
@@ -138,16 +138,22 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
         CachedLayersPage page = new CachedLayersPage();
 
         tester.startPage(page);
-        //print(page, true, true);
-        Component component = tester.getComponentFromLastRenderedPage( "table:listContainer:items:1:itemProperties:6:component:menu");
+        // print(page, true, true);
+        Component component =
+                tester.getComponentFromLastRenderedPage(
+                        "table:listContainer:items:1:itemProperties:6:component:menu");
         List<AttributeModifier> attr = component.getBehaviors(AttributeModifier.class);
         try {
             IModel<?> model = (IModel<?>) getReplaceModelMethod.invoke(attr.get(0));
-            assertTrue("Unmangled names fail", model.getObject().toString().contains("http://localhost:80/context/gwc/demo/cgf"));
+            assertTrue(
+                    "Unmangled names fail",
+                    model.getObject()
+                            .toString()
+                            .contains("http://localhost:80/context/gwc/demo/cgf"));
             return;
-          } catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
-          }
+        }
     }
 
     @Test
@@ -163,14 +169,19 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
         CachedLayersPage page = new CachedLayersPage();
 
         tester.startPage(page);
-        Component component = tester.getComponentFromLastRenderedPage( "table:listContainer:items:1:itemProperties:6:component:menu");
+        Component component =
+                tester.getComponentFromLastRenderedPage(
+                        "table:listContainer:items:1:itemProperties:6:component:menu");
         List<AttributeModifier> attr = component.getBehaviors(AttributeModifier.class);
         try {
             IModel<?> model = (IModel<?>) getReplaceModelMethod.invoke(attr.get(0));
-            assertTrue("Mangled names fail", model.getObject().toString().contains("http://rewrite/context/gwc/demo/cgf"));
+
+            assertTrue(
+                    "Mangled names fail",
+                    model.getObject().toString().contains("http://rewrite/gwc/demo/cgf"));
             return;
-          } catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
-          }
+        }
     }
 }

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
@@ -7,6 +7,12 @@ package org.geoserver.gwc.web.layer;
 
 import static org.junit.Assert.*;
 
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
+import org.apache.wicket.model.IModel;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -24,7 +30,21 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class CachedLayersPageTest extends GeoServerWicketTestSupport {
-
+    private final static Method getReplaceModelMethod;
+    /*
+     * Yes, we do need to use reflection here as the stupid wicket model is private and has no setter which
+     * makes it hard to test!
+     * See https://cwiki.apache.org/confluence/display/WICKET/Testing+Pages 
+     */
+    static {
+      try {
+        getReplaceModelMethod = AttributeModifier.class.getDeclaredMethod("getReplaceModel");
+        getReplaceModelMethod.setAccessible(true);
+      } catch (Exception e) {
+        e.printStackTrace();
+        throw new RuntimeException(e);
+      }
+    }
     @Rule
     public GeoServerExtensionsHelper.ExtensionsHelperRule extensions =
             new GeoServerExtensionsHelper.ExtensionsHelperRule();
@@ -91,7 +111,7 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
                 "table:listContainer:items:1:itemProperties:7:component:seedLink",
                 "http://localhost:80/context/gwc/rest/seed/cgf:Polygons");
     }
-
+   
     @Test
     public void testMangleSeedLink() {
         // Mimic a Proxy URL mangler
@@ -108,5 +128,49 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
         tester.assertModelValue(
                 "table:listContainer:items:1:itemProperties:7:component:seedLink",
                 "http://rewrite/gwc/rest/seed/cgf:Polygons");
+    }
+    
+    @Test
+    public void testNoManglePreviewLink() {
+
+        // Don't add a mangler
+
+        CachedLayersPage page = new CachedLayersPage();
+
+        tester.startPage(page);
+        //print(page, true, true);
+        Component component = tester.getComponentFromLastRenderedPage( "table:listContainer:items:1:itemProperties:6:component:menu");
+        List<AttributeModifier> attr = component.getBehaviors(AttributeModifier.class);
+        try {
+            IModel<?> model = (IModel<?>) getReplaceModelMethod.invoke(attr.get(0));
+            assertTrue("Unmangled names fail", model.getObject().toString().contains("http://localhost:80/context/gwc/demo/cgf"));
+            return;
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+    }
+
+    @Test
+    public void testManglePreviewLink() {
+        // Mimic a Proxy URL mangler
+        URLMangler testMangler =
+                (base, path, map, type) -> {
+                    base.setLength(0);
+                    base.append("http://rewrite/");
+                };
+        extensions.singleton("testMangler", testMangler, URLMangler.class);
+
+        CachedLayersPage page = new CachedLayersPage();
+
+        tester.startPage(page);
+        Component component = tester.getComponentFromLastRenderedPage( "table:listContainer:items:1:itemProperties:6:component:menu");
+        List<AttributeModifier> attr = component.getBehaviors(AttributeModifier.class);
+        try {
+            IModel<?> model = (IModel<?>) getReplaceModelMethod.invoke(attr.get(0));
+            assertTrue("Mangled names fail", model.getObject().toString().contains("http://rewrite/context/gwc/demo/cgf"));
+            return;
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
     }
 }


### PR DESCRIPTION
Added buildURL call when building the link to the tiled layers preview.
Made during the foss4g2018 code sprint with [mirandadam](https://github.com/mirandadam) 