### PR TITLE
[GEOS-9336] Integration test for WFSDataStore when doing a GetFeature operation having special chars in PropertyName

### DIFF
--- a/src/wfs/src/test/java/org/geoserver/wfs/remote/v2_0/WfsRemoteStoreTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/remote/v2_0/WfsRemoteStoreTest.java
@@ -1,0 +1,297 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.remote.v2_0;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.geoserver.catalog.CascadeDeleteVisitor;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.TestHttpClientProvider;
+import org.geoserver.test.http.MockHttpClient;
+import org.geoserver.test.http.MockHttpResponse;
+import org.geoserver.util.IOUtils;
+import org.geoserver.wfs.v2_0.WFS20TestSupport;
+import org.geotools.data.DataAccess;
+import org.geotools.data.util.NullProgressListener;
+import org.geotools.data.wfs.WFSDataStore;
+import org.geotools.data.wfs.WFSDataStoreFactory;
+import org.geotools.feature.NameImpl;
+import org.geotools.util.decorate.Wrapper;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Contains integration tests related with GeoServer WFS 2.0 remote store. */
+public class WfsRemoteStoreTest extends WFS20TestSupport {
+
+    @Test
+    public void testAddRemoteWfsLayer() throws Exception {
+
+        // configure the test environment
+        Map<String, String> environment = new HashMap<>();
+        // get tiger roads schemas location
+        URL tigerRoadsSchema =
+                WfsRemoteStoreTest.class.getResource("tiger_roads_describe_feature_type.xml");
+        assertThat(tigerRoadsSchema, notNullValue());
+        environment.put("TIGER_ROADS_SCHEMA_LOCATION", tigerRoadsSchema.toString());
+
+        // setup http mock for the remote WFS server
+        MockHttpClient httpClient = new MockHttpClient();
+        // register the http calls the http mock should expect
+        registerHttpGetFromResource(
+                httpClient,
+                "/ows?REQUEST=DescribeFeatureType"
+                        + "&VERSION=2.0.0"
+                        + "&TYPENAMES=tiger%3Atiger_roads"
+                        + "&NAMESPACES=xmlns%28tiger%2Chttp%3A%2F%2Fwww.census.gov%29"
+                        + "&SERVICE=WFS",
+                "tiger_roads_describe_feature_type.xml");
+        registerHttpGetFromResource(
+                httpClient,
+                "/ows?PROPERTYNAME=the_geom"
+                        + "&TYPENAME=tiger%3Atiger_roads"
+                        + "&REQUEST=GetFeature"
+                        + "&RESULTTYPE=RESULTS"
+                        + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
+                        + "&VERSION=2.0.0"
+                        + "&SERVICE=WFS",
+                "tiger_roads_get_feature_resp_1.xml",
+                environment);
+        registerHttpGetFromResource(
+                httpClient,
+                "/ows?PROPERTYNAME=the_geom%2CCFCC%2CNAME"
+                        + "&TYPENAME=tiger%3Atiger_roads"
+                        + "&REQUEST=GetFeature"
+                        + "&RESULTTYPE=RESULTS"
+                        + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
+                        + "&VERSION=2.0.0"
+                        + "&SERVICE=WFS",
+                "tiger_roads_get_feature_resp_1.xml",
+                environment);
+
+        try {
+            // add the remote wfs store using a file capabilities document
+            DataStoreInfo storeInfo =
+                    createWfsDataStore(
+                            getCatalog(), "RemoteWfsStore", "remote_wfs_capabilities.xml");
+
+            // retrieve the wfs store and make sure we set it to use our mocked http client
+            DataAccess dataStore = storeInfo.getDataStore(new NullProgressListener());
+            WFSDataStore wfsDatStore = extractWfsDataStore(dataStore);
+            wfsDatStore.getWfsClient().setHttpClient(httpClient);
+
+            // create a feature based on a remote layer (feature type)
+            createWfsRemoteLayer(getCatalog(), storeInfo, "tiger_tiger_roads");
+
+            // perform a get feature request to make sure the layer works properly
+            MockHttpServletResponse response =
+                    getAsServletResponse(
+                            "wfs?request=GetFeature&typenames=gs:tiger_tiger_roads&version=2.0.0&service=wfs");
+            assertThat(response.getStatus(), is(200));
+            String content = response.getContentAsString();
+            assertThat(content, notNullValue());
+            assertThat(content.contains("numberMatched=\"1\" numberReturned=\"1\""), is(true));
+        } finally {
+            // let's clean the catalog
+            DataStoreInfo dataStoreInfo =
+                    getCatalog().getStoreByName("RemoteWfsStore", DataStoreInfo.class);
+            if (dataStoreInfo != null) {
+                // the store exists let's remove it, the associated layer will also be removed
+                CascadeDeleteVisitor visitor = new CascadeDeleteVisitor(getCatalog());
+                dataStoreInfo.accept(visitor);
+            }
+        }
+    }
+
+    @Test
+    public void testAddRemoteWfsLayerSpecialChars() throws Exception {
+
+        // configure the test environment
+        Map<String, String> environment = new HashMap<>();
+        // get tiger roads schemas location
+        URL tigerRoadsSchema =
+                WfsRemoteStoreTest.class.getResource(
+                        "tiger_roads_describe_feature_type_special_chars.xml");
+        assertThat(tigerRoadsSchema, notNullValue());
+        environment.put("TIGER_ROADS_SCHEMA_LOCATION", tigerRoadsSchema.toString());
+
+        // setup http mock for the remote WFS server
+        MockHttpClient httpClient = new MockHttpClient();
+        // register the http calls the http mock should expect
+        registerHttpGetFromResource(
+                httpClient,
+                "/ows?REQUEST=DescribeFeatureType"
+                        + "&VERSION=2.0.0"
+                        + "&TYPENAMES=tiger%3Atiger_roads"
+                        + "&NAMESPACES=xmlns%28tiger%2Chttp%3A%2F%2Fwww.census.gov%29"
+                        + "&SERVICE=WFS",
+                "tiger_roads_describe_feature_type_special_chars.xml");
+        registerHttpGetFromResource(
+                httpClient,
+                "/ows?PROPERTYNAME=the_geom"
+                        + "&TYPENAME=tiger%3Atiger_roads"
+                        + "&REQUEST=GetFeature"
+                        + "&RESULTTYPE=RESULTS"
+                        + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
+                        + "&VERSION=2.0.0"
+                        + "&SERVICE=WFS",
+                "tiger_roads_get_feature_resp_special_chars.xml",
+                environment);
+        registerHttpGetFromResource(
+                httpClient,
+                "/ows?PROPERTYNAME=the_geom%2C%C3%A6nd%2C%C3%B8st%2Cn%C3%B8j"
+                        + "&TYPENAME=tiger%3Atiger_roads"
+                        + "&REQUEST=GetFeature"
+                        + "&RESULTTYPE=RESULTS"
+                        + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
+                        + "&VERSION=2.0.0"
+                        + "&SERVICE=WFS",
+                "tiger_roads_get_feature_resp_special_chars.xml",
+                environment);
+
+        try {
+            // add the remote wfs store using a file capabilities document
+            DataStoreInfo storeInfo =
+                    createWfsDataStore(
+                            getCatalog(), "RemoteWfsStore", "remote_wfs_capabilities.xml");
+
+            // retrieve the wfs store and make sure we set it to use our mocked http client
+            DataAccess dataStore = storeInfo.getDataStore(new NullProgressListener());
+            WFSDataStore wfsDatStore = extractWfsDataStore(dataStore);
+            wfsDatStore.getWfsClient().setHttpClient(httpClient);
+
+            // create a feature based on a remote layer (feature type)
+            createWfsRemoteLayer(getCatalog(), storeInfo, "tiger_tiger_roads");
+
+            // perform a get feature request to make sure the layer works properly
+            MockHttpServletResponse response =
+                    getAsServletResponse(
+                            "wfs?request=GetFeature&typenames=gs:tiger_tiger_roads&version=2.0.0&service=wfs");
+            assertThat(response.getStatus(), is(200));
+            String content = response.getContentAsString();
+            assertThat(content, notNullValue());
+            assertThat(content.contains("numberMatched=\"1\" numberReturned=\"1\""), is(true));
+        } finally {
+            // let's clean the catalog
+            DataStoreInfo dataStoreInfo =
+                    getCatalog().getStoreByName("RemoteWfsStore", DataStoreInfo.class);
+            if (dataStoreInfo != null) {
+                // the store exists let's remove it, the associated layer will also be removed
+                CascadeDeleteVisitor visitor = new CascadeDeleteVisitor(getCatalog());
+                dataStoreInfo.accept(visitor);
+            }
+        }
+    }
+
+    /**
+     * Helper method that creates a layer in GeoServer catalog from a WFS remote store, the provided
+     * layer name should match an entry on the remote WFS server.
+     */
+    private static LayerInfo createWfsRemoteLayer(
+            Catalog catalog, DataStoreInfo storeInfo, String name) throws Exception {
+        // let's create the feature type based on the remote layer capabilities description
+        CatalogBuilder catalogBuilder = new CatalogBuilder(catalog);
+        catalogBuilder.setStore(storeInfo);
+        // the following call will trigger a describe feature type call to the remote server
+        FeatureTypeInfo featureTypeInfo = catalogBuilder.buildFeatureType(new NameImpl("", name));
+        catalog.add(featureTypeInfo);
+        // create the layer info based on the feature type info we just created
+        LayerInfo layerInfo = catalogBuilder.buildLayer(featureTypeInfo);
+        catalog.add(layerInfo);
+        // return the layer info we just created
+        layerInfo = catalog.getLayerByName(name);
+        assertThat(layerInfo, notNullValue());
+        return layerInfo;
+    }
+
+    /**
+     * Helper method that creates a WFS data store based ont he provided capabilities document,
+     * which should be a resource available in the classpath. The created store will be saved in the
+     * GeoServer catalog on the default workspace.
+     */
+    private static DataStoreInfo createWfsDataStore(
+            Catalog catalog, String name, String capabilitiesDocument) {
+        // get the capabilities document url
+        URL url = WfsRemoteStoreTest.class.getResource(capabilitiesDocument);
+        assertThat(url, notNullValue());
+        // build the wfs data store
+        CatalogBuilder catalogBuilder = new CatalogBuilder(catalog);
+        DataStoreInfo storeInfo = catalogBuilder.buildDataStore(name);
+        storeInfo.setType("Web Feature Server (NG)");
+        storeInfo.getConnectionParameters().put(WFSDataStoreFactory.URL.key, url);
+        storeInfo.getConnectionParameters().put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
+        // local capabilities document are only supported in testing mode
+        storeInfo.getConnectionParameters().put("TESTING", Boolean.TRUE);
+        catalog.add(storeInfo);
+        // return the wfs data store we just build
+        storeInfo = catalog.getStoreByName(name, DataStoreInfo.class);
+        assertThat(storeInfo, notNullValue());
+        return storeInfo;
+    }
+
+    /**
+     * Help method that register in the provided mock HTTP client an HTTP GET URL and the respective
+     * response, the response will be retrieved from the provided resource name which should be
+     * available in the class-path. The provided environment map will be used to substitute any
+     * matching place holder.
+     */
+    private static void registerHttpGetFromResource(
+            MockHttpClient httpClient,
+            String url,
+            String resourceName,
+            Map<String, String> environment)
+            throws Exception {
+        // get the resource URL
+        URL finalUrl = new URL(TestHttpClientProvider.MOCKSERVER + url);
+        try (InputStream input = WfsRemoteStoreTest.class.getResourceAsStream(resourceName)) {
+            assertThat(input, notNullValue());
+            // get the resource content to a string
+            String content = IOUtils.toString(input);
+            for (Map.Entry<String, String> entry : environment.entrySet()) {
+                // if a placeholder exists replace it whit the corresponding value
+                content = content.replaceAll("\\$\\{" + entry.getKey() + "}", entry.getValue());
+            }
+            // use the content resolved with the provided environment
+            httpClient.expectGet(finalUrl, new MockHttpResponse(content, "text/xml"));
+        }
+    }
+
+    /**
+     * Help method that register in the provided mock HTTP client an HTTP GET URL and the respective
+     * response, the response will be retrieved from the provided resource name which should be
+     * available in the class-path.
+     */
+    private static void registerHttpGetFromResource(
+            MockHttpClient httpClient, String url, String resourceName) throws Exception {
+        URL finalUrl = new URL(TestHttpClientProvider.MOCKSERVER + url);
+        URL resourceUrl = WfsRemoteStoreTest.class.getResource(resourceName);
+        assertThat(resourceUrl, notNullValue());
+        httpClient.expectGet(finalUrl, new MockHttpResponse(resourceUrl, "text/xml"));
+    }
+
+    /**
+     * Helper method that obtains a WFS data store from a generic data access by unwrapping it if
+     * necessary.
+     */
+    private static WFSDataStore extractWfsDataStore(DataAccess dataStore) {
+        assertThat(dataStore, notNullValue());
+        if (dataStore instanceof Wrapper) {
+            // an exception will be throw if no wfs data store can be found
+            return ((Wrapper) dataStore).unwrap(WFSDataStore.class);
+        }
+        assertThat(dataStore, instanceOf(WFSDataStore.class));
+        return (WFSDataStore) dataStore;
+    }
+}

