### PR TITLE
fix [GEOS-8968] Geoserver printing plugin (print-lib) leaves opened files

### DIFF
--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.1.2</version>
+      <version>2.1.3</version>
     </dependency>
       
     <dependency>


### PR DESCRIPTION
Geoserver printing plugin (print-lib) leaves opened files

- upgrade to print-lib 2.1.3 with this problem already solved