### PR TITLE
[GEOS-9183] Fix for Solr circular Spring Bean reference exception

### DIFF
--- a/src/community/solr/src/main/java/applicationContext.xml
+++ b/src/community/solr/src/main/java/applicationContext.xml
@@ -8,8 +8,11 @@ This code is licensed under the GPL 2.0 license, available at the root applicati
 
 	<bean id="solrXStreamInitializer" class="org.geoserver.solr.SolrXStreamInitializer" />
 	
-	<bean id="solrFeatureTypeCallback" class="org.geoserver.solr.SolrFeatureTypeCallback" >
+	<bean id="solrFeatureTypeCallback" class="org.geoserver.solr.SolrFeatureTypeCallback" />
+    <bean id="solrCatalogInitializer" class="org.geoserver.solr.SolrFeatureTypeCallback.CatalogInitializer"
+      init-method="initBean" >
       <constructor-arg index="0" ref="catalog" />
+      <constructor-arg index="1" ref="solrFeatureTypeCallback" />
     </bean>
 
 	<bean id="solrConfigPanel" class="org.geoserver.solr.SolrConfigurationPanelInfo">


### PR DESCRIPTION
This PR provides a fix for [GEOS-9183] Unresolvable Spring circular reference on Solr module.

Since this bug can be reproduced only on Apache Tomcat 7 runtime environment and only dependency injection init method refactoring is involved, no integration test was added.

Tested on Apache Tomcat 7.0.93.

https://osgeo-org.atlassian.net/browse/GEOS-9183