### PR TITLE
[GEOS-9330]-2: Follow up on NcWMS getTimeSeries noData management

### DIFF
--- a/doc/en/user/source/community/ncwms/index.rst
+++ b/doc/en/user/source/community/ncwms/index.rst
@@ -246,4 +246,17 @@ Sample chart output:
 .. figure:: images/geoserver-GetTimeSeries.png
    :align: center
 
-**Note:** Since GeoServer 2.17, nodata pixels will not be reported in the result list/chart.
+**Note:** Since GeoServer 2.17, nodata pixels will not be reported in the result chart. Moreover, entries in CSV list related to nodata pixels will report time but will have no pixel value reported, as in the example below for times 2014-02-01 and 2014-05-01:
+
+
+.. code-block:: none
+
+    # Latitude: 40.396728515625
+    # Longitude: -0.6921386718750019
+    Time (UTC),Temperature (degrees)
+    2014-01-01T00:00:00.000Z,0.4194810092449188
+    2014-02-01T00:00:00.000Z,
+    2014-03-01T00:00:00.000Z,3.1670899391174316
+    2014-04-01T00:00:00.000Z,4.932330131530762
+    2014-05-01T00:00:00.000Z,
+    2014-06-01T00:00:00.000Z,0.8373379707336426

--- a/doc/en/user/source/services/wms/reference.rst
+++ b/doc/en/user/source/services/wms/reference.rst
@@ -426,7 +426,7 @@ They are fully documented in the :ref:`wms_vendor_parameters` section.
      - Feature properties to be returned
    * - ``exclude_nodata_result``
      - No
-     - When set to true, a feature will not be returned if the queried pixel value is nodata.
+     - When set to true, a *NaN* will be returned when the feature's queried pixel value is nodata.
 
 An example request for feature information from the ``topp:states`` layer in HTML format is: ::
 

--- a/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/GetTimeSeriesResponse.java
+++ b/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/GetTimeSeriesResponse.java
@@ -133,7 +133,9 @@ public class GetTimeSeriesResponse extends Response {
                     SimpleFeature f = fi.next();
                     Date date = (Date) f.getAttribute("date");
                     Double value = (Double) f.getAttribute("value");
-                    series.add(new Millisecond(date), value);
+                    if (!Double.isNaN(value)) {
+                        series.add(new Millisecond(date), value);
+                    }
                 }
             }
         }
@@ -186,7 +188,8 @@ public class GetTimeSeriesResponse extends Response {
                     SimpleFeature f = fi.next();
                     Date date = (Date) f.getAttribute("date");
                     Double value = (Double) f.getAttribute("value");
-                    writer.println(isoFormatter.format(date) + "," + value);
+                    writer.println(
+                            isoFormatter.format(date) + "," + (Double.isNaN(value) ? "" : value));
                 }
             }
         }

--- a/src/community/ncwms/src/test/java/org/geoserver/wms/ncwms/NcWmsGetTimeSeriesTest.java
+++ b/src/community/ncwms/src/test/java/org/geoserver/wms/ncwms/NcWmsGetTimeSeriesTest.java
@@ -342,17 +342,21 @@ public class NcWmsGetTimeSeriesTest extends WMSDimensionsTestSupport {
         setNearestMatch(TIMESERIES, ResourceInfo.TIME, null);
     }
 
-    /** Test we aren't getting a result when hitting a nodata pixel */
+    /** Test we are getting an empty result when hitting a nodata pixel */
     @Test
-    public void testNoResultsWhenNodata() throws Exception {
+    public void testEmptyResultsWhenNodata() throws Exception {
         setupRasterDimension(
                 TIMESERIES, ResourceInfo.TIME, DimensionPresentation.LIST, null, null, null);
         String url = REQUEST_ON_NODATA_PIXEL;
         String rawCsv = getAsString(url);
         String[] csvLines = rawCsv.split("\\r?\\n");
 
-        // Make sure we aren't getting any result, only the CSV Headers is returned.
-        Assert.assertEquals("No Results", CSV_HEADER_ROWS, csvLines.length);
+        // Make sure we aren getting an empty value on nodata
+        Assert.assertEquals("CSV Number of results", CSV_HEADER_ROWS + 1, csvLines.length);
+        String line = csvLines[CSV_HEADER_ROWS];
+        String[] lineSplit = line.split(",");
+        // Nothing get found after the comma, meaning the result is empty
+        Assert.assertEquals(1, lineSplit.length);
     }
 
     private void setNearestMatch(QName layer, String dimension, String nearestAcceptableInterval) {

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
@@ -290,7 +290,9 @@ public class RasterLayerIdentifier implements LayerIdentifier {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine("Returning no result due to nodata pixel");
                 }
-                return null;
+                for (int i = 0; i < pixelValues.length; i++) {
+                    pixelValues[i] = Double.NaN;
+                }
             }
             pixel = wrapPixelInFeatureCollection(coverage, pixelValues, cinfo.getQualifiedName());
         } catch (PointOutsideCoverageException e) {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -1281,7 +1281,7 @@ public class GetFeatureInfoTest extends WMSTestSupport {
     }
 
     @Test
-    public void testOnNodataValueGetNoResults() throws Exception {
+    public void testOnNodataValueGetNans() throws Exception {
         String timeseries = getLayerId(TIMESERIES);
         String request =
                 "wms?version=1.1.1&BBOX=1,42,2,44&format=jpeg"
@@ -1303,6 +1303,6 @@ public class GetFeatureInfoTest extends WMSTestSupport {
         // we should get back no results in that case
         String request2 = request + "&EXCLUDE_NODATA_RESULT=true";
         result = getAsString(request2);
-        assertTrue(result.contains("no feature"));
+        assertTrue(result.indexOf("NaN") > 0);
     }
 }


### PR DESCRIPTION
Tweaking a bit the nodata management on ncWMS, spitting out an empty value on csv so that we know the time was available but a nodata value was there.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
