### PR TITLE
Add POST example with keyword search

### DIFF
--- a/doc/en/user/source/community/csw-iso/tutorial.rst
+++ b/doc/en/user/source/community/csw-iso/tutorial.rst
@@ -152,3 +152,23 @@ This should yield the following result::
       </csw:DomainValues>
     </csw:GetDomainResponse>
 
+To request more than the first 10 records or for more complex queries you can use a HTTP POST request with an XML query as the request body. For example, using the maxRecords option in the following request it is possible to return the first 50 layers with "ImageMosaic" in a keyword::
+  
+  http://localhost:8080/geoserver/csw
+  
+Postbody::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <GetRecords service="CSW" version="2.0.2" maxRecords="50" startPosition="1" resultType="results" outputFormat="application/xml" outputSchema="http://www.opengis.net/cat/csw/2.0.2" xmlns="http://www.opengis.net/cat/csw/2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ows="http://www.opengis.net/ows" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 ../../../csw/2.0.2/CSW-discovery.xsd">
+      <Query typeNames="csw:Record">
+      	<ElementSetName typeNames="csw:Record">full</ElementSetName>
+      	<Constraint version="1.1.0">
+      	  <ogc:Filter>
+      	    <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
+      	      <ogc:PropertyName>dc:subject</ogc:PropertyName>
+      	      <ogc:Literal>%ImageMosaic%</ogc:Literal>
+      	    </ogc:PropertyIsLike>
+      	  </ogc:Filter>
+      	</Constraint>
+      </Query>
+    </GetRecords>


### PR DESCRIPTION
This proposal adds and example of how you might query CSW using an HTTP POST request and also demonstrates how to search the keywords and increase the number of results returned.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
