### PR TITLE
[GEOS-9296] Fix race condition in audit logger initialization

### DIFF
--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/auditlog/AuditLogger.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/auditlog/AuditLogger.java
@@ -62,7 +62,7 @@ public class AuditLogger implements RequestDataListener, ApplicationListener<App
 
     MonitorConfig config;
 
-    RequestDumper dumper;
+    volatile RequestDumper dumper;
 
     int rollLimit;
 
@@ -80,8 +80,8 @@ public class AuditLogger implements RequestDataListener, ApplicationListener<App
         templateConfig.setTemplateLoader(new AuditTemplateLoader(loader));
     }
 
-    void initDumper() throws IOException {
-        if (getProperty("enabled", Boolean.class, false)) {
+    synchronized void initDumper() throws IOException {
+        if (this.dumper == null && getProperty("enabled", Boolean.class, false)) {
             // prepare the config
             rollLimit = getProperty("roll_limit", Integer.class, DEFAULT_ROLLING_LIMIT);
             path = System.getProperty("GEOSERVER_AUDIT_PATH");

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/auditlog/AuditLoggerTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/auditlog/AuditLoggerTest.java
@@ -1,0 +1,103 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.monitor.auditlog;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.geoserver.monitor.MonitorConfig;
+import org.geoserver.monitor.RequestData;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.support.GenericApplicationContext;
+
+public class AuditLoggerTest {
+
+    @Rule public TemporaryFolder directory = new TemporaryFolder();
+
+    private File bad;
+    private File good;
+    private GeoServerResourceLoader loader;
+    private MonitorConfig config;
+    private GenericApplicationContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        this.bad = this.directory.newFolder("bad");
+        this.good = this.directory.newFolder("good");
+        System.setProperty("GEOSERVER_AUDIT_PATH", this.good.getAbsolutePath());
+        this.loader = new GeoServerResourceLoader(this.directory.getRoot());
+        this.config = new MonitorConfig(this.loader);
+        this.config.getProperties().put("audit.enabled", "true");
+        this.config.getProperties().put("audit.path", this.bad.getAbsolutePath());
+        this.context = new GenericApplicationContext();
+        this.context.getBeanFactory().registerSingleton("resourceLoader", this.loader);
+        this.context.refresh();
+        new GeoServerExtensions().setApplicationContext(this.context);
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("GEOSERVER_AUDIT_PATH");
+        new GeoServerExtensions().setApplicationContext(null);
+    }
+
+    @Test
+    public void testInitDumperRaceCondition() throws Exception {
+        // Run the test multiple times since the race condition can only
+        // happen during the audit logger initialization.
+        int numTests = 10;
+        int numRequests = 8;
+        for (int i = 0; i < numTests; i++) {
+            AuditLogger logger = new AuditLogger(this.config, this.loader);
+            List<Callable<Object>> tasks = new ArrayList<>(numRequests);
+            for (int j = 0; j < numRequests; j++) {
+                RequestData data = new RequestData();
+                data.setId(1);
+                data.setHost("localhost");
+                data.setStartTime(new Date(0));
+                data.setEndTime(new Date(0));
+                tasks.add(Executors.callable(() -> logger.requestPostProcessed(data)));
+            }
+            ExecutorService executor = Executors.newFixedThreadPool(numRequests);
+            try {
+                for (Future<Object> future : executor.invokeAll(tasks)) {
+                    future.get();
+                }
+            } finally {
+                executor.shutdownNow();
+                logger.onApplicationEvent(new ContextClosedEvent(this.context));
+            }
+        }
+        // Verify that no log files were created in the properties file directory.
+        assertThat(this.bad.listFiles(), emptyArray());
+        // Verify that each test wrote a single log file to the system property directory.
+        File[] files = this.good.listFiles();
+        assertThat(files, arrayWithSize(numTests));
+        // Verify that all log files have the same byte size.
+        long size = files[0].length();
+        assertThat(size, greaterThan(0L));
+        for (int i = 1; i < numTests; i++) {
+            assertEquals(size, files[i].length());
+        }
+    }
+}


### PR DESCRIPTION
This pull request synchronizes the audit logger initialization to fix a race condition that could cause the audit log files to be written to the wrong directory. https://osgeo-org.atlassian.net/browse/GEOS-9296

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [X] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
