### PR TITLE
[GEOS-9307] Bump com.thoughtworks.xstream:xstream from 1.4.10 to 1.4.11.1

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/WPSXStreamLoader.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/WPSXStreamLoader.java
@@ -318,7 +318,7 @@ public class WPSXStreamLoader extends XStreamServiceLoader<WPSInfo> {
                 UnmarshallingContext context,
                 Collection collection,
                 Collection target) {
-            Object item = this.readItem(reader, context, collection);
+            Object item = this.readBareItem(reader, context, collection);
             // Remove anything that threw an error upon deserialization
             if (!PROCESS_GROUP_ERROR.equals(item)) {
                 target.add(item);

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -25,7 +25,6 @@ import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
 import com.thoughtworks.xstream.converters.reflection.SortableFieldKeySorter;
 import com.thoughtworks.xstream.converters.reflection.SunUnsafeReflectionProvider;
 import com.thoughtworks.xstream.core.ClassLoaderReference;
-//import com.thoughtworks.xstream.io.ExtendedHierarchicalStreamWriterHelper;
 import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
@@ -2414,9 +2413,7 @@ public class XStreamPersister {
         @Override
         protected void writeCompleteItem(
                 Object item, MarshallingContext context, HierarchicalStreamWriter writer) {
-            // ExtendedHierarchicalStreamWriterHelper.startNode(writer, "string", Keyword.class);
-            //writer.startNode("string", Keyword.class);
-            writer.startNode(String.valueOf(Keyword.class));
+            writer.startNode("string");
             context.convertAnother(item);
             writer.endNode();
         }

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -25,7 +25,7 @@ import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
 import com.thoughtworks.xstream.converters.reflection.SortableFieldKeySorter;
 import com.thoughtworks.xstream.converters.reflection.SunUnsafeReflectionProvider;
 import com.thoughtworks.xstream.core.ClassLoaderReference;
-import com.thoughtworks.xstream.io.ExtendedHierarchicalStreamWriterHelper;
+//import com.thoughtworks.xstream.io.ExtendedHierarchicalStreamWriterHelper;
 import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
@@ -914,7 +914,7 @@ public class XStreamPersister {
                         reader.moveDown();
                     }
 
-                    value = readItem(reader, context, map);
+                    value = readBareItem(reader, context, map);
 
                     if (old) {
                         reader.moveUp();
@@ -928,7 +928,7 @@ public class XStreamPersister {
         }
 
         @Override
-        protected Object readItem(
+        protected Object readBareItem(
                 HierarchicalStreamReader reader, UnmarshallingContext context, Object current) {
             return reader.getValue();
         }
@@ -1033,11 +1033,11 @@ public class XStreamPersister {
             Object value;
             try {
                 reader.moveDown();
-                key = readItem(reader, context, map);
+                key = readBareItem(reader, context, map);
                 reader.moveUp();
 
                 reader.moveDown();
-                value = readItem(reader, context, map);
+                value = readBareItem(reader, context, map);
             } catch (CannotResolveClassException e) {
                 LOGGER.log(
                         Level.WARNING,
@@ -1102,7 +1102,7 @@ public class XStreamPersister {
                     if (v != null) {
                         writer.startNode("entry");
                         writer.addAttribute("key", key.toString());
-                        writeItem(v, context, writer);
+                        writeCompleteItem(v, context, writer);
                         writer.endNode();
                     }
                 }
@@ -1118,7 +1118,7 @@ public class XStreamPersister {
                 // in this case we also support complex objects
                 while (reader.hasMoreChildren()) {
                     reader.moveDown();
-                    value = readItem(reader, context, map);
+                    value = readBareItem(reader, context, map);
                     reader.moveUp();
                 }
                 reader.moveUp();
@@ -1256,7 +1256,7 @@ public class XStreamPersister {
         }
 
         @Override
-        protected void writeItem(
+        protected void writeCompleteItem(
                 Object item, MarshallingContext context, HierarchicalStreamWriter writer) {
             ClassAliasingMapper cam =
                     (ClassAliasingMapper) mapper().lookupMapperOfType(ClassAliasingMapper.class);
@@ -1312,7 +1312,7 @@ public class XStreamPersister {
         }
 
         @Override
-        protected Object readItem(
+        protected Object readBareItem(
                 HierarchicalStreamReader reader, UnmarshallingContext context, Object current) {
             Class theClass = clazz;
             if (subclasses != null) {
@@ -1332,10 +1332,10 @@ public class XStreamPersister {
         }
 
         @Override
-        protected void writeItem(
+        protected void writeCompleteItem(
                 Object item, MarshallingContext context, HierarchicalStreamWriter writer) {
 
-            super.writeItem(unwrapProxies(item), context, writer);
+            super.writeCompleteItem(unwrapProxies(item), context, writer);
         }
     }
 
@@ -2406,15 +2406,17 @@ public class XStreamPersister {
         }
 
         @Override
-        protected Object readItem(
+        protected Object readBareItem(
                 HierarchicalStreamReader reader, UnmarshallingContext context, Object current) {
             return context.convertAnother(current, Keyword.class);
         }
 
         @Override
-        protected void writeItem(
+        protected void writeCompleteItem(
                 Object item, MarshallingContext context, HierarchicalStreamWriter writer) {
-            ExtendedHierarchicalStreamWriterHelper.startNode(writer, "string", Keyword.class);
+            // ExtendedHierarchicalStreamWriterHelper.startNode(writer, "string", Keyword.class);
+            //writer.startNode("string", Keyword.class);
+            writer.startNode(String.valueOf(Keyword.class));
             context.convertAnother(item);
             writer.endNode();
         }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1162,7 +1162,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.10</version>
+      <version>1.4.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
+++ b/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
@@ -88,7 +88,7 @@ public abstract class XStreamCatalogListConverter
                     }
 
                     @Override
-                    protected void writeItem(
+                    protected void writeCompleteItem(
                             Object item,
                             MarshallingContext context,
                             HierarchicalStreamWriter writer) {


### PR DESCRIPTION
This adresses GEOS-9307, bump fixes CVE-2013-7285 and CVE-2019-10173.
See also: https://x-stream.github.io/changes.html
Replaces #3761 with a build fix.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
