### PR TITLE
[GEOS-9081][2.14.x] Allow expressions in ColorMapEntry labels for GetLegendGraphic.

### DIFF
--- a/doc/en/user/source/styling/sld/reference/rastersymbolizer.rst
+++ b/doc/en/user/source/styling/sld/reference/rastersymbolizer.rst
@@ -196,7 +196,7 @@ The value ``false`` (the default) specifies that the color scale is calculated u
 CQL Expressions
 """""""""""""""
 
-Most of the ColorMapEntry attributes (color, quantity and opacity) can be defined using ``cql expressions``, with the ${...expression...} syntax.
+All of the ColorMapEntry attributes (color, quantity, label and opacity) can be defined using ``cql expressions``, with the ${...expression...} syntax.
 
 CQL expressions are useful to make the color map dynamic, using values taken from the client:    
 

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/Cell.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/Cell.java
@@ -190,7 +190,7 @@ public abstract class Cell {
                     new ColorManager.SimpleColorManager(
                             color, opacity, requestedDimension, borderColor));
 
-            final String label = currentCME.getLabel();
+            final String label = LegendUtils.getLabel(currentCME);
             final double quantity = LegendUtils.getQuantity(currentCME);
             final String symbol = " = ";
 
@@ -412,7 +412,7 @@ public abstract class Cell {
                     new ColorManager.SimpleColorManager.GradientColorManager(
                             color, opacity, previousColor, requestedDimension, borderColor));
 
-            String label = currentCME.getLabel();
+            String label = LegendUtils.getLabel(currentCME);
             double quantity = LegendUtils.getQuantity(currentCME);
 
             // Added variation for DynamicColorMap
@@ -591,7 +591,7 @@ public abstract class Cell {
                     new ColorManager.SimpleColorManager(
                             color, opacity, requestedDimension, borderColor));
 
-            String label = currentCME.getLabel();
+            String label = LegendUtils.getLabel(currentCME);
             double quantity1 =
                     leftEdge
                             ? LegendUtils.getQuantity(currentCME)

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendUtils.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendUtils.java
@@ -528,6 +528,22 @@ public class LegendUtils {
     }
 
     /**
+     * Extracts the label part from the provided {@link ColorMapEntry}.
+     *
+     * @param entry the provided {@link ColorMapEntry} from which we should extract the label part.
+     * @return the label part for the provided {@link ColorMapEntry}.
+     */
+    public static String getLabel(final ColorMapEntry entry) {
+        ensureNotNull(entry, "entry");
+        String labelString = entry.getLabel();
+        if (labelString != null && labelString.startsWith("${")) {
+            Expression label = ExpressionExtractor.extractCqlExpressions(labelString);
+            labelString = label.evaluate(null, String.class);
+        }
+        return labelString;
+    }
+
+    /**
      * Finds the applicable Rules for the given scale denominator.
      *
      * @param ftStyles

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/AbstractLegendGraphicOutputFormatTest.java
@@ -984,9 +984,22 @@ public class AbstractLegendGraphicOutputFormatTest extends BaseLegendTest {
 
             // was the legend painted?
             assertNotBlank("testColorMapWithCql", image, LegendUtils.DEFAULT_BG_COLOR);
+            int fixedWidth = image.getWidth();
+
+            // "-49 - -20 mm"
+            String fixedLabel = entries[2].getLabel();
+            entries[2].setLabel(
+                    "${Concatenate('-', '4', '9', ' ', '-', ' ', '-', '2', '0', ' ', 'm', 'm')}");
+            assertEquals(fixedLabel, LegendUtils.getLabel(entries[2]));
+
+            image = this.legendProducer.buildLegendGraphic(req);
 
             // was the legend painted?
             assertNotBlank("testColorMapWithCql", image, LegendUtils.DEFAULT_BG_COLOR);
+
+            // check that the legend images with the fixed label string and the
+            // expression that generates the label string have the same widths.
+            assertEquals(fixedWidth, image.getWidth());
         } finally {
             RenderedImage ri = coverage.getRenderedImage();
             if (coverage instanceof GridCoverage2D) {


### PR DESCRIPTION
2.14.x backport for https://github.com/geoserver/geoserver/pull/3307