### PR TITLE
Change staging directory from release to distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ target
 cucumber-report
 .mvn
 
-# Release process artifacts
-release/
+# staging release artifacts
+distribution/
 
 # NSG CITE testst data directory
 data/citensg-1.0/gwc/cite*

--- a/build/build_release.sh
+++ b/build/build_release.sh
@@ -97,7 +97,7 @@ fi
 # move to root of source tree
 pushd .. > /dev/null
 
-dist=`pwd`/release/$tag
+dist=`pwd`/distribution/$tag
 mkdir -p $dist/plugins
 
 echo "Building release with following parameters:"
@@ -375,5 +375,5 @@ fi
 
 popd > /dev/null
 
-echo "build complete, artifacts available at $DIST_URL/$tag"
+echo "build complete, artifacts available at $DIST_URL/distribution/$tag"
 exit 0

--- a/build/publish_release.sh
+++ b/build/publish_release.sh
@@ -86,7 +86,7 @@ popd > /dev/null
 
 # upload artifacts to sourceforge
 
-pushd release/$tag > /dev/null
+pushd distribution/$tag > /dev/null
 
 if [ -z $SKIP_UPLOAD ]; then
   rsync -ave "ssh -i $SF_PK" *-bin.zip *-war.zip *doc.zip *.pdf $SF_USER@$SF_HOST:/home/pfs/project/g/ge/geoserver/GeoServer/$tag/

--- a/doc/en/developer/source/release-guide/index.rst
+++ b/doc/en/developer/source/release-guide/index.rst
@@ -178,15 +178,10 @@ Run the `geoserver-release <https://build.geoserver.org/view/geoserver/job/geose
 
 This job will checkout the specified branch/revision and build the GeoServer
 release artifacts against the GeoTools/GeoWebCache versions specified. When
-successfully complete all release artifacts will be uploaded to the following
-location::
+successfully complete all release artifacts will be listed under artifacts in the job summary.
 
-   http://build.geoserver.org/geoserver/release/<RELEASE>
-
-Additionally when the job completes it fires off two jobs for building the
-Windows and OSX installers. These jobs run on different hudson instances.
-When those jobs complete the ``.exe`` and ``.dmg`` artifacts will be uploaded
-to the location referenced above.
+Additionally when the job completes it fires off a job for a windows worker. When this job
+completes it will list the ``.exe`` artifacts.
 
 Test the Artifacts
 ------------------


### PR DESCRIPTION
This prevents gitignore from conflicting with src/release folder.