### PR TITLE
[GEOS-8990] Update docs with warning about OL incompatibilites

### DIFF
--- a/doc/en/user/source/extensions/vectortiles/tutorial.rst
+++ b/doc/en/user/source/extensions/vectortiles/tutorial.rst
@@ -25,7 +25,9 @@ On the other hand, the main disadvantage of vector tiles is that the geographic 
 Vector tile formats
 -------------------
 
-GeoServer can also produce vector tiles in three formats: GeoJSON, TopoJSON, and MapBox Vector (MVT). These are also supported by OpenLayers 3 and other clients.
+GeoServer can also produce vector tiles in three formats: GeoJSON, TopoJSON, and MapBox Vector (MVT). These are also supported by OpenLayers and other clients.
+
+.. warning:: When using vector tiles, be sure to use an up-to-date client. Older clients do not support all vector tiles capabilites and may result in rendering errors. We recommend using the latest version of OpenLayers (Currently v5.3.0).
 
 * MVT is the preferred format for production.
 


### PR DESCRIPTION
https://github.com/geoserver/geoserver/pull/3223 is incompatible with OL 3.17.1, works fine with OL 5.3.0

See also: https://github.com/GeoWebCache/geowebcache/pull/715