### PR TITLE
[GEOS-9132] Style Validation fix for i18N.

### DIFF
--- a/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
+++ b/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
@@ -39,8 +39,31 @@
     </xsd:complexType>
   </xsd:element>
   <xsd:element name="Name" type="xsd:string"/>
-  <xsd:element name="Title" type="xsd:string"/>
-  <xsd:element name="Abstract" type="xsd:string"/>
+  <xsd:element name="Title" type="sld:InternationalStringType"/>
+  <xsd:element name="Abstract" type="sld:InternationalStringType"/>
+  
+  <xsd:complexType name="InternationalStringType" mixed="true">
+    <xsd:annotation>
+      <xsd:documentation>
+        The "InternationalStringType" contains localized elements for the
+        container element.  A "mixed" element-content
+        model is used with localized value elements and default text value.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">        
+      <xsd:element ref="sld:Localized"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  
+  <xsd:element name="Localized">
+    <xsd:complexType>
+      <xsd:simpleContent>
+          <xsd:extension base="xsd:string">
+             <xsd:attribute name="lang" type="xsd:string" />
+          </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>    
+  </xsd:element>
 
 <!-- *********************************************************************** -->
   <xsd:annotation>

--- a/src/main/src/test/java/org/vfny/geoserver/util/SLDValidatorTest.java
+++ b/src/main/src/test/java/org/vfny/geoserver/util/SLDValidatorTest.java
@@ -31,6 +31,14 @@ public class SLDValidatorTest {
         assertFalse(errors.isEmpty());
     }
 
+    /** Tests validation for Localized tag. See GEOS-9132. */
+    @Test
+    public void testi18nValid() throws Exception {
+        SLDValidator validator = new SLDValidator();
+        List errors = validator.validateSLD(getClass().getResourceAsStream("validi18n.sld"));
+        assertTrue(errors.isEmpty());
+    }
+
     void showErrors(List errors) {
         for (Exception err : (List<Exception>) errors) {
             System.out.println(err.getMessage());

--- a/src/main/src/test/java/org/vfny/geoserver/util/validi18n.sld
+++ b/src/main/src/test/java/org/vfny/geoserver/util/validi18n.sld
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" 
+ xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+ xmlns="http://www.opengis.net/sld" 
+ xmlns:ogc="http://www.opengis.net/ogc" 
+ xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- a Named Layer is the basic building block of an SLD document -->
+  <NamedLayer>
+    <Name>default_point</Name>
+    <UserStyle>
+    <!-- Styles can have names, titles and abstracts -->
+      <Title>Default Point
+        <Localized lang="en">English title</Localized>
+        <Localized lang="it">Titolo in italiano</Localized>
+      </Title>
+      <Abstract>A sample style that draws a point</Abstract>
+      <!-- FeatureTypeStyles describe how to render different features -->
+      <!-- A FeatureTypeStyle for rendering points -->
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>rule1</Name>
+          <Title>Red Square
+			<Localized lang="en">English title</Localized>
+            <Localized lang="it">Titolo in italiano</Localized>
+          </Title>
+          <Abstract>A 6 pixel square with a red fill and no stroke</Abstract>
+            <PointSymbolizer>
+              <Graphic>
+                <Mark>
+                  <WellKnownName>square</WellKnownName>
+                  <Fill>
+                    <CssParameter name="fill">#FF0000</CssParameter>
+                  </Fill>
+                </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Fix Geoserver New Style page validation throwing an error when using Localized tags in Title.

- Internal validation schema updated.
- Added a test using a new SLD file using Localized tags inside Title tag.

See:
https://osgeo-org.atlassian.net/browse/GEOS-9132