### PR TITLE
windows service fix

### DIFF
--- a/src/release/installer/win/wrapper.conf
+++ b/src/release/installer/win/wrapper.conf
@@ -22,7 +22,7 @@ wrapper.java.library.path.1=wrapper/lib
 # Java Additional Parameters
 wrapper.java.additional.1=-Djetty.base=.
 wrapper.java.additional.2=-DGEOSERVER_DATA_DIR="%GEOSERVER_DATA_DIR%"
-wrapper.java.additional.3=-Djava.io.tmpdir=./work
+wrapper.java.additional.3=-Djava.io.tmpdir=work
 
 # Initial Java Heap Size (in MB)
 wrapper.java.initmemory=128

--- a/src/release/wrapper/bin/wrapper/wrapper.conf
+++ b/src/release/wrapper/bin/wrapper/wrapper.conf
@@ -14,8 +14,6 @@ wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperSimpleApp
 #  needed starting from 1
 wrapper.java.classpath.1=bin/wrapper/lib/wrapper.jar
 wrapper.java.classpath.2=start.jar
-#wrapper.java.classpath.3=lib/jetty-6.0.1.jar
-#wrapper.java.classpath.3=lib/jetty-util-6.0.1.jar
 wrapper.java.classpath.3=lib/*.jar
 
 # Java Library Path (location of Wrapper.DLL or libwrapper.so)
@@ -23,19 +21,20 @@ wrapper.java.library.path.1=lib
 
 # Java Additional Parameters
 wrapper.java.additional.1=-Djetty.home=.
-wrapper.java.additional.2=-DGEOSERVER_DATA_DIR=%GEOSERVER_DATA_DIR%
+wrapper.java.additional.2=-DGEOSERVER_DATA_DIR="%GEOSERVER_DATA_DIR%"
 #wrapper.java.additional.3=-Dwebapp.path=../../
 
 # Initial Java Heap Size (in MB)
-wrapper.java.initmemory=3
+wrapper.java.initmemory=128
 
 # Maximum Java Heap Size (in MB)
-wrapper.java.maxmemory=64
+wrapper.java.maxmemory=756
 
 # Application parameters.  Add parameters as needed starting from 1
 wrapper.app.parameter.1=org.eclipse.jetty.start.Main
-# wrapper.app.parameter.2=../../documents/admin.xml
 wrapper.app.parameter.2=etc/jetty.xml
+wrapper.app.parameter.3=--module=http
+wrapper.app.parameter.4=jetty.port=8080
 
 #********************************************************************
 # Wrapper Logging Properties
@@ -83,7 +82,7 @@ wrapper.ntservice.name=GeoServer
 wrapper.ntservice.displayname=GeoServer
 
 # Description of the service
-wrapper.ntservice.description=
+wrapper.ntservice.description=GeoServer is an open source software server written in Java that allows users to share and edit geospatial data.
 
 # Service dependencies.  Add dependencies as needed starting from 1
 wrapper.ntservice.dependency.1=


### PR DESCRIPTION
Use of a relative path for java tmp folder throws off zip-slip checks