### PR TITLE
[GEOS-9328] WCS 2 - CRS Extension not implemented correctly

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCapabilitiesTransformer.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCapabilitiesTransformer.java
@@ -127,10 +127,11 @@ public class WCS20GetCapabilitiesTransformer extends TransformerBase {
             this.extensions = GeoServerExtensions.extensions(WCSExtendedCapabilitiesProvider.class);
             // register namespaces provided by extended capabilities
             NamespaceSupport namespaces = getNamespaceSupport();
-            namespaces.declarePrefix(
-                    "wcscrs", "http://www.opengis.net/wcs/service-extension/crs/1.0");
+            namespaces.declarePrefix("wcs", "http://www.opengis.net/wcs/2.0");
             namespaces.declarePrefix(
                     "int", "http://www.opengis.net/WCS_service-extension_interpolation/1.0");
+
+            namespaces.declarePrefix("crs", "http://www.opengis.net/wcs/crs/1.0");
 
             for (WCSExtendedCapabilitiesProvider cp : extensions) {
                 cp.registerNamespaces(namespaces);
@@ -296,12 +297,13 @@ public class WCS20GetCapabilitiesTransformer extends TransformerBase {
             } else {
                 codes = wcs.getSRS();
             }
+            start("crs:CrsMetadata");
             for (String code : codes) {
                 if (!code.equals("WGS84(DD)")) {
-                    element("wcscrs:crsSupported", "http://www.opengis.net/def/crs/EPSG/0/" + code);
+                    element("crs:crsSupported", "http://www.opengis.net/def/crs/EPSG/0/" + code);
                 }
             }
-
+            end("crs:CrsMetadata");
             // add the supported interpolation methods
             element(
                     "int:interpolationSupported",

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSTestSupport.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSTestSupport.java
@@ -243,7 +243,7 @@ public abstract class WCSTestSupport extends GeoServerSystemTestSupport {
         // init xmlunit
         Map<String, String> namespaces = new HashMap<String, String>();
         namespaces.put("wcs", "http://www.opengis.net/wcs/2.0");
-        namespaces.put("wcscrs", "http://www.opengis.net/wcs/service-extension/crs/1.0");
+        namespaces.put("crs", "http://www.opengis.net/wcs/crs/1.0");
         namespaces.put("ows", "http://www.opengis.net/ows/2.0");
         namespaces.put("xlink", "http://www.w3.org/1999/xlink");
         namespaces.put("int", "http://www.opengis.net/WCS_service-extension_interpolation/1.0");
@@ -314,7 +314,7 @@ public abstract class WCSTestSupport extends GeoServerSystemTestSupport {
                 dom);
         assertXpathEvaluatesTo(
                 "1",
-                "count(//wcs:ServiceMetadata/wcs:Extension[wcscrs:crsSupported = 'http://www.opengis.net/def/crs/EPSG/0/4326'])",
+                "count(//wcs:ServiceMetadata/wcs:Extension/crs:CrsMetadata[crs:crsSupported = 'http://www.opengis.net/def/crs/EPSG/0/4326'])",
                 dom);
 
         // check the interpolation extension

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/GetCapabilitiesTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/GetCapabilitiesTest.java
@@ -69,7 +69,8 @@ public class GetCapabilitiesTest extends WCSTestSupport {
         // print(dom);
         NodeList list =
                 xpath.getMatchingNodes(
-                        "//wcs:ServiceMetadata/wcs:Extension/wcscrs:crsSupported", dom);
+                        "//wcs:ServiceMetadata/wcs:Extension/crs:CrsMetadata/crs:crsSupported",
+                        dom);
         assertTrue(list.getLength() > 1000);
 
         // setup limited list
@@ -82,7 +83,8 @@ public class GetCapabilitiesTest extends WCSTestSupport {
         // print(dom);
         list =
                 xpath.getMatchingNodes(
-                        "//wcs:ServiceMetadata/wcs:Extension/wcscrs:crsSupported", dom);
+                        "//wcs:ServiceMetadata/wcs:Extension/crs:CrsMetadata/crs:crsSupported",
+                        dom);
         assertEquals(2, list.getLength());
     }
 

--- a/src/wcs2_0/src/test/resources/crs/requestGetCoverageOutputCRS.xml
+++ b/src/wcs2_0/src/test/resources/crs/requestGetCoverageOutputCRS.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <wcs:GetCoverage
   xmlns:wcs="http://www.opengis.net/wcs/2.0"
-  xmlns:wcscrs="http://www.opengis.net/wcs/service-extension/crs/1.0"
+  xmlns:crs="http://www.opengis.net/wcs/crs/1.0"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opengis.net/wcs/2.0 http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
   service="WCS"
   version="2.0.1">
   <wcs:Extension>
-    <wcscrs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857</wcscrs:outputCrs>
+    <crs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857</crs:outputCrs>
   </wcs:Extension>
   <wcs:CoverageId>wcs__BlueMarble</wcs:CoverageId>
   <wcs:format>image/tiff</wcs:format>

--- a/src/wcs2_0/src/test/resources/crs/requestGetCoverageSubsettingCRS.xml
+++ b/src/wcs2_0/src/test/resources/crs/requestGetCoverageSubsettingCRS.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <wcs:GetCoverage
   xmlns:wcs="http://www.opengis.net/wcs/2.0"
-  xmlns:wcscrs="http://www.opengis.net/wcs/service-extension/crs/1.0"
+  xmlns:crs="http://www.opengis.net/wcs/crs/1.0"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opengis.net/wcs/2.0 http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
@@ -18,8 +18,8 @@
 		<wcs:TrimHigh>-43.0</wcs:TrimHigh>
 	</wcs:DimensionTrim>    
   <wcs:Extension>
-    <wcscrs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/4326</wcscrs:subsettingCrs>
-    <wcscrs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857</wcscrs:outputCrs>  
+    <crs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/4326</crs:subsettingCrs>
+    <crs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857</crs:outputCrs>  
   </wcs:Extension>
   <wcs:CoverageId>wcs__BlueMarble</wcs:CoverageId>
   <wcs:format>image/tiff</wcs:format>

--- a/src/wcs2_0/src/test/resources/crs/requestGetCoverageSubsettingTrimCRS.xml
+++ b/src/wcs2_0/src/test/resources/crs/requestGetCoverageSubsettingTrimCRS.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <wcs:GetCoverage xmlns:wcs="http://www.opengis.net/wcs/2.0"
-	xmlns:wcscrs="http://www.opengis.net/wcs/service-extension/crs/1.0"
+	xmlns:crs="http://www.opengis.net/wcs/crs/1.0"
 	xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.opengis.net/wcs/2.0 http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
 	service="WCS" version="2.0.1">
 	<wcs:Extension>
-		<wcscrs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/3857
-		</wcscrs:subsettingCrs>
-		<wcscrs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857
-		</wcscrs:outputCrs>
+		<crs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/3857
+		</crs:subsettingCrs>
+		<crs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857
+		</crs:outputCrs>
 	</wcs:Extension>
 	<wcs:CoverageId>wcs__BlueMarble</wcs:CoverageId>
 	<wcs:DimensionTrim>

--- a/src/wcs2_0/src/test/resources/crs/requestGetCoverageSubsettingTrimCRS2.xml
+++ b/src/wcs2_0/src/test/resources/crs/requestGetCoverageSubsettingTrimCRS2.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <wcs:GetCoverage xmlns:wcs="http://www.opengis.net/wcs/2.0"
-	xmlns:wcscrs="http://www.opengis.net/wcs/service-extension/crs/1.0"
+	xmlns:crs="http://www.opengis.net/wcs/crs/1.0"
 	xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.opengis.net/wcs/2.0 http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
 	service="WCS" version="2.0.1">
 	<wcs:Extension>
-		<wcscrs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/3857
-		</wcscrs:subsettingCrs>
-		<wcscrs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857
-		</wcscrs:outputCrs>
+		<crs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/3857
+		</crs:subsettingCrs>
+		<crs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3857
+		</crs:outputCrs>
 	</wcs:Extension>
 	<wcs:CoverageId>wcs__BlueMarble</wcs:CoverageId>
 	<wcs:DimensionTrim>

--- a/src/wcs2_0/src/test/resources/getcapabilities/getCap.xml
+++ b/src/wcs2_0/src/test/resources/getcapabilities/getCap.xml
@@ -2,4 +2,5 @@
 <wcs:GetCapabilities service="WCS"
 	xmlns:ows="http://www.opengis.net/ows/1.1" 
 	xmlns:wcs="http://www.opengis.net/wcs/2.0" 
+	xmlns:crs="http://www.opengis.net/wcs/crs/1.0" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>

--- a/src/wcs2_0/src/test/resources/requestGetCoverageAcrossDatelineMercatorPacific.xml
+++ b/src/wcs2_0/src/test/resources/requestGetCoverageAcrossDatelineMercatorPacific.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <wcs:GetCoverage xmlns:wcs="http://www.opengis.net/wcs/2.0"
-  xmlns:wcscrs="http://www.opengis.net/wcs/service-extension/crs/1.0"
+  xmlns:crs="http://www.opengis.net/wcs/crs/1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opengis.net/wcs/2.0 
                   http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
@@ -19,7 +19,7 @@
   <wcs:format>image/tiff</wcs:format>
   <wcs:Extension>
      <!-- Mercator centered on 150°, request is roughly for long(160,-160),lat(0, 40)-->
-    <wcscrs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/3832</wcscrs:subsettingCrs>
-    <wcscrs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/4326</wcscrs:outputCrs>
+    <crs:subsettingCrs>http://www.opengis.net/def/crs/EPSG/0/3832</crs:subsettingCrs>
+    <crs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/4326</crs:outputCrs>
   </wcs:Extension>
 </wcs:GetCoverage>

--- a/src/wcs2_0/src/test/resources/requestGetCoverageAcrossDatelinePolar.xml
+++ b/src/wcs2_0/src/test/resources/requestGetCoverageAcrossDatelinePolar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <wcs:GetCoverage xmlns:wcs="http://www.opengis.net/wcs/2.0"
-  xmlns:wcscrs="http://www.opengis.net/wcs/service-extension/crs/1.0"
+  xmlns:crs="http://www.opengis.net/wcs/crs/1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opengis.net/wcs/2.0 
                   http://schemas.opengis.net/wcs/2.0/wcsAll.xsd"
@@ -19,6 +19,6 @@
   <wcs:format>image/tiff</wcs:format>
   <wcs:Extension>
      <!-- "WGS 84 / UPS South -->
-    <wcscrs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3031</wcscrs:outputCrs>
+    <crs:outputCrs>http://www.opengis.net/def/crs/EPSG/0/3031</crs:outputCrs>
   </wcs:Extension>
 </wcs:GetCoverage>


### PR DESCRIPTION
fixed WCS 2 Capability document as per OGC specs [WCS.2 Specs](https://portal.opengeospatial.org/files/54209)
-wcscrs changed to crs
-added crs:CrsMetadata to wcs:Extension
-moved crsSupported(s) inside crs:CrsMetadata
-updated unit tests
-fixed namespaces in test resources



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
