### PR TITLE
Fix for WFS 3 MapBox response on /items breaking georeferencing

### DIFF
--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/DefaultWebFeatureService30.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/DefaultWebFeatureService30.java
@@ -37,6 +37,7 @@ import org.geoserver.wfs3.response.CollectionDocument;
 import org.geoserver.wfs3.response.CollectionsDocument;
 import org.geoserver.wfs3.response.ConformanceDocument;
 import org.geoserver.wfs3.response.LandingPageDocument;
+import org.geoserver.wfs3.response.TilingSchemeDescriptionDocument;
 import org.geoserver.wfs3.response.TilingSchemesDocument;
 import org.geotools.util.logging.Logging;
 import org.geowebcache.config.DefaultGridsets;
@@ -190,5 +191,11 @@ public class DefaultWebFeatureService30 implements WebFeatureService30 {
         FeatureCollectionResponse response = gf.run(new GetFeatureRequest.WFS20(request));
 
         return response;
+    }
+
+    @Override
+    public TilingSchemeDescriptionDocument describeTilingScheme(
+            TilingSchemeDescriptionRequest request) {
+        return new TilingSchemeDescriptionDocument(geoServer, request.getGridSet());
     }
 }

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/TileDataRequest.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/TileDataRequest.java
@@ -5,6 +5,7 @@
 package org.geoserver.wfs3;
 
 import org.apache.commons.lang3.StringUtils;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 
 /** Current tiling request scope data, for context propagation */
 public class TileDataRequest {
@@ -13,6 +14,7 @@ public class TileDataRequest {
     private Long level;
     private Long row;
     private Long col;
+    private ReferencedEnvelope bboxEnvelope;
 
     public TileDataRequest() {}
 
@@ -50,5 +52,13 @@ public class TileDataRequest {
 
     public void setCol(Long col) {
         this.col = col;
+    }
+
+    public ReferencedEnvelope getBboxEnvelope() {
+        return bboxEnvelope;
+    }
+
+    public void setBboxEnvelope(ReferencedEnvelope bboxEnvelope) {
+        this.bboxEnvelope = bboxEnvelope;
     }
 }

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/TilingSchemeDescriptionRequest.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/TilingSchemeDescriptionRequest.java
@@ -1,0 +1,20 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3;
+
+import org.geowebcache.grid.GridSet;
+
+public class TilingSchemeDescriptionRequest extends BaseRequest {
+
+    private GridSet gridSet;
+
+    public GridSet getGridSet() {
+        return gridSet;
+    }
+
+    public void setGridSet(GridSet gridSet) {
+        this.gridSet = gridSet;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/WFS3Filter.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/WFS3Filter.java
@@ -105,6 +105,11 @@ public class WFS3Filter implements GeoServerFilter {
                 request = "api";
             } else if (pathInfo.endsWith("/conformance") || pathInfo.endsWith("/conformance/")) {
                 request = "conformance";
+            } else if (pathInfo.matches("/tilingSchemes/([^/]+)/?")) {
+                request = "describeTilingScheme";
+                Matcher matcher = Pattern.compile("/tilingSchemes/([^/]+)/?").matcher(pathInfo);
+                boolean matches = matcher.matches();
+                this.tilingScheme = matcher.group(1);
             } else if (pathInfo.startsWith("/collections")) {
                 List<Function<String, Boolean>> matchers = new ArrayList<>();
                 matchers.add(

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/WebFeatureService30.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/WebFeatureService30.java
@@ -10,6 +10,7 @@ import org.geoserver.wfs3.response.CollectionDocument;
 import org.geoserver.wfs3.response.CollectionsDocument;
 import org.geoserver.wfs3.response.ConformanceDocument;
 import org.geoserver.wfs3.response.LandingPageDocument;
+import org.geoserver.wfs3.response.TilingSchemeDescriptionDocument;
 import org.geoserver.wfs3.response.TilingSchemesDocument;
 import org.geotools.util.Version;
 
@@ -67,6 +68,9 @@ public interface WebFeatureService30 {
 
     /** Tiling Schemes available list */
     TilingSchemesDocument tilingSchemes(TilingSchemesRequest request);
+
+    /** Tiling Scheme detail */
+    TilingSchemeDescriptionDocument describeTilingScheme(TilingSchemeDescriptionRequest request);
 
     /** Queries Features for the requested tile coordinate */
     FeatureCollectionResponse getTile(GetFeatureType request);

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/GetFeatureKvpRequestReader.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/GetFeatureKvpRequestReader.java
@@ -100,8 +100,12 @@ public class GetFeatureKvpRequestReader extends org.geoserver.wfs.kvp.GetFeature
             filters.add(filterFactory.id(ids));
         }
         if (kvp.containsKey("bbox")) {
-            Filter bboxFilter = bboxFilter(kvp.get("bbox"));
+            Object bbox = kvp.get("bbox");
+            Filter bboxFilter = bboxFilter(bbox);
             filters.add(bboxFilter);
+            // trace requested bbox envelope for use on MVT output crop
+            if (bbox instanceof ReferencedEnvelope)
+                tileData.setBboxEnvelope((ReferencedEnvelope) bbox);
         }
         if (kvp.containsKey("time")) {
             Object timeSpecification = kvp.get("time");

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/TilingSchemeDetailKVPReader.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/kvp/TilingSchemeDetailKVPReader.java
@@ -1,0 +1,26 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3.kvp;
+
+import java.util.Map;
+import org.geoserver.wfs3.TilingSchemeDescriptionRequest;
+import org.geowebcache.grid.GridSet;
+
+public class TilingSchemeDetailKVPReader extends BaseKvpRequestReader {
+
+    public TilingSchemeDetailKVPReader() {
+        super(TilingSchemeDescriptionRequest.class);
+    }
+
+    @Override
+    public Object read(Object request, Map kvp, Map rawKvp) throws Exception {
+        TilingSchemeDescriptionRequest req =
+                (TilingSchemeDescriptionRequest) super.read(request, kvp, rawKvp);
+        if (kvp.containsKey("tilingScheme")) {
+            req.setGridSet((GridSet) kvp.get("tilingScheme"));
+        }
+        return req;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/BoundingBoxDocument.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/BoundingBoxDocument.java
@@ -1,0 +1,60 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3.response;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+public class BoundingBoxDocument {
+
+    private String crs;
+    private String lowerCorner;
+    private String upperCorner;
+    private String type = "BoundingBox";
+
+    public BoundingBoxDocument() {}
+
+    public BoundingBoxDocument(String crs, String lowerCorner, String upperCorner) {
+        super();
+        this.crs = crs;
+        this.lowerCorner = lowerCorner;
+        this.upperCorner = upperCorner;
+    }
+
+    @JacksonXmlProperty(localName = "crs")
+    public String getCrs() {
+        return crs;
+    }
+
+    public void setCrs(String crs) {
+        this.crs = crs;
+    }
+
+    @JacksonXmlProperty(localName = "lowerCorner")
+    public String getLowerCorner() {
+        return lowerCorner;
+    }
+
+    public void setLowerCorner(String lowerCorner) {
+        this.lowerCorner = lowerCorner;
+    }
+
+    @JacksonXmlProperty(localName = "upperCorner")
+    public String getUpperCorner() {
+        return upperCorner;
+    }
+
+    public void setUpperCorner(String upperCorner) {
+        this.upperCorner = upperCorner;
+    }
+
+    @JacksonXmlProperty(localName = "type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TileMatrixDocument.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TileMatrixDocument.java
@@ -1,0 +1,93 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3.response;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+public class TileMatrixDocument {
+
+    private Long matrixHeight;
+    private Long matrixWidth;
+    private Integer tileHeight;
+    private Integer tileWidht;
+    private String identifier;
+    private Double scaleDenominator;
+    private String topLeftCorner;
+    private String type = "TileMatrix";
+
+    public TileMatrixDocument() {}
+
+    @JacksonXmlProperty(localName = "MatrixHeight")
+    public Long getMatrixHeight() {
+        return matrixHeight;
+    }
+
+    public void setMatrixHeight(Long matrixHeight) {
+        this.matrixHeight = matrixHeight;
+    }
+
+    @JacksonXmlProperty(localName = "MatrixWidth")
+    public Long getMatrixWidth() {
+        return matrixWidth;
+    }
+
+    public void setMatrixWidth(Long matrixWidth) {
+        this.matrixWidth = matrixWidth;
+    }
+
+    @JacksonXmlProperty(localName = "tileHeight")
+    public Integer getTileHeight() {
+        return tileHeight;
+    }
+
+    public void setTileHeight(Integer tileHeight) {
+        this.tileHeight = tileHeight;
+    }
+
+    @JacksonXmlProperty(localName = "tileWidht")
+    public Integer getTileWidht() {
+        return tileWidht;
+    }
+
+    public void setTileWeidht(Integer tileWidht) {
+        this.tileWidht = tileWidht;
+    }
+
+    @JacksonXmlProperty(localName = "identifier")
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    @JacksonXmlProperty(localName = "scaleDenominator")
+    public Double getScaleDenominator() {
+        return scaleDenominator;
+    }
+
+    public void setScaleDenominator(Double scaleDenominator) {
+        this.scaleDenominator = scaleDenominator;
+    }
+
+    @JacksonXmlProperty(localName = "topLeftCorner")
+    public String getTopLeftCorner() {
+        return topLeftCorner;
+    }
+
+    public void setTopLeftCorner(String topLeftCorner) {
+        this.topLeftCorner = topLeftCorner;
+    }
+
+    @JacksonXmlProperty(localName = "type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemeDescriptionDocument.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemeDescriptionDocument.java
@@ -1,0 +1,84 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs3.response;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.config.GeoServer;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.Grid;
+import org.geowebcache.grid.GridSet;
+
+/** The object representing the list of available tiling schemes */
+@JacksonXmlRootElement(localName = "TilingSchemeDescription")
+public class TilingSchemeDescriptionDocument {
+
+    private final GeoServer geoServer;
+    private final GridSet gridSet;
+
+    public TilingSchemeDescriptionDocument(GeoServer geoServer, GridSet gridSet) {
+        this.geoServer = geoServer;
+        this.gridSet = gridSet;
+    }
+
+    @JacksonXmlProperty(localName = "identifier")
+    public String getIdentifier() {
+        return gridSet.getName();
+    }
+
+    @JacksonXmlProperty(localName = "supportedCRS")
+    public String getSupportedCRS() {
+        return gridSet.getSrs().toString();
+    }
+
+    @JacksonXmlProperty(localName = "title")
+    public String getTitle() {
+        return gridSet.getName();
+    }
+
+    @JacksonXmlProperty(localName = "type")
+    public String getType() {
+        return "TileMatrixSet";
+    }
+
+    @JacksonXmlProperty(localName = "wellKnownScaleSet")
+    public String getWellKnownScaleSet() {
+        return "http://www.opengis.net/def/wkss/OGC/1.0/" + gridSet.getName();
+    }
+
+    @JacksonXmlProperty(localName = "boundingBox")
+    public BoundingBoxDocument getBoundingBox() {
+        BoundingBox bbox = gridSet.getBounds();
+        BoundingBoxDocument bboxDoc = new BoundingBoxDocument();
+        bboxDoc.setLowerCorner(String.format("%f %f", bbox.getMinX(), bbox.getMinY()));
+        bboxDoc.setUpperCorner(String.format("%f %f", bbox.getMaxX(), bbox.getMaxY()));
+        bboxDoc.setCrs("http://www.opengis.net/def/crs/EPSG/0/" + gridSet.getSrs().getNumber());
+        return bboxDoc;
+    }
+
+    @JacksonXmlProperty(localName = "TileMatrix")
+    public List<TileMatrixDocument> getTileMatrix() {
+        List<TileMatrixDocument> tileMatrix = new ArrayList<>();
+        for (Integer i = 0; i < gridSet.getNumLevels(); i++) {
+            Grid grid = gridSet.getGrid(i);
+            TileMatrixDocument tm = new TileMatrixDocument();
+            tm.setIdentifier(i.toString());
+            tm.setMatrixHeight(grid.getNumTilesHigh());
+            tm.setMatrixWidth(grid.getNumTilesWide());
+            tm.setScaleDenominator(grid.getScaleDenominator());
+            tm.setTileHeight(256);
+            tm.setTileWeidht(256);
+            tm.setTopLeftCorner(
+                    String.format(
+                            "%f %f",
+                            gridSet.getOrderedTopLeftCorner(i)[0],
+                            gridSet.getOrderedTopLeftCorner(i)[1]));
+            tileMatrix.add(tm);
+        }
+        return tileMatrix;
+    }
+}

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemeDetailResponse.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemeDetailResponse.java
@@ -1,0 +1,16 @@
+package org.geoserver.wfs3.response;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.platform.Operation;
+
+public class TilingSchemeDetailResponse extends JacksonResponse {
+
+    public TilingSchemeDetailResponse(GeoServer gs) {
+        super(gs, TilingSchemeDescriptionDocument.class);
+    }
+
+    @Override
+    protected String getFileName(Object value, Operation operation) {
+        return "tilingSchemeDetail";
+    }
+}

--- a/src/community/wfs3/src/main/resources/applicationContext.xml
+++ b/src/community/wfs3/src/main/resources/applicationContext.xml
@@ -28,6 +28,7 @@
         <value>collection</value>
         <value>GetFeature</value> <!-- this allows to re-use the WFS 2.0 machinery for getting features -->
         <value>tilingSchemes</value>
+        <value>describeTilingScheme</value>
         <value>getTile</value>
       </list>
     </constructor-arg>
@@ -95,6 +96,8 @@
     <property name="tileData" ref="wfs3TileDataRequest" />
   </bean>
   <bean id="tilingSchemesKvpRequestReader" class="org.geoserver.wfs3.kvp.TilingSchemesKVPReader"/>
+  <bean id="tilingSchemeDetailKvpRequestReader" class="org.geoserver.wfs3.kvp.TilingSchemeDetailKVPReader"/>
+  
   <!-- response generation -->
   <bean id="openAPIResponse" class="org.geoserver.wfs3.response.OpenAPIResponse">
     <constructor-arg ref="geoServer"/>
@@ -146,6 +149,9 @@
     <property name="gridSets" ref="wfs3DefaultGridsets" />
   </bean>
   <bean id="tilingSchemesResponse" class="org.geoserver.wfs3.response.TilingSchemesResponse">
+    <constructor-arg ref="geoServer"/>
+  </bean>
+  <bean id="tilingSchemeDetailResponse" class="org.geoserver.wfs3.response.TilingSchemeDetailResponse">
     <constructor-arg ref="geoServer"/>
   </bean>
 

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetFeatureMapboxOutputFormatTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetFeatureMapboxOutputFormatTest.java
@@ -62,4 +62,28 @@ public class GetFeatureMapboxOutputFormatTest extends WFS3TestSupport {
                 "LINESTRING (134.0928 90.6752, 170.6752 74.6752, 213.3248 53.3248)",
                 featuresList.get(1).getGeometry().toText());
     }
+
+    /** Tests mapbox protobuf encoding for features in items, with bbox filter */
+    @Test
+    public void testItemsFeatureBuildingsBBOX() throws Exception {
+        // get ptb inputstream
+        String roadSegments = getEncodedName(MockData.BUILDINGS);
+        // real building bbox is BBOX=0.002,0.001,0.0024,0.0008
+        // we will crop it to BBOX=0.002,0.001,0.0024,0.0003
+        String path =
+                "wfs3/collections/"
+                        + roadSegments
+                        + "/items?f=application%2Fx-protobuf%3Btype%3Dmapbox-vector&resolution=10000"
+                        + "&BBOX=0.002,0.001,0.0024,0.0003";
+        MockHttpServletResponse response = getAsServletResponse(path);
+        byte[] responseBytes = response.getContentAsByteArray();
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        FeatureIterable fiter = decoder.decode(responseBytes);
+        List<Feature> featuresList = fiter.asList();
+        assertEquals(1, featuresList.size());
+        assertEquals("cite__Buildings", featuresList.get(0).getLayerName());
+        assertEquals(
+                "POLYGON ((0 73.1392, 0 0, 256 0, 256 73.1392, 0 73.1392))",
+                featuresList.get(0).getGeometry().toText());
+    }
 }

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/TilingSchemesTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/TilingSchemesTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.wfs3;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.jayway.jsonpath.DocumentContext;
@@ -23,5 +24,50 @@ public class TilingSchemesTest extends WFS3TestSupport {
         assertTrue(schemesSet.contains("GlobalCRS84Geometric"));
         assertTrue(schemesSet.contains("GoogleMapsCompatible"));
         assertTrue(schemesSet.size() == 2);
+    }
+
+    @Test
+    public void testTilingSchemeDescriptionGoogleMapsCompatible() throws Exception {
+        DocumentContext jsonDoc = getAsJSONPath("wfs3/tilingSchemes/GoogleMapsCompatible", 200);
+        assertEquals(
+                "http://www.opengis.net/def/crs/EPSG/0/3857",
+                jsonDoc.read("boundingBox.crs", String.class));
+        assertEquals(
+                "-20037508.340000 -20037508.340000",
+                jsonDoc.read("boundingBox.lowerCorner", String.class));
+        assertEquals(
+                "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible",
+                jsonDoc.read("wellKnownScaleSet", String.class));
+        assertEquals(
+                559082263.9508929d,
+                jsonDoc.read("tileMatrix[0].scaleDenominator", Double.class),
+                0.001d);
+        assertEquals(
+                new Integer(1073741824), jsonDoc.read("tileMatrix[30].matrixWidth", Integer.class));
+    }
+
+    @Test
+    public void testTilingSchemeDescriptionGlobalCRS84Geometric() throws Exception {
+        DocumentContext jsonDoc = getAsJSONPath("wfs3/tilingSchemes/GlobalCRS84Geometric", 200);
+        assertEquals(
+                "http://www.opengis.net/def/crs/EPSG/0/4326",
+                jsonDoc.read("boundingBox.crs", String.class));
+        assertEquals(
+                "-180.000000 -90.000000", jsonDoc.read("boundingBox.lowerCorner", String.class));
+        assertEquals(
+                "http://www.opengis.net/def/wkss/OGC/1.0/GlobalCRS84Geometric",
+                jsonDoc.read("wellKnownScaleSet", String.class));
+        assertEquals(
+                2.795411320143589E8d,
+                jsonDoc.read("tileMatrix[0].scaleDenominator", Double.class),
+                0.000000000000001E8d);
+        assertEquals(
+                new Integer(4194304), jsonDoc.read("tileMatrix[21].matrixWidth", Integer.class));
+    }
+
+    @Test
+    public void testTilingSchemeDescriptionError() throws Exception {
+        DocumentContext jsonDoc = getAsJSONPath("wfs3/tilingSchemes/errorNameX", 500);
+        assertEquals("Invalid gridset name errorNameX", jsonDoc.read("description", String.class));
     }
 }


### PR DESCRIPTION
WFS 3 MapBox response on /items breaks georeferencing, this PR fix this issue.

Detail:
Currently the response encodes using the collection bbox, which might not be the one requested (can be smaller, can be larger). However the client only has the requested bbox to do referencing, so the encoding "area" must perfectly match the requested bbox.