### PR TITLE
GEOS-9326 Hz-cluster: fix service events

### DIFF
--- a/src/community/hz-cluster/src/main/java/org/geoserver/cluster/ConfigChangeEvent.java
+++ b/src/community/hz-cluster/src/main/java/org/geoserver/cluster/ConfigChangeEvent.java
@@ -10,6 +10,7 @@ import static com.google.common.base.Objects.equal;
 import com.google.common.base.Objects;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.geoserver.catalog.AttributionInfo;
@@ -117,6 +118,12 @@ public class ConfigChangeEvent extends Event {
 
     /** type of config change */
     Type type;
+
+    List<String> propertyNames;
+
+    List<Object> oldValues;
+
+    List<Object> newValues;
 
     private String nativeName;
 
@@ -234,5 +241,29 @@ public class ConfigChangeEvent extends Event {
     @Nullable
     public String getNativeName() {
         return nativeName;
+    }
+
+    public List<String> getPropertyNames() {
+        return propertyNames;
+    }
+
+    public void setPropertyNames(List<String> propertyNames) {
+        this.propertyNames = propertyNames;
+    }
+
+    public List<Object> getOldValues() {
+        return oldValues;
+    }
+
+    public void setOldValues(List<Object> oldValues) {
+        this.oldValues = oldValues;
+    }
+
+    public List<Object> getNewValues() {
+        return newValues;
+    }
+
+    public void setNewValues(List<Object> newValues) {
+        this.newValues = newValues;
     }
 }

--- a/src/community/hz-cluster/src/main/java/org/geoserver/cluster/hazelcast/HzSynchronizer.java
+++ b/src/community/hz-cluster/src/main/java/org/geoserver/cluster/hazelcast/HzSynchronizer.java
@@ -179,6 +179,19 @@ public abstract class HzSynchronizer extends GeoServerSynchronizer
         return ev;
     }
 
+    ConfigChangeEvent newChangeEvent(
+            Info subj,
+            Type type,
+            List<String> propNames,
+            List<Object> oldValues,
+            List<Object> newValues) {
+        ConfigChangeEvent event = newChangeEvent(subj, type);
+        event.setPropertyNames(propNames);
+        event.setOldValues(oldValues);
+        event.setNewValues(newValues);
+        return event;
+    }
+
     @Override
     public void handleAddEvent(CatalogAddEvent event) throws CatalogException {
         dispatch(newChangeEvent(event, Type.ADD));
@@ -209,7 +222,7 @@ public abstract class HzSynchronizer extends GeoServerSynchronizer
         if (propertyNames.size() == 1 && propertyNames.contains("updateSequence")) {
             return;
         }
-        dispatch(newChangeEvent(global, Type.MODIFY));
+        dispatch(newChangeEvent(global, Type.MODIFY, propertyNames, oldValues, newValues));
     }
 
     @Override
@@ -223,7 +236,7 @@ public abstract class HzSynchronizer extends GeoServerSynchronizer
             List<String> propertyNames,
             List<Object> oldValues,
             List<Object> newValues) {
-        dispatch(newChangeEvent(service, Type.MODIFY));
+        dispatch(newChangeEvent(service, Type.MODIFY, propertyNames, oldValues, newValues));
     }
 
     @Override
@@ -251,12 +264,12 @@ public abstract class HzSynchronizer extends GeoServerSynchronizer
         if (propertyNames.size() == 1 && propertyNames.contains("updateSequence")) {
             return;
         }
-        dispatch(newChangeEvent(settings, Type.MODIFY));
+        dispatch(newChangeEvent(settings, Type.MODIFY, propertyNames, oldValues, newValues));
     }
 
     @Override
     public void handleSettingsPostModified(SettingsInfo settings) {
-        dispatch(newChangeEvent(settings, Type.MODIFY));
+        dispatch(newChangeEvent(settings, Type.POST_MODIFY));
     }
 
     @Override

