### PR TITLE
Wfs3 tiling scheme description double format locale

### DIFF
--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemeDescriptionDocument.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/TilingSchemeDescriptionDocument.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import org.geoserver.config.GeoServer;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.Grid;
@@ -54,8 +55,8 @@ public class TilingSchemeDescriptionDocument {
     public BoundingBoxDocument getBoundingBox() {
         BoundingBox bbox = gridSet.getBounds();
         BoundingBoxDocument bboxDoc = new BoundingBoxDocument();
-        bboxDoc.setLowerCorner(String.format("%f %f", bbox.getMinX(), bbox.getMinY()));
-        bboxDoc.setUpperCorner(String.format("%f %f", bbox.getMaxX(), bbox.getMaxY()));
+        bboxDoc.setLowerCorner(String.format(Locale.US, "%f %f", bbox.getMinX(), bbox.getMinY()));
+        bboxDoc.setUpperCorner(String.format(Locale.US, "%f %f", bbox.getMaxX(), bbox.getMaxY()));
         bboxDoc.setCrs("http://www.opengis.net/def/crs/EPSG/0/" + gridSet.getSrs().getNumber());
         return bboxDoc;
     }
@@ -74,6 +75,7 @@ public class TilingSchemeDescriptionDocument {
             tm.setTileWeidht(256);
             tm.setTopLeftCorner(
                     String.format(
+                            Locale.US,
                             "%f %f",
                             gridSet.getOrderedTopLeftCorner(i)[0],
                             gridSet.getOrderedTopLeftCorner(i)[1]));

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/TilingSchemesTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/TilingSchemesTest.java
@@ -10,9 +10,26 @@ import static org.junit.Assert.assertTrue;
 import com.jayway.jsonpath.DocumentContext;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TilingSchemesTest extends WFS3TestSupport {
+
+    private Locale originalLocale;
+
+    @Before
+    public void setup() {
+        originalLocale = Locale.getDefault();
+        // locale setting to test coordinate encode on US locale
+        Locale.setDefault(Locale.ITALY);
+    }
+
+    @After
+    public void onFinish() {
+        Locale.setDefault(originalLocale);
+    }
 
     /** Tests the "wfs3/tilingScheme" json response */
     @Test
@@ -63,6 +80,9 @@ public class TilingSchemesTest extends WFS3TestSupport {
                 0.000000000000001E8d);
         assertEquals(
                 new Integer(4194304), jsonDoc.read("tileMatrix[21].matrixWidth", Integer.class));
+        assertEquals(
+                "90.000000 -180.000000",
+                jsonDoc.read("tileMatrix[21].topLeftCorner", String.class));
     }
 
     @Test


### PR DESCRIPTION
This PR fix the problem on tiling scheme description on no-US Locale JVM setting.  Now doubles format are always on Locale.US