### PR TITLE
[GEOS-9271] NullPointerException on WFS ComplexGeoJsonWriter Link check

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
@@ -340,7 +340,7 @@ class ComplexGeoJsonWriter {
      * feature resolved as a link.
      */
     @SuppressWarnings("unchecked")
-    private boolean checkIfFeatureIsLinked(Property property, Map<NameImpl, String> attributes) {
+    static boolean checkIfFeatureIsLinked(Property property, Map<NameImpl, String> attributes) {
         if (!(property instanceof ComplexAttribute)) {
             // not a complex attribute, so we don't consider it a candidate to be a linked one
             return false;
@@ -350,10 +350,12 @@ class ComplexGeoJsonWriter {
             // has properties, so not a chained feature resolved as a link
             return false;
         }
-        for (NameImpl key : attributes.keySet()) {
-            if (key != null && key.getLocalPart().equalsIgnoreCase("href")) {
-                // we found a link
-                return true;
+        if (attributes != null) {
+            for (NameImpl key : attributes.keySet()) {
+                if (key != null && "href".equalsIgnoreCase(key.getLocalPart())) {
+                    // we found a link
+                    return true;
+                }
             }
         }
         // no link was found, so not a chained feature resolved as a link

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/ComplexGeoJsonWriterTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/ComplexGeoJsonWriterTest.java
@@ -1,0 +1,147 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import org.junit.Test;
+import org.opengis.feature.ComplexAttribute;
+import org.opengis.feature.IllegalAttributeException;
+import org.opengis.feature.Property;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.ComplexType;
+import org.opengis.feature.type.Name;
+import org.opengis.feature.type.PropertyDescriptor;
+import org.opengis.feature.type.PropertyType;
+import org.opengis.filter.identity.Identifier;
+
+public class ComplexGeoJsonWriterTest {
+
+    /*
+     * Tests Null safety when attribute parameter is null in checkIfFeatureIsLinked util method.
+     */
+    @Test
+    public void testCheckIfFeatureIsLinkedNullSafeAttr() {
+        Property property = generateTestComplexAttribute();
+        boolean checkIfFeatureIsLinked =
+                ComplexGeoJsonWriter.checkIfFeatureIsLinked(property, null);
+        assertFalse(checkIfFeatureIsLinked);
+    }
+
+    private ComplexAttribute generateTestComplexAttribute() {
+        return new ComplexAttribute() {
+
+            @Override
+            public void setValue(Object newValue) {}
+
+            @Override
+            public boolean isNillable() {
+                return false;
+            }
+
+            @Override
+            public Map<Object, Object> getUserData() {
+                return null;
+            }
+
+            @Override
+            public Name getName() {
+                return null;
+            }
+
+            @Override
+            public Identifier getIdentifier() {
+                return null;
+            }
+
+            @Override
+            public AttributeDescriptor getDescriptor() {
+                return null;
+            }
+
+            @Override
+            public void validate() throws IllegalAttributeException {}
+
+            @Override
+            public void setValue(Collection<Property> values) {}
+
+            @Override
+            public Collection<? extends Property> getValue() {
+                return null;
+            }
+
+            @Override
+            public ComplexType getType() {
+                return null;
+            }
+
+            @Override
+            public Property getProperty(String name) {
+                return null;
+            }
+
+            @Override
+            public Property getProperty(Name name) {
+                return null;
+            }
+
+            @Override
+            public Collection<Property> getProperties(String name) {
+                Property prop =
+                        new Property() {
+
+                            @Override
+                            public void setValue(Object newValue) {}
+
+                            @Override
+                            public boolean isNillable() {
+                                return false;
+                            }
+
+                            @Override
+                            public Object getValue() {
+                                return null;
+                            }
+
+                            @Override
+                            public Map<Object, Object> getUserData() {
+                                return null;
+                            }
+
+                            @Override
+                            public PropertyType getType() {
+                                return null;
+                            }
+
+                            @Override
+                            public Name getName() {
+                                return null;
+                            }
+
+                            @Override
+                            public PropertyDescriptor getDescriptor() {
+                                return null;
+                            }
+                        };
+                ArrayList<Property> list = new ArrayList<Property>();
+                list.add(prop);
+                return list;
+            }
+
+            @Override
+            public Collection<Property> getProperties(Name name) {
+                return null;
+            }
+
+            @Override
+            public Collection<Property> getProperties() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Description

GeoJSON output request Geoserver throws a NullPointerException on WFS ComplexGeoJsonWriter class -> checkIfFeatureIsLinked method, due to null userData object (attributes parameter) in properties not being null safe checked before using its methods.

This PR adds null-safe checks fixing the issue.

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9271

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
