### PR TITLE
Fix doc about changing jetty port

### DIFF
--- a/src/release/RUNNING.txt
+++ b/src/release/RUNNING.txt
@@ -115,10 +115,11 @@ distribution of GeoServer:
     is the default HTTP port that GeoServer attempts to bind to at startup.
     To change this port, open the file:
 
-       $GEOSERVER_HOME/etc/jetty.xml
-    
-    and search for '8080'.  Change it to a port that isn't in use, but is
-    greater than 1024 (such as 8090).  Save this file and restart GeoServer.
+       $GEOSERVER_HOME/start.ini
+
+    and search for 'jetty.port' or '8080'.  Change it to a port that isn't
+    in use, but is greater than 1024 (such as 8090).  Save this file and
+    restart GeoServer.
     Make sure, of course, that you try to access GeoServer on the new port:
 
        http://localhost:####


### PR DESCRIPTION
Seems that the text in RUNNING.txt was written for older
versions of jetty.

In current version you need to change the portnummer in start.ini
if I'm correct... Well I happened to need to do it, can THIS worked,
the 8080 is not available anymore in any file in etc folder