### PR TITLE
[GEOS-9022] geoserver Style page, after expand button, html breaks

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/js/jquery.fullscreen.js
+++ b/src/web/core/src/main/java/org/geoserver/web/js/jquery.fullscreen.js
@@ -1,5 +1,5 @@
 $( document ).ready(function() {
-
+    var fullscreen = false;
     var editorDefault = 300;
     var previewDefault = 300;
 
@@ -47,7 +47,13 @@ $( document ).ready(function() {
         var img = $("#fullscreen-img");
         var page = $("#page");
         var pagePane = $("#page-pane");
-        document.documentElement.style.overflow = "hidden";
+        fullscreen = !fullscreen;
+        if (!fullscreen) {
+          document.documentElement.style.overflow = "unset";
+        } else {
+          document.documentElement.style.overflow = "hidden";
+        }
+        
         img.toggleClass("fullscreen-image-in")
         page.toggleClass("fullscreen");
         pagePane.toggleClass("page-pane-fullscreen");


### PR DESCRIPTION
This issue cannot be unit tested, would be nice if someone could verify manually?
@tixvieira @ianturton or @tbarsballe would be good candidates as they were involved in the discussion