### PR TITLE
[GEOS-8945] Missing Spatial Index in OSEO Setup Instructions

### DIFF
--- a/src/community/oseo/oseo-core/src/test/resources/postgis.sql
+++ b/src/community/oseo/oseo-core/src/test/resources/postgis.sql
@@ -229,3 +229,6 @@ create table granule (
   "location" varchar not null,
   "the_geom" geometry(Polygon, 4326) not null
 );
+
+-- manually generated indexes
+CREATE INDEX "idx_granule_the_geom" ON granule USING GIST("the_geom");


### PR DESCRIPTION
Adding the missing index on the geometry attribute of the "granule". This can have a significant impact on systems with a great number of published granules