### PR TITLE
Follow up on scale/offset imageio-ext and gt support

### DIFF
--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
@@ -9,6 +9,7 @@ import static org.geotools.coverage.grid.io.AbstractGridFormat.BACKGROUND_COLOR;
 import static org.geotools.coverage.grid.io.AbstractGridFormat.FOOTPRINT_BEHAVIOR;
 import static org.geotools.coverage.grid.io.AbstractGridFormat.INPUT_TRANSPARENT_COLOR;
 import static org.geotools.coverage.grid.io.AbstractGridFormat.OVERVIEW_POLICY;
+import static org.geotools.coverage.grid.io.AbstractGridFormat.RESCALE_PIXELS;
 import static org.geotools.coverage.grid.io.AbstractGridFormat.USE_JAI_IMAGEREAD;
 import static org.geotools.gce.imagemosaic.ImageMosaicFormat.ACCURATE_RESOLUTION;
 import static org.geotools.gce.imagemosaic.ImageMosaicFormat.ALLOW_MULTITHREADING;
@@ -198,7 +199,8 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
                     String parameterKey = mapModel.getExpression();
                     if (USE_JAI_IMAGEREAD.getName().getCode().equals(parameterKey)
                             || ACCURATE_RESOLUTION.getName().getCode().equals(parameterKey)
-                            || ALLOW_MULTITHREADING.getName().getCode().equals(parameterKey)) {
+                            || ALLOW_MULTITHREADING.getName().getCode().equals(parameterKey)
+                            || RESCALE_PIXELS.getName().getCode().equals(parameterKey)) {
                         assertThat(
                                 parameterKey, c, CoreMatchers.instanceOf(CheckBoxParamPanel.class));
                     } else if (EXCESS_GRANULE_REMOVAL.getName().getCode().equals(parameterKey)


### PR DESCRIPTION
Follows up with https://github.com/geotools/geotools/pull/2409 and restores the build (changes in GT caused one test failure in web/core due to an unexpected new read parameter in mosaic)