### PR TITLE
[GEOS-9163] Added 'https://' protocol support for default Data Store Edit Panel and URLModel class

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
@@ -270,12 +270,14 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
 
     /**
      * Makes sure the file path for shapefiles do start with file:// otherwise stuff like
-     * /home/user/file.shp won't be recognized as valid...
+     * /home/user/file.shp won't be recognized as valid... <br>
+     * Added support for http:// and https:// protocols.
      *
      * @author aaime
      */
-    private final class URLModel extends MapModel {
-        private URLModel(IModel model, String expression) {
+    static final class URLModel extends MapModel {
+
+        URLModel(IModel model, String expression) {
             super(model, expression);
         }
 
@@ -284,7 +286,8 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
             String file = (String) object;
             if (!file.startsWith("file://")
                     && !file.startsWith("file:")
-                    && !file.startsWith("http://")) file = "file://" + file;
+                    && !file.startsWith("http://")
+                    && !file.startsWith("https://")) file = "file://" + file;
             super.setObject(file);
         }
     }

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/URLModelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/URLModelTest.java
@@ -1,0 +1,69 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.web.data.store;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.geoserver.web.data.store.DefaultDataStoreEditPanel.URLModel;
+import org.junit.Test;
+
+/**
+ * Testing class for {@link URLModel} use cases.
+ *
+ * @author Fernando Mino - Geosolutions
+ */
+public class URLModelTest {
+
+    private static final String URL_VALUE = "https://www.geoserver.org";
+    private static final String URL_PARAM = "urlParam";
+
+    /** Test a bug validating the URL protocol disallowing to use 'https://' as valid one. */
+    @Test
+    public void testHttpsURLSetValue() {
+        Map<String, Object> params = new HashMap<String, Object>();
+        IModel model = Model.ofMap(params);
+        URLModel urlModel = new URLModel(model, URL_PARAM);
+        urlModel.setObject(URL_VALUE);
+        assertEquals(URL_VALUE, urlModel.getObject());
+    }
+
+    /** Tests setting and getting a http:// protocol URL. */
+    @Test
+    public void testHttpURLSetValue() {
+        final String urlValue = "http://www.geoserver.org/";
+        Map<String, Object> params = new HashMap<String, Object>();
+        IModel model = Model.ofMap(params);
+        URLModel urlModel = new URLModel(model, URL_PARAM);
+        urlModel.setObject(urlValue);
+        assertEquals(urlValue, urlModel.getObject());
+    }
+
+    /** Tests setting and getting a file:// protocol URL. */
+    @Test
+    public void testFileURLSetValue() {
+        final String urlValue = "file:///home/fernando/mino.xml";
+        Map<String, Object> params = new HashMap<String, Object>();
+        IModel model = Model.ofMap(params);
+        URLModel urlModel = new URLModel(model, URL_PARAM);
+        urlModel.setObject(urlValue);
+        assertEquals(urlValue, urlModel.getObject());
+    }
+
+    /** Tests setting an URL without protocol and getting it with file:// added. */
+    @Test
+    public void testNonProtocolUrl() {
+        final String urlValue = "/home/geosolutions/file.xml";
+        Map<String, Object> params = new HashMap<String, Object>();
+        IModel model = Model.ofMap(params);
+        URLModel urlModel = new URLModel(model, URL_PARAM);
+        urlModel.setObject(urlValue);
+        assertEquals("file://" + urlValue, urlModel.getObject());
+    }
+}


### PR DESCRIPTION
Added support for https:// on default datastore edit panel, and added tests for URLModel class use cases.

https://osgeo-org.atlassian.net/browse/GEOS-9163