### PR TITLE
[Backport 2.15.x][GEOS-8982] GetCapabilities on a single layer fails if a style is duplicated

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -13,6 +13,7 @@ import static org.geoserver.ows.util.ResponseUtils.appendQueryString;
 import static org.geoserver.ows.util.ResponseUtils.buildSchemaURL;
 import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import static org.geoserver.ows.util.ResponseUtils.params;
+import static org.geoserver.wms.capabilities.CapabilityUtil.validateLegendInfo;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -1506,18 +1507,19 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
          * Writes layer LegendURL pointing to the user supplied icon URL, if any, or to the proper
          * GetLegendGraphic operation if an URL was not supplied.
          *
-         * <p>It is common practice to supply a URL to a WMS accesible legend graphic when it is
+         * <p>It is common practice to supply a URL to a WMS accessible legend graphic when it is
          * difficult to create a dynamic legend for a layer.
          *
          * @param layerName The name of the layer.
          * @param legend The user specified legend url. If null a default url pointing back to the
          *     GetLegendGraphic operation will be automatically created.
-         * @param style The styel for the layer.
-         * @param sampleStyle The styel to use for sample sizing.
+         * @param style The style for the layer.
+         * @param sampleStyle The style to use for sample sizing.
          */
         protected void handleLegendURL(
                 LayerInfo layer, LegendInfo legend, StyleInfo style, StyleInfo sampleStyle) {
-            if (legend != null) {
+            // if legend is valid, use it
+            if (validateLegendInfo(legend)) {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine("using user supplied legend URL");
                 }

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geotools.styling.FeatureTypeStyle;
@@ -185,5 +186,13 @@ public final class CapabilityUtil {
         Double scaleHint = Math.sqrt(Math.pow((scaleDenominator * sizeStandardRenderPixel), 2) * 2);
 
         return scaleHint;
+    }
+
+    /** Returns true if legend accomplish some rules to be a valid one. */
+    public static boolean validateLegendInfo(LegendInfo legend) {
+        return legend != null
+                && legend.getOnlineResource() != null
+                && legend.getHeight() > 0
+                && legend.getWidth() > 0;
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -12,6 +12,7 @@ import static org.geoserver.ows.util.ResponseUtils.appendQueryString;
 import static org.geoserver.ows.util.ResponseUtils.buildSchemaURL;
 import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import static org.geoserver.ows.util.ResponseUtils.params;
+import static org.geoserver.wms.capabilities.CapabilityUtil.validateLegendInfo;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -1488,7 +1489,8 @@ public class GetCapabilitiesTransformer extends TransformerBase {
          */
         protected void handleLegendURL(
                 LayerInfo layer, LegendInfo legend, StyleInfo style, StyleInfo sampleStyle) {
-            if (legend != null) {
+            // add CapabilityUtil.validateLegendInfo
+            if (validateLegendInfo(legend)) {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine("using user supplied legend URL");
                 }

--- a/src/wms/src/test/java/org/geoserver/wms/LegendNonValidCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/LegendNonValidCapabilitiesTest.java
@@ -1,0 +1,120 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.geoserver.catalog.LegendInfo;
+import org.geoserver.catalog.impl.LegendInfoImpl;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.data.test.SystemTestData.LayerProperty;
+import org.geoserver.platform.resource.Resource;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/** Test setup for GEOS-8982. Does a check on Style capabilities using a non valid LegendInfo. */
+public class LegendNonValidCapabilitiesTest extends WMSTestSupport {
+
+    private static final String CAPABILITIES_REQUEST_1_3_0 =
+            "wms?request=getCapabilities&version=1.3.0";
+    private static final String CAPABILITIES_REQUEST_1_1_1 =
+            "wms?request=getCapabilities&version=1.1.1";
+
+    private static final String LAYER_NAME = "watertemp";
+    private static final QName LAYER_QNAME =
+            new QName(MockData.DEFAULT_URI, LAYER_NAME, MockData.DEFAULT_PREFIX);
+    private static final String LAYER_FILE = "custwatertemp.zip";
+    private static final String STYLE_NAME = "temperature";
+    private static final String STYLE_FILE = "temperature.sld";
+    private static final String LEGEND_FORMAT = "image/png";
+
+    private static final int LEGEND_WIDTH = 22;
+    private static final int LEGEND_HEIGHT = 121;
+    private static final String BASE = "http://127.0.0.1:8080/geoserver";
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        // create the non-valid legendInfo to test
+        LegendInfo legend = new LegendInfoImpl();
+        legend.setWidth(0);
+        legend.setHeight(0);
+        legend.setFormat(LEGEND_FORMAT);
+        legend.setOnlineResource(null);
+
+        // add legend.png to styles directory
+        Resource resource = getResourceLoader().get("styles/legend.png");
+        getResourceLoader().copyFromClassPath("legend.png", resource.file(), getClass());
+
+        // add layer
+        testData.addStyle(null, STYLE_NAME, STYLE_FILE, getClass(), getCatalog(), legend);
+        Map<SystemTestData.LayerProperty, Object> propertyMap =
+                new HashMap<SystemTestData.LayerProperty, Object>();
+        propertyMap.put(LayerProperty.STYLE, STYLE_NAME);
+
+        testData.addRasterLayer(
+                LAYER_QNAME, LAYER_FILE, null, propertyMap, SystemTestData.class, getCatalog());
+
+        // For global set-up
+        GeoServerInfo global = getGeoServer().getGlobal();
+        global.getSettings().setProxyBaseUrl(BASE);
+        getGeoServer().save(global);
+
+        WMSInfo wms = getGeoServer().getService(WMSInfo.class);
+        wms.getSRS().add("EPSG:4326");
+        getGeoServer().save(wms);
+
+        Map<String, String> namespaces = new HashMap<String, String>();
+        namespaces.put("xlink", "http://www.w3.org/1999/xlink");
+        namespaces.put("", "http://www.opengis.net/wms");
+        namespaces.put("wms", "http://www.opengis.net/wms");
+        getTestData().registerNamespaces(namespaces);
+        XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(namespaces));
+    }
+
+    @Test
+    public void testCapabilities_1_3_0() throws Exception {
+        Document dom = dom(get(CAPABILITIES_REQUEST_1_3_0), false);
+
+        final String legendUrlPath =
+                "//wms:Layer[wms:Name='gs:" + LAYER_NAME + "']/wms:Style/wms:LegendURL";
+
+        // Ensure capabilities document reflects the specified legend info
+        assertXpathEvaluatesTo(String.valueOf(LEGEND_WIDTH), legendUrlPath + "/@width", dom);
+        assertXpathEvaluatesTo(String.valueOf(LEGEND_HEIGHT), legendUrlPath + "/@height", dom);
+        assertXpathEvaluatesTo(LEGEND_FORMAT, legendUrlPath + "/wms:Format", dom);
+        assertXpathEvaluatesTo(
+                BASE
+                        + "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fpng&width=20"
+                        + "&height=20&layer=gs%3Awatertemp",
+                legendUrlPath + "/wms:OnlineResource/@xlink:href",
+                dom);
+    }
+
+    @Test
+    public void testCapabilities_1_1_1() throws Exception {
+        Document dom = dom(get(CAPABILITIES_REQUEST_1_1_1), true);
+        final String legendUrlPath = "//Layer[Name='gs:" + LAYER_NAME + "']/Style/LegendURL";
+
+        // Ensure capabilities document reflects the specified legend info
+        assertXpathEvaluatesTo(String.valueOf(LEGEND_WIDTH), legendUrlPath + "/@width", dom);
+        assertXpathEvaluatesTo(String.valueOf(LEGEND_HEIGHT), legendUrlPath + "/@height", dom);
+        assertXpathEvaluatesTo(LEGEND_FORMAT, legendUrlPath + "/Format", dom);
+        assertXpathEvaluatesTo(
+                BASE
+                        + "/wms?request=GetLegendGraphic&format=image%2Fpng&width=20"
+                        + "&height=20&layer=gs%3Awatertemp",
+                legendUrlPath + "/OnlineResource/@xlink:href",
+                dom);
+    }
+}


### PR DESCRIPTION
This PR adds extra LegendInfo validation rules on WMS Capabilities_1_3_0_Translator class, fixing the bug described on:
https://osgeo-org.atlassian.net/browse/GEOS-8982

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
