### PR TITLE
[Backport 2.16.x][GEOS-8356] WMS GetFeatureInfo formats text/plain, GeoJSON don't handle time correctly

### DIFF
--- a/src/main/src/main/java/org/geoserver/data/util/TemporalUtils.java
+++ b/src/main/src/main/java/org/geoserver/data/util/TemporalUtils.java
@@ -1,0 +1,56 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.data.util;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import org.geotools.util.factory.Hints;
+import org.geotools.xml.impl.DatatypeConverterImpl;
+
+/**
+ * Date and Time related util functions.
+ *
+ * @author Fernando Mino - Geosolutions
+ */
+public final class TemporalUtils {
+
+    private TemporalUtils() {}
+
+    /**
+     * Returns a print ready string representation for a Date value, handling timezone
+     * configurations and date/datetime difference.
+     */
+    public static String printDate(Date date) {
+        if (date == null) return "null";
+        Calendar calendar = toCalendar(date);
+        // if it's only a date, no time involved
+        if (date instanceof java.sql.Date) {
+            return DatatypeConverterImpl.getInstance().printDate(calendar);
+        } else {
+            // timestamp handling
+            return DatatypeConverterImpl.getInstance().printDateTime(calendar);
+        }
+    }
+
+    private static Calendar toCalendar(Date date) {
+        Object hint = Hints.getSystemDefault(Hints.LOCAL_DATE_TIME_HANDLING);
+        Calendar calendar;
+        if (Boolean.TRUE.equals(hint)) {
+            calendar = Calendar.getInstance();
+        } else {
+            calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        }
+        calendar.clear();
+        calendar.setTimeInMillis(date.getTime());
+        return calendar;
+    }
+
+    /** Return true if DateTime format configuration is enabled. */
+    public static boolean isDateTimeFormatEnabled() {
+        Object hint = Hints.getSystemDefault(Hints.DATE_TIME_FORMAT_HANDLING);
+        return !Boolean.FALSE.equals(hint);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/data/test/TemporalData.properties
+++ b/src/main/src/test/java/org/geoserver/data/test/TemporalData.properties
@@ -1,0 +1,2 @@
+_=id:String,altitude:int,pointProperty:Point:srid=4326,dateTimeProperty:java.sql.Timestamp,dateProperty:java.sql.Date
+Points.0=t0000| 500| POINT(39.73245 2.00342)|2006-06-27 22:00:00|2006-12-12

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.sf.json.JSONException;
 import org.geoserver.config.GeoServer;
+import org.geoserver.data.util.TemporalUtils;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.platform.GeoServerExtensions;
@@ -460,6 +461,11 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat {
                                     jsonWriter.writeGeom((Geometry) value);
                                 }
                             }
+                        } else if (Date.class.isAssignableFrom(ad.getType().getBinding())
+                                && TemporalUtils.isDateTimeFormatEnabled()) {
+                            // Temporal types print handling
+                            jsonWriter.key(ad.getLocalName());
+                            jsonWriter.value(TemporalUtils.printDate((Date) value));
                         } else {
                             jsonWriter.key(ad.getLocalName());
                             jsonWriter.value(value);

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/TextFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/TextFeatureInfoOutputFormat.java
@@ -10,9 +10,11 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import net.opengis.wfs.FeatureCollectionType;
+import org.geoserver.data.util.TemporalUtils;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geoserver.wms.WMS;
@@ -102,8 +104,8 @@ public class TextFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
 
                             for (AttributeDescriptor descriptor : types) {
                                 final Name name = descriptor.getName();
-                                if (Geometry.class.isAssignableFrom(
-                                        descriptor.getType().getBinding())) {
+                                final Class<?> binding = descriptor.getType().getBinding();
+                                if (Geometry.class.isAssignableFrom(binding)) {
                                     // writer.println(types[j].getName() + " =
                                     // [GEOMETRY]");
 
@@ -130,6 +132,12 @@ public class TextFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
                                         // GEOS-6829
                                         writer.println(name + " = null");
                                     }
+                                } else if (Date.class.isAssignableFrom(binding)
+                                        && TemporalUtils.isDateTimeFormatEnabled()) {
+                                    // Temporal types print handling
+                                    String printValue =
+                                            TemporalUtils.printDate((Date) f.getAttribute(name));
+                                    writer.println(name + " = " + printValue);
                                 } else {
                                     writer.println(name + " = " + f.getAttribute(name));
                                 }


### PR DESCRIPTION
The following formats: text/html, GeoJSON, text/plain don't have any special treatment for date \ times and simply do a to string regardless of the timezone or time format in WMS GetFeatureInfo.

This is PR fixes GeoJSON, text/plain temporal types formatting handling.

Text/html is managed by Freemarker template engine, but checking how to override it.

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-8356

Requires:
geotools/geotools#2477

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
