### PR TITLE
Follow up on GWC #724, fixes GEOS-8995, GEOS-8910

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/dispatch/GwcServiceDispatcherCallback.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/dispatch/GwcServiceDispatcherCallback.java
@@ -43,9 +43,9 @@ public class GwcServiceDispatcherCallback extends AbstractDispatcherCallback
     public static final ThreadLocal<String> GWC_OPERATION = new ThreadLocal<>();
 
     private static final Pattern GWC_WS_VIRTUAL_SERVICE_PATTERN =
-            Pattern.compile("([^/]+)/gwc/service");
+            Pattern.compile("([^/]+)/gwc/service.*");
     private static final Pattern GWC_LAYER_VIRTUAL_SERVICE_PATTERN =
-            Pattern.compile("([^/]+)/([^/]+)/gwc/service");
+            Pattern.compile("([^/]+)/([^/]+)/gwc/service.*");
 
     private final Catalog catalog;
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -1384,7 +1384,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
                                         baseUrl,
                                         legendInfo.getOnlineResource(),
                                         null,
-                                        URLMangler.URLType.RESOURCE));
+                                        URLMangler.URLType.SERVICE));
                 legends.put(styleInfo.prefixedName(), gwcLegendInfo.build());
             } else {
                 int finalWidth = GetLegendGraphicRequest.DEFAULT_WIDTH;

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -1783,6 +1783,51 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
     }
 
     @Test
+    public void testGetCapabilitiesWithRestEndpointsWorkspaceService() throws Exception {
+        MockHttpServletRequest request =
+                createRequest(
+                        MockData.CITE_PREFIX
+                                + "/gwc"
+                                + WMTSService.REST_PATH
+                                + "/WMTSCapabilities.xml");
+        request.setMethod("GET");
+
+        Request mockRequest = mock(Request.class);
+        when(mockRequest.getHttpRequest()).thenReturn(request);
+        Dispatcher.REQUEST.set(mockRequest);
+
+        MockHttpServletResponse response = dispatch(request, null);
+
+        Document doc = dom(new ByteArrayInputStream(response.getContentAsByteArray()), true);
+        print(doc);
+
+        // check legend backlink and that it has the workspace specification
+        assertEquals(
+                "http://localhost:8080/geoserver/cite/ows?service=WMS&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=cite%3ABasicPolygons",
+                WMTS_XPATH_10.evaluate(
+                        "//wmts:Contents/wmts:Layer[ows:Title='BasicPolygons']/wmts:Style/wmts:LegendURL/@xlink:href",
+                        doc));
+        // check tile resources
+        assertEquals(
+                "http://localhost:8080/geoserver/cite/gwc/service/wmts/rest/cite:BasicPolygons/{style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}?format=image/png",
+                WMTS_XPATH_10.evaluate(
+                        "//wmts:Contents/wmts:Layer[ows:Title='BasicPolygons']/wmts:ResourceURL[@format='image/png' and @resourceType='tile']/@template",
+                        doc));
+        // check featureinfo resource
+        assertEquals(
+                "http://localhost:8080/geoserver/cite/gwc/service/wmts/rest/cite:BasicPolygons/{style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}?format=text/plain",
+                WMTS_XPATH_10.evaluate(
+                        "//wmts:Contents/wmts:Layer[ows:Title='BasicPolygons']/wmts:ResourceURL[@format='text/plain' and @resourceType='FeatureInfo']/@template",
+                        doc));
+        // check backlink too
+        assertEquals(
+                "1",
+                WMTS_XPATH_10.evaluate(
+                        "count(//wmts:Capabilities/wmts:ServiceMetadataURL[@xlink:href='http://localhost:8080/geoserver/cite/gwc/service/wmts/rest/WMTSCapabilities.xml'])",
+                        doc));
+    }
+
+    @Test
     public void testGetTileWithRestEndpoints() throws Exception {
 
         MockHttpServletRequest request =


### PR DESCRIPTION
Follows up (and requires) https://github.com/GeoWebCache/geowebcache/pull/725

Added for early feedback, I think I still need to add a test for the backlinks to resources.
Surprisingly the exists tests did not fail despite the current user not being logged in as admin, but the same non authenticated requests would have failed in a running GeoServer with a 401.