### PR TITLE
[GEOS-9141] Fixed invalid WCS 2.0.1 DescribeCoverage with elevation and custom dimensions.

### DIFF
--- a/src/wcs2_0/src/main/resources/schemas/wcs/2.0/wcsgs.xsd
+++ b/src/wcs2_0/src/main/resources/schemas/wcs/2.0/wcsgs.xsd
@@ -30,4 +30,69 @@
     </sequence>
     <attribute name="default"/>
   </complexType>
+
+  <element name="ElevationDomain" type="wcsgs:ElevationDomainType">
+    <annotation>
+      <documentation>A description of the elevation domain for this coverage
+      </documentation>
+    </annotation>
+  </element>
+  <complexType name="ElevationDomainType">
+    <choice minOccurs="0" maxOccurs="unbounded">
+      <element ref="wcsgs:SingleValue" />
+      <element ref="wcsgs:Range" />
+    </choice>
+    <attribute name="uom" />
+    <attribute name="default" />
+  </complexType>
+
+  <element name="DimensionDomain" type="wcsgs:DimensionDomainType">
+    <annotation>
+      <documentation>A description of a custom domain for this coverage
+      </documentation>
+    </annotation>
+  </element>
+  <complexType name="DimensionDomainType">
+    <choice minOccurs="0" maxOccurs="unbounded">
+      <element ref="gml:AbstractTimeObject" />
+      <element ref="wcsgs:SingleValue" />
+      <element ref="wcsgs:Range" />
+    </choice>
+    <attribute name="name" />
+    <attribute name="uom" />
+    <attribute name="default" />
+  </complexType>
+
+  <element name="SingleValue" type="string">
+    <annotation>
+      <documentation>A non-temporal dimension value
+      </documentation>
+    </annotation>
+  </element>
+  <element name="Range" type="wcsgs:RangeType">
+    <annotation>
+      <documentation>A non-temporal dimension range
+      </documentation>
+    </annotation>
+  </element>
+  <complexType name="RangeType">
+    <sequence>
+      <element name="start" type="string" />
+      <element name="end" type="string" />
+      <element ref="wcsgs:Interval" minOccurs="0" />
+    </sequence>
+  </complexType>
+  <element name="Interval" type="wcsgs:IntervalType">
+    <annotation>
+      <documentation>The discrete interval of a non-temporal dimension range
+      </documentation>
+    </annotation>
+  </element>
+  <complexType name="IntervalType">
+    <simpleContent>
+      <extension base="string">
+        <attribute name="unit" />
+      </extension>
+    </simpleContent>
+  </complexType>
 </schema>

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/DescribeCoverageTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/DescribeCoverageTest.java
@@ -575,6 +575,7 @@ public class DescribeCoverageTest extends WCSTestSupport {
                 "m");
         Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=sf__timeranges");
         //        print(dom);
+        checkValidationErrors(dom, getWcs20Schema());
 
         checkElevationRangesEnvelope(dom);
 
@@ -610,6 +611,7 @@ public class DescribeCoverageTest extends WCSTestSupport {
                 null);
         Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=sf__timeranges");
         //        print(dom);
+        checkValidationErrors(dom, getWcs20Schema());
 
         checkElevationRangesEnvelope(dom);
 
@@ -634,6 +636,7 @@ public class DescribeCoverageTest extends WCSTestSupport {
                 getLayerId(WATTEMP), ResourceInfo.ELEVATION, DimensionPresentation.LIST, null);
         Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=sf__watertemp");
         //        print(dom);
+        checkValidationErrors(dom, getWcs20Schema());
 
         checkWaterTempElevationEnvelope(dom);
 
@@ -658,6 +661,7 @@ public class DescribeCoverageTest extends WCSTestSupport {
                 getLayerId(TIMERANGES), ResourceInfo.ELEVATION, DimensionPresentation.LIST, null);
         Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=sf__timeranges");
         //        print(dom);
+        checkValidationErrors(dom, getWcs20Schema());
 
         checkElevationRangesEnvelope(dom);
 
@@ -751,6 +755,7 @@ public class DescribeCoverageTest extends WCSTestSupport {
                 null);
         Document dom = getAsDOM(DESCRIBE_URL + "&coverageId=sf__multidim");
         //        print(dom);
