### PR TITLE
[GEOS-9377] Geoserver startup gets blocked with unresponsive WMSStore

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/WMSLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/WMSLayerInfo.java
@@ -54,4 +54,10 @@ public interface WMSLayerInfo extends ResourceInfo {
     public Set<StyleInfo> getStyles();
 
     public StyleInfo getDefaultStyle();
+
+    public void reloadRemoteStyles();
+
+    public List<StyleInfo> getAllAvailableRemoteStyles();
+
+    public void setAllAvailableRemoteStyles(List<StyleInfo> allAvailableRemoteStyles);
 }

--- a/src/main/src/main/java/org/geoserver/catalog/WMSLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/WMSLayerInfo.java
@@ -47,17 +47,13 @@ public interface WMSLayerInfo extends ResourceInfo {
 
     void reset();
 
-    public String getPrefferedFormat();
+    public String getPreferredFormat();
 
-    public void setPrefferedFormat(String prefferedFormat);
+    public void setPreferredFormat(String prefferedFormat);
 
     public Set<StyleInfo> getStyles();
 
     public StyleInfo getDefaultStyle();
 
-    public void reloadRemoteStyles();
-
     public List<StyleInfo> getAllAvailableRemoteStyles();
-
-    public void setAllAvailableRemoteStyles(List<StyleInfo> allAvailableRemoteStyles);
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/WMSLayerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/WMSLayerInfoImpl.java
@@ -29,7 +29,7 @@ import org.opengis.util.ProgressListener;
 public class WMSLayerInfoImpl extends ResourceInfoImpl implements WMSLayerInfo {
 
     protected String forcedRemoteStyle = "";
-    protected String prefferedFormat = "image/png";
+    protected String preferredFormat = "image/png";
 
     private List<String> selectedRemoteFormats = new ArrayList<String>();
 
@@ -60,7 +60,8 @@ public class WMSLayerInfoImpl extends ResourceInfoImpl implements WMSLayerInfo {
     public void reset() {
         selectedRemoteStyles.clear();
         selectedRemoteFormats.clear();
-        reloadRemoteStyles();
+        getAllAvailableRemoteStyles().clear();
+        getAllAvailableRemoteStyles().addAll(getRemoteStyleInfos());
         // select all formats for use
         selectedRemoteStyles.addAll(remoteStyles());
         // set empty to take whatever is on remote server
@@ -120,18 +121,18 @@ public class WMSLayerInfoImpl extends ResourceInfoImpl implements WMSLayerInfo {
     }
 
     @Override
-    public String getPrefferedFormat() {
-        return this.prefferedFormat;
+    public String getPreferredFormat() {
+        return this.preferredFormat;
     }
 
     @Override
-    public void setPrefferedFormat(String prefferedFormat) {
-        this.prefferedFormat = (prefferedFormat == null) ? "image/png" : prefferedFormat;
+    public void setPreferredFormat(String preferredFormat) {
+        this.preferredFormat = (preferredFormat == null) ? "image/png" : preferredFormat;
     }
 
     @Override
     public boolean isFormatValid(String format) {
-        if (prefferedFormat.equalsIgnoreCase(format)) return true;
+        if (preferredFormat.equalsIgnoreCase(format)) return true;
         else return selectedRemoteFormats.contains(format);
     }
 
@@ -257,15 +258,8 @@ public class WMSLayerInfoImpl extends ResourceInfoImpl implements WMSLayerInfo {
         this.selectedRemoteStyles = selectedRemoteStyles;
     }
 
-    public void reloadRemoteStyles() {
-        this.allAvailableRemoteStyles = new ArrayList<StyleInfo>(getRemoteStyleInfos());
-    }
-
     public List<StyleInfo> getAllAvailableRemoteStyles() {
+        if (allAvailableRemoteStyles == null) allAvailableRemoteStyles = new ArrayList<StyleInfo>();
         return allAvailableRemoteStyles;
-    }
-
-    public void setAllAvailableRemoteStyles(List<StyleInfo> allAvailableRemoteStyles) {
-        this.allAvailableRemoteStyles = allAvailableRemoteStyles;
     }
 }

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingWMSLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingWMSLayerInfo.java
@@ -336,4 +336,19 @@ public class DecoratingWMSLayerInfo extends AbstractDecorator<WMSLayerInfo>
     public StyleInfo getDefaultStyle() {
         return delegate.getDefaultStyle();
     }
+
+    @Override
+    public void reloadRemoteStyles() {
+        delegate.reloadRemoteStyles();
+    }
+
+    @Override
+    public List<StyleInfo> getAllAvailableRemoteStyles() {
+        return delegate.getAllAvailableRemoteStyles();
+    }
+
+    @Override
+    public void setAllAvailableRemoteStyles(List<StyleInfo> allAvailableRemoteStyles) {
+        delegate.setAllAvailableRemoteStyles(allAvailableRemoteStyles);
+    }
 }

--- a/src/main/src/main/java/org/geoserver/security/decorators/DecoratingWMSLayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/DecoratingWMSLayerInfo.java
@@ -318,13 +318,13 @@ public class DecoratingWMSLayerInfo extends AbstractDecorator<WMSLayerInfo>
     }
 
     @Override
-    public String getPrefferedFormat() {
-        return delegate.getPrefferedFormat();
+    public String getPreferredFormat() {
+        return delegate.getPreferredFormat();
     }
 
     @Override
-    public void setPrefferedFormat(String prefferedFormat) {
-        delegate.setPrefferedFormat(prefferedFormat);
+    public void setPreferredFormat(String prefferedFormat) {
+        delegate.setPreferredFormat(prefferedFormat);
     }
 
     @Override
@@ -338,17 +338,7 @@ public class DecoratingWMSLayerInfo extends AbstractDecorator<WMSLayerInfo>
     }
 
     @Override
-    public void reloadRemoteStyles() {
-        delegate.reloadRemoteStyles();
-    }
-
-    @Override
     public List<StyleInfo> getAllAvailableRemoteStyles() {
         return delegate.getAllAvailableRemoteStyles();
-    }
-
-    @Override
-    public void setAllAvailableRemoteStyles(List<StyleInfo> allAvailableRemoteStyles) {
-        delegate.setAllAvailableRemoteStyles(allAvailableRemoteStyles);
     }
 }

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
@@ -187,7 +187,7 @@ public class WMSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
         WMSLayerInfo wmsLayerInfo = (WMSLayerInfo) layerModel.getObject().getResource();
         // for new only
         if (layerModel.getObject().getId() == null) wmsLayerInfo.reset();
-
+        wmsLayerInfo.reloadRemoteStyles();
         // empty string to use whatever default remote server has
         List<String> remoteSyles = new ArrayList<String>();
         remoteSyles.add("");

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
@@ -187,7 +187,11 @@ public class WMSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
         WMSLayerInfo wmsLayerInfo = (WMSLayerInfo) layerModel.getObject().getResource();
         // for new only
         if (layerModel.getObject().getId() == null) wmsLayerInfo.reset();
-        wmsLayerInfo.reloadRemoteStyles();
+        else {
+            wmsLayerInfo.getAllAvailableRemoteStyles().clear();
+        }
+        // reload latest styles
+        wmsLayerInfo.getAllAvailableRemoteStyles().addAll(wmsLayerInfo.getRemoteStyleInfos());
         // empty string to use whatever default remote server has
         List<String> remoteSyles = new ArrayList<String>();
         remoteSyles.add("");
@@ -218,7 +222,7 @@ public class WMSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
         DropDownChoice<String> remoteForamts =
                 new DropDownChoice<String>(
                         "remoteFormatsDropDown",
-                        new PropertyModel<String>(wmsLayerInfo, "prefferedFormat"),
+                        new PropertyModel<String>(wmsLayerInfo, "preferredFormat"),
                         wmsLayerInfo.availableFormats());
 
         remoteForamtsContainer.add(remoteForamts);

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
@@ -223,7 +223,7 @@ public class WMSLayerConfigTest extends GeoServerWicketTestSupport {
 
         // asserting Remote Style UI fields
         tester.assertModelValue(
-                "form:panel:remoteformats:remoteFormatsDropDown", wmsLayer.getPrefferedFormat());
+                "form:panel:remoteformats:remoteFormatsDropDown", wmsLayer.getPreferredFormat());
         tester.assertModelValue(
                 "form:panel:remoteformats:remoteFormatsPalette",
                 new HashSet<String>(wmsLayer.availableFormats()));

--- a/src/wms/src/main/java/org/geoserver/wms/GetMap.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMap.java
@@ -698,7 +698,7 @@ public class GetMap {
 
                     // if the format is not selected then fall back to preffered
                     if (!wmsLayer.isFormatValid(imageFormat))
-                        imageFormat = wmsLayer.getPrefferedFormat();
+                        imageFormat = wmsLayer.getPreferredFormat();
 
                     Layer = new WMSLayer(wms, gt2Layer, style, imageFormat);
 

--- a/src/wms/src/test/java/org/geoserver/wms/WMSCascadeTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSCascadeTestSupport.java
@@ -93,7 +93,7 @@ public abstract class WMSCascadeTestSupport extends WMSTestSupport {
         WMSLayerInfo roadsWmsLayer = cb.buildWMSLayer("roads_wms_130");
         roadsWmsLayer.setName("roads_wms_130");
         roadsWmsLayer.reset();
-        roadsWmsLayer.setPrefferedFormat("image/jpeg");
+        roadsWmsLayer.setPreferredFormat("image/jpeg");
         getCatalog().add(roadsWmsLayer);
         LayerInfo wmsRaodsLayer = cb.buildLayer(roadsWmsLayer);
         getCatalog().add(wmsRaodsLayer);
@@ -157,7 +157,7 @@ public abstract class WMSCascadeTestSupport extends WMSTestSupport {
         WMSLayerInfo roadsWmsLayer = cb.buildWMSLayer("roads_wms");
         roadsWmsLayer.setName("roads_wms");
         roadsWmsLayer.reset();
-        roadsWmsLayer.setPrefferedFormat("image/jpeg");
+        roadsWmsLayer.setPreferredFormat("image/jpeg");
         getCatalog().add(roadsWmsLayer);
         LayerInfo wmsRaodsLayer = cb.buildLayer(roadsWmsLayer);
 

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/WMSCascadeTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/WMSCascadeTest.java
@@ -98,8 +98,7 @@ public class WMSCascadeTest extends WMSCascadeTestSupport {
 
         LayerInfo info = getCatalog().getLayerByName("roads_wms");
         WMSLayerInfo wmsLayer = (WMSLayerInfo) info.getResource();
-        wmsLayer.setPrefferedFormat("image/jpeg");
-
+        wmsLayer.setPreferredFormat("image/jpeg");
         String getMapRequest =
                 "wms?service=WMS&version=1.1.0"
                         + "&request=GetMap"


### PR DESCRIPTION
-moved remote calls for styles out of getters
-remote calls for styles will only be made when configuring/reloading Cascaded WMS Layer from UI



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
