### PR TITLE
GEOS-9169 ResourcePool datastore cache cluster-safe

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -2493,7 +2493,12 @@ public class ResourcePool {
         public void handleModifyEvent(CatalogModifyEvent event) {}
 
         public void handlePostModifyEvent(CatalogPostModifyEvent event) {
-            event.getSource().accept(this);
+            CatalogInfo source = event.getSource();
+            source.accept(this);
+
+            if (source instanceof FeatureTypeInfo) {
+                flushDataStore((FeatureTypeInfo) source);
+            }
         }
 
         public void handleRemoveEvent(CatalogRemoveEvent event) {


### PR DESCRIPTION
This one is not really possible to test because you need a clustered set-up with hazelcast.

However, it is a minimal and trivial change, that does not break any tests and can be easily understood to improve cluster-safety.