### PR TITLE
WFS3 MVT, GeoJSON tiles and tilingSchemes Implementation

### DIFF
--- a/src/community/wfs3/pom.xml
+++ b/src/community/wfs3/pom.xml
@@ -37,6 +37,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geowebcache</groupId>
+  	  <artifactId>gwc-core</artifactId>
+      <version>${gwc.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/wfs3/pom.xml
+++ b/src/community/wfs3/pom.xml
@@ -32,6 +32,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.extension</groupId>
+  	  <artifactId>gs-vectortiles</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -79,7 +84,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/GetFeatureType.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/GetFeatureType.java
@@ -7,4 +7,16 @@ package org.geoserver.wfs3;
 import net.opengis.wfs20.impl.GetFeatureTypeImpl;
 
 /** This class extends WFS 2.0 GetFeatureType just to allow having a custom KVP reader for it */
-public class GetFeatureType extends GetFeatureTypeImpl {}
+public class GetFeatureType extends GetFeatureTypeImpl {
+
+    private String resolution;
+
+    /** Custom vector tile resolution */
+    public String getResolution() {
+        return resolution;
+    }
+
+    public void setResolution(String resolution) {
+        this.resolution = resolution;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/GetFeatureType.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/GetFeatureType.java
@@ -9,14 +9,14 @@ import net.opengis.wfs20.impl.GetFeatureTypeImpl;
 /** This class extends WFS 2.0 GetFeatureType just to allow having a custom KVP reader for it */
 public class GetFeatureType extends GetFeatureTypeImpl {
 
-    private String resolution;
+    private Integer resolution;
 
     /** Custom vector tile resolution */
-    public String getResolution() {
+    public Integer getResolution() {
         return resolution;
     }
 
-    public void setResolution(String resolution) {
+    public void setResolution(Integer resolution) {
         this.resolution = resolution;
     }
 }

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/TileDataRequest.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/TileDataRequest.java
@@ -1,0 +1,54 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** Current tiling request scope data, for context propagation */
+public class TileDataRequest {
+
+    private String tilingScheme;
+    private Long level;
+    private Long row;
+    private Long col;
+
+    public TileDataRequest() {}
+
+    public boolean isTileRequest() {
+        return (StringUtils.isNotBlank(tilingScheme) && level != null && row != null & col != null);
+    }
+
+    public String getTilingScheme() {
+        return tilingScheme;
+    }
+
+    public void setTilingScheme(String tilingScheme) {
+        this.tilingScheme = tilingScheme;
+    }
+
+    public Long getLevel() {
+        return level;
+    }
+
+    public void setLevel(Long level) {
+        this.level = level;
+    }
+
+    public Long getRow() {
+        return row;
+    }
+
+    public void setRow(Long row) {
+        this.row = row;
+    }
+
+    public Long getCol() {
+        return col;
+    }
+
+    public void setCol(Long col) {
+        this.col = col;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/TilingSchemesRequest.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/TilingSchemesRequest.java
@@ -1,0 +1,7 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3;
+
+public class TilingSchemesRequest extends BaseRequest {}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/WFS3Filter.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/WFS3Filter.java
@@ -25,13 +25,13 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.ws.RequestWrapper;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.filters.GeoServerFilter;
 import org.geoserver.ows.HttpErrorCodeException;
 import org.geoserver.wfs.kvp.BBoxKvpParser;
 import org.geoserver.wfs3.response.RFCGeoJSONFeaturesResponse;
+import org.geoserver.wms.mapbox.MapBoxTileBuilderFactory;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.logging.Logging;
 import org.springframework.http.HttpStatus;
@@ -91,6 +91,10 @@ public class WFS3Filter implements GeoServerFilter {
         private String outputFormat;
         private String featureId;
         private String limit;
+        private String tilingScheme;
+        private String level;
+        private String row;
+        private String col;
 
         private RequestWrapper(HttpServletRequest wrapped) {
             super(wrapped);
@@ -159,6 +163,28 @@ public class WFS3Filter implements GeoServerFilter {
                             }
                             return matches;
                         });
+                // collections/{collectionId}/tiles/{tilingSchemeId}/{level}/{row}/{col}
+                matchers.add(
+                        path -> {
+                            Matcher matcher =
+                                    Pattern.compile(
+                                                    "/collections/([^/]+)/tiles/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?")
+                                            .matcher(path);
+                            boolean matches = matcher.matches();
+                            if (matches) {
+                                request = "getTile";
+                                String layerName = matcher.group(1);
+                                if (layerName != null) {
+                                    layerName = urlDecode(layerName);
+                                }
+                                setLayerName(layerName);
+                                this.tilingScheme = urlDecode(matcher.group(2));
+                                this.level = urlDecode(matcher.group(3));
+                                this.row = urlDecode(matcher.group(4));
+                                this.col = urlDecode(matcher.group(5));
+                            }
+                            return matches;
+                        });
 
                 // loop over the matchers
                 boolean matched = false;
@@ -173,6 +199,8 @@ public class WFS3Filter implements GeoServerFilter {
                     throw new HttpErrorCodeException(
                             HttpStatus.NOT_FOUND.value(), "Unsupported path " + pathInfo);
                 }
+            } else if (pathInfo.startsWith("/tilingSchemes")) {
+                request = "tilingSchemes";
             } else {
                 throw new HttpErrorCodeException(
                         HttpStatus.NOT_FOUND.value(), "Unsupported path " + pathInfo);
@@ -195,6 +223,8 @@ public class WFS3Filter implements GeoServerFilter {
                 }
             } else if ("getFeature".equals(request)) {
                 this.outputFormat = RFCGeoJSONFeaturesResponse.MIME;
+            } else if ("getTile".equals(request)) {
+                this.outputFormat = MapBoxTileBuilderFactory.MIME_TYPE;
             }
 
             // support for the limit parameter
@@ -245,7 +275,12 @@ public class WFS3Filter implements GeoServerFilter {
             filtered.put("service", new String[] {"WFS"});
             filtered.put("version", new String[] {"3.0.0"});
             filtered.put("request", new String[] {request});
-            filtered.put("srsName", new String[] {"EPSG:4326"});
+            if ("GoogleMapsCompatible".equals(this.tilingScheme)) {
+                filtered.put("srsName", new String[] {"EPSG:3857"});
+            } else {
+                filtered.put("srsName", new String[] {"EPSG:4326"});
+            }
+
             String bbox = super.getParameter("bbox");
             if (bbox != null) {
                 try {
@@ -274,6 +309,10 @@ public class WFS3Filter implements GeoServerFilter {
             if (limit != null && !limit.isEmpty()) {
                 filtered.put("count", new String[] {limit});
             }
+            if (tilingScheme != null) filtered.put("tilingScheme", new String[] {tilingScheme});
+            if (level != null) filtered.put("level", new String[] {level});
+            if (row != null) filtered.put("row", new String[] {row});
+            if (col != null) filtered.put("col", new String[] {col});
             return filtered;
         }
 

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/WebFeatureService30.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/WebFeatureService30.java
@@ -10,6 +10,7 @@ import org.geoserver.wfs3.response.CollectionDocument;
 import org.geoserver.wfs3.response.CollectionsDocument;
 import org.geoserver.wfs3.response.ConformanceDocument;
 import org.geoserver.wfs3.response.LandingPageDocument;
+import org.geoserver.wfs3.response.TilingSchemesDocument;
 import org.geotools.util.Version;
 
 public interface WebFeatureService30 {
@@ -63,4 +64,10 @@ public interface WebFeatureService30 {
      * @return
      */
     FeatureCollectionResponse getFeature(GetFeatureType request);
+
+    /** Tiling Schemes available list */
+    TilingSchemesDocument tilingSchemes(TilingSchemesRequest request);
+
+    /** Queries Features for the requested tile coordinate */
+    FeatureCollectionResponse getTile(GetFeatureType request);
 }

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/GetFeatureKvpRequestReader.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/GetFeatureKvpRequestReader.java
@@ -23,8 +23,12 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.request.Query;
 import org.geoserver.wfs3.GetFeatureType;
+import org.geoserver.wfs3.TileDataRequest;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.DateRange;
+import org.geowebcache.config.DefaultGridsets;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSet;
 import org.locationtech.jts.geom.Envelope;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.filter.Filter;
@@ -35,8 +39,13 @@ import org.opengis.filter.identity.FeatureId;
 
 public class GetFeatureKvpRequestReader extends org.geoserver.wfs.kvp.GetFeatureKvpRequestReader {
 
-    public GetFeatureKvpRequestReader(GeoServer geoServer, FilterFactory filterFactory) {
+    private DefaultGridsets gridSets;
+    private TileDataRequest tileData;
+
+    public GetFeatureKvpRequestReader(
+            GeoServer geoServer, FilterFactory filterFactory, DefaultGridsets gridSets) {
         super(GetFeatureType.class, null, geoServer, filterFactory);
+        this.gridSets = gridSets;
     }
 
     @Override
@@ -51,7 +60,7 @@ public class GetFeatureKvpRequestReader extends org.geoserver.wfs.kvp.GetFeature
         }
         // resolution vendor parameter:
         if (kvp.containsKey("resolution")) {
-            gf.setResolution((String) kvp.get("resolution"));
+            gf.setResolution((Integer) kvp.get("resolution"));
         }
         return gf;
     }
@@ -99,7 +108,46 @@ public class GetFeatureKvpRequestReader extends org.geoserver.wfs.kvp.GetFeature
             Filter filter = buildTimeFilter(timeSpecification, timeProperties);
             filters.add(filter);
         }
+        // BBOX filter for tileScheme, level, col, row
+        if (kvp.containsKey("level")
+                && kvp.containsKey("row")
+                && kvp.containsKey("col")
+                && kvp.containsKey("tilingScheme")) {
+            try {
+                long level = Long.parseLong((String) kvp.get("level"));
+                long col = Long.parseLong((String) kvp.get("col"));
+                long row = Long.parseLong((String) kvp.get("row"));
+                String tilingScheme = (String) kvp.get("tilingScheme");
+                GridSet gridset = gridSet(tilingScheme);
+                // gridset.getSrs()
+                if (gridset != null) {
+                    BoundingBox gbbox = gridset.boundsFromIndex(new long[] {col, row, level});
+                    filters.add(
+                            filterFactory.bbox(
+                                    "",
+                                    gbbox.getMinX(),
+                                    gbbox.getMinY(),
+                                    gbbox.getMaxX(),
+                                    gbbox.getMaxY(),
+                                    gridset.getSrs().toString()));
+                    // tile request scoped data
+                    tileData.setTilingScheme(tilingScheme);
+                    tileData.setLevel(level);
+                    tileData.setCol(col);
+                    tileData.setRow(row);
+                }
+            } catch (NumberFormatException e) {
+                // don't worry, all will be fine
+            }
+        }
         return mergeFiltersAnd(filters);
+    }
+
+    private GridSet gridSet(String tilingScheme) {
+        if (gridSets.getGridSet(tilingScheme).isPresent()) {
+            return gridSets.getGridSet(tilingScheme).get();
+        }
+        return null;
     }
 
     private Filter buildTimeFilter(Object timeSpec, List<String> timeProperties) {
@@ -214,5 +262,13 @@ public class GetFeatureKvpRequestReader extends org.geoserver.wfs.kvp.GetFeature
         }
         throw new ServiceException(
                 "Internal error, did not expect to find this value for the bbox: " + bbox);
+    }
+
+    public TileDataRequest getTileData() {
+        return tileData;
+    }
+
+    public void setTileData(TileDataRequest tileData) {
+        this.tileData = tileData;
     }
 }

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/GetFeatureKvpRequestReader.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/GetFeatureKvpRequestReader.java
@@ -49,6 +49,10 @@ public class GetFeatureKvpRequestReader extends org.geoserver.wfs.kvp.GetFeature
         if (!kvp.containsKey("outputFormat")) {
             gf.setOutputFormat(null);
         }
+        // resolution vendor parameter:
+        if (kvp.containsKey("resolution")) {
+            gf.setResolution((String) kvp.get("resolution"));
+        }
         return gf;
     }
 

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/TilingSchemesKVPReader.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/TilingSchemesKVPReader.java
@@ -1,0 +1,14 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3.kvp;
+
+import org.geoserver.wfs3.TilingSchemesRequest;
+
+public class TilingSchemesKVPReader extends BaseKvpRequestReader {
+
+    public TilingSchemesKVPReader() {
+        super(TilingSchemesRequest.class);
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/WFS3TileResolutionKvpParser.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/WFS3TileResolutionKvpParser.java
@@ -1,0 +1,14 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3.kvp;
+
+import org.geoserver.ows.kvp.IntegerKvpParser;
+
+public class WFS3TileResolutionKvpParser extends IntegerKvpParser {
+
+    public WFS3TileResolutionKvpParser() {
+        super("resolution");
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/GeoJsonSimplifiedBuilder.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/GeoJsonSimplifiedBuilder.java
@@ -1,0 +1,49 @@
+/* (c) 2014 - 2018 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3.response;
+
+import java.io.Writer;
+import javax.measure.Unit;
+import net.sf.json.JSONException;
+import net.sf.json.util.JSONBuilder;
+import org.geoserver.wfs.json.GeoJSONBuilder;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.precision.CoordinatePrecisionReducerFilter;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import si.uom.SI;
+
+/** GeoJsonBuilder extension that writes simplified coordinates decimals on geometries */
+public class GeoJsonSimplifiedBuilder extends GeoJSONBuilder {
+
+    private CoordinateReferenceSystem mapCrs;
+    private CoordinatePrecisionReducerFilter precisionReducerFilter;
+
+    public GeoJsonSimplifiedBuilder(Writer w, CoordinateReferenceSystem mapCrs) {
+        super(w);
+        this.mapCrs = mapCrs;
+        // initialize precisionReducerFilter
+        Unit<?> unit = this.mapCrs.getCoordinateSystem().getAxis(0).getUnit();
+        Unit<?> standardUnit = unit.getSystemUnit();
+        PrecisionModel pm = null;
+        if (SI.RADIAN.equals(standardUnit)) {
+            pm = new PrecisionModel(1e6); // truncate coords at 6 decimals
+        } else if (SI.METRE.equals(standardUnit)) {
+            pm = new PrecisionModel(100); // truncate coords at 2 decimals
+        }
+        if (pm != null) {
+            precisionReducerFilter = new CoordinatePrecisionReducerFilter(pm);
+        }
+    }
+
+    @Override
+    public JSONBuilder writeGeom(Geometry geometry) throws JSONException {
+        if (precisionReducerFilter != null) {
+            geometry.apply(precisionReducerFilter);
+        }
+        return super.writeGeom(geometry);
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/GetFeatureMapboxOutputFormat.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/GetFeatureMapboxOutputFormat.java
@@ -1,0 +1,155 @@
+package org.geoserver.wfs3.response;
+
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.TreeMap;
+import no.ecc.vectortile.VectorTileEncoder;
+import no.ecc.vectortile.VectorTileEncoderNoClip;
+import org.geoserver.config.GeoServer;
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.ServiceException;
+import org.geoserver.wfs.WFSGetFeatureOutputFormat;
+import org.geoserver.wfs.request.FeatureCollectionResponse;
+import org.geoserver.wfs3.GetFeatureType;
+import org.geoserver.wfs3.WebFeatureService30;
+import org.geoserver.wms.mapbox.MapBoxTileBuilderFactory;
+import org.geoserver.wms.vector.Pipeline;
+import org.geoserver.wms.vector.PipelineBuilder;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.Version;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.Attribute;
+import org.opengis.feature.ComplexAttribute;
+import org.opengis.feature.GeometryAttribute;
+import org.opengis.feature.Property;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/** Mapbox protobuf WFS3 output format */
+public class GetFeatureMapboxOutputFormat extends WFSGetFeatureOutputFormat {
+
+    private double overSamplingFactor = 2.0;
+
+    public GetFeatureMapboxOutputFormat(GeoServer gs) {
+        super(gs, MapBoxTileBuilderFactory.MIME_TYPE);
+    }
+
+    @Override
+    public String getMimeType(Object value, Operation operation) throws ServiceException {
+        return MapBoxTileBuilderFactory.MIME_TYPE;
+    }
+
+    @Override
+    protected void write(
+            FeatureCollectionResponse featureCollection, OutputStream output, Operation getFeature)
+            throws IOException, ServiceException {
+        GetFeatureType getFeatureType = (GetFeatureType) getFeature.getParameters()[0];
+        Integer resolution = 256;
+        try {
+            resolution = Integer.parseInt(getFeatureType.getResolution());
+        } catch (NumberFormatException e) {
+            // continue with default
+        }
+        FeatureCollection collection = featureCollection.getFeatures().get(0);
+        // paint area, default 256x256
+        final Rectangle paintArea = new Rectangle(resolution, resolution);
+        // get CRS
+        CoordinateReferenceSystem refSys =
+                collection
+                        .getSchema()
+                        .getGeometryDescriptor()
+                        .getType()
+                        .getCoordinateReferenceSystem();
+        ReferencedEnvelope area = ReferencedEnvelope.create(collection.getBounds(), refSys);
+        // Build the Pipeline (sort of coordinates transformer)
+        Pipeline pipeline = getPipeline(area, paintArea, refSys, resolution / 32);
+        // setup the vector tile encoder
+        VectorTileEncoder encoder = new VectorTileEncoderNoClip(resolution, resolution / 32, false);
+        // encode every feature
+        try (FeatureIterator<SimpleFeature> features = collection.features()) {
+            while (features.hasNext()) {
+                // get Feature and its attributes
+                SimpleFeature feature = features.next();
+                Geometry geom = (Geometry) feature.getDefaultGeometryProperty().getValue();
+                Geometry finalGeom = finalGeom = pipeline.execute(geom);
+                final String layerName = feature.getName().getLocalPart();
+                final Map<String, Object> properties = getProperties(feature);
+                // add to encoder (if have at least a coordinate to encode)
+                if (finalGeom.getCoordinates().length > 0)
+                    encoder.addFeature(layerName, properties, finalGeom);
+            }
+            // write encoded stream
+            output.write(encoder.encode());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Map<String, Object> getProperties(ComplexAttribute feature) {
+        Map<String, Object> props = new TreeMap<>();
+        for (Property p : feature.getProperties()) {
+            if (!(p instanceof Attribute) || (p instanceof GeometryAttribute)) {
+                continue;
+            }
+            String name = p.getName().getLocalPart();
+            Object value;
+            if (p instanceof ComplexAttribute) {
+                value = getProperties((ComplexAttribute) p);
+            } else {
+                value = p.getValue();
+            }
+            if (value != null) {
+                props.put(name, value);
+            }
+        }
+        return props;
+    }
+
+    /**
+     * Builds the Pipeline (sort of coordinates transformer)
+     *
+     * @param renderingArea area coordinates to render
+     * @param paintArea pixel rectangle
+     * @param sourceCrs CRS for the geometries
+     * @param buffer pixel buffer t add
+     * @return Pipeline builded object
+     */
+    protected Pipeline getPipeline(
+            final ReferencedEnvelope renderingArea,
+            final Rectangle paintArea,
+            CoordinateReferenceSystem sourceCrs,
+            int buffer) {
+        Pipeline pipeline;
+        try {
+            final PipelineBuilder builder =
+                    PipelineBuilder.newBuilder(
+                            renderingArea, paintArea, sourceCrs, overSamplingFactor, buffer);
+
+            pipeline =
+                    builder.preprocess()
+                            .transform(true)
+                            .simplify(true)
+                            .clip(true, true)
+                            .collapseCollections()
+                            .build();
+        } catch (FactoryException e) {
+            throw new ServiceException(e);
+        }
+        return pipeline;
+    }
+
+    @Override
+    protected boolean canHandleInternal(Operation operation) {
+        return WebFeatureService30.V3.compareTo(operation.getService().getVersion()) <= 0;
+    }
+
+    @Override
+    public boolean canHandle(Version version) {
+        return WebFeatureService30.V3.compareTo(version) <= 0;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemesDocument.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemesDocument.java
@@ -1,0 +1,33 @@
+package org.geoserver.wfs3.response;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.Arrays;
+import java.util.List;
+import org.geoserver.config.GeoServer;
+import org.geowebcache.config.DefaultGridsets;
+
+@JacksonXmlRootElement(localName = "TilingSchemes")
+public class TilingSchemesDocument {
+
+    private final GeoServer geoServer;
+    private final DefaultGridsets gridSets;
+    private List<String> schemesNames;
+
+    public TilingSchemesDocument(GeoServer geoServer, DefaultGridsets gridSets) {
+        this.geoServer = geoServer;
+        this.gridSets = gridSets;
+        schemesNames =
+                Arrays.asList(
+                        gridSets.worldEpsg4326().getName(), gridSets.worldEpsg3857().getName());
+    }
+
+    @JacksonXmlProperty(localName = "TilingSchemes")
+    public List<String> getTilingSchemes() {
+        return schemesNames;
+    }
+
+    public void setTilingSchemes(List<String> schemesNames) {
+        this.schemesNames = schemesNames;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemesResponse.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemesResponse.java
@@ -1,0 +1,16 @@
+package org.geoserver.wfs3.response;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.platform.Operation;
+
+public class TilingSchemesResponse extends JacksonResponse {
+
+    public TilingSchemesResponse(GeoServer gs) {
+        super(gs, TilingSchemesDocument.class);
+    }
+
+    @Override
+    protected String getFileName(Object value, Operation operation) {
+        return "tilingSchemes";
+    }
+}

--- a/src/community/wfs3/src/main/resources/applicationContext.xml
+++ b/src/community/wfs3/src/main/resources/applicationContext.xml
@@ -101,7 +101,9 @@
     <constructor-arg ref="geoServer"/>
     <constructor-arg ref="xmlConfiguration-1.1"/>
   </bean>
-
+  <bean id="featuresMapboxResponse" class="org.geoserver.wfs3.response.GetFeatureMapboxOutputFormat">
+    <constructor-arg ref="geoServer"/>
+  </bean>
 
   <!-- Hack to map WFS3 requests parameters to OGC KVP lookalikes -->
   <bean id="wfs3Filter" class="org.geoserver.wfs3.WFS3Filter">

--- a/src/community/wfs3/src/main/resources/applicationContext.xml
+++ b/src/community/wfs3/src/main/resources/applicationContext.xml
@@ -3,8 +3,14 @@
   the GPL 2.0 license, available at the root application directory. -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-          http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="
+	     http://www.springframework.org/schema/beans             
+	     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd         
+	     http://www.springframework.org/schema/context
+	     http://www.springframework.org/schema/context/spring-context-3.0.xsd          
+	     http://www.springframework.org/schema/aop         
+	     http://www.springframework.org/schema/aop/spring-aop-3.0.xsd"
 >
 
   <!-- service declaration -->
@@ -21,6 +27,8 @@
         <value>collections</value>
         <value>collection</value>
         <value>GetFeature</value> <!-- this allows to re-use the WFS 2.0 machinery for getting features -->
+        <value>tilingSchemes</value>
+        <value>getTile</value>
       </list>
     </constructor-arg>
     <property name="customCapabilitiesLink" value="../wfs3/"/>
@@ -28,6 +36,7 @@
   <bean id="wfs30ServiceTarget" class="org.geoserver.wfs3.DefaultWebFeatureService30">
     <constructor-arg ref="geoServer"/>
     <constructor-arg ref="wfsService20"/>
+    <constructor-arg ref="wfs3DefaultGridsets" />
     <property name="filterFactory" ref="filterFactory"/>
   </bean>
   <bean id="wfsService30" class="org.springframework.aop.framework.ProxyFactoryBean">
@@ -48,6 +57,10 @@
     <property name="service" value="WFS"/>
     <property name="version" value="3.0.0"/>
   </bean>
+  <bean id="wfs3ResolutionKvpParser" class="org.geoserver.wfs3.kvp.WFS3TileResolutionKvpParser">
+    <property name="service" value="WFS"/>
+    <property name="version" value="3.0.0"/>
+  </bean>
   <bean id="apiKvpRequestReader" class="org.geoserver.wfs3.kvp.APIRequestKVPReader"/>
   <bean id="contentKvpRequestReader" class="org.geoserver.wfs3.kvp.LandingPageRequestKVPReader"/>
   <bean id="collectionKvpRequestReader" class="org.geoserver.wfs3.kvp.CollectionRequestKVPReader"/>
@@ -56,7 +69,10 @@
   <bean id="getFeatureKvpRequestReader" class="org.geoserver.wfs3.kvp.GetFeatureKvpRequestReader">
     <constructor-arg index="0" ref="geoServer"/>
     <constructor-arg index="1" ref="filterFactory"/>
+    <constructor-arg index="2" ref="wfs3DefaultGridsets"/>
+    <property name="tileData" ref="wfs3TileDataRequest" />
   </bean>
+  <bean id="tilingSchemesKvpRequestReader" class="org.geoserver.wfs3.kvp.TilingSchemesKVPReader"/>
   
   <!-- response generation -->
   <bean id="openAPIResponse" class="org.geoserver.wfs3.response.OpenAPIResponse">
@@ -92,6 +108,8 @@
   </bean>
   <bean id="rfcGeoJsonFeaturesResponse" class="org.geoserver.wfs3.response.RFCGeoJSONFeaturesResponse">
     <constructor-arg ref="geoServer"/>
+    <property name="tileData" ref="wfs3TileDataRequest" />
+    <property name="gridSets" ref="wfs3DefaultGridsets" />
   </bean>
   <bean id="featuresHTMLResponse" class="org.geoserver.wfs3.response.GetFeatureHTMLOutputFormat">
     <constructor-arg ref="resourceLoader"/>
@@ -102,6 +120,11 @@
     <constructor-arg ref="xmlConfiguration-1.1"/>
   </bean>
   <bean id="featuresMapboxResponse" class="org.geoserver.wfs3.response.GetFeatureMapboxOutputFormat">
+    <constructor-arg ref="geoServer"/>
+    <property name="tileData" ref="wfs3TileDataRequest" />
+    <property name="gridSets" ref="wfs3DefaultGridsets" />
+  </bean>
+  <bean id="tilingSchemesResponse" class="org.geoserver.wfs3.response.TilingSchemesResponse">
     <constructor-arg ref="geoServer"/>
   </bean>
 
@@ -152,6 +175,23 @@
   <bean id="wfs3LocalWorkspaceURLManger" class="org.geoserver.ows.LocalWorkspaceURLMangler">
     <constructor-arg value="wfs3"/>
   </bean>
-
+  
+  <bean id="wfs3DefaultGridsets" class="org.geowebcache.config.DefaultGridsets">
+    <!-- Should we used EPSG:900913 instead of EPSG:3857 ? -->
+    <constructor-arg type="boolean" value="FALSE" />
+    <!--
+      Should the default grids be named EPSG:4326 and EPSG:900913 (TRUE),
+      or (FALSE) use the new names similar to what WMTS suggests,
+      GlobalCRS84Geometric and GoogleMapsCompatible ? 
+      
+      If you say FALSE here, you have to manually
+      rename the directories and entries in the H2 database.
+     -->
+     <constructor-arg type="boolean" value="FALSE" />
+  </bean>
+  
+  <bean id="wfs3TileDataRequest" class="org.geoserver.wfs3.TileDataRequest"	scope="request">
+  	<aop:scoped-proxy/>
+  </bean>
 
 </beans>

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetFeatureMapboxOutputFormatTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetFeatureMapboxOutputFormatTest.java
@@ -1,0 +1,65 @@
+package org.geoserver.wfs3;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import no.ecc.vectortile.VectorTileDecoder;
+import no.ecc.vectortile.VectorTileDecoder.Feature;
+import no.ecc.vectortile.VectorTileDecoder.FeatureIterable;
+import org.geoserver.data.test.MockData;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Mapbox protobuf encoding test cases */
+public class GetFeatureMapboxOutputFormatTest extends WFS3TestSupport {
+
+    /** Tests mapbox protobuf encoding for features in items */
+    @Test
+    public void testItemsFeatureBuildingsEncode() throws Exception {
+        // get ptb inputstream
+        String roadSegments = getEncodedName(MockData.BUILDINGS);
+        String path =
+                "wfs3/collections/"
+                        + roadSegments
+                        + "/items?f=application%2Fx-protobuf%3Btype%3Dmapbox-vector&resolution=10000";
+        MockHttpServletResponse response = getAsServletResponse(path);
+        byte[] responseBytes = response.getContentAsByteArray();
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        FeatureIterable fiter = decoder.decode(responseBytes);
+        List<Feature> featuresList = fiter.asList();
+        assertEquals(2, featuresList.size());
+        assertEquals("Buildings", featuresList.get(0).getLayerName());
+        assertEquals(
+                "POLYGON ((0 256, 0 153.6, 64 153.6, 64 256, 0 256))",
+                featuresList.get(0).getGeometry().toText());
+        assertEquals("Buildings", featuresList.get(1).getLayerName());
+        assertEquals(
+                "POLYGON ((192 102.4, 192 0, 256 0, 256 102.4, 192 102.4))",
+                featuresList.get(1).getGeometry().toText());
+    }
+
+    /** Tests mapbox protobuf encoding for features in items */
+    @Test
+    public void testItemsFeatureRoadsEncode() throws Exception {
+        // get ptb inputstream
+        String roadSegments = getEncodedName(MockData.ROAD_SEGMENTS);
+        String path =
+                "wfs3/collections/"
+                        + roadSegments
+                        + "/items?f=application%2Fx-protobuf%3Btype%3Dmapbox-vector&resolution=10000";
+        MockHttpServletResponse response = getAsServletResponse(path);
+        byte[] responseBytes = response.getContentAsByteArray();
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        FeatureIterable fiter = decoder.decode(responseBytes);
+        List<Feature> featuresList = fiter.asList();
+        assertEquals(5, featuresList.size());
+        assertEquals("RoadSegments", featuresList.get(0).getLayerName());
+        assertEquals(
+                "LINESTRING (0 160, 30.464 144, 48.768 133.3248, 85.3248 117.3248, 134.0928 90.6752)",
+                featuresList.get(0).getGeometry().toText());
+        assertEquals("RoadSegments", featuresList.get(1).getLayerName());
+        assertEquals(
+                "LINESTRING (134.0928 90.6752, 170.6752 74.6752, 213.3248 53.3248)",
+                featuresList.get(1).getGeometry().toText());
+    }
+}

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetTileTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetTileTest.java
@@ -1,0 +1,126 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3;
+
+import static org.junit.Assert.assertEquals;
+
+import com.jayway.jsonpath.DocumentContext;
+import java.net.URLEncoder;
+import java.util.List;
+import no.ecc.vectortile.VectorTileDecoder;
+import no.ecc.vectortile.VectorTileDecoder.Feature;
+import no.ecc.vectortile.VectorTileDecoder.FeatureIterable;
+import org.geoserver.data.test.MockData;
+import org.geoserver.wfs3.response.RFCGeoJSONFeaturesResponse;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Test cases for GetTile requests */
+public class GetTileTest extends WFS3TestSupport {
+
+    /** Tests getTile with MVT format */
+    @Test
+    public void testGetTileMTV() throws Exception {
+        String roadSegments = getEncodedName(MockData.ROAD_SEGMENTS);
+        String path =
+                "wfs3/collections/" + roadSegments + "/tiles/GlobalCRS84Geometric/12/2047/4095";
+        MockHttpServletResponse response = getAsServletResponse(path);
+        byte[] responseBytes = response.getContentAsByteArray();
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        FeatureIterable fiter = decoder.decode(responseBytes);
+        List<Feature> featuresList = fiter.asList();
+        assertEquals(2, featuresList.size());
+        assertEquals("RoadSegments", featuresList.get(0).getLayerName());
+        assertEquals(
+                "LINESTRING (232 3, 241 1, 248 -1, 257 -4)",
+                featuresList.get(0).getGeometry().toText());
+        assertEquals("RoadSegments", featuresList.get(1).getLayerName());
+        assertEquals("LINESTRING (248 14, 248 -1)", featuresList.get(1).getGeometry().toText());
+    }
+
+    /** Tests getTile with MVT format, Web Mercator projection */
+    @Test
+    public void testGetTileMTVMercator() throws Exception {
+        String roadSegments = getEncodedName(MockData.ROAD_SEGMENTS);
+        String path =
+                "wfs3/collections/" + roadSegments + "/tiles/GoogleMapsCompatible/16/32768/32767";
+        MockHttpServletResponse response = getAsServletResponse(path);
+        byte[] responseBytes = response.getContentAsByteArray();
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        FeatureIterable fiter = decoder.decode(responseBytes);
+        List<Feature> featuresList = fiter.asList();
+        assertEquals(2, featuresList.size());
+        assertEquals("RoadSegments", featuresList.get(0).getLayerName());
+        assertEquals(
+                "LINESTRING (87 276, 107 270, 135 261, 191 247, 265 223)",
+                featuresList.get(0).getGeometry().toText());
+        assertEquals("RoadSegments", featuresList.get(1).getLayerName());
+        assertEquals("LINESTRING (191 276, 191 247)", featuresList.get(1).getGeometry().toText());
+    }
+
+    /** Tests getTile with GeoJSON format */
+    @Test
+    public void testGetTileGeoJSON() throws Exception {
+        String roadSegments = getEncodedName(MockData.ROAD_SEGMENTS);
+        String path =
+                "wfs3/collections/"
+                        + roadSegments
+                        + "/tiles/GlobalCRS84Geometric/12/2047/4095"
+                        + "?f="
+                        + URLEncoder.encode(RFCGeoJSONFeaturesResponse.MIME, "UTF-8");
+        DocumentContext jsdoc = getAsJSONPath(path, 200);
+        // features[0].geometry.type = "MultiLineString"
+        assertEquals(jsdoc.read("features[0].geometry.type", String.class), "MultiLineString");
+        List<Double> list = jsdoc.read("features[0].geometry.coordinates[0][0]", List.class);
+        assertEquals(-0.0042d, list.get(0), 0.0001d);
+        assertEquals(-6.0E-4d, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][1]", List.class);
+        assertEquals(-0.0032, list.get(0), 0.0001d);
+        assertEquals(-3.0E-4, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][2]", List.class);
+        assertEquals(-0.0026, list.get(0), 0.0001d);
+        assertEquals(-1.0E-4, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][3]", List.class);
+        assertEquals(-0.0014, list.get(0), 0.0001d);
+        assertEquals(2.0E-4, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][4]", List.class);
+        assertEquals(2.0E-4, list.get(0), 0.0001d);
+        assertEquals(7.0E-4, list.get(1), 0.0001d);
+        // "numberReturned":2
+        assertEquals(jsdoc.read("numberReturned", Integer.class).intValue(), 2);
+    }
+
+    /** Tests getTile with GeoJSON format, Web Mercator tilingSchema */
+    @Test
+    public void testGetTileGeoJSONMercator() throws Exception {
+        String roadSegments = getEncodedName(MockData.ROAD_SEGMENTS);
+        String path =
+                "wfs3/collections/"
+                        + roadSegments
+                        + "/tiles/GoogleMapsCompatible/16/32768/32767"
+                        + "?f="
+                        + URLEncoder.encode(RFCGeoJSONFeaturesResponse.MIME, "UTF-8");
+        ;
+        DocumentContext jsdoc = getAsJSONPath(path, 200);
+        assertEquals(jsdoc.read("features[0].geometry.type", String.class), "MultiLineString");
+        List<Double> list = jsdoc.read("features[0].geometry.coordinates[0][0]", List.class);
+        assertEquals(-467.54, list.get(0), 0.0001d);
+        assertEquals(-66.79, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][1]", List.class);
+        assertEquals(-356.22, list.get(0), 0.0001d);
+        assertEquals(-33.4, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][2]", List.class);
+        assertEquals(-289.43, list.get(0), 0.0001d);
+        assertEquals(-11.13, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][3]", List.class);
+        assertEquals(-155.85, list.get(0), 0.0001d);
+        assertEquals(22.26, list.get(1), 0.0001d);
+        list = jsdoc.read("features[0].geometry.coordinates[0][4]", List.class);
+        assertEquals(22.26, list.get(0), 0.0001d);
+        assertEquals(77.92, list.get(1), 0.0001d);
+        // "numberReturned":2
+        assertEquals(jsdoc.read("numberReturned", Integer.class).intValue(), 2);
+    }
+}

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/TilingSchemesTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/TilingSchemesTest.java
@@ -1,0 +1,27 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3;
+
+import static org.junit.Assert.assertTrue;
+
+import com.jayway.jsonpath.DocumentContext;
+import java.util.Arrays;
+import java.util.HashSet;
+import org.junit.Test;
+
+public class TilingSchemesTest extends WFS3TestSupport {
+
+    /** Tests the "wfs3/tilingScheme" json response */
+    @Test
+    public void testTilingSchemesResponse() throws Exception {
+        DocumentContext jsonDoc = getAsJSONPath("wfs3/tilingSchemes", 200);
+        String scheme1 = jsonDoc.read("$.tilingSchemes[0]", String.class);
+        String scheme2 = jsonDoc.read("$.tilingSchemes[1]", String.class);
+        HashSet<String> schemesSet = new HashSet<>(Arrays.asList(scheme1, scheme2));
+        assertTrue(schemesSet.contains("GlobalCRS84Geometric"));
+        assertTrue(schemesSet.contains("GoogleMapsCompatible"));
+        assertTrue(schemesSet.size() == 2);
+    }
+}

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/WFS3TestSupport.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/WFS3TestSupport.java
@@ -91,4 +91,9 @@ public class WFS3TestSupport extends GeoServerSystemTestSupport {
         Document document = Jsoup.parse(response.getContentAsString());
         return document;
     }
+
+    protected byte[] getAsByteArray(String url) throws Exception {
+        MockHttpServletResponse response = getAsMockHttpServletResponse(url, 200);
+        return response.getContentAsByteArray();
+    }
 }

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/Pipeline.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/Pipeline.java
@@ -10,7 +10,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 
 /** A chainable unary operation on a geometry. */
-abstract class Pipeline {
+public abstract class Pipeline {
 
     protected static final Geometry EMPTY = new GeometryFactory().createPoint((Coordinate) null);
 
@@ -19,7 +19,7 @@ abstract class Pipeline {
             new Pipeline() {
 
                 @Override
-                protected final Geometry execute(Geometry geom) {
+                public final Geometry execute(Geometry geom) {
                     return geom;
                 }
 
@@ -48,7 +48,7 @@ abstract class Pipeline {
      * @return
      * @throws Exception
      */
-    Geometry execute(Geometry geom) throws Exception {
+    public Geometry execute(Geometry geom) throws Exception {
         Preconditions.checkNotNull(next, getClass().getName());
         Geometry g = _run(geom);
         if (g == null || g.isEmpty()) {

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
@@ -37,7 +37,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
 
-class PipelineBuilder {
+public class PipelineBuilder {
 
     // The base simplification tolerance for screen coordinates.
     private static final double PIXEL_BASE_SAMPLE_SIZE = 0.25;


### PR DESCRIPTION
This PR implements the Mapbox vector tile output format for the “collections/{collectionId}/items” WFS 3 endpoint, tilingSchemes list output and getTiles endpoint.
Also adds a "resolution" integer vendor parameter (256 by default) for to reach smallers features that aren't printed with default tile resolution.

Get items example:
```
http://localhost:8080/geoserver/wfs3/collections/topp__solar/items?f=application%2Fx-protobuf%3Btype%3Dmapbox-vector&resolution=10000
```
Get tiling schemes list example:
```
http://localhost:8080/geoserver/wfs3/tilingSchemes
```
Get tile example:
```
http://localhost:8080/geoserver/wfs3/collections/st__solar/tiles/GlobalCRS84Geometric/12/2055/2318
```
