### PR TITLE
[Backport 2.16.x][GEOS-9133] hyperspectral image configuration support in "bin" package

### DIFF
--- a/src/release/jetty/etc/jetty.xml
+++ b/src/release/jetty/etc/jetty.xml
@@ -94,7 +94,19 @@
       -->
     </New>
 
-
+    <!-- =========================================================== -->
+    <!-- Set maxFormContentSize and maxFormKeys Request configuration-->
+    <!-- for handling hyperspectral images and large post.           -->
+    <!-- =========================================================== -->
+    <Call name="setAttribute">
+      <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
+      <Arg>500000</Arg>
+    </Call>
+    <Call name="setAttribute">
+      <Arg>org.eclipse.jetty.server.Request.maxFormKeys</Arg>
+      <Arg>2000</Arg>
+    </Call>
+    
     <!-- =========================================================== -->
     <!-- Set the default handler structure for the Server            -->
     <!-- A handler collection is used to pass received requests to   -->

--- a/src/web/app/src/test/java/org/geoserver/web/Start.java
+++ b/src/web/app/src/test/java/org/geoserver/web/Start.java
@@ -112,7 +112,9 @@ public class Start {
             jettyServer.setHandler(wah);
             wah.setTempDirectory(new File("target/work"));
             // this allows to send large SLD's from the styles form
-            wah.getServletContext().getContextHandler().setMaxFormContentSize(1024 * 1024 * 2);
+            wah.getServletContext().getContextHandler().setMaxFormContentSize(1024 * 1024 * 5);
+            // this allows to configure hyperspectral images
+            wah.getServletContext().getContextHandler().setMaxFormKeys(2000);
 
             String jettyConfigFile = System.getProperty("jetty.config.file");
             if (jettyConfigFile != null) {


### PR DESCRIPTION
This PR adds hyperspectral image configuration support in "bin" package due to form too big.

This is a draft since an hyperspectral image is required for testing purposes.

https://osgeo-org.atlassian.net/browse/GEOS-9133

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
