### PR TITLE
Update YAML featurestyles.rst

### DIFF
--- a/doc/en/user/source/styling/ysld/reference/featurestyles.rst
+++ b/doc/en/user/source/styling/ysld/reference/featurestyles.rst
@@ -90,7 +90,7 @@ The following is the basic syntax of a feature style. Note that the contents of 
        ...
      rules:
      - ...
-     x-firstMatch: <boolean>
+     x-ruleEvaluation: <text>
      x-composite: <text>
      x-composite-base: <boolean>
 
@@ -139,10 +139,10 @@ The following properties are equivalent to SLD "vendor options".
      - Required?
      - Description
      - Default value
-   * - ``x-FirstMatch``
+   * - ``x-ruleEvaluation``
      - No
-     - Stops rule evaluation after the first match. Can make the rendering more efficient by reducing the number of rules that need to be traversed by features, as well as simplyfing the rule filters.
-     - ``false``
+     - When equals to ``first`` - stops rule evaluation after the first match. Can make the rendering more efficient by reducing the number of rules that need to be traversed by features, as well as simplyfing the rule filters.
+     - ``all``
    * - ``x-composite``
      - No
      - Allows for both alpha compositing and color blending options between buffers. There are many options; :ref:`see below <ysld_reference_featurestyles_composite>`.
@@ -388,7 +388,7 @@ When drawn, the outer line has a width of 8 pixels and the inner line has a widt
 First match
 ~~~~~~~~~~~
 
-Given a style that has many rules with distinct outcomes, it may be advantageous to employ ``x-firstMatch`` so as to improve rendering efficiency and simplify those rules.
+Given a style that has many rules with distinct outcomes, it may be advantageous to employ ``x-ruleEvaluation: first`` so as to improve rendering efficiency and simplify those rules.
 
 This first example shows the standard way of creating rules for a dataset. There are villages, towns, and cities (``type = 'village'``, ``type = 'town'`` or ``type = 'city'``) and they have an ``industry`` which could be either ``fishing`` or other values.
 
@@ -422,7 +422,7 @@ This first example shows the standard way of creating rules for a dataset. There
        - point:
            <<: *allotherplaces
 
-Using the ``x-firstMatch: true`` parameter, the style is simplified:
+Using the ``x-ruleEvaluation: first`` parameter, the style is simplified:
 
 .. code-block:: yaml
    :linenos:
@@ -430,7 +430,7 @@ Using the ``x-firstMatch: true`` parameter, the style is simplified:
 
    feature-styles:
    - name: with_first_match
-     x-firstMatch: true
+     x-ruleEvaluation: first
      rules:
      - name: fishing_town
        filter: ${type = 'town' AND industry = 'fishing'}


### PR DESCRIPTION
new x-ruleEvaluation parameter instead old x-firstMatch

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
