### PR TITLE
[GEOS-9007][2.14.x] Fixed the KML output format ignoring the sortBy parameter when querying the records for a vector layer.

### DIFF
--- a/src/kml/src/main/java/org/geoserver/kml/utils/KMLFeatureAccessor.java
+++ b/src/kml/src/main/java/org/geoserver/kml/utils/KMLFeatureAccessor.java
@@ -140,6 +140,7 @@ public class KMLFeatureAccessor {
         // now, if a definition query has been established for this layer,
         // be sure to respect it by combining it with the bounding box one.
         q = DataUtilities.mixQueries(q, layer.getQuery(), "KMLEncoder");
+        q.setSortBy(layer.getQuery().getSortBy());
 
         // check the regionating strategy
         RegionatingStrategy regionatingStrategy = null;

--- a/src/kml/src/test/java/org/geoserver/kml/KMLTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/KMLTest.java
@@ -250,6 +250,9 @@ public class KMLTest extends WMSTestSupport {
 
         // print(doc);
         assertXpathEvaluatesTo("5", "count(//kml:Placemark)", doc);
+
+        // FID is mapped to the Placemark id attribute in the KML document
+        // verify that the features in the KML are sorted by ascending FID
         assertXpathEvaluatesTo("RoadSegments.1107532045088", "//kml:Placemark[1]/@id", doc);
         assertXpathEvaluatesTo("RoadSegments.1107532045089", "//kml:Placemark[2]/@id", doc);
         assertXpathEvaluatesTo("RoadSegments.1107532045089", "//kml:Placemark[3]/@id", doc);
@@ -271,6 +274,9 @@ public class KMLTest extends WMSTestSupport {
 
         // print(doc);
         assertXpathEvaluatesTo("5", "count(//kml:Placemark)", doc);
+
+        // FID is mapped to the Placemark id attribute in the KML document
+        // verify that the features in the KML are sorted by descending FID
         assertXpathEvaluatesTo("RoadSegments.1107532045091", "//kml:Placemark[1]/@id", doc);
         assertXpathEvaluatesTo("RoadSegments.1107532045090", "//kml:Placemark[2]/@id", doc);
         assertXpathEvaluatesTo("RoadSegments.1107532045089", "//kml:Placemark[3]/@id", doc);

--- a/src/kml/src/test/java/org/geoserver/kml/KMLTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/KMLTest.java
@@ -237,6 +237,48 @@ public class KMLTest extends WMSTestSupport {
     }
 
     @Test
+    public void testVectorWithSortByAscending() throws Exception {
+        Document doc =
+                getAsDOM(
+                        "wms?request=getmap&service=wms&version=1.1.1"
+                                + "&format="
+                                + KMLMapOutputFormat.MIME_TYPE
+                                + "&layers="
+                                + getLayerId(MockData.ROAD_SEGMENTS)
+                                + "&styles=&height=1024&width=1024&bbox=-180,-90,180,90&srs=EPSG:4326"
+                                + "&sortBy=FID A");
+
+        // print(doc);
+        assertXpathEvaluatesTo("5", "count(//kml:Placemark)", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045088", "//kml:Placemark[1]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045089", "//kml:Placemark[2]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045089", "//kml:Placemark[3]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045090", "//kml:Placemark[4]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045091", "//kml:Placemark[5]/@id", doc);
+    }
+
+    @Test
+    public void testVectorWithSortByDescending() throws Exception {
+        Document doc =
+                getAsDOM(
+                        "wms?request=getmap&service=wms&version=1.1.1"
+                                + "&format="
+                                + KMLMapOutputFormat.MIME_TYPE
+                                + "&layers="
+                                + getLayerId(MockData.ROAD_SEGMENTS)
+                                + "&styles=&height=1024&width=1024&bbox=-180,-90,180,90&srs=EPSG:4326"
+                                + "&sortBy=FID D");
+
+        // print(doc);
+        assertXpathEvaluatesTo("5", "count(//kml:Placemark)", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045091", "//kml:Placemark[1]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045090", "//kml:Placemark[2]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045089", "//kml:Placemark[3]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045089", "//kml:Placemark[4]/@id", doc);
+        assertXpathEvaluatesTo("RoadSegments.1107532045088", "//kml:Placemark[5]/@id", doc);
+    }
+
+    @Test
     public void testBasicVector() throws Exception {
         Document doc =
                 getAsDOM(


### PR DESCRIPTION
2.14.x backport for https://github.com/geoserver/geoserver/pull/3236