### PR TITLE
GEOS-9033 Allow configuring services on a per layer basis - Layer Group preview fix

### DIFF
--- a/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
@@ -300,7 +300,8 @@ public class MapPreviewPage extends GeoServerBasePage {
                     DisabledServiceResourceFilter.disabledServices(linfo.getResource());
             return disabledServices.stream().noneMatch(d -> d.equalsIgnoreCase(serviceName));
         }
-        return false;
+        // layer group and backward compatibility
+        return true;
     }
 
     /**

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
@@ -246,4 +246,20 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
             catalog.save(ft);
         }
     }
+
+    /** Test for layer group service support check */
+    @Test
+    public void testHasServiceSupport() throws Exception {
+        Catalog cat = getCatalog();
+        LayerGroupInfo lg = cat.getFactory().createLayerGroup();
+        lg.setName("linkgroup");
+        lg.setWorkspace(cat.getWorkspaceByName("sf"));
+        lg.getLayers().add(cat.getLayerByName(getLayerId(MockData.PRIMITIVEGEOFEATURE)));
+        new CatalogBuilder(cat).calculateLayerGroupBounds(lg);
+        cat.add(lg);
+        tester.startPage(MapPreviewPage.class);
+        tester.assertRenderedPage(MapPreviewPage.class);
+        MapPreviewPage page = (MapPreviewPage) tester.getLastRenderedPage();
+        assertTrue(page.hasServiceSupport("sf:linkgroup", "WMS"));
+    }
 }


### PR DESCRIPTION
This PR fix a bug related to layer groups preview hiding WMS and WFS preview links since Resource doesn't exists for them.