### PR TITLE
[GEOS-9263] Style editor extension point not working

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -467,10 +467,8 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
                             public Panel getPanel(String panelId) {
                                 StyleEditTabPanel tabPanel;
                                 try {
-                                    tabPanel =
-                                            panelClass
-                                                    .getConstructor(String.class, IModel.class)
-                                                    .newInstance(panelId, styleModel);
+                                    tabPanel = panelClass.getConstructor(String.class, AbstractStylePage.class)
+                                            .newInstance(panelId, AbstractStylePage.this);
                                 } catch (Exception e) {
                                     throw new WicketRuntimeException(e);
                                 }

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -467,8 +467,11 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
                             public Panel getPanel(String panelId) {
                                 StyleEditTabPanel tabPanel;
                                 try {
-                                    tabPanel = panelClass.getConstructor(String.class, AbstractStylePage.class)
-                                            .newInstance(panelId, AbstractStylePage.this);
+                                    tabPanel =
+                                            panelClass
+                                                    .getConstructor(
+                                                            String.class, AbstractStylePage.class)
+                                                    .newInstance(panelId, AbstractStylePage.this);
                                 } catch (Exception e) {
                                     throw new WicketRuntimeException(e);
                                 }

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -13,6 +13,7 @@ import java.awt.*;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -27,6 +28,7 @@ import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.apache.wicket.util.tester.FormTester;
 import org.apache.wicket.util.tester.WicketTester;
@@ -50,6 +52,7 @@ import org.geotools.util.URLs;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.springframework.util.Assert;
 import org.w3c.dom.Document;
 
 public class StyleEditPageTest extends GeoServerWicketTestSupport {
@@ -719,4 +722,28 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
         // check the SvgParameter has been interpreted and we get a red fill, not a gray one
         assertPixel(panel.legendImage, 10, 10, Color.RED);
     }
+
+    private static class StyleEditTabPanelTest extends StyleEditTabPanel {
+
+        /**
+         * @param id     The id given to the panel.
+         * @param parent
+         */
+        public StyleEditTabPanelTest(String id, AbstractStylePage parent) {
+            super(id, parent);
+        }
+    }
+
+    @Test
+    public void testStyleTabExtensionPoint() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        StyleInfo styleInfo = new StyleInfoImpl(null);
+        styleInfo.setName("point");
+        styleInfo.setFilename("test.sld");
+
+        StyleEditPage page = new StyleEditPage(styleInfo);
+        Object tabPanel = StyleEditTabPanelTest.class.getConstructor(String.class, AbstractStylePage.class)
+                .newInstance("someid", page);
+        Assert.notNull(tabPanel, "Constructor for plugin tab panels has a broken signature.");
+    }
+
 }

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -28,7 +28,6 @@ import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
-import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.apache.wicket.util.tester.FormTester;
 import org.apache.wicket.util.tester.WicketTester;
@@ -726,7 +725,7 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
     private static class StyleEditTabPanelTest extends StyleEditTabPanel {
 
         /**
-         * @param id     The id given to the panel.
+         * @param id The id given to the panel.
          * @param parent
          */
         public StyleEditTabPanelTest(String id, AbstractStylePage parent) {
@@ -735,15 +734,18 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
     }
 
     @Test
-    public void testStyleTabExtensionPoint() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testStyleTabExtensionPoint()
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException,
+                    InstantiationException {
         StyleInfo styleInfo = new StyleInfoImpl(null);
         styleInfo.setName("point");
         styleInfo.setFilename("test.sld");
 
         StyleEditPage page = new StyleEditPage(styleInfo);
-        Object tabPanel = StyleEditTabPanelTest.class.getConstructor(String.class, AbstractStylePage.class)
-                .newInstance("someid", page);
+        Object tabPanel =
+                StyleEditTabPanelTest.class
+                        .getConstructor(String.class, AbstractStylePage.class)
+                        .newInstance("someid", page);
         Assert.notNull(tabPanel, "Constructor for plugin tab panels has a broken signature.");
     }
-
 }


### PR DESCRIPTION
## Description

Fixes the extension point enabling others to provide custom tabs to the style editor. JIRA Ticket: https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-9263

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
