### PR TITLE
[GEOS-9378] Add note to CSRF section with error message in

### DIFF
--- a/doc/en/user/source/security/webadmin/csrf.rst
+++ b/doc/en/user/source/security/webadmin/csrf.rst
@@ -5,7 +5,13 @@ CSRF Protection
 
 The GeoServer web admin employs a CSRF (Cross-Site Request Forgery) protection filter that will block any form submissions that didn't appear to originate from GeoServer. This can sometimes cause problems for certain proxy configurations.
 
-To whitelist your proxy with the CSRF filter, you can use the ``GEOSERVER_CSRF_WHITELIST`` property. This property is a comma-seperated list of domains, of the form ``<domainname>.<TLD>``, and can contain a subdomains.
+.. note:: Symptoms of this problem may include the WPS request builder (and
+  other wicket pages) failing with an HTTP status of 403 and the message "Origin
+  does not correspond to request". However, you may need to view the page
+  response in a debugger to see this, to the end user it will appear as if the
+  form section of the page is just missing.
+
+To white list your proxy with the CSRF filter, you can use the ``GEOSERVER_CSRF_WHITELIST`` property. This property is a comma-separated list of domains, of the form ``<domainname>.<TLD>``, and can contain a subdomains.
 Alternatively, you can disable the CSRF filter by setting the ``GEOSERVER_CSRF_DISABLED`` property to ``true``.
 
 Each of these properties is set through one of the standard means:


### PR DESCRIPTION
It would be nice if searching for "Origin does not correspond to request" and GeoServer had a chance of finding the CSRF page (rather than an old jira issue).



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
