### PR TITLE
[GEOS-8964]: Fix IllegalArgumentExcep on turboJPEG writing -bkp to 2.14.x

### DIFF
--- a/src/extension/libjpeg-turbo/src/main/java/org/geoserver/map/turbojpeg/TurboJpegImageWorker.java
+++ b/src/extension/libjpeg-turbo/src/main/java/org/geoserver/map/turbojpeg/TurboJpegImageWorker.java
@@ -88,8 +88,8 @@ final class TurboJpegImageWorker extends ImageWorker {
 
         // go to component color model if needed
         ColorModel cm = image.getColorModel();
+        forceComponentColorModel(false, true, true);
         final boolean hasAlpha = cm.hasAlpha();
-        forceComponentColorModel();
         cm = image.getColorModel();
 
         // rescale to 8 bit

--- a/src/extension/libjpeg-turbo/src/test/java/org/geoserver/map/turbojpeg/TurboImageWorkerTest.java
+++ b/src/extension/libjpeg-turbo/src/test/java/org/geoserver/map/turbojpeg/TurboImageWorkerTest.java
@@ -6,11 +6,17 @@
 package org.geoserver.map.turbojpeg;
 
 import it.geosolutions.imageio.plugins.turbojpeg.TurboJpegUtilities;
+import it.geosolutions.jaiext.range.NoDataContainer;
+import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.awt.image.WritableRaster;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
+import javax.media.jai.PlanarImage;
+import javax.media.jai.RasterFactory;
 import org.geotools.image.ImageWorker;
 import org.geotools.test.TestData;
 import org.junit.Assert;
@@ -64,6 +70,44 @@ public class TurboImageWorkerTest extends Assert {
         } catch (Exception e) {
             // TODO: handle exception
         }
+    }
+
+    @Test
+    public void writeIndexedWithAlpha() throws IOException {
+        if (SKIP_TESTS) {
+            LOGGER.warning(ERROR_LIB_MESSAGE);
+            return;
+        }
+
+        // Create paletted image
+        final byte bb[] = new byte[256];
+        for (int i = 0; i < 200; i++) {
+            bb[i] = (byte) i;
+        }
+        int noDataValue = 200;
+        NoDataContainer noData = new NoDataContainer(noDataValue);
+        final IndexColorModel icm = new IndexColorModel(8, 256, bb, bb, bb);
+        final WritableRaster raster =
+                RasterFactory.createWritableRaster(icm.createCompatibleSampleModel(512, 512), null);
+        for (int i = raster.getMinX(); i < raster.getMinX() + raster.getWidth(); i++) {
+            for (int j = raster.getMinY(); j < raster.getMinY() + raster.getHeight(); j++) {
+                if (i - raster.getMinX() < raster.getWidth() / 2) {
+                    raster.setSample(i, j, 0, (i + j) / 32);
+                } else {
+                    raster.setSample(i, j, 0, 200);
+                }
+            }
+        }
+        // Set no data
+        BufferedImage bi = new BufferedImage(icm, raster, false, null);
+        PlanarImage planarImage = PlanarImage.wrapRenderedImage(bi);
+        planarImage.setProperty(NoDataContainer.GC_NODATA, noData);
+
+        // create output file
+        final File output = TestData.temp(this, "outputNoAlpha.jpeg");
+        new TurboJpegImageWorker(planarImage).writeTurboJPEG(new FileOutputStream(output), .5f);
+        // No exceptions occurred so far.
+        assertTrue("Unable to create output file", output.exists() && output.isFile());
     }
 
     @Test


### PR DESCRIPTION
Depends on
https://github.com/geotools/geotools/pull/2095