### PR TITLE
GEOS-8958 - ClientStreamAbortedException should be logged at debug level

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/png/PNGJWriter.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/png/PNGJWriter.java
@@ -9,7 +9,6 @@ import ar.com.hjg.pngj.FilterType;
 import it.geosolutions.imageio.plugins.png.PNGWriter;
 import java.awt.image.RenderedImage;
 import java.io.OutputStream;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.WMSMapContent;
@@ -27,81 +26,77 @@ import org.geotools.util.logging.Logging;
  */
 public class PNGJWriter {
 
-    private static final Logger LOGGER = Logging.getLogger(PNGJWriter.class);
+  private static final Logger LOGGER = Logging.getLogger(PNGJWriter.class);
 
-    public RenderedImage writePNG(
-            RenderedImage image, OutputStream outStream, float quality, WMSMapContent mapContent) {
-        // what kind of scaline filtering are we going to use?
-        FilterType filterType = getFilterType(mapContent);
-        // Creation of a new PNGWriter object
-        PNGWriter writer = new PNGWriter();
-        // Check if a Scanline is supported by the writer
-        boolean isScanlineSupported = writer.isScanlineSupported(image);
-        // If it is not supported, then the image is rescaled to bytes
-        if (!isScanlineSupported) {
-            image =
-                    new ImageWorker(image)
-                            .rescaleToBytes()
-                            .forceComponentColorModel()
-                            .getRenderedImage();
-        }
-
-        RenderedImage output = null;
-        // Image writing
-        try {
-            output = writer.writePNG(image, outStream, quality, filterType);
-        } catch (Exception e) {
-            throw new ServiceException("Failed to encode the PNG", e);
-        }
-
-        return output;
+  public RenderedImage writePNG(
+      RenderedImage image, OutputStream outStream, float quality, WMSMapContent mapContent) {
+    // what kind of scaline filtering are we going to use?
+    FilterType filterType = getFilterType(mapContent);
+    // Creation of a new PNGWriter object
+    PNGWriter writer = new PNGWriter();
+    // Check if a Scanline is supported by the writer
+    boolean isScanlineSupported = writer.isScanlineSupported(image);
+    // If it is not supported, then the image is rescaled to bytes
+    if (!isScanlineSupported) {
+      image = new ImageWorker(image).rescaleToBytes().forceComponentColorModel().getRenderedImage();
     }
 
-    /**
-     * SUB filtering is useful for raster images with "high" variation, otherwise we go for NONE,
-     * empirically it provides better compression at lower effort
-     *
-     * @param mapContent
-     */
-    private FilterType getFilterType(WMSMapContent mapContent) {
-        RasterSymbolizerVisitor visitor = new RasterSymbolizerVisitor();
-        for (Layer layer : mapContent.layers()) {
-            // check if the style has a raster symbolizer, don't trust the layer type as
-            // we don't know in advance if there is a rendering transformation
-            // WMS cascading is a ugly case, we might be cascading a map that is vector, but
-            // we don't get to know
-            Style style = layer.getStyle();
-            if (style != null) {
-                style.accept(visitor);
-                if (visitor.highChangeRasterSymbolizer) {
-                    return FilterType.FILTER_SUB;
-                }
-            }
-        }
-
-        return FilterType.FILTER_NONE;
+    RenderedImage output = null;
+    // Image writing
+    try {
+      output = writer.writePNG(image, outStream, quality, filterType);
+    } catch (Exception e) {
+      throw new ServiceException("Failed to encode the PNG", e);
     }
 
-    /**
-     * Check if the style contains a "high change" raster symbolizer, that is, one that generates a
-     * continuous set of values for which SUB filtering provides better results
-     *
-     * @author Andrea Aime - GeoSolutions
-     */
-    class RasterSymbolizerVisitor extends AbstractStyleVisitor {
+    return output;
+  }
 
-        boolean highChangeRasterSymbolizer;
-
-        public void visit(org.geotools.styling.RasterSymbolizer raster) {
-            if (raster.getColorMap() == null) {
-                highChangeRasterSymbolizer = true;
-                return;
-            }
-
-            int cmType = raster.getColorMap().getType();
-            if (cmType != ColorMap.TYPE_INTERVALS && cmType != ColorMap.TYPE_VALUES) {
-                highChangeRasterSymbolizer = true;
-            }
+  /**
+   * SUB filtering is useful for raster images with "high" variation, otherwise we go for NONE,
+   * empirically it provides better compression at lower effort
+   *
+   * @param mapContent
+   */
+  private FilterType getFilterType(WMSMapContent mapContent) {
+    RasterSymbolizerVisitor visitor = new RasterSymbolizerVisitor();
+    for (Layer layer : mapContent.layers()) {
+      // check if the style has a raster symbolizer, don't trust the layer type as
+      // we don't know in advance if there is a rendering transformation
+      // WMS cascading is a ugly case, we might be cascading a map that is vector, but
+      // we don't get to know
+      Style style = layer.getStyle();
+      if (style != null) {
+        style.accept(visitor);
+        if (visitor.highChangeRasterSymbolizer) {
+          return FilterType.FILTER_SUB;
         }
+      }
     }
+
+    return FilterType.FILTER_NONE;
+  }
+
+  /**
+   * Check if the style contains a "high change" raster symbolizer, that is, one that generates a
+   * continuous set of values for which SUB filtering provides better results
+   *
+   * @author Andrea Aime - GeoSolutions
+   */
+  class RasterSymbolizerVisitor extends AbstractStyleVisitor {
+
+    boolean highChangeRasterSymbolizer;
+
+    public void visit(org.geotools.styling.RasterSymbolizer raster) {
+      if (raster.getColorMap() == null) {
+        highChangeRasterSymbolizer = true;
+        return;
+      }
+
+      int cmType = raster.getColorMap().getType();
+      if (cmType != ColorMap.TYPE_INTERVALS && cmType != ColorMap.TYPE_VALUES) {
+        highChangeRasterSymbolizer = true;
+      }
+    }
+  }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/map/png/PNGJWriter.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/png/PNGJWriter.java
@@ -51,8 +51,7 @@ public class PNGJWriter {
         try {
             output = writer.writePNG(image, outStream, quality, filterType);
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Failed to encode the PNG", e);
-            throw new ServiceException(e);
+            throw new ServiceException("Failed to encode the PNG", e);
         }
 
         return output;


### PR DESCRIPTION
Linked to this PR: https://github.com/geoserver/geoserver/pull/3153

Doing multiple WMS GetMap requests, result on a message "Failed to encode the PNG" at Error level.
At ows dispatcher class the level is FINER.

@aaime commented on the old pull request:
A simple approach could be to just avoid logging and have the exception go up the chain, it will get logged by the Dispatcher if it's not a client stream aborted exception, e.g.:
       } catch (Exception e) {
            throw new ServiceException("Failed to encode the PNG", e);
        }

I tested and it works fine.
It logs as a TRACE level as expected.