### PR TITLE
Add responsive images to MapML html response as fallback

### DIFF
--- a/src/community/mapml/src/main/java/org/geoserver/mapml/tcrs/TiledCRS.java
+++ b/src/community/mapml/src/main/java/org/geoserver/mapml/tcrs/TiledCRS.java
@@ -103,6 +103,26 @@ public class TiledCRS {
                 new Bounds(pb.min.divideBy(TILESIZE).floor(), pb.max.divideBy(TILESIZE).floor());
         return tb;
     }
+    /**
+     * Transforms the point (in projected units) into a bounds centred on that point, in projected
+     * units, matching the size of the display bounds
+     *
+     * @param zoom the zoom at which the bounds will be calculated
+     * @param projectedCentre the projected coordinates of the centre of the new bounds
+     * @param displayBounds a rectangle with origin at 0,0 of the size of display in px
+     * @return
+     */
+    public Bounds getProjectedBoundsForDisplayBounds(
+            int zoom, Point projectedCentre, Bounds displayBounds) {
+        Point tcrsCentre = transform(projectedCentre, zoom);
+        Point tcrsMin =
+                tcrsCentre.subtract(
+                        new Point(displayBounds.getWidth() / 2, displayBounds.getHeight() / 2));
+        Point tcrsMax =
+                tcrsCentre.add(
+                        new Point(displayBounds.getWidth() / 2, displayBounds.getHeight() / 2));
+        return new Bounds(untransform(tcrsMin, zoom), untransform(tcrsMax, zoom));
+    }
 
     public int getMaxZoom() {
         return Collections.max(tileBounds.keySet());
@@ -136,6 +156,26 @@ public class TiledCRS {
         return zoom;
     }
 
+    /**
+     * Returns a zoom at which the projected bounds when rendered at the specified display width and
+     * height will fit, when centered on bounds' centre point.
+     *
+     * @param prjb - the (projected) bounds to find a zoom that fits for
+     * @param dsplyb - the pixel bounds which the projected bounds must fit within
+     * @return zoom
+     */
+    public int fitProjectedBoundsToDisplay(Bounds prjb, Bounds dsplyb) {
+        int zoom = 0;
+        for (int i = 0; i < this.getMaxZoom(); i++) {
+            zoom = i;
+            Bounds pxb = this.getPixelBounds(prjb, i);
+            if (!(dsplyb.getWidth() >= pxb.getWidth() && dsplyb.getHeight() >= pxb.getHeight())) {
+                zoom = i - 1;
+                break;
+            }
+        }
+        return zoom;
+    }
     /**
      * For testing purposes need to be able to set the pagesize.
      *


### PR DESCRIPTION
This change applies only to code in the MapML Community Moduel.

This commit adds a `<picture>` element to the html response for a MapML preview page, which provides a basic map in the case where script fails to load or run.  The objective of this is to demonstrate / prove the use of the <map> element as a reasonable extension point of HTML for maps. Interactivity is not provided, but likely could be, in the form of `<area>` elements with (pixel-based) coordinates in the map coordinate reference system as appropriate to the requested map.

@cmhodgson please review

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.



For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
