### PR TITLE
Fix web-app jetty:run configuration to allow running from jar packaging [GEOS-9187]

### DIFF
--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -333,7 +333,7 @@
 		<inherited>true</inherited>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-war-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.3</version>
 		<configuration>
 			<warName>geoserver</warName>
 			<webappDirectory>${project.build.directory}/geoserver</webappDirectory>
@@ -376,7 +376,6 @@
 				<configuration>
 					<artifacts>
 						<artifact>
-							<classifier>war</classifier>
 							<file>${project.build.directory}/geoserver.war</file>
 							<type>war</type>
 						</artifact>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -314,6 +314,9 @@
               <maxIdleTime>10000</maxIdleTime>
             </connector>
           </connectors>
+          <supportedPackagings>
+            <supportedPackaging>jar</supportedPackaging>
+          </supportedPackagings>
           <stopPort>${jetty.stopPort}</stopPort>
           <stopKey>GEOSERVER_JETTY_STOPKEY</stopKey>
           <daemon>false</daemon>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -333,7 +333,7 @@
 		<inherited>true</inherited>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-war-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.2</version>
 		<configuration>
 			<warName>geoserver</warName>
 			<webappDirectory>${project.build.directory}/geoserver</webappDirectory>
@@ -376,6 +376,7 @@
 				<configuration>
 					<artifacts>
 						<artifact>
+							<classifier>war</classifier>
 							<file>${project.build.directory}/geoserver.war</file>
 							<type>war</type>
 						</artifact>


### PR DESCRIPTION
PR covers two changes:

* [x] update jetty configuration to allow running from jar
* [x] update maven-war-plugin to latest version and use of war classifier

See [GEOS-9187](https://osgeo-org.atlassian.net/browse/GEOS-9187) for details.