### PR TITLE
Tiles API returns error if png and png8 are both configured, due to duplicated format key

### DIFF
--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TiledCollectionDocument.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TiledCollectionDocument.java
@@ -121,7 +121,7 @@ public class TiledCollectionDocument extends AbstractDocument {
                 addLinkForFormat(
                         this.id,
                         baseURL,
-                        dataFormat.getMimeType(),
+                        dataFormat.getFormat(),
                         "/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}",
                         "tiles");
             }
@@ -132,7 +132,7 @@ public class TiledCollectionDocument extends AbstractDocument {
                 addLinkForFormat(
                         this.id,
                         baseURL,
-                        imgeFormat.getMimeType(),
+                        imgeFormat.getFormat(),
                         "/maps/{styleId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}",
                         "tiles");
             }
@@ -185,7 +185,7 @@ public class TiledCollectionDocument extends AbstractDocument {
                         "ogc/tiles/collections/" + ResponseUtils.urlEncode(layerName) + path,
                         Collections.singletonMap("f", format),
                         URLMangler.URLType.SERVICE);
-        addLink(new Link(apiUrl, rel, format, layerName + " tiles as " + format.toString()));
+        addLink(new Link(apiUrl, rel, format, layerName + " tiles as " + format));
     }
 
     CollectionExtents getExtentFromGridsets(TileLayer tileLayer)

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TilesService.java
@@ -359,7 +359,7 @@ public class TilesService {
                         .filter(mt -> renderedTile ? !mt.isVector() : mt.isVector())
                         .collect(
                                 Collectors.toMap(
-                                        mt -> MediaType.parseMediaType(mt.toString()), mt -> mt));
+                                        mt -> MediaType.parseMediaType(mt.getFormat()), mt -> mt));
         // process the requested types in order, return the first compatible layer type
         for (MediaType requestedType : requestedTypes) {
             for (Map.Entry<MediaType, MimeType> layerType : layerTypes.entrySet()) {

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/GetTileTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/GetTileTest.java
@@ -151,6 +151,34 @@ public class GetTileTest extends TilesTestSupport {
         assertEquals(MapBoxTileBuilderFactory.MIME_TYPE, sr.getContentType());
 
         // check the headers
+        checkRoadGwcHeaders(layerId, sr);
+
+        // check it can actually be read as a vector tile
+        VectorTileDecoder.FeatureIterable features =
+                new VectorTileDecoder().decode(sr.getContentAsByteArray());
+        // one road is before greenwich, not included in this tile
+        assertEquals(4, features.asList().size());
+    }
+
+    @Test
+    public void testPng8Tile() throws Exception {
+        String layerId = getLayerId(MockData.ROAD_SEGMENTS);
+        MockHttpServletResponse sr =
+                getAsServletResponse(
+                        "ogc/tiles/collections/"
+                                + layerId
+                                + "/maps/RoadSegments/tiles/EPSG:900913/EPSG:900913:10/511/512?f=image/png8");
+        assertEquals(200, sr.getStatus());
+        assertEquals("image/png", sr.getContentType());
+        checkRoadGwcHeaders(layerId, sr);
+
+        // check it can actually be read as a PNG
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(sr.getContentAsByteArray()));
+        assertNotBlank("testPng8Tile", image, null);
+    }
+
+    public void checkRoadGwcHeaders(String layerId, MockHttpServletResponse sr) {
+        // check the headers
         assertEquals("EPSG:900913", sr.getHeader("geowebcache-gridset"));
         assertEquals("EPSG:900913", sr.getHeader("geowebcache-crs"));
         // gwc has y axis inverted, mind
@@ -162,11 +190,5 @@ public class GetTileTest extends TilesTestSupport {
         assertEquals("no-cache", sr.getHeader("Cache-Control"));
         assertNotNull(sr.getHeader("ETag"));
         assertNotNull(sr.getHeader("Last-Modified"));
-
-        // check it can actually be read as a vector tile
-        VectorTileDecoder.FeatureIterable features =
-                new VectorTileDecoder().decode(sr.getContentAsByteArray());
-        // one road is before greenwich, not included in this tile
-        assertEquals(4, features.asList().size());
     }
 }

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/TilesTestSupport.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/TilesTestSupport.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.api.tiles;
 
+import java.util.Set;
 import org.geoserver.api.OGCApiTestSupport;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
@@ -16,6 +17,7 @@ import org.geoserver.data.test.SystemTestData;
 import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geowebcache.mime.ApplicationMime;
+import org.geowebcache.mime.ImageMime;
 
 public class TilesTestSupport extends OGCApiTestSupport {
 
@@ -34,7 +36,10 @@ public class TilesTestSupport extends OGCApiTestSupport {
         // add vector tiles as a format
         String roadId = getLayerId(MockData.ROAD_SEGMENTS);
         GeoServerTileLayer roadTiles = (GeoServerTileLayer) getGWC().getTileLayerByName(roadId);
-        roadTiles.getInfo().getMimeFormats().add(ApplicationMime.mapboxVector.getMimeType());
+        Set<String> formats = roadTiles.getInfo().getMimeFormats();
+        formats.add(ApplicationMime.mapboxVector.getMimeType());
+        // also add png8
+        formats.add(ImageMime.png8.getFormat());
         getGWC().save(roadTiles);
 
         // reduce it to its actual bounding box to see grid subsets

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
@@ -496,37 +496,8 @@ public abstract class AbstractAppSchemaTestSupport extends GeoServerSystemTestSu
      * @param bgColor the background color for which differing pixels are looked for
      */
     protected void assertNotBlank(String testName, BufferedImage image, Color bgColor) {
-        int pixelsDiffer = countNonBlankPixels(testName, image, bgColor);
+        int pixelsDiffer = super.countNonBlankPixels(testName, image, bgColor);
         assertTrue(testName + " image is completely blank", 0 < pixelsDiffer);
-    }
-
-    /**
-     * For WMS tests.
-     *
-     * <p>Counts the number of non black pixels
-     *
-     * @param testName
-     * @param image
-     * @param bgColor
-     */
-    protected int countNonBlankPixels(String testName, BufferedImage image, Color bgColor) {
-        int pixelsDiffer = 0;
-
-        for (int y = 0; y < image.getHeight(); y++) {
-            for (int x = 0; x < image.getWidth(); x++) {
-                if (image.getRGB(x, y) != bgColor.getRGB()) {
-                    ++pixelsDiffer;
-                }
-            }
-        }
-
-        LOGGER.fine(
-                testName
-                        + ": pixel count="
-                        + (image.getWidth() * image.getHeight())
-                        + " non bg pixels: "
-                        + pixelsDiffer);
-        return pixelsDiffer;
     }
 
     /**

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.awt.*;
@@ -1908,6 +1909,66 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
         di.setNearestMatchEnabled(nearestMatch);
         di.setAcceptableInterval(acceptableInterval);
         getCatalog().save(info);
+    }
+
+    /**
+     * Asserts that the image is not blank, in the sense that there must be pixels different from
+     * the passed background color.
+     *
+     * @param testName the name of the test to throw meaningfull messages if something goes wrong
+     * @param image the imgage to check it is not "blank"
+     * @param bgColor the background color for which differing pixels are looked for
+     */
+    protected void assertNotBlank(String testName, BufferedImage image, Color bgColor) {
+        int pixelsDiffer = countNonBlankPixels(testName, image, bgColor);
+        assertTrue(testName + " image is comlpetely blank", 0 < pixelsDiffer);
+    }
+
+    /**
+     * Asserts that the image is blank, in the sense that all pixels will be equal to the background
+     * color
+     *
+     * @param testName the name of the test to throw meaningful messages if something goes wrong
+     * @param image the image to check it is not "blank"
+     * @param bgColor the background color for which differing pixels are looked for
+     */
+    protected void assertBlank(String testName, BufferedImage image, Color bgColor) {
+        int pixelsDiffer = countNonBlankPixels(testName, image, bgColor);
+        assertEquals(testName + " image is completely blank", 0, pixelsDiffer);
+    }
+
+    /**
+     * Counts the number of non black pixels
+     *
+     * @param testName
+     * @param image
+     * @param bgColor
+     */
+    protected int countNonBlankPixels(String testName, BufferedImage image, Color bgColor) {
+        int pixelsDiffer = 0;
+
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int rgb = image.getRGB(x, y);
+                if (bgColor == null || bgColor.getAlpha() == 0) {
+                    if (((rgb >> 24) & 0xff) != 0) {
+                        ++pixelsDiffer;
+                    }
+                } else {
+                    if (rgb != bgColor.getRGB()) {
+                        ++pixelsDiffer;
+                    }
+                }
+            }
+        }
+
+        LOGGER.fine(
+                testName
+                        + ": pixel count="
+                        + (image.getWidth() * image.getHeight())
+                        + " non bg pixels: "
+                        + pixelsDiffer);
+        return pixelsDiffer;
     }
 
     //

--- a/src/wms/src/test/java/org/geoserver/wms/WMSTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSTestSupport.java
@@ -287,59 +287,6 @@ public abstract class WMSTestSupport extends GeoServerSystemTestSupport {
     }
 
     /**
-     * Asserts that the image is not blank, in the sense that there must be pixels different from
-     * the passed background color.
-     *
-     * @param testName the name of the test to throw meaningfull messages if something goes wrong
-     * @param image the imgage to check it is not "blank"
-     * @param bgColor the background color for which differing pixels are looked for
-     */
-    protected void assertNotBlank(String testName, BufferedImage image, Color bgColor) {
-        int pixelsDiffer = countNonBlankPixels(testName, image, bgColor);
-        assertTrue(testName + " image is comlpetely blank", 0 < pixelsDiffer);
-    }
-
-    /**
-     * Asserts that the image is blank, in the sense that all pixels will be equal to the background
-     * color
-     *
-     * @param testName the name of the test to throw meaningful messages if something goes wrong
-     * @param image the image to check it is not "blank"
-     * @param bgColor the background color for which differing pixels are looked for
-     */
-    protected void assertBlank(String testName, BufferedImage image, Color bgColor) {
-        int pixelsDiffer = countNonBlankPixels(testName, image, bgColor);
-        assertEquals(testName + " image is completely blank", 0, pixelsDiffer);
-    }
-
-    /**
-     * Counts the number of non black pixels
-     *
-     * @param testName
-     * @param image
-     * @param bgColor
-     */
-    protected int countNonBlankPixels(String testName, BufferedImage image, Color bgColor) {
-        int pixelsDiffer = 0;
-
-        for (int y = 0; y < image.getHeight(); y++) {
-            for (int x = 0; x < image.getWidth(); x++) {
-                if (image.getRGB(x, y) != bgColor.getRGB()) {
-                    ++pixelsDiffer;
-                }
-            }
-        }
-
-        LOGGER.fine(
-                testName
-                        + ": pixel count="
-                        + (image.getWidth() * image.getHeight())
-                        + " non bg pixels: "
-                        + pixelsDiffer);
-        return pixelsDiffer;
-    }
-
-    /**
      * Utility method to run the transformation on tr with the provided request and returns the
      * result as a DOM.
      *


### PR DESCRIPTION
Simple core test refactor (pulling up a method to be shared, via automated refactoring) and changes in the OGC API community module. Just running though PR to get the QA validation.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
