### PR TITLE
Fix GWC RESTIntegration test to work after recent Spring MVC fix (2.14.x backport)

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
@@ -213,7 +213,7 @@ public class RESTIntegrationTest extends GeoServerSystemTestSupport {
         assertEquals(
                 expected,
                 response.getContentAsString()
-                        .substring(response.getContentAsString().indexOf(":") + 2));
+                        .substring(response.getContentAsString().indexOf(":") + 1));
     }
 
     @Test
@@ -441,10 +441,7 @@ public class RESTIntegrationTest extends GeoServerSystemTestSupport {
         MockHttpServletResponse response = super.deleteAsServletResponse(url);
         assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
         // See GWC's TileLayerRestlet
-        assertEquals(
-                "Unknown layer: badLayerName",
-                response.getContentAsString()
-                        .substring(response.getContentAsString().indexOf(":") + 2));
+        assertEquals("Unknown layer: badLayerName", response.getContentAsString());
     }
 
     @Test


### PR DESCRIPTION
Backport of #3545 to fix [recent 2.14.x failures](https://build.geoserver.org/view/geoserver/job/geoserver-2.14.x/587/console) in Jenkins