### PR TITLE
docs: Update user manual to reflect modified mapbox vector tiles MIME type

### DIFF
--- a/doc/en/user/source/extensions/vectortiles/install.rst
+++ b/doc/en/user/source/extensions/vectortiles/install.rst
@@ -22,7 +22,7 @@ To verify that the extension was installed successfully
 
    * ``application/json;type=geojson``
    * ``application/json;type=topojson``
-   * ``application/x-protobuf;type=mapbox-vector``
+   * ``application/vnd.mapbox-vector-tile``
 
    .. figure:: img/vectortiles_tileformats.png
 

--- a/doc/en/user/source/extensions/vectortiles/tutorial.rst
+++ b/doc/en/user/source/extensions/vectortiles/tutorial.rst
@@ -39,7 +39,7 @@ GeoServer can also produce vector tiles in three formats: GeoJSON, TopoJSON, and
      - MIME
      - Description
    * - `MapBox Vector (MVT) <https://github.com/mapbox/vector-tile-spec>`_
-     - ``application/x-protobuf;type=mapbox-vector``
+     - ``application/vnd.mapbox-vector-tile``
      - **Recommended Format** This is an efficient binary format that is widely supported by almost all Vector Tile applications.
    * - `GeoJSON <http://geojson.org/>`_
      - ``application/json;type=geojson``
@@ -70,7 +70,7 @@ For this tutorial, we'll be using the layer ``opengeo:countries`` to show off th
 
    * ``application/json;type=geojson``
    * ``application/json;type=topojson``
-   * ``application/x-protobuf;type=mapbox-vector``
+   * ``application/vnd.mapbox-vector-tile``
 
    .. figure:: img/vectortiles_tileformats.png
 

--- a/doc/en/user/source/styling/mbstyle/reference/spec.rst
+++ b/doc/en/user/source/styling/mbstyle/reference/spec.rst
@@ -153,7 +153,7 @@ Data source specifications.
           "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile
               &SERVICE=WMTS&VERSION=1.0.0&LAYER=mapbox:streets&STYLE=
               &TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913
-              &FORMAT=application/x-protobuf;type=mapbox-vector
+              &FORMAT=application/vnd.mapbox-vector-tile
               &TILECOL={x}&TILEROW={y}"
         ],
         "minZoom": 0,
@@ -438,7 +438,7 @@ Mapbox, the ``"url"`` value should be of the form ``mapbox://mapid``.
       "tiles": [
         "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS
             &VERSION=1.0.0&LAYER=mapbox:streets&STYLE=&TILEMATRIX=EPSG:900913:{z}
-            &TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector
+            &TILEMATRIXSET=EPSG:900913&FORMAT=application/vnd.mapbox-vector-tile
             &TILECOL={x}&TILEROW={y}"
       ],
       "minZoom": 0,

--- a/doc/en/user/source/styling/mbstyle/source.rst
+++ b/doc/en/user/source/styling/mbstyle/source.rst
@@ -9,7 +9,7 @@ GeoServer can be configured to serve layers as vector tiles which can be used as
 
 2. Install the :ref:`Vector Tiles <vectortiles.install>` extension.
 
-3. Follow the :ref:`vectortiles.tutorial` to publish your layers in ``application/x-protobuf;type=mapbox-vector`` format (You only need to do the "Publish vector tiles in GeoWebCache" step).
+3. Follow the :ref:`vectortiles.tutorial` to publish your layers in ``application/vnd.mapbox-vector-tile`` format (You only need to do the "Publish vector tiles in GeoWebCache" step).
 
 Once these steps are complete, you will be able to use your GeoServer layers in any Mapbox-compatible client application that can access your GeoServer.
 
@@ -20,7 +20,7 @@ The source syntax to use these GeoServer layers in your MapBox Style is::
       "tiles": [
         "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS
             &VERSION=1.0.0&LAYER=<workspace>:<layer>&STYLE=&TILEMATRIX=EPSG:900913:{z}
-            &TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector
+            &TILEMATRIXSET=EPSG:900913&FORMAT=application/vnd.mapbox-vector-tile
             &TILECOL={x}&TILEROW={y}"
       ],
       "minZoom": 0,

--- a/doc/en/user/source/styling/workshop/mbstyle/mbstyle.rst
+++ b/doc/en/user/source/styling/workshop/mbstyle/mbstyle.rst
@@ -79,7 +79,7 @@ A GeoServer vector tile source would be defined like this:
       "cookbook": {
         "type": "vector",
         "tiles": [
-          "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=cookbook&STYLE=&TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector&TILECOL={x}&TILEROW={y}"
+          "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=cookbook&STYLE=&TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
         ],
         "minZoom": 0,
         "maxZoom": 14


### PR DESCRIPTION
The code was modified in https://github.com/geoserver/geoserver/commit/62d6887dba4ab115e690139c56a182c9ee58002d

This just modifies docs / examples to match.

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

