### PR TITLE
GEOS-8958 - ClientStreamAbortedException should be logged at debug level

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/png/PNGJWriter.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/png/PNGJWriter.java
@@ -51,8 +51,7 @@ public class PNGJWriter {
         try {
             output = writer.writePNG(image, outStream, quality, filterType);
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Failed to encode the PNG", e);
-            throw new ServiceException(e);
+            throw new ServiceException("Failed to encode the PNG", e);
         }
 
         return output;


### PR DESCRIPTION
Linked to this PR: https://github.com/geoserver/geoserver/pull/3153

Doing multiple WMS GetMap requests, result on a message "Failed to encode the PNG" at Error level.
At ows dispatcher class the level is FINER.

@aaime commented on the old pull request:
A simple approach could be to just avoid logging and have the exception go up the chain, it will get logged by the Dispatcher if it's not a client stream aborted exception, e.g.:
       } catch (Exception e) {
            throw new ServiceException("Failed to encode the PNG", e);
        }

I tested and it works fine.
It logs as a TRACE level as expected.