### PR TITLE
[GEOS-9209] Enhance StyleInfo with MetadataMap on Catalog object and Rest entpoint (2.15.x.backport).

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/StyleInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/StyleInfo.java
@@ -109,4 +109,12 @@ public interface StyleInfo extends CatalogInfo {
      * <pre>getName()</pre>
      */
     String prefixedName();
+
+    /**
+     * A persistent map of metadata.
+     *
+     * <p>Data in this map is intended to be persisted. Common case of use is to have services
+     * associate various bits of data with a particular style.
+     */
+    MetadataMap getMetadata();
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/StyleInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/StyleInfoImpl.java
@@ -33,6 +33,8 @@ public class StyleInfoImpl implements StyleInfo {
 
     protected transient Catalog catalog;
 
+    protected MetadataMap metadata = new MetadataMap();
+
     protected StyleInfoImpl() {}
 
     public StyleInfoImpl(Catalog catalog) {
@@ -117,6 +119,21 @@ public class StyleInfoImpl implements StyleInfo {
 
     public void setLegend(LegendInfo legend) {
         this.legend = legend;
+    }
+
+    @Override
+    public MetadataMap getMetadata() {
+        // non nullable
+        checkMetadataNotNull();
+        return metadata;
+    }
+
+    public void setMetadata(MetadataMap metadata) {
+        this.metadata = metadata;
+    }
+
+    private void checkMetadataNotNull() {
+        if (metadata == null) metadata = new MetadataMap();
     }
 
     public void accept(CatalogVisitor visitor) {

--- a/src/main/src/test/java/org/geoserver/catalog/CatalogIntegrationTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/CatalogIntegrationTest.java
@@ -637,4 +637,51 @@ public class CatalogIntegrationTest extends GeoServerSystemTestSupport {
                 getDataDirectory().getStyles(secondaryWs, "images", "square16.svg");
         assertEquals(Resource.Type.RESOURCE, relativeSvg.getType());
     }
+
+    /** Checks MetadataMap storing object for StyleInfo on catalog. */
+    @Test
+    public void testStyleMetadataMap() throws Exception {
+        final Catalog catalog = getCatalog();
+        StyleInfo style = catalog.getStyleByName("Lakes");
+        style.getMetadata().put("timeToLive", "500");
+        catalog.save(style);
+        // check saved value
+        StyleInfo styletoCheck = catalog.getStyleByName("Lakes");
+        assertEquals(1, styletoCheck.getMetadata().size());
+        assertTrue(styletoCheck.getMetadata().get("timeToLive") != null);
+        String timeToLive = (String) styletoCheck.getMetadata().get("timeToLive");
+        assertEquals("500", timeToLive);
+    }
+
+    /** Checks default not null MetadataMap storing object for StyleInfo on catalog. */
+    @Test
+    public void testStyleMetadataMapNotNull() throws Exception {
+        final Catalog catalog = getCatalog();
+        StyleInfo styletoCheck = catalog.getStyleByName("relative");
+        assertTrue(styletoCheck.getMetadata() != null);
+        assertEquals(0, styletoCheck.getMetadata().size());
+    }
+
+    /** Checks MetadataMap storing object updates for StyleInfo on catalog. */
+    @Test
+    public void testStyleMetadataMapUpdates() throws Exception {
+        setupInitialStyleToUpdate();
+        final Catalog catalog = getCatalog();
+        StyleInfo styletoCheck = catalog.getStyleByName("Lakes");
+        assertEquals(2, styletoCheck.getMetadata().size());
+        styletoCheck.getMetadata().remove("timeToLive");
+        catalog.save(styletoCheck);
+        // check updated metadataMap
+        styletoCheck = catalog.getStyleByName("Lakes");
+        assertEquals(1, styletoCheck.getMetadata().size());
+        assertTrue(styletoCheck.getMetadata().get("timeToLive") == null);
+    }
+
+    private void setupInitialStyleToUpdate() {
+        final Catalog catalog = getCatalog();
+        StyleInfo style = catalog.getStyleByName("Lakes");
+        style.getMetadata().put("timeToLive", "500");
+        style.getMetadata().put("maxCacheEntries", "20");
+        catalog.save(style);
+    }
 }

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
@@ -13,9 +13,11 @@ import static org.junit.Assert.*;
 
 import java.io.*;
 import java.net.URL;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import net.sf.json.JSON;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -435,6 +437,109 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
 
         style = catalog.getStyleByName("Ponds");
         assertEquals("Forests.sld", style.getFilename());
+    }
+
+    /** Test for getting style with metadataMap value via Rest GET, XML format. */
+    @Test
+    public void testGetWithMetadataAsXML() throws Exception {
+        StyleInfo style = catalog.getStyleByName("Ponds");
+        style.getMetadata().put("cacheAgeMax", "300");
+        catalog.save(style);
+        Document dom = getAsDOM(RestBaseController.ROOT_PATH + "/styles/Ponds.xml");
+
+        assertEquals("style", dom.getDocumentElement().getNodeName());
+        assertXpathEvaluatesTo("Ponds", "/style/name", dom);
+        assertXpathEvaluatesTo("Ponds.sld", "/style/filename", dom);
+        assertXpathEvaluatesTo("300", "/style/metadata/entry[@key='cacheAgeMax']", dom);
+    }
+
+    /** Test for getting style with metadataMap value via Rest GET, JSON format. */
+    @Test
+    public void testGetWithMetadataAsJSON() throws Exception {
+        StyleInfo style = catalog.getStyleByName("Ponds");
+        style.getMetadata().put("cacheAgeMax", "300");
+        style.getMetadata().put("surename", "test1");
+        catalog.save(style);
+        JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/styles/Ponds.json");
+
+        JSONObject styleJson = ((JSONObject) json).getJSONObject("style");
+        assertEquals("Ponds", styleJson.get("name"));
+        assertEquals("Ponds.sld", styleJson.get("filename"));
+        Collection<JSONObject> entryCollection =
+                JSONArray.toCollection(
+                        styleJson.getJSONObject("metadata").getJSONArray("entry"),
+                        JSONObject.class);
+        assertEquals(2, entryCollection.size());
+        assertTrue(
+                entryCollection
+                        .stream()
+                        .anyMatch(
+                                j ->
+                                        "cacheAgeMax".equals(j.getString("@key"))
+                                                && "300".equals(j.getString("$"))));
+        assertTrue(
+                entryCollection
+                        .stream()
+                        .anyMatch(
+                                j ->
+                                        "surename".equals(j.getString("@key"))
+                                                && "test1".equals(j.getString("$"))));
+    }
+
+    /** Checks saving an style with metadataMap value via Rest PUT. */
+    @Test
+    public void testPutWithMetadata() throws Exception {
+        StyleInfo style = catalog.getStyleByName("Ponds");
+        assertEquals("Ponds.sld", style.getFilename());
+
+        String xml =
+                "<style>"
+                        + "<name>Ponds</name>"
+                        + "<filename>Forests.sld</filename>"
+                        + "<metadata> <entry key=\"cacheAgeMax\">300</entry> </metadata>"
+                        + "</style>";
+
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/styles/Ponds", xml.getBytes(), "text/xml");
+        assertEquals(200, response.getStatus());
+
+        style = catalog.getStyleByName("Ponds");
+        assertEquals("Forests.sld", style.getFilename());
+        MetadataMap metadata = style.getMetadata();
+        assertNotNull(metadata);
+        assertTrue(metadata.size() == 1);
+        assertEquals("300", metadata.get("cacheAgeMax"));
+    }
+
+    /** Checks saving an style with metadataMap value via Rest PUT using JSON format. */
+    @Test
+    public void testPutJSONWithMetadata() throws Exception {
+        StyleInfo style = catalog.getStyleByName("Ponds");
+        assertEquals("Ponds.sld", style.getFilename());
+
+        String json =
+                "{\"style\": {\"name\":\"Ponds\",\"format\":\"sld\",\"languageVersion\":{\"version\":\"1.0.0\"},"
+                        + "\"filename\":\"Ponds.sld\","
+                        + "\"metadata\":{"
+                        + "\"entry\":[{\"@key\":\"cacheAgeMax\",\"$\":\"300\"}"
+                        + ",{\"@key\":\"surename\",\"$\":\"test1\"}]}}"
+                        + "}";
+
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/styles/Ponds.json",
+                        json.getBytes(),
+                        "application/json");
+        assertEquals(200, response.getStatus());
+
+        style = catalog.getStyleByName("Ponds");
+        assertEquals("Ponds.sld", style.getFilename());
+        MetadataMap metadata = style.getMetadata();
+        assertNotNull(metadata);
+        assertTrue(metadata.size() == 2);
+        assertEquals("300", metadata.get("cacheAgeMax"));
+        assertEquals("test1", metadata.get("surename"));
     }
 
     @Test


### PR DESCRIPTION
This PR enhances StyleInfo and StyleInfoImpl Catalog objects adding a MetadataMap attribute for being serialized by Xstream.
Also adds Rest integration tests on Restconfig module.

2.15.x backport.

https://osgeo-org.atlassian.net/browse/GEOS-9209