### PR TITLE
[GEOS-9268] Make MongoDB App-Schema schema rebuilder endpoints only rebuild schemas present in mappings

### DIFF
--- a/doc/en/api/1.0.0/datastores.yaml
+++ b/doc/en/api/1.0.0/datastores.yaml
@@ -395,6 +395,11 @@ paths:
           required: false
           description: Max number of objects for use in new generated schema.
           type: integer
+        - name: schema
+          in: query
+          required: false
+          description: Name of schema to re-build.
+          type: string
       responses:
         200:
           description: OK		

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBSupport.java
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBSupport.java
@@ -70,7 +70,7 @@ public abstract class ComplexMongoDBSupport extends GeoServerSystemTestSupport {
 
     protected static final String STATIONS_STORE_NAME = UUID.randomUUID().toString();
     private static final String STATIONS_DATA_BASE_NAME = UUID.randomUUID().toString();
-    private static final String STATIONS_COLLECTION_NAME = "stations";
+    protected static final String STATIONS_COLLECTION_NAME = "stations";
 
     private static MongoClient MONGO_CLIENT;
 


### PR DESCRIPTION
## Description

This PR improves MongoDB App-Schema schema rebuild REST endpoint, building only schemas used in declared mappings and giving an extra parameter to define a schema name to re-build.

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9268

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
