### PR TITLE
[GEOS-8813] Add support for WMTS layers to GeoFence plugin

### DIFF
--- a/src/extension/geofence/pom.xml
+++ b/src/extension/geofence/pom.xml
@@ -102,6 +102,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-restconfig</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
         </dependency>

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -14,19 +14,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
-import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.CatalogInfo;
-import org.geoserver.catalog.CoverageInfo;
-import org.geoserver.catalog.FeatureTypeInfo;
-import org.geoserver.catalog.LayerGroupInfo;
-import org.geoserver.catalog.LayerInfo;
-import org.geoserver.catalog.Predicates;
-import org.geoserver.catalog.PublishedInfo;
-import org.geoserver.catalog.ResourceInfo;
-import org.geoserver.catalog.StoreInfo;
-import org.geoserver.catalog.StyleInfo;
-import org.geoserver.catalog.WMSLayerInfo;
-import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.*;
 import org.geoserver.geofence.config.GeoFenceConfiguration;
 import org.geoserver.geofence.config.GeoFenceConfigurationManager;
 import org.geoserver.geofence.core.model.LayerAttribute;
@@ -45,15 +33,7 @@ import org.geoserver.platform.ExtensionPriority;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.Service;
 import org.geoserver.platform.ServiceException;
-import org.geoserver.security.CatalogMode;
-import org.geoserver.security.CoverageAccessLimits;
-import org.geoserver.security.DataAccessLimits;
-import org.geoserver.security.LayerGroupAccessLimits;
-import org.geoserver.security.ResourceAccessManager;
-import org.geoserver.security.StyleAccessLimits;
-import org.geoserver.security.VectorAccessLimits;
-import org.geoserver.security.WMSAccessLimits;
-import org.geoserver.security.WorkspaceAccessLimits;
+import org.geoserver.security.*;
 import org.geoserver.security.impl.GeoServerRole;
 import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geoserver.wms.GetLegendGraphicRequest;
@@ -496,6 +476,10 @@ public class GeofenceAccessManager
             MultiPolygon rasterFilter = buildRasterFilter(rule);
 
             return new WMSAccessLimits(catalogMode, readFilter, rasterFilter, true);
+        } else if (resource instanceof WMTSLayerInfo) {
+            MultiPolygon rasterFilter = buildRasterFilter(rule);
+
+            return new WMTSAccessLimits(catalogMode, readFilter, rasterFilter);
         } else {
             throw new IllegalArgumentException("Don't know how to handle resource " + resource);
         }

