### PR TITLE
[GEOS-9256]: fixed conflict between params-extractor and monitor plugins, corectly unwrapping request wrapper added by monitor

### DIFF
--- a/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
+++ b/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
 
-abstract class TestSupport {
+public abstract class TestSupport {
 
     private static final File TEST_DIRECTORY =
             new File(System.getProperty("java.io.tmpdir"), "params-extractor-data-directory");

--- a/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/UrlManglerTest.java
+++ b/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/UrlManglerTest.java
@@ -1,0 +1,77 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.params.extractor;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequestWrapper;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.Request;
+import org.geoserver.platform.GeoServerExtensions;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public final class UrlManglerTest extends TestSupport {
+    protected static GeoServerDataDirectory getDataDirectory() {
+        return (GeoServerDataDirectory) GeoServerExtensions.bean("dataDirectory");
+    }
+
+    @Override
+    public void voidClean() throws IOException {
+        super.voidClean();
+        Dispatcher.REQUEST.remove();
+    }
+
+    @Test
+    public void testSimpleWrappedRequest() {
+
+        Map<String, String[]> params = new HashMap<String, String[]>();
+
+        MockHttpServletRequest httpRequest =
+                new MockHttpServletRequest(
+                        "GET", "http://127.0.0.1/geoserver/it.geosolutions/param/wms");
+        UrlTransform transform = new UrlTransform("/geoserver/workspace/param/wms", params);
+        transform.removeMatch("/param");
+        RequestWrapper wrapper = new RequestWrapper(transform, httpRequest);
+        Request request = new Request();
+        request.setHttpRequest(wrapper);
+        request.setRequest("GetCapabilities");
+
+        Dispatcher.REQUEST.set(request);
+        UrlMangler mangler = new UrlMangler(getDataDirectory());
+        StringBuilder path = new StringBuilder("/geoserver/workspace/param/wms");
+        Map<String, String> kvp = new HashMap<String, String>();
+        mangler.mangleURL(new StringBuilder(), path, kvp, null);
+        assertEquals("workspace/param/wms", path.toString());
+    }
+
+    @Test
+    public void testDoubleWrappedRequest() {
+
+        Map<String, String[]> params = new HashMap<String, String[]>();
+
+        MockHttpServletRequest httpRequest =
+                new MockHttpServletRequest(
+                        "GET", "http://127.0.0.1/geoserver/it.geosolutions/param/wms");
+        UrlTransform transform = new UrlTransform("/geoserver/workspace/param/wms", params);
+        transform.removeMatch("/param");
+        RequestWrapper wrapper = new RequestWrapper(transform, httpRequest);
+        HttpServletRequestWrapper secondWrapper = new HttpServletRequestWrapper(wrapper);
+        Request request = new Request();
+        request.setHttpRequest(secondWrapper);
+        request.setRequest("GetCapabilities");
+
+        Dispatcher.REQUEST.set(request);
+        UrlMangler mangler = new UrlMangler(getDataDirectory());
+        StringBuilder path = new StringBuilder("/geoserver/workspace/param/wms");
+        Map<String, String> kvp = new HashMap<String, String>();
+        mangler.mangleURL(new StringBuilder(), path, kvp, null);
+        assertEquals("workspace/param/wms", path.toString());
+    }
+}


### PR DESCRIPTION
…

## Description

Fixed conflict between params-extractor and monitor plugins, corectly unwrapping request wrapper added by monitor

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
