### PR TITLE
[GEOS-8762] Fix Monitor asynchronous post processing does not play well with security

### DIFF
--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
@@ -247,7 +247,7 @@ public class MonitorFilter implements GeoServerFilter {
      * Audit consumer function to be executed on the underlying PostProcessTask thread. Will receive
      * {@link RequestData} and {@link Authentication} from thread execution.
      */
-    public void setExecutionAudit(BiConsumer<RequestData, Authentication> executionAudit) {
+    void setExecutionAudit(BiConsumer<RequestData, Authentication> executionAudit) {
         this.executionAudit = executionAudit;
     }
 
@@ -306,7 +306,7 @@ public class MonitorFilter implements GeoServerFilter {
          * Audit consumer function. Will receive post processed {@link RequestData} and run time
          * {@link Authentication}.
          */
-        public void setExecutionAudit(BiConsumer<RequestData, Authentication> executionAudit) {
+        void setExecutionAudit(BiConsumer<RequestData, Authentication> executionAudit) {
             this.executionAudit = executionAudit;
         }
     }

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.FilterChain;
@@ -43,6 +44,8 @@ public class MonitorFilter implements GeoServerFilter {
     MonitorRequestFilter requestFilter;
 
     ExecutorService postProcessExecutor;
+
+    BiConsumer<RequestData, Authentication> executionAudit;
 
     public MonitorFilter(Monitor monitor, MonitorRequestFilter requestFilter) {
         this.monitor = monitor;
@@ -176,7 +179,16 @@ public class MonitorFilter implements GeoServerFilter {
         monitor.complete();
 
         // post processing
-        postProcessExecutor.execute(new PostProcessTask(monitor, data, req, resp));
+        PostProcessTask task =
+                new PostProcessTask(
+                        monitor,
+                        data,
+                        req,
+                        resp,
+                        SecurityContextHolder.getContext().getAuthentication());
+        // Execution Audit
+        task.setExecutionAudit(executionAudit);
+        postProcessExecutor.execute(task);
 
         if (error != null) {
             if (error instanceof RuntimeException) {
@@ -231,26 +243,40 @@ public class MonitorFilter implements GeoServerFilter {
         }
     }
 
+    /**
+     * Audit consumer function to be executed on the underlying PostProcessTask thread. Will receive
+     * {@link RequestData} and {@link Authentication} from thread execution.
+     */
+    public void setExecutionAudit(BiConsumer<RequestData, Authentication> executionAudit) {
+        this.executionAudit = executionAudit;
+    }
+
     static class PostProcessTask implements Runnable {
 
         Monitor monitor;
         RequestData data;
         HttpServletRequest request;
         HttpServletResponse response;
+        Authentication propagatedAuth;
+
+        BiConsumer<RequestData, Authentication> executionAudit;
 
         PostProcessTask(
                 Monitor monitor,
                 RequestData data,
                 HttpServletRequest request,
-                HttpServletResponse response) {
+                HttpServletResponse response,
+                Authentication propagatedAuth) {
             this.monitor = monitor;
             this.data = data;
             this.request = request;
             this.response = response;
+            this.propagatedAuth = propagatedAuth;
         }
 
         public void run() {
             try {
+                SecurityContextHolder.getContext().setAuthentication(propagatedAuth);
                 List<RequestPostProcessor> pp = new ArrayList();
                 pp.add(new ReverseDNSPostProcessor());
                 pp.addAll(GeoServerExtensions.extensions(RequestPostProcessor.class));
@@ -265,11 +291,23 @@ public class MonitorFilter implements GeoServerFilter {
 
                 monitor.postProcessed(data);
             } finally {
+                if (executionAudit != null)
+                    executionAudit.accept(
+                            data, SecurityContextHolder.getContext().getAuthentication());
                 monitor = null;
                 data = null;
                 request = null;
                 response = null;
+                SecurityContextHolder.getContext().setAuthentication(null);
             }
+        }
+
+        /**
+         * Audit consumer function. Will receive post processed {@link RequestData} and run time
+         * {@link Authentication}.
+         */
+        public void setExecutionAudit(BiConsumer<RequestData, Authentication> executionAudit) {
+            this.executionAudit = executionAudit;
         }
     }
 }


### PR DESCRIPTION
This PR:
- Fix Authentication propagation between Monitor filter and its underlying PostProcessTask thread.
- For testing purposes adds an (optional-nullable) audit functional consumer to Monitor filter for having feedback of RequestData and Authentication variables from threadpool's background thread scope.

https://osgeo-org.atlassian.net/browse/GEOS-8762