### PR TITLE
[GEOS-9357] WCS 2.0 scalefactor=0 can cause excess memory usage

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/ScalingPolicy.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/ScalingPolicy.java
@@ -664,6 +664,12 @@ enum ScalingPolicy {
             case ScaleByFactor:
                 final ScaleByFactorType scaleByFactorType = scaling.getScaleByFactor();
                 double scaleFactor = scaleByFactorType.getScaleFactor();
+                if (scaleFactor <= 0) {
+                    throw new WCS20Exception(
+                            "Invalid scale factor, needs to be a positive number",
+                            WCS20Exception.WCS20ExceptionCode.InvalidScaleFactor,
+                            Double.toString(scaleFactor));
+                }
                 return new double[] {scaleFactor, scaleFactor};
             case ScaleAxesByFactor:
                 final ScaleAxisByFactorType scaleType = scaling.getScaleAxesByFactor();


### PR DESCRIPTION
It's already covered by a test, but the test took several seconds to enter the expected error condition because it was attempting a large rescale. This also brought the system in a near OOM condition that might have been the cause for the random WCS test failures.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
