### PR TITLE
[GEOS-9221] Upgrade spring security to 5.1.5 (backport to 2.15.x)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1958,7 +1958,7 @@
   <gwc.version>1.15-SNAPSHOT</gwc.version>
   <jts.version>1.16.0</jts.version>
   <spring.version>5.1.1.RELEASE</spring.version>
-  <spring.security.version>5.1.1.RELEASE</spring.security.version>
+  <spring.security.version>5.1.5.RELEASE</spring.security.version>
   <servlet-api.version>3.0.1</servlet-api.version>
   <jetty.version>9.4.12.v20180830</jetty.version>
   <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>


### PR DESCRIPTION
## Description

The main goal of this pull request is to back port the upgrade of Spring Security 5.1.1 to 5.1.5 which was done on the master branch. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] If this is your first contribution, confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) and sent a CLA as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
