### PR TITLE
[GEOS-9218] Parameter Extractor plugin prevents the Monitor plugin to log requests

### DIFF
--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/RequestWrapper.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/RequestWrapper.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
@@ -18,8 +19,6 @@ public final class RequestWrapper extends HttpServletRequestWrapper {
     private final UrlTransform urlTransform;
     private final Map originalParameters;
 
-    private final Pattern pathsPattern;
-
     private final String pathInfo;
     private final String servletPath;
 
@@ -29,13 +28,20 @@ public final class RequestWrapper extends HttpServletRequestWrapper {
         super(request);
         this.urlTransform = urlTransform;
         originalParameters = request.getParameterMap();
-        pathsPattern =
+        // extract URL portions for servletpath and pathinfo
+        final Pattern pathsPattern =
                 Pattern.compile(
                         "^"
                                 + request.getContextPath()
-                                + "(/[^\\?^/]+)(/[^\\?]*[^/^\\?])?/?(\\??.*)?$");
-        pathInfo = extractPathInfo(urlTransform.getOriginalRequestUri());
-        servletPath = extractServletPath(urlTransform.getOriginalRequestUri());
+                                + "(/[^?/#]+)(/[^?#]*[^/?#])?(?:/|/?[?#].*)?$");
+        Matcher matcher = pathsPattern.matcher(urlTransform.getOriginalRequestUri());
+        if (matcher.matches()) {
+            servletPath = Optional.ofNullable(matcher.group(1)).orElse("");
+            pathInfo = Optional.ofNullable(matcher.group(2)).orElse("");
+        } else {
+            pathInfo = "";
+            servletPath = "";
+        }
         parameters = new HashMap<>(super.getParameterMap());
         parameters.putAll(urlTransform.getParameters());
     }
@@ -90,21 +96,5 @@ public final class RequestWrapper extends HttpServletRequestWrapper {
     @Override
     public String[] getParameterValues(final String name) {
         return getParameterMap().get(name);
-    }
-
-    private String extractPathInfo(String requestUri) {
-        Matcher matcher = pathsPattern.matcher(requestUri);
-        if (matcher.matches()) {
-            return matcher.group(2);
-        }
-        return "";
-    }
-
-    private String extractServletPath(String requestUri) {
-        Matcher matcher = pathsPattern.matcher(requestUri);
-        if (matcher.matches()) {
-            return matcher.group(1);
-        }
-        return "";
     }
 }

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/RequestWrapper.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/RequestWrapper.java
@@ -18,8 +18,7 @@ public final class RequestWrapper extends HttpServletRequestWrapper {
     private final UrlTransform urlTransform;
     private final Map originalParameters;
 
-    private final Pattern pathInfoPattern;
-    private final Pattern servletPathPattern;
+    private final Pattern pathsPattern;
 
     private final String pathInfo;
     private final String servletPath;
@@ -30,8 +29,11 @@ public final class RequestWrapper extends HttpServletRequestWrapper {
         super(request);
         this.urlTransform = urlTransform;
         originalParameters = request.getParameterMap();
-        pathInfoPattern = Pattern.compile("^" + request.getContextPath() + "([^/]+?).*$");
-        servletPathPattern = Pattern.compile("^" + request.getContextPath() + "[^/]+?/([^/]+?).*$");
+        pathsPattern =
+                Pattern.compile(
+                        "^"
+                                + request.getContextPath()
+                                + "(/[^\\?^/]+)(/[^\\?]*[^/^\\?])?/?(\\??.*)?$");
         pathInfo = extractPathInfo(urlTransform.getOriginalRequestUri());
         servletPath = extractServletPath(urlTransform.getOriginalRequestUri());
         parameters = new HashMap<>(super.getParameterMap());
@@ -91,15 +93,15 @@ public final class RequestWrapper extends HttpServletRequestWrapper {
     }
 
     private String extractPathInfo(String requestUri) {
-        Matcher matcher = pathInfoPattern.matcher(requestUri);
+        Matcher matcher = pathsPattern.matcher(requestUri);
         if (matcher.matches()) {
-            return matcher.group(1);
+            return matcher.group(2);
         }
         return "";
     }
 
     private String extractServletPath(String requestUri) {
-        Matcher matcher = servletPathPattern.matcher(requestUri);
+        Matcher matcher = pathsPattern.matcher(requestUri);
         if (matcher.matches()) {
             return matcher.group(1);
         }

--- a/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/RequestWrapperTest.java
+++ b/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/RequestWrapperTest.java
@@ -1,0 +1,70 @@
+package org.geoserver.params.extractor;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/** Tests for {@link RequestWrapper} methods. */
+public class RequestWrapperTest {
+
+    /** Tests getServletPath correct value. */
+    @Test
+    public void testServletPath() {
+        UrlTransform urlTransform =
+                new UrlTransform("/geoserver/it.geosolutions/wms/what", buildParameters());
+        MockHttpServletRequest request =
+                new MockHttpServletRequest(
+                        "GET", "http://127.0.0.1/geoserver/it.geosolutions/wms/what");
+        RequestWrapper requestWrapper = new RequestWrapper(urlTransform, request);
+        assertEquals("/geoserver", requestWrapper.getServletPath());
+    }
+
+    /** Tests getServletPath correct value. */
+    @Test
+    public void testServletPathWithQueryParams() {
+        UrlTransform urlTransform =
+                new UrlTransform(
+                        "/geoserver/it.geosolutions/wms/what?parameter=value", buildParameters());
+        MockHttpServletRequest request =
+                new MockHttpServletRequest(
+                        "GET",
+                        "http://127.0.0.1/geoserver/it.geosolutions/wms/what?parameter=value");
+        RequestWrapper requestWrapper = new RequestWrapper(urlTransform, request);
+        assertEquals("/geoserver", requestWrapper.getServletPath());
+    }
+
+    /** Tests getPathInfo correct value. */
+    @Test
+    public void testPathInfo() {
+        UrlTransform urlTransform =
+                new UrlTransform("/geoserver/it.geosolutions/wms/what", buildParameters());
+        MockHttpServletRequest request =
+                new MockHttpServletRequest(
+                        "GET", "http://127.0.0.1/geoserver/it.geosolutions/wms/what");
+        RequestWrapper requestWrapper = new RequestWrapper(urlTransform, request);
+        assertEquals("/it.geosolutions/wms/what", requestWrapper.getPathInfo());
+    }
+
+    /** Tests getPathInfo correct value. */
+    @Test
+    public void testPathInfoWithQueryParams() {
+        UrlTransform urlTransform =
+                new UrlTransform(
+                        "/geoserver/it.geosolutions/wms/what/?parameter=value", buildParameters());
+        MockHttpServletRequest request =
+                new MockHttpServletRequest(
+                        "GET",
+                        "http://127.0.0.1/geoserver/it.geosolutions/wms/what/?parameter=value");
+        RequestWrapper requestWrapper = new RequestWrapper(urlTransform, request);
+        assertEquals("/it.geosolutions/wms/what", requestWrapper.getPathInfo());
+    }
+
+    private Map<String, String[]> buildParameters() {
+        Map<String, String[]> params = new HashMap<>();
+        params.put("test", new String[] {"1", "2"});
+        return params;
+    }
+}


### PR DESCRIPTION
If the Parameter Extraction plugin and the Monitor Plugin are installed, every request that is rewritten by the Parameter Extraction plugin is not logged in the Monitoring Plugin audit files.

This PR fix RequestWrapper class and its path extract methods, so Monitor module can read its paths properly.

See:
https://osgeo-org.atlassian.net/browse/GEOS-9218