### PR TITLE
[GEOS-9357] Credentials for WMTS service are not used 

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/store/WMTSStoreNewPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/WMTSStoreNewPage.java
@@ -134,7 +134,7 @@ public class WMTSStoreNewPage extends AbstractWMTSStorePage {
                     }
                 }
 
-                WebMapTileServer server = new WebMapTileServer(new URL(url));
+                WebMapTileServer server = new WebMapTileServer(new URL(url), client, null);
                 server.getCapabilities();
             } catch (IOException | ServiceException e) {
                 IValidationError err =


### PR DESCRIPTION
Pass entered credentials to underlying WebMapTileServer component. Fixes issue of accessing WMTS server protected by Basic Authentication (same code exists for WMSStoreNewPage). 

Jira issue: https://osgeo-org.atlassian.net/browse/GEOS-9357

