### PR TITLE
[GEOS-9299] update docguide to reflect new processes and fix typos

### DIFF
--- a/doc/en/docguide/source/background.rst
+++ b/doc/en/docguide/source/background.rst
@@ -8,7 +8,11 @@ Welcome!  From all of the GeoServer users and developers, we are happy to see th
 Writing Documentation
 ---------------------
 
-GeoServer documentation written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_, a lightweight markup syntax, and built into HTML and PDF content using `Sphinx <http://sphinx.pocoo.org>`_, a documentation framework written by the developers of Python.  In this way, the documentation could be merged with the source code of GeoServer itself, and exist in the `same repository <https://github.com/geoserver/geoserver>`_.  With this merge, version control follows naturally, so documentation can now be version specific.  Since the repository requires authentication to make changes, authors must be granted access before being able to directly contribute to the documentation.  While this does slightly raise the barrier to entry, the ability to control the quality of the documentation was seen as a greater benefit.
+GeoServer documentation written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_, a lightweight markup syntax, and built into HTML and PDF content using `Sphinx <http://sphinx.pocoo.org>`_, a documentation framework written by the developers of Python.  In this way, the documentation could be merged with the source code of GeoServer itself, and exist in the `same repository <https://github.com/geoserver/geoserver>`_.  With this merge, version control follows naturally, so documentation can now be version specific.  
+
+We handle changes to the documentation in the same way as we do changes to the code base, so you need to make a branch for your change and submit it as a "pull request" to the main repository, this is all explained in the :ref:`workflow` section later.
+
+Since the repository requires authentication to make changes, authors who plan large changes can be granted access so they are able to directly contribute to the documentation.  While this does slightly raise the barrier to entry, the ability to control the quality of the documentation was seen as a greater benefit.
 
 .. note:: Prior to the use of Sphinx GeoServer documentation was created using a wiki as part of the GeoServer home page. While this allowed anyone to sign up and contribute documentation we ended up with problems of vandalism and lacked features we now enjoy (Version control, PDF export).
 

--- a/doc/en/docguide/source/contributing.rst
+++ b/doc/en/docguide/source/contributing.rst
@@ -3,7 +3,33 @@
 Contributing
 ============
 
-There are many ways to contribute to the GeoServer documentation.  The following are listed roughly in order of "most involved" to "least involved".
+There are many ways to contribute to the GeoServer documentation.  The following are listed roughly in order of "least involved" to "most involved".
+
+Post Snark on Twitter
+---------------------
+
+Because there is nothing we developers like more than a pointless argument about
+how bad our documentation is. It's even better if it is in public so our bosses
+can see how we are productively using our time. 
+
+**Hint**: don't do this, if you have a problem with the documentation then at
+least make a note of the issue so that someone might fix it for you.
+
+File an issue
+-------------
+
+If you don't want to write the documentation, and/or would like to suggest a page that isn't included, you can request it.  Use JIRA to file an issue.  Please include the name of the page, content, and the place where this new information should be included.  As with all issues, it is not guaranteed that someone will fulfill your request.
+
+.. _file_an_issue_with_patch:
+
+File an issue and include a documentation patch
+-----------------------------------------------
+
+GeoServer uses `JIRA <https://osgeo-org.atlassian.net/projects/GEOS>`_ for issue tracking.  New documentation is treated like part of the code, so those who want to submit content (patches etc) can use a pull request or file an issue with JIRA and attach the content to the issue.  If the content is deemed satisfactory, a contributor with commit rights will add the content to the documentation.
+
+For more information see `CONTRIBUTING.md <https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md>`_ in GitHub.
+
+GitHub supports direct reviewing and editing of documentation pages, any edit you make will be automatically forked and submitted to the project team as a pull request.
 
 .. _commit_rights:
 
@@ -17,20 +43,4 @@ To gain documentation commit rights, the process is similar to gaining commit ri
 To request commit rights, please send an email to the `GeoServer developers list <https://lists.sourceforge.net/lists/listinfo/geoserver-devel>`_.  Please note that this access may only be to the documentation, and not the source code.
 
 Once you have commit rights, please see the section on :ref:`workflow` for creating and editing the documentation.
-
-.. _file_an_issue_with_patch:
-
-File an issue and include a documentation patch
------------------------------------------------
-
-GeoServer uses `JIRA <https://osgeo-org.atlassian.net/projects/GEOS>`_ for issue tracking.  New documentation is treated like part of the code, so those who want to submit content (patches etc) can use a pull request or file an issue with JIRA and attach the content to the issue.  If the content is deemed satisfactory, a contributor with commit rights will add the content to the documentation.
-
-For more information see `CONTRIBUTING.md <https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md>`_ in GitHub.
-
-GitHub supports direct reviewing and editing of documentation pages, any edit you make will be automatically forked and submitted to the project team as a pull request.
-
-File an issue
--------------
-
-If you don't want to write the documentation, and/or would like to suggest a page that isn't included, you can request it.  Use JIRA to file an issue.  Please include the name of the page, content, and the place where this new information should be included.  As with all issues, it is not guaranteed that someone will fulfill your request.
 

