### PR TITLE
[GEOS-8929] Alias old com.vividsolutions.jts.geom.* to new org.locationtech.jts.geom.* in XStream reader

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/OneWayPackageAliasingMapper.java
+++ b/src/main/src/main/java/org/geoserver/config/util/OneWayPackageAliasingMapper.java
@@ -1,0 +1,27 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config.util;
+
+import com.thoughtworks.xstream.mapper.Mapper;
+import com.thoughtworks.xstream.mapper.PackageAliasingMapper;
+
+/**
+ * Variant of {@link PackageAliasingMapper} that only applies aliases when reading a serialized
+ * representation. When writing to a serialized representation it delegates to the wrapped {@link
+ * Mapper}
+ */
+public class OneWayPackageAliasingMapper extends PackageAliasingMapper {
+    private final Mapper wrapped;
+
+    public OneWayPackageAliasingMapper(Mapper wrapped) {
+        super(wrapped);
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public String serializedClass(final Class type) {
+        return wrapped.serializedClass(type);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -1038,6 +1038,36 @@ public class XStreamPersisterTest {
         assertNotNull(vt2.getNativeSrid(geometryName));
     }
 
+    /* Test for GEOS-8929 */
+    @Test
+    public void testOldJTSBindingConversion() throws Exception {
+        Catalog catalog = new CatalogImpl();
+        CatalogFactory cFactory = catalog.getFactory();
+
+        WorkspaceInfo ws = cFactory.createWorkspace();
+        ws.setName("foo");
+        catalog.add(ws);
+
+        NamespaceInfo ns = cFactory.createNamespace();
+        ns.setPrefix("acme");
+        ns.setURI("http://acme.org");
+        catalog.add(ns);
+
+        DataStoreInfo ds = cFactory.createDataStore();
+        ds.setWorkspace(ws);
+        ds.setName("foo");
+        catalog.add(ds);
+
+        persister.setCatalog(catalog);
+        FeatureTypeInfo ft =
+                persister.load(
+                        getClass().getResourceAsStream("/org/geoserver/config/old_jts_binding.xml"),
+                        FeatureTypeInfo.class);
+        assertNotNull(ft);
+        assertEquals(
+                org.locationtech.jts.geom.LineString.class, ft.getAttributes().get(0).getBinding());
+    }
+
     @Test
     public void testCRSConverter() throws Exception {
         CoordinateReferenceSystem crs = CRS.decode("EPSG:4326");

--- a/src/main/src/test/resources/org/geoserver/config/old_jts_binding.xml
+++ b/src/main/src/test/resources/org/geoserver/config/old_jts_binding.xml
@@ -1,0 +1,86 @@
+<featureType>
+    <id>FeatureTypeInfoImpl--570ae188:124761b8d78:-7fc5</id>
+    <name>roads</name>
+    <nativeName>roads</nativeName>
+    <namespace>
+        <id>NamespaceInfoImpl--570ae188:124761b8d78:-8000</id>
+    </namespace>
+    <title>Spearfish roads</title>
+    <abstract>Sample data from GRASS, road layout, Spearfish, South Dakota, USA</abstract>
+    <keywords>
+        <string>sfRoads</string>
+        <string>spearfish</string>
+        <string>roads</string>
+    </keywords>
+    <nativeCRS class="projected">PROJCS[&quot;NAD27 / UTM zone 13N&quot;,
+        GEOGCS[&quot;NAD27&quot;,
+        DATUM[&quot;North American Datum 1927&quot;,
+        SPHEROID[&quot;Clarke 1866&quot;, 6378206.4, 294.9786982138982, AUTHORITY[&quot;EPSG&quot;,&quot;7008&quot;]],
+        TOWGS84[-4.2, 135.4, 181.9, 0.0, 0.0, 0.0, 0.0],
+        AUTHORITY[&quot;EPSG&quot;,&quot;6267&quot;]],
+        PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],
+        UNIT[&quot;degree&quot;, 0.017453292519943295],
+        AXIS[&quot;Geodetic longitude&quot;, EAST],
+        AXIS[&quot;Geodetic latitude&quot;, NORTH],
+        AUTHORITY[&quot;EPSG&quot;,&quot;4267&quot;]],
+        PROJECTION[&quot;Transverse_Mercator&quot;],
+        PARAMETER[&quot;central_meridian&quot;, -105.0],
+        PARAMETER[&quot;latitude_of_origin&quot;, 0.0],
+        PARAMETER[&quot;scale_factor&quot;, 0.9996],
+        PARAMETER[&quot;false_easting&quot;, 500000.0],
+        PARAMETER[&quot;false_northing&quot;, 0.0],
+        UNIT[&quot;m&quot;, 1.0],
+        AXIS[&quot;Easting&quot;, EAST],
+        AXIS[&quot;Northing&quot;, NORTH],
+        AUTHORITY[&quot;EPSG&quot;,&quot;26713&quot;]]</nativeCRS>
+    <srs>EPSG:26713</srs>
+    <nativeBoundingBox>
+        <minx>589434.8564686741</minx>
+        <maxx>609527.2102150217</maxx>
+        <miny>4914006.337837095</miny>
+        <maxy>4928063.398014731</maxy>
+        <crs class="projected">EPSG:26713</crs>
+    </nativeBoundingBox>
+    <latLonBoundingBox>
+        <minx>-103.87741691493184</minx>
+        <maxx>-103.62231404880659</maxx>
+        <miny>44.37087275281798</miny>
+        <maxy>44.50015918338962</maxy>
+        <crs>EPSG:4326</crs>
+    </latLonBoundingBox>
+    <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+    <enabled>true</enabled>
+    <metadata>
+        <entry key="cacheAgeMax">3600</entry>
+        <entry key="kml.regionateFeatureLimit">10</entry>
+        <entry key="indexingEnabled">false</entry>
+        <entry key="cachingEnabled">true</entry>
+        <entry key="dirName">sfRoads_roads</entry>
+    </metadata>
+    <store class="dataStore">
+        <id>DataStoreInfoImpl--570ae188:124761b8d78:-7fdb</id>
+    </store>
+    <attributes>
+        <attribute>
+            <name>the_geom</name>
+            <minOccurs>0</minOccurs>
+            <maxOccurs>1</maxOccurs>
+            <nillable>false</nillable>
+            <binding>com.vividsolutions.jts.geom.LineString</binding>
+        </attribute>
+        <attribute>
+            <name>cat</name>
+            <minOccurs>0</minOccurs>
+            <maxOccurs>1</maxOccurs>
+            <nillable>false</nillable>
+        </attribute>
+        <attribute>
+            <name>label</name>
+            <minOccurs>0</minOccurs>
+            <maxOccurs>1</maxOccurs>
+            <nillable>false</nillable>
+        </attribute>
+    </attributes>
+    <maxFeatures>0</maxFeatures>
+    <numDecimals>0</numDecimals>
+</featureType>


### PR DESCRIPTION
For https://osgeo-org.atlassian.net/browse/GEOS-8929

This change only affects reading; writing output is unchanged.
It is possible to alter this so that writing is likewise aliased in order to address [GEOS-8886](https://osgeo-org.atlassian.net/browse/GEOS-8886); see discussion in that ticket.