### PR TITLE
[GEOS-8974] Vector tiles ring orientations do not match the latest MVT spec

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1264,7 +1264,7 @@
     <dependency>
       <groupId>no.ecc.vectortile</groupId>
       <artifactId>java-vector-tile</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.3</version>
     </dependency>
     <dependency>
       <groupId>com.ning</groupId>

--- a/src/release/ext-vectortiles.xml
+++ b/src/release/ext-vectortiles.xml
@@ -12,7 +12,7 @@
         <include>gs-vectortiles*.jar</include>
         <include>java-vector-tile*.jar</include>
         <include>gson*.jar</include>
-        <include>protobuf-javanano*.jar</include>
+        <include>protobuf-java*.jar</include>
       </includes>      
     </fileSet>
   </fileSets>


### PR DESCRIPTION
The ring orientation fix has been done in the java-vector-tiles libraries, we just need to upgrade and handle the changed protobuf dependencies.