### PR TITLE
[GEOS-8971] + [GEOS-8990] (vectortiles fixes) - 2.14.x backport

### DIFF
--- a/doc/en/user/source/extensions/vectortiles/tutorial.rst
+++ b/doc/en/user/source/extensions/vectortiles/tutorial.rst
@@ -25,7 +25,9 @@ On the other hand, the main disadvantage of vector tiles is that the geographic 
 Vector tile formats
 -------------------
 
-GeoServer can also produce vector tiles in three formats: GeoJSON, TopoJSON, and MapBox Vector (MVT). These are also supported by OpenLayers 3 and other clients.
+GeoServer can also produce vector tiles in three formats: GeoJSON, TopoJSON, and MapBox Vector (MVT). These are also supported by OpenLayers and other clients.
+
+.. warning:: When using vector tiles, be sure to use an up-to-date client. Older clients do not support all vector tiles capabilites and may result in rendering errors. We recommend using the latest version of OpenLayers (Currently v5.3.0).
 
 * MVT is the preferred format for production.
 

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
@@ -33,4 +33,37 @@ public class MapBoxTileBuilderFactory implements VectorTileBuilderFactory {
     public MapBoxTileBuilder newBuilder(Rectangle screenSize, ReferencedEnvelope mapArea) {
         return new MapBoxTileBuilder(screenSize, mapArea);
     }
+
+    /**
+     * For Mapbox tiles, since they are rendered in screen/tile space, oversampling produces more
+     * consistent results when zooming. See this question here:
+     *
+     * <p>https://github.com/mapbox/vector-tiles/issues/45
+     *
+     * @return
+     */
+    @Override
+    public boolean shouldOversampleScale() {
+        return true;
+    }
+
+    /**
+     * Use 16x oversampling to match actual Mapbox tile extent, which is 4096 for 900913 tiles
+     *
+     * @return
+     */
+    @Override
+    public int getOversampleX() {
+        return 16;
+    }
+
+    /**
+     * Use 16x oversampling to match actual Mapbox tile extent, which is 4096 for 900913 tiles
+     *
+     * @return
+     */
+    @Override
+    public int getOversampleY() {
+        return 16;
+    }
 }

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/mapbox/MapBoxTileBuilderFactory.java
@@ -5,7 +5,7 @@
 package org.geoserver.wms.mapbox;
 
 import com.google.common.collect.ImmutableSet;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.util.Set;
 import org.geoserver.wms.vector.VectorTileBuilderFactory;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -13,9 +13,11 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 /** @author Niels Charlier */
 public class MapBoxTileBuilderFactory implements VectorTileBuilderFactory {
 
-    public static final String MIME_TYPE = "application/x-protobuf;type=mapbox-vector";
+    public static final String MIME_TYPE = "application/vnd.mapbox-vector-tile";
+    public static final String LEGACY_MIME_TYPE = "application/x-protobuf;type=mapbox-vector";
 
-    public static final Set<String> OUTPUT_FORMATS = ImmutableSet.of(MIME_TYPE, "pbf");
+    public static final Set<String> OUTPUT_FORMATS =
+            ImmutableSet.of(MIME_TYPE, LEGACY_MIME_TYPE, "pbf");
 
     @Override
     public Set<String> getOutputFormats() {

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileBuilderFactory.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileBuilderFactory.java
@@ -26,4 +26,26 @@ public interface VectorTileBuilderFactory {
      * @param mapArea The extent of the tile in target CRS coordinates
      */
     VectorTileBuilder newBuilder(Rectangle screenSize, ReferencedEnvelope mapArea);
+
+    /**
+     * Whether tiles from this builder should be "oversampled", that is, "rendered" at a higher
+     * resolution than the tile resolution. The motivation for this is Mapbox vector tiles, which
+     * are rendered in screen space per tile and have inconsistent behavior while zooming at lower
+     * resolutions.
+     *
+     * @return whether this builder requires oversampling. defaults to false.
+     */
+    default boolean shouldOversampleScale() {
+        return false;
+    }
+
+    /** @return the horizontal oversampling factor. default is 1, no oversampling */
+    default int getOversampleX() {
+        return 1;
+    }
+
+    /** @return the vertical oversampling factor. default is 1, no oversampling */
+    default int getOversampleY() {
+        return 1;
+    }
 }

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -94,12 +94,16 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
         checkArgument(mapContent.getMapWidth() > 0);
         checkArgument(mapContent.getMapHeight() > 0);
 
-        // mapContent.setMapWidth(5 * mapContent.getMapWidth());
-        // mapContent.setMapHeight(5 * mapContent.getMapHeight());
-
         final ReferencedEnvelope renderingArea = mapContent.getRenderingArea();
-        final Rectangle paintArea =
-                new Rectangle(mapContent.getMapWidth(), mapContent.getMapHeight());
+        int mapWidth = mapContent.getMapWidth();
+        int mapHeight = mapContent.getMapHeight();
+        Rectangle paintArea = new Rectangle(mapWidth, mapHeight);
+        if (this.tileBuilderFactory.shouldOversampleScale()) {
+            paintArea =
+                    new Rectangle(
+                            this.tileBuilderFactory.getOversampleX() * mapWidth,
+                            this.tileBuilderFactory.getOversampleY() * mapHeight);
+        }
 
         VectorTileBuilder vectorTileBuilder;
         vectorTileBuilder = this.tileBuilderFactory.newBuilder(paintArea, renderingArea);

--- a/src/extension/vectortiles/src/main/resources/GeoServerApplication.properties
+++ b/src/extension/vectortiles/src/main/resources/GeoServerApplication.properties
@@ -1,0 +1,3 @@
+format.wms.application/json;type\=topojson=TopoJSON Vector Tiles
+format.wms.application/vnd.mapbox-vector-tile=MapBox Vector Tiles
+format.wms.application/json;type\=geojson=GeoJSON Vector Tiles

--- a/src/extension/vectortiles/src/main/resources/org/geoserver/gwc/advertised_formats.properties
+++ b/src/extension/vectortiles/src/main/resources/org/geoserver/gwc/advertised_formats.properties
@@ -2,6 +2,5 @@
 # Contribute vector tile formats to the configuration UI.
 # See org.geoserver.gwc.GWC.getAdvertisedCachedFormats(PublishedType) javadocs
 # for more info.
-# application/json;type=topojson, application/json;type=geojson, application/x-protobuf;type=mapbox-vector
-formats.vector = application/json;type=topojson, application/x-protobuf;type=mapbox-vector, application/json;type=geojson
-formats.layergroup = application/json;type=topojson, application/x-protobuf;type=mapbox-vector, application/json;type=geojson
+formats.vector = application/json;type=topojson, application/vnd.mapbox-vector-tile, application/json;type=geojson
+formats.layergroup = application/json;type=topojson, application/vnd.mapbox-vector-tile, application/json;type=geojson

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTilesIntegrationTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTilesIntegrationTest.java
@@ -80,10 +80,9 @@ public class VectorTilesIntegrationTest extends WMSTestSupport {
         byte[] responseBytes = response.getContentAsByteArray();
         VectorTileDecoder decoder = new VectorTileDecoder();
         List<VectorTileDecoder.Feature> featuresList = decoder.decode(responseBytes).asList();
-        // MapBox encoder skips too small geometries
-        assertEquals(3, featuresList.size());
+        assertEquals(5, featuresList.size());
         assertEquals(
-                2,
+                3,
                 featuresList
                         .stream()
                         .filter(f -> "Route 5".equals(f.getAttributes().get("NAME")))
@@ -94,6 +93,7 @@ public class VectorTilesIntegrationTest extends WMSTestSupport {
                         .stream()
                         .filter(f -> "Main Street".equals(f.getAttributes().get("NAME")))
                         .count());
+        assertEquals("Extent should be 12288", 12288, featuresList.get(0).getExtent());
     }
 
     @Test

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTilesIntegrationTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTilesIntegrationTest.java
@@ -10,9 +10,12 @@ import static org.junit.Assert.assertThat;
 
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import java.util.List;
 import net.minidev.json.JSONArray;
+import no.ecc.vectortile.VectorTileDecoder;
 import org.geoserver.data.test.MockData;
 import org.geoserver.wms.WMSTestSupport;
+import org.geoserver.wms.mapbox.MapBoxTileBuilderFactory;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -52,6 +55,45 @@ public class VectorTilesIntegrationTest extends WMSTestSupport {
                                 json.read(
                                         "$.features[?(@.properties.NAME == 'Dirt Road by Green Forest')]"))
                         .size());
+    }
+
+    @Test
+    public void testSimpleMVT() throws Exception {
+        checkSimpleMVT(MapBoxTileBuilderFactory.MIME_TYPE);
+    }
+
+    @Test
+    public void testSimpleMVTLegacyMime() throws Exception {
+        checkSimpleMVT(MapBoxTileBuilderFactory.LEGACY_MIME_TYPE);
+    }
+
+    public void checkSimpleMVT(String mimeType) throws Exception {
+        String request =
+                "wms?service=WMS&version=1.1.0&request=GetMap&layers="
+                        + getLayerId(MockData.ROAD_SEGMENTS)
+                        + "&styles=&bbox=-1,-1,1,1&width=768&height=330&srs=EPSG:4326"
+                        + "&format="
+                        + mimeType;
+        MockHttpServletResponse response = getAsServletResponse(request);
+        // the standard mime type is returned
+        assertEquals(MapBoxTileBuilderFactory.MIME_TYPE, response.getContentType());
+        byte[] responseBytes = response.getContentAsByteArray();
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        List<VectorTileDecoder.Feature> featuresList = decoder.decode(responseBytes).asList();
+        // MapBox encoder skips too small geometries
+        assertEquals(3, featuresList.size());
+        assertEquals(
+                2,
+                featuresList
+                        .stream()
+                        .filter(f -> "Route 5".equals(f.getAttributes().get("NAME")))
+                        .count());
+        assertEquals(
+                1,
+                featuresList
+                        .stream()
+                        .filter(f -> "Main Street".equals(f.getAttributes().get("NAME")))
+                        .count());
     }
 
     @Test

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.java
@@ -121,10 +121,11 @@ public class CachingOptionsPanel extends Panel {
         configs.add(gutterChoice);
 
         {
-            List<String> formats;
-            formats = new ArrayList<>(GWC.getAdvertisedCachedFormats(PublishedType.VECTOR));
+            List<String> formats =
+                    new ArrayList<>(GWC.getAdvertisedCachedFormats(PublishedType.VECTOR));
             IModel<List<String>> vectorFormatsModel =
                     new PropertyModel<List<String>>(gwcConfigModel, "defaultVectorCacheFormats");
+            mergeExisting(formats, vectorFormatsModel.getObject());
             vectorFormatsGroup = new CheckGroup<String>("vectorFormatsGroup", vectorFormatsModel);
             configs.add(vectorFormatsGroup);
             ListView<String> formatsList =
@@ -146,6 +147,7 @@ public class CachingOptionsPanel extends Panel {
             formats = new ArrayList<>(GWC.getAdvertisedCachedFormats(PublishedType.RASTER));
             IModel<List<String>> rasterFormatsModel =
                     new PropertyModel<List<String>>(gwcConfigModel, "defaultCoverageCacheFormats");
+            mergeExisting(formats, rasterFormatsModel.getObject());
             rasterFormatsGroup = new CheckGroup<String>("rasterFormatsGroup", rasterFormatsModel);
             configs.add(rasterFormatsGroup);
             ListView<String> formatsList =
@@ -166,6 +168,7 @@ public class CachingOptionsPanel extends Panel {
             formats = new ArrayList<>(GWC.getAdvertisedCachedFormats(PublishedType.GROUP));
             IModel<List<String>> otherFormatsModel =
                     new PropertyModel<List<String>>(gwcConfigModel, "defaultOtherCacheFormats");
+            mergeExisting(formats, otherFormatsModel.getObject());
             otherFormatsGroup = new CheckGroup<String>("otherFormatsGroup", otherFormatsModel);
             configs.add(otherFormatsGroup);
             ListView<String> formatsList =
@@ -232,5 +235,12 @@ public class CachingOptionsPanel extends Panel {
         vectorFormatsGroup.add(validator);
         rasterFormatsGroup.add(validator);
         otherFormatsGroup.add(validator);
+    }
+
+    /** Merges the elements of existingFormats missing from formats into formats */
+    private void mergeExisting(List<String> formats, Collection<String> existingFormats) {
+        for (String x : existingFormats) {
+            if (!formats.contains(x)) formats.add(x);
+        }
     }
 }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
@@ -12,6 +12,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.apache.wicket.AttributeModifier;
@@ -303,6 +304,7 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
 
         final List<String> formats;
         formats = Lists.newArrayList(GWC.getAdvertisedCachedFormats(info.getType()));
+        mergeExisting(formats, mimeFormatsModel.getObject());
 
         ListView<String> cacheFormatsList =
                 new ListView<String>("cacheFormats", formats) {
@@ -558,5 +560,12 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
     @Override
     protected void onBeforeRender() {
         super.onBeforeRender();
+    }
+
+    /** Merges the elements of existingFormats missing from formats into formats */
+    private void mergeExisting(List<String> formats, Collection<String> existingFormats) {
+        for (String x : existingFormats) {
+            if (!formats.contains(x)) formats.add(x);
+        }
     }
 }

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCSettingsPageTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCSettingsPageTest.java
@@ -38,6 +38,14 @@ public class GWCSettingsPageTest extends GeoServerWicketTestSupport {
         super.login();
     }
 
+    @Before
+    public void cleanupBogusVectorFormat() throws IOException {
+        GWC gwc = GWC.get();
+        GWCConfig config = gwc.getConfig();
+        config.getDefaultVectorCacheFormats().remove("foo/bar");
+        gwc.saveConfig(config);
+    }
+
     @Test
     public void testPageLoad() {
         GWCSettingsPage page = new GWCSettingsPage();
@@ -149,6 +157,7 @@ public class GWCSettingsPageTest extends GeoServerWicketTestSupport {
         GWC gwc = GWC.get();
         GWCConfig config = gwc.getConfig();
         config.setCacheLayersByDefault(true);
+        config.getDefaultVectorCacheFormats().add("foo/bar");
         gwc.saveConfig(config);
 
         GWCSettingsPage page = new GWCSettingsPage();
@@ -158,6 +167,7 @@ public class GWCSettingsPageTest extends GeoServerWicketTestSupport {
 
         final List<String> vectorFormats =
                 new ArrayList<>(GWC.getAdvertisedCachedFormats(PublishedType.VECTOR));
+        vectorFormats.add("foo/bar");
         final List<String> rasterFormats =
                 new ArrayList<>(GWC.getAdvertisedCachedFormats(PublishedType.RASTER));
         final List<String> groupFormats =


### PR DESCRIPTION
Backport of https://github.com/geoserver/geoserver/pull/3175 + https://github.com/geoserver/geoserver/pull/3223 (Since the second one somewhat depends upon the first)

Depends upon https://github.com/GeoWebCache/geowebcache/pull/712