### PR TITLE
[GEOS-9142] Added missing metadata to WCS 2.0.1 GetCapabilities and DescribeCoverage.

### DIFF
--- a/src/extension/wcs2_0-eo/core/src/main/java/org/geoserver/wcs2_0/eo/response/DescribeEOCoverageSetTransformer.java
+++ b/src/extension/wcs2_0-eo/core/src/main/java/org/geoserver/wcs2_0/eo/response/DescribeEOCoverageSetTransformer.java
@@ -138,6 +138,8 @@ public class DescribeEOCoverageSetTransformer extends TransformerBase {
                     atts(
                             "xmlns:eop",
                             "http://www.opengis.net/eop/2.0", //
+                            "xmlns:ows",
+                            "http://www.opengis.net/ows/2.0",
                             "xmlns:gml",
                             "http://www.opengis.net/gml/3.2", //
                             "xmlns:wcsgs",

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/GMLTransformer.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/GMLTransformer.java
@@ -286,6 +286,7 @@ class GMLTransformer extends TransformerBase {
             start("gmlcov:metadata");
             start("gmlcov:Extension");
 
+            handleAdditionalMetadata(context);
             if (dimensionsHelper != null) {
 
                 // handle time if necessary
@@ -304,6 +305,10 @@ class GMLTransformer extends TransformerBase {
 
             end("gmlcov:Extension");
             end("gmlcov:metadata");
+        }
+
+        protected void handleAdditionalMetadata(Object context) {
+            // Override to do something.
         }
 
         /**

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20DescribeCoverageTransformer.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20DescribeCoverageTransformer.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.wcs2_0.response;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.geoserver.ows.util.ResponseUtils.buildSchemaURL;
 
 import java.io.IOException;
@@ -15,7 +16,9 @@ import net.opengis.wcs20.DescribeCoverageType;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.KeywordInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MetadataLinkInfo;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wcs.CoverageCleanerCallback;
 import org.geoserver.wcs2_0.GetCoverage;
@@ -38,6 +41,7 @@ import org.geotools.wcs.v2_0.WCS;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.datum.PixelInCell;
+import org.vfny.geoserver.util.ResponseUtils;
 import org.vfny.geoserver.wcs.WcsException;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.AttributesImpl;
@@ -231,6 +235,8 @@ public class WCS20DescribeCoverageTransformer extends GMLTransformer {
 
                 // starting encoding
                 start("wcs:CoverageDescription", coverageAttributes);
+                elementSafe("gml:description", ci.getDescription());
+                elementSafe("gml:name", ci.getTitle());
 
                 // handle domain
                 final StringBuilder builder = new StringBuilder();
@@ -294,6 +300,33 @@ public class WCS20DescribeCoverageTransformer extends GMLTransformer {
                 if (coverage != null) {
                     CoverageCleanerCallback.addCoverages(coverage);
                 }
+            }
+        }
+
+        @Override
+        protected void handleAdditionalMetadata(Object context) {
+            if (context instanceof CoverageInfo) {
+                CoverageInfo ci = (CoverageInfo) context;
+                List<KeywordInfo> keywords = ci.getKeywords();
+                if (keywords != null && !keywords.isEmpty()) {
+                    start("ows:Keywords");
+                    keywords.forEach(kw -> element("ows:Keyword", kw.getValue()));
+                    end("ows:Keywords");
+                }
+                ci.getMetadataLinks().forEach(this::handleMetadataLink);
+            }
+        }
+
+        private void handleMetadataLink(MetadataLinkInfo mdl) {
+            if (isNotBlank(mdl.getContent())) {
+                String url = ResponseUtils.proxifyMetadataLink(mdl, request.getBaseUrl());
+                AttributesImpl attributes = new AttributesImpl();
+                if (isNotBlank(mdl.getAbout())) {
+                    attributes.addAttribute("", "about", "about", "", mdl.getAbout());
+                }
+                attributes.addAttribute("", "xlink:type", "xlink:type", "", "simple");
+                attributes.addAttribute("", "xlink:href", "xlink:href", "", url);
+                element("ows:Metadata", null, attributes);
             }
         }
 

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCapabilitiesTransformer.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCapabilitiesTransformer.java
@@ -27,6 +27,7 @@ import net.opengis.wcs20.GetCapabilitiesType;
 import org.geoserver.ExtendedCapabilitiesProvider;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.KeywordInfo;
+import org.geoserver.catalog.MetadataLinkInfo;
 import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
@@ -47,6 +48,7 @@ import org.geotools.xml.transform.TransformerBase;
 import org.geotools.xml.transform.Translator;
 import org.opengis.geometry.BoundingBox;
 import org.vfny.geoserver.global.CoverageInfoLabelComparator;
+import org.vfny.geoserver.util.ResponseUtils;
 import org.vfny.geoserver.wcs.WcsException;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -624,12 +626,16 @@ public class WCS20GetCapabilitiesTransformer extends TransformerBase {
 
         private void handleCoverageSummary(CoverageInfo cv) throws Exception {
             start("wcs:CoverageSummary");
+            elementIfNotEmpty("ows:Title", cv.getTitle());
+            elementIfNotEmpty("ows:Abstract", cv.getDescription());
+            handleKeywords(cv.getKeywords());
             String covId = NCNameResourceCodec.encode(cv);
             element("wcs:CoverageId", covId);
             element("wcs:CoverageSubtype", "RectifiedGridCoverage"); // TODO make this parametric
 
             handleWGS84BoundingBox(cv.getLatLonBoundingBox());
             handleBoundingBox(cv.boundingBox());
+            cv.getMetadataLinks().forEach(this::handleMetadataLink);
 
             end("wcs:CoverageSummary");
         }
@@ -670,6 +676,19 @@ public class WCS20GetCapabilitiesTransformer extends TransformerBase {
                             .append(boundingBox.getUpperCorner().getOrdinate(1))
                             .toString());
             end("ows:BoundingBox");
+        }
+
+        private void handleMetadataLink(MetadataLinkInfo mdl) {
+            if (isNotBlank(mdl.getContent())) {
+                String url = ResponseUtils.proxifyMetadataLink(mdl, request.getBaseUrl());
+                AttributesImpl attributes = new AttributesImpl();
+                if (isNotBlank(mdl.getAbout())) {
+                    attributes.addAttribute("", "about", "about", "", mdl.getAbout());
+                }
+                attributes.addAttribute("", "xlink:type", "xlink:type", "", "simple");
+                attributes.addAttribute("", "xlink:href", "xlink:href", "", url);
+                element("ows:Metadata", null, attributes);
+            }
         }
 
         private void handleLanguages() {


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-9142

I am not familiar with the EO module but the sample DescribeEOCoverageSet responses in the module actually include the xmlns:ows namespace even though GeoServer wasn't writing it to its responses.