### PR TITLE
Documenting ImageMosaic-Indexer's WrapStore parameter - bkpt to 2.15.x

### DIFF
--- a/doc/en/user/source/data/raster/imagemosaic/configuration.rst
+++ b/doc/en/user/source/data/raster/imagemosaic/configuration.rst
@@ -254,6 +254,9 @@ In addition to the required envelope and location attributes, the schema for the
    * - Wildcard
      - N
      - Wildcard used to specify which files should be scanned by the indexer. (For instance: ".")
+   * - WrapStore
+     - N
+     - By default, PostgreSQL identifiers can't be longer than 63 chars. Longer names will be truncated to that fixed length. When dealing with multidimensional datasets (for instance: NetCDFs, GRIBs) each variable (NetCDF) or parameter (GRIB) is indexed into a table with the same name. Therefore an atmosphere-absorption-optical-thickness-due-to-particulate-organic-matter-ambient-aerosol-particles NetCDF CF variable will be associated to a table with the same name. PostgreSQL will truncate that to atmosphere-absorption-optical-thickness-due-to-particulate-orga breaking the one-to-one mapping thus breaking the proper functioning. Setting the WrapStore flag to ``true`` will establish a hidden mapping between full long names and truncated table names to support proper working.
    * - MosaicCRS
      - N
      - The "native" CRS of the mosaic, that is, the one in which footprints are collected. Useful when dealing with granules in multiple CRSs (see tutorial)


### PR DESCRIPTION
Backport of Documenting ImageMosaic-Indexer's WrapStore parameter