### PR TITLE
[GEOS-9190]: Unable to create feature type through REST if two stores on different workspaces have the same name

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
@@ -171,7 +171,7 @@ public class FeatureTypeController extends AbstractCatalogController {
             UriComponentsBuilder builder)
             throws Exception {
 
-        DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
+        final DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
         // ensure the store matches up
         if (ftInfo.getStore() != null && storeName != null) {
             if (!storeName.equals(ftInfo.getStore().getName())) {
@@ -182,7 +182,10 @@ public class FeatureTypeController extends AbstractCatalogController {
                                 + ftInfo.getStore().getName(),
                         HttpStatus.FORBIDDEN);
             }
-            dsInfo = ftInfo.getStore();
+            // HACK: override the StoreInfo in case there's a store named the same on a
+            // different workspace. The FeatureTypeInfo deserialization doesn't know how to
+            // disambiguate to ftInfo may come in with the wrong Store
+            ftInfo.setStore(dsInfo);
         } else {
             ftInfo.setStore(dsInfo);
         }

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
@@ -69,7 +69,35 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
                 dom.getElementsByTagName("featureType").getLength());
     }
 
+    @Test // GEOS-9190
+    public void testCreateFeatureTypeSameStoreNameDifferentWorkspace() throws Exception {
+        final boolean configureFeatureType = false;
+        final String ws1 = "gs";
+        final String ws2 = "sf";
+        // create two stores named "pds" on different workspaces
+        addPropertyDataStore(ws1, configureFeatureType);
+        addPropertyDataStore(ws2, configureFeatureType);
+
+        String xml = "<featureType><name>pdsa</name><store>pds</store></featureType>";
+
+        MockHttpServletResponse response;
+        String ws1FetureTypesPath =
+                BASEPATH + "/workspaces/" + ws1 + "/datastores/pds/featuretypes";
+        String ws2FeatureTypesPath =
+                BASEPATH + "/workspaces/" + ws2 + "/datastores/pds/featuretypes";
+
+        response = postAsServletResponse(ws1FetureTypesPath, xml, "text/xml");
+        assertEquals(201, response.getStatus());
+
+        response = postAsServletResponse(ws2FeatureTypesPath, xml, "text/xml");
+        assertEquals(201, response.getStatus());
+    }
+
     void addPropertyDataStore(boolean configureFeatureType) throws Exception {
+        addPropertyDataStore("gs", configureFeatureType);
+    }
+
+    void addPropertyDataStore(String workspace, boolean configureFeatureType) throws Exception {
         ByteArrayOutputStream zbytes = new ByteArrayOutputStream();
         ZipOutputStream zout = new ZipOutputStream(zbytes);
 
@@ -95,10 +123,16 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
         zout.close();
 
         String q = "configure=" + (configureFeatureType ? "all" : "none");
-        put(
-                BASEPATH + "/workspaces/gs/datastores/pds/file.properties?" + q,
-                zbytes.toByteArray(),
-                "application/zip");
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        BASEPATH
+                                + "/workspaces/"
+                                + workspace
+                                + "/datastores/pds/file.properties?"
+                                + q,
+                        zbytes.toByteArray(),
+                        "application/zip");
+        assertEquals(201, response.getStatus());
     }
 
     void addGeomlessPropertyDataStore(boolean configureFeatureType) throws Exception {


### PR DESCRIPTION
Fix a bug by which it's not possible to create a FeatureType
through the REST API on a store if another store with the same
name exists on a different Workspace (race condition: may succeed
if the FeatureTypeInfo request body deserialization picks up
the correct StoreInfo by chance)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
