### PR TITLE
[GEOS-8940] Tile Layers page layer names bring to the "Publishing" tab by default

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/publish/PublishedConfigurationPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/publish/PublishedConfigurationPage.java
@@ -252,7 +252,9 @@ public abstract class PublishedConfigurationPage<T extends PublishedInfo>
                                 tabPanelCustomModels.keySet())
                         .indexOf(selectedTabClass);
         if (selectedTabIndex > -1) {
-            tabbedPanel.setSelectedTab(selectedTabIndex);
+            // add differential to match index of tabPanelCustomModels with total tabs count
+            int diff = (tabbedPanel.getTabs().size() - tabPanelCustomModels.size());
+            tabbedPanel.setSelectedTab(selectedTabIndex + diff);
         }
     }
 

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
@@ -182,4 +182,21 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
             throw new RuntimeException(e);
         }
     }
+
+    @Test
+    public void testAutoTileCachingTabSelection() {
+        // this tests asserts that when a layer is clicked on Tile Layer page
+        // the resulting navigation page should have the 'Tile Caching' tab selected by itself
+        CachedLayersPage page = new CachedLayersPage();
+
+        // load tiles layer list page
+        tester.startPage(page);
+        tester.assertRenderedPage(CachedLayersPage.class);
+
+        // click on the first layer
+        tester.clickLink("table:listContainer:items:1:itemProperties:1:component:link", true);
+
+        // UI should navigate to ResourceConfiguration Page with Tiles tab selected
+        tester.assertComponent("publishedinfo:tabs:panel", LayerCacheOptionsTabPanel.class);
+    }
 }


### PR DESCRIPTION
-fixed, clicking coming to layer page from Tile layers list selects 'Tile
Caching'

When clicking a layer from Tiles Admin list, the tab selected by default was Publishing when it should have been Tile Caching.

https://osgeo-org.atlassian.net/browse/GEOS-8940
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
