### PR TITLE
Updated WFS GetFeature using bbox text & example

### DIFF
--- a/doc/en/user/source/services/wfs/reference.rst
+++ b/doc/en/user/source/services/wfs/reference.rst
@@ -304,7 +304,9 @@ For more than one property from a single feature, use a comma-separated list of 
 
 While the above permutations for a GetFeature request focused on non-spatial parameters, it is also possible to query for features based on geometry. While there are limited options available in a GET request for spatial queries (more are available in POST requests using filters), filtering by bounding box (BBOX) is supported.
 
-The BBOX parameter allows you to search for features that are contained (or partially contained) inside a box of user-defined coordinates. The format of the BBOX parameter is ``bbox=a1,b1,a2,b2``where ``a1``, ``b1``, ``a2``, and ``b2`` represent the coordinate values. The order of coordinates passed to the BBOX parameter depends on the coordinate system used. (This is why the coordinate syntax isn't represented with ``x`` or ``y``.) To specify the coordinate system, append ``srsName=CRS`` to the WFS request, where ``CRS`` is the Coordinate Reference System you wish to use.
+The BBOX parameter allows you to search for features that are contained (or partially contained) inside a box of user-defined coordinates. The format of the BBOX parameter is ``bbox=a1,b1,a2,b2,[crs]`` where ``a1``, ``b1``, ``a2``, and ``b2`` represent the coordinate values, and ``[crs]`` represents the name of the CRS for the bbox coordinates if it is different to the featureTypes native CRS. The order of coordinates passed to the BBOX parameter depends on the coordinate system used. (This is why the coordinate syntax isn't represented with ``x`` or ``y``.)
+
+To specify the coordinate system for the returned features, append ``srsName=CRS`` to the WFS request, where ``CRS`` is the Coordinate Reference System you wish to use.
 
 As for which corners of the bounding box to specify, the only requirement is for a bottom corner (left or right) to be provided first. For example, bottom left and top right, or bottom right and top left.
 
@@ -316,7 +318,7 @@ An example request involving returning features based on bounding box would be i
      request=GetFeature&
      typeNames=namespace:featuretype&
      srsName=CRS
-     bbox=a1,b1,a2,b2
+     bbox=a1,b1,a2,b2,CRS
 
 
 LockFeature

--- a/doc/en/user/source/services/wfs/reference.rst
+++ b/doc/en/user/source/services/wfs/reference.rst
@@ -304,13 +304,24 @@ For more than one property from a single feature, use a comma-separated list of 
 
 While the above permutations for a GetFeature request focused on non-spatial parameters, it is also possible to query for features based on geometry. While there are limited options available in a GET request for spatial queries (more are available in POST requests using filters), filtering by bounding box (BBOX) is supported.
 
-The BBOX parameter allows you to search for features that are contained (or partially contained) inside a box of user-defined coordinates. The format of the BBOX parameter is ``bbox=a1,b1,a2,b2,[crs]`` where ``a1``, ``b1``, ``a2``, and ``b2`` represent the coordinate values, and ``[crs]`` represents the name of the CRS for the bbox coordinates if it is different to the featureTypes native CRS. The order of coordinates passed to the BBOX parameter depends on the coordinate system used. (This is why the coordinate syntax isn't represented with ``x`` or ``y``.)
+The BBOX parameter allows you to search for features that are contained (or partially contained) inside a box of user-defined coordinates. The format of the BBOX parameter is ``bbox=a1,b1,a2,b2,[crs]`` where ``a1``, ``b1``, ``a2``, and ``b2`` represent the coordinate values. The optional ``crs`` parameter is used to name the CRS for the bbox coordinates (if they are different to the featureTypes native CRS.) The order of coordinates passed to the BBOX parameter depends on the coordinate system used
+(this is why the coordinate syntax isn't represented with ``x`` or ``y``.)
 
 To specify the coordinate system for the returned features, append ``srsName=CRS`` to the WFS request, where ``CRS`` is the Coordinate Reference System you wish to use.
 
 As for which corners of the bounding box to specify, the only requirement is for a bottom corner (left or right) to be provided first. For example, bottom left and top right, or bottom right and top left.
 
-An example request involving returning features based on bounding box would be in the following format::  
+An example request returning features based on a bounding box (using the featureTypes native CRS)::
+
+   http://example.com/geoserver/wfs?
+     service=wfs&
+     version=2.0.0&
+     request=GetFeature&
+     typeNames=namespace:featuretype&
+     srsName=CRS
+     bbox=a1,b1,a2,b2
+
+To request features using a bounding box with CRS different from featureTypes native CRS::
 
    http://example.com/geoserver/wfs?
      service=wfs&
@@ -319,7 +330,6 @@ An example request involving returning features based on bounding box would be i
      typeNames=namespace:featuretype&
      srsName=CRS
      bbox=a1,b1,a2,b2,CRS
-
 
 LockFeature
 ~~~~~~~~~~~


### PR DESCRIPTION
## Description

Updated WFS GetFeature using bbox description and example to include the optional ``[CRS]`` parameter value for cases where the bbox is in a different coordinate system to the featureTypes native coordinate system.

Modified description text to indicate that ``srsName=CRS`` parameter specifies the resulting output features CRS, and not the CRS of the bbox.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [N/A] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [N/A] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [N/A] PR for bug fixes and small new features are presented as a single commit
- [N/A] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [N/A] New unit tests have been added covering the changes
- [N/A] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [N/A] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
