### PR TITLE
Release guide update

### DIFF
--- a/doc/en/developer/source/release-guide/index.rst
+++ b/doc/en/developer/source/release-guide/index.rst
@@ -114,8 +114,6 @@ When creating the first release candidate of a series, there are some extra step
     * ``doc/en/developer/source/conf.py``
     * ``doc/en/docguide/source/conf.py``
     * ``doc/en/user/source/conf.py``
-    * ``doc/es/user/source/conf.py``
-    * ``doc/fr/user/source/conf.py``
 
 * Commit the changes and push to the master branch on GitHub::
 


### PR DESCRIPTION
Very minor updates to the release guide, based on differences encountered during the 2.16-RC release - just removing the en and fr doc dirs from the guide, as those dors were removed recently.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
