### PR TITLE
gt-sldservice fix

### DIFF
--- a/src/extension/sldService/pom.xml
+++ b/src/extension/sldService/pom.xml
@@ -50,11 +50,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <version>1.1</version>
-        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
remove xom dependency that is unused and was raising warnings for jdk11