### PR TITLE
[GEOS-9336] Added fileEncoding=UTF-8 in surefire's configuration to a…

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1519,6 +1519,7 @@
      <testFailureIgnore>${allow.test.failure.ignore}</testFailureIgnore>
      <excludedGroups>${test.excludedGroups}</excludedGroups>
      <argLine>@{argLine} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=debug</argLine>
+     <argLine>-Dfile.encoding=UTF-8</argLine>
     </configuration>
    </plugin>
 


### PR DESCRIPTION
…void continuos failing of test testAddRemoteWfsLayerSpecialChars

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [X] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
