### PR TITLE
[GEOS-9208] SLDService raster classifier updates layer default style …

### DIFF
--- a/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/RasterizerTest.java
+++ b/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/RasterizerTest.java
@@ -18,6 +18,7 @@ import org.geotools.styling.ColorMap;
 import org.geotools.styling.ColorMapEntry;
 import org.geotools.styling.RasterSymbolizer;
 import org.geotools.styling.Rule;
+import org.geotools.styling.Style;
 import org.junit.Test;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -82,6 +83,7 @@ public class RasterizerTest extends SLDServiceBaseTest {
     public void testRasterizeOptions() throws Exception {
         LayerInfo l = getCatalog().getLayerByName("wcs:World");
         assertEquals("raster", l.getDefaultStyle().getName());
+        Style defaultStyle1 = l.getDefaultStyle().getStyle();
         final String restPath =
                 RestBaseController.ROOT_PATH
                         + "/sldservice/wcs:World/"
@@ -97,12 +99,15 @@ public class RasterizerTest extends SLDServiceBaseTest {
         ColorMap map = checkColorMap(baos.toString(), 5);
         checkColorEntry(map.getColorMapEntries()[1], "#FF0000", "10.0", "1.0");
         checkColorEntry(map.getColorMapEntries()[5], "#0000FF", "50.0", "1.0");
+        Style defaultStyle2 = l.getDefaultStyle().getStyle();
+        assertEquals(defaultStyle1, defaultStyle2);
     }
 
     @Test
     public void testRasterizeOptions2() throws Exception {
         LayerInfo l = getCatalog().getLayerByName("wcs:World");
         assertEquals("raster", l.getDefaultStyle().getName());
+        Style defaultStyle1 = l.getDefaultStyle().getStyle();
         final String restPath =
                 RestBaseController.ROOT_PATH
                         + "/sldservice/wcs:World/"
@@ -118,6 +123,8 @@ public class RasterizerTest extends SLDServiceBaseTest {
         ColorMap map = checkColorMap(baos.toString(), 5);
         checkColorEntry(map.getColorMapEntries()[1], "#FF0000", "10.00", "1.0");
         checkColorEntry(map.getColorMapEntries()[5], "#0000FF", "50.00", "1.0");
+        Style defaultStyle2 = l.getDefaultStyle().getStyle();
+        assertEquals(defaultStyle1, defaultStyle2);
     }
 
     private ColorMap checkColorMap(String resultXml, int classes) {


### PR DESCRIPTION
…by mistake

<Include a few sentences describing the overall goals for this PR (pull request).>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
