### PR TITLE
[GEOS-8957] Clean up remaining doc warnings and switch configuration

### DIFF
--- a/doc/en/build.xml
+++ b/doc/en/build.xml
@@ -45,7 +45,7 @@
   <target name="user" depends="init"
     description="Generate user html documentation for GeoServer">
     <mkdir dir="${build.directory}"/>
-    <antcall target="sphinx-ignore-warnings">
+    <antcall target="sphinx">
       <param name="id" value="user" />
       <param name="build" value="html" />
     </antcall>
@@ -54,7 +54,7 @@
   <target name="user-pdf" depends="init" if="pdflatex.available"
     description="Generate user PDF documentation for GeoServer">
     <mkdir dir="${build.directory}"/>
-    <antcall target="sphinx-ignore-warnings">
+    <antcall target="sphinx">
       <param name="id" value="user" />
       <param name="build" value="latex" />
     </antcall>
@@ -96,12 +96,6 @@
   <target name="full" depends="docguide,user,developer">
   </target>
 
-  <target name="sphinx-ignore-warnings" if="sphinx.available">
-    <exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}/source">
-      <arg line="-D release=${project.version} -q -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
-    </exec>
-  </target>
-    
   <target name="sphinx" if="sphinx.available">
                 <echo message="Running sphinx-build -D release=${project.version} -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/> 
     <exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}/source">

--- a/doc/en/release/user.xml
+++ b/doc/en/release/user.xml
@@ -1,17 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ======================================================================
-       Assembly descriptor for binaries. This descriptor is a modified
-       copy of the Maven "bin" predefined descriptor published there:
-
-       http://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html#bin
-
-       It will creates a "gt2-${project.version}-bin.zip" file.  This file
-       will contains a "gt2-${project.version}" root directory, which will
-       contains every JAR copied by our custom "jar-collector" plugin.
-
-       $Id$
-       $URL$
-     ====================================================================== -->
 <assembly>
   <id>userguide</id>
   <formats>

--- a/doc/en/user/source/community/solr/optimize.rst
+++ b/doc/en/user/source/community/solr/optimize.rst
@@ -30,21 +30,17 @@ With this setup the polygonal geometry will still be used for all spatial filter
 rendering, unless the style otherwise specifical demands for the centroid.
 
 Then, a style with scale dependencies can be setup in order to fetch only then centroids
-when fairly zoomed out, like in the following CSS example:
+when fairly zoomed out, like in the following CSS example: ::
 
