### PR TITLE
[GEOS-8967] Reduce verbosity in WPS tests.

### DIFF
--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSExecuteTransformerTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSExecuteTransformerTest.java
@@ -176,7 +176,7 @@ public class WPSExecuteTransformerTest extends GeoServerWicketTestSupport {
         WPSExecuteTransformer tx = new WPSExecuteTransformer();
         tx.setIndentation(2);
         String xml = tx.transform(executeClipAndShip);
-        System.out.println(xml);
+        // System.out.println(xml);
         String expected =
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
                         + "  <ows:Identifier>gs:CropCoverage</ows:Identifier>\n"

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/WPSXStreamLoaderTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/WPSXStreamLoaderTest.java
@@ -134,7 +134,6 @@ public class WPSXStreamLoaderTest extends WPSTestSupport {
 
         // check the xml
         String xml = FileUtils.readFileToString(new File(root, "wps.xml"));
-        System.out.println(xml);
         Document dom = dom(xml);
 
         // geometry factory


### PR DESCRIPTION
One case is just dumping what was read from the file, which is not useful.