### PR TITLE
[GEOS-8936] Allow Additional Styles select boxes to scroll

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -93,6 +93,39 @@ input[readonly] {
   padding: 0;
 }
 
+
+.palette-header {
+  margin-right: -2px;
+}
+
+.palette-theme-default .palette-choices > div {
+  width: 100%;
+  overflow-x: scroll;
+  border: 1px solid rgb(187, 187, 187);
+  margin: 0.5em 0;
+}
+
+.palette-theme-default .palette-selected > div {
+  width: 100%;
+  overflow-x: scroll;
+  border: 1px solid rgb(187, 187, 187);
+  margin: 0.5em 0;
+}
+
+.palette-theme-default .palette-choices select {
+  min-width: 100%;
+  width: auto;
+  margin: 0;
+  border: none;
+}
+
+.palette-theme-default .palette-selected select {
+  min-width: 100%;
+  width: auto;
+  margin: 0;
+  border: none;
+}
+
 /*-----------------------
 Utility Classes
 -----------------------*/

--- a/src/web/core/src/main/resources/org/apache/wicket/extensions/markup/html/form/palette/Palette.html
+++ b/src/web/core/src/main/resources/org/apache/wicket/extensions/markup/html/form/palette/Palette.html
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+<wicket:panel>
+
+<input type="hidden" wicket:id="recorder"/>
+
+<div class="palette-choices">
+	<span wicket:id="availableHeader" class="palette-header">[available header]</span>
+	<div><select wicket:id="choices">[choices]</select></div>
+</div>
+
+<div class="palette-buttons">
+	<div>
+		<button type="button" wicket:id="addButton" class="palette-add"><div></div></button>
+		<button type="button" wicket:id="removeButton" class="palette-remove"><div></div></button>
+		<button type="button" wicket:id="moveUpButton" class="palette-up"><div></div></button>
+		<button type="button" wicket:id="moveDownButton" class="palette-down"><div></div></button>
+		<button type="button" wicket:id="addAllButton" class="palette-addAll"><div></div></button>
+		<button type="button" wicket:id="removeAllButton" class="palette-removeAll"><div></div></button>
+	</div>
+</div>
+
+<div class="palette-selected">
+	<span wicket:id="selectedHeader" class="palette-header">[selected header]</span>
+	<div><select wicket:id="selection">[selection]</select></div>
+</div>
+
+<div class="palette-clearer">
+</div>
+
+</wicket:panel>
+</body>
+</html>


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8936

This fix modifies the Palette.html template used by wicket, wrapping the each of the `<select>` elements in a div so that a horizontal scroll can be added (the select element does *not* support horizontal scroll on its own). Note: Wicket, and by extension the original Palette.html, is licensed under Apache 2.0, which is compatible with GPL and permits modified files to be relicensed.

Limitations:

* If you have a wide style name such that horizontal scrolling is required, the vertical scroll bar for the select will start off outside the visible region of the `<select>`. This is a limitation of how the select element works.

* If you have an especially large style name, the default style select box higher up on the page will overflow the screen. This is unrelated to this change, but was discovered during testing (this can be seen in the example below).

Example of horizontal scroll in action (On OS X, so the actual scrollbar is hidden by the OS):

![styles_scroll_1](https://user-images.githubusercontent.com/9271497/45704577-23e58680-bb2c-11e8-929e-28e1f9a86736.png)

I've tested these changes on both Windows and OS X, and on Chrome, Firefox, Safari, Edge, and Internet Explorer to confirm they work on all modern browsers. Older browser versions were not tested.

No test case since the wicket tester doesn't support testing the actual size/rendering of web elements.