-.. code-block:: css
-
-    [@scale > 50000] { 
-      geometry: [centroid]; 
+    [@scale > 50000] {
+      geometry: [centroid];
       mark: symbol(square);
     }
-    
     :mark {
       fill: red;
       size: 3;
     }​
-    
-    [@scale <= 50000] { 
+    [@scale <= 50000] {
       fill: red;
       stroke: black;
     }

--- a/doc/en/user/source/data/app-schema/mongo-tutorial.rst
+++ b/doc/en/user/source/data/app-schema/mongo-tutorial.rst
@@ -13,7 +13,7 @@ The use case for this tutorial will be to serve through app-schema the informati
 
 First of all let's insert some test data in a MongoDB data store:
 
-.. code-block:: json 
+.. code-block:: javascript
 
     db.stations.insert({
         "id": "1",

--- a/doc/en/user/source/data/app-schema/wms-support.rst
+++ b/doc/en/user/source/data/app-schema/wms-support.rst
@@ -143,9 +143,7 @@ If you want to store a separate standard template for complex feature collection
 Read the tutorial on :ref:`tutorial_freemarkertemplate` for more information on how to use the freemarker templates.
 Freemarker templates support recursive calls, which can be useful for templating complex content.
 For example, the following freemarker template creates a table of features with a column for each property, 
-and will create another table inside each cell that contains a feature as property:
-
-.. code-block:: html
+and will create another table inside each cell that contains a feature as property: ::
 
   <#-- 
   Macro's used for content

--- a/doc/en/user/source/rest/api/accesscontrol.rst
+++ b/doc/en/user/source/rest/api/accesscontrol.rst
@@ -134,9 +134,7 @@ Formats for GET,POST and PUT:
    </rules> 
 
 
-**JSON**
-
-.. code-block:: json
+**JSON** ::
 
    {
    "*.*.r": "*",

--- a/doc/en/user/source/rest/api/manifests.rst
+++ b/doc/en/user/source/rest/api/manifests.rst
@@ -57,10 +57,8 @@ Usage
 ~~~~~
 
 
-The model is very simple and is shared between the version and the resource requests to parse both requests.
+The model is very simple and is shared between the version and the resource requests to parse both requests.::
 
-.. code-block:: xml
- 
    <about>
      <resource name="{NAME}">
        <{KEY}>{VALUE}</{KEY}>

--- a/doc/en/user/source/services/wfs/outputformats.rst
+++ b/doc/en/user/source/services/wfs/outputformats.rst
@@ -105,19 +105,20 @@ The JSON output format (and JSONP if enabled) return feature content as a `GeoJS
 The output properties can include the use of lists and maps:
 
 .. code-block:: json
-   
-   {   "type": "Feature",
-       "id": "example.3",
-       "geometry": {
-          "type": "POINT",
-          "coordinates": [ -75.70742, 38.557476 ],
-       },
-       "geometry_name": "geom",
-       "properties": {
-            "CONDITION": "Orange",
-            "RANGE": ​{"min":"37","max":"93"}
-       }
-   }
+
+    {
+      "type": "Feature",
+      "id": "example.3",
+      "geometry": {
+        "type": "POINT",
+        "coordinates": [ -75.70742, 38.557476 ],
+      },
+      "geometry_name": "geom",
+      "properties": {
+        "CONDITION": "Orange",
+        "RANGE": {"min":"37","max":"93"}
+      }
+    }
 
 JSON output ``format_options``:
 

--- a/doc/en/user/source/services/wms/googleearth/tutorials/time/time.rst
+++ b/doc/en/user/source/services/wms/googleearth/tutorials/time/time.rst
@@ -98,9 +98,7 @@ When setting up a time template for your own dataset the most important issue is
 
 While GeoServer will try its best to parse the data there are cases in which your data is in a format which it cannot parse. When this occurs it is necessary to explicitly specify the format. Luckily Freemarker provides us with functionality to do just this.
 
-Consider the date time ``12:30 on January 01, 2007`` specified in the following format: ``01?01%2007&12$30!00``. When creating the template we need to explicitly tell Freemarker the format the date time is in with the datetime function.  This is an example time template file (time.ftl) file with explicit formatting:
-
-.. code-block:: html
+Consider the date time ``12:30 on January 01, 2007`` specified in the following format: ``01?01%2007&12$30!00``. When creating the template we need to explicitly tell Freemarker the format the date time is in with the datetime function.  This is an example time template file (time.ftl) file with explicit formatting: ::
 
   ${DATETIME_ATTRIBUTE_NAME.value?datetime("M?d%y&H:m:s")}
 

--- a/doc/en/user/source/services/wms/reference.rst
+++ b/doc/en/user/source/services/wms/reference.rst
@@ -121,10 +121,8 @@ They are fully documented in the :ref:`wms_vendor_parameters` section.
      - request the capabilities document in a certain format
 
 
-A example GetCapabilities request is:
+A example GetCapabilities request is: ::
 
-.. code-block:: xml
- 
    http://localhost:8080/geoserver/wms?
    service=wms&
    version=1.1.1&
@@ -246,9 +244,7 @@ The standard parameters for the GetMap operation are:
 GeoServer provides a number of useful vendor-specific parameters for the GetMap operation.  
 These are documented in the :ref:`wms_vendor_parameters` section.
 
-Example WMS request for ``topp:states`` layer to be output as a PNG map image in SRS EPGS:4326 and using default styling is:
-
-.. code-block:: xml
+Example WMS request for ``topp:states`` layer to be output as a PNG map image in SRS EPGS:4326 and using default styling is: ::
 
    http://localhost:8080/geoserver/wms?
    request=GetMap
@@ -425,9 +421,7 @@ They are fully documented in the :ref:`wms_vendor_parameters` section.
      - No
      - Feature properties to be returned
 
-An example request for feature information from the ``topp:states`` layer in HTML format is:
-
-.. code-block:: xml
+An example request for feature information from the ``topp:states`` layer in HTML format is: ::
 
    http://localhost:8080/geoserver/wms?
    request=GetFeatureInfo
@@ -447,9 +441,7 @@ An example request for feature information from the ``topp:states`` layer in HTM
    &y=145
    &exceptions=application%2Fvnd.ogc.se_xml
 
-An example request for feature information in GeoJSON format is:
-
-.. code-block:: xml
+An example request for feature information in GeoJSON format is: ::
 
    http://localhost:8080/geoserver/wms?
    &INFO_FORMAT=application/json
@@ -579,9 +571,7 @@ The supported formats are:
      - Return a JsonP in the form: paddingOutput(...jsonp...). See :ref:`wms_vendor_parameters` to change the callback name.  Note that this format is disabled by default (See :ref:`wms_global_variables`).
      
 
-An example request in XML (default) format on a layer is:
-
-.. code-block:: xml
+An example request in XML (default) format on a layer is: :
 
    http://localhost:8080/geoserver/topp/wms?service=WMS
    &version=1.1.1
@@ -598,9 +588,7 @@ An example request in XML (default) format on a layer is:
       </LayerDescription>
    </WMS_DescribeLayerResponse>
 
-An example request for feature description in JSON format on a layer group is:
-
-.. code-block:: xml
+An example request for feature description in JSON format on a layer group is: ::
 
    http://localhost:8080/geoserver/wms?service=WMS
    &version=1.1.1
@@ -609,33 +597,31 @@ An example request for feature description in JSON format on a layer group is:
    &outputFormat=application/json
    
 
-The result will be:
+The result will be: ::
 
-.. code-block:: xml
-
-   {
-   version: "1.1.1",
-   layerDescriptions: [
-   {
-      layerName: "sf:roads",
-      owsURL: "http://localhost:8080/geoserver/wfs/WfsDispatcher?",
-      owsType: "WFS",
-      typeName: "sf:roads"
-   },
-   {
-      layerName: "topp:tasmania_roads",
-      owsURL: "http://localhost:8080/geoserver/wfs/WfsDispatcher?",
-      owsType: "WFS",
-      typeName: "topp:tasmania_roads"
-   },
-   {
-      layerName: "nurc:mosaic",
-      owsURL: "http://localhost:8080/geoserver/wcs?",
-      owsType: "WCS",
-      typeName: "nurc:mosaic"
-   }
-   ]
-   }
+  {
+    version: "1.1.1",
+    layerDescriptions: [
+      {
+          layerName: "sf:roads",
+          owsURL: "http://localhost:8080/geoserver/wfs/WfsDispatcher?",
+          owsType: "WFS",
+          typeName: "sf:roads"
+      },
+      {
+          layerName: "topp:tasmania_roads",
+          owsURL: "http://localhost:8080/geoserver/wfs/WfsDispatcher?",
+          owsType: "WFS",
+          typeName: "topp:tasmania_roads"
+      },
+      {
+          layerName: "nurc:mosaic",
+          owsURL: "http://localhost:8080/geoserver/wcs?",
+          owsType: "WCS",
+          typeName: "nurc:mosaic"
+      }
+    ]
+   
 
 
 .. _wms_getlegendgraphic:

--- a/doc/en/user/source/styling/css/cookbook/line.rst
+++ b/doc/en/user/source/styling/css/cookbook/line.rst
@@ -218,7 +218,7 @@ thickness for the main line and a 1 pixel width for the perpendicular hatches.
 Code
 ~~~~
 
-.. code-block:: css 
+.. code-block:: scss
    :linenos:
 
     * { 
@@ -255,7 +255,7 @@ Without using the dash array the lines would be densely populated with dots, eac
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos:
 
     * { 
@@ -311,7 +311,7 @@ Code
 ~~~~
 
 
-.. code-block:: css
+.. code-block:: scss
    :linenos:
 
     * { 

--- a/doc/en/user/source/styling/css/cookbook/point.rst
+++ b/doc/en/user/source/styling/css/cookbook/point.rst
@@ -57,7 +57,7 @@ This example specifies points be styled as red circles with a diameter of 6 pixe
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos: 
 
     * { 
@@ -90,7 +90,7 @@ This example adds a stroke (or border) around the :ref:`css_cookbook_points_simp
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos: 
 
     * { 
@@ -122,7 +122,7 @@ This example creates a square instead of a circle, colors it green, sizes it to 
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos: 
 
     * { 
@@ -153,7 +153,7 @@ This example draws a triangle, creates a black stroke identical to the :ref:`css
 Code
 ~~~~   
 
-.. code-block:: css
+.. code-block:: scss
    :linenos:
 
     * { 
@@ -185,7 +185,7 @@ This example styles each point as a graphic instead of as a simple shape.
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos:
 
     * { 
@@ -218,7 +218,7 @@ This example shows a text label on the :ref:`css_cookbook_points_simplepoint` th
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos:
 
     * { 
@@ -253,7 +253,7 @@ Code
 ~~~~   
 
 
-.. code-block:: css 
+.. code-block:: scss 
    :linenos:
 
     * { 
@@ -293,7 +293,7 @@ This example builds on the previous example, :ref:`css_cookbook_points_pointwith
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos:
 
     * { 
@@ -333,7 +333,7 @@ This example alters the size of the symbol based on the value of the population 
 Code
 ~~~~
 
-.. code-block:: css
+.. code-block:: scss
    :linenos:
 
     * {
@@ -411,7 +411,7 @@ This example alters the style of the points at different zoom levels.
 Code
 ~~~~
 
-.. code-block:: css 
+.. code-block:: scss 
    :linenos:
 
 
@@ -474,7 +474,7 @@ The result of this style is that points are drawn larger as one zooms in and sma
 
 While this example uses on purpose cascading to show a different possible setup, the same style could be written as:
 
-.. code-block:: css 
+.. code-block:: scss 
    :linenos:
 
     * {

--- a/doc/en/user/source/styling/css/cookbook/polygon.rst
+++ b/doc/en/user/source/styling/css/cookbook/polygon.rst
@@ -186,7 +186,7 @@ Code
 ~~~~
 
 
-.. code-block:: css 
+.. code-block:: scss 
    :linenos:
  
     * { 

--- a/doc/en/user/source/styling/css/directives.rst
+++ b/doc/en/user/source/styling/css/directives.rst
@@ -12,7 +12,7 @@ All directives are declared at the beginning of the CSS sheet and follow the sam
   
 For example:
 
-.. code-block:: css
+.. code-block:: scss
 
   @mode 'Flat';
   @styleTitle 'The title;

--- a/doc/en/user/source/styling/css/examples/randomfills.rst
+++ b/doc/en/user/source/styling/css/examples/randomfills.rst
@@ -11,7 +11,7 @@ Simple random distribution
 
 Here is an example distributing up to 50 small "slash" symbols in a 100x100 pixel tile (in case of conflicts the symbol will be skipped), enabling random symbol rotation), and setting the seed to "5" to get a distribution different than the default one:
 
-.. code-block:: css
+.. code-block:: scss
 
     * {
       fill: symbol("shape://slash");
@@ -39,7 +39,7 @@ Thematic map using point density
 
 Randomized distributions can also be used for thematic mapping, for example, here is the SLD for a version of topp:states that displays the number of inhabitantìs varying the density of a random point distribution:
 
-.. code-block:: css
+.. code-block:: scss
 
     * { 
       fill: symbol("circle");

--- a/doc/en/user/source/styling/css/nested.rst
+++ b/doc/en/user/source/styling/css/nested.rst
@@ -3,7 +3,7 @@
 Nested rules
 ============
 
-.. highlight:: css
+.. highlight:: scss
 
 Starting with GeoServer 2.10 the CSS modules supports rule nesting, that is, 
 a child rule can be written among properties of a parent rule.

--- a/doc/en/user/source/styling/css/styledmarks.rst
+++ b/doc/en/user/source/styling/css/styledmarks.rst
@@ -3,7 +3,7 @@
 Styled marks
 ============
 
-.. highlight:: css
+.. highlight:: scss
 
 GeoServer's CSS module provides a collection of predefined symbols that you can
 use and combine to create simple marks, strokes, and fill patterns without

--- a/doc/en/user/source/styling/css/transformation.rst
+++ b/doc/en/user/source/styling/css/transformation.rst
@@ -3,7 +3,7 @@
 Rendering transformations in CSS
 ================================
 
-.. highlight:: css
+.. highlight:: scss
 
 Starting with GeoServer 2.10 the CSS modules supports rendering transformations via the
 ``transform`` property.

--- a/doc/en/user/source/styling/css/tutorial.rst
+++ b/doc/en/user/source/styling/css/tutorial.rst
@@ -268,7 +268,7 @@ The fourth and final rule is a bit different. It applies a label and outline to 
       </TextSymbolizer>
     </Rule>
 
-.. highlight:: css
+.. highlight:: scss
 
 This introduces the idea of rendering an extracted value (``STATE_ABBR``) directly into the map, unlike all of the rules thus far. For this, you can use a CQL expression wrapped in square braces (``[]``) as the value of a CSS property. It is also necessary to surround values containing whitespace, such as ``Times New Roman``, with single- or double-quotes (``"``, ``'``). With these details in mind, let's write the rule::
 

--- a/doc/en/user/source/styling/workshop/mbstyle/linestring.rst
+++ b/doc/en/user/source/styling/workshop/mbstyle/linestring.rst
@@ -104,31 +104,37 @@ We only specified the line layer, so all of the boilerplate arround was generate
 #. Additional properties cane be used fine-tune appearance. Use **line-color** to specify the colour and width of the line.
 
    .. code-block:: json
-      :emphasize-lines: 2
-   
-      "paint": {
-        "line-color": "blue"
+      :emphasize-lines: 3
+
+      {
+        "paint": {
+          "line-color": "blue"
+        }
       }
 
 #. **line-width** lets us make the line wider
 
    .. code-block:: json
-      :emphasize-lines: 3
-   
-      "paint": {
-        "line-color": "blue",
-        "line-width": 2
+      :emphasize-lines: 4
+
+      {
+        "paint": {
+          "line-color": "blue",
+          "line-width": 2
+        }
       }
 
 #. **line-dasharray** applies a dot dash pattern.
 
    .. code-block:: json
-      :emphasize-lines: 4
+      :emphasize-lines: 5
       
-      "paint": {
-        "line-color": "blue",
-        "line-width": 2,
-        "line-dasharray": [5, 2]
+      {
+        "paint": {
+          "line-color": "blue",
+          "line-width": 2,
+          "line-dasharray": [5, 2]
+        }
       }
 
 #. Check the :guilabel:`Map` tab to preview the result.

--- a/doc/en/user/source/styling/workshop/mbstyle/mbstyle.rst
+++ b/doc/en/user/source/styling/workshop/mbstyle/mbstyle.rst
@@ -57,9 +57,7 @@ The following root-level properties are required for all MBStyles. Additional ro
 `layers`    An array of layer style objects
 =========== ========================================================================
 
-For example:
-
- .. code-block:: json
+For example: ::
 
     {
         "version": 8,
@@ -77,15 +75,16 @@ A GeoServer vector tile source would be defined like this:
 
  .. code-block:: json
 
-    "cookbook": {
-      "type": "vector",
-      "tiles": [
-        "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=cookbook&STYLE=&TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector&TILECOL={x}&TILEROW={y}"
-      ],
-      "minZoom": 0,
-      "maxZoom": 14
+    {
+      "cookbook": {
+        "type": "vector",
+        "tiles": [
+          "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=cookbook&STYLE=&TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector&TILECOL={x}&TILEROW={y}"
+        ],
+        "minZoom": 0,
+        "maxZoom": 14
+      }
     }
-
 
 Layers
 ~~~~~~

--- a/doc/en/user/source/styling/workshop/mbstyle/point.rst
+++ b/doc/en/user/source/styling/workshop/mbstyle/point.rst
@@ -722,7 +722,7 @@ Dynamic Styling
    This expression should result in sizes between 5 and 9 and will need to be applied to both point **size** and label **displacement**.
    
    .. code-block:: json
-      :emphasize-lines: 8-15, 30-37
+      :emphasize-lines: 8-15
 
       {
         "id": "point_0",
@@ -742,7 +742,11 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+      :emphasize-lines: 14-21
+
       {
         "id": "point_0_text",
         "type": "symbol",
@@ -766,7 +770,7 @@ Dynamic Styling
           },
         }
       }
-   
+
    .. image:: ../style/img/point_07_expression.png
 
 #. Next we can use ``FEATURECLA`` to check for capital cities.
@@ -797,13 +801,14 @@ Dynamic Styling
    Also add the spritesheet url to the top of the style if it is not present:
 
    .. code-block:: json
-      :emphasize-lines: 3
+      :emphasize-lines: 4
 
-      "version": 8,
-      "name": "point_example",
-      "sprite": "http://localhost:8080/geoserver/styles/sprites",
+      {
+        "version": 8,
+        "name": "point_example",
+        "sprite": "http://localhost:8080/geoserver/styles/sprites",
+      }
 
-   
    And updating the populated places selectors to ignore capital cities:
 
    .. code-block:: json
@@ -828,7 +833,10 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_7_text",
         "type": "symbol",
@@ -853,7 +861,10 @@ Dynamic Styling
             ]
           }
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_5",
         "type": "circle",
@@ -874,7 +885,10 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_5_text",
         "type": "symbol",
@@ -899,7 +913,10 @@ Dynamic Styling
             ]
           }
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_4",
         "type": "circle",
@@ -920,7 +937,10 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_4_text",
         "type": "symbol",
@@ -945,7 +965,10 @@ Dynamic Styling
             ]
           }
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_3",
         "type": "circle",
@@ -959,7 +982,10 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_3_text",
         "type": "symbol",
@@ -984,7 +1010,10 @@ Dynamic Styling
             ]
           }
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_2",
         "type": "circle",
@@ -1005,7 +1034,10 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_2_text",
         "type": "symbol",
@@ -1030,7 +1062,10 @@ Dynamic Styling
             ]
           }
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_1",
         "type": "circle",
@@ -1050,7 +1085,10 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_1_text",
         "type": "symbol",
@@ -1074,7 +1112,10 @@ Dynamic Styling
             ]
           }
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_0",
         "type": "circle",
@@ -1094,7 +1135,10 @@ Dynamic Styling
           "circle-stroke-color": "black",
           "circle-stroke-width": 1
         }
-      },
+      }
+
+   .. code-block:: json
+
       {
         "id": "point_0_text",
         "type": "symbol",

--- a/doc/en/user/source/styling/workshop/ysld/done.rst
+++ b/doc/en/user/source/styling/workshop/ysld/done.rst
@@ -472,9 +472,7 @@ Answer for :ref:`Challenge Layer Group <ysld.point.q3>`:
 
    .. image:: ../style/img/point_challenge_1.png
 
-   This is opportunity to revisit label halo settings from :doc:`polygon`:
-   
-   .. code-block:: css
+   This is opportunity to revisit label halo settings from :doc:`polygon`: ::
 
       symbolizers:
       - point:


### PR DESCRIPTION
This makes use of the scss parser, which seems more tolerant. There are still a couple of cases that aren't parsed and we have no syntax highlighting, but they're minor.