### PR TITLE
[GEOS-8973] add srs lookup to REST coverage handler

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -832,8 +832,16 @@ public class CatalogBuilder {
 
         CoordinateReferenceSystem nativeCRS = cinfo.getNativeCRS();
 
-        if (cinfo.getSRS() == null) {
-            cinfo.setSRS(nativeCRS.getIdentifiers().toArray()[0].toString());
+        if (nativeCRS != null) {
+            try {
+                Integer code = CRS.lookupEpsgCode(nativeCRS, false);
+                if (code != null) {
+                    cinfo.setSRS("EPSG:" + code);
+                    cinfo.setProjectionPolicy(ProjectionPolicy.FORCE_DECLARED);
+                }
+            } catch (FactoryException e) {
+                LOGGER.log(Level.WARNING, "SRS lookup failed", e);
+            }
         }
 
         if (cinfo.getProjectionPolicy() == null) {

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
@@ -237,6 +237,25 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
     }
 
     @Test
+    public void testInitCoverageSRSLookup_GEOS8973() throws Exception {
+        Catalog cat = getCatalog();
+        CatalogBuilder cb = new CatalogBuilder(cat);
+        cb.setStore(cat.getCoverageStoreByName(MockData.WORLD.getLocalPart()));
+        CoverageInfo cinfo = cb.buildCoverage();
+        cinfo.setSRS(null);
+        String wkt =
+                "GEOGCS[\"ED50\",\n"
+                        + "  DATUM[\"European Datum 1950\",\n"
+                        + "  SPHEROID[\"International 1924\", 6378388.0, 297.0]],\n"
+                        + "PRIMEM[\"Greenwich\", 0.0],\n"
+                        + "UNIT[\"degree\", 0.017453292519943295]]";
+        CoordinateReferenceSystem testCRS = CRS.parseWKT(wkt);
+        cinfo.setNativeCRS(testCRS);
+        cb.initCoverage(cinfo, "srs lookup");
+        assertEquals("EPSG:4230", cinfo.getSRS());
+    }
+
+    @Test
     public void testNativeBoundsDefensiveCopy() throws Exception {
         Catalog cat = getCatalog();
         CatalogBuilder cb = new CatalogBuilder(cat);


### PR DESCRIPTION
[GEOS-8973](https://osgeo-org.atlassian.net/browse/GEOS-8973)

This adds CRS lookup to the REST coverage handler to avoid ArrayIndexOutOfBounds exceptions when the source files NativeCRS is missing identifiers.