### PR TITLE
[GEOS-9240] Add App-Schema MongoDb PropertyIsNull filter testing.

### DIFF
--- a/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBSupport.java
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBSupport.java
@@ -4,6 +4,10 @@
  */
 package org.geoserver.test.onlineTest;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
+
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
@@ -43,11 +47,8 @@ import org.geoserver.util.IOUtils;
 import org.geotools.feature.NameImpl;
 import org.geotools.image.test.ImageAssert;
 import org.geotools.util.URLs;
-import static org.hamcrest.CoreMatchers.is;
 import org.hamcrest.MatcherAssert;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -73,8 +74,8 @@ public abstract class ComplexMongoDBSupport extends GeoServerSystemTestSupport {
     private static MongoClient MONGO_CLIENT;
 
     // xpath engines used to check WFS responses
-    private XpathEngine WFS11_XPATH_ENGINE;
-    private XpathEngine WFS20_XPATH_ENGINE;
+    protected XpathEngine WFS11_XPATH_ENGINE;
+    protected XpathEngine WFS20_XPATH_ENGINE;
 
     @Before
     public void beforeTest() {

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBTest.java
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBTest.java
@@ -4,11 +4,29 @@
  */
 package org.geoserver.test.onlineTest;
 
+import org.junit.Test;
+import org.w3c.dom.Document;
+
 /** Tests the integration between MongoDB and App-schema. */
 public class ComplexMongoDBTest extends ComplexMongoDBSupport {
 
     @Override
     protected String getPathOfMappingsToUse() {
         return "/mappings/stations.xml";
+    }
+
+    @Test
+    public void testAttributeIsNull() throws Exception {
+        Document document =
+                getAsDOM(
+                        "wfs?request=GetFeature&version=1.1.0&typename=st:StationFeature"
+                                + "&filter=<Filter><PropertyIsNull>"
+                                + "<PropertyName>StationFeature/nullableField</PropertyName>"
+                                + "</PropertyIsNull></Filter>");
+        checkCount(
+                WFS11_XPATH_ENGINE,
+                document,
+                2,
+                "/wfs:FeatureCollection/gml:featureMembers/st:StationFeature");
     }
 }

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/resources/data/stations1.json
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/resources/data/stations1.json
@@ -11,6 +11,7 @@
     ],
     "type": "Point"
   },
+  "nullableField": null,
   "measurements": [
     {
       "name": "temp",

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/resources/mappings/stations.xml
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/resources/mappings/stations.xml
@@ -88,6 +88,12 @@
             <OCQL>jsonSelect('geometry')</OCQL>
           </sourceExpression>
         </AttributeMapping>
+        <AttributeMapping>
+          <targetAttribute>st:nullableField</targetAttribute>
+          <sourceExpression>
+            <OCQL>jsonSelect('nullableField')</OCQL>
+          </sourceExpression>
+        </AttributeMapping>
       </attributeMappings>
     </FeatureTypeMapping>
     <FeatureTypeMapping>

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/resources/schemas/stations.xsd
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/resources/schemas/stations.xsd
@@ -51,6 +51,7 @@
           <xs:element name="contact" minOccurs="0" maxOccurs="1" type="st:ContactType"/>
           <xs:element name="measurement" minOccurs="0" maxOccurs="unbounded" type="st:MeasurementPropertyType"/>
           <xs:element name="geometry" type="gml:GeometryPropertyType" minOccurs="0" maxOccurs="1"/>
+          <xs:element name="nullableField" minOccurs="0" maxOccurs="1" type="xs:string"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>


### PR DESCRIPTION
## Description

This PR adds testing for PropertyIsNull filter on App-Schema MongoDB test module.

Requires merged:
https://github.com/geotools/geotools/pull/2426

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9240

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
