### PR TITLE
GEOS-9051 Printing plugin upgrade version of JTS from vividsolutions to locationtech

### DIFF
--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.1.3</version>
+      <version>2.1.4</version>
     </dependency>
       
     <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1911,7 +1911,7 @@
   <poi.version>3.17</poi.version>
   <wicket.version>7.6.0</wicket.version>
   <ant.version>1.8.4</ant.version>
-  <imageio-ext.version>1.1.28</imageio-ext.version>
+  <imageio-ext.version>1.1.25</imageio-ext.version>
   <jaiext.version>1.1.2</jaiext.version>
   <java.awt.headless>true</java.awt.headless>
   <sun.java2d.d3d>true</sun.java2d.d3d>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1911,7 +1911,7 @@
   <poi.version>3.17</poi.version>
   <wicket.version>7.6.0</wicket.version>
   <ant.version>1.8.4</ant.version>
-  <imageio-ext.version>1.1.25</imageio-ext.version>
+  <imageio-ext.version>1.1.28</imageio-ext.version>
   <jaiext.version>1.1.2</jaiext.version>
   <java.awt.headless>true</java.awt.headless>
   <sun.java2d.d3d>true</sun.java2d.d3d>


### PR DESCRIPTION
Printing plugin upgrade version of JTS from vividsolutions to locationtech.

Mapfish print 2.1.4 released:
https://github.com/mapfish/mapfish-print/pull/772
