### PR TITLE
Fixed YSLD doc for priority labeling.

### DIFF
--- a/doc/en/user/source/styling/workshop/ysld/done.rst
+++ b/doc/en/user/source/styling/workshop/ysld/done.rst
@@ -496,8 +496,8 @@ Answer for :ref:`Challenge Layer Group <ysld.point.q3>`:
                 fill-color: `lightgray`
                 radius: 2
                 opacity: 0.7
-              x-max-displacement: 90
-              x-label-priority: ${`0` - LABELRANK}
+              priority: ${`0` - LABELRANK}
+              x-maxDisplacement: 90
 
    Using a lightgray halo, 0.7 opacity and radius 2 fades out the complexity immediately surrounding the label text improving legibility.
 

--- a/doc/en/user/source/styling/workshop/ysld/point.rst
+++ b/doc/en/user/source/styling/workshop/ysld/point.rst
@@ -585,7 +585,7 @@ Dynamic Styling
 
       ${10 - LABELRANK}
 
-   This expression will result in values between 0 and 10 and will be used for the **x-labelPriority**.
+   This expression will result in values between 0 and 10 and will be used for the **priority**.
 
    .. code-block:: yaml
       :emphasize-lines: 2,19,20

--- a/doc/en/user/source/styling/workshop/ysld/polygon.rst
+++ b/doc/en/user/source/styling/workshop/ysld/polygon.rst
@@ -514,13 +514,13 @@ When working with labels a map can become busy very quickly, and difficult to re
 
    .. image:: ../style/img/polygon_label_5.png
 
-#. And advanced technique for manually taking control of conflict resolution is the use of the  **x-labelPriority**.
+#. And advanced technique for manually taking control of conflict resolution is the use of the  **priority**.
 
    This property takes an expression which is used in the event of a conflict. The label with the highest priority "wins."
 
 #. The Natural Earth dataset we are using includes a **labelrank** intended to control what labels are displayed based on zoom level.
 
-   The values for **labelrank** go from 0 (for zoomed out) to 20 (for zoomed in). To use this value for **x-labelPriority** we need to swap the values around so a **scalerank** of 1 is given the highest priority.
+   The values for **labelrank** go from 0 (for zoomed out) to 20 (for zoomed in). To use this value for **priority** we need to swap the values around so a **scalerank** of 1 is given the highest priority.
 
    .. code-block:: yaml
       :emphasize-lines: 20

--- a/doc/en/user/source/styling/ysld/reference/symbolizers/text.rst
+++ b/doc/en/user/source/styling/ysld/reference/symbolizers/text.rst
@@ -30,6 +30,7 @@ The full syntax of a text symbolizer is::
       anchor: <tuple>
       displacement: <tuple>
       rotation: <expression>
+      priority: <expression>
       halo:
         radius: <expression>
         fill-color: <color>
@@ -56,7 +57,6 @@ The full syntax of a text symbolizer is::
       x-graphic-resize: <none|proportional|stretch>
       x-group: <boolean>
       x-labelAllGroup: <boolean>
-      x-labelPriority: <expression>
       x-repeat: <expression>
       x-maxAngleDelta: <expression>
       x-maxDisplacement: <expression>
@@ -152,6 +152,10 @@ where:
      - No
      - Value (in degrees) or rotation of the label. Larger values increase counter-clockwise rotation. A value of ``180`` will make the label upside-down. Only valid for when ``type`` is set to ``point``.
      - ``0`` 
+   * - ``priority``
+     - No
+     - The priority used when choosing which labels to display during conflict resolution. Higher priority values take precedence over lower priority values.
+     - 1000
    * - ``halo``
      - No
      - Creates a shaded area around the label for easier legibility
@@ -256,10 +260,6 @@ The following properties are equivalent to SLD "vendor options".
      - No
      - Used in conjunction with ``x-group``. When ``true`` all items in a group are labeled. When ``false``, only the largest geometry in the group is labeled. Valid for lines only.
      - ``false``
-   * - ``x-labelPriority``
-     - No
-     - The priority used when choosing which labels to display during conflict resolution. Higher priority values take precedence over lower priority values. 
-     - 1000
    * - ``x-repeat``
      - No
      - Desired distance (in pixels) between labels drawn on a group. If zero, only one label will be drawn. Used in conjunction with ``x-group``. Valid for lines only.


### PR DESCRIPTION
Changed "x-label-priority" and "x-labelPriority" in the YSLD documentation to "priority".  Also, fixed an instance where "x-max-displacement" was being used instead of "x-maxDisplacement".