### PR TITLE
[GEOS-9034] Have SLDService raster classification work against large raster datasets

### DIFF
--- a/doc/en/user/source/extensions/sldservice/index.rst
+++ b/doc/en/user/source/extensions/sldservice/index.rst
@@ -135,7 +135,7 @@ The parameters usable to customize the ColorMap are:
      - 2
    * - attribute (mandatory)
      - Classification attribute
-     - For vector layers, one of the layer attribute names, for raster layers, a band number
+     - For vector layers, one of the layer attribute names, for raster layers, a band number (starting from one, like in the raster symbolizer)
      - No default for vectors, "1" for rasters
    * - method
      - Classification method
@@ -200,6 +200,10 @@ The parameters usable to customize the ColorMap are:
    * - customClasses
      - allows specifying a set of custom classes (client driven style); no classes calculation will happen (method, intervals, etc. are ignored)
      - classes in the following format: <min>,<max>,<color>;...;<minN>,<maxN>,<colorN>)
+     - 
+   * - bbox
+     - allows to run the classification on a specific bounding box. Recommended when the overall dataset is too big, and the classification can be performed on a smaller dataset, or to enhance the visualization of a particular subset of data
+     - same syntax as WMS/WFS, expected axis order is east/north unless the spatial reference system is explicitly provided, ``minx,miny,max,maxy[,srsName]``
      - 
     
 Examples

