### PR TITLE
[GEOS-9262] Update ogcapi module to return title and description in landing page

### DIFF
--- a/src/community/ogcapi/src/main/java/org/geoserver/api/features/LandingPageDocument.java
+++ b/src/community/ogcapi/src/main/java/org/geoserver/api/features/LandingPageDocument.java
@@ -13,6 +13,8 @@ package org.geoserver.api.features;
 
 import static org.geoserver.ows.util.ResponseUtils.buildURL;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.util.Collections;
@@ -28,8 +30,12 @@ import org.springframework.http.MediaType;
  * A class representing the WFS3 server "contents" in a way that Jackson can easily translate to
  * JSON/YAML (and can be used as a Freemarker template model)
  */
+@JsonPropertyOrder({"title", "description", "links"})
 @JacksonXmlRootElement(localName = "LandingPage", namespace = "http://www.opengis.net/wfs/3.0")
 public class LandingPageDocument extends AbstractDocument {
+
+    final String title;
+    final String description;
 
     public LandingPageDocument(WFSInfo wfs, Catalog catalog, String featuresBase) {
         String baseUrl = RequestInfo.get().getBaseURL();
@@ -81,6 +87,8 @@ public class LandingPageDocument extends AbstractDocument {
                 "collections",
                 null,
                 "data");
+        title = (wfs.getTitle() == null) ? "WFS 3.0 server" : wfs.getTitle();
+        description = (wfs.getAbstract() == null) ? "" : wfs.getAbstract();
     }
 
     /** Builds service links for the given response types */
@@ -104,5 +112,15 @@ public class LandingPageDocument extends AbstractDocument {
             }
             addLink(link);
         }
+    }
+
+    @JacksonXmlProperty(localName = "Title")
+    public String getTitle() {
+        return title;
+    }
+
+    @JacksonXmlProperty(localName = "Description")
+    public String getDescription() {
+        return description;
     }
 }

--- a/src/community/ogcapi/src/test/java/org/geoserver/api/features/LandingPageTest.java
+++ b/src/community/ogcapi/src/test/java/org/geoserver/api/features/LandingPageTest.java
@@ -139,6 +139,10 @@ public class LandingPageTest extends FeaturesTestSupport {
                 "data",
                 "data",
                 "data");
+        // check title
+        assertEquals("WFS 3.0 server", json.read("title"));
+        // check description
+        assertEquals("", json.read("description"));
     }
 
     static <T> void assertJSONList(DocumentContext json, String path, T... expected) {


### PR DESCRIPTION
This was added to the spec at https://github.com/opengeospatial/WFS_FES/commit/5b450ef18404d4a4fdb443f6444142c89ed4445f

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates
*Not applicable*

