### PR TITLE
[GEOS-8875] Implement FIDs for Mapbox vector tiles

### DIFF
--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilder.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilder.java
@@ -9,16 +9,19 @@ import static org.geoserver.wms.mapbox.MapBoxTileBuilderFactory.MIME_TYPE;
 import java.awt.Rectangle;
 import java.io.IOException;
 import java.util.Map;
+import java.util.logging.Logger;
 import no.ecc.vectortile.VectorTileEncoder;
 import no.ecc.vectortile.VectorTileEncoderNoClip;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.map.RawMap;
 import org.geoserver.wms.vector.VectorTileBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Geometry;
 
 /** @author Niels Charlier */
 public class MapBoxTileBuilder implements VectorTileBuilder {
+    private static final Logger LOGGER = Logging.getLogger(MapBoxTileBuilder.class);
 
     private VectorTileEncoder encoder;
 
@@ -36,8 +39,19 @@ public class MapBoxTileBuilder implements VectorTileBuilder {
             String geometryName,
             Geometry geometry,
             Map<String, Object> properties) {
+        int id = -1;
+        if (featureId.matches(".*\\.[0-9]+")) {
+            try {
+                id = Integer.parseInt(featureId.split("\\.")[1]);
+            } catch (NumberFormatException e) {
+            }
+        }
 
-        encoder.addFeature(layerName, properties, geometry);
+        if (id < 0) {
+            LOGGER.warning("Cannot obtain numeric id from featureId: " + featureId);
+        }
+
+        encoder.addFeature(layerName, properties, geometry, id);
     }
 
     @Override

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1264,7 +1264,7 @@
     <dependency>
       <groupId>no.ecc.vectortile</groupId>
       <artifactId>java-vector-tile</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.3</version>
     </dependency>
     <dependency>
       <groupId>com.ning</groupId>


### PR DESCRIPTION
In order to make it work I had to execute `mvn install` for the `java-vector-tile` library locally. I guess we need to add version 1.3.3 to the Boundless Maven repo: https://repo.boundlessgeo.com/main/no/ecc/vectortile/java-vector-tile/

Also, I'm a bit unsure about the fid parsing. Currently it only checks `<anything>.<number>` and uses `-1` (interpreted as no FID by the underlying library) if it cannot be parsed. Are there any other possible FIDs that GeoServer can send and that I need to take into account?