### PR TITLE
Reduce tests verboseness

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/api/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/api/features/ApiTest.java
@@ -193,7 +193,7 @@ public class ApiTest extends FeaturesTestSupport {
         assertEquals("application/x-yaml", response.getContentType());
         String yaml = string(new ByteArrayInputStream(response.getContentAsString().getBytes()));
 
-        System.out.println(yaml);
+        // System.out.println(yaml);
 
         ObjectMapper mapper = Yaml.mapper();
         OpenAPI api = mapper.readValue(yaml, OpenAPI.class);

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/api/images/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/api/images/ApiTest.java
@@ -149,7 +149,7 @@ public class ApiTest extends ImagesTestSupport {
         assertEquals(200, response.getStatus());
         assertEquals("application/x-yaml", response.getContentType());
         String yaml = string(new ByteArrayInputStream(response.getContentAsString().getBytes()));
-        System.out.println(yaml);
+        // System.out.println(yaml);
 
         ObjectMapper mapper = Yaml.mapper();
         OpenAPI api = mapper.readValue(yaml, OpenAPI.class);

--- a/src/community/oseo/oseo-core/src/test/java/org/geoserver/opensearch/eo/JDBCOpenSearchAccessTest.java
+++ b/src/community/oseo/oseo-core/src/test/java/org/geoserver/opensearch/eo/JDBCOpenSearchAccessTest.java
@@ -420,7 +420,7 @@ public class JDBCOpenSearchAccessTest {
 
     @Test
     public void testCustomProductClassGranules() throws Exception {
-        System.out.println(osAccess.getNames());
+        // System.out.println(osAccess.getNames());
         FeatureSource<FeatureType, Feature> featureSource =
                 osAccess.getFeatureSource(new NameImpl(TEST_NAMESPACE, "GS_TEST"));
         assertEquals(0, featureSource.getCount(Query.ALL));

--- a/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionLayerTest.java
+++ b/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionLayerTest.java
@@ -74,12 +74,6 @@ public class CollectionLayerTest extends OSEORestTestSupport {
     }
 
     @Override
-    protected String getLogConfiguration() {
-        // return "/GEOTOOLS_DEVELOPER_LOGGING.properties";
-        return super.getLogConfiguration();
-    }
-
-    @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         // PNGJ has bugs with band selected data, fall back on JDK
         super.onSetUp(testData);

--- a/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionsControllerTest.java
+++ b/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionsControllerTest.java
@@ -34,12 +34,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 public class CollectionsControllerTest extends OSEORestTestSupport {
 
-    @Override
-    protected String getLogConfiguration() {
-        // return "/GEOTOOLS_DEVELOPER_LOGGING.properties";
-        return super.getLogConfiguration();
-    }
-
     @Test
     public void testGetCollections() throws Exception {
         DocumentContext json = getAsJSONPath("/rest/oseo/collections", 200);

--- a/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/ProductsControllerTest.java
+++ b/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/ProductsControllerTest.java
@@ -70,12 +70,6 @@ public class ProductsControllerTest extends OSEORestTestSupport {
         return true;
     }
 
-    @Override
-    protected String getLogConfiguration() {
-        // return "/GEOTOOLS_DEVELOPER_LOGGING.properties";
-        return super.getLogConfiguration();
-    }
-
     @Before
     public void cleanupTestProduct() throws IOException {
         DataStoreInfo ds = getCatalog().getDataStoreByName("oseo");

--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/config/DefaultControlFlowConfigurationTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/config/DefaultControlFlowConfigurationTest.java
@@ -64,7 +64,7 @@ public class DefaultControlFlowConfigurationTest {
 
         assertEquals(10, controllers.size());
 
-        System.out.println(controllers);
+        // System.out.println(controllers);
 
         assertTrue(controllers.get(0) instanceof RateFlowController);
         RateFlowController rfc = (RateFlowController) controllers.get(0);

--- a/src/extension/css/src/test/java/org/geoserver/community/css/web/StyleEditCssRecoveryTest.java
+++ b/src/extension/css/src/test/java/org/geoserver/community/css/web/StyleEditCssRecoveryTest.java
@@ -37,7 +37,7 @@ public class StyleEditCssRecoveryTest extends GeoServerWicketTestSupport {
 
     protected void setUpTestData(SystemTestData testData) throws Exception {
         super.setUpTestData(testData);
-        System.out.println("setUpTestData()");
+        // System.out.println("setUpTestData()");
 
         Date t0 = new Date(1483228800000L); // Midnight Jan 1, 2017 UTC
         List<String> testStyleNames =

--- a/src/extension/geofence/src/test/java/org/geoserver/geofence/CacheReaderTest.java
+++ b/src/extension/geofence/src/test/java/org/geoserver/geofence/CacheReaderTest.java
@@ -227,7 +227,7 @@ public class CacheReaderTest extends GeofenceBaseTest {
 
         // reloading should have been triggered
         ticker.setMillisec(700);
-        System.out.println("sleeping...");
+        // System.out.println("sleeping...");
         Thread.sleep(500);
         // System.out.println(cachedRuleReader.getStats());
         assertEquals(hitExp, cachedRuleReader.getStats().hitCount());

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportControllerTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportControllerTest.java
@@ -351,7 +351,7 @@ public class ImportControllerTest extends ImporterTestSupport {
 
         res = dispatch(req);
         assertEquals(200, res.getStatus());
-        System.out.println(res.getContentAsString());
+        // System.out.println(res.getContentAsString());
         assertEquals("text/html", res.getContentType());
     }
 

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportDataControllerTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportDataControllerTest.java
@@ -42,7 +42,7 @@ public class ImportDataControllerTest extends ImporterTestSupport {
     public void testGetFile() throws Exception {
         JSONObject json =
                 (JSONObject) getAsJSON(ROOT_PATH + "/imports/0/data/files/archsites.shp", 200);
-        System.out.println(json);
+        // System.out.println(json);
         assertEquals("archsites.shp", json.getString("file"));
         assertEquals("archsites.prj", json.getString("prj"));
     }

--- a/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSNetCDFMosaicTest.java
+++ b/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSNetCDFMosaicTest.java
@@ -289,7 +289,7 @@ public class WCSNetCDFMosaicTest extends WCSNetCDFBaseTest {
 
             // we expect a single granule which covers the entire mosaic
             for (GridCoverage2D c : stack.getGranules()) {
-                System.out.println(c.getEnvelope());
+                // System.out.println(c.getEnvelope());
                 assertEquals(45., c.getEnvelope2D().getHeight(), 0.001);
                 assertEquals(30., c.getEnvelope2D().getWidth(), 0.001);
             }

--- a/src/extension/security/cas/src/test/java/org/geoserver/security/cas/CasAuthenticationTest.java
+++ b/src/extension/security/cas/src/test/java/org/geoserver/security/cas/CasAuthenticationTest.java
@@ -49,7 +49,6 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
@@ -167,11 +166,11 @@ public class CasAuthenticationTest extends AbstractAuthenticationProviderTest {
                     "logoutRequest", paramValue.substring(paramValue.indexOf("=") + 1));
             try {
                 GeoServerSecurityFilterChainProxy proxy = getProxy();
-                System.out.println("SERVCIE: " + service);
-                System.out.println("URL: " + request.getRequestURL().toString());
-                for (SecurityFilterChain c : proxy.getFilterChains()) {
-                    System.out.println(c.toString());
-                }
+                //                System.out.println("SERVCIE: " + service);
+                //                System.out.println("URL: " + request.getRequestURL().toString());
+                //                for (SecurityFilterChain c : proxy.getFilterChains()) {
+                //                    System.out.println(c.toString());
+                //                }
                 proxy.doFilter(request, response, chain);
             } catch (ServletException e) {
                 throw new RuntimeException(e);

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/topojson/TopoJSONEncoderTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/topojson/TopoJSONEncoderTest.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.output.NullOutputStream;
 import org.geoserver.wms.topojson.TopoGeom.GeometryColleciton;
 import org.junit.Test;
 import org.locationtech.jts.geom.LineString;
@@ -38,7 +39,7 @@ public class TopoJSONEncoderTest {
         layers.put("topp:states", layer);
 
         Topology topology = new Topology(identity, arcs, layers);
-        Writer writer = new OutputStreamWriter(System.out);
+        Writer writer = new OutputStreamWriter(new NullOutputStream());
         encoder.encode(topology, writer);
     }
 
@@ -67,7 +68,7 @@ public class TopoJSONEncoderTest {
         layers.put("topp:states", layer);
         Topology topology = new Topology(tx, arcs, layers);
 
-        Writer writer = new OutputStreamWriter(System.out);
+        Writer writer = new OutputStreamWriter(new NullOutputStream());
         encoder.encode(topology, writer);
     }
 

--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSExecuteTransformerTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSExecuteTransformerTest.java
@@ -63,7 +63,7 @@ public class WPSExecuteTransformerTest extends GeoServerWicketTestSupport {
         WPSExecuteTransformer tx = new WPSExecuteTransformer();
         tx.setIndentation(2);
         String xml = tx.transform(executeBuffer);
-        System.out.println(xml);
+        // System.out.println(xml);
 
         String expected =
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -326,8 +326,8 @@ public class WPSExecuteTransformerTest extends GeoServerWicketTestSupport {
         if (!p.getValidationErrors().isEmpty()) {
             for (Iterator e = p.getValidationErrors().iterator(); e.hasNext(); ) {
                 SAXParseException ex = (SAXParseException) e.next();
-                System.out.println(
-                        ex.getLineNumber() + "," + ex.getColumnNumber() + " -" + ex.toString());
+                // System.out.println(
+                //       ex.getLineNumber() + "," + ex.getColumnNumber() + " -" + ex.toString());
             }
             fail("Document did not validate.");
         }

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ppio/ProcessParameterIOTest2.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ppio/ProcessParameterIOTest2.java
@@ -28,6 +28,6 @@ public class ProcessParameterIOTest2 extends WPSTestSupport {
     public void testGetWFSByMimeType() {
         Parameter p = new Parameter<>("WFS", WFSPPIO.class);
         ProcessParameterIO ppio = ProcessParameterIO.find(p, null, "text/xml");
-        System.out.println(ppio);
+        // System.out.println(ppio);
     }
 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCDataSecurityTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCDataSecurityTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +26,6 @@ import org.geoserver.data.test.CiteTestData;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.data.test.SystemTestData.LayerProperty;
-import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.CatalogMode;
 import org.geoserver.security.CoverageAccessLimits;
@@ -440,25 +438,27 @@ public class GWCDataSecurityTest extends WMSTestSupport {
     @Test
     public void testPermissionCropTileWmts() throws Exception {
 
-        System.out.println(
-                Arrays.toString(
-                        GWC.get()
-                                .getTileLayerByName("sf:mosaic")
-                                .getGridSubset("EPSG:900913")
-                                .getCoverage(13)));
-        System.out.println(
-                GWC.get()
-                        .getTileLayerByName("sf:mosaic")
-                        .getGridSubset("EPSG:900913")
-                        .getOriginalExtent());
-        System.out.println(
-                ((LayerInfo)
-                                ((GeoServerTileLayer) (GWC.get().getTileLayerByName("sf:mosaic")))
-                                        .getPublishedInfo())
-                        .getResource()
-                        .getLatLonBoundingBox());
-        System.out.println(
-                getCatalog().getLayerByName("sf:mosaic").getResource().getLatLonBoundingBox());
+        //        System.out.println(
+        //                Arrays.toString(
+        //                        GWC.get()
+        //                                .getTileLayerByName("sf:mosaic")
+        //                                .getGridSubset("EPSG:900913")
+        //                                .getCoverage(13)));
+        //        System.out.println(
+        //                GWC.get()
+        //                        .getTileLayerByName("sf:mosaic")
+        //                        .getGridSubset("EPSG:900913")
+        //                        .getOriginalExtent());
+        //        System.out.println(
+        //                ((LayerInfo)
+        //                                ((GeoServerTileLayer)
+        // (GWC.get().getTileLayerByName("sf:mosaic")))
+        //                                        .getPublishedInfo())
+        //                        .getResource()
+        //                        .getLatLonBoundingBox());
+        //        System.out.println(
+        //
+        // getCatalog().getLayerByName("sf:mosaic").getResource().getLatLonBoundingBox());
         doPermissionCropTileTest(
                 (layer, index) ->
                         String.format(

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderIntTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderIntTest.java
@@ -108,7 +108,7 @@ public class CatalogBuilderIntTest extends GeoServerSystemTestSupport {
             }
         }
         mosaic.mkdir();
-        System.out.println(mosaic.getAbsolutePath());
+        // System.out.println(mosaic.getAbsolutePath());
 
         // build the reference coverage into a byte array
         GridCoverageFactory factory = new GridCoverageFactory();

--- a/src/main/src/test/java/org/geoserver/config/util/LayerIdentifierInfoListConverterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/LayerIdentifierInfoListConverterTest.java
@@ -64,7 +64,7 @@ public class LayerIdentifierInfoListConverterTest {
         list.add(id2);
 
         String actual = LayerIdentifierInfoListConverter.toString(list);
-        System.out.println(actual);
+        // System.out.println(actual);
         String expected =
                 "[{\"authority\":\"auth1\",\"identifier\":\"IDENTIFIER_1\"},{\"authority\":\"auth2\",\"identifier\":\"IDENTIFIER_2\"}]";
         assertEquals(expected, actual);

--- a/src/main/src/test/java/org/geoserver/system/status/SystemInfoCollectorTest.java
+++ b/src/main/src/test/java/org/geoserver/system/status/SystemInfoCollectorTest.java
@@ -25,12 +25,13 @@ public class SystemInfoCollectorTest extends GeoServerSystemTestSupport {
         final Metrics collected = systemInfoCollector.retrieveAllSystemInfo();
         final List<MetricValue> metrics = collected.getMetrics();
         for (MetricValue m : metrics) {
-            if (m.getAvailable()) {
-                System.out.println(
-                        m.getName() + " IS available -> " + m.getValue() + " " + m.getUnit());
-            } else {
-                System.err.println(m.getName() + " IS NOT available");
-            }
+            //            if (m.getAvailable()) {
+            //                System.out.println(
+            //                        m.getName() + " IS available -> " + m.getValue() + " " +
+            // m.getUnit());
+            //            } else {
+            //                System.err.println(m.getName() + " IS NOT available");
+            //            }
             collector.checkThat(
                     "Metric for " + m.getName() + " available but value is not retrived",
                     (m.getAvailable() && !m.getValue().equals(BaseSystemInfoCollector.DEFAULT_VALUE)

--- a/src/main/test/org/vfny/geoserver/config/ValidationTest.java
+++ b/src/main/test/org/vfny/geoserver/config/ValidationTest.java
@@ -35,21 +35,21 @@ public class ValidationTest extends TestCase {
 		pluginConfig.setClassName(GazetteerNameValidation.class.getName());
 		testConfig.setPlugIn(pluginConfig);
 
-		System.out.println(testConfig.toString());
-		System.out.println("--------------------------------------");
-		for (int i = 0; i < testConfig.getPropertyDescriptors().length; i++) {
-			
-			System.out.println(testConfig.getPropertyDescriptors()[i].getClass().getName());
-			System.out.println(testConfig.getPropertyDescriptors()[i].getDisplayName());
-			System.out.println(testConfig.getPropertyDescriptors()[i].getShortDescription());
-			
-			System.out.println(testConfig.getPropertyDescriptors()[i].attributeNames());
-			System.out.println("--------------------------------------");
-		}
-
-		System.out.println("--------------------------------------");
-		System.out.println("--------------------------------------");
-		System.out.println("--------------------------------------");
+//		System.out.println(testConfig.toString());
+//		System.out.println("--------------------------------------");
+//		for (int i = 0; i < testConfig.getPropertyDescriptors().length; i++) {
+//			
+//			System.out.println(testConfig.getPropertyDescriptors()[i].getClass().getName());
+//			System.out.println(testConfig.getPropertyDescriptors()[i].getDisplayName());
+//			System.out.println(testConfig.getPropertyDescriptors()[i].getShortDescription());
+//			
+//			System.out.println(testConfig.getPropertyDescriptors()[i].attributeNames());
+//			System.out.println("--------------------------------------");
+//		}
+//
+//		System.out.println("--------------------------------------");
+//		System.out.println("--------------------------------------");
+//		System.out.println("--------------------------------------");
 		
 		
 		testConfig = new TestConfig();
@@ -61,16 +61,16 @@ public class ValidationTest extends TestCase {
 
 		PropertyDescriptor [] pd = pluginConfig.getPropertyDescriptors();
 		
-		System.out.println(pluginConfig.toString());
-		System.out.println("--------------------------------------");
-		for (int i = 0; i < pluginConfig.getPropertyDescriptors().length; i++) {
-			
-			System.out.println(pd[i].getClass().getName());
-			System.out.println(ArgumentConfig.getDisplayName(pd[i]));
-			System.out.println(ArgumentConfig.getDescription(pd[i]));
-			
-			System.out.println("--------------------------------------");
-		}
+//		System.out.println(pluginConfig.toString());
+//		System.out.println("--------------------------------------");
+//		for (int i = 0; i < pluginConfig.getPropertyDescriptors().length; i++) {
+//			
+//			System.out.println(pd[i].getClass().getName());
+//			System.out.println(ArgumentConfig.getDisplayName(pd[i]));
+//			System.out.println(ArgumentConfig.getDescription(pd[i]));
+//			
+//			System.out.println("--------------------------------------");
+//		}
 		
 
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1518,8 +1518,7 @@
      <printSummary>true</printSummary>
      <testFailureIgnore>${allow.test.failure.ignore}</testFailureIgnore>
      <excludedGroups>${test.excludedGroups}</excludedGroups>
-     <argLine>@{argLine} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=debug</argLine>
-     <argLine>-Dfile.encoding=UTF-8</argLine>
+     <argLine>@{argLine} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=debug -Dfile.encoding=UTF-8</argLine>
     </configuration>
    </plugin>
 

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
@@ -304,7 +304,7 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
 
         String dom = getAsString(BASEPATH + "/workspaces/gs/datastores/pds/featuretypes.xml");
 
-        System.out.println(dom);
+        // System.out.println(dom);
     }
 
     @Test
@@ -716,7 +716,7 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
                 getAsString(
                         BASEPATH
                                 + "/workspaces/sf/datastores/sf/featuretypes/PrimitiveGeoFeature.json");
-        System.out.println(json);
+        // System.out.println(json);
         MockHttpServletResponse response =
                 putAsServletResponse(
                         BASEPATH + "/workspaces/sf/datastores/sf/featuretypes/PrimitiveGeoFeature",

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerControllerTest.java
@@ -288,7 +288,7 @@ public class LayerControllerTest extends CatalogRESTTestSupport {
         MockHttpServletResponse response =
                 postAsServletResponse(ROOT_PATH + "/workspaces/cite/styles", xml);
 
-        System.out.println(response.getContentAsString());
+        // System.out.println(response.getContentAsString());
         assertEquals(201, response.getStatus());
         assertThat(response.getContentType(), CoreMatchers.startsWith(MediaType.TEXT_PLAIN_VALUE));
         assertNotNull(cat.getStyleByName("cite", "foo"));

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
@@ -156,7 +156,7 @@ public class WorkspaceTest extends CatalogRESTTestSupport {
         assertEquals(201, response.getStatus());
         assertEquals(MediaType.TEXT_PLAIN_VALUE, response.getContentType());
         assertNotNull(response.getHeader("Location"));
-        System.out.println(response.getHeader("Location"));
+        // System.out.println(response.getHeader("Location"));
         assertTrue(response.getHeader("Location").endsWith("/workspaces/foo"));
 
         WorkspaceInfo ws = getCatalog().getWorkspaceByName("foo");

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/xml/GetCoverageXmlParserTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/xml/GetCoverageXmlParserTest.java
@@ -263,7 +263,7 @@ public class GetCoverageXmlParserTest {
         assertEquals("urn:ogc:def:crs:EPSG:6.6:4326", gridCRS.getGridBaseCRS());
         assertEquals("urn:ogc:def:method:WCS:1.1:2dSimpleGrid", gridCRS.getGridType());
         assertEquals("urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS", gridCRS.getGridCS());
-        System.out.println(gridCRS.getGridOrigin().getClass() + ": " + gridCRS.getGridOrigin());
+        // System.out.println(gridCRS.getGridOrigin().getClass() + ": " + gridCRS.getGridOrigin());
         assertTrue(Arrays.equals(new Double[] {10.0, 20.0}, (Double[]) gridCRS.getGridOrigin()));
         assertTrue(Arrays.equals(new Double[] {1.0, 2.0}, (Double[]) gridCRS.getGridOffsets()));
     }

--- a/src/web/core/src/test/java/org/geoserver/web/system/status/SystemStatusMonitorPanelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/system/status/SystemStatusMonitorPanelTest.java
@@ -40,7 +40,7 @@ public class SystemStatusMonitorPanelTest extends GeoServerWicketTestSupport {
         TagTester time1 = tester.getTagByWicketId("time");
         assertNotNull(time1);
         Date firstTime = formatter.parse(time1.getValue());
-        System.out.println(firstTime.getTime());
+        // System.out.println(firstTime.getTime());
         // Execute timer
         Thread.sleep(1000);
         tester.executeAllTimerBehaviors(tester.getLastRenderedPage());

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
@@ -65,7 +65,7 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
         // move to next page
         GeoServerTablePanel table =
                 (GeoServerTablePanel) tester.getComponentFromLastRenderedPage("table");
-        System.out.println(table.getDataProvider().size());
+        // System.out.println(table.getDataProvider().size());
         tester.clickLink("table:navigatorBottom:navigator:next", true);
 
         DataView data =

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/passwd/MasterPasswordChangePanelTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/passwd/MasterPasswordChangePanelTest.java
@@ -57,7 +57,7 @@ public class MasterPasswordChangePanelTest extends AbstractSecurityWicketTestSup
     @Test
     public void testPasswordViolatesPolicy() throws Exception {
         String mpw = getMasterPassword();
-        System.out.println("testPasswordViolatesPolicy: " + mpw);
+        // System.out.println("testPasswordViolatesPolicy: " + mpw);
         ft.setValue("currentPassword", mpw);
         ft.setValue("newPassword", "bar");
         ft.setValue("newPasswordConfirm", "bar");
@@ -68,7 +68,7 @@ public class MasterPasswordChangePanelTest extends AbstractSecurityWicketTestSup
     @Test
     public void testPasswordChange() throws Exception {
         String mpw = getMasterPassword();
-        System.out.println("testPasswordChange: " + mpw);
+        // System.out.println("testPasswordChange: " + mpw);
         ft.setValue("currentPassword", mpw);
         ft.setValue("newPassword", "Foobar2012");
         ft.setValue("newPasswordConfirm", "Foobar2012");

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/TransactionTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/TransactionTest.java
@@ -1021,7 +1021,7 @@ public class TransactionTest extends WFS20TestSupport {
 
         MockHttpServletResponse resp = postAsServletResponse("wfs", xml, "application/soap+xml");
         assertEquals("application/soap+xml", resp.getContentType());
-        System.out.println(resp.getContentAsString());
+        // System.out.println(resp.getContentAsString());
         Document dom = dom(new ByteArrayInputStream(resp.getContentAsString().getBytes()));
         assertEquals("soap:Envelope", dom.getDocumentElement().getNodeName());
         assertEquals(1, dom.getElementsByTagName("wfs:TransactionResponse").getLength());

--- a/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerJsonTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/describelayer/DescribeLayerJsonTest.java
@@ -77,7 +77,7 @@ public class DescribeLayerJsonTest extends WMSTestSupport {
                         + JSONType.json;
 
         String result = getAsString(request);
-        System.out.println(result);
+        // System.out.println(result);
 
         checkJSONDescribeLayer(result, layer);
     }


### PR DESCRIPTION
Attempt to further reduce the build verboseness. And checking if Travis ends up really ignoring the quietTests flag somehow. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
