### PR TITLE
backport: Removing RequestUtils deprecated method

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -49,7 +49,6 @@ import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.ows.Request;
 import org.geoserver.ows.URLMangler;
-import org.geoserver.ows.util.RequestUtils;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.rest.RequestInfo;
 import org.geoserver.wms.GetLegendGraphicRequest;
@@ -1477,7 +1476,8 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         Request owsRequest = Dispatcher.REQUEST.get();
         if (owsRequest != null) {
             // retrieve the base URL from the dispatcher request
-            return RequestUtils.baseURL(Dispatcher.REQUEST.get().getHttpRequest());
+            return org.geoserver.ows.util.ResponseUtils.baseURL(
+                    Dispatcher.REQUEST.get().getHttpRequest());
         }
         // let's see if a REST end-point was targeted
         RequestInfo restRequest = RequestInfo.get();

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -46,6 +46,7 @@ import org.geoserver.ows.util.KvpMap;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.ows.util.OwsUtils;
 import org.geoserver.ows.util.RequestUtils;
+import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.Service;
@@ -730,7 +731,8 @@ public class Dispatcher extends AbstractController {
                         OwsUtils.setter(requestBean.getClass(), "baseUrl", String.class);
                 if (setBaseUrl != null) {
                     setBaseUrl.invoke(
-                            requestBean, new String[] {RequestUtils.baseURL(req.getHttpRequest())});
+                            requestBean,
+                            new String[] {ResponseUtils.baseURL(req.getHttpRequest())});
                 }
 
                 // another couple of thos of those lovley cite things, version+service has to

--- a/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
@@ -27,23 +27,6 @@ import org.geotools.util.Version;
 public class RequestUtils {
 
     /**
-     * Pulls out the base url ( from the client point of view ), from the given request object.
-     *
-     * @return A String of the form "&lt;scheme&gt;://&lt;server&gt;:&lt;port&gt;/&lt;context&gt;/"
-     * @deprecated Use {@link ResponseUtils#baseURL(HttpServletRequest)} instead
-     */
-    public static String baseURL(HttpServletRequest req) {
-        StringBuffer sb = new StringBuffer(req.getScheme());
-        sb.append("://")
-                .append(req.getServerName())
-                .append(":")
-                .append(req.getServerPort())
-                .append(req.getContextPath())
-                .append("/");
-        return sb.toString();
-    }
-
-    /**
      * Pulls out the first IP address from the X-Forwarded-For request header if it was provided;
      * otherwise just gets the client IP address.
      *


### PR DESCRIPTION
backporting this commit, so that this backport will actually do something: 

https://github.com/geoserver/geoserver/pull/3735