### PR TITLE
[GEOS-9018] Only use Ctrl-Space to trigger autocomplete

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/wicket/CodeMirrorEditor.js
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/CodeMirrorEditor.js
@@ -54,14 +54,6 @@ var editor = CodeMirror.fromTextArea(textarea, {
 });
 editor.getWrapperElement().style.fontSize = "12px"; 
 editor.refresh();
-CodeMirror.on(window, 'keyup', function(event) {
-  var blacklist = [
-      27 // Esc
-  ];
-  if (!blacklist.includes(event.keyCode)) {
-    completeIfValidPos(document.gsEditors.editor);
-  }
-});
 
 if(!document.gsEditors) {
     document.gsEditors = {};

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/js/codemirror/js/xml-hint.js
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/js/codemirror/js/xml-hint.js
@@ -2406,7 +2406,7 @@
   function getVersion(style) {
     var styleHeader = style.match(/<.*StyledLayerDescriptor[^]+?>/);
     if (styleHeader != null && styleHeader[0] != null) {
-        var version = styleHeader[0].match(/version="(.*)"/);
+        var version = styleHeader[0].match(/version="(.*?)"/);
         if (version != null && version[1] != null) {
             return version[1];
         } else {


### PR DESCRIPTION
Follow-up to https://github.com/geoserver/geoserver/pull/3244

Disables automatic autocomplete on keyup - now Ctrl-Space is the only autocomplete method