--- a/src/community/hz-cluster/src/test/java/org/geoserver/cluster/hazelcast/HzSynchronizerRecvTest.java
+++ b/src/community/hz-cluster/src/test/java/org/geoserver/cluster/hazelcast/HzSynchronizerRecvTest.java
@@ -183,7 +183,8 @@ public abstract class HzSynchronizerRecvTest extends HzSynchronizerTest {
             sync = getSynchronizer();
             sync.initialize(configWatcher);
             ConfigChangeEvent evt =
-                    new ConfigChangeEvent(globalId, null, GeoServerInfoImpl.class, Type.MODIFY);
+                    new ConfigChangeEvent(
+                            globalId, null, GeoServerInfoImpl.class, Type.POST_MODIFY);
 
             // Mock a message coming in from the cluster
 
@@ -221,7 +222,8 @@ public abstract class HzSynchronizerRecvTest extends HzSynchronizerTest {
             sync = getSynchronizer();
             sync.initialize(configWatcher);
             ConfigChangeEvent evtGs =
-                    new ConfigChangeEvent(globalId, null, GeoServerInfoImpl.class, Type.MODIFY);
+                    new ConfigChangeEvent(
+                            globalId, null, GeoServerInfoImpl.class, Type.POST_MODIFY);
             ConfigChangeEvent evtLayer =
                     new ConfigChangeEvent(layerId, layerName, LayerInfoImpl.class, Type.MODIFY);
 
@@ -264,7 +266,8 @@ public abstract class HzSynchronizerRecvTest extends HzSynchronizerTest {
             sync = getSynchronizer();
             sync.initialize(configWatcher);
             ConfigChangeEvent evtGs =
-                    new ConfigChangeEvent(globalId, null, GeoServerInfoImpl.class, Type.MODIFY);
+                    new ConfigChangeEvent(
+                            globalId, null, GeoServerInfoImpl.class, Type.POST_MODIFY);
 
             // Mock a message coming in from the cluster
 
@@ -296,7 +299,8 @@ public abstract class HzSynchronizerRecvTest extends HzSynchronizerTest {
             sync = getSynchronizer();
             sync.initialize(configWatcher);
             ConfigChangeEvent evtGs =
-                    new ConfigChangeEvent(globalId, null, GeoServerInfoImpl.class, Type.MODIFY);
+                    new ConfigChangeEvent(
+                            globalId, null, GeoServerInfoImpl.class, Type.POST_MODIFY);
 
             // Mock a message coming in from the cluster
 
@@ -450,7 +454,8 @@ public abstract class HzSynchronizerRecvTest extends HzSynchronizerTest {
             sync = getSynchronizer();
             sync.initialize(configWatcher);
             ConfigChangeEvent evt =
-                    new ConfigChangeEvent(settingsId, null, SettingsInfoImpl.class, Type.MODIFY);
+                    new ConfigChangeEvent(
+                            settingsId, null, SettingsInfoImpl.class, Type.POST_MODIFY);
             evt.setWorkspaceId(workspaceId);
 
             // Mock a message coming in from the cluster
@@ -484,7 +489,8 @@ public abstract class HzSynchronizerRecvTest extends HzSynchronizerTest {
             sync = getSynchronizer();
             sync.initialize(configWatcher);
             ConfigChangeEvent evt =
-                    new ConfigChangeEvent(settingsId, null, LoggingInfoImpl.class, Type.MODIFY);
+                    new ConfigChangeEvent(
+                            settingsId, null, LoggingInfoImpl.class, Type.POST_MODIFY);
 
             // Mock a message coming in from the cluster
 
@@ -518,7 +524,7 @@ public abstract class HzSynchronizerRecvTest extends HzSynchronizerTest {
             sync.initialize(configWatcher);
 
             ConfigChangeEvent evt =
-                    new ConfigChangeEvent(serviceId, null, WMSInfoImpl.class, Type.MODIFY);
+                    new ConfigChangeEvent(serviceId, null, WMSInfoImpl.class, Type.POST_MODIFY);
 
             // Mock a message coming in from the cluster
 


### PR DESCRIPTION
Hz-cluster: unlike for catalog items, for services only post-modify events are sent, not other events such as modify, add, delete
As a consequence the service config web pages are not cluster-safe