### PR TITLE
[GEOS-8955] Disable docs for Resumable REST and REST mapper.

### DIFF
--- a/doc/en/user/source/community/index.rst
+++ b/doc/en/user/source/community/index.rst
@@ -25,12 +25,10 @@ officially part of the GeoServer releases. They are however built along with the
    jdbcconfig/index
    mbtiles/index
    geopkg/index
-   rest/index
    pgraster/pgraster
    wps-download/index
    jms-cluster/index
    solr/index
-   rest-upload/index
    geomesa/index
    gwc-distributed/index
    gdal/index
@@ -52,3 +50,8 @@ officially part of the GeoServer releases. They are however built along with the
    monitor-hibernate/index
    taskmanager/index
    qose-module/index
+
+.. Temporarily disabled (see src/community/pom.xml)
+   rest-upload/index
+   rest/index
+   


### PR DESCRIPTION
The community modules have been disabled for a couple of years, this makes the docs consistent.