### PR TITLE
[GEOS-9222] Permit extensibility of Common Formats from Layer Preview page

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/AbstractMapPreviewPageTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/web/AbstractMapPreviewPageTest.java
@@ -37,7 +37,10 @@ public class AbstractMapPreviewPageTest extends GeoServerWicketTestSupport {
         // collect GML links model objects
         List<String> gmlLinks = new ArrayList<String>();
         for (int i = 1; i <= EXPECTED_GML_LINKS.size(); i++) {
-            ExternalLink gmlLink = (ExternalLink) items.get(i + ":itemProperties:3:component:gml");
+            ExternalLink gmlLink =
+                    (ExternalLink)
+                            items.get(i + ":itemProperties:3:component:commonFormat:1")
+                                    .getDefaultModelObject();
             assertNotNull(gmlLink);
             gmlLinks.add(gmlLink.getDefaultModelObjectAsString());
         }

--- a/src/web/demo/src/main/java/applicationContext.xml
+++ b/src/web/demo/src/main/java/applicationContext.xml
@@ -35,7 +35,25 @@
     <property name="scope" value="org.geoserver.web.demo.MapPreviewPage"/>
     <property name="javaScriptFilename" value="mappreview_keyshortcut.js"/>
   </bean>
-    
+  
+  <bean id="openLayersPreview" class="org.geoserver.web.demo.OpenLayersFormatLink">
+    <property name="id" value="ol"/>
+    <property name="titleKey" value="ol.title"/>
+    <property name="order" value="10"/>
+  </bean>
+  <bean id="gMLPreview" class="org.geoserver.web.demo.GMLFormatLink">
+    <property name="id" value="gml"/>
+    <property name="titleKey" value="gml.title"/>
+    <property name="order" value="20"/>
+    <property name="geoserver">
+      <ref bean="geoServer"/>
+    </property>
+  </bean>
+  <bean id="kMLPreview" class="org.geoserver.web.demo.KMLFormatLink">
+    <property name="id" value="kml"/>
+    <property name="titleKey" value="kml.title"/>
+    <property name="order" value="30"/>
+  </bean>
   <bean id="demoRequests" class="org.geoserver.web.DemoLinkInfo">
     <property name="id" value="demoRequests"/>
     <property name="titleKey" value="DemoRequestsPage.title"/>

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/CommonFormatLink.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/CommonFormatLink.java
@@ -1,0 +1,59 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.demo;
+
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.geoserver.web.ToolLinkExternalInfo;
+
+/**
+ * Extension point for MapPreviewPage. Subclasses will implement getFormatLink which returns an
+ * ExternalLink to a layer preview in the subclass format represented by the subclass e.g.
+ * GMLFormatLink.
+ *
+ * @author prushforth
+ */
+public abstract class CommonFormatLink extends ToolLinkExternalInfo
+        implements Comparable<CommonFormatLink> {
+
+    private final String componentId = "theLink";
+
+    private int order = 1000;
+
+    public CommonFormatLink() {
+        super();
+    }
+
+    /**
+     * Returns an ExternalLink object that is used to link to the layer preview.
+     *
+     * @param layer the PreviewLayer object for which the preview link is returned
+     * @return
+     */
+    public abstract ExternalLink getFormatLink(PreviewLayer layer);
+
+    @Override
+    public void setComponentClass(Class<ExternalLink> componentClass) {}
+
+    public String getComponentId() {
+        return componentId;
+    }
+
+    /**
+     * @param order orders the list of common formats, by default new formats will be added at the
+     *     of the list.
+     */
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    @Override
+    public int compareTo(CommonFormatLink other) {
+        return getOrder() - other.getOrder();
+    }
+}

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/GMLFormatLink.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/GMLFormatLink.java
@@ -1,0 +1,56 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.demo;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.model.StringResourceModel;
+import org.geoserver.config.GeoServer;
+import org.geoserver.web.demo.PreviewLayer.GMLOutputParams;
+import org.geoserver.web.demo.PreviewLayer.PreviewLayerType;
+import org.geoserver.wfs.WFSInfo;
+
+public class GMLFormatLink extends CommonFormatLink {
+
+    private GeoServer geoserver;
+
+    /** GML output params computation may be expensive, results are cached in this map */
+    private final transient Map<String, GMLOutputParams> gmlParamsCache =
+            new HashMap<String, GMLOutputParams>();
+
+    @Override
+    public ExternalLink getFormatLink(PreviewLayer layer) {
+        ExternalLink gmlLink =
+                new ExternalLink(
+                        this.getComponentId(),
+                        layer.getGmlLink(gmlParamsCache) + this.getMaxFeatures(),
+                        (new StringResourceModel(this.getTitleKey(), (Component) null, null))
+                                .getString());
+        gmlLink.setVisible(
+                layer.getType() == PreviewLayerType.Vector && layer.hasServiceSupport("WFS"));
+        return gmlLink;
+    }
+
+    /**
+     * Generates the maxFeatures element of the WFS request using the value of
+     * maxNumberOfFeaturesForPreview. Values <= 0 give no limit.
+     *
+     * @return "&maxFeatures=${maxNumberOfFeaturesForPreview}" or "" if
+     *     maxNumberOfFeaturesForPreview <= 0"
+     */
+    private String getMaxFeatures() {
+        WFSInfo service = geoserver.getService(WFSInfo.class);
+        if (service.getMaxNumberOfFeaturesForPreview() > 0) {
+            return "&maxFeatures=" + service.getMaxNumberOfFeaturesForPreview();
+        }
+        return "";
+    }
+
+    public void setGeoserver(GeoServer geoserver) {
+        this.geoserver = geoserver;
+    }
+}

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/KMLFormatLink.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/KMLFormatLink.java
@@ -1,0 +1,24 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.demo;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.model.StringResourceModel;
+
+public class KMLFormatLink extends CommonFormatLink {
+
+    @Override
+    public ExternalLink getFormatLink(PreviewLayer layer) {
+        ExternalLink kmlLink =
+                new ExternalLink(
+                        this.getComponentId(),
+                        layer.getWmsLink() + "/kml?layers=" + layer.getName(),
+                        (new StringResourceModel(this.getTitleKey(), (Component) null, null))
+                                .getString());
+        kmlLink.setVisible(layer.hasServiceSupport("WMS"));
+        return kmlLink;
+    }
+}

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.html
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.html
@@ -14,7 +14,9 @@
   
   <!-- The fragment for the common links -->
   <wicket:fragment wicket:id="commonLinks">
-  <div style="white-space: nowrap;"><a target="_blank" wicket:id="ol"></a>&nbsp;<a target="_blank" wicket:id="kml"></a>&nbsp;<a target="_blank" wicket:id="gml"></a></div>
+    <span style="white-space: nowrap;" wicket:id="commonFormat">
+      <a target="_blank" href="#" wicket:id="theLink">theTitle</a>&nbsp;
+    </span>
   </wicket:fragment>
   
   <!--  The custom drop down with optgroups -->

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/OpenLayersFormatLink.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/OpenLayersFormatLink.java
@@ -1,0 +1,25 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.demo;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.model.StringResourceModel;
+
+public class OpenLayersFormatLink extends CommonFormatLink {
+
+    @Override
+    public ExternalLink getFormatLink(PreviewLayer layer) {
+
+        ExternalLink olLink =
+                new ExternalLink(
+                        this.getComponentId(),
+                        layer.getWmsLink() + "&format=application/openlayers",
+                        (new StringResourceModel(this.getTitleKey(), (Component) null, null))
+                                .getString());
+        olLink.setVisible(layer.hasServiceSupport("WMS"));
+        return olLink;
+    }
+}

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
@@ -23,6 +23,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedType;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.ResponseUtils;
+import org.geoserver.security.DisabledServiceResourceFilter;
 import org.geoserver.web.CatalogIconFactory;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.wfs.xml.GML32OutputFormat;
@@ -342,6 +343,21 @@ public class PreviewLayer {
         // recursively check super types
         AttributeType parent = featureType.getSuper();
         return findFeatureTypeGmlVersion(parent);
+    }
+    /**
+     * Returns true if serviceName is available for resource, otherwise false
+     *
+     * @param serviceName "WFS" or "WMS"
+     */
+    public boolean hasServiceSupport(String serviceName) {
+        LayerInfo linfo = GeoServerApplication.get().getCatalog().getLayerByName(this.getName());
+        if (linfo != null && linfo.getResource() != null && serviceName != null) {
+            List<String> disabledServices =
+                    DisabledServiceResourceFilter.disabledServices(linfo.getResource());
+            return disabledServices.stream().noneMatch(d -> d.equalsIgnoreCase(serviceName));
+        }
+        // layer group and backward compatibility
+        return true;
     }
 
     private boolean isAbstractFeatureType(AttributeType type) {

--- a/src/web/demo/src/main/resources/GeoServerApplication.properties
+++ b/src/web/demo/src/main/resources/GeoServerApplication.properties
@@ -22,6 +22,10 @@ MapPreviewPage.th.title=Title
 MapPreviewPage.th.commonFormats=Common Formats
 MapPreviewPage.th.allFormats=All Formats
 
+ol.title=OpenLayers
+kml.title=KML
+gml.title=GML
+
 SRSListPage.title=SRS List
 SRSListPage.shortDescription=List of all SRS known to GeoServer
 SRSListPage.description=List of SRS known to GeoServer. You can choose the authority, filter based \

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
@@ -212,8 +212,14 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
                     path = c.getPageRelativePath();
 
                     // check visible links
-                    ExternalLink olLink = (ExternalLink) c.get("itemProperties:3:component:ol");
-                    ExternalLink gmlLink = (ExternalLink) c.get("itemProperties:3:component:gml");
+                    ExternalLink olLink =
+                            (ExternalLink)
+                                    c.get("itemProperties:3:component:commonFormat:0")
+                                            .getDefaultModelObject();
+                    ExternalLink gmlLink =
+                            (ExternalLink)
+                                    c.get("itemProperties:3:component:commonFormat:1")
+                                            .getDefaultModelObject();
 
                     assertEquals(
                             "http://localhost:80/context/cite/wms?service=WMS&amp;version=1.1.0&amp;request=GetMap&amp;layers=cite%3ALakes%20%2B%20a%20plus&amp;bbox=-180.0%2C-90.0%2C180.0%2C90.0&amp;width=768&amp;height=384&amp;srs=EPSG%3A4326&amp;format=application/openlayers",
@@ -245,21 +251,5 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
             ft.setName("Lines");
             catalog.save(ft);
         }
-    }
-
-    /** Test for layer group service support check */
-    @Test
-    public void testHasServiceSupport() throws Exception {
-        Catalog cat = getCatalog();
-        LayerGroupInfo lg = cat.getFactory().createLayerGroup();
-        lg.setName("linkgroup");
-        lg.setWorkspace(cat.getWorkspaceByName("sf"));
-        lg.getLayers().add(cat.getLayerByName(getLayerId(MockData.PRIMITIVEGEOFEATURE)));
-        new CatalogBuilder(cat).calculateLayerGroupBounds(lg);
-        cat.add(lg);
-        tester.startPage(MapPreviewPage.class);
-        tester.assertRenderedPage(MapPreviewPage.class);
-        MapPreviewPage page = (MapPreviewPage) tester.getLastRenderedPage();
-        assertTrue(page.hasServiceSupport("sf:linkgroup", "WMS"));
     }
 }

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerTest.java
@@ -1,0 +1,32 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.demo;
+
+import static org.junit.Assert.assertTrue;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.web.GeoServerApplication;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.junit.Test;
+
+public class PreviewLayerTest extends GeoServerWicketTestSupport {
+
+    /** Test for layer group service support check */
+    @Test
+    public void testHasServiceSupport() throws Exception {
+        Catalog cat = GeoServerApplication.get().getCatalog();
+        LayerGroupInfo lg = cat.getFactory().createLayerGroup();
+        lg.setName("linkgroup");
+        lg.setWorkspace(cat.getWorkspaceByName("sf"));
+        lg.getLayers().add(cat.getLayerByName(getLayerId(MockData.PRIMITIVEGEOFEATURE)));
+        new CatalogBuilder(cat).calculateLayerGroupBounds(lg);
+        cat.add(lg);
+        PreviewLayer layer = new PreviewLayer(lg);
+        assertTrue(layer.hasServiceSupport("WMS"));
+    }
+}


### PR DESCRIPTION
## Description

Allow extension modules to add to the set of "Common Formats" links in the Layer Preview page on a per-layer basis.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
  -> this got a little odd, and as a result there are two commits and a merge commit.  Maybe they can be squashed on acceptance of this PR?
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates
  added a few javadoc comments

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
