### PR TITLE
[GEOS-9148][2.14.x] Fixed NPE for WCS 1.0.0 GetCoverage requests that don't intersect the coverage bounding box.

### DIFF
--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/DefaultWebCoverageService100.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/DefaultWebCoverageService100.java
@@ -614,9 +614,14 @@ public class DefaultWebCoverageService100 implements WebCoverageService100 {
             //
             // compute intersection envelope to be used
             GeneralEnvelope destinationEnvelope =
-                    (GeneralEnvelope)
-                            getHorizontalEnvelope(
-                                    computeIntersectionEnvelope(requestedEnvelope, nativeEnvelope));
+                    computeIntersectionEnvelope(requestedEnvelope, nativeEnvelope);
+            if (destinationEnvelope == null) {
+                throw new WcsException(
+                        "The request bbox is outside of the coverage area",
+                        InvalidParameterValue,
+                        "bbox");
+            }
+            destinationEnvelope = (GeneralEnvelope) getHorizontalEnvelope(destinationEnvelope);
             if (targetCRS != null) {
                 destinationEnvelope = CRS.transform(destinationEnvelope, targetCRS);
                 destinationEnvelope.setCoordinateReferenceSystem(targetCRS);


### PR DESCRIPTION
2.14.x backport for https://github.com/geoserver/geoserver/pull/3397