--- a/src/extension/geofence/src/test/java/org/geoserver/geofence/AccessManagerWMTSLayerTest.java
+++ b/src/extension/geofence/src/test/java/org/geoserver/geofence/AccessManagerWMTSLayerTest.java
@@ -1,0 +1,178 @@
+package org.geoserver.geofence;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import org.geoserver.catalog.*;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.Request;
+import org.geoserver.rest.catalog.WMTSLayerTest;
+import org.geoserver.security.WMTSAccessLimits;
+import org.geoserver.test.http.MockHttpClient;
+import org.geoserver.test.http.MockHttpResponse;
+import org.geotools.feature.NameImpl;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.w3c.dom.Document;
+
+public class AccessManagerWMTSLayerTest extends GeofenceBaseTest {
+
+    private static final String LAYER_NAME = "AMSR2_Snow_Water_Equivalent";
+
+    @Rule public TestHttpClientRule clientMocker = new TestHttpClientRule();
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        // GeoFenceBaseTest enables the secure catalog, so we need to login first
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+
+        // add a wmts store
+        CatalogBuilder cb = new CatalogBuilder(catalog);
+        cb.setWorkspace(catalog.getWorkspaceByName("sf"));
+        WMTSStoreInfo wmts = cb.buildWMTSStore("demo");
+        wmts.setCapabilitiesURL(
+                clientMocker.getServer()
+                        + "/geoserver/gwc?REQUEST=GetCapabilities&VERSION=1.0.0&SERVICE=WMTS");
+        catalog.add(wmts);
+
+        // and a wmts layer as well (cannot use the builder, would turn this test into an online one
+        addWmtsLayer();
+
+        // logout before running any tests
+        logout();
+    }
+
+    public void addWmtsLayer() throws Exception {
+        String capabilities =
+                clientMocker.getServer()
+                        + "/geoserver/gwc?REQUEST=GetCapabilities&VERSION=1.0.0&SERVICE=WMTS";
+        WMTSLayerInfo wml = catalog.getResourceByName("sf", LAYER_NAME, WMTSLayerInfo.class);
+        if (wml == null) {
+            wml = catalog.getFactory().createWMTSLayer();
+            wml.setName(LAYER_NAME);
+            wml.setNativeName("topp:" + LAYER_NAME);
+            wml.setStore(catalog.getStoreByName("demo", WMTSStoreInfo.class));
+            wml.setCatalog(catalog);
+            wml.setNamespace(catalog.getNamespaceByPrefix("sf"));
+            wml.setSRS("EPSG:4326");
+            CoordinateReferenceSystem wgs84 = CRS.decode("EPSG:4326");
+            wml.setNativeCRS(wgs84);
+            wml.setLatLonBoundingBox(new ReferencedEnvelope(-110, 0, -60, 50, wgs84));
+            wml.setProjectionPolicy(ProjectionPolicy.FORCE_DECLARED);
+
+            catalog.add(wml);
+
+            LayerInfo layer = catalog.getFactory().createLayer();
+            layer.setResource(wml);
+            layer.setName(LAYER_NAME);
+            layer.setEnabled(true);
+            catalog.add(layer);
+        }
+
+        MockHttpClient client = new MockHttpClient();
+        client.expectGet(
+                new URL(capabilities),
+                new MockHttpResponse(
+                        WMTSLayerTest.class.getResource("nasa.getcapa.xml"), "text/xml"));
+        clientMocker.bind(client, capabilities);
+    }
+
+    @After
+    public void removeLayer() throws Exception {
+        if (IS_GEOFENCE_AVAILABLE) {
+            LayerInfo l = catalog.getLayerByName(new NameImpl("sf", LAYER_NAME));
+            if (l != null) {
+                catalog.remove(l);
+            }
+        }
+    }
+
+    @Test
+    public void testWmsLimited() {
+        if (!IS_GEOFENCE_AVAILABLE) {
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken user =
+                new UsernamePasswordAuthenticationToken("wmsuser", "wmsuser");
+
+        // check layer in the sf workspace with a wfs request
+        Request request = new Request();
+        request.setService("WFS");
+        request.setRequest("GetFeature");
+        Dispatcher.REQUEST.set(request);
+
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        LayerInfo wmtsLayer = catalog.getLayerByName("sf:" + LAYER_NAME);
+        assertNotNull(wmtsLayer);
+        logout();
+
+        WMTSAccessLimits limits = (WMTSAccessLimits) accessManager.getAccessLimits(user, wmtsLayer);
+        // TODO: Why is this EXCLUDE, how is it set
+        assertEquals(Filter.INCLUDE, limits.getReadFilter());
+
+        // now fake a getmap request (using a service and request with a different case than the
+        // geofenceService)
+        request = new Request();
+        request.setService("wms");
+        Dispatcher.REQUEST.set(request);
+        limits = (WMTSAccessLimits) accessManager.getAccessLimits(user, wmtsLayer);
+        assertEquals(Filter.INCLUDE, limits.getReadFilter());
+
+        // Test resource as well
+        limits = (WMTSAccessLimits) accessManager.getAccessLimits(user, wmtsLayer.getResource());
+        assertEquals(Filter.INCLUDE, limits.getReadFilter());
+    }
+
+    @Test
+    public void testGetWmtsLayer() {
+        if (!IS_GEOFENCE_AVAILABLE) {
+            return;
+        }
+
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+
+        WorkspaceInfo ws = catalog.getWorkspaceByName("sf");
+        assertNotNull(ws);
+
+        WMTSStoreInfo store = catalog.getStoreByName("sf", "demo", WMTSStoreInfo.class);
+        assertNotNull(store);
+
+        LayerInfo layer = catalog.getLayerByName("sf:" + LAYER_NAME);
+        assertNotNull(layer);
+        assertNotNull(layer.getResource());
+        assertTrue(layer.getResource() instanceof WMTSLayerInfo);
+
+        logout();
+    }
+
+    @Test
+    public void testWmsGetCapabilites() throws Exception {
+        if (!IS_GEOFENCE_AVAILABLE) {
+            return;
+        }
+        login("sf", "sf", "ROLE_SF_ADMIN");
+        MockHttpServletResponse response = getAsServletResponse("wms?request=GetCapabilities");
+        assertEquals(200, response.getStatus());
+        try (InputStream inputStream = new ByteArrayInputStream(response.getContentAsByteArray())) {
+            Document dom = dom(inputStream);
+            assertEquals("WMS_Capabilities", dom.getDocumentElement().getNodeName());
+            assertXpathEvaluatesTo("4", "count(//Layer[starts-with(Name, 'sf:')])", dom);
+            assertXpathEvaluatesTo("1", "count(//Name[text()='sf:" + LAYER_NAME + "'])", dom);
+        }
+    }
+}

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -108,6 +108,10 @@
    <artifactId>gt-wms</artifactId>
   </dependency>
   <dependency>