+        checkValidationErrors(dom, getWcs20Schema());
 
         checkTimeElevationRangesEnvelope(dom);
 
@@ -911,43 +916,35 @@ public class DescribeCoverageTest extends WCSTestSupport {
 
     private void checkWaterTempElevationEnvelope(Document dom) throws XpathException {
         // check the envelope with time
-        assertXpathEvaluatesTo("1", "count(//gml:boundedBy/gml:EnvelopeWithTimePeriod)", dom);
+        assertXpathEvaluatesTo("1", "count(//gml:boundedBy/gml:Envelope)", dom);
         assertXpathEvaluatesTo(
-                "Lat Long elevation",
-                "//gml:boundedBy/gml:EnvelopeWithTimePeriod/@axisLabels",
-                dom);
-        assertXpathEvaluatesTo(
-                "Deg Deg m", "//gml:boundedBy/gml:EnvelopeWithTimePeriod/@uomLabels", dom);
-        assertXpathEvaluatesTo(
-                "3", "//gml:boundedBy/gml:EnvelopeWithTimePeriod/@srsDimension", dom);
+                "Lat Long elevation", "//gml:boundedBy/gml:Envelope/@axisLabels", dom);
+        assertXpathEvaluatesTo("Deg Deg m", "//gml:boundedBy/gml:Envelope/@uomLabels", dom);
+        assertXpathEvaluatesTo("3", "//gml:boundedBy/gml:Envelope/@srsDimension", dom);
         assertXpathEvaluatesTo(
                 "40.562080748421806 0.23722068851276978 0.0",
-                "//gml:boundedBy/gml:EnvelopeWithTimePeriod/gml:lowerCorner",
+                "//gml:boundedBy/gml:Envelope/gml:lowerCorner",
                 dom);
         assertXpathEvaluatesTo(
                 "44.55808294568743 14.592757149389236 100.0",
-                "//gml:boundedBy/gml:EnvelopeWithTimePeriod/gml:upperCorner",
+                "//gml:boundedBy/gml:Envelope/gml:upperCorner",
                 dom);
     }
 
     private void checkElevationRangesEnvelope(Document dom) throws XpathException {
         // check the envelope with time
-        assertXpathEvaluatesTo("1", "count(//gml:boundedBy/gml:EnvelopeWithTimePeriod)", dom);
+        assertXpathEvaluatesTo("1", "count(//gml:boundedBy/gml:Envelope)", dom);
         assertXpathEvaluatesTo(
-                "Lat Long elevation",
-                "//gml:boundedBy/gml:EnvelopeWithTimePeriod/@axisLabels",
-                dom);
-        assertXpathEvaluatesTo(
-                "Deg Deg m", "//gml:boundedBy/gml:EnvelopeWithTimePeriod/@uomLabels", dom);
-        assertXpathEvaluatesTo(
-                "3", "//gml:boundedBy/gml:EnvelopeWithTimePeriod/@srsDimension", dom);
+                "Lat Long elevation", "//gml:boundedBy/gml:Envelope/@axisLabels", dom);
+        assertXpathEvaluatesTo("Deg Deg m", "//gml:boundedBy/gml:Envelope/@uomLabels", dom);
+        assertXpathEvaluatesTo("3", "//gml:boundedBy/gml:Envelope/@srsDimension", dom);
         assertXpathEvaluatesTo(
                 "40.562080748421806 0.23722068851276978 20.0",
-                "//gml:boundedBy/gml:EnvelopeWithTimePeriod/gml:lowerCorner",
+                "//gml:boundedBy/gml:Envelope/gml:lowerCorner",
                 dom);
         assertXpathEvaluatesTo(
                 "44.55808294568743 14.592757149389236 150.0",
-                "//gml:boundedBy/gml:EnvelopeWithTimePeriod/gml:upperCorner",
+                "//gml:boundedBy/gml:Envelope/gml:upperCorner",
                 dom);
     }
 


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-9141

This pull request combines the following changes:
1. Changes "gml:EnvelopeWithTimePeriod" to "gml:Envelope" for coverages with an elevation dimension and no time dimension.
1. Ensures unique "gml:id" attributes for custom temporal dimensions.
1. Adds "ElevationDomain" and "DimensionDomain" to wcsgs.xsd.

No new unit tests were added but schema validation was added to all of the DescribeCoverage unit tests for elevation and custom dimensions.