### PR TITLE
[GEOS-9088] Appschema OR performance improvement on postgresql (2.14.x backport)

### DIFF
--- a/doc/en/user/source/data/app-schema/joining.rst
+++ b/doc/en/user/source/data/app-schema/joining.rst
@@ -83,3 +83,27 @@ Much like joining support, native encoding of nested filters is turned on by def
 Or, alternatively, by setting the value of the Java System Property "app-schema.encodeNestedFilters" to "false", for example ::
 
      java -DGEOSERVER_DATA_DIR=... -Dapp-schema.encodeNestedFilters=false Start
+
+UNION performance improvement for OR conditions
+-----------------------------------------------
+
+OR conditions are difficult to optimize for postgresql and are usually slow.  App-Schema improves OR condition performance using UNION clauses instead OR for nested filter subqueries.
+
+With UNION improvement enabled main OR binary operator on nested filter subquery will rebuild normal OR query like::
+
+     SELECT id, name FROM table WHERE name = "A" OR name = "B"
+
+to::
+
+     SELECT id, name FROM table WHERE name = "A" UNION SELECT id, name FROM table WHERE name = "B"
+
+UNION improvement is disabled by default, and it is enabled by adding to your app-schema.properties file the line ::
+
+     app-schema.orUnionReplace = true
+	 
+Or, alternatively, by setting the value of the Java System Property "app-schema.orUnionReplace" to "true", for example ::
+
+     java -DGEOSERVER_DATA_DIR=... -Dapp-schema.orUnionReplace=true Start
+	
+.. note::
+    This optimization will only be applied when a PostgresSQL database is being used.

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SimpleAttributeFeatureChainWfsTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.AppSchemaDataAccessRegistry;
 import org.geotools.data.complex.FeatureTypeMapping;
 import org.geotools.data.complex.filter.ComplexFilterSplitter;
 import org.geotools.data.jdbc.FilterToSQLException;
@@ -534,6 +535,15 @@ public class SimpleAttributeFeatureChainWfsTest extends AbstractAppSchemaTestSup
         //            "appschematest"."MAPPEDFEATUREWITHNESTEDNAME"."ID" = "chain_link_1"."MF_ID"))
         assertTrue(encodedCombined.matches("^\\(.*GUNTHORPE FORMATION.*OR.*EXISTS.*\\)$"));
         assertContainsFeatures(fs.getFeatures(combined), "mf1", "mf3");
+        // test UNION improvement on
+        AppSchemaDataAccessRegistry.getAppSchemaProperties()
+                .setProperty("app-schema.orUnionReplace", "true");
+        try {
+            assertContainsFeatures(fs.getFeatures(combined), "mf1", "mf3");
+        } finally {
+            AppSchemaDataAccessRegistry.getAppSchemaProperties()
+                    .setProperty("app-schema.orUnionReplace", "false");
+        }
 
         /*
          * test filter comparing multiple nested attributes
@@ -558,6 +568,42 @@ public class SimpleAttributeFeatureChainWfsTest extends AbstractAppSchemaTestSup
         assertTrue(NestedFilterToSQL.isNestedFilter(unrolled));
 
         assertContainsFeatures(fs.getFeatures(notEquals), "mf1", "mf2", "mf3", "mf4");
+    }
+
+    /** Checks a nested OR condition with UNION improvement on and off */
+    @Test
+    public void testUnionImprovement() throws IOException, FilterToSQLException {
+        FeatureTypeInfo ftInfo = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+        FeatureSource fs = ftInfo.getFeatureSource(new NullProgressListener(), null);
+        AppSchemaDataAccess da = (AppSchemaDataAccess) fs.getDataStore();
+        FeatureTypeMapping rootMapping = da.getMappingByNameOrElement(ftInfo.getQualifiedName());
+        // make sure nested filters encoding is enabled, otherwise skip test
+        assumeTrue(shouldTestNestedFiltersEncoding(rootMapping));
+
+        JDBCDataStore store = (JDBCDataStore) rootMapping.getSource().getDataStore();
+        NestedFilterToSQL nestedFilterToSQL = createNestedFilterEncoder(rootMapping);
+
+        FilterFactoryImplNamespaceAware ff = new FilterFactoryImplNamespaceAware();
+        ff.setNamepaceContext(rootMapping.getNamespaces());
+
+        PropertyIsEqualTo regularFilter =
+                ff.equals(ff.property("gml:name[2]"), ff.literal("nameone 2"));
+        PropertyIsEqualTo nestedFilter =
+                ff.equals(ff.property("gml:name[2]"), ff.literal("nameone 4"));
+        Or combined = ff.or(regularFilter, nestedFilter);
+
+        assertContainsFeatures(fs.getFeatures(combined), "mf2", "mf3");
+        // set improvement to on
+        AppSchemaDataAccessRegistry.getAppSchemaProperties()
+                .setProperty("app-schema.orUnionReplace", "true");
+        try {
+            FeatureTypeInfo ftInfo1 = getCatalog().getFeatureTypeByName("gsml", "MappedFeature");
+            FeatureSource fs1 = ftInfo.getFeatureSource(new NullProgressListener(), null);
+            assertContainsFeatures(fs1.getFeatures(combined), "mf2", "mf3");
+        } finally {
+            AppSchemaDataAccessRegistry.getAppSchemaProperties()
+                    .setProperty("app-schema.orUnionReplace", "false");
+        }
     }
 
     private void checkMf1(Document doc) {


### PR DESCRIPTION
Is known that OR queries are difficult to optimize for postgresql and are usually slow.

The fix for slow queries with OR involved is using UNION queries, so we need optimize certain complex subqueries. The slow appschema subquery involved is that generated by NestedFilterToSQL class so we need to change the use of OR clause in the root condition for UNION queries.

Since this performance issue affect postgresql, the fix should be isolated for this datasource only, and adding a system property for disable.

We'll need execute online tests with postgresql and geoserver-appschema with new improvement enabled and disabled.

Depends on Geotools PR:
https://github.com/geotools/geotools/pull/2225