### PR TITLE
[Backport 2.16.x][GEOS-9248] Allow setting Entity Expansion limit on WFS XML Readers.

### DIFF
--- a/doc/en/user/source/services/wfs/webadmin.rst
+++ b/doc/en/user/source/services/wfs/webadmin.rst
@@ -122,3 +122,16 @@ Option :guilabel:`Override MIME Type` allows the selection of the MIME type that
 .. figure:: img/services_WFS_mimetype.png
 
 The available MIME types are: ``application/gml+xml; version=3.2``, ``text/xml; subtype=gml/3.2`` and ``text/xml``. 
+
+Configure XML Entity Expansion limit on WFS XML readers
+-------------------------------------------------------
+
+By default WFS XML readers sets Entity Expansion limit to 100, but it can be configured via the ``org.geoserver.wfs.xml.entityExpansionLimit`` system property / web.xml init parameter / Environment variable.
+
+For example on command line we can adjust adding parameter:
+
+    -Dorg.geoserver.wfs.xml.entityExpansionLimit=50
+	
+Or in Tomcat properties file (``{TOMCAT_HOME}/conf/catalina.properties``) adding the line:
+
+    org.geoserver.wfs.xml.entityExpansionLimit=50

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
@@ -10,17 +10,20 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.ows.XmlRequestReader;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wfs.CatalogNamespaceSupport;
 import org.geoserver.wfs.WFSException;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.xml.gml3.AbstractGeometryTypeBinding;
 import org.geotools.gml2.FeatureTypeCache;
 import org.geotools.gml2.SrsSyntax;
+import org.geotools.util.Converters;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.OptionalComponentParameter;
 import org.geotools.xsd.Parser;
