### PR TITLE
[GEOS-9133] hyperspectral image configuration support in "bin" package

### DIFF
--- a/src/release/jetty/etc/jetty.xml
+++ b/src/release/jetty/etc/jetty.xml
@@ -94,7 +94,19 @@
       -->
     </New>
 
-
+    <!-- =========================================================== -->
+    <!-- Set maxFormContentSize and maxFormKeys Request configuration-->
+    <!-- for handling hyperspectral images and large post.           -->
+    <!-- =========================================================== -->
+    <Call name="setAttribute">
+      <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
+      <Arg>500000</Arg>
+    </Call>
+    <Call name="setAttribute">
+      <Arg>org.eclipse.jetty.server.Request.maxFormKeys</Arg>
+      <Arg>2000</Arg>
+    </Call>
+    
     <!-- =========================================================== -->
     <!-- Set the default handler structure for the Server            -->
     <!-- A handler collection is used to pass received requests to   -->

--- a/src/web/app/src/test/java/org/geoserver/web/Start.java
+++ b/src/web/app/src/test/java/org/geoserver/web/Start.java
@@ -112,7 +112,9 @@ public class Start {
             jettyServer.setHandler(wah);
             wah.setTempDirectory(new File("target/work"));
             // this allows to send large SLD's from the styles form
-            wah.getServletContext().getContextHandler().setMaxFormContentSize(1024 * 1024 * 2);
+            wah.getServletContext().getContextHandler().setMaxFormContentSize(1024 * 1024 * 5);
+            // this allows to configure hyperspectral images
+            wah.getServletContext().getContextHandler().setMaxFormKeys(2000);
 
             String jettyConfigFile = System.getProperty("jetty.config.file");
             if (jettyConfigFile != null) {


### PR DESCRIPTION
This PR adds hyperspectral image configuration support in "bin" package due to form too big.

This is a draft since an hyperspectral image is required for testing purposes.

https://osgeo-org.atlassian.net/browse/GEOS-9133