--- a/doc/en/docguide/source/install.rst
+++ b/doc/en/docguide/source/install.rst
@@ -41,7 +41,7 @@ Ubuntu
 
 #. Install Sphinx using :command:`pip`::
   
-      pip install sphinx
+      pip install --user sphinx
   
 #. To test for a successful installation, navigate to your GeoServer source checkout, go into the :file:`doc/en` directory and run::
   
@@ -49,10 +49,6 @@ Ubuntu
   
    This should generate HTML pages in the :file:`doc/en/target/user/html` directory.
    
-#. If you want to generate PDF files this command should get you the necessary tools::
-  
-      sudo apt-get install texlive texlive-latex-extra
-
 Mac OS X
 --------
 

--- a/doc/en/docguide/source/installlatex.rst
+++ b/doc/en/docguide/source/installlatex.rst
@@ -15,9 +15,11 @@ Windows
 Ubuntu
 ------ 
 
-1. Install the following TeX Live packages::
+#. Install the following TeX Live packages::
 
-    sudo apt-get install texlive-base texlive-bibtex-extra texlive-binaries texlive-common texlive-doc-* texlive-extra-utils texlive-font-utils texlive-fonts-extra texlive-fonts-extra-doc texlive-fonts-recommended texlive-fonts-recommended-doc texlive-formats-extra texlive-full texlive-games texlive-generic-extra texlive-generic-recommended texlive-humanities texlive-humanities-doc texlive-lang-* texlive-latex-base texlive-latex-base-doc texlive-latex-extra texlive-latex-extra-doc texlive-latex-recommended texlive-latex-recommended-doc texlive-latex3 texlive-luatex texlive-math-extra texlive-metapost texlive-metapost-doc texlive-music texlive-omega texlive-pictures texlive-pictures-doc texlive-plain-extra texlive-pstricks texlive-pstricks-doc texlive-publishers texlive-publishers-doc texlive-science texlive-science-doc texlive-xetex
+      sudo apt-get install -y texlive-base texlive-latex-recommended \
+        texlive-science texlive-latex-extra texlive-extra-utils
+
 
 2. As an alternative to (1), you can install the standard `TeX Live <http://tug.org/texlive/acquire-netinstall.html>`_ distribution, then install `texliveonfly <http://www.ctan.org/tex-archive/support/texliveonfly>`_ to install any missing packages as they are needed.
 

--- a/doc/en/docguide/source/sphinx.rst
+++ b/doc/en/docguide/source/sphinx.rst
@@ -120,12 +120,14 @@ Sections
 
 Use sections to break up long pages and to help Sphinx generate tables of contents.
 
-The top of the page (i.e. the title) should have a double underline::
+The top of the page (i.e. the title) should have a double underline, using an
+equals sign (``=``)::
 
    Camel Spotting
    ==============
    
-Subsequent section headers should have a single underline::
+Subsection headers should have a single underline, using a dash character
+(``-``)::
 
    Camel Spotting
    ==============
@@ -139,7 +141,7 @@ Subsequent section headers should have a single underline::
    Recording its Serial Number
    ---------------------------
    
