### PR TITLE
[GEOS-8886] Add migration guide for REST API Change due to JTS Upgrade

### DIFF
--- a/doc/en/user/source/installation/upgrade.rst
+++ b/doc/en/user/source/installation/upgrade.rst
@@ -24,3 +24,35 @@ GeoJSON encoding (GeoServer 2.6 and newer)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As of GeoServer 2.6, the GeoJSON produced by the WFS service no longer uses a non-standard encoding for the CRS. To reenable this behavior for compatibility purposes, set ``GEOSERVER_GEOJSON_LEGACY_CRS=true`` as a system property, context parameter, or environment variable.
+
+JTS Type Bindings (GeoServer 2.14 and newer)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As of GeoServer 2.14, the output produced by :ref:`REST <rest>` featuretype and structured coverage requests using a different package name (``org.locationtech`` instead of ``com.vividsolutions``) for geometry type bindings, due to the upgrade to JTS (Java Topology Suite) 1.16.0. For example:
+
+Before::
+
+    ...
+    <attribute>
+      <name>geom</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>com.vividsolutions.jts.geom.Point</binding>
+    </attribute>
+    ...
+
+After::
+
+    ...
+    <attribute>
+      <name>geom</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>org.locationtech.jts.geom.Point</binding>
+    </attribute>
+    ...
+
+
+Any REST clients which rely on this binding information should be updated to support the new names.


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-8886

See also: https://github.com/geoserver/geoserver/pull/3102 (Which has the actual REST api documentation changes associated with this issue)