### PR TITLE
Fix MapML community module NPE when querying images returning no geometry

### DIFF
--- a/src/community/mapml/src/main/java/org/geoserver/mapml/MapMLGenerator.java
+++ b/src/community/mapml/src/main/java/org/geoserver/mapml/MapMLGenerator.java
@@ -94,6 +94,8 @@ public class MapMLGenerator {
                     factory.createGeometryCollection(
                             buildGeometryCollection(
                                     (org.locationtech.jts.geom.GeometryCollection) g)));
+        } else if (g == null) {
+            // do nothing because geom.geometryContent is null by default
         } else {
             throw new IOException("Unknown geometry type: " + g.getGeometryType());
         }

--- a/src/community/mapml/src/main/java/org/geoserver/mapml/xml/Feature.java
+++ b/src/community/mapml/src/main/java/org/geoserver/mapml/xml/Feature.java
@@ -107,7 +107,12 @@ public class Feature {
     }
 
     public void setGeometry(GeometryContent geometry) {
-        this.geometry = geometry;
+        // fixes NPE, allows MapML feature to have no <geometry> element if
+        // there is no geometry associated to the feature, a situation that
+        // comes up when querying an image for RGB values for example
+        if (geometry.getGeometryContent() != null) {
+            this.geometry = geometry;
+        }
     }
 
     public JAXBElement getBbox() {


### PR DESCRIPTION
## Description

I noticed that when I used the MapML client to query example layers like "A sample ArcGrid file" or "North America sample imagery" in the default Preview Layers, that a null pointer exception occurred.  There are no tests for this module (yet).  The checkstyle build profile reports a bunch of failures because _generated_ files (mostly) don't have a license header.  Not sure what to do there (I didn't commit them).  No Jira for this,  I will do that after submitting.  Hopefully have not missed anything. LMK. Attn: @cmhodgson 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] If this is your first contribution, confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) and sent a CLA as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
