### PR TITLE
Use Charset.defaultCharset() to test resource operations

### DIFF
--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
@@ -424,7 +424,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
 
         Resource newRes = getDataDirectory().get("/mydir/mynewres");
         try (InputStream is = newRes.in()) {
-            Assert.assertEquals(STR_MY_NEW_TEST, IOUtils.toString(is, "UTF-8"));
+            Assert.assertEquals(STR_MY_NEW_TEST, IOUtils.toString(is, Charset.defaultCharset()));
         }
 
         newRes.delete();
@@ -440,7 +440,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
         assertTrue(Resources.exists(myRes));
         assertTrue(Resources.exists(newRes));
         try (InputStream is = newRes.in()) {
-            Assert.assertEquals(STR_MY_TEST, IOUtils.toString(is, "UTF-8"));
+            Assert.assertEquals(STR_MY_TEST, IOUtils.toString(is, Charset.defaultCharset()));
         }
 
         newRes.delete();
@@ -456,7 +456,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
         Assert.assertFalse(Resources.exists(myRes));
         assertTrue(Resources.exists(newRes));
         try (InputStream is = newRes.in()) {
-            Assert.assertEquals(STR_MY_TEST, IOUtils.toString(is, "UTF-8"));
+            Assert.assertEquals(STR_MY_TEST, IOUtils.toString(is, Charset.defaultCharset()));
         }
 
         newRes.renameTo(myRes);

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
@@ -49,6 +49,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
     private Resource myRes;
 
     public ResourceControllerTest() {
+        // platform specific test, may not be UTF-8
         CharsetEncoder encoder = Charset.defaultCharset().newEncoder();
         if (encoder.canEncode("éö")) {
             STR_MY_TEST = "This is my test. é ö";


### PR DESCRIPTION
Looking to fix a charset dependent test