### PR TITLE
[GEOS-8944] GWC fails to cache tiles if GeoFence with source IP driven rules are used for authentication (backport 2.13.x)

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -7,6 +7,7 @@ package org.geoserver.gwc;
 
 import static org.geoserver.data.test.MockData.BASIC_POLYGONS;
 import static org.geoserver.gwc.GWC.tileLayerName;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.greaterThan;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.namespace.QName;
 import org.apache.commons.httpclient.util.DateUtil;
@@ -182,6 +184,9 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
                 "BasicPolygonsNoCrs.properties",
                 this.getClass(),
                 catalog);
+
+        // clean up the recorded http requests
+        HttpRequestRecorderCallback.reset();
     }
 
     protected GridSet namedGridsetCopy(final String newName, final GridSet oldGridset) {
@@ -761,6 +766,38 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
         assertTrue(
                 response.getContentAsString(),
                 response.getContentAsString().contains("Could not find layer cdf:BasicPolygons"));
+    }
+
+    @Test
+    public void testDirectWMSIntegrationCustomHost() throws Exception {
+        final GWC gwc = GWC.get();
+        gwc.getConfig().setDirectWMSIntegrationEnabled(true);
+
+        final String layerName = BASIC_POLYGONS.getPrefix() + ":" + BASIC_POLYGONS.getLocalPart();
+
+        String requestURL = buildGetMap(true, layerName, "EPSG:4326", null) + "&tiled=true";
+        MockHttpServletRequest request = createRequest(requestURL);
+        request.setMethod("GET");
+        request.setContent(new byte[] {});
+        final String THE_HOST = "foobar";
+        request.setRemoteHost(THE_HOST);
+        MockHttpServletResponse response = dispatch(request, null);
+
+        // check everything went as expected
+        assertEquals(200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+        assertEquals(layerName, response.getHeader("geowebcache-layer"));
+        assertEquals("[0, 0, 0]", response.getHeader("geowebcache-tile-index"));
+        assertEquals("-180.0,-90.0,0.0,90.0", response.getHeader("geowebcache-tile-bounds"));
+        assertEquals("EPSG:4326", response.getHeader("geowebcache-gridset"));
+        assertEquals("EPSG:4326", response.getHeader("geowebcache-crs"));
+
+        // check we have the two requests recorded, and the
+        ArrayList<HttpServletRequest> requests = HttpRequestRecorderCallback.getRequests();
+        assertEquals(2, requests.size());
+        assertThat(requests.get(1), instanceOf(FakeHttpServletRequest.class));
+        FakeHttpServletRequest fake = (FakeHttpServletRequest) requests.get(1);
+        assertEquals(THE_HOST, fake.getRemoteHost());
     }
 
     @Test

--- a/src/gwc/src/test/java/org/geoserver/gwc/HttpRequestRecorderCallback.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/HttpRequestRecorderCallback.java
@@ -1,0 +1,37 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.geoserver.ows.AbstractDispatcherCallback;
+import org.geoserver.ows.Request;
+
+/** Integration tests support class that keeps track of the requests send to the dispatcher. */
+public final class HttpRequestRecorderCallback extends AbstractDispatcherCallback {
+
+    static List<HttpServletRequest> requests = new ArrayList<>();
+
+    public static void reset() {
+        synchronized (requests) {
+            requests.clear();
+        }
+    }
+
+    public static ArrayList<HttpServletRequest> getRequests() {
+        synchronized (requests) {
+            return new ArrayList<>(requests);
+        }
+    }
+
+    @Override
+    public Request init(Request request) {
+        synchronized (requests) {
+            requests.add(request.getHttpRequest());
+        }
+        return super.init(request);
+    }
+}

--- a/src/gwc/src/test/resources/gwc-integration-test.xml
+++ b/src/gwc/src/test/resources/gwc-integration-test.xml
@@ -8,5 +8,6 @@
 <beans>
 
   <bean id="balancedRequestTester" class="org.geoserver.gwc.BalancedRequestTester"/>
+  <bean id="requestRecorder" class="org.geoserver.gwc.HttpRequestRecorderCallback"/>
 
 </beans>


### PR DESCRIPTION
**Backport of: https://github.com/geoserver/geoserver/pull/3126**

Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8944