### PR TITLE
[GEOS-9027] MongoDB complex store iterator enters in an infinite loop if no ID is defined (backport 2.14.x)

### DIFF
--- a/src/extension/app-schema/app-schema-mongo-test/src/test/resources/mappings/stations.xml
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/resources/mappings/stations.xml
@@ -52,8 +52,14 @@
         <AttributeMapping>
           <targetAttribute>st:StationFeature</targetAttribute>
           <idExpression>
-            <OCQL>jsonSelect('id')</OCQL>
+            <OCQL>collectionId()</OCQL>
           </idExpression>
+        </AttributeMapping>
+        <AttributeMapping>
+          <targetAttribute>st:id</targetAttribute>
+          <sourceExpression>
+            <OCQL>jsonSelect('id')</OCQL>
+          </sourceExpression>
         </AttributeMapping>
         <AttributeMapping>
           <targetAttribute>st:name</targetAttribute>

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/resources/schemas/stations.xsd
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/resources/schemas/stations.xsd
@@ -46,6 +46,7 @@
     <xs:complexContent>
       <xs:extension base="gml:AbstractFeatureType">
         <xs:sequence>
+          <xs:element name="id" minOccurs="1" maxOccurs="1" type="xs:string"/>
           <xs:element name="name" minOccurs="1" maxOccurs="1" type="xs:string"/>
           <xs:element name="contact" minOccurs="0" maxOccurs="1" type="st:ContactType"/>
           <xs:element name="measurement" minOccurs="0" maxOccurs="unbounded" type="st:MeasurementPropertyType"/>


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-9027