-Should these sections require subsections, use the back quote::
+Should these subsections require subsubsections, use the back quote (`````)::
 
    Intro to the Camel
    ------------------

--- a/doc/en/docguide/source/style.rst
+++ b/doc/en/docguide/source/style.rst
@@ -119,7 +119,7 @@ For example, Java and XML make no distinction between a single space and multipl
    <namespace:tagname attributename="attributevalue" attribute2="attributevalue"
       nextattribute="this is on another line"/>
 
-For shell scripts, new lines can be escaped with a backslash character (\). It is also recommended to use a simple {{$ }} prompt to save space. For example::
+For shell scripts, new lines can be escaped with a backslash character (\\). It is also recommended to use a simple ``$`` prompt to save space. For example::
 
    $ /org/jdk1.5.0*/bin/java \
       -cp /home/user/.m2/repository/org/geoserver/*/*.jar \

--- a/doc/en/docguide/source/tutorial.rst
+++ b/doc/en/docguide/source/tutorial.rst
@@ -8,14 +8,14 @@ A tutorial should have a clear goal and present step-by-step instructions to ach
 Example Tutorial
 ----------------
 
-This intoductory sentence should state the intent and goal of the tutorial. Keep it brief.
+This introductory sentence should state the intent and goal of the tutorial. Keep it brief.
 
-This next block should state any assumptions that you the writer are making. Present them in list form. Example: 
+This next block should state any assumptions that you the writer are making. Present them in list form, for example: 
 
-This tutorial assumes:
+  This tutorial assumes:
 
-* GeoServer is running on http://localhost:8080/geoserver
-* PostGIS is installed on the system
+  * GeoServer is running on http://localhost:8080/geoserver
+  * PostGIS is installed on the system
 
 Getting started
 ```````````````
@@ -25,19 +25,12 @@ State any introductory steps in this section. These might include:
 * Downloading data
 * Creating a database
 
-First section
-`````````````
-
-In a single sentence, state what will be acheived in this section.
-
-#. Step one
-#. Step two
-
-
-Second section
+Other sections
 ``````````````
 
-In a single sentence, state what will be acheived in this section.
+In a single sentence, state what will be achieved in this section. Then list
+the steps the user needs to take:
 
 #. Step one
 #. Step two
+

--- a/doc/en/docguide/source/workflow.rst
+++ b/doc/en/docguide/source/workflow.rst
@@ -13,12 +13,36 @@ GeoServer documentation aims to mirror the development process of the software i
 Check out source
 ----------------
 
+Software
+````````
+
+You must use the version control software `git` to retrieve files. 
+
+* https://windows.github.com
+* https://mac.github.com
+* http://git-scm.com/downloads/guis
+* Or use git on the command line
+
+
 Repository
 ``````````
 
 This documentation source code exists in the same repository as the GeoServer source code::
 
    https://github.com/geoserver/geoserver
+
+Follow these instructions to fork the GeoServer repository:
+
+* https://help.github.com/articles/fork-a-repo
+
+  Substituting ``geoserver/geoserver`` in place of ``octocat/Spoon-Knife``,
+  when you are finished ``git remote -v`` should show::
+
+   $  git remote -v
+   origin    https://github.com/YOUR_USERNAME/geoserver.git (fetch)
+   origin    https://github.com/YOUR_USERNAME/geoserver.git (push)
+   upstream  https://github.com/geoserver/geoserver.git (fetch)
+   upstream  https://github.com/geoserver/geoserver.git (push)
 
 Within this repository are the various branches and tags associated with releases, and the documentation is always inside a :file:`doc` path.  Inside this path, the repository contains directories corresponding to different translations.  The languages are referred to by a two letter code, with ``en`` (English) being the default.
 
@@ -47,19 +71,6 @@ Inside this directory, there are four directories::
    * - :file:`theme`
      - GeoServer Sphinx theme (common to all three projects)
 
-Software
-````````
-
-You must use a version control software to retrieve files. 
-
-* https://windows.github.com
-* https://mac.github.com
-* http://git-scm.com/downloads/guis
-* Or use git on the command line
-
-Follow these instructions to fork the GeoServer repository:
-
-* https://help.github.com/articles/fork-a-repo
 
 Make changes
 ------------
@@ -70,7 +81,7 @@ Documentation in Sphinx is written in `reStructuredText <http://docutils.sourcef
 Build and test locally
 ----------------------
 
-You should install Sphinx on your local system to build the documentation locally and view any changes made.  Sphinx builds the reStructuredText files into HTML pages and PDF files.
+You should install Sphinx on your local system (see :ref:`install_sphinx`) to build the documentation locally and view any changes made.  Sphinx builds the reStructuredText files into HTML pages and PDF files.
 
 HTML
 ````
@@ -92,15 +103,8 @@ PDF
 
 #. Run the following command::
 
-      make latex
-
-   The resulting LaTeX pages will be contained in :file:`doc/en/user/build/latex`.
-
-#. Change to the :file:`doc/en/user/build/latex` directory.
-
-#. Run the following command::
-
-      pdflatex [GeoServerProject].tex
+    
+      ant user-pdf
 
    This will create a PDF file called :file:`{GeoServerProject}.pdf` in the same directory
 
@@ -116,13 +120,30 @@ Commit changes
 
 .. warning:: If you have any errors or warnings in your project, please fix them before committing!
 
-The final step is to commit the changes to the repository.  If you are using Subversion, the command to use is::
+The final step is to commit the changes to a branch in *your* repository,
+using these commands:: 
 
+   git checkout -b doc-fix
    git add [path/file(s)]
    git commit -m "message describing your fix"
-   git push
+   git push origin doc-fix
    
-where :file:`{path/file(s)}` is the path and file(s) you wish to commit to the repository.
+You can use any name you like for the branch, often I use the issue number so I
+can tell my branches apart if I need to find them later.
+:file:`{path/file(s)}` is the path and file(s) you wish to commit to the repository. If you are unclear about which files you have changed you can use ``git status -sb`` to list the files that you have changed, this will give you a list of changed files, and indicate the ones that still need to be added to this commit::
+
+    $ git status -sb 
+    ## update
+     M docguide/source/background.rst
+     M docguide/source/contributing.rst
+     M docguide/source/install.rst
+     M docguide/source/installlatex.rst
+     M docguide/source/workflow.rst
+
+Here the ``M`` indicate these files are modified but not added. Once ``git add
+*.rst`` is run the indicator will change to ``A``, files that are not under
+git's control will show a ``?`` these are new files that you may need to add if
+you have created them for the documentation.
 
 When ready return to the GitHub website and submit a pull request:
 


### PR DESCRIPTION
This PR updates the docguide to reflect the changes to the process over the years, such as the retirement of  `make`, the easier ways to add latex to an ubuntu machine now. It also reverses the order of contribution paths to now run from easy to hard to avoid putting new users off.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)


Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
