### PR TITLE
[GEOS-9136] Upgrade GDAL dependencies to 2.x

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1965,7 +1965,7 @@
   <poi.version>4.0.0</poi.version>
   <wicket.version>7.6.0</wicket.version>
   <ant.version>1.8.4</ant.version>
-  <imageio-ext.version>1.2.1</imageio-ext.version>
+  <imageio-ext.version>1.3.0</imageio-ext.version>
   <jaiext.version>1.1.7</jaiext.version>
   <java.awt.headless>true</java.awt.headless>
   <sun.java2d.d3d>true</sun.java2d.d3d>


### PR DESCRIPTION
It's in particular interesting to check the native library installation section, which has been overhauled to use generally available GDAL binaries.
Given the amount of edits it's likely easier to review the final result:
https://github.com/geoserver/geoserver/blob/b7f01358b3c4d6106ead57c622d6f2a60dc41a5d/doc/en/user/source/data/raster/gdal.rst