### PR TITLE
WIP: add a crumbs path to wfs3 html representation

### DIFF
--- a/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/collection.ftl
+++ b/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/collection.ftl
@@ -1,3 +1,6 @@
+<#global pagetitle=model.name>
+<#global pagepath="/collections/"+model.name>
+<#global pagecrumbs="<a href='"+serviceLink("wfs3")+"'>Home</a><a href='"+serviceLink("wfs3")+"/collections'>Collections</a><b>"+model.name+"</b>">
 <#include "common-header.ftl">
        <h2>${model.name}</h2>
        <#assign collection=model>

--- a/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/collections.ftl
+++ b/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/collections.ftl
@@ -1,5 +1,8 @@
+<#global pagetitle="Collections">
+<#global pagepath="/collections">
+<#global pagecrumbs="<a href='"+serviceLink("wfs3")+"'>Home</a><b>Collections<b>">
 <#include "common-header.ftl">
-       <h2>GeoServer WFS3 collections</h2>
+       <h2>Collections</h2>
        <p>This document lists all the collections available in the WFS 3 service.<br/>
        This document is also available as <#list model.getLinksExcept(null, "text/html") as link><a href="${link.href}">${link.type}</a><#if link_has_next>, </#if></#list>.</p>
        

--- a/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/common-header.ftl
+++ b/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/common-header.ftl
@@ -1,13 +1,21 @@
 <#setting locale="en_US">
 <html>
   <head>
+      <title>${pagetitle}</title>
+      <meta name="language" content="en-US">
+      <meta name="description" content="OGC API provided by GeoServer">
       <link rel="stylesheet" href="${resourceLink("wfs3css/blueprint/screen.css")}" type="text/css" media="screen, projection" />
       <link rel="stylesheet" href="${resourceLink("wfs3css/blueprint/print.css")}" type="text/css" media="print" />
       <link rel="stylesheet" href="${resourceLink("wfs3css/geoserver.css")}" type="text/css" media="screen, projection" />
       <link rel="stylesheet" href="${resourceLink("wfs3css/blueprint/ie.css")}" type="text/css" media="screen, projection" />
+      <link rel="canonical" type="text/html" href="${serviceLink("wfs3")+pagepath}"/>
   </head>
 <body>
    <div id="header">
      <a href="${serviceLink("wfs3")}"></a>
    </div>
+   <div id="crumbs">
+   ${pagecrumbs}
+   </div>
+
    <div id="content">

--- a/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/getfeature-header.ftl
+++ b/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/getfeature-header.ftl
@@ -1,2 +1,6 @@
+<#global pagetitle="Items">
+<#global pagepath="/collections/">
+<#global pagecrumbs="<a href='"+serviceLink("wfs3")+"'>Home</a><a href='"+serviceLink("wfs3")+"/collections'>Collections</a><a href='"+serviceLink("wfs3")+"/collections'>Collection</a><b>Items</b>">
+
 <#include "common-header.ftl">
 

--- a/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/landingPage.ftl
+++ b/src/community/wfs3/src/main/resources/org/geoserver/wfs3/response/landingPage.ftl
@@ -1,6 +1,9 @@
+<#global pagetitle=service.title!"OGC API provided by GeoServer">
+<#global pagepath="">
+<#global pagecrumbs="<b>Home</b>">
 <#include "common-header.ftl">
    <div id="content">
-       <h2>${service.title!"GeoServer WFS 3 Service"}</h2>
+       <h2>${pagetitle}</h2>
        <p>${service.abstract!""}<br/>
        This is the landing page of the WFS 3 service, providing links to the service API and its contents.
        <br/> 

--- a/src/community/wfs3/src/main/resources/wfs3css/geoserver.css
+++ b/src/community/wfs3/src/main/resources/wfs3css/geoserver.css
@@ -112,3 +112,15 @@ border-bottom: 2px solid #c6e09b;
 select {
  margin: 0;
 }
+
+#crumbs {
+  background-color: #c6e09b;
+  margin-top: -5px;
+  padding: 10px;
+}
+
+#crumbs a:before, #crumbs b:before {
+  content: ">>";
+  font-size: x-small;
+  padding: 5px;
+}


### PR DESCRIPTION
This PR is a work in progress, not to be merged. It introduces a crumbspath in the html representation of wfs3 (ogc api features) responses. And adds some best practices used by search engines, such as a title header and a canonical url.

@aaime already responded on gitter to this investigation with:

> btw, the wfs3 module is abandonware, I'll keep it there for a while because there is code that can be useful, but the action moved to ogcapi. At the same time, ogcapi is still quite green and needs improvement/cleanup in the dispatcher before others can jump in an implement other services

Goal of the PR to show how minimal changes can improve the usability of the html representation. A first next task would be to move the developments to the OAPI branch and evaluate if building of the crumbspath makes sense as part of the templates, this can probably better be managed in the java code.

A consideration from this effort is that each change currently needs a clean install. To consider is to move the templates outside the compiled package (into the datafolder), so users can easily override it to their needs at runtime.

![image](https://user-images.githubusercontent.com/299829/60041981-e7e3e100-96bc-11e9-9dd9-42a823b97a77.png)

