### PR TITLE
[GEOS-9131] App-schema multiple sortBy support on SQL testing

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SortByTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SortByTest.java
@@ -30,7 +30,44 @@ public class SortByTest extends AbstractAppSchemaTestSupport {
                         "wfs?request=GetFeature&version=2.0&outputFormat=gml32&typename=gsml:MappedFeature&sortBy=gml:name");
         LOGGER.info("WFS GetFeature response:\n" + prettyString(doc));
 
-        // check order
+        checkSortByNameResponse(doc);
+    }
+
+    @Test
+    public void testGetMappedFeatureMultipleSortby() throws Exception {
+        String query =
+                "<wfs:GetFeature service=\"WFS\" version=\"2.0.0\"\n"
+                        + "    xmlns:gsml=\"urn:cgi:xmlns:CGI:GeoSciML-Core:3.0.0\"\n"
+                        + "    xmlns:wfs=\"http://www.opengis.net/wfs/2.0\"\n"
+                        + "    xmlns:fes=\"http://www.opengis.net/fes/2.0\"\n"
+                        + "    xmlns:gml=\"http://www.opengis.net/gml/3.2\">\n"
+                        + "    <wfs:Query typeNames=\"gsml:MappedFeature\" srsName=\"EPSG:4326\">\n"
+                        + "        <fes:Filter>\n"
+                        + "            <fes:PropertyIsLike wildCard=\"*\"\n"
+                        + "                singleChar=\".\" escapeChar=\"\\\">\n"
+                        + "                <fes:ValueReference>gsml:MappedFeature/gsml:specification/gsml:GeologicUnit/gml:description\n"
+                        + "                </fes:ValueReference>\n"
+                        + "                <fes:Literal>*</fes:Literal>\n"
+                        + "            </fes:PropertyIsLike>\n"
+                        + "        </fes:Filter>\n"
+                        + "        <fes:SortBy>\n"
+                        + "            <fes:SortProperty>\n"
+                        + "                <fes:ValueReference>gsml:MappedFeature/gml:name</fes:ValueReference>\n"
+                        + "                <fes:SortOrder>ASC</fes:SortOrder>\n"
+                        + "            </fes:SortProperty>\n"
+                        + "            <fes:SortProperty>\n"
+                        + "                <fes:ValueReference>gsml:MappedFeature</fes:ValueReference>\n"
+                        + "                <fes:SortOrder>ASC</fes:SortOrder>\n"
+                        + "            </fes:SortProperty>\n"
+                        + "        </fes:SortBy>\n"
+                        + "    </wfs:Query>\n"
+                        + "</wfs:GetFeature>\n"
+                        + "";
+        Document doc = postAsDOM("wfs?request=GetFeature&version=2.0&outputFormat=gml32", query);
+        checkSortByNameResponse(doc);
+    }
+
+    private void checkSortByNameResponse(Document doc) {
         assertXpathEvaluatesTo(
                 "mf3", "//wfs:FeatureCollection/wfs:member[1]/gsml:MappedFeature/@gml:id", doc);
         assertXpathEvaluatesTo(


### PR DESCRIPTION
Executing a WFS query with nested filter and multiple sortBy expressions throws an malformed SQL exception on App-schema and Postgresql.

This PR tests fix for SQL nested filter building on multiple sortBy expressions did on [GEOT-6252]

https://osgeo-org.atlassian.net/browse/GEOT-6252
https://osgeo-org.atlassian.net/browse/GEOS-9131

Depends on Geotools PR:
https://github.com/geotools/geotools/pull/2277