@@ -40,6 +43,9 @@ import org.xml.sax.InputSource;
  * @author Justin Deoliveira, OpenGeo
  */
 public class WFSXmlUtils {
+
+    public static final String ENTITY_EXPANSION_LIMIT =
+            "org.geoserver.wfs.xml.entityExpansionLimit";
 
     public static void initRequestParser(Parser parser, WFSInfo wfs, GeoServer geoServer, Map kvp) {
         // check the strict flag to determine if we should validate or not
@@ -156,6 +162,17 @@ public class WFSXmlUtils {
                 ((org.geotools.gml3.GMLConfiguration) dep).setSrsSyntax(srsSyntax);
             }
         }
+    }
+
+    /**
+     * Returns the Entity Expansion Limit configuration from system property
+     * "org.geoserver.wfs.xml.entityExpansionLimit". Returns 100 as default if no system property is
+     * configured.
+     */
+    public static Integer getEntityExpansionLimitConfiguration() {
+        return Optional.ofNullable(GeoServerExtensions.getProperty(ENTITY_EXPANSION_LIMIT))
+                .map(p -> Converters.convert(p, Integer.class))
+                .orElse(100);
     }
 
     static class DirectObjectParameter extends BasicComponentParameter {

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_0_0/WfsXmlReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_0_0/WfsXmlReader.java
@@ -16,6 +16,7 @@ import org.geoserver.util.EntityResolverProvider;
 import org.geoserver.wfs.CatalogNamespaceSupport;
 import org.geoserver.wfs.WFSException;
 import org.geoserver.wfs.xml.WFSURIHandler;
+import org.geoserver.wfs.xml.WFSXmlUtils;
 import org.geotools.util.Version;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
@@ -27,6 +28,7 @@ import org.geotools.xsd.Parser;
  *     <p>TODO: there is too much duplication with the 1.1.0 reader, factor it out.
  */
 public class WfsXmlReader extends XmlRequestReader {
+
     /** Xml Configuration */
     Configuration configuration;
     /** geoserver configuration */
@@ -66,6 +68,8 @@ public class WfsXmlReader extends XmlRequestReader {
         // set validation based on strict or not
         parser.setValidating(strict.booleanValue());
         WFSURIHandler.addToParser(geoServer, parser);
+        // set entity expansion limit
+        parser.setEntityExpansionLimit(WFSXmlUtils.getEntityExpansionLimitConfiguration());
 
         // parse
         Object parsed = parser.parse(reader);

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/WfsXmlReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/v1_1_0/WfsXmlReader.java
@@ -55,6 +55,8 @@ public class WfsXmlReader extends XmlRequestReader {
         Parser parser = new Parser(configuration);
         parser.setStrict(false);
         parser.setEntityResolver(entityResolverProvider.getEntityResolver());
+        // set entity expansion limit
+        parser.setEntityExpansionLimit(WFSXmlUtils.getEntityExpansionLimitConfiguration());
 
         WFSXmlUtils.initRequestParser(parser, wfs, geoServer, kvp);
         Object parsed = WFSXmlUtils.parseRequest(parser, reader, wfs);

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/v2_0/WfsXmlReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/v2_0/WfsXmlReader.java
@@ -43,7 +43,8 @@ public class WfsXmlReader extends XmlRequestReader {
 
         Parser parser = new Parser(config);
         parser.setEntityResolver(entityResolverProvider.getEntityResolver());
-
+        // set entity expansion limit
+        parser.setEntityExpansionLimit(WFSXmlUtils.getEntityExpansionLimitConfiguration());
         WFSInfo wfs = wfs();
 
         WFSXmlUtils.initRequestParser(parser, wfs, gs, kvp);

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/TransactionTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/TransactionTest.java
@@ -26,6 +26,7 @@ import org.geoserver.wfs.GMLInfo;
 import org.geoserver.wfs.StoredQuery;
 import org.geoserver.wfs.WFSException;
 import org.geoserver.wfs.WFSInfo;
+import org.geoserver.wfs.xml.WFSXmlUtils;
 import org.geotools.data.DataStore;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -38,6 +39,7 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class TransactionTest extends WFS20TestSupport {
@@ -1296,5 +1298,56 @@ public class TransactionTest extends WFS20TestSupport {
             gml.setOverrideGMLAttributes(true);
             getGeoServer().save(wfs);
         }
+    }
+
+    /** Tests XML entity expansion limit on parsing with system property configuration. */
+    @Test
+    public void testEntityExpansionLimitOnTransaction() throws Exception {
+        try {
+            System.getProperties().setProperty(WFSXmlUtils.ENTITY_EXPANSION_LIMIT, "1");
+            Document dom = postAsDOM("wfs", xmlEntityExpansionLimitBody());
+            NodeList serviceExceptionList = dom.getElementsByTagName("ows:ExceptionText");
+            assertEquals(1, serviceExceptionList.getLength());
+            Node serviceException = serviceExceptionList.item(0);
+            // the service exception should contain the JAXP00010001 error code, that means entity
+            // expansion limit is working.
+            assertTrue(serviceException.getTextContent().contains("JAXP00010001"));
+        } finally {
+            System.getProperties().remove(WFSXmlUtils.ENTITY_EXPANSION_LIMIT);
+        }
+    }
+
+    private String xmlEntityExpansionLimitBody() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<!DOCTYPE convert [ <!ENTITY lol \"lol\"><!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;\"> ]>"
+                + "<wfs:Transaction service='WFS' version='2.0.0' "
+                + " xmlns:wfs='"
+                + WFS.NAMESPACE
+                + "' xmlns:gml='"
+                + GML.NAMESPACE
+                + "' "
+                + " xmlns:sf='http://cite.opengeospatial.org/gmlsf'>"
+                + "<wfs:Insert handle='insert-1'>"
+                + " <sf:PrimitiveGeoFeatureId gml:id='PrimitiveGeoFeatureId.gmlsf0-f01'>"
+                + "  <gml:description>"
+                + "Fusce tellus ante, tempus nonummy, ornare sed, accumsan nec, leo."
+                + "Vivamus pulvinar molestie nisl."
+                + "</gml:description>"
+                + "<gml:name>Aliquam condimentum felis sit amet est.</gml:name>"
+                + "<gml:identifier codeSpace=\"fooBar\">PrimitiveGeoFeatureId.gmlsf0-f01</gml:identifier>"
+                // + "<gml:name
+                // codeSpace='http://cite.opengeospatial.org/gmlsf'>cite.gmlsf0-f01</gml:name>"
+                + "<sf:curveProperty>"
+                + "  <gml:LineString gml:id='cite.gmlsf0-g01' srsName='urn:x-fes:def:crs:EPSG:6.11.2:4326'>"
+                + "   <gml:posList>&lol1;</gml:posList>"
+                + " </gml:LineString>"
+                + "</sf:curveProperty>"
+                + "<sf:intProperty>1025</sf:intProperty>"
+                + "<sf:measurand>7.405E2</sf:measurand>"
+                + "<sf:dateTimeProperty>2006-06-23T12:43:12+01:00</sf:dateTimeProperty>"
+                + "<sf:decimalProperty>90.62</sf:decimalProperty>"
+                + "</sf:PrimitiveGeoFeatureId>"
+                + "</wfs:Insert>"
+                + "</wfs:Transaction>";
     }
 }


### PR DESCRIPTION
Currently WFS XML Readers (example: org.geoserver.wfs.xml.v1_0_0.WfsXmlReader) don't have a way to set an Entity expansion limit configuration. A good improvement could be having a configuration System Property that allows to achieve this task and setting a low default (100 as example?).

See Entity Expansion limit on documentation:
https://docs.oracle.com/javase/tutorial/jaxp/limits/using.html

This PR uses improved Geotools XML Parser API and adds a org.geoserver.wfs.xml.entityExpansionLimit System Property for configuring Entity Expansion Limit with 100 as default value.

Depends on Geotools PR:
geotools/geotools#2437

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9248

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