--- a/src/extension/sldService/pom.xml
+++ b/src/extension/sldService/pom.xml
@@ -117,5 +117,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/BaseSLDServiceController.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/BaseSLDServiceController.java
@@ -1,3 +1,7 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.sldservice.rest;
 
 import javax.xml.transform.TransformerException;

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ImageReader.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ImageReader.java
@@ -1,0 +1,236 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * Copyright (C) 2007-2008-2009 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.sldservice.rest;
+
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.rest.RestException;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridEnvelope2D;
+import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.coverage.processing.CoverageProcessor;
+import org.geotools.geometry.Envelope2D;
+import org.geotools.geometry.GeneralEnvelope;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.image.ImageWorker;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.operation.transform.AffineTransform2D;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
+import org.opengis.coverage.grid.GridEnvelope;
+import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValue;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.datum.PixelInCell;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Helper class that reads the best image out of the provided CoverageInfo, taking into account
+ * subsampling, overviews, band selection and bounding box restrictions
+ */
+class ImageReader {
+    private static final CoverageProcessor PROCESSOR = CoverageProcessor.getInstance();
+
+    private ArrayList<GeneralParameterValue> readParameters;
+    private final ReferencedEnvelope envelope;
+    private CoverageInfo coverageInfo;
+    private int selectedBand;
+    private boolean bandSelected;
+    private RenderedImage image;
+    private int maxPixels;
+    private GridCoverage2D coverage;
+
+    public ImageReader(
+            CoverageInfo coverageInfo,
+            int selectedBand,
+            int maxPixels,
+            ReferencedEnvelope envelope) {
+        this.coverageInfo = coverageInfo;
+        this.selectedBand = selectedBand;
+        this.envelope = envelope;
+        this.maxPixels = maxPixels;
+    }
+
+    public ImageReader invoke() throws IOException, TransformException, FactoryException {
+        // grab the raster, for the time being, read fully trying to force deferred loading where
+        // possible
+        readParameters = new ArrayList<>();
+        GridCoverage2DReader reader =
+                (GridCoverage2DReader) coverageInfo.getGridCoverageReader(null, null);
+        ParameterValue<Boolean> useImageRead = AbstractGridFormat.USE_JAI_IMAGEREAD.createValue();
+        useImageRead.setValue(true);
+        readParameters.add(useImageRead);
+
+        // grab the original grid geometry
+        GridEnvelope originalGridrange = reader.getOriginalGridRange();
+        GeneralEnvelope originalEnvelope = reader.getOriginalEnvelope();
+        MathTransform g2w = reader.getOriginalGridToWorld(PixelInCell.CELL_CORNER);
+        CoordinateReferenceSystem crs = originalEnvelope.getCoordinateReferenceSystem();
+        GridGeometry2D originalGeometry =
+                new GridGeometry2D(originalGridrange, PixelInCell.CELL_CORNER, g2w, crs, null);
+        GridGeometry2D readGeometry = new GridGeometry2D(originalGeometry);
+
+        // do we need to restrict to a specific bounding box?
+        ReferencedEnvelope readEnvelope = null;
+        if (envelope != null) {
+            ReferencedEnvelope envelopeInNativeCRS = envelope.transform(crs, true);
+            readEnvelope =
+                    envelopeInNativeCRS.intersection(
+                            ReferencedEnvelope.reference(originalEnvelope));
+            if (readEnvelope.isEmpty() || readEnvelope.isNull()) {
+                throw new RestException(
+                        "Specified bounding box does not match the data original envelope "
+                                + originalEnvelope,
+                        HttpStatus.BAD_REQUEST);
+            }
+
+            GeneralEnvelope ers = CRS.transform(g2w.inverse(), readEnvelope);
+            GridEnvelope gridToRead =
+                    new GridEnvelope2D(
+                            (int) Math.floor(ers.getMinimum(0)),
+                            (int) Math.floor(ers.getMinimum(1)),
+                            (int) Math.ceil(ers.getSpan(0)),
+                            (int) Math.ceil(ers.getSpan(1)));
+            readGeometry = new GridGeometry2D(gridToRead, PixelInCell.CELL_CORNER, g2w, crs, null);
+        }
+
+        // subsample the raster if needed
+        GridEnvelope2D gridRange = readGeometry.getGridRange2D();
+        long pixels = gridRange.getSpan(0) * (long) gridRange.getSpan(1);
+        if (pixels > maxPixels) {
+            double pixelRatio = Math.sqrt(pixels / (double) maxPixels);
+
+            int readWidth = (int) Math.max(1, Math.round(gridRange.getSpan(0) / pixelRatio));
+            int readHeight = (int) Math.max(1, Math.round(gridRange.getSpan(1) / pixelRatio));
+            GridEnvelope2D reducedRange =
+                    new GridEnvelope2D(gridRange.x, gridRange.y, readWidth, readHeight);
+            readGeometry = new GridGeometry2D(reducedRange, readGeometry.getEnvelope());
+        }
+
+        if (!readGeometry.equals(originalGeometry)) {
+            ParameterValue<GridGeometry2D> ggParam =
+                    AbstractGridFormat.READ_GRIDGEOMETRY2D.createValue();
+            ggParam.setValue(readGeometry);
+            readParameters.add(ggParam);
+        }
+
+        // can we delegate band selection to the reader? if so, it can help a lot, especially
+        // on coverage views merging bands coming from different sources
+        bandSelected = false;
+        if (reader.getFormat()
+                .getReadParameters()
+                .getDescriptor()
+                .descriptors()
+                .contains(AbstractGridFormat.BANDS)) {
+            SampleModel sampleModel = reader.getImageLayout().getSampleModel(null);
+            if (sampleModel != null) {
+                verifyBandSelection(selectedBand, sampleModel);
+                if (sampleModel.getNumBands() > 1) {
+                    ParameterValue<int[]> value = AbstractGridFormat.BANDS.createValue();
+                    // this param is zero based, the service is like SLD, 1-based
+                    value.setValue(new int[] {selectedBand - 1});
+                    readParameters.add(value);
+                    bandSelected = true;
+                }
+            }
+        }
+
+        // finally perform the read
+        coverage =
+                reader.read(
+                        readParameters.toArray(new GeneralParameterValue[readParameters.size()]));
+
+        // the reader can do a best-effort on grid geometry, might not have cut it
+        if (readEnvelope != null && isUncut(coverage, readGeometry)) {
+            ReferencedEnvelope bounds = ReferencedEnvelope.reference(readGeometry.getEnvelope2D());
+            Polygon polygon = JTS.toGeometry(bounds);
+            Geometry roi = polygon.getFactory().createMultiPolygon(new Polygon[] {polygon});
+
+            // perform the crops
+            final ParameterValueGroup param =
+                    PROCESSOR.getOperation("CoverageCrop").getParameters();
+            param.parameter("Source").setValue(coverage);
+            param.parameter("Envelope").setValue(bounds);
+            param.parameter("ROI").setValue(roi);
+
+            coverage = (GridCoverage2D) PROCESSOR.doOperation(param);
+        }
+
+        image = coverage.getRenderedImage();
+
+        // do we need to perform band selection?
+        SampleModel sampleModel = image.getSampleModel();
+        if (!bandSelected && sampleModel.getNumBands() > 1) {
+            verifyBandSelection(selectedBand, sampleModel);
+            ImageWorker iw = new ImageWorker(image);
+            // this param is zero based, the service is like SLD, 1-based
+            iw.retainBands(new int[] {selectedBand - 1});
+            image = iw.getRenderedImage();
+            bandSelected = true;
+        }
+
+        return this;
+    }
+
+    private boolean isUncut(GridCoverage2D coverage, GridGeometry2D targetGridGeometry) {
+        Envelope2D actual = coverage.getEnvelope2D();
+        Envelope2D expected = targetGridGeometry.getEnvelope2D();
+        AffineTransform2D at = (AffineTransform2D) targetGridGeometry.getGridToCRS2D();
+        double resX = at.getScaleX();
+        double resY = at.getScaleY();
+
+        return Math.abs(actual.getMinimum(0) - expected.getMinimum(0)) > resX
+                || Math.abs(actual.getMinimum(1) - expected.getMinimum(1)) > resY
+                || Math.abs(actual.getMaximum(0) - expected.getMaximum(0)) > resX
+                || Math.abs(actual.getMaximum(1) - expected.getMaximum(1)) > resY;
+    }
+
+    /**
+     * Returns true if a band has been selected (and as such, we'll need to add a channel selection
+     * in the raster symbolizer)
+     *
+     * @return
+     */
+    public boolean isBandSelected() {
+        return bandSelected;
+    }
+
+    /** Returns the image to be classified */
+    public RenderedImage getImage() {
+        return image;
+    }
+
+    ArrayList<GeneralParameterValue> getReadParameters() {
+        return readParameters;
+    }
+
+    GridCoverage2D getCoverage() {
+        return coverage;
+    }
+
+    private void verifyBandSelection(int selectedBand, SampleModel sampleModel) {
+        int numBands = sampleModel.getNumBands();
+        if (selectedBand < 0 || selectedBand > numBands) {
+            throw new RestException(
+                    "Invalid property value for raster layer, must be a valid band number, between 0 and "
+                            + (numBands - 1)
+                            + ", but was "
+                            + selectedBand,
+                    HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ReferencedEnvelopeConverter.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ReferencedEnvelopeConverter.java
@@ -1,0 +1,28 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.sldservice.rest;
+
+import org.geoserver.rest.RestException;
+import org.geoserver.wfs.kvp.BBoxKvpParser;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReferencedEnvelopeConverter implements Converter<String, ReferencedEnvelope> {
+
+    BBoxKvpParser parser = new BBoxKvpParser();
+
+    @Override
+    public ReferencedEnvelope convert(String source) {
+        try {
+            return (ReferencedEnvelope) parser.parse(source);
+        } catch (Exception e) {
+            throw new RestException(
+                    "Invalid bounding box specification ", HttpStatus.BAD_REQUEST, e);
+        }
+    }
+}

--- a/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/SLDServiceBaseTest.java
+++ b/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/SLDServiceBaseTest.java
@@ -10,7 +10,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.io.StringReader;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.rest.catalog.CatalogRESTTestSupport;
@@ -22,8 +21,6 @@ import org.geotools.styling.Style;
 import org.geotools.styling.StyledLayer;
 import org.geotools.styling.StyledLayerDescriptor;
 import org.geotools.xml.styling.SLDParser;
-import org.junit.After;
-import org.junit.Before;
 
 public abstract class SLDServiceBaseTest extends CatalogRESTTestSupport {
 
@@ -32,19 +29,7 @@ public abstract class SLDServiceBaseTest extends CatalogRESTTestSupport {
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         // do not setup other test data, not used, not needed
-    }
-
-    @Before
-    public void loadData() throws Exception {
-        getTestData().addWorkspace(getTestData().WCS_PREFIX, getTestData().WCS_URI, getCatalog());
         getTestData().addDefaultRasterLayer(getTestData().WORLD, getCatalog());
-    }
-
-    @After
-    public void restoreLayers() throws IOException {
-        revertLayer(SystemTestData.BASIC_POLYGONS);
-        removeWorkspace(getTestData().WCS_PREFIX);
-        removeLayer(getTestData().WCS_PREFIX, getTestData().WORLD.getLocalPart());
     }
 
     protected Rule[] checkSLD(String resultXml) {

--- a/src/extension/sldService/src/test/java/org/geoserver/sldservice/utils/classifier/RulesBuilderTest.java
+++ b/src/extension/sldService/src/test/java/org/geoserver/sldservice/utils/classifier/RulesBuilderTest.java
@@ -4,7 +4,7 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.sldservice.rest;
+package org.geoserver.sldservice.utils.classifier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -14,7 +14,6 @@ import java.awt.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.geoserver.sldservice.utils.classifier.RulesBuilder;
 import org.geoserver.sldservice.utils.classifier.impl.BlueColorRamp;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.memory.MemoryDataStore;

--- a/src/rest/src/main/java/org/geoserver/rest/RestConfiguration.java
+++ b/src/rest/src/main/java/org/geoserver/rest/RestConfiguration.java
@@ -20,6 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
@@ -168,6 +170,14 @@ public class RestConfiguration extends WebMvcConfigurationSupport {
         // custom PathHelper
         configurer.setUrlPathHelper(new GeoServerUrlPathHelper());
         configurer.getUrlPathHelper().setAlwaysUseFullPath(true);
+    }
+
+    @Override
+    protected void addFormatters(FormatterRegistry registry) {
+        // add all configured Spring Converter classes to allow extension/pluggability
+        for (Converter converter : GeoServerExtensions.extensions(Converter.class)) {
+            registry.addConverter(converter);
+        }
     }
 
     static class GeoServerUrlPathHelper extends UrlPathHelper {


### PR DESCRIPTION
* Use histogram based operations, instead of collecting all possible values from the raster
* If the raster is too big, subsample it
* Allow the caller to define a significant area of interest and work on it instead of using the full extent (bbox)