--- a/src/wfs/src/test/resources/org/geoserver/wfs/remote/v2_0/tiger_roads_describe_feature_type_special_chars.xml
+++ b/src/wfs/src/test/resources/org/geoserver/wfs/remote/v2_0/tiger_roads_describe_feature_type_special_chars.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2"
+            xmlns:tiger="http://www.census.gov" xmlns:wfs="http://www.opengis.net/wfs/2.0"
+            elementFormDefault="qualified" targetNamespace="http://www.census.gov">
+  <xsd:import namespace="http://www.opengis.net/gml/3.2"
+              schemaLocation="http://localhost:8061/geoserver/schemas/gml/3.2.1/gml.xsd"/>
+  <xsd:complexType name="tiger_roadsType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element maxOccurs="1" minOccurs="0" name="the_geom" nillable="true" type="gml:MultiCurvePropertyType"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="ænd" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="øst" nillable="true" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="nøj" nillable="true" type="xsd:string"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="tiger_roads" substitutionGroup="gml:AbstractFeature" type="tiger:tiger_roadsType"/>
+</xsd:schema>

--- a/src/wfs/src/test/resources/org/geoserver/wfs/remote/v2_0/tiger_roads_get_feature_resp_special_chars.xml
+++ b/src/wfs/src/test/resources/org/geoserver/wfs/remote/v2_0/tiger_roads_get_feature_resp_special_chars.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection numberMatched="1" numberReturned="1" timeStamp="2019-09-16T11:21:07.322Z"
+                       xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:tiger="http://www.census.gov"
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://www.census.gov ${TIGER_ROADS_SCHEMA_LOCATION}">
+  <wfs:member>
+    <tiger:tiger_roads gml:id="tiger_roads.1">
+      <tiger:the_geom>
+        <gml:MultiCurve gml:id="tiger_roads.1.the_geom" srsDimension="2"
+                        srsName="urn:ogc:def:crs:EPSG::4326">
+        <gml:curveMember>
+        <gml:LineString gml:id="tiger_roads.1.the_geom.1">
+          <gml:posList>-73.999559 40.73158 -73.999079 40.732188</gml:posList>
+        </gml:LineString>
+        </gml:curveMember>
+        </gml:MultiCurve>
+      </tiger:the_geom>
+      <tiger:ænd>ænd</tiger:ænd>
+      <tiger:øst>øst</tiger:øst>
+      <tiger:nøj>nøj</tiger:nøj>
+    </tiger:tiger_roads>
+  </wfs:member>
+</wfs:FeatureCollection>
+


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
