### PR TITLE
Set WellKnownName as optional

### DIFF
--- a/doc/en/user/source/styling/sld/reference/pointsymbolizer.rst
+++ b/doc/en/user/source/styling/sld/reference/pointsymbolizer.rst
@@ -126,7 +126,7 @@ The ``<Mark>`` element has the sub-elements:
      - **Required?**
      - **Description**
    * - ``<WellKnownName>``
-     - Yes
+     - No
      - The name of the shape.  
        Standard SLD shapes are ``circle``, ``square``, ``triangle``, ``star``, ``cross``, or ``x``.  Default is ``square``.
    * - ``<Fill>``

--- a/doc/fr/user/source/styling/sld-reference/pointsymbolizer.rst
+++ b/doc/fr/user/source/styling/sld-reference/pointsymbolizer.rst
@@ -56,7 +56,7 @@ Within the ``<Mark>`` tag, there are also additional tags:
      - **Required?**
      - **Description**
    * - ``<WellKnownName>``
-     - Yes
+     - No
      - The name of the common shape.  Options are ``circle``, ``square``, ``triangle``, ``star``, ``cross``, or ``x``.  Default is ``square``.
    * - ``<Fill>``
      - No (when using ``<Stroke>``)


### PR DESCRIPTION
According to the [StyledLayerDescriptor.xsd](http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd) the element `<WellKnownName>` is not required in a `<Mark>` (see also excerpt below) - its `minOccurs` is set to `0`. The documentation was updated accordingly.

Excerpt from StyledLayerDescriptor.xsd:
```
<xsd:element name="Mark">
  <xsd:annotation>
    <xsd:documentation>
      A "Mark" specifies a geometric shape and applies coloring to it.
    </xsd:documentation>
  </xsd:annotation>
  <xsd:complexType>
    <xsd:sequence>
      <xsd:element ref="sld:WellKnownName" minOccurs="0"/>
      <xsd:element ref="sld:Fill" minOccurs="0"/>
      <xsd:element ref="sld:Stroke" minOccurs="0"/>
    </xsd:sequence>
  </xsd:complexType>
</xsd:element>
```