### PR TITLE
Mapfish Print - Error when loading fonts, with configDir in windows machines

### DIFF
--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.1.4</version>
+      <version>2.1.5</version>
     </dependency>
       
     <dependency>


### PR DESCRIPTION
Merge from: https://github.com/geoserver/geoserver/pull/3673

Upgrade of mapfish-print lib version to support font configuration on windows machines.

Reference:
mapfish/mapfish-print#998

Already release on central maven:
http://central.maven.org/maven2/org/mapfish/print/print-lib/2.1.5/
