### PR TITLE
Add schema.cache.dir system property usage to user manual

### DIFF
--- a/doc/en/user/source/data/app-schema/app-schema-resolution.rst
+++ b/doc/en/user/source/data/app-schema/app-schema-resolution.rst
@@ -75,3 +75,4 @@ If your GeoServer instance is deployed on a network whose firewall rules prevent
 #. Or: Deploy JAR files containing all required schema files on the classpath (see `Classpath`_ above).
 #. Or: Use a catalog (see `OASIS Catalog`_ above).
 
+.. warning:: System property "schema.cache.dir" with a cache directory location is required for using a mapping file from a remote URL with 'http://' or 'https://' protocol.


### PR DESCRIPTION
Adds a warning about schema.cache.dir system property requirement for remote URL mapping file to user manual.