+   <groupId>org.geotools</groupId>
+   <artifactId>gt-wmts</artifactId>
+  </dependency>
+  <dependency>
    <groupId>org.geotools.xsd</groupId>
    <artifactId>gt-xsd-sld</artifactId>
   </dependency>

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -103,6 +103,7 @@ import org.geotools.ows.wms.WebMapServer;
 import org.geotools.ows.wms.xml.WMSSchema;
 import org.geotools.ows.wmts.WebMapTileServer;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
+import org.geotools.ows.wmts.model.WMTSLayer;
 import org.geotools.referencing.CRS;
 import org.geotools.styling.Style;
 import org.geotools.styling.StyleImpl;
@@ -1974,7 +1975,7 @@ public class ResourcePool {
      * @param info
      * @throws IOException
      */
-    public Layer getWMTSLayer(WMTSLayerInfo info) throws IOException {
+    public WMTSLayer getWMTSLayer(WMTSLayerInfo info) throws IOException {
 
         String name = info.getName();
         if (info.getNativeName() != null) {
@@ -1985,7 +1986,7 @@ public class ResourcePool {
 
         caps = info.getStore().getWebMapTileServer(null).getCapabilities();
 
-        for (Layer layer : caps.getLayerList()) {
+        for (WMTSLayer layer : caps.getLayerList()) {
             if (layer != null && name.equals(layer.getName())) {
                 return layer;
             }

--- a/src/main/src/main/java/org/geoserver/catalog/WMTSLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/WMTSLayerInfo.java
@@ -5,7 +5,7 @@
 package org.geoserver.catalog;
 
 import java.io.IOException;
-import org.geotools.ows.wms.Layer;
+import org.geotools.ows.wmts.model.WMTSLayer;
 import org.opengis.util.ProgressListener;
 
 public interface WMTSLayerInfo extends ResourceInfo {
@@ -13,5 +13,5 @@ public interface WMTSLayerInfo extends ResourceInfo {
     public WMTSStoreInfo getStore();
 
     /** Returns the raw WMTS layer associated to this resource */
-    public Layer getWMTSLayer(ProgressListener listener) throws IOException;
+    public WMTSLayer getWMTSLayer(ProgressListener listener) throws IOException;
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/WMTSLayerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/WMTSLayerInfoImpl.java
@@ -9,7 +9,7 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogVisitor;
 import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WMTSStoreInfo;
-import org.geotools.ows.wms.Layer;
+import org.geotools.ows.wmts.model.WMTSLayer;
 import org.opengis.util.ProgressListener;
 
 @SuppressWarnings("serial")
@@ -21,7 +21,7 @@ public class WMTSLayerInfoImpl extends ResourceInfoImpl implements WMTSLayerInfo
         super(catalog);
     }
 
-    public Layer getWMTSLayer(ProgressListener listener) throws IOException {
+    public WMTSLayer getWMTSLayer(ProgressListener listener) throws IOException {
         return catalog.getResourcePool().getWMTSLayer(this);
     }
 

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingWMTSLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingWMTSLayerInfo.java
@@ -19,7 +19,7 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WMTSStoreInfo;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.ows.wms.Layer;
+import org.geotools.ows.wmts.model.WMTSLayer;
 import org.geotools.util.decorate.AbstractDecorator;
 import org.opengis.feature.type.Name;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -153,7 +153,7 @@ public class DecoratingWMTSLayerInfo extends AbstractDecorator<WMTSLayerInfo>
         return delegate.getTitle();
     }
 
-    public Layer getWMTSLayer(ProgressListener listener) throws IOException {
+    public WMTSLayer getWMTSLayer(ProgressListener listener) throws IOException {
         return delegate.getWMTSLayer(listener);
     }
 

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredWMTSLayer.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredWMTSLayer.java
@@ -15,6 +15,8 @@ import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wms.StyleImpl;
 import org.geotools.ows.wms.xml.Dimension;
 import org.geotools.ows.wms.xml.Extent;
+import org.geotools.ows.wmts.model.TileMatrixSetLink;
+import org.geotools.ows.wmts.model.WMTSLayer;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
@@ -23,12 +25,13 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  *
  * @author Emanuele Tajariol (etj at geo-solutions dot it)
  */
-public class SecuredWMTSLayer extends Layer {
-    Layer delegate;
+public class SecuredWMTSLayer extends WMTSLayer {
+    WMTSLayer delegate;
 
     WrapperPolicy policy;
 
-    public SecuredWMTSLayer(Layer delegate, WrapperPolicy policy) {
+    public SecuredWMTSLayer(WMTSLayer delegate, WrapperPolicy policy) {
+        super(delegate.getTitle());
         this.delegate = delegate;
         this.policy = policy;
     }
@@ -72,6 +75,64 @@ public class SecuredWMTSLayer extends Layer {
     // --------------------------------------------------------------------------------------
     // Purely delegated methods
     // --------------------------------------------------------------------------------------
+
+    public Map<String, TileMatrixSetLink> getTileMatrixLinks() {
+        return delegate.getTileMatrixLinks();
+    }
+
+    public void addTileMatrixLinks(List<TileMatrixSetLink> limitList) {
+        delegate.addTileMatrixLinks(limitList);
+    }
+
+    public void addTileMatrixLink(TileMatrixSetLink link) {
+        delegate.addTileMatrixLink(link);
+    }
+
+    public List<String> getFormats() {
+        return delegate.getFormats();
+    }
+
+    public void setFormats(List<String> formats) {
+        delegate.setFormats(formats);
+    }
+
+    public List<String> getInfoFormats() {
+        return delegate.getInfoFormats();
+    }
+
+    public void setInfoFormats(List<String> infoFormats) {
+        delegate.setInfoFormats(infoFormats);
+    }
+
+    public void putResourceURL(String format, String template) {
+        delegate.putResourceURL(format, template);
+    }
+
+    public String getTemplate(String key) {
+        return delegate.getTemplate(key);
+    }
+
+    public void addSRS(CoordinateReferenceSystem crs) {
+        delegate.addSRS(crs);
+    }
+
+    public CoordinateReferenceSystem getPreferredCRS() {
+        return delegate.getPreferredCRS();
+    }
+
+    public void setPreferredCRS(CoordinateReferenceSystem preferredCRS) {
+        delegate.setPreferredCRS(preferredCRS);
+    }
+
+    public void setDefaultStyle(StyleImpl style) {
+        delegate.setDefaultStyle(style);
+    }
+
+    public StyleImpl getDefaultStyle() {
+        return delegate.getDefaultStyle();
+    }
+
+    // ---------------------------------------------------------------------------------------
 
     public void addChildren(Layer child) {
         delegate.addChildren(child);

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredWMTSLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredWMTSLayerInfo.java
@@ -11,7 +11,7 @@ import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WMTSStoreInfo;
 import org.geoserver.security.SecureCatalogImpl;
 import org.geoserver.security.WrapperPolicy;
-import org.geotools.ows.wms.Layer;
+import org.geotools.ows.wmts.model.WMTSLayer;
 import org.opengis.util.ProgressListener;
 
 /**
@@ -29,8 +29,8 @@ public class SecuredWMTSLayerInfo extends DecoratingWMTSLayerInfo {
     }
 
     @Override
-    public Layer getWMTSLayer(ProgressListener listener) throws IOException {
-        Layer layer = super.getWMTSLayer(listener);
+    public WMTSLayer getWMTSLayer(ProgressListener listener) throws IOException {
+        WMTSLayer layer = super.getWMTSLayer(listener);
         if (layer == null) {
             return layer;
         } else {

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredWebMapTileServer.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredWebMapTileServer.java
@@ -32,7 +32,7 @@ public class SecuredWebMapTileServer extends WebMapTileServer {
     WebMapTileServer delegate;
 
     public SecuredWebMapTileServer(WebMapTileServer delegate) throws IOException, ServiceException {
-        super(delegate);
+        super(delegate.getCapabilities());
         this.delegate = delegate;
     }
 

--- a/src/main/src/test/java/org/geoserver/security/decorators/SecuredWMTSLayerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/decorators/SecuredWMTSLayerTest.java
@@ -1,0 +1,64 @@
+package org.geoserver.security.decorators;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.net.URL;
+import org.geoserver.catalog.TestHttpClientProvider;
+import org.geoserver.catalog.TestHttpClientRule;
+import org.geoserver.catalog.impl.WMTSStoreInfoImpl;
+import org.geoserver.security.AccessLimits;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.WrapperPolicy;
+import org.geoserver.test.http.MockHttpClient;
+import org.geoserver.test.http.MockHttpResponse;
+import org.geotools.data.ows.HTTPClient;
+import org.geotools.ows.ServiceException;
+import org.geotools.ows.wmts.WebMapTileServer;
+import org.geotools.ows.wmts.map.WMTSCoverageReader;
+import org.geotools.ows.wmts.model.WMTSLayer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SecuredWMTSLayerTest {
+
+    @Rule public TestHttpClientRule clientMocker = new TestHttpClientRule();
+
+    protected final WrapperPolicy policy =
+            WrapperPolicy.readOnlyHide(new AccessLimits(CatalogMode.HIDE));
+
+    // First layer in nasa.getcapa.xml
+    protected static final String LAYER_TITLE = "Snow Water Equivalent (AMSR2, GCOM-W1)";
+
+    @Test
+    public void testCanSecure() {
+        WMTSLayer layer = new WMTSLayer(LAYER_TITLE);
+        layer = new SecuredWMTSLayer(layer, policy);
+        assertNotNull(layer);
+        assertEquals(LAYER_TITLE, layer.getTitle());
+    }
+
+    @Test
+    public void testCoverageReader() throws IOException, ServiceException {
+        String capabilitiesURL =
+                clientMocker.getServer()
+                        + "/geoserver/gwc?REQUEST=GetCapabilities&VERSION=1.0.0&SERVICE=WMTS";
+        URL serverURL = new URL(capabilitiesURL);
+        MockHttpClient mockClient = new MockHttpClient();
+        mockClient.expectGet(
+                serverURL,
+                new MockHttpResponse(
+                        WMTSStoreInfoImpl.class.getResource("nasa.getcapa.xml"), "text/xml"));
+        TestHttpClientProvider.bind(mockClient, serverURL);
+        HTTPClient client = TestHttpClientProvider.get(capabilitiesURL);
+
+        WebMapTileServer wmts =
+                new SecuredWebMapTileServer(new WebMapTileServer(serverURL, client, null));
+        WMTSLayer layer =
+                new SecuredWMTSLayer(
+                        wmts.getCapabilities().getLayerList().iterator().next(), policy);
+
+        WMTSCoverageReader coverageReader = new WMTSCoverageReader(wmts, layer);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/decorators/SecuredWebMapTileServerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/decorators/SecuredWebMapTileServerTest.java
@@ -1,0 +1,42 @@
+package org.geoserver.security.decorators;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.net.URL;
+import org.geoserver.catalog.TestHttpClientProvider;
+import org.geoserver.catalog.TestHttpClientRule;
+import org.geoserver.catalog.impl.WMTSStoreInfoImpl;
+import org.geoserver.test.http.MockHttpClient;
+import org.geoserver.test.http.MockHttpResponse;
+import org.geotools.data.ows.HTTPClient;
+import org.geotools.ows.ServiceException;
+import org.geotools.ows.wmts.WebMapTileServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SecuredWebMapTileServerTest {
+
+    @Rule public TestHttpClientRule clientMocker = new TestHttpClientRule();
+
+    @Test
+    public void testCanSecure() throws IOException, ServiceException {
+        String capabilitiesURL =
+                clientMocker.getServer()
+                        + "/geoserver/gwc?REQUEST=GetCapabilities&VERSION=1.0.0&SERVICE=WMTS";
+        URL serverURL = new URL(capabilitiesURL);
+        MockHttpClient mockClient = new MockHttpClient();
+        mockClient.expectGet(
+                serverURL,
+                new MockHttpResponse(
+                        WMTSStoreInfoImpl.class.getResource("nasa.getcapa.xml"), "text/xml"));
+        TestHttpClientProvider.bind(mockClient, serverURL);
+        HTTPClient client = TestHttpClientProvider.get(capabilitiesURL);
+
+        WebMapTileServer wmts = new WebMapTileServer(serverURL, client, null);
+        assertNotNull(wmts);
+
+        wmts = new SecuredWebMapTileServer(wmts);
+        assertNotNull(wmts);
+    }
+}


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-8813

When WMTS was added to GeoServer
 a) GeoFence was not updated with support for it
 b) The GeoServer Security subsystem was only updated to include minimal support for it.

This fixes both these issues, and as a result, the linked bug (The geofence changes are split into a separate commit from the core api changes).

Note: This fix required nontrivial API changes to the core WMTSLayerInfo API (so that SecuredWMTSLayer would actually delegate to the wrapped WMTSLayer properly). 

(Now that Planet Federal has a signed CLA again, I've got a bit of a backlog of bugfixes I'm contributing. Obviously, merging them is going to have to wait until the build server is working again)