### PR TITLE
GEOS-8935: introduced new coordinates formatting options for WFS GML output formats

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/FeatureTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/FeatureTypeInfo.java
@@ -93,8 +93,19 @@ public interface FeatureTypeInfo extends ResourceInfo {
      */
     void setPadWithZeros(boolean padWithZeros);
 
+    /**
+     * True if numbers should always be formatted as decimal (no scientific notation allowed).
+     *
+     * @return
+     */
     boolean getForcedDecimal();
 
+    /**
+     * Set to true if numbers should always be formatted as decimal (no scientific notation
+     * allowed).
+     *
+     * @param forcedDecimal
+     */
     void setForcedDecimal(boolean forcedDecimal);
 
     /**

--- a/src/main/src/main/java/org/geoserver/catalog/FeatureTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/FeatureTypeInfo.java
@@ -80,6 +80,24 @@ public interface FeatureTypeInfo extends ResourceInfo {
     void setNumDecimals(int numDecimals);
 
     /**
+     * If numbers float should be formatted right-padding them with zeros.
+     *
+     * @return
+     */
+    boolean getPadWithZeros();
+
+    /**
+     * Sets wether float numbers should be formatted right-padding them with zeros.
+     *
+     * @param padWithZeros
+     */
+    void setPadWithZeros(boolean padWithZeros);
+
+    boolean getForcedDecimal();
+
+    void setForcedDecimal(boolean forcedDecimal);
+
+    /**
      * Tolerance used to linearize this feature type, as an absolute value expressed in the
      * geometries own CRS
      */

--- a/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/FeatureTypeInfoImpl.java
@@ -34,6 +34,8 @@ public class FeatureTypeInfoImpl extends ResourceInfoImpl implements FeatureType
 
     protected int maxFeatures;
     protected int numDecimals;
+    protected boolean padWithZeros;
+    protected boolean forcedDecimal;
 
     protected List<AttributeTypeInfo> attributes = new ArrayList<AttributeTypeInfo>();
     protected List<String> responseSRS = new ArrayList<String>();
@@ -252,5 +254,25 @@ public class FeatureTypeInfoImpl extends ResourceInfoImpl implements FeatureType
     @Override
     public void setEncodeMeasures(boolean encodeMeasures) {
         this.encodeMeasures = encodeMeasures;
+    }
+
+    @Override
+    public boolean getPadWithZeros() {
+        return padWithZeros;
+    }
+
+    @Override
+    public void setPadWithZeros(boolean padWithZeros) {
+        this.padWithZeros = padWithZeros;
+    }
+
+    @Override
+    public boolean getForcedDecimal() {
+        return forcedDecimal;
+    }
+
+    @Override
+    public void setForcedDecimal(boolean forcedDecimal) {
+        this.forcedDecimal = forcedDecimal;
     }
 }

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingFeatureTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingFeatureTypeInfo.java
@@ -334,4 +334,24 @@ public abstract class DecoratingFeatureTypeInfo extends AbstractDecorator<Featur
     public void setEncodeMeasures(boolean encodeMeasures) {
         delegate.setEncodeMeasures(encodeMeasures);
     }
+
+    @Override
+    public boolean getPadWithZeros() {
+        return delegate.getPadWithZeros();
+    }
+
+    @Override
+    public void setPadWithZeros(boolean padWithZeros) {
+        delegate.setPadWithZeros(padWithZeros);
+    }
+
+    @Override
+    public boolean getForcedDecimal() {
+        return delegate.getForcedDecimal();
+    }
+
+    @Override
+    public void setForcedDecimal(boolean forcedDecimal) {
+        delegate.setForcedDecimal(forcedDecimal);
+    }
 }

--- a/src/web/wfs/src/main/java/org/geoserver/wfs/web/publish/WFSLayerConfig.html
+++ b/src/web/wfs/src/main/java/org/geoserver/wfs/web/publish/WFSLayerConfig.html
@@ -18,6 +18,14 @@
             <div wicket:id="maxDecimalsBorder">
               <input id="maxDecimals" class="text" wicket:id="maxDecimals" type="text"></input>
             </div>
+            <label for="padWithZeros"><wicket:message key="padWithZeros">Right-pad decimals with zeros</wicket:message></label>
+            <div wicket:id="padWithZerosBorder">
+              <input id="padWithZeros" wicket:id="padWithZeros" type="checkbox"></input>
+            </div>
+            <label for="forcedDecimal"><wicket:message key="forcedDecimal">Force decimals, don't use scientific notation</wicket:message></label>
+            <div wicket:id="forcedDecimalBorder">
+              <input id="forcedDecimal" wicket:id="forcedDecimal" type="checkbox"></input>
+            </div>
           </li>
         </ul>
       </fieldset>

--- a/src/web/wfs/src/main/java/org/geoserver/wfs/web/publish/WFSLayerConfig.java
+++ b/src/web/wfs/src/main/java/org/geoserver/wfs/web/publish/WFSLayerConfig.java
@@ -49,6 +49,20 @@ public class WFSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
         Border mdb = new FormComponentFeedbackBorder("maxDecimalsBorder");
         mdb.add(maxDecimals);
         add(mdb);
+        CheckBox padWithZeros =
+                new CheckBox(
+                        "padWithZeros", new PropertyModel<Boolean>(model, "resource.padWithZeros"));
+        Border pwzb = new FormComponentFeedbackBorder("padWithZerosBorder");
+        pwzb.add(padWithZeros);
+        add(pwzb);
+
+        CheckBox forcedDecimal =
+                new CheckBox(
+                        "forcedDecimal",
+                        new PropertyModel<Boolean>(model, "resource.forcedDecimal"));
+        Border fdb = new FormComponentFeedbackBorder("forcedDecimalBorder");
+        fdb.add(forcedDecimal);
+        add(fdb);
         CheckBox skipNumberMatched =
                 new CheckBox(
                         "skipNumberMatched",

--- a/src/web/wfs/src/main/resources/GeoServerApplication.properties
+++ b/src/web/wfs/src/main/resources/GeoServerApplication.properties
@@ -33,6 +33,8 @@ WFSAdminPage.otherSRS.message=A comma separated list of EPSG codes, e.g. 4326,38
    response. 
 
 WFSLayerConfig.maxDecimals=Maximum number of decimals
+WFSLayerConfig.padWithZeros=Right-pad decimals with zeros
+WFSLayerConfig.forcedDecimal=Forced decimal notation, don't use scientific notation
 WFSLayerConfig.perReqFeatureLimit=Per-Request Feature Limit
 WFSLayerConfig.wfsSettings=WFS Settings
 WFSLayerConfig.featureSettings=Feature Settings

--- a/src/web/wfs/src/test/java/org/geoserver/wfs/web/WFSLayerConfigTest.java
+++ b/src/web/wfs/src/test/java/org/geoserver/wfs/web/WFSLayerConfigTest.java
@@ -39,4 +39,50 @@ public final class WFSLayerConfigTest extends GeoServerWicketTestSupport {
         ft.submit();
         tester.assertModelValue("form:panel:encodeMeasures", false);
     }
+
+    @Test
+    public void testForceDecimalCheckbox() {
+        // get a test layer and instantiate the model
+        final LayerInfo layer = getCatalog().getLayerByName(MockData.PONDS.getLocalPart());
+        Model<LayerInfo> model = new Model<>(layer);
+        FormTestPage page =
+                new FormTestPage((ComponentBuilder) id -> new WFSLayerConfig(id, model));
+        // let's start the page and check that the components are correctly instantiated
+        tester.startPage(page);
+        tester.assertRenderedPage(FormTestPage.class);
+        tester.assertComponent("form", Form.class);
+        // check that the checkbox is available
+        tester.assertComponent(
+                "form:panel:forcedDecimalBorder:forcedDecimalBorder_body:forcedDecimal",
+                CheckBox.class);
+        // unselect the checkbox, no measures should be selected
+        FormTester ft = tester.newFormTester("form");
+        ft.setValue("panel:forcedDecimalBorder:forcedDecimalBorder_body:forcedDecimal", true);
+        ft.submit();
+        tester.assertModelValue(
+                "form:panel:forcedDecimalBorder:forcedDecimalBorder_body:forcedDecimal", true);
+    }
+
+    @Test
+    public void testPadWithZerosCheckbox() {
+        // get a test layer and instantiate the model
+        final LayerInfo layer = getCatalog().getLayerByName(MockData.PONDS.getLocalPart());
+        Model<LayerInfo> model = new Model<>(layer);
+        FormTestPage page =
+                new FormTestPage((ComponentBuilder) id -> new WFSLayerConfig(id, model));
+        // let's start the page and check that the components are correctly instantiated
+        tester.startPage(page);
+        tester.assertRenderedPage(FormTestPage.class);
+        tester.assertComponent("form", Form.class);
+        // check that the checkbox is available
+        tester.assertComponent(
+                "form:panel:padWithZerosBorder:padWithZerosBorder_body:padWithZeros",
+                CheckBox.class);
+        // unselect the checkbox, no measures should be selected
+        FormTester ft = tester.newFormTester("form");
+        ft.setValue("panel:padWithZerosBorder:padWithZerosBorder_body:padWithZeros", true);
+        ft.submit();
+        tester.assertModelValue(
+                "form:panel:padWithZerosBorder:padWithZerosBorder_body:padWithZeros", true);
+    }
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSGetFeatureOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSGetFeatureOutputFormat.java
@@ -247,7 +247,7 @@ public abstract class WFSGetFeatureOutputFormat extends WFSResponse {
                             catalog,
                             (FeatureCollection) featureCollections.get(i),
                             fti -> fti.getPadWithZeros());
-            if (pad != null && pad.booleanValue()) {
+            if (Boolean.TRUE.equals(pad)) {
                 padWithZeros = true;
             }
         }
@@ -263,7 +263,7 @@ public abstract class WFSGetFeatureOutputFormat extends WFSResponse {
                             catalog,
                             (FeatureCollection) featureCollections.get(i),
                             fti -> fti.getForcedDecimal());
-            if (forced != null && forced.booleanValue()) {
+            if (Boolean.TRUE.equals(forced)) {
                 forcedDecimal = true;
             }
         }
@@ -286,7 +286,7 @@ public abstract class WFSGetFeatureOutputFormat extends WFSResponse {
                             catalog,
                             (FeatureCollection) featureCollections.get(i),
                             fti -> fti.getEncodeMeasures());
-            if (measures != null && !measures.booleanValue()) {
+            if (Boolean.FALSE.equals(measures)) {
                 // no measures should be encoded
                 encodeMeasures = false;
             }

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
@@ -117,6 +117,8 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat {
         // one type, we really need to set it on the feature level
         int srs = -1;
         int numDecimals = -1;
+        boolean padWithZeros = false;
+        boolean forcedDecimal = false;
         for (int i = 0; i < results.getFeature().size(); i++) {
             // FeatureResults features = (FeatureResults) f.next();
             FeatureCollection features = (FeatureCollection) results.getFeature().get(i);
@@ -175,6 +177,14 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat {
                     numDecimals =
                             numDecimals == -1 ? ftiDecimals : Math.max(numDecimals, ftiDecimals);
                 }
+                boolean pad = ((FeatureTypeInfo) meta).getPadWithZeros();
+                if (pad) {
+                    padWithZeros = true;
+                }
+                boolean force = ((FeatureTypeInfo) meta).getForcedDecimal();
+                if (force) {
+                    forcedDecimal = true;
+                }
             }
         }
 
@@ -188,6 +198,8 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat {
 
         transformer.setIndentation(wfs.isVerbose() ? INDENT_SIZE : (NO_FORMATTING));
         transformer.setNumDecimals(numDecimals);
+        transformer.setPadWithZeros(padWithZeros);
+        transformer.setForceDecimalEncoding(forcedDecimal);
         transformer.setFeatureBounding(wfs.isFeatureBounding());
         transformer.setCollectionBounding(wfs.isFeatureBounding());
         transformer.setEncoding(Charset.forName(settings.getCharset()));

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3FeatureTransformer.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3FeatureTransformer.java
@@ -45,13 +45,22 @@ public class GML3FeatureTransformer extends FeatureTransformer {
         }
 
         protected GeometryTranslator createGeometryTranslator(
-                ContentHandler handler, int numDecimals) {
-            return new GML3GeometryTranslator(handler, numDecimals);
+                ContentHandler handler,
+                int numDecimals,
+                boolean padWithZeros,
+                boolean forceDecimalEncoding) {
+            return new GML3GeometryTranslator(
+                    handler, numDecimals, padWithZeros, forceDecimalEncoding);
         }
 
         protected GeometryTranslator createGeometryTranslator(
-                ContentHandler handler, int numDecimals, boolean useDummyZ) {
-            return new GML3GeometryTranslator(handler, numDecimals, useDummyZ);
+                ContentHandler handler,
+                int numDecimals,
+                boolean padWithZeros,
+                boolean forceDecimalEncoding,
+                boolean useDummyZ) {
+            return new GML3GeometryTranslator(
+                    handler, numDecimals, padWithZeros, forceDecimalEncoding, useDummyZ);
         }
 
         protected Attributes encodeFeatureId(SimpleFeature f) {

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3GeometryTranslator.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3GeometryTranslator.java
@@ -21,6 +21,23 @@ public class GML3GeometryTranslator extends GeometryTranslator {
         super(handler, numDecimals);
     }
 
+    public GML3GeometryTranslator(
+            ContentHandler handler,
+            int numDecimals,
+            boolean padWithZeros,
+            boolean forceDecimalEncoding,
+            boolean useDummyZ) {
+        super(handler, numDecimals, padWithZeros, forceDecimalEncoding, useDummyZ);
+    }
+
+    public GML3GeometryTranslator(
+            ContentHandler handler,
+            int numDecimals,
+            boolean padWithZeros,
+            boolean forceDecimalEncoding) {
+        super(handler, numDecimals, padWithZeros, forceDecimalEncoding);
+    }
+
     protected String boxName() {
         return "Envelope";
     }

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
@@ -125,6 +125,8 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
         List featureCollections = results.getFeature();
 
         int numDecimals = getNumDecimals(featureCollections, geoServer, catalog);
+        boolean padWithZeros = getPadWithZeros(featureCollections, geoServer, catalog);
+        boolean forcedDecimal = getForcedDecimal(featureCollections, geoServer, catalog);
 
         GetFeatureRequest request = GetFeatureRequest.adapt(getFeature.getParameters()[0]);
 
@@ -230,7 +232,8 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
 
         Configuration configuration = customizeConfiguration(this.configuration, ns2metas, gft);
         boolean encodeMeasures = encodeMeasures(featureCollections, catalog);
-        updateConfiguration(configuration, numDecimals, encodeMeasures);
+        updateConfiguration(
+                configuration, numDecimals, padWithZeros, forcedDecimal, encodeMeasures);
         Encoder encoder = createEncoder(configuration, ns2metas, gft);
 
         encoder.setEncoding(Charset.forName(geoServer.getSettings().getCharset()));
@@ -310,11 +313,17 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
     }
 
     protected void updateConfiguration(
-            Configuration configuration, int numDecimals, boolean encodeMeasures) {
+            Configuration configuration,
+            int numDecimals,
+            boolean padWithZeros,
+            boolean forcedDecimal,
+            boolean encodeMeasures) {
         // GML 3.1. configuration
         GMLConfiguration gml31 = configuration.getDependency(GMLConfiguration.class);
         if (gml31 != null) {
             gml31.setNumDecimals(numDecimals);
+            gml31.setPadWithZeros(padWithZeros);
+            gml31.setForceDecimalEncoding(forcedDecimal);
             gml31.setEncodeMeasures(encodeMeasures);
             return;
         }
@@ -323,6 +332,8 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
                 configuration.getDependency(org.geotools.gml3.v3_2.GMLConfiguration.class);
         if (gml32 != null) {
             gml32.setNumDecimals(numDecimals);
+            gml32.setPadWithZeros(padWithZeros);
+            gml32.setForceDecimalEncoding(forcedDecimal);
             gml32.setEncodeMeasures(encodeMeasures);
         }
     }

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
@@ -14,10 +14,47 @@ import org.geoserver.data.test.MockData;
 import org.geoserver.wfs.WFSTestSupport;
 import org.geotools.feature.NameImpl;
 import org.geotools.wfs.v2_0.WFS;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
 public class GMLOutputFormatTest extends WFSTestSupport {
+    private int defaultNumDecimals = -1;
+    private boolean defaultForceDecimal = false;
+    private boolean defaultPadWithZeros = false;
+
+    @Before
+    public void saveDefaultFormattingOptions() {
+        if (defaultNumDecimals < 0) {
+            FeatureTypeInfo info =
+                    getGeoServer()
+                            .getCatalog()
+                            .getResourceByName(
+                                    new NameImpl(
+                                            MockData.BASIC_POLYGONS.getPrefix(),
+                                            MockData.BASIC_POLYGONS.getLocalPart()),
+                                    FeatureTypeInfo.class);
+            defaultNumDecimals = info.getNumDecimals();
+            defaultForceDecimal = info.getForcedDecimal();
+            defaultPadWithZeros = info.getPadWithZeros();
+        }
+    }
+
+    @After
+    public void restoreDefaultFormattingOptions() {
+        FeatureTypeInfo info =
+                getGeoServer()
+                        .getCatalog()
+                        .getResourceByName(
+                                new NameImpl(
+                                        MockData.BASIC_POLYGONS.getPrefix(),
+                                        MockData.BASIC_POLYGONS.getLocalPart()),
+                                FeatureTypeInfo.class);
+        info.setNumDecimals(defaultNumDecimals);
+        info.setForcedDecimal(defaultForceDecimal);
+        info.setPadWithZeros(defaultPadWithZeros);
+    }
 
     @Test
     public void testGML2() throws Exception {

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
@@ -9,8 +9,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.wfs.WFSTestSupport;
+import org.geotools.feature.NameImpl;
 import org.geotools.wfs.v2_0.WFS;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -58,6 +60,35 @@ public class GMLOutputFormatTest extends WFSTestSupport {
         assertEquals("FeatureCollection", dom.getDocumentElement().getLocalName());
         assertNotNull(getFirstElementByTagName(dom, "gml:outerBoundaryIs"));
         assertNull(getFirstElementByTagName(dom, "gml:exterior"));
+    }
+
+    @Test
+    public void testGML2CoordinatesFormatting() throws Exception {
+        enableCoordinatesFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml2&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        assertEquals(
+                "-2.0000,-1.0000 2.0000,6.0000",
+                dom.getElementsByTagName("gml:coordinates").item(0).getTextContent());
+    }
+
+    private void enableCoordinatesFormatting() {
+        FeatureTypeInfo info =
+                getGeoServer()
+                        .getCatalog()
+                        .getResourceByName(
+                                new NameImpl(
+                                        MockData.BASIC_POLYGONS.getPrefix(),
+                                        MockData.BASIC_POLYGONS.getLocalPart()),
+                                FeatureTypeInfo.class);
+        info.setNumDecimals(4);
+        info.setForcedDecimal(true);
+        info.setPadWithZeros(true);
+        getGeoServer().getCatalog().save(info);
     }
 
     @Test
@@ -120,6 +151,20 @@ public class GMLOutputFormatTest extends WFSTestSupport {
     }
 
     @Test
+    public void testGML3CoordinatesFormatting() throws Exception {
+        enableCoordinatesFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml3&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        assertEquals(
+                "-1.0000 0.0000 0.0000 1.0000 1.0000 0.0000 0.0000 -1.0000 -1.0000 0.0000",
+                dom.getElementsByTagName("gml:posList").item(0).getTextContent());
+    }
+
+    @Test
     public void testGML32() throws Exception {
         Document dom =
                 getAsDOM(
@@ -129,5 +174,19 @@ public class GMLOutputFormatTest extends WFSTestSupport {
                                 + MockData.BASIC_POLYGONS.getLocalPart());
         assertEquals(WFS.NAMESPACE, dom.getDocumentElement().getNamespaceURI());
         assertEquals("FeatureCollection", dom.getDocumentElement().getLocalName());
+    }
+
+    @Test
+    public void testGML32CoordinatesFormatting() throws Exception {
+        enableCoordinatesFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=2.0.0&outputFormat=gml32&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        assertEquals(
+                "0.0000 -1.0000 1.0000 0.0000 0.0000 1.0000 -1.0000 0.0000 0.0000 -1.0000",
+                dom.getElementsByTagName("gml:posList").item(0).getTextContent());
     }
 }


### PR DESCRIPTION
Enables configuration of new formatting options introduced with GEOT-6119 for WFS GML output formats