### PR TITLE
Remove JDK internals from rendering status panel

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/RenderingEngineStatus.java
+++ b/src/platform/src/main/java/org/geoserver/platform/RenderingEngineStatus.java
@@ -5,41 +5,16 @@
 package org.geoserver.platform;
 
 import java.util.Optional;
-import sun.java2d.pipe.RenderingEngine;
 
 /** @author Morgan Thompson - Boundless */
 public class RenderingEngineStatus implements ModuleStatus {
 
-    private static final String UNKNOWN = "unknown";
+    private static final String DEFAULT = "PLATFORM DEFAULT";
 
-    private String engine;
     private String provider;
 
-    @SuppressWarnings("unchecked")
     public RenderingEngineStatus() {
-
-        Class<RenderingEngine> renderer;
-        try {
-            renderer =
-                    (Class<RenderingEngine>)
-                            sun.java2d.pipe.RenderingEngine.getInstance().getClass();
-        } catch (Throwable e) {
-            engine = UNKNOWN;
-            provider = UNKNOWN;
-            return;
-        }
-        engine = renderer.getSimpleName();
-
-        Package pkg = renderer.getPackage();
-        if (pkg.getName().contains("marlin")) {
-            provider = "Marlin";
-        } else if (pkg.getName().contains("sun.dc")) {
-            provider = "OracleJDK";
-        } else if (pkg.getName().contains("sun.java2d")) {
-            provider = "OpenJDK";
-        } else {
-            provider = pkg.getName();
-        }
+        this.provider = System.getProperty("sun.java2d.renderer", DEFAULT);
     }
 
     @Override
@@ -75,20 +50,10 @@ public class RenderingEngineStatus implements ModuleStatus {
     @Override
     public Optional<String> getMessage() {
         StringBuilder msg = new StringBuilder();
-        msg.append("Java 2D configured with ");
-        msg.append(engine);
-        msg.append(".\n");
+        msg.append("Java 2D renderer configured with: ");
 
-        msg.append("Provider: ");
         msg.append(provider);
-        msg.append("\n");
 
-        String config = System.getProperty("sun.java2d.renderer");
-
-        if (config != null) {
-            msg.append("Configuration: -Dsun.java2d.renderer=");
-            msg.append(config);
-        }
         return Optional.of(msg.toString());
     }
 

--- a/src/platform/src/test/java/org/geoserver/platform/RenderingEngineStatusTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/RenderingEngineStatusTest.java
@@ -4,67 +4,15 @@
  */
 package org.geoserver.platform;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
-import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.geotools.util.logging.Logging;
 import org.junit.Test;
-import sun.java2d.pipe.RenderingEngine;
 
 public class RenderingEngineStatusTest {
 
-    private static final Logger LOGGER = Logging.getLogger("org.geoserver.platform");
-    private Optional<String> statusMessage;
-    private String engine;
-    private String provider;
-    private String msg;
-    private static final String UNKNOWN = "unknown";
-
-    @SuppressWarnings("unchecked")
     @Test
     public void RenderingEngineStatusTest() {
         RenderingEngineStatus res = new RenderingEngineStatus();
-        Class<RenderingEngine> renderer;
-        try {
-            renderer =
-                    (Class<RenderingEngine>)
-                            sun.java2d.pipe.RenderingEngine.getInstance().getClass();
-        } catch (Throwable e) {
-            engine = UNKNOWN;
-            provider = UNKNOWN;
-            return;
-        }
-        engine = renderer.getSimpleName();
-        statusMessage = res.getMessage();
-        Package pkg = renderer.getPackage();
-        if (pkg.getName().contains("marlin")) {
-            provider = "Marlin";
-        } else if (pkg.getName().contains("sun.dc")) {
-            provider = "OracleJDK";
-        } else if (pkg.getName().contains("sun.java2d")) {
-            provider = "OpenJDK";
-        } else {
-            provider = pkg.getName();
-        }
-        String config = System.getProperty("sun.java2d.renderer");
-        if (config != null) {
-            msg =
-                    String.format(
-                            "Java 2D configured with %s.\nProvider: %s\nConfiguration: -Dsun.java2d.renderer=%s",
-                            engine, provider, config);
-        } else {
-            msg = String.format("Java 2D configured with %s.\nProvider: %s\n", engine, provider);
-        }
-        if (provider.equals("Marlin")
-                || provider.equals("OracleJDK")
-                || provider.equals("OpenJDK")) {
-            assertEquals(msg, statusMessage.get());
-        } else {
-            LOGGER.log(Level.WARNING, "Unknown Java Provider");
-        }
-
-        assertEquals(System.getProperty("java.version"), res.getVersion().orElse(null));
+        assertTrue(res.getMessage().isPresent());
     }
 }


### PR DESCRIPTION
Providing slightly less information in this page in order to remove dependence on internals.