### PR TITLE
[GEOS-6977][2.15.x] Fixed WCS 1.0.0 GetCoverage KVP ignoring elevation and custom dimension parameters.

### DIFF
--- a/src/wcs1_0/src/main/java/applicationContext.xml
+++ b/src/wcs1_0/src/main/java/applicationContext.xml
@@ -94,6 +94,11 @@
     <constructor-arg ref="geoServer"/>
   </bean>
 
+  <bean id="wcs100ElevationKvpParser" class="org.geoserver.wcs.kvp.ElevationKvpParser">
+    <constructor-arg value="ELEVATION"/>
+    <constructor-arg ref="geoServer"/>
+  </bean>
+
 
   <!-- kvp request readers -->
 

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/ElevationKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/ElevationKvpParser.java
@@ -1,0 +1,34 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs.kvp;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.ows.kvp.ElevationParser;
+import org.geoserver.wcs.WCSInfo;
+
+/**
+ * A {@link ElevationKvpParser} picking the max number of values to be parsed from the WCS
+ * configuration
+ */
+public class ElevationKvpParser extends org.geoserver.ows.kvp.ElevationKvpParser {
+
+    private final GeoServer geoServer;
+
+    /**
+     * Creates the parser specifying the name of the key to latch to.
+     *
+     * @param key The key whose associated value to parse.
+     */
+    public ElevationKvpParser(String key, GeoServer geoServer) {
+        super(key);
+        this.geoServer = geoServer;
+    }
+
+    protected ElevationParser getElevationParser() {
+        WCSInfo info = geoServer.getService(WCSInfo.class);
+        int maxRequestedDimensionValues = info.getMaxRequestedDimensionValues();
+        return new ElevationParser(maxRequestedDimensionValues);
+    }
+}

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/ElevationKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/ElevationKvpParser.java
@@ -7,6 +7,7 @@ package org.geoserver.wcs.kvp;
 import org.geoserver.config.GeoServer;
 import org.geoserver.ows.kvp.ElevationParser;
 import org.geoserver.wcs.WCSInfo;
+import org.geotools.util.Version;
 
 /**
  * A {@link ElevationKvpParser} picking the max number of values to be parsed from the WCS
@@ -23,6 +24,8 @@ public class ElevationKvpParser extends org.geoserver.ows.kvp.ElevationKvpParser
      */
     public ElevationKvpParser(String key, GeoServer geoServer) {
         super(key);
+        setService("WCS");
+        setVersion(new Version("1.0.0"));
         this.geoServer = geoServer;
     }
 

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
@@ -45,6 +45,7 @@ import org.geotools.metadata.i18n.Errors;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.util.DateRange;
+import org.geotools.util.NumberRange;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -396,6 +397,7 @@ public class Wcs10GetCoverageRequestReader extends EMFKvpRequestReader {
      * @param rangeSubset
      * @param axis
      */
+    @SuppressWarnings("unchecked")
     private void checkTypeAxisRange(
             final RangeSubsetType rangeSubset, Object axis, String axisName) {
         if (axis instanceof String) {
@@ -467,6 +469,27 @@ public class Wcs10GetCoverageRequestReader extends EMFKvpRequestReader {
 
             axisSubset.getSingleValue().add(singleValue);
 
+            rangeSubset.getAxisSubset().add(axisSubset);
+        } else if (axis instanceof Collection) {
+            AxisSubsetType axisSubset = Wcs10Factory.eINSTANCE.createAxisSubsetType();
+            axisSubset.setName(axisName);
+            for (Object value : (Collection<?>) axis) {
+                if (value instanceof NumberRange) {
+                    NumberRange<?> range = (NumberRange<?>) value;
+                    IntervalType interval = Wcs10Factory.eINSTANCE.createIntervalType();
+                    TypedLiteralType min = Wcs10Factory.eINSTANCE.createTypedLiteralType();
+                    TypedLiteralType max = Wcs10Factory.eINSTANCE.createTypedLiteralType();
+                    min.setValue(Double.toString(range.getMinimum()));
+                    max.setValue(Double.toString(range.getMaximum()));
+                    interval.setMin(min);
+                    interval.setMax(max);
+                    axisSubset.getInterval().add(interval);
+                } else {
+                    TypedLiteralType singleValue = Wcs10Factory.eINSTANCE.createTypedLiteralType();
+                    singleValue.setValue(String.valueOf(value));
+                    axisSubset.getSingleValue().add(singleValue);
+                }
+            }
             rangeSubset.getAxisSubset().add(axisSubset);
         }
     }

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import net.opengis.gml.CodeType;
 import net.opengis.gml.DirectPositionType;
 import net.opengis.gml.Gml4wcsFactory;
@@ -34,6 +35,9 @@ import net.opengis.wcs10.TimeSequenceType;
 import net.opengis.wcs10.TypedLiteralType;
 import net.opengis.wcs10.Wcs10Factory;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.ows.kvp.EMFKvpRequestReader;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.ows.util.KvpUtils.Tokenizer;
@@ -388,6 +392,27 @@ public class Wcs10GetCoverageRequestReader extends EMFKvpRequestReader {
             if (axis instanceof AxisSubsetType) {
                 rangeSubset.getAxisSubset().add(axis);
             } else checkTypeAxisRange(rangeSubset, axis, "ELEVATION");
+        }
+
+        // check for custom dimensions
+        CoverageInfo coverage = this.catalog.getCoverageByName(coverageName);
+        if (coverage != null) {
+            for (Entry<String, ?> entry : coverage.getMetadata().entrySet()) {
+                String name = entry.getKey();
+                if (name.startsWith(ResourceInfo.CUSTOM_DIMENSION_PREFIX)
+                        && entry.getValue() instanceof DimensionInfo
+                        && ((DimensionInfo) entry.getValue()).isEnabled()) {
+                    name = name.substring(ResourceInfo.CUSTOM_DIMENSION_PREFIX.length());
+                    Object value = kvp.get(name);
+                    // ignore anything that got converted by a KVP parser so that they
+                    // are only handled as keywords and not as a custom dimension since
+                    // WCS 1.0.0 does not define away to avoid these name clashes.
+                    if (value instanceof String) {
+                        name = name.toUpperCase();
+                        checkTypeAxisRange(rangeSubset, Arrays.asList(value), name);
+                    }
+                }
+            }
         }
 
         return rangeSubset;

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/CustomDimensionsTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/CustomDimensionsTest.java
@@ -57,6 +57,20 @@ public class CustomDimensionsTest extends CoverageTestSupport {
     }
 
     @Test
+    public void testGetCoverageKVPBadValue() throws Exception {
+        // check that we get no data when requesting an incorrect value for custom dimension
+        String request = getWaterTempRequestKVP("bad_dimension_value");
+        MockHttpServletResponse response = getAsServletResponse(request);
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertNull(image);
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toLowerCase());
+        response = getAsServletResponse(request);
+        image = ImageIO.read(getBinaryInputStream(response));
+        assertNull(image);
+    }
+
+    @Test
     public void testGetCoverageGoodValue() throws Exception {
         // check that we get data when requesting a correct value for custom dimension
         String request = getWaterTempRequest("CustomDimValueA");
@@ -70,6 +84,30 @@ public class CustomDimensionsTest extends CoverageTestSupport {
         image = ImageIO.read(getBinaryInputStream(response));
         assertNotNull(image);
         assertEquals("image/tiff", response.getContentType());
+    }
+
+    @Test
+    public void testGetCoverageKVPGoodValue() throws Exception {
+        // check that we get data when requesting a correct value for custom dimension
+        String request = getWaterTempRequestKVP("CustomDimValueA");
+        MockHttpServletResponse response = getAsServletResponse(request);
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertNotNull(image);
+        assertEquals("image/tiff", response.getContentType());
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toLowerCase());
+        response = getAsServletResponse(request);
+        image = ImageIO.read(getBinaryInputStream(response));
+        assertNotNull(image);
+        assertEquals("image/tiff", response.getContentType());
+    }
+
+    private String getWaterTempRequestKVP(String dimensionValue) {
+        String url =
+                "wcs?service=WCS&version=1.0.0&request=GetCoverage"
+                        + "&sourceCoverage=%s&format=GEOTIFF&width=25&height=24"
+                        + "&crs=EPSG:4326&bbox=0.237,40.562,14.593,44.558&%s=%s";
+        return String.format(url, getLayerId(CUST_WATTEMP), DIMENSION_NAME, dimensionValue);
     }
 
     private String getWaterTempRequest(String dimensionValue) {

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/DynamicDimensionsTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/DynamicDimensionsTest.java
@@ -61,6 +61,20 @@ public class DynamicDimensionsTest extends CoverageTestSupport {
     }
 
     @Test
+    public void testGetCoverageKVPBadValue() throws Exception {
+        // check that we get no data when requesting an incorrect value for custom dimension
+        String request = getWaterTempRequestKVP("bad_dimension_value");
+        MockHttpServletResponse response = getAsServletResponse(request);
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertNull(image);
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toUpperCase());
+        response = getAsServletResponse(request);
+        image = ImageIO.read(getBinaryInputStream(response));
+        assertNull(image);
+    }
+
+    @Test
     public void testGetCoverageGoodValue() throws Exception {
         // check that we get data when requesting a correct value for custom dimension
         String request = getWaterTempRequest("100");
@@ -74,6 +88,30 @@ public class DynamicDimensionsTest extends CoverageTestSupport {
         image = ImageIO.read(getBinaryInputStream(response));
         assertNotNull(image);
         assertEquals("image/tiff", response.getContentType());
+    }
+
+    @Test
+    public void testGetCoverageKVPGoodValue() throws Exception {
+        // check that we get data when requesting a correct value for custom dimension
+        String request = getWaterTempRequestKVP("100");
+        MockHttpServletResponse response = getAsServletResponse(request);
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertNotNull(image);
+        assertEquals("image/tiff", response.getContentType());
+
+        request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toUpperCase());
+        response = getAsServletResponse(request);
+        image = ImageIO.read(getBinaryInputStream(response));
+        assertNotNull(image);
+        assertEquals("image/tiff", response.getContentType());
+    }
+
+    private String getWaterTempRequestKVP(String dimensionValue) {
+        String url =
+                "wcs?service=WCS&version=1.0.0&request=GetCoverage"
+                        + "&sourceCoverage=%s&format=GEOTIFF&width=25&height=24"
+                        + "&crs=EPSG:4326&bbox=0.237,40.562,14.593,44.558&%s=%s";
+        return String.format(url, getLayerId(WATTEMP), DIMENSION_NAME, dimensionValue);
     }
 
     private String getWaterTempRequest(String dimensionValue) {


### PR DESCRIPTION
2.15.x backport for https://github.com/geoserver/geoserver/pull/3389