### PR TITLE
[GEOS-8990] - Add an option to scale the vector tile size

### DIFF
--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
@@ -33,4 +33,32 @@ public class MapBoxTileBuilderFactory implements VectorTileBuilderFactory {
     public MapBoxTileBuilder newBuilder(Rectangle screenSize, ReferencedEnvelope mapArea) {
         return new MapBoxTileBuilder(screenSize, mapArea);
     }
+
+    /**
+     * For Mapbox tiles, since they are rendered in screen/tile space, oversampling produces more
+     * consistent results when zooming. See this question here:
+     *
+     * <p>https://github.com/mapbox/vector-tiles/issues/45
+     *
+     * @return
+     */
+    @Override
+    public boolean shouldOversampleScale() {
+        return true;
+    }
+
+    /**
+     * Use 16x oversampling to match actual Mapbox tile extent, which is 4096 for 900913 tiles
+     *
+     * @return
+     */
+    @Override
+    public int getOversampleX() {
+        return 16;
+    }
+
+    @Override
+    public int getOversampleY() {
+        return 16;
+    }
 }

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
@@ -57,6 +57,11 @@ public class MapBoxTileBuilderFactory implements VectorTileBuilderFactory {
         return 16;
     }
 
+    /**
+     * Use 16x oversampling to match actual Mapbox tile extent, which is 4096 for 900913 tiles
+     *
+     * @return
+     */
     @Override
     public int getOversampleY() {
         return 16;

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileBuilderFactory.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileBuilderFactory.java
@@ -26,4 +26,26 @@ public interface VectorTileBuilderFactory {
      * @param mapArea The extent of the tile in target CRS coordinates
      */
     VectorTileBuilder newBuilder(Rectangle screenSize, ReferencedEnvelope mapArea);
+
+    /**
+     * Whether tiles from this builder should be "oversampled", that is, "rendered" at a higher
+     * resolution than the tile resolution. The motivation for this is Mapbox vector tiles, which
+     * are rendered in screen space per tile and have inconsistent behavior while zooming at lower
+     * resolutions.
+     *
+     * @return whether this builder requires oversampling. defaults to false.
+     */
+    default boolean shouldOversampleScale() {
+        return false;
+    }
+
+    /** @return the horizontal oversampling factor. default is 1, no oversampling */
+    default int getOversampleX() {
+        return 1;
+    }
+
+    /** @return the vertical oversampling factor. default is 1, no oversampling */
+    default int getOversampleY() {
+        return 1;
+    }
 }

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -94,12 +94,16 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
         checkArgument(mapContent.getMapWidth() > 0);
         checkArgument(mapContent.getMapHeight() > 0);
 
-        // mapContent.setMapWidth(5 * mapContent.getMapWidth());
-        // mapContent.setMapHeight(5 * mapContent.getMapHeight());
-
         final ReferencedEnvelope renderingArea = mapContent.getRenderingArea();
-        final Rectangle paintArea =
-                new Rectangle(mapContent.getMapWidth(), mapContent.getMapHeight());
+        int mapWidth = mapContent.getMapWidth();
+        int mapHeight = mapContent.getMapHeight();
+        Rectangle paintArea = new Rectangle(mapWidth, mapHeight);
+        if (this.tileBuilderFactory.shouldOversampleScale()) {
+            paintArea =
+                    new Rectangle(
+                            this.tileBuilderFactory.getOversampleX() * mapWidth,
+                            this.tileBuilderFactory.getOversampleY() * mapHeight);
+        }
 
         VectorTileBuilder vectorTileBuilder;
         vectorTileBuilder = this.tileBuilderFactory.newBuilder(paintArea, renderingArea);

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTilesIntegrationTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTilesIntegrationTest.java
@@ -80,10 +80,9 @@ public class VectorTilesIntegrationTest extends WMSTestSupport {
         byte[] responseBytes = response.getContentAsByteArray();
         VectorTileDecoder decoder = new VectorTileDecoder();
         List<VectorTileDecoder.Feature> featuresList = decoder.decode(responseBytes).asList();
-        // MapBox encoder skips too small geometries
-        assertEquals(3, featuresList.size());
+        assertEquals(5, featuresList.size());
         assertEquals(
-                2,
+                3,
                 featuresList
                         .stream()
                         .filter(f -> "Route 5".equals(f.getAttributes().get("NAME")))
@@ -94,6 +93,7 @@ public class VectorTilesIntegrationTest extends WMSTestSupport {
                         .stream()
                         .filter(f -> "Main Street".equals(f.getAttributes().get("NAME")))
                         .count());
+        assertEquals("Extent should be 12288", 12288, featuresList.get(0).getExtent());
     }
 
     @Test


### PR DESCRIPTION
In practice, only MVT is interested in this, but because of how the paint area is set up it needed to be more generic, that's why I added it to the VTMOF.java interface.