### PR TITLE
[GEOS-9084][2.14.x] Made custom dimension names in WCS GetCoverage requests case insensitive.

### DIFF
--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/DefaultWebCoverageService100.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/DefaultWebCoverageService100.java
@@ -448,9 +448,15 @@ public class DefaultWebCoverageService100 implements WebCoverageService100 {
                     AxisSubsetType axis = (AxisSubsetType) axisSubset.get(i);
                     String axisName = axis.getName();
                     if (!axisName.equalsIgnoreCase(WCSUtils.ELEVATION)) {
+                        String key = ResourceInfo.CUSTOM_DIMENSION_PREFIX + axisName;
                         Object dimInfo =
                                 meta.getMetadata()
-                                        .get(ResourceInfo.CUSTOM_DIMENSION_PREFIX + axisName);
+                                        .entrySet()
+                                        .stream()
+                                        .filter(e -> e.getKey().equalsIgnoreCase(key))
+                                        .findFirst()
+                                        .map(e -> e.getValue())
+                                        .orElse(null);
                         axisName = axisName.toUpperCase(); // using uppercase with imagemosaic
                         if (dimInfo instanceof DimensionInfo && dimensions.hasDomain(axisName)) {
                             int valueCount = axis.getSingleValue().size();

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/CustomDimensionsTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/CustomDimensionsTest.java
@@ -49,6 +49,11 @@ public class CustomDimensionsTest extends CoverageTestSupport {
         MockHttpServletResponse response = postAsServletResponse("wcs", request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
         assertNull(image);
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toLowerCase());
+        response = postAsServletResponse("wcs", request);
+        image = ImageIO.read(getBinaryInputStream(response));
+        assertNull(image);
     }
 
     @Test
@@ -57,6 +62,12 @@ public class CustomDimensionsTest extends CoverageTestSupport {
         String request = getWaterTempRequest("CustomDimValueA");
         MockHttpServletResponse response = postAsServletResponse("wcs", request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertNotNull(image);
+        assertEquals("image/tiff", response.getContentType());
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toLowerCase());
+        response = postAsServletResponse("wcs", request);
+        image = ImageIO.read(getBinaryInputStream(response));
         assertNotNull(image);
         assertEquals("image/tiff", response.getContentType());
     }

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/DynamicDimensionsTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/DynamicDimensionsTest.java
@@ -53,6 +53,11 @@ public class DynamicDimensionsTest extends CoverageTestSupport {
         MockHttpServletResponse response = postAsServletResponse("wcs", request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
         assertNull(image);
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toUpperCase());
+        response = postAsServletResponse("wcs", request);
+        image = ImageIO.read(getBinaryInputStream(response));
+        assertNull(image);
     }
 
     @Test
@@ -61,6 +66,12 @@ public class DynamicDimensionsTest extends CoverageTestSupport {
         String request = getWaterTempRequest("100");
         MockHttpServletResponse response = postAsServletResponse("wcs", request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertNotNull(image);
+        assertEquals("image/tiff", response.getContentType());
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toUpperCase());
+        response = postAsServletResponse("wcs", request);
+        image = ImageIO.read(getBinaryInputStream(response));
         assertNotNull(image);
         assertEquals("image/tiff", response.getContentType());
     }

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -671,6 +671,11 @@ public class GetCoverageTest extends WCSTestSupport {
 
         // same result as time first
         checkPixelValue(response, 10, 10, 18.2849999185419);
+
+        request = request.replace("ELEVATION", "elevation");
+        response = postAsServletResponse("wcs", request);
+        assertEquals("image/tiff", response.getContentType());
+        checkPixelValue(response, 10, 10, 18.2849999185419);
     }
 
     @Test
@@ -688,6 +693,11 @@ public class GetCoverageTest extends WCSTestSupport {
           Value: 13.337999683572
         */
 
+        checkPixelValue(response, 10, 10, 13.337999683572);
+
+        request = request.replace("ELEVATION", "elevation");
+        response = postAsServletResponse("wcs", request);
+        assertEquals("image/tiff", response.getContentType());
         checkPixelValue(response, 10, 10, 13.337999683572);
     }
 

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
@@ -805,7 +805,8 @@ public class WCSDimensionsSubsetHelper {
                 }
 
                 // only care for custom dimensions
-                if (dimensionKeys.contains(dimension)) {
+                if (dimensionKeys.stream().anyMatch(dimension::equalsIgnoreCase)) {
+                    dimension = dimension.toUpperCase(); // using uppercase with imagemosaic
                     List<Object> selectedValues = new ArrayList<Object>();
 
                     // now decide what to do

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/xml/GetCoverageTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/xml/GetCoverageTest.java
@@ -851,6 +851,9 @@ public class GetCoverageTest extends WCSTestSupport {
         request = request.replace("${slicePointCustom}", "20");
         // timeranges is really just an expanded watertemp
         checkWaterTempValue(request, 18.478999927756377);
+
+        request = request.replace("WAVELENGTH", "wavelength");
+        checkWaterTempValue(request, 18.478999927756377);
     }
 
     @Test
@@ -868,6 +871,9 @@ public class GetCoverageTest extends WCSTestSupport {
         request = request.replace("${Custom}", "WAVELENGTH");
         request = request.replace("${slicePointCustom}", "80");
         // timeranges is really just an expanded watertemp
+        checkWaterTempValue(request, 14.52999974018894136);
+
+        request = request.replace("WAVELENGTH", "wavelength");
         checkWaterTempValue(request, 14.52999974018894136);
     }
 
@@ -892,6 +898,9 @@ public class GetCoverageTest extends WCSTestSupport {
         request = request.replace("${CustomTwo}", "CUSTOM");
         request = request.replace("${slicePointCustomTwo}", "99");
         // timeranges is really just an expanded watertemp
+        checkWaterTempValue(request, 14.52999974018894136);
+
+        request = request.replace("WAVELENGTH", "wavelength").replace("CUSTOM", "custom");
         checkWaterTempValue(request, 14.52999974018894136);
     }
 
@@ -1242,6 +1251,14 @@ public class GetCoverageTest extends WCSTestSupport {
 
         MockHttpServletResponse response = postAsServletResponse("wcs", request);
         String errorMessage =
+                checkOws20Exception(response, 404, InvalidSubsetting.getExceptionCode(), "subset");
+        assertEquals(
+                "Requested WAVELENGTH subset does not intersect the available values [12/24, 25/80]",
+                errorMessage);
+
+        request = request.replace("WAVELENGTH", "wavelength");
+        response = postAsServletResponse("wcs", request);
+        errorMessage =
                 checkOws20Exception(response, 404, InvalidSubsetting.getExceptionCode(), "subset");
         assertEquals(
                 "Requested WAVELENGTH subset does not intersect the available values [12/24, 25/80]",


### PR DESCRIPTION
2.14.x backport for https://github.com/geoserver/geoserver/pull/3309