### PR TITLE
Default SLD abstracts updated to fit the style

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/default_line.sld
+++ b/src/main/src/main/java/org/geoserver/config/default_line.sld
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0" 
-		xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-		xmlns="http://www.opengis.net/sld" 
-		xmlns:ogc="http://www.opengis.net/ogc" 
-		xmlns:xlink="http://www.w3.org/1999/xlink" 
+<StyledLayerDescriptor version="1.0.0"
+		xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+		xmlns="http://www.opengis.net/sld"
+		xmlns:ogc="http://www.opengis.net/ogc"
+		xmlns:xlink="http://www.w3.org/1999/xlink"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		<!-- a named layer is the basic building block of an sld document -->
 
@@ -11,9 +11,9 @@
 		<Name>Default Line</Name>
 		<UserStyle>
 		    <!-- they have names, titles and abstracts -->
-		  
+
 			<Title>A boring default style</Title>
-			<Abstract>A sample style that just prints out a green line</Abstract>
+			<Abstract>A sample style that just prints out a blue line</Abstract>
 			<!-- FeatureTypeStyles describe how to render different features -->
 			<!-- a feature type for lines -->
 
@@ -21,8 +21,8 @@
 				<!--FeatureTypeName>Feature</FeatureTypeName-->
 				<Rule>
 					<Name>Rule 1</Name>
-					<Title>Green Line</Title>
-					<Abstract>A green line with a 2 pixel width</Abstract>
+					<Title>Blue Line</Title>
+					<Abstract>A blue line with a 1 pixel width</Abstract>
 
 					<!-- like a polygonsymbolizer -->
 					<LineSymbolizer>
@@ -36,4 +36,3 @@
 		</UserStyle>
 	</NamedLayer>
 </StyledLayerDescriptor>
-

--- a/src/main/src/main/java/org/geoserver/config/default_point.sld
+++ b/src/main/src/main/java/org/geoserver/config/default_point.sld
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0" 
-		xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-		xmlns="http://www.opengis.net/sld" 
-		xmlns:ogc="http://www.opengis.net/ogc" 
-		xmlns:xlink="http://www.w3.org/1999/xlink" 
+<StyledLayerDescriptor version="1.0.0"
+		xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+		xmlns="http://www.opengis.net/sld"
+		xmlns:ogc="http://www.opengis.net/ogc"
+		xmlns:xlink="http://www.w3.org/1999/xlink"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		<!-- a named layer is the basic building block of an sld document -->
 
@@ -11,9 +11,9 @@
 		<Name>Default Point</Name>
 		<UserStyle>
 		    <!-- they have names, titles and abstracts -->
-		  
+
 			<Title>A boring default style</Title>
-			<Abstract>A sample style that just prints out a purple square</Abstract>
+			<Abstract>A sample style that just prints out a red square</Abstract>
 			<!-- FeatureTypeStyles describe how to render different features -->
 			<!-- a feature type for points -->
 
@@ -22,7 +22,7 @@
 				<Rule>
 					<Name>Rule 1</Name>
 					<Title>RedSquare</Title>
-					<Abstract>A red fill with an 11 pixel size</Abstract>
+					<Abstract>A red fill with an 6 pixel size</Abstract>
 
 					<!-- like a linesymbolizer but with a fill too -->
 					<PointSymbolizer>
@@ -42,4 +42,3 @@
 		</UserStyle>
 	</NamedLayer>
 </StyledLayerDescriptor>
-

--- a/src/main/src/main/java/org/geoserver/config/default_polygon.sld
+++ b/src/main/src/main/java/org/geoserver/config/default_polygon.sld
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0" 
-    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
-    xmlns="http://www.opengis.net/sld" 
-    xmlns:ogc="http://www.opengis.net/ogc" 
-    xmlns:xlink="http://www.w3.org/1999/xlink" 
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <!-- a named layer is the basic building block of an sld document -->
 
@@ -11,9 +11,9 @@
     <Name>Default Polygon</Name>
     <UserStyle>
         <!-- they have names, titles and abstracts -->
-      
+
       <Title>A boring default style</Title>
-      <Abstract>A sample style that just prints out a transparent red interior with a red outline</Abstract>
+      <Abstract>A sample style that just prints out a grey interior with a black outline</Abstract>
       <!-- FeatureTypeStyles describe how to render different features -->
       <!-- a feature type for polygons -->
 
@@ -21,8 +21,8 @@
         <!--FeatureTypeName>Feature</FeatureTypeName-->
         <Rule>
           <Name>Rule 1</Name>
-          <Title>RedFill RedOutline</Title>
-          <Abstract>50% transparent red fill with a red outline 1 pixel in width</Abstract>
+          <Title>GreyFill BlackOutline</Title>
+          <Abstract>Grey fill with a black outline 1 pixel in width</Abstract>
 
           <!-- like a linesymbolizer but with a fill too -->
           <PolygonSymbolizer>
@@ -40,4 +40,3 @@
     </UserStyle>
   </NamedLayer>
 </StyledLayerDescriptor>
-


### PR DESCRIPTION
## Description

The default geoserver sld styles contained the wrong abstract for the styles, so I changed the abstract.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
