### PR TITLE
Security LDAP docs fix (2.15.x)

### DIFF
--- a/doc/en/user/source/security/tutorials/ldap/index.rst
+++ b/doc/en/user/source/security/tutorials/ldap/index.rst
@@ -134,7 +134,7 @@ bill is a member of the ``admin`` group so he would be assigned a role named
 
    If you want support for hierarchical LDAP groups:
    
-   * Check ``Enable Hierarchical groups search `` box.
+   * Check ``Enable Hierarchical groups search`` box.
    * Set ``Max depth for hierarchical groups search`` to 10 (-1 for infinite depth, or the depth number you want to support).
    * Set ``Nested group search filter`` to "member={0}"
 


### PR DESCRIPTION
This PR fixes a failure on Security LDAP docs build because an extra space character.

2.15.x branch.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
