### PR TITLE
[2.15.x] Encode the code attribute in WMS service exception reports.

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/WMSServiceExceptionHandler.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSServiceExceptionHandler.java
@@ -333,7 +333,7 @@ public class WMSServiceExceptionHandler extends ServiceExceptionHandler {
 
         // exception code
         if ((exception.getCode() != null) && !exception.getCode().equals("")) {
-            sb.append(" code=\"" + exception.getCode() + "\"");
+            sb.append(" code=\"" + ResponseUtils.encodeXML(exception.getCode()) + "\"");
         }
 
         // exception locator


### PR DESCRIPTION
2.15.x backport for https://github.com/geoserver/geoserver/pull/3488