### PR TITLE
[Backport 2.15.x][GEOS-9321] WFS GeoJSONBuilder limits max nested level to 20

### DIFF
--- a/doc/en/user/source/services/wfs/outputformats.rst
+++ b/doc/en/user/source/services/wfs/outputformats.rst
@@ -129,3 +129,7 @@ JSON output ``format_options``:
    If id_policy is not specified the geotools default feature id generation is used.
 
 * ``format_options=callback:<parseResponse>`` applies only to the JSONP output format. See :ref:`wms_vendor_parameters` to change the callback name. Note that this format is disabled by default (See :ref:`wms_global_variables`).
+
+JSON output ``system properties``:
+
+* ``json.maxDepth=<max_value>`` is used to determine the max number of allowed JSON nested objects on encoding phase.  By default the value is 100.

--- a/src/community/security/keycloak/pom.xml
+++ b/src/community/security/keycloak/pom.xml
@@ -48,7 +48,6 @@
 		<dependency>
 			<groupId>net.sf.json-lib</groupId>
 			<artifactId>json-lib</artifactId>
-			<classifier>jdk15</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>

--- a/src/community/security/oauth2-geonode/pom.xml
+++ b/src/community/security/oauth2-geonode/pom.xml
@@ -47,7 +47,6 @@
 		<dependency>
 			<groupId>net.sf.json-lib</groupId>
 			<artifactId>json-lib</artifactId>
-			<classifier>jdk15</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>

--- a/src/community/security/oauth2-github/pom.xml
+++ b/src/community/security/oauth2-github/pom.xml
@@ -47,7 +47,6 @@
 		<dependency>
 			<groupId>net.sf.json-lib</groupId>
 			<artifactId>json-lib</artifactId>
-			<classifier>jdk15</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>

--- a/src/community/security/oauth2-openid-connect/pom.xml
+++ b/src/community/security/oauth2-openid-connect/pom.xml
@@ -50,7 +50,6 @@
 		<dependency>
 			<groupId>net.sf.json-lib</groupId>
 			<artifactId>json-lib</artifactId>
-			<classifier>jdk15</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -44,7 +44,6 @@
   <dependency>
    <groupId>net.sf.json-lib</groupId>
    <artifactId>json-lib</artifactId>
-   <classifier>jdk15</classifier>
   </dependency>
   <dependency>
    <groupId>commons-beanutils</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1073,9 +1073,8 @@
    </dependency>
    <dependency> 
      <groupId>net.sf.json-lib</groupId> 
-     <artifactId>json-lib</artifactId> 
-     <classifier>jdk15</classifier>
-     <version>2.4</version>
+     <artifactId>json-lib</artifactId>
+     <version>2.4.2-geoserver</version>
    </dependency>
    <dependency>
      <groupId>org.codehaus.jackson</groupId>

--- a/src/wfs/pom.xml
+++ b/src/wfs/pom.xml
@@ -60,7 +60,6 @@
     <dependency>
       <groupId>net.sf.json-lib</groupId>
       <artifactId>json-lib</artifactId>
-      <classifier>jdk15</classifier>
     </dependency>
     <dependency>
       <groupId>xmlunit</groupId>

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
@@ -27,6 +27,7 @@ public class GeoJSONBuilderTest {
 
     @Before
     public void setUp() {
+        System.clearProperty("json.maxDepth");
         writer = new StringWriter();
         builder = new GeoJSONBuilder(writer);
         builder.setEncodeMeasures(true);
@@ -482,5 +483,36 @@ public class GeoJSONBuilderTest {
         assertEquals(
                 "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0,0,1],[1,1,0,2],[1,0,0,3],[0,0,0,1]]]]}",
                 writer.toString());
+    }
+
+    /** Checks max json nested level should allow up to 100 by default. */
+    @Test
+    public void testMaxNestedLevel() {
+        builder.object();
+        addLevels(builder, 0, 99);
+        builder.endObject();
+    }
+
+    /** Checks max json nested level should allow up to 120 via system property. */
+    @Test
+    public void testMaxNestedLevelSystemParameter() {
+        try {
+            System.setProperty("json.maxDepth", "120");
+            final StringWriter writer = new StringWriter();
+            final GeoJSONBuilder builder = new GeoJSONBuilder(writer);
+            builder.object();
+            addLevels(builder, 0, 119);
+            builder.endObject();
+        } finally {
+            System.clearProperty("json.maxDepth");
+        }
+    }
+
+    private void addLevels(final GeoJSONBuilder builder, int level, final int max) {
+        if (level >= max) return;
+        level++;
+        builder.key("inner").object();
+        addLevels(builder, level, max);
+        builder.endObject();
     }
 }


### PR DESCRIPTION
This PR upgrades json-lib version and adds testing or the max nested limit issue on WFS GeoJson encoding.

https://osgeo-org.atlassian.net/browse/GEOS-9321

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
