### PR TITLE
GEOS-9189 - Fix REST endpoint for datastore delete without recurse flag

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreController.java
@@ -201,7 +201,6 @@ public class DataStoreController extends AbstractCatalogController {
         new CatalogBuilder(catalog).updateDataStore(original, info);
         catalog.validate(original, false).throwIfInvalid();
         catalog.save(original);
-        clear(original);
 
         LOGGER.info("PUT datastore " + workspaceName + "," + storeName);
     }
@@ -217,22 +216,15 @@ public class DataStoreController extends AbstractCatalogController {
             throws IOException {
 
         DataStoreInfo ds = getExistingDataStore(workspaceName, storeName);
-        if (!recurse) {
-            if (!catalog.getStoresByWorkspace(workspaceName, DataStoreInfo.class).isEmpty()) {
-                for (DataStoreInfo dataStoreInfo :
-                        catalog.getStoresByWorkspace(workspaceName, DataStoreInfo.class)) {
-                    if (dataStoreInfo.getName().equalsIgnoreCase(storeName)) {
-                        break;
-                    }
-                    throw new RestException("datastore not empty", HttpStatus.FORBIDDEN);
-                }
-            }
-            catalog.remove(ds);
-        } else {
+        if (recurse) {
             new CascadeDeleteVisitor(catalog).visit(ds);
+        } else {
+            try {
+                catalog.remove(ds);
+            } catch (IllegalArgumentException e) {
+                throw new RestException(e.getMessage(), HttpStatus.FORBIDDEN, e);
+            }
         }
-        catalog.remove(ds);
-        clear(ds);
 
         LOGGER.info("DELETE datastore " + workspaceName + ":s" + workspaceName);
     }
@@ -244,10 +236,6 @@ public class DataStoreController extends AbstractCatalogController {
                     "No such datastore: " + workspaceName + "," + storeName);
         }
         return original;
-    }
-
-    void clear(DataStoreInfo info) {
-        catalog.getResourcePool().clear(info);
     }
 
     @Override

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/DataStoreControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/DataStoreControllerTest.java
@@ -18,7 +18,6 @@ import java.util.Properties;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.geoserver.catalog.CascadeDeleteVisitor;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.SystemTestData;
@@ -36,12 +35,9 @@ public class DataStoreControllerTest extends CatalogRESTTestSupport {
 
     @Before
     public void addDataStores() throws IOException {
+        removeStore("sf", "newDataStore"); // may have been created by other tests
         // the store configuration gets ruined by tests in more than one way, let's recreate it
-        DataStoreInfo sfStore = getCatalog().getDataStoreByName("sf");
-        if (sfStore != null) {
-            CascadeDeleteVisitor remover = new CascadeDeleteVisitor(getCatalog());
-            remover.visit(sfStore);
-        }
+        removeStore("sf", "sf");
         getTestData().addVectorLayer(SystemTestData.PRIMITIVEGEOFEATURE, catalog);
         getTestData().addVectorLayer(SystemTestData.AGGREGATEGEOFEATURE, catalog);
         getTestData().addVectorLayer(SystemTestData.GENERICENTITY, catalog);
@@ -190,15 +186,19 @@ public class DataStoreControllerTest extends CatalogRESTTestSupport {
     }
 
     File setupNewDataStore() throws Exception {
+        return setupNewDataStore("newDataStore");
+    }
+
+    File setupNewDataStore(String name) throws Exception {
         Properties props = new Properties();
         props.put("_", "name:StringpointProperty:Point");
         props.put("NewDataStore.0", "'zero'|POINT(0 0)");
         props.put("NewDataStore.1", "'one'|POINT(1 1)");
 
-        File dir = new File("./target/nds");
-        dir.mkdir();
+        File dir = new File("./target/nds/" + name);
+        dir.mkdirs();
 
-        File file = new File(dir, "newDataStore.properties");
+        File file = new File(dir, name + ".properties");
         file.deleteOnExit();
         dir.deleteOnExit();
 
@@ -443,6 +443,67 @@ public class DataStoreControllerTest extends CatalogRESTTestSupport {
                 fail();
             }
         }
+    }
+
+    @Test // GEOS-9189
+    public void testDeleteNonEmptyNonRecursiveNonUniqueStoreOnWorkspace() throws Exception {
+        // create two additional stores besides "sf" on workspace "sf", one that would
+        // be sorted before and one after "sf". Failure is order dependent, if the store
+        // to be deleted is the first one returned by catalog.getStoresByWorkspace(...)
+        // then no failure occurs
+        String store1 = "aa_sf";
+        String store2 = "zz_sf";
+        createDataStore("sf", store1);
+        createDataStore("sf", store2);
+        try {
+            List<DataStoreInfo> dataStoresByWorkspace = catalog.getDataStoresByWorkspace("sf");
+            assertEquals(3, dataStoresByWorkspace.size());
+
+            assertEquals(
+                    200,
+                    deleteAsServletResponse(ROOT_PATH + "/workspaces/sf/datastores/" + store1)
+                            .getStatus());
+            assertEquals(
+                    200,
+                    deleteAsServletResponse(ROOT_PATH + "/workspaces/sf/datastores/" + store2)
+                            .getStatus());
+            assertNull(catalog.getDataStoreByName("sf", store1));
+            assertNull(catalog.getDataStoreByName("sf", store2));
+        } finally {
+            removeStore("sf", store1);
+            removeStore("sf", store2);
+        }
+    }
+
+    private void createDataStore(String workspace, String name) throws Exception {
+        removeStore(workspace, name);
+        File dir = setupNewDataStore(name);
+        String xml =
+                "<dataStore>"
+                        + "<name>"
+                        + name
+                        + "</name>"
+                        + "<connectionParameters>"
+                        + "<entry>"
+                        + "<string>namespace</string>"
+                        + "<string>"
+                        + workspace
+                        + "</string>"
+                        + "</entry>"
+                        + "<entry>"
+                        + "<string>directory</string>"
+                        + "<string>"
+                        + dir.getAbsolutePath()
+                        + "</string>"
+                        + "</entry>"
+                        + "</connectionParameters>"
+                        + "<workspace>"
+                        + workspace
+                        + "</workspace>"
+                        + "</dataStore>";
+        MockHttpServletResponse response =
+                postAsServletResponse(ROOT_PATH + "/workspaces/sf/datastores", xml, "text/xml");
+        assertEquals(201, response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Deleting a datastore without a recurse parameter set should
fail if there are FeatureTypes configured for that DataStore.

Instead, the logic was checking if the datastore existed
on its workspace, but fails if there are any other datastore in the same workspace, 
which is unrelated to deleting a given datastore.

This patch simplifies `DataStoreController.dataStoreDelete()`
letting the catalog comply if the DataStore cannot be deleted,
since the DataStore being empty is a precondition on
`Catalog.remove(DataStoreInfo)` anyways.

Removed the extra unnnecessary call to `Catalog.remove()`.

Removed the calls to `ResourcePool.clear()` since that's already
handled by the internal machinery.