### PR TITLE
Removing gml:id from GML 3.1 geometry encoding

### DIFF
--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
@@ -878,4 +878,19 @@ public class GetFeatureTest extends WFSTestSupport {
         assertEquals(4, json.getJSONArray("features").size());
         assertEquals(15, json.getInt("totalFeatures"));
     }
+
+    /** gml:id should not be present on GML 3.1 geometry XML tag */
+    @Test
+    public void testNoGmlIdOnGeometry() throws Exception {
+        Document doc =
+                getAsDOM(
+                        "wfs?request=GetFeature&typeName=cite:NamedPlaces&version=1.1.0&service=wfs&featureId=NamedPlaces.1107531895891");
+
+        assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
+        XMLAssert.assertXpathEvaluatesTo(
+                "0",
+                "count(//wfs:FeatureCollection/gml:featureMembers/cite:NamedPlaces/cite:the_geom"
+                        + "/gml:MultiSurface/gml:surfaceMember/gml:Polygon[@gml:id])",
+                doc);
+    }
 }


### PR DESCRIPTION
This PR adds an Integration Test for "Removing gml:id on geometry encoding for WFS 1.1.0 GML 3.1"

Depends on this Geotools PR:
https://github.com/geotools/geotools/pull/2103