### PR TITLE
[GEOS-9288] Azure Blobstore shows values instead of parameter names if ALLOW_ENV_PARAMETRIZATION is active

### DIFF
--- a/src/community/gwc-azure-blob/src/main/java/org/geoserver/gwc/web/blob/AzureBlobStoreType.java
+++ b/src/community/gwc-azure-blob/src/main/java/org/geoserver/gwc/web/blob/AzureBlobStoreType.java
@@ -20,7 +20,8 @@ public class AzureBlobStoreType implements BlobStoreType<AzureBlobStoreInfo> {
     public AzureBlobStoreInfo newConfigObject() {
         AzureBlobStoreInfo config = new AzureBlobStoreInfo();
         config.setEnabled(true);
-        config.setMaxConnections(AzureBlobStoreInfo.DEFAULT_CONNECTIONS);
+        config.setMaxConnections(
+                Integer.valueOf(AzureBlobStoreInfo.DEFAULT_CONNECTIONS).toString());
         return config;
     }
 

--- a/src/community/gwc-azure-blob/src/main/resources/applicationContext.xml
+++ b/src/community/gwc-azure-blob/src/main/resources/applicationContext.xml
@@ -11,7 +11,7 @@
    Bean configuration file for the gwc-azure-blob module
   </description>
   
-  <bean id="AzureBlobStoreConfigProvider" class="org.geowebcache.azure.AzureBlobStoreConfigProvider" depends-on="geoWebCacheExtensions">
+  <bean id="AzureBlobStoreConfigProvider" class="org.geowebcache.azure.AzureBlobStoreConfigProvider">
     <description>
       Contributes XStream configuration settings to org.geowebcache.config.XMLConfiguration to encode AzureBlobStoreInfo instances
     </description>

--- a/src/community/gwc-azure-blob/src/test/java/org/geoserver/gwc/web/blob/AzureBlobStorePageTest.java
+++ b/src/community/gwc-azure-blob/src/test/java/org/geoserver/gwc/web/blob/AzureBlobStorePageTest.java
@@ -93,7 +93,8 @@ public class AzureBlobStorePageTest extends GeoServerWicketTestSupport {
         assertEquals("myAccountName", azureConfig.getAccountName());
         assertEquals("myAccountKey", azureConfig.getAccountKey());
         assertEquals(
-                AzureBlobStoreInfo.DEFAULT_CONNECTIONS, azureConfig.getMaxConnections().intValue());
+                String.valueOf(AzureBlobStoreInfo.DEFAULT_CONNECTIONS),
+                azureConfig.getMaxConnections());
 
         GWC.get().removeBlobStores(Collections.singleton("myblobstore"));
     }
@@ -104,7 +105,7 @@ public class AzureBlobStorePageTest extends GeoServerWicketTestSupport {
         Field id = BlobStoreInfo.class.getDeclaredField("name");
         id.setAccessible(true);
         id.set(sconfig, "myblobstore");
-        sconfig.setMaxConnections(50);
+        sconfig.setMaxConnections("50");
         sconfig.setContainer("myContainer");
         sconfig.setAccountName("myAccountName");
         sconfig.setAccountKey("myAccountKey");

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -1319,7 +1319,7 @@
       <dependencies>
         <dependency>
           <groupId>org.geoserver.community</groupId>
-          <artifactId>gs-gwc-azure</artifactId>
+          <artifactId>gs-gwc-azure-blob</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>


### PR DESCRIPTION
This PR aligns with GeoWebCache Azure Blobstore fixes on ALLOW_ENV_PARAMETRIZATION variable resolving.

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9288

Requires:
https://github.com/GeoWebCache/geowebcache/pull/779

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
