### PR TITLE
Remove some dead or unnecessary code that causes JDK11 issues.

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/support/AbstractReferenceDataSetup.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/onlineTest/support/AbstractReferenceDataSetup.java
@@ -5,12 +5,9 @@
  */
 package org.geoserver.test.onlineTest.support;
 
-import com.sun.rowset.CachedRowSetImpl;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -140,28 +137,6 @@ public abstract class AbstractReferenceDataSetup extends JDBCTestSetup {
         } catch (IOException ioe) {
             System.out.println("Unable to write out example fixture " + exFixtureFile);
             ioe.printStackTrace();
-        }
-    }
-
-    /**
-     * This method doesn't not handle paging therefore care must be taken when dealing with large
-     * dataset.
-     *
-     * @param sql statement
-     * @return CachedRowSetImpl the result from the execution of the sql
-     */
-    public CachedRowSetImpl runWithResult(String sql) throws Exception {
-        // connect
-        Connection conn = getConnection();
-        Statement st = null;
-        try {
-            st = conn.createStatement();
-            CachedRowSetImpl crs = new CachedRowSetImpl();
-            crs.populate(st.executeQuery(sql));
-            return crs;
-        } finally {
-            st.close();
-            conn.close();
         }
     }
 

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/FeatureResourceConfigurationPanelTest.java
@@ -9,7 +9,6 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.junit.Test;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class FeatureResourceConfigurationPanelTest extends GeoServerWicketTestSupport {
     @Test()
@@ -28,12 +27,12 @@ public class FeatureResourceConfigurationPanelTest extends GeoServerWicketTestSu
 
                             @Override
                             public void setObject(Object o) {
-                                throw new NotImplementedException();
+                                throw new RuntimeException("Not implemented");
                             }
 
                             @Override
                             public void detach() {
-                                throw new NotImplementedException();
+                                throw new RuntimeException("Not implemented");
                             }
                         });
         panel.resourceUpdated(null);


### PR DESCRIPTION
Just a couple small changes removing Sun package references from test cases. Removed a method that is unused, and in another case removed the internal NotImplementedException for a simple RuntimeException (in code that should be unreachable anyway).