### PR TITLE
No feature type for workspace with multiple datastore

### DIFF
--- a/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
@@ -99,6 +99,7 @@ public class SystemTestData extends CiteTestData {
         public static LayerProperty<ReferencedEnvelope> LATLON_ENVELOPE =
                 new LayerProperty<ReferencedEnvelope>();
         public static LayerProperty<Integer> SRS = new LayerProperty<Integer>();
+        public static LayerProperty<String> STORE = new LayerProperty<String>();
     }
 
     /** Keys for overriding default layer properties */
@@ -592,6 +593,12 @@ public class SystemTestData extends CiteTestData {
         String prefix = qName.getPrefix();
         String name = qName.getLocalPart();
         String uri = qName.getNamespaceURI();
+        String storeName;
+        if (LayerProperty.STORE.get(props, null) != null) {
+            storeName = LayerProperty.STORE.get(props, null);
+        } else {
+            storeName = prefix;
+        }
 
         // configure workspace if it doesn;t already exist
         if (catalog.getWorkspaceByName(prefix) == null) {
@@ -600,12 +607,12 @@ public class SystemTestData extends CiteTestData {
 
         // configure store if it doesn't already exist
 
-        File storeDir = catalog.getResourceLoader().findOrCreateDirectory(prefix);
+        File storeDir = catalog.getResourceLoader().findOrCreateDirectory(storeName);
 
-        DataStoreInfo store = catalog.getDataStoreByName(prefix);
+        DataStoreInfo store = catalog.getDataStoreByName(storeName);
         if (store == null) {
             store = catalog.getFactory().createDataStore();
-            store.setName(prefix);
+            store.setName(storeName);
             store.setWorkspace(catalog.getWorkspaceByName(prefix));
             store.setEnabled(true);
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
@@ -313,8 +313,14 @@ public class FeatureTypeController extends AbstractCatalogController {
             @RequestParam(name = "quietOnNotFound", required = false, defaultValue = "false")
                     Boolean quietOnNotFound) {
 
-        DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
-        FeatureTypeInfo ftInfo = catalog.getFeatureTypeByDataStore(dsInfo, featureTypeName);
+        FeatureTypeInfo ftInfo;
+        if (storeName != null) {
+            DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
+            ftInfo = catalog.getFeatureTypeByDataStore(dsInfo, featureTypeName);
+        } else {
+            NamespaceInfo ns = catalog.getNamespaceByPrefix(workspaceName);
+            ftInfo = catalog.getFeatureTypeByName(ns, featureTypeName);
+        }
         checkFeatureTypeExists(ftInfo, workspaceName, storeName, featureTypeName);
 
         return wrapObject(ftInfo, FeatureTypeInfo.class);

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.rest.catalog;
 
 import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.geoserver.data.test.MockData.SF_PREFIX;
 import static org.geoserver.rest.RestBaseController.ROOT_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -17,9 +18,12 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import javax.xml.namespace.QName;
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 import org.geoserver.catalog.AttributeTypeInfo;
@@ -27,6 +31,7 @@ import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.data.test.CiteTestData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.rest.RestBaseController;
 import org.geotools.data.DataAccess;
@@ -722,6 +727,24 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
         // Fetch the feature from the catalog again, and ensure nothing changed.
         FeatureTypeInfo after = catalog.getFeatureTypeByName("sf", "PrimitiveGeoFeature");
         assertEquals(before, after);
+    }
+
+    @Test
+    public void testGetWithMultipleStore() throws Exception {
+        QName geometryless = CiteTestData.GEOMETRYLESS;
+        QName qName =
+                new QName(geometryless.getNamespaceURI(), geometryless.getLocalPart(), SF_PREFIX);
+        Map<SystemTestData.LayerProperty, Object> props = new HashMap<>();
+        props.put(SystemTestData.LayerProperty.STORE, "tempStore");
+        getTestData().addVectorLayer(qName, props, catalog);
+
+        MockHttpServletResponse layerStore1 =
+                getAsServletResponse(ROOT_PATH + "/workspaces/sf/featuretypes/GenericEntity.json");
+        MockHttpServletResponse layerStore2 =
+                getAsServletResponse(ROOT_PATH + "/workspaces/sf/featuretypes/Geometryless.json");
+
+        assertEquals(layerStore1.getStatus(), 200);
+        assertEquals(layerStore2.getStatus(), 200);
     }
 
     public static void assertContains(String message, String contains) {


### PR DESCRIPTION
## Description

Fix https://osgeo-org.atlassian.net/browse/GEOS-9217
Copy of PR https://github.com/geoserver/geoserver/pull/3509 for branch 2.15.x

## Checklist

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates