### PR TITLE
[GEOS-9245] GeoFence rule update fails with NPE on an empty area

### DIFF
--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/JaxbRule.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/JaxbRule.java
@@ -190,7 +190,7 @@ public class JaxbRule {
         }
 
         public void setAllowedArea(MultiPolygon allowedArea) {
-            this.allowedArea = allowedArea.toText();
+            this.allowedArea = allowedArea != null ? allowedArea.toText() : null;
         }
 
         @XmlElement

--- a/src/extension/geofence/src/test/java/org/geoserver/geofence/rest/JaxbRuleTest.java
+++ b/src/extension/geofence/src/test/java/org/geoserver/geofence/rest/JaxbRuleTest.java
@@ -1,0 +1,22 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.geofence.rest;
+
+import static org.junit.Assert.assertNull;
+
+import org.geoserver.geofence.rest.xml.JaxbRule;
+import org.junit.Test;
+
+public class JaxbRuleTest {
+
+    @Test
+    public void testSetArea() {
+        JaxbRule.LayerDetails details = new JaxbRule.LayerDetails();
+        // used to NPE here
+        details.setAllowedArea(null);
+        assertNull(details.getAllowedArea());
+    }
+}


### PR DESCRIPTION
## Description

Include a few sentences describing the overall goals for this PR (pull request).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
