### PR TITLE
[GEOS-9276] WMS configuration UI, watermark file input allows to validate a remote HTTP URL

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/wicket/FileExistsValidator.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/FileExistsValidator.java
@@ -55,6 +55,7 @@ public class FileExistsValidator implements IValidator<String> {
         try {
             URI uri = new URI(uriSpec);
             if (uri.getScheme() != null && !"file".equals(uri.getScheme())) {
+                // if delegate is null, remote URL is allowed
                 if (delegate != null) {
                     delegate.validate(validatable);
                     InputStream is = null;
@@ -71,6 +72,13 @@ public class FileExistsValidator implements IValidator<String> {
                     } finally {
                         IOUtils.closeQuietly(is);
                     }
+                } else {
+                    // no remote URL allowed and it isn't a file -> validation error
+                    IValidationError err =
+                            new ValidationError("FileExistsValidator.remoteNotAllowed")
+                                    .addKey("FileExistsValidator.remoteNotAllowed")
+                                    .setVariable("file", uriSpec);
+                    validatable.error(err);
                 }
                 return;
             } else {

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -248,6 +248,7 @@ FileDataView.size = Size
 
 FileExistsValidator.fileNotFoundError = Could not find file: ${file}
 FileExistsValidator.unreachable = Connection to resource failed: ${file}
+FileExistsValidator.remoteNotAllowed = Remote resource not allowed: ${file}
 
 FileParamPanel.browse=Browse...
 

--- a/src/web/core/src/test/java/org/geoserver/web/wicket/FileExistsValidatorTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/wicket/FileExistsValidatorTest.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.web.wicket;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.io.Files;
@@ -58,5 +59,18 @@ public class FileExistsValidatorTest {
 
         validator.validate(validatable);
         assertTrue(validatable.isValid());
+    }
+
+    /**
+     * Checks validation error is present if remote URL is not allowed and an http:// url is
+     * validated.
+     */
+    @Test
+    public void testRemoteNotAllowed() throws Exception {
+        StringValidatable validatable =
+                new StringValidatable("http://localhost:8080/BlueMarble.tiff");
+        FileExistsValidator validator2 = new FileExistsValidator(false);
+        validator2.validate(validatable);
+        assertFalse(validatable.isValid());
     }
 }

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.java
@@ -194,7 +194,7 @@ public class WMSAdminPage extends BaseServiceAdminPage<WMSInfo> {
                 new TextField(
                         "watermark.uRL",
                         new FileModel(new PropertyModel<String>(form.getModel(), "watermark.URL")));
-        watermarkUrlField.add(new FileExistsValidator(true));
+        watermarkUrlField.add(new FileExistsValidator(false));
         watermarkUrlField.setOutputMarkupId(true);
         form.add(watermarkUrlField);
         form.add(


### PR DESCRIPTION
## Description

In WMS configuration page (main or workspace) the watermark file input allows to validate a remote http url making a request on it to check if exists.  This PR makes Watermark input detects introduced text is not a file url and don't make any tcp/ip connection to reach the resource.

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9276

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
