### PR TITLE
[GEOS-8754] OpenLayers 3 preview fails to display projected maps in WMS 1.3

### DIFF
--- a/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
+++ b/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
@@ -283,7 +283,9 @@
       var projection = new ol.proj.Projection({
           code: '${request.SRS?js_string}',
           units: '${units?js_string}',
+          <#if yx == "true">
           axisOrientation: 'neu',
+          </#if>
           global: ${global}
       });
       var map = new ol.Map({


### PR DESCRIPTION
"neu" is not a "new" misnomer, it's really "north east up", so it should be used only for flipped CRSes