### PR TITLE
[GEOS-9231] Speed up data_dir load when there are lots of DataStoreInfos

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.config;
 
+import com.google.common.base.Stopwatch;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -391,7 +392,10 @@ public abstract class GeoServerLoader {
         Resource f = resourceLoader.get("catalog.xml");
         if (!Resources.exists(f)) {
             // assume 2.x style data directory
+            Stopwatch sw = Stopwatch.createStarted();
+            LOGGER.info("Loading catalog...");
             CatalogImpl catalog2 = (CatalogImpl) readCatalog(xp);
+            LOGGER.info("Read catalog in " + sw.stop());
             // make to remove the old resource pool catalog listener
             ((CatalogImpl) catalog).sync(catalog2);
         } else {


### PR DESCRIPTION
Backport of #3450 onto 2.15.x

ConfigurationPasswordEncryptionHelper.decode(String)
is called by XstreamPersister -> StoreInfoConverter
for each DataStoreInfo read from the data directory at
start up time.

This patch makes it use a ConcurrentMap internally
instead of a HashMap, and removes the sychronization
on its CACHE member variable. Additionally, and most
importantly, caches the encryptable store parameter
names by StoreInfo.getType() too, avoiding the fallback
to full DataAccessFactory parameter lookup, which
implies a rather expensive call to getCatalog() \
.getResourcePool().getDataStoreFactory((DataStoreInfo) info)

As a result, loading time when there are lots of
DataStoreInfos is reduced to about 1/3 of the time
it takes without this patch.
