### PR TITLE
[GEOS-8504] Wrong URL scheme in layer preview

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
@@ -142,7 +142,10 @@ public abstract class AbstractOpenLayersMapOutputFormat implements GetMapOutputF
                 queryString = baseUrl.substring(idx); // include question mark
                 baseUrl = baseUrl.substring(0, idx); // leave out question mark
             }
-            map.put("baseUrl", canonicUrl(baseUrl));
+            final String canonicBaseUrl = canonicUrl(baseUrl);
+            map.put("baseUrl", canonicBaseUrl);
+            // register a protocol-relative base URL for fetching HTML static resources
+            map.put("relBaseUrl", makeProtocolRelativeURL(canonicBaseUrl));
 
             // TODO: replace service path with call to buildURL since it does this
             // same dance
@@ -176,6 +179,12 @@ public abstract class AbstractOpenLayersMapOutputFormat implements GetMapOutputF
         } catch (TemplateException e) {
             throw new ServiceException(e);
         }
+    }
+
+    private String makeProtocolRelativeURL(String url) {
+        if (!url.startsWith("http")) return url;
+        int startFrom = url.startsWith("https://") ? 6 : 5;
+        return url.substring(startFrom);
     }
 
     /**

--- a/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers2MapTemplate.ftl
+++ b/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers2MapTemplate.ftl
@@ -4,7 +4,7 @@
     <head>
         <title>OpenLayers map preview</title>
         <!-- Import OL CSS, auto import does not work with our minified OL.js build -->
-        <link rel="stylesheet" type="text/css" href="${baseUrl}/openlayers/theme/default/style.css"/>
+        <link rel="stylesheet" type="text/css" href="${relBaseUrl}/openlayers/theme/default/style.css"/>
         <!-- Basic CSS definitions -->
         <style type="text/css">
             /* General settings */
@@ -103,7 +103,7 @@
             }
         </style>
         <!-- Import OpenLayers, reduced, wms read only version -->
-        <script src="${baseUrl}/openlayers/OpenLayers.js" type="text/javascript">
+        <script src="${relBaseUrl}/openlayers/OpenLayers.js" type="text/javascript">
         </script>
         <script defer="defer" type="text/javascript">
             var map;

--- a/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
+++ b/src/wms/src/main/resources/org/geoserver/wms/map/OpenLayers3MapTemplate.ftl
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <link rel="stylesheet" href="${baseUrl}/openlayers3/ol.css" type="text/css">
+    <link rel="stylesheet" href="${relBaseUrl}/openlayers3/ol.css" type="text/css">
     <style>
         .ol-zoom {
           top: 52px;
@@ -127,7 +127,7 @@
             padding: .2em .2em;
         }
     </style>
-    <script src="${baseUrl}/openlayers3/ol.js" type="text/javascript"></script>
+    <script src="${relBaseUrl}/openlayers3/ol.js" type="text/javascript"></script>
     <title>OpenLayers map preview</title>
   </head>
   <body>

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
@@ -293,7 +293,7 @@ public class GetMapIntegrationTest extends WMSTestSupport {
                                     + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=100,78,104,80&WIDTH=300&HEIGHT=150");
 
             assertXpathEvaluatesTo(
-                    "http://www.geoserver.org:1234/gs/openlayers/OpenLayers.js",
+                    "//www.geoserver.org:1234/gs/openlayers/OpenLayers.js",
                     "//xhtml:script[contains(@src, 'OpenLayers.js')]/@src",
                     dom);
         } finally {

--- a/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapTemplateTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapTemplateTest.java
@@ -55,6 +55,7 @@ public class OpenLayersMapTemplateTest extends WMSTestSupport {
         map.put("request", mapContent.getRequest());
         map.put("maxResolution", Double.valueOf(0.0005)); // just a random number
         map.put("baseUrl", "http://localhost:8080/geoserver/wms");
+        map.put("relBaseUrl", "//localhost:8080/geoserver/wms");
         map.put("parameters", new ArrayList());
         map.put("layerName", "layer");
         map.put("units", "degrees");


### PR DESCRIPTION
This PR adds a fix for a mixed protocol issue on Openlayers WMS map preview static resources (js and css).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
