### PR TITLE
[GEOS-9083][2.14.x] Added back missing default master password warning.

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
@@ -1714,15 +1714,26 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
 
     /** Checks the specified password against the master password. */
     public boolean checkMasterPassword(String passwd) {
-        return checkMasterPassword(passwd.toCharArray());
+        return checkMasterPassword(passwd.toCharArray(), true);
+    }
+
+    /** Checks the specified password against the master password. */
+    public boolean checkMasterPassword(String passwd, boolean forLogin) {
+        return checkMasterPassword(passwd.toCharArray(), forLogin);
     }
 
     /** Checks the specified password against the master password. */
     public boolean checkMasterPassword(char[] passwd) {
+        return checkMasterPassword(passwd, true);
+    }
+
+    /** Checks the specified password against the master password. */
+    public boolean checkMasterPassword(char[] passwd, boolean forLogin) {
         try {
-            if (!this.masterPasswordProviderHelper
-                    .loadConfig(this.masterPasswordConfig.getProviderName())
-                    .isLoginEnabled()) {
+            if (forLogin
+                    && !this.masterPasswordProviderHelper
+                            .loadConfig(this.masterPasswordConfig.getProviderName())
+                            .isLoginEnabled()) {
                 return false;
             }
         } catch (IOException e) {

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityHomePageContentProvider.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityHomePageContentProvider.java
@@ -91,7 +91,7 @@ public class SecurityHomePageContentProvider implements GeoServerHomePageContent
             }
 
             // check for default master password
-            boolean visibility = manager.checkMasterPassword(DEFAULT_ADMIN_PASSWD);
+            boolean visibility = manager.checkMasterPassword(DEFAULT_ADMIN_PASSWD, false);
 
             Label label =
                     new Label(

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/SecurityHomePageContentProviderTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/SecurityHomePageContentProviderTest.java
@@ -1,0 +1,35 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.web;
+
+import org.geoserver.security.password.MasterPasswordProviderConfig;
+import org.junit.Test;
+
+public class SecurityHomePageContentProviderTest extends AbstractSecurityWicketTestSupport {
+
+    @Test
+    public void testMasterPasswordMessageWithLoginDisabled() throws Exception {
+        checkMasterPasswordMessage(false);
+    }
+
+    @Test
+    public void testMasterPasswordMessageWithLoginEnabled() throws Exception {
+        checkMasterPasswordMessage(true);
+    }
+
+    private void checkMasterPasswordMessage(boolean loginEnabled) throws Exception {
+        MasterPasswordProviderConfig masterPasswordConfig =
+                getSecurityManager()
+                        .loadMasterPassswordProviderConfig(
+                                getSecurityManager().getMasterPasswordConfig().getProviderName());
+        masterPasswordConfig.setLoginEnabled(loginEnabled);
+        getSecurityManager().saveMasterPasswordProviderConfig(masterPasswordConfig);
+        tester.startComponentInPage(
+                new SecurityHomePageContentProvider().getPageBodyComponent("swp"));
+        tester.assertComponent("swp", SecurityHomePageContentProvider.SecurityWarningsPanel.class);
+        tester.assertVisible("swp:mpmessage");
+        tester.assertVisible("swp:mplink");
+    }
+}


### PR DESCRIPTION
2.14.x backport for https://github.com/geoserver/geoserver/pull/3308