### PR TITLE
[GEOS-7636] GetLegendGraphic online resource is ignored on rasters

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetLegendGraphicRequest.java
@@ -134,6 +134,21 @@ public class GetLegendGraphicRequest extends WMSRequest {
             this.layerName = featureType.getName();
         }
 
+        /**
+         * LegendRequest for a feature type, additional details (title and legend graphic) provided
+         * by MapLayerInfo.
+         *
+         * @param featureType
+         * @param layerName layerName distinct to featureType name
+         */
+        public LegendRequest(FeatureType featureType, Name layerName) {
+            if (featureType == null) {
+                throw new NullPointerException("FeatureType required for LegendRequest");
+            }
+            this.featureType = featureType;
+            this.layerName = layerName;
+        }
+
         public String getLayer() {
             return layer;
         }

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
@@ -270,7 +270,12 @@ public class BufferedImageLegendGraphicBuilder {
                 legendImage = getLayerLegend(legend, w, h, transparent, request);
             }
 
-            if (buildRasterLegend) {
+            if (useProvidedLegend && legendImage != null) {
+                if (titleImage != null) {
+                    layersImages.add(titleImage);
+                }
+                layersImages.add(legendImage);
+            } else if (buildRasterLegend) {
                 final RasterLayerLegendHelper rasterLegendHelper =
                         new RasterLayerLegendHelper(request, gt2Style, ruleName);
                 final BufferedImage image = rasterLegendHelper.getLegend();
@@ -280,11 +285,6 @@ public class BufferedImageLegendGraphicBuilder {
                     }
                     layersImages.add(image);
                 }
-            } else if (useProvidedLegend && legendImage != null) {
-                if (titleImage != null) {
-                    layersImages.add(titleImage);
-                }
-                layersImages.add(legendImage);
             } else {
                 final Feature sampleFeature;
                 if (layer == null || hasVectorTransformation) {

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
@@ -248,7 +248,9 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
             throws FactoryRegistryException, IOException, TransformException, SchemaException {
         FeatureType featureType = getLayerFeatureType(layerInfo);
         if (featureType != null) {
-            LegendRequest legend = request.new LegendRequest(featureType);
+            LegendRequest legend =
+                    request
+                    .new LegendRequest(featureType, layerInfo.getResource().getQualifiedName());
             legend.setLayerInfo(layerInfo);
 
             MapLayerInfo mli = new MapLayerInfo(layerInfo);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -60,7 +60,8 @@ public class GetLegendGraphicTest extends WMSTestSupport {
         File file = getResourceLoader().createFile("styles", "legend.png");
         getResourceLoader().copyFromClassPath("../legend.png", file, getClass());
         testData.addStyle(null, "custom", "point_test.sld", getClass(), catalog, legend);
-
+        // add a raster_legend style with legend to test on raster
+        testData.addStyle(null, "raster_legend", "raster.sld", getClass(), catalog, legend);
         // setup a ws specific style with custom legend too
         WorkspaceInfo defaultWorkspace = catalog.getDefaultWorkspace();
         File wsFile =
@@ -362,5 +363,23 @@ public class GetLegendGraphicTest extends WMSTestSupport {
                         + "&format=image/png&width=20&height=20";
         BufferedImage image = getAsImage(base, "image/png");
         assertEquals(80, image.getHeight());
+    }
+
+    /**
+     * Test for GEOS-7636 GetLegendGraphic ignores the OnlineResource configured in the style for
+     * raster layers
+     */
+    @Test
+    public void testLegendOnRaster() throws Exception {
+        String base =
+                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                        + "&layer=wcs:World&style=raster_legend"
+                        + "&format=image/png&width=22&height=22";
+
+        BufferedImage image = getAsImage(base, "image/png");
+        Resource resource = getResourceLoader().get("styles/legend.png");
+        BufferedImage expected = ImageIO.read(resource.file());
+
+        assertEquals(getPixelColor(expected, 10, 2).getRGB(), getPixelColor(image, 10, 2).getRGB());
     }
 }


### PR DESCRIPTION
Fix and test for GEOS-7636 "GetLegendGraphic ignores the OnlineResource configured in the style for raster layers"

This PR modify some nested conditional logic that prevented to show the correct OnlineResource and always returned the standard blue square.  Now GetLegendGraphic shows the proper image.

https://osgeo-org.atlassian.net/browse/GEOS-7636