### PR TITLE
[GEOS-9153] WCS 2.0 scaling policies do not account for scaling factor already applied during read (due to subsampling and overview)

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/ScalingPolicy.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/ScalingPolicy.java
@@ -102,7 +102,7 @@ enum ScalingPolicy {
             }
 
             // return coverage unchanged if we don't scale
-            if (scaleFactors[0] == 1 && scaleFactors[1] == 0) {
+            if (scaleFactors[0] == 1 && scaleFactors[1] == 1) {
                 // NO SCALING do we need interpolation?
                 if (interpolation instanceof InterpolationNearest) {
                     return sourceGC;

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/ScalingPolicy.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/ScalingPolicy.java
@@ -82,19 +82,27 @@ enum ScalingPolicy {
 
             // get scale factor
             double[] scaleFactors = getScaleFactors(scaling);
-            double scaleFactor = scaleFactors[0];
-            scaleFactor = arrangeScaleFactors(hints, new double[] {scaleFactor, scaleFactor})[0];
+            // reading the data can cause the coverage to have asymmetric pre-applied scale factors
+            // due to small numerical differences in their values, so keep both
+            scaleFactors =
+                    arrangeScaleFactors(hints, new double[] {scaleFactors[0], scaleFactors[0]});
 
             // checks
-            if (scaleFactor <= 0) {
+            if (scaleFactors[0] <= 0) {
                 throw new WCS20Exception(
                         "Invalid scale factor",
                         WCS20Exception.WCS20ExceptionCode.InvalidScaleFactor,
-                        String.valueOf(scaleFactor));
+                        String.valueOf(scaleFactors[0]));
+            }
+            if (scaleFactors[1] <= 0) {
+                throw new WCS20Exception(
+                        "Invalid scale factor",
+                        WCS20Exception.WCS20ExceptionCode.InvalidScaleFactor,
+                        String.valueOf(scaleFactors[0]));
             }
 
             // return coverage unchanged if we don't scale
-            if (scaleFactor == 1) {
+            if (scaleFactors[0] == 1 && scaleFactors[1] == 0) {
                 // NO SCALING do we need interpolation?
                 if (interpolation instanceof InterpolationNearest) {
                     return sourceGC;
@@ -129,8 +137,12 @@ enum ScalingPolicy {
                     new GridEnvelope2D(
                             0,
                             0,
-                            (int) (gridRange.getSpan(gridGeometry.gridDimensionX) * scaleFactor),
-                            (int) (gridRange.getSpan(gridGeometry.gridDimensionY) * scaleFactor)),
+                            (int)
+                                    (gridRange.getSpan(gridGeometry.gridDimensionX)
+                                            * scaleFactors[0]),
+                            (int)
+                                    (gridRange.getSpan(gridGeometry.gridDimensionY)
+                                            * scaleFactors[1])),
                     sourceGC.getRenderedImage().getSampleModel());
 
             // === scale
@@ -143,8 +155,8 @@ enum ScalingPolicy {
                             interpolation != null
                                     ? interpolation
                                     : InterpolationPolicy.getDefaultPolicy().getInterpolation());
-            parameters.parameter("xScale").setValue(scaleFactor);
-            parameters.parameter("yScale").setValue(scaleFactor);
+            parameters.parameter("xScale").setValue(scaleFactors[0]);
+            parameters.parameter("yScale").setValue(scaleFactors[1]);
             parameters.parameter("xTrans").setValue(0.0);
             parameters.parameter("yTrans").setValue(0.0);
             return (GridCoverage2D)
@@ -445,9 +457,9 @@ enum ScalingPolicy {
 
             // get scale factor
             double scaleFactors[] = getScaleFactors(scaling);
+            scaleFactors = arrangeScaleFactors(hints, scaleFactors);
             double scaleFactorX = scaleFactors[0];
             double scaleFactorY = scaleFactors[1];
-            scaleFactors = arrangeScaleFactors(hints, scaleFactors);
 
             // unscale
             if (scaleFactorX == 1.0 && scaleFactorY == 1.0) {

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/ScaleKvpTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/ScaleKvpTest.java
@@ -425,8 +425,10 @@ public class ScaleKvpTest extends WCSKVPTestSupport {
             assertEquals(50, targetCoverage.getGridGeometry().getGridRange().getSpan(0));
             assertEquals(50, targetCoverage.getGridGeometry().getGridRange().getSpan(1));
 
-            // get extrema
-            assertEquals(29.0, new ImageWorker(targetCoverage.getRenderedImage()).getMaximums()[0]);
+            // get extrema (allow some difference as sub-sampling on read will be skipping input
+            // pixels)
+            assertEquals(
+                    29.0, new ImageWorker(targetCoverage.getRenderedImage()).getMaximums()[0], 1);
         } finally {
             try {
                 readerTarget.dispose();


### PR DESCRIPTION
No new tests because it fixes a build failure that would occur merging https://github.com/geotools/geotools/pull/2354
Basically the GeoTools change triggers a but in GeoServer which then fails the build in the WCS 2.0 module, unless this PR gets applied.