### PR TITLE
[GEOS-9109] Styles referring to relative icons in subdirectories fail to change workspace

### DIFF
--- a/src/main/src/test/java/org/geoserver/catalog/CatalogIntegrationTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/CatalogIntegrationTest.java
@@ -20,6 +20,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
 import org.geoserver.catalog.CascadeRemovalReporter.ModificationType;
 import org.geoserver.catalog.event.CatalogEvent;
 import org.geoserver.catalog.event.CatalogListener;
@@ -40,6 +41,7 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.styling.LineSymbolizer;
 import org.geotools.styling.PointSymbolizer;
+import org.geotools.util.Version;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -72,21 +74,40 @@ public class CatalogIntegrationTest extends GeoServerSystemTestSupport {
 
     @Override
     protected void onSetUp(SystemTestData testData) throws IOException {
+        final Catalog catalog = getCatalog();
         testData.addStyle(
-                "singleStyleGroup",
-                "singleStyleGroup.sld",
-                CatalogIntegrationTest.class,
-                getCatalog());
+                "singleStyleGroup", "singleStyleGroup.sld", CatalogIntegrationTest.class, catalog);
         testData.addStyle(
-                "multiStyleGroup",
-                "multiStyleGroup.sld",
-                CatalogIntegrationTest.class,
-                getCatalog());
+                "multiStyleGroup", "multiStyleGroup.sld", CatalogIntegrationTest.class, catalog);
         testData.addStyle(
                 "recursiveStyleGroup",
                 "recursiveStyleGroup.sld",
                 CatalogIntegrationTest.class,
-                getCatalog());
+                catalog);
+
+        // add a style with relative resource references, and resources in sub-directories
+        testData.addStyle("relative", "se_relativepath.sld", ResourcePoolTest.class, catalog);
+        StyleInfo style = catalog.getStyleByName("relative");
+        style.setFormatVersion(new Version("1.1.0"));
+        catalog.save(style);
+        File images = new File(testData.getDataDirectoryRoot(), "styles/images");
+        assertTrue(images.mkdir());
+        File image = new File("./src/test/resources/org/geoserver/catalog/rockFillSymbol.png");
+        assertTrue(image.exists());
+        FileUtils.copyFileToDirectory(image, images);
+        File svg = new File("./src/test/resources/org/geoserver/catalog/square16.svg");
+        assertTrue(svg.exists());
+        FileUtils.copyFileToDirectory(svg, images);
+
+        // add a workspace for style move testing
+        final CatalogFactory factory = catalog.getFactory();
+        final WorkspaceInfo secondaryWs = factory.createWorkspace();
+        secondaryWs.setName("secondary");
+        final NamespaceInfo secondaryNs = factory.createNamespace();
+        secondaryNs.setPrefix("secondary");
+        secondaryNs.setURI("http://www.geoserver.org/secondary");
+        catalog.add(secondaryWs);
+        catalog.add(secondaryNs);
     }
 
     @Test
@@ -597,5 +618,23 @@ public class CatalogIntegrationTest extends GeoServerSystemTestSupport {
         // check the default point style has been re-created
         final StyleInfo point = getCatalog().getStyleByName("point");
         assertNotNull(point);
+    }
+
+    @Test
+    public void testChangeStyleWorkspaceRelativeResources() throws Exception {
+        // move style to a different workspace
+        final Catalog catalog = getCatalog();
+        final StyleInfo style = catalog.getStyleByName("relative");
+        final WorkspaceInfo secondaryWs = catalog.getWorkspaceByName("secondary");
+        style.setWorkspace(secondaryWs);
+        catalog.save(style);
+
+        // check the referenced image and svg has been moved keeping the relative position
+        final Resource relativeImage =
+                getDataDirectory().getStyles(secondaryWs, "images", "rockFillSymbol.png");
+        assertEquals(Resource.Type.RESOURCE, relativeImage.getType());
+        final Resource relativeSvg =
+                getDataDirectory().getStyles(secondaryWs, "images", "square16.svg");
+        assertEquals(Resource.Type.RESOURCE, relativeSvg.getType());
     }
 }

--- a/src/main/src/test/resources/org/geoserver/catalog/se_relativepath.sld
+++ b/src/main/src/test/resources/org/geoserver/catalog/se_relativepath.sld
@@ -19,6 +19,20 @@
               </se:GraphicFill>
             </se:Fill>
           </se:PolygonSymbolizer>
+          <se:PolygonSymbolizer>
+            <se:Fill>
+              <se:GraphicFill>
+                <se:Graphic>
+                  <se:Mark>
+                    <se:WellKnownName>file://images/square16.svg</se:WellKnownName>
+                    <se:Fill>
+                      <se:SvgParameter name="fill">0xFF0000</se:SvgParameter>
+                    </se:Fill>
+                  </se:Mark>
+                </se:Graphic>
+              </se:GraphicFill>
+            </se:Fill>
+          </se:PolygonSymbolizer>
         </se:Rule>
       </se:FeatureTypeStyle>
     </UserStyle>

--- a/src/main/src/test/resources/org/geoserver/catalog/square16.svg
+++ b/src/main/src/test/resources/org/geoserver/catalog/square16.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="Nuovo documento 1">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="375"
+     inkscape:cy="1091.4286"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,0)">
+    <rect
+       style="fill:#0000ff;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="rect2993"
+       width="16"
+       height="16"
+       x="0"
+       y="0"
+       transform="translate(0,0)" />
+  </g>
+</svg>


### PR DESCRIPTION
Depends on a couple of GeoTools fixes, hopefully they are already deployed