### PR TITLE
[GEOS-9161] Complex attributes with date simple content are not encoed properly by the ComplexJSONBuilder

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GeoJsonOutputFormatWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GeoJsonOutputFormatWfsTest.java
@@ -88,14 +88,19 @@ public final class GeoJsonOutputFormatWfsTest extends AbstractAppSchemaTestSuppo
         // get the station from the response
         JSONObject station = getStationPropertiesById(geoJson, "st.1");
         assertThat(station, notNullValue());
+        // validate the station name
+        JSONObject name = station.getJSONObject("name");
+        assertThat(name.size(), is(2));
+        assertThat(name.get("value"), is("station1"));
+        assertThat(name.get("@code"), is("st1"));
         // validate the station contact
-        JSONArray contact = station.getJSONArray("contact");
+        JSONObject contact = station.getJSONObject("contact");
         assertThat(contact.size(), is(2));
-        JSONArray phone = contact.getJSONObject(0).getJSONArray("phone");
+        assertThat(contact.get("@mail"), is("st1@stations.org"));
+        JSONObject phone = contact.getJSONObject("phone");
         assertThat(phone.size(), is(2));
-        assertThat(phone.getString(0), is("95482156"));
-        JSONObject timezone = phone.getJSONObject(1);
-        assertThat(timezone.get("timeZone"), is("CET"));
+        assertThat(phone.get("value"), is("95482156"));
+        assertThat(phone.get("@timeZone"), is("CET"));
         // check the x-links for measurements exist
         JSONArray measurements = station.getJSONArray("measurements");
         assertThat(measurements.size(), is(2));

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/Gsml32Borehole.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/Gsml32Borehole.properties
@@ -1,3 +1,3 @@
 _=ID:String,BOREHOLE_ID:String,GEOM:Geometry,SAMPLE_ID:String,SAMPLE_DATA_ID:String,SAMPLING_DATE:Date,SAMPLE_TYPE:String,INTERVAL_BEGIN:Double,INTERVAL_END:Double,PROPERTY:String,NUMERIC_VALUE:Double,UNIT_OF_MEASURE:String,TEXT_VALUE:String,STRATNO:String,STRATNAME:String,TOTAL_DEPTH:double
-17322=17322|borehole.GA.17322|POINT(-28.4139 121.142)|100|2251225|14-Jul-02|core diamond|57.9|66.4|magnetic susceptibility|940|10-5 SI||29921|Arthurton Granite|153.92
-17338=17338|borehole.GA.17338|POINT(-12.15 100.142)|102|128|15-Jul-02|core diamond|85.3|89.6|purpose|||geochronology|29921|Arthurton Granite|91.55
+17322=17322|borehole.GA.17322|POINT(-28.4139 121.142)|100|2251225|2014-07-02T00:00:00Z|core diamond|57.9|66.4|magnetic susceptibility|940|10-5 SI||29921|Arthurton Granite|153.92
+17338=17338|borehole.GA.17338|POINT(-12.15 100.142)|102|128|2015-07-02T00:00:00Z|core diamond|85.3|89.6|purpose|||geochronology|29921|Arthurton Granite|91.55

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/Gsml32Borehole.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/Gsml32Borehole.xml
@@ -119,10 +119,10 @@
 						<value>'rock'</value>
 					</ClientProperty>
 				</AttributeMapping>                
-				<AttributeMapping>
+				<!--AttributeMapping>
 					<targetAttribute>sa:relatedSamplingFeature/sa:SamplingFeatureComplex/sa:relatedSamplingFeature/spec:SF_Specimen/spec:samplingTime/gml:TimeInstant</targetAttribute>
 					<idExpression><OCQL>strConcat('borehole.specimen.samplingTime.GA.', SAMPLE_ID)</OCQL></idExpression>
-				</AttributeMapping>  
+				</AttributeMapping-->  
 				<AttributeMapping>
 					<targetAttribute>sa:relatedSamplingFeature/sa:SamplingFeatureComplex/sa:relatedSamplingFeature/spec:SF_Specimen/spec:samplingTime/gml:TimeInstant/gml:timePosition</targetAttribute>
 					<sourceExpression><OCQL>SAMPLING_DATE</OCQL></sourceExpression>

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
@@ -7,6 +7,7 @@ package org.geoserver.wfs.json;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -416,7 +417,10 @@ class ComplexGeoJsonWriter {
             return null;
         }
         Object value = simpleContent.getValue();
-        if (value instanceof Number || value instanceof String || value instanceof Character) {
+        if (value instanceof Number
+                || value instanceof String
+                || value instanceof Character
+                || value instanceof Date) {
             // the extract value is a simple Java type
             return value;
         }

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
@@ -179,12 +179,16 @@ public class GeoJSONBuilder extends JSONBuilder {
         // adjust the order of X and Y ordinates if needed
         if (axisOrder == CRS.AxisOrder.NORTH_EAST) {
             // encode latitude first and then longitude
-            roundedValue(y);
+            if (!Double.isNaN(y)) { // for 1d linear referencing cases
+                roundedValue(y);
+            }
             roundedValue(x);
         } else {
             // encode longitude first and then latitude
             roundedValue(x);
-            roundedValue(y);
+            if (!Double.isNaN(y)) { // for 1d linear referencing cases
+                roundedValue(y);
+            }
         }
         // if Z value is not available but we have a measure, we set Z value to zero
         z = Double.isNaN(z) && !Double.isNaN(m) ? 0 : z;


### PR DESCRIPTION
Comes with a fix for "[GEOS-9160] JSON encoding of 1-d linear geometries fails" as I could not get the date test running otherwise.