### PR TITLE
Revert "Update Jetty deprecated properties"

### DIFF
--- a/src/release/jetty/start.ini
+++ b/src/release/jetty/start.ini
@@ -59,10 +59,10 @@ jetty.delayDispatchUntilContent=false
 --module=http
 
 # HTTP port to listen on
-jetty.http.port=8080
+jetty.port=8080
 
 # HTTP idle timeout in milliseconds
-jetty.http.idleTimeout=30000
+http.timeout=30000
 
 # HTTP Socket.soLingerTime in seconds. (-1 to disable)
 # http.soLingerTime=-1


### PR DESCRIPTION
Reverts geoserver/geoserver#3331, I believe it's the cause of all the CITE test failures (the CITE machinery uses old ways of setting ports that apparently are not working anymore if the configuration contains the new property names)