### PR TITLE
Fix GWC RESTIntegration test to work after recent Spring MVC fix

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
@@ -213,7 +213,7 @@ public class RESTIntegrationTest extends GeoServerSystemTestSupport {
         assertEquals(
                 expected,
                 response.getContentAsString()
-                        .substring(response.getContentAsString().indexOf(":") + 2));
+                        .substring(response.getContentAsString().indexOf(":") + 1));
     }
 
     @Test
@@ -441,10 +441,7 @@ public class RESTIntegrationTest extends GeoServerSystemTestSupport {
         MockHttpServletResponse response = super.deleteAsServletResponse(url);
         assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
         // See GWC's TileLayerRestlet
-        assertEquals(
-                "Unknown layer: badLayerName",
-                response.getContentAsString()
-                        .substring(response.getContentAsString().indexOf(":") + 2));
+        assertEquals("Unknown layer: badLayerName", response.getContentAsString());
     }
 
     @Test


### PR DESCRIPTION
After some recent changes on master (I'm not sure exactly which one, but I'm guessing the depreciation removal PR), the GWC RESTIntegrationTest is failing.

Looking into the failures, it appears they are only affecting tests that were modified to work around some changes introduced by the Spring MVC REST update a couple years ago (see: https://github.com/geoserver/geoserver/commit/a354c9dd5177c0a739efcfc40bece4ece5b7afd2 ).

After restoring the tests to their original state (or something close to it) everything seems to be passing again.

