### PR TITLE
Add directions on building and running on windows

### DIFF
--- a/doc/en/developer/source/quickstart/intellij.rst
+++ b/doc/en/developer/source/quickstart/intellij.rst
@@ -73,3 +73,10 @@ Access GeoServer front page
 
 * After a few seconds, GeoServer should be accessible at: `<http://localhost:8080/geoserver>`_
 * The default ``admin`` password is ``geoserver``.
+
+Run GeoServer from Intellij on Windows
+---------------------------
+
+#. Add bash to your windows environment path and restart intellij.  
+#. Rebuild the security-tests project in the security module.  Right click on the security-tests project and click Rebuild.  Otherwise,  there will be symbol errors such as "cannot find symbol AbstractUserGroupServiceTest".
+#. Using wcs1_1 as the working directory, run a mvn clean install.  Some of the generated code from this project does not get include in the build.  This causes errors like "cannot find symbol class ASTAxisId"

--- a/doc/en/developer/source/quickstart/intellij.rst
+++ b/doc/en/developer/source/quickstart/intellij.rst
@@ -52,6 +52,7 @@ Run GeoServer from Intellij
       :width: 800
 
 #. While you have the ``Edit Configurations`` dialog open, you can fine tune your launch environment (including setting a GEOSERVER_DATA_DIR). When you are happy with your settings, click ``OK``.
+#. If there are errors such as "cannot find symbol class ASTAxisId", some generated code is not being included in the build.  Using wcs1_1 as the working directory, run a ``mvn clean install``.  
 #. You can now re-run GeoServer. Select ``Run -> Run 'Start'``
 
 .. note::
@@ -78,5 +79,4 @@ Run GeoServer from Intellij on Windows
 ---------------------------
 
 #. Add bash to your Windows environment path and restart Intellij.  
-#. Rebuild the security-tests project in the security module.  Right click on the security-tests project and click Rebuild.  Otherwise,  there will be symbol errors such as "cannot find symbol AbstractUserGroupServiceTest".
-#. Using wcs1_1 as the working directory, run a ``mvn clean install``.  Some of the generated code from this project does not get include in the build.  This causes errors like "cannot find symbol class ASTAxisId"
+#. If there are errors such as "cannot find symbol AbstractUserGroupServiceTest", rebuild the security-tests project in the security module.  Right click on the security-tests project and click Rebuild.  

--- a/doc/en/developer/source/quickstart/intellij.rst
+++ b/doc/en/developer/source/quickstart/intellij.rst
@@ -76,7 +76,7 @@ Access GeoServer front page
 * The default ``admin`` password is ``geoserver``.
 
 Run GeoServer from Intellij on Windows
----------------------------
+--------------------------------------
 
 #. Add bash to your Windows environment path and restart Intellij.  
 #. If there are errors such as "cannot find symbol AbstractUserGroupServiceTest", rebuild the security-tests project in the security module.  Right click on the security-tests project and click Rebuild.  

--- a/doc/en/developer/source/quickstart/intellij.rst
+++ b/doc/en/developer/source/quickstart/intellij.rst
@@ -77,6 +77,6 @@ Access GeoServer front page
 Run GeoServer from Intellij on Windows
 ---------------------------
 
-#. Add bash to your windows environment path and restart intellij.  
+#. Add bash to your Windows environment path and restart Intellij.  
 #. Rebuild the security-tests project in the security module.  Right click on the security-tests project and click Rebuild.  Otherwise,  there will be symbol errors such as "cannot find symbol AbstractUserGroupServiceTest".
-#. Using wcs1_1 as the working directory, run a mvn clean install.  Some of the generated code from this project does not get include in the build.  This causes errors like "cannot find symbol class ASTAxisId"
+#. Using wcs1_1 as the working directory, run a ``mvn clean install``.  Some of the generated code from this project does not get include in the build.  This causes errors like "cannot find symbol class ASTAxisId"


### PR DESCRIPTION
Having issues getting Geoserver to build and run on Intellij using Windows 10.  After writing to the dev mailing list, it was suggested by Andrea Aime that I create a pull request to document how to fix the issues.  