### PR TITLE
[Backports JIRA GEOS-9220] Upgrade spring-security-oauth2 version from 2.0.11 to 2.0.16

### DIFF
--- a/src/community/security/oauth2-core/pom.xml
+++ b/src/community/security/oauth2-core/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.11.RELEASE</version>
+			<version>2.0.16.RELEASE</version>
 		</dependency>
 
 		<dependency>

--- a/src/community/security/oauth2-geonode/pom.xml
+++ b/src/community/security/oauth2-geonode/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.11.RELEASE</version>
+			<version>2.0.16.RELEASE</version>
 		</dependency>
 
 		<dependency>

--- a/src/community/security/oauth2-github/pom.xml
+++ b/src/community/security/oauth2-github/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.11.RELEASE</version>
+			<version>2.0.16.RELEASE</version>
 		</dependency>
 
 		<dependency>

--- a/src/community/security/oauth2-google/pom.xml
+++ b/src/community/security/oauth2-google/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.11.RELEASE</version>
+			<version>2.0.16.RELEASE</version>
 		</dependency>
 
 		<dependency>

--- a/src/community/security/oauth2-openid-connect/pom.xml
+++ b/src/community/security/oauth2-openid-connect/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.11.RELEASE</version>
+			<version>2.0.16.RELEASE</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION

## Description

Backports to 2.15.x fix for JIRA GEOS-9220: "Upgrade spring-security-oauth2 version from 2.0.11 to 2.0.16"