### PR TITLE
Fix for GEOS-8786 aka render exception

### DIFF
--- a/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.java
+++ b/src/web/security/ldap/src/main/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanel.java
@@ -26,6 +26,7 @@ import org.geoserver.security.ldap.LDAPSecurityProvider;
 import org.geoserver.security.ldap.LDAPSecurityServiceConfig;
 import org.geoserver.security.web.auth.AuthenticationProviderPanel;
 import org.geoserver.security.web.usergroup.UserGroupServiceChoice;
+import org.geoserver.web.GeoServerBasePage;
 import org.geoserver.web.util.MapModel;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -194,7 +195,7 @@ public class LDAPAuthProviderPanel extends AuthenticationProviderPanel<LDAPSecur
                                     (LDAPSecurityServiceConfig) getForm().getModelObject();
                             doTest(ldapConfig, username, password);
 
-                            target.add(getPage().get("feedback"));
+                            ((GeoServerBasePage) this.getPage()).addFeedbackPanels(target);
                         }
 
                         void doTest(


### PR DESCRIPTION
See GEOS-8786: a Wicket exception was throws because since the
there is a bottom AND top feedback bar, the pointer to the 'feedback'
returns null.
Use addFeedbackPanels from GeoServerBasePage to direct the msgs
to the feedback components

This is followup for: https://github.com/geoserver/geoserver/pull/3034 
which can be closed then.