### PR TITLE
[GEOS-8944] GWC fails to cache tiles if GeoFence with source IP driven rules are used for authentication

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/HttpRequestRecorderCallback.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/HttpRequestRecorderCallback.java
@@ -1,0 +1,37 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.geoserver.ows.AbstractDispatcherCallback;
+import org.geoserver.ows.Request;
+
+/** Integration tests support class that keeps track of the requests send to the dispatcher. */
+public final class HttpRequestRecorderCallback extends AbstractDispatcherCallback {
+
+    static List<HttpServletRequest> requests = new ArrayList<>();
+
+    public static void reset() {
+        synchronized (requests) {
+            requests.clear();
+        }
+    }
+
+    public static ArrayList<HttpServletRequest> getRequests() {
+        synchronized (requests) {
+            return new ArrayList<>(requests);
+        }
+    }
+
+    @Override
+    public Request init(Request request) {
+        synchronized (requests) {
+            requests.add(request.getHttpRequest());
+        }
+        return super.init(request);
+    }
+}

--- a/src/gwc/src/test/resources/gwc-integration-test.xml
+++ b/src/gwc/src/test/resources/gwc-integration-test.xml
@@ -8,5 +8,6 @@
 <beans>
 
   <bean id="balancedRequestTester" class="org.geoserver.gwc.BalancedRequestTester"/>
+  <bean id="requestRecorder" class="org.geoserver.gwc.HttpRequestRecorderCallback"/>
 
 </beans>


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8944