### PR TITLE
Fix various issues related to URL checking

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -1890,7 +1890,7 @@ public class ResourcePool {
 
         WMSCapabilities caps = info.getStore().getWebMapServer(null).getCapabilities();
         for (Layer layer : caps.getLayerList()) {
-            if (name.equals(layer.getName())) {
+            if (layer != null && name.equals(layer.getName())) {
                 return layer;
             }
         }
@@ -1917,7 +1917,7 @@ public class ResourcePool {
         caps = info.getStore().getWebMapTileServer(null).getCapabilities();
 
         for (Layer layer : caps.getLayerList()) {
-            if (name.equals(layer.getName())) {
+            if (layer != null && name.equals(layer.getName())) {
                 return layer;
             }
         }

--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityFilterChainProxy.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityFilterChainProxy.java
@@ -30,6 +30,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.firewall.DefaultHttpFirewall;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 public class GeoServerSecurityFilterChainProxy
@@ -203,6 +204,7 @@ public class GeoServerSecurityFilterChainProxy
             securityManager.getAuthenticationCache().removeAll();
 
             proxy = new FilterChainProxy(filterChains);
+            proxy.setFirewall(new DefaultHttpFirewall());
             proxy.afterPropertiesSet();
             chainsInitialized = true;
         }


### PR DESCRIPTION
Issues addressed by this change:
* [GEOS-8913] Layer Preview URL contained a potentially malicious String
* [GEOS-8988] WMTS tile requests fail with 'RequestRejectedException: The request was rejected because the URL was not normalized'
* [GEOS-9054] Geoserver object names cannot contain special characters (dot,...) when the are used in URLs for the REST API.

I've tried to use a tamed down StrictHttpFirewall but there is no way to configure it so that it allows layer group usage in WMTS restful request (which ends up having a double slahs, as the style name is a empty string).
Verified it works manually, did not find a reasonable way to check it with an actual test (our mocks have no cooking management, security chain is not enabled, and the like).

Ah, this PR comes with a side issue that I've found while testing, simple NPE checking, again, would require a broken WMS/WMTS server to be reproduced in tests.