### PR TITLE
GEOS-9051 Printing plugin upgrade version of JTS from vividsolutions to locationtech

### DIFF
--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.1.3</version>
+      <version>2.1.4</version>
     </dependency>
       
     <dependency>


### PR DESCRIPTION
Printing plugin upgrade version of JTS from vividsolutions to locationtech.

Mapfish print 2.1.4 released:
mapfish/mapfish-print#772