### PR TITLE
[GEOS-8933] Requesting workspaces triggers an NPE when proxy headers

### DIFF
--- a/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
@@ -123,6 +123,11 @@ public class ProxifyingURLMangler implements URLMangler {
      */
     private StringBuilder mangleURLHeaders(StringBuilder baseURL, String proxyBase) {
 
+        // If the request is not an OWS request, does not proxy the URL
+        if (Dispatcher.REQUEST.get() == null) {
+            return baseURL;
+        }
+
         // If the proxy base URL does not contain templates, fall back to
         // the fixed URL cse
         if (!proxyBase.contains(TEMPLATE_PREFIX)) {

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/AdminRequestTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/AdminRequestTest.java
@@ -114,7 +114,7 @@ public class AdminRequestTest extends CatalogRESTTestSupport {
         assertEquals(1, dom.getElementsByTagName("workspace").getLength());
     }
 
-    @Test 
+    @Test
     public void testWorkspacesWithProxyHeaders() throws Exception {
         GeoServerInfo ginfo = getGeoServer().getGlobal();
         SettingsInfo settings = getGeoServer().getGlobal().getSettings();

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/AdminRequestTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/AdminRequestTest.java
@@ -114,7 +114,7 @@ public class AdminRequestTest extends CatalogRESTTestSupport {
         assertEquals(1, dom.getElementsByTagName("workspace").getLength());
     }
 
-    @Test
+    @Test 
     public void testWorkspacesWithProxyHeaders() throws Exception {
         GeoServerInfo ginfo = getGeoServer().getGlobal();
         SettingsInfo settings = getGeoServer().getGlobal().getSettings();


### PR DESCRIPTION
            are used for the proxy URL

- Added a guard to avoid proxying an URL when it does not come from the
  OWS Dispatcher.