### PR TITLE
[GEOS-9280] Uploading of SLD from GeoNode fails (Backport to 2.15.x)

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
@@ -117,7 +117,7 @@ public class StyleController extends AbstractCatalogController {
             MediaType.APPLICATION_JSON_VALUE,
             MediaTypeExtensions.TEXT_JSON_VALUE
         },
-        produces = MediaType.TEXT_PLAIN_VALUE
+        produces = {MediaType.TEXT_PLAIN_VALUE, MediaType.APPLICATION_XML_VALUE}
     )
     @ResponseStatus(HttpStatus.CREATED)
     public String stylePost(

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
@@ -432,6 +432,22 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
     }
 
     @Test
+    public void testPostToWorkspaceApplicationXML() throws Exception {
+        Catalog cat = getCatalog();
+        assertNull(cat.getStyleByName("gs", "foo"));
+
+        String xml = "<style>" + "<name>foo</name>" + "<filename>foo.sld</filename>" + "</style>";
+        MockHttpServletResponse response =
+                postAsServletResponse(RestBaseController.ROOT_PATH + "/workspaces/gs/styles", xml);
+        response.setContentType(MediaType.APPLICATION_XML_VALUE);
+        assertEquals(201, response.getStatus());
+        assertThat(
+                response.getContentType(),
+                CoreMatchers.startsWith(MediaType.APPLICATION_XML_VALUE));
+        assertNotNull(cat.getStyleByName("gs", "foo"));
+    }
+
+    @Test
     public void testPut() throws Exception {
         StyleInfo style = catalog.getStyleByName("Ponds");
         assertEquals("Ponds.sld", style.getFilename());


### PR DESCRIPTION
## Description

Fixes a problem where the wrong REST endpoint is called when POSTing a style.  Needed for backwards capability with GeoNode 2.10rc5

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)

The following are required only for core and extension modules, while they are welcomed, but not required, for community modules:
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
