### PR TITLE
[GEOS-9020] Vector tiles: clip before running topology preserving simplification

### DIFF
--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -157,8 +157,8 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
             pipeline =
                     builder.preprocess()
                             .transform(transformToScreenCoordinates)
-                            .simplify(transformToScreenCoordinates)
                             .clip(clipToMapBounds, transformToScreenCoordinates)
+                            .simplify(transformToScreenCoordinates)
                             .collapseCollections()
                             .build();
         } catch (FactoryException e) {


### PR DESCRIPTION
As reported on list, with a single complex geometry (1.5 million points, australia shoreline) the speedup factor of swapping the ops is around 10 times, but even with a Natural Earth 10m admin units (provinces) it is still between 3 and 4 times faster, from an informal bench.

Seeding the NE admin units with the existing code, up to level 10, 16 threads, and blocking computation after a minute, shows each thread build like 3k tiles:

![selezione_436](https://user-images.githubusercontent.com/325433/48674482-24f75c00-eb4d-11e8-88f0-61c54259e39d.png)

Swapping the operation and repeating gives around 11k tiles per thread instead:

![selezione_435](https://user-images.githubusercontent.com/325433/48674485-2fb1f100-eb4d-11e8-816f-bddcbbdb5127.png)
