### PR TITLE
Remove spring-asm dependency from jms-cluster

### DIFF
--- a/src/community/jms-cluster/activemqBroker/pom.xml
+++ b/src/community/jms-cluster/activemqBroker/pom.xml
@@ -145,11 +145,6 @@
 				<artifactId>spring-web</artifactId>
 				<version>${spring.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-asm</artifactId>
-				<version>${spring.version}</version>
-			</dependency>
 			<!-- added to solve: problem with class file or dependent class; nested 
 				exception is java.lang.NoClassDefFoundError: org/springframework/context/SmartLifecycle -->
 			<dependency>
@@ -224,10 +219,6 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-asm</artifactId>
 		</dependency>
 		<!-- added to solve: problem with class file or dependent class; nested 
 			exception is java.lang.NoClassDefFoundError: org/springframework/context/SmartLifecycle -->


### PR DESCRIPTION
spring-asm was merged into spring-core with the release of Spring 3.2.0, and should no longer be included as a dependency.