### PR TITLE
[GEOS-9260] Update the session token after a successful login.

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerUserNamePasswordAuthenticationFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerUserNamePasswordAuthenticationFilter.java
@@ -21,6 +21,8 @@ import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy;
+import org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy;
 
 /**
  * User name / password authentication filter
@@ -81,6 +83,14 @@ public class GeoServerUserNamePasswordAuthenticationFilter extends GeoServerComp
         filter.setRememberMeServices(rms);
         GeoServerWebAuthenticationDetailsSource s = new GeoServerWebAuthenticationDetailsSource();
         filter.setAuthenticationDetailsSource(s);
+
+        try {
+            // Prevent session fixation when using Servlet 3.1+
+            filter.setSessionAuthenticationStrategy(new ChangeSessionIdAuthenticationStrategy());
+        } catch (IllegalStateException e) {
+            // Prevent session fixation when using < Servlet 3.1
+            filter.setSessionAuthenticationStrategy(new SessionFixationProtectionStrategy());
+        }
 
         filter.setAllowSessionCreation(false);
         // filter.setFilterProcessesUrl(URL_FOR_LOGIN);

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
@@ -61,7 +61,10 @@ public class GeoServerSecuredPageTest extends GeoServerWicketTestSupport {
         request.setMethod("POST");
         request.setParameter("username", "admin");
         request.setParameter("password", "geoserver");
+        String oldSessionId = request.getSession().getId();
         dispatch(request);
+        // verify that the session ID changed
+        assertNotEquals(oldSessionId, request.getSession().getId());
         // the session in wicket tester mock does not disappear, the only
         // way to see if it has been invalidated is to check that the attributes are gone...
         assertNull(session.getAttribute("test"));


### PR DESCRIPTION
## Description

This pull request sets an appropriate Spring Security authentication strategy to ensure that the session token is updated after successful username/password authentication.
https://osgeo-org.atlassian.net/browse/GEOS-9260

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [X] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
