### PR TITLE
json and topojson tiles are returned a odd binary string blobs instead of json due to jackson converter catching all

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/api/ByteArrayMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/api/ByteArrayMessageConverter.java
@@ -1,0 +1,64 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.api;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import org.geoserver.platform.ExtensionPriority;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractGenericHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+/** Because binary means binary (aka dump the damn thing as is) * */
+@Component
+public class ByteArrayMessageConverter extends AbstractGenericHttpMessageConverter<byte[]>
+        implements ExtensionPriority {
+
+    public static final String OPEN_API_VALUE = "application/openapi+json;version=3.0";
+    public static final MediaType OPEN_API = MediaType.parseMediaType(OPEN_API_VALUE);
+
+    public ByteArrayMessageConverter() {
+        super(MediaType.ALL);
+    }
+
+    @Override
+    protected void writeInternal(byte[] bytes, Type type, HttpOutputMessage outputMessage)
+            throws IOException, HttpMessageNotWritableException {
+        outputMessage.getBody().write(bytes);
+    }
+
+    @Override
+    public boolean canRead(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return byte[].class.equals(clazz);
+    }
+
+    @Override
+    protected byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage inputMessage)
+            throws IOException, HttpMessageNotReadableException {
+        throw new UnsupportedOperationException("Reading is not supported");
+    }
+
+    @Override
+    public byte[] read(Type type, Class<?> contextClass, HttpInputMessage inputMessage)
+            throws IOException, HttpMessageNotReadableException {
+        throw new UnsupportedOperationException("Reading is not supported");
+    }
+
+    @Override
+    public int getPriority() {
+        // dodge other converters that are based on string conversion
+        return ExtensionPriority.HIGHEST;
+    }
+}

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TilesService.java
@@ -363,7 +363,7 @@ public class TilesService {
         // process the requested types in order, return the first compatible layer type
         for (MediaType requestedType : requestedTypes) {
             for (Map.Entry<MediaType, MimeType> layerType : layerTypes.entrySet()) {
-                if (requestedType.isCompatibleWith(layerType.getKey())) {
+                if (requestedType.equals(layerType.getKey())) {
                     // requested types can be generic, layer types are specific
                     return layerType.getValue();
                 }

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/TilesTestSupport.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/TilesTestSupport.java
@@ -37,7 +37,9 @@ public class TilesTestSupport extends OGCApiTestSupport {
         String roadId = getLayerId(MockData.ROAD_SEGMENTS);
         GeoServerTileLayer roadTiles = (GeoServerTileLayer) getGWC().getTileLayerByName(roadId);
         Set<String> formats = roadTiles.getInfo().getMimeFormats();
-        formats.add(ApplicationMime.mapboxVector.getMimeType());
+        formats.add(ApplicationMime.mapboxVector.getFormat());
+        formats.add(ApplicationMime.topojson.getFormat());
+        formats.add(ApplicationMime.geojson.getFormat());
         // also add png8
         formats.add(ImageMime.png8.getFormat());
         getGWC().save(roadTiles);


### PR DESCRIPTION
Again just using the PR facilities for QA here

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
