### PR TITLE
[GEOS-9385] GWC initialization thrashes CPU and filesystem at startup 

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/config/GWCInitializer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/config/GWCInitializer.java
@@ -309,6 +309,7 @@ public class GWCInitializer implements GeoServerReinitializer {
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.finest("Adding Layers to avoid In Memory Caching");
         }
+        // it is ok to use the ForkJoinPool.commonPool() here, there's no I/O involved
         tileLayerCatalog
                 .getLayerIds()
                 .parallelStream()

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
@@ -718,6 +718,7 @@ public class CatalogConfiguration implements TileLayerConfiguration {
         try {
             this.layerCache.invalidateAll();
             this.tileLayerCatalog.reset();
+            this.tileLayerCatalog.initialize();
         } finally {
             lock.releaseWriteLock();
         }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
@@ -89,10 +89,6 @@ public class CatalogConfiguration implements TileLayerConfiguration {
             } finally {
                 lock.releaseReadLock();
             }
-            if (null == tileLayer) {
-                throw new IllegalArgumentException(
-                        "GeoServer layer or layer group '" + layerId + "' does not exist");
-            }
             return tileLayer;
         }
     }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
@@ -68,7 +68,7 @@ public class DefaultTileLayerCatalog implements TileLayerCatalog {
                 public @Override ForkJoinWorkerThread newThread(ForkJoinPool pool) {
                     String name =
                             String.format(
-                                    "%s-%d",
+                                    "ForkJoinPool.%s-%d",
                                     DefaultTileLayerCatalog.class.getSimpleName(),
                                     threadIdSeq.incrementAndGet());
                     ForkJoinWorkerThread thread =

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
@@ -286,10 +286,14 @@ public class DefaultTileLayerCatalog implements TileLayerCatalog {
         return layer == null ? null : layer.clone();
     }
 
-    private synchronized void checkInitialized() {
-        if (!initialized) {
-            initialize();
-        }
+    /**
+     * Precondition check all public methods should make before proceeding to ensure they've been
+     * called on an initialized state
+     *
+     * @throws IllegalStateException if this layer catalog has not been initialized yet
+     */
+    private void checkInitialized() {
+        Preconditions.checkState(this.initialized, "DefaultTileLayerCatalog is not initialized");
     }
 
     @Override

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/DefaultTileLayerCatalog.java
@@ -34,9 +34,9 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.AsynchResourceIterator;
 import org.geoserver.config.util.SecureXStream;
 import org.geoserver.ows.LocalWorkspace;
-import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resource.Type;
@@ -78,24 +78,17 @@ public class DefaultTileLayerCatalog implements TileLayerCatalog {
                 }
             };
 
-    private static final int INITIALIZATION_PARALLELISM;
+    /**
+     * Reuse the value initialized for I/O parallelism through the {@code
+     * org.geoserver.catalog.loadingThreads} System property
+     */
+    private static final int INITIALIZATION_PARALLELISM =
+            AsynchResourceIterator.ASYNCH_RESOURCE_THREADS;
     /**
      * Thread local of XStream used during initialization parallel execution, to circumvent the
      * terrible concurrency of XStream
      */
     private static ThreadLocal<XStream> INITIALIZATION_SERIALIZER = new ThreadLocal<>();
-
-    static {
-        String value = GeoServerExtensions.getProperty("org.geoserver.catalog.loadingThreads");
-        if (value != null) {
-            INITIALIZATION_PARALLELISM = Integer.parseInt(value);
-        } else {
-            // empirical determination after benchmarks, the value is related not the
-            // available CPUs, but by how well the disk handles parallel access, different
-            // disk subsystems will have a different optimal value
-            INITIALIZATION_PARALLELISM = 4;
-        }
-    }
 
     private ConcurrentMap<String, GeoServerTileLayerInfo> layersById;
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -14,7 +14,7 @@ import static org.geoserver.ows.util.ResponseUtils.params;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
-import java.awt.*;
+import java.awt.Dimension;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.Cookie;
@@ -115,7 +116,17 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
 
     private String configErrorMessage;
 
-    private Map<String, GridSubset> subSets;
+    /**
+     * Lazily and atomically initialized mapping of {@link GridSubset#getName() name} to {@link
+     * GridSubset}.
+     *
+     * <p>Not to be used directly but through {@link #gridSubsets()} for querying. The map is not
+     * synchronized nor a {@code ConcurrentMap}. The reference held by this variable is reset to
+     * null instead on mutating operations such as {@link #addGridSubset} and {@link
+     * #removeGridSubset} for it to be re-computed from the corresponding {@link
+     * GeoServerTileLayerInfo} when needed.
+     */
+    private final AtomicReference<Map<String, GridSubset>> _subSets;
 
     private static LayerListenerList listeners = new LayerListenerList();
 
@@ -123,9 +134,19 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
 
     private Catalog catalog;
 
-    private String publishedId;
+    /**
+     * The {@link Catalog}'s {@link LayerInfo} or {@link LayerGroupInfo} id, when created through a
+     * constructor that receives the id instead of the {@link PublishedInfo} instance itself. See
+     * {@link #getPublishedInfo()}
+     */
+    private final String publishedInfoId;
 
-    private volatile PublishedInfo publishedInfo;
+    /**
+     * Atomic reference to the {@link PublishedInfo} this tile layer references. Either assigned
+     * directly at a constructor that receives the {@code PublishedInfo}, or computed lazily and
+     * atomically from the {@code PublishedInfo} id held at {@link #publishedInfoId}
+     */
+    private final AtomicReference<PublishedInfo> _publishedInfo;
 
     private LegendSample legendSample;
 
@@ -140,8 +161,10 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         checkNotNull(configDefaults, "configDefaults");
 
         this.gridSetBroker = gridsets;
-        this.publishedInfo = publishedInfo;
+        this._publishedInfo = new AtomicReference<>(publishedInfo);
+        this.publishedInfoId = publishedInfo.getId();
         this.info = TileLayerInfoUtil.loadOrCreate(getPublishedInfo(), configDefaults);
+        this._subSets = new AtomicReference<>();
     }
 
     public GeoServerTileLayer(
@@ -153,25 +176,29 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         checkNotNull(state, "state");
 
         this.gridSetBroker = gridsets;
-        this.publishedInfo = publishedInfo;
+        this._publishedInfo = new AtomicReference<>(publishedInfo);
+        this.publishedInfoId = publishedInfo.getId();
         this.info = state;
+        this._subSets = new AtomicReference<>();
         TileLayerInfoUtil.checkAutomaticStyles(publishedInfo, state);
     }
 
     public GeoServerTileLayer(
             final Catalog catalog,
             final String publishedId,
-            final GridSetBroker gridsets,
+            final GridSetBroker gridsetBroker,
             final GeoServerTileLayerInfo state) {
         checkNotNull(catalog, "catalog");
         checkNotNull(publishedId, "publishedId");
-        checkNotNull(gridsets, "gridsets");
+        checkNotNull(gridsetBroker, "gridsets");
         checkNotNull(state, "state");
 
-        this.gridSetBroker = gridsets;
+        this.gridSetBroker = gridsetBroker;
         this.catalog = catalog;
-        this.publishedId = publishedId;
+        this.publishedInfoId = publishedId;
+        this._publishedInfo = new AtomicReference<>();
         this.info = state;
+        this._subSets = new AtomicReference<>();
     }
 
     @Override
@@ -302,8 +329,9 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         }
 
         ReferencedEnvelope latLongBbox;
-        if (getPublishedInfo() instanceof LayerGroupInfo) {
-            LayerGroupInfo groupInfo = (LayerGroupInfo) getPublishedInfo();
+        final PublishedInfo publishedInfo = getPublishedInfo();
+        if (publishedInfo instanceof LayerGroupInfo) {
+            LayerGroupInfo groupInfo = (LayerGroupInfo) publishedInfo;
             try {
                 ReferencedEnvelope bounds = groupInfo.getBounds();
                 boolean lenient = true;
@@ -333,35 +361,48 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         return latLongBbox;
     }
 
+    /**
+     * @return the {@link LayerInfo} or {@link LayerGroupInfo} this tile layer is associated with
+     * @throws IllegalStateException if this {@code GeoServerTileLayer} was created with a {@link
+     *     PublishedInfo} id but such object does not exist in the {@link Catalog}
+     * @implNote The returned {@link PublishedInfo} is either assigned at construction time, or
+     *     lazily obtained from the catalog here in a thread contention free way
+     */
     public PublishedInfo getPublishedInfo() {
+        PublishedInfo publishedInfo = this._publishedInfo.get();
         if (publishedInfo == null) {
-            synchronized (this) {
-                if (publishedInfo == null) {
-                    // see if it's a layer or a layer group
-                    PublishedInfo work = catalog.getLayer(publishedId);
-                    if (work == null) {
-                        work = catalog.getLayerGroup(publishedId);
-                    }
-
-                    if (work != null) {
-                        TileLayerInfoUtil.checkAutomaticStyles(work, info);
-                    } else {
-                        throw new IllegalStateException(
-                                "Could not locate a layer or layer group with id "
-                                        + publishedId
-                                        + " within GeoServer configuration, the GWC configuration seems to be out of synch");
-                    }
-                    this.publishedInfo = work;
-                }
-            }
+            publishedInfo =
+                    this._publishedInfo.accumulateAndGet(
+                            null,
+                            (currVal, nullUpdateVal) -> {
+                                if (currVal == null) {
+                                    // see if it's a layer or a layer group
+                                    PublishedInfo catalogLayer = catalog.getLayer(publishedInfoId);
+                                    if (catalogLayer == null) {
+                                        catalogLayer = catalog.getLayerGroup(publishedInfoId);
+                                    }
+                                    if (catalogLayer == null) {
+                                        throw new IllegalStateException(
+                                                "Could not locate a layer or layer group with id "
+                                                        + publishedInfoId
+                                                        + " within GeoServer configuration, the GWC configuration seems to be out of synch");
+                                    } else {
+                                        TileLayerInfoUtil.checkAutomaticStyles(catalogLayer, info);
+                                    }
+                                    return catalogLayer;
+                                }
+                                // returning null when the current value is not null, prevents
+                                // accumulateAndGet from replacing the current reference
+                                return null;
+                            });
         }
-
         return publishedInfo;
     }
 
     private ResourceInfo getResourceInfo() {
-        return getPublishedInfo() instanceof LayerInfo
-                ? ((LayerInfo) getPublishedInfo()).getResource()
+        PublishedInfo publishedInfo = getPublishedInfo();
+        return publishedInfo instanceof LayerInfo
+                ? ((LayerInfo) publishedInfo).getResource()
                 : null;
     }
 
@@ -379,7 +420,11 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         List<String> keywords = Collections.emptyList();
         List<ContactInformation> contacts = Collections.emptyList();
 
-        ResourceInfo resourceInfo = getResourceInfo();
+        PublishedInfo publishedInfo = getPublishedInfo();
+        ResourceInfo resourceInfo =
+                publishedInfo instanceof LayerInfo
+                        ? ((LayerInfo) publishedInfo).getResource()
+                        : null;
         if (resourceInfo != null) {
             title = resourceInfo.getTitle();
             description = resourceInfo.getAbstract();
@@ -798,34 +843,44 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
 
     /** @see org.geowebcache.layer.TileLayer#getGridSubsets() */
     @Override
-    public synchronized Set<String> getGridSubsets() {
-        checkGridSubsets();
-        return new HashSet<String>(subSets.keySet());
+    public Set<String> getGridSubsets() {
+        return new HashSet<String>(gridSubsets().keySet());
     }
 
     @Override
     public GridSubset getGridSubset(final String gridSetId) {
-        checkGridSubsets();
-        return subSets.get(gridSetId);
+        return gridSubsets().get(gridSetId);
     }
 
-    private synchronized void checkGridSubsets() {
-        if (this.subSets == null) {
-            ReferencedEnvelope latLongBbox = getLatLonBbox();
-            try {
-                this.subSets = getGrids(latLongBbox, gridSetBroker);
-            } catch (ConfigurationException e) {
-                String msg = "Can't create grids for '" + getName() + "': " + e.getMessage();
-                LOGGER.log(Level.WARNING, msg, e);
-                setConfigErrorMessage(msg);
-            }
+    /**
+     * Returns the cached grid subsets from {@link #_subSets} if present, or atomically computes it
+     * and returns the cached reference.
+     */
+    private Map<String, GridSubset> gridSubsets() {
+        Map<String, GridSubset> gridSubsets = this._subSets.get();
+        // compute the grid subsets atomically without thread contention
+        while (gridSubsets == null) {
+            // pass null as the update value (first arg) so it's lazly computed inside the
+            // function only if needed
+            gridSubsets =
+                    this._subSets.accumulateAndGet(
+                            null,
+                            (currValue, nullNewValue) -> {
+                                if (currValue == null) {
+                                    return computeGridSubsets();
+                                }
+                                // returning null when the current value is not null, prevents
+                                // accumulateAndGet from replacing the current reference
+                                return null;
+                            });
         }
+        return gridSubsets;
     }
 
     @Override
-    public synchronized GridSubset removeGridSubset(String gridSetId) {
-        checkGridSubsets();
-        final GridSubset oldValue = this.subSets.remove(gridSetId);
+    public GridSubset removeGridSubset(String gridSetId) {
+        gridSubsets();
+        final GridSubset oldValue = gridSubsets().remove(gridSetId);
 
         Set<XMLGridSubset> gridSubsets = new HashSet<XMLGridSubset>(info.getGridSubsets());
         for (Iterator<XMLGridSubset> it = gridSubsets.iterator(); it.hasNext(); ) {
@@ -835,6 +890,8 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
             }
         }
         info.setGridSubsets(gridSubsets);
+        // reset lazy value
+        this._subSets.set(null);
         return oldValue;
     }
 
@@ -847,7 +904,24 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         Set<XMLGridSubset> gridSubsets = new HashSet<XMLGridSubset>(info.getGridSubsets());
         gridSubsets.add(gridSubsetInfo);
         info.setGridSubsets(gridSubsets);
-        this.subSets = null;
+        // reset lazy value
+        this._subSets.set(null);
+    }
+
+    /**
+     * Actually computes the layer's {@link GridSubset}s. This method is intended as a helper for
+     * {@link #gridSubsets()} to compute the mappings atomically in a lock-free way
+     */
+    private Map<String, GridSubset> computeGridSubsets() {
+        ReferencedEnvelope latLongBbox = getLatLonBbox();
+        try {
+            return getGrids(latLongBbox, gridSetBroker);
+        } catch (ConfigurationException e) {
+            String msg = "Can't create grids for '" + getName() + "': " + e.getMessage();
+            LOGGER.log(Level.WARNING, msg, e);
+            setConfigErrorMessage(msg);
+            throw new IllegalStateException(e);
+        }
     }
 
     private Map<String, GridSubset> getGrids(
@@ -929,11 +1003,12 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         }
 
         ReferencedEnvelope nativeBounds;
-        if (getResourceInfo() != null) {
+        final ResourceInfo resourceInfo = getResourceInfo();
+        if (resourceInfo != null) {
             // projection policy for these bounds are already taken care of by the geoserver
             // configuration
             try {
-                nativeBounds = getResourceInfo().boundingBox();
+                nativeBounds = resourceInfo.boundingBox();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -1299,6 +1374,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
 
     @Override
     public Map<String, org.geowebcache.config.legends.LegendInfo> getLayerLegendsInfo() {
+        final PublishedInfo publishedInfo = getPublishedInfo();
         if (!(publishedInfo instanceof LayerInfo)) {
             return Collections.emptyMap();
         }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -161,22 +161,6 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
     public GeoServerTileLayer(
             final Catalog catalog,
             final String publishedId,
-            final GWCConfig configDefaults,
-            final GridSetBroker gridsets) {
-        checkNotNull(catalog, "catalog");
-        checkNotNull(publishedId, "publishedId");
-        checkNotNull(gridsets, "gridsets");
-        checkNotNull(configDefaults, "configDefaults");
-
-        this.gridSetBroker = gridsets;
-        this.catalog = catalog;
-        this.publishedId = publishedId;
-        this.info = TileLayerInfoUtil.loadOrCreate(getPublishedInfo(), configDefaults);
-    }
-
-    public GeoServerTileLayer(
-            final Catalog catalog,
-            final String publishedId,
             final GridSetBroker gridsets,
             final GeoServerTileLayerInfo state) {
         checkNotNull(catalog, "catalog");

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
@@ -15,6 +15,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Level;
@@ -54,6 +55,21 @@ public class StyleParameterFilter extends ParameterFilter {
 
     public StyleParameterFilter() {
         super("STYLES");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getKey(), this.allowedStyles);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof StyleParameterFilter)) {
+            return false;
+        }
+        StyleParameterFilter s = (StyleParameterFilter) o;
+        return Objects.equals(getKey(), s.getKey())
+                && Objects.equals(allowedStyles, s.allowedStyles);
     }
 
     @Override

--- a/src/gwc/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
@@ -101,8 +101,10 @@ public class RESTIntegrationTest extends GeoServerSystemTestSupport {
         assertXpathEvaluatesTo("true", "/GeoServerLayer/enabled", dom);
         assertXpathEvaluatesTo("image/png", "/GeoServerLayer/mimeFormats/string[1]", dom);
         assertXpathEvaluatesTo("image/jpeg", "/GeoServerLayer/mimeFormats/string[2]", dom);
-        assertXpathEvaluatesTo(
-                "EPSG:900913", "/GeoServerLayer/gridSubsets/gridSubset[1]/gridSetName", dom);
+
+        assertXpathEvaluatesTo("2", "count(/GeoServerLayer/gridSubsets/gridSubset)", dom);
+        assertXpathExists("/GeoServerLayer/gridSubsets/gridSubset[gridSetName='EPSG:900913']", dom);
+        assertXpathExists("/GeoServerLayer/gridSubsets/gridSubset[gridSetName='EPSG:4326']", dom);
         assertXpathNotExists("/GeoServerLayer/autoCacheStyles", dom);
     }
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogConfigurationLayerConformanceTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogConfigurationLayerConformanceTest.java
@@ -162,6 +162,7 @@ public class CatalogConfigurationLayerConformanceTest extends LayerConfiguration
                 new XMLConfiguration(
                         context.getContextProvider(), (ConfigurationResourceProvider) null);
         TileLayerCatalog tlCatalog = new DefaultTileLayerCatalog(resourceLoader, xmlConfig);
+        tlCatalog.initialize();
 
         return new CatalogConfiguration(catalog, tlCatalog, gsBroker);
     }
@@ -179,7 +180,7 @@ public class CatalogConfigurationLayerConformanceTest extends LayerConfiguration
                 new XMLConfiguration(
                         context.getContextProvider(), (ConfigurationResourceProvider) null);
         TileLayerCatalog tlCatalog = new DefaultTileLayerCatalog(resourceLoader, xmlConfig);
-
+        tlCatalog.initialize();
         return new CatalogConfiguration(catalog, tlCatalog, gsBroker);
     }
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/DefaultTileLayerCatalogTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/DefaultTileLayerCatalogTest.java
@@ -54,6 +54,7 @@ public class DefaultTileLayerCatalogTest {
                                 new SecureXStream(), (WebApplicationContext) null, Context.PERSIST);
 
         catalog = new DefaultTileLayerCatalog(resourceLoader, xStream);
+        catalog.initialize();
     }
 
     @Test

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/DefaultTileLayerCatalogTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/DefaultTileLayerCatalogTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import org.apache.commons.io.FileUtils;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.config.util.SecureXStream;
@@ -47,9 +48,10 @@ public class DefaultTileLayerCatalogTest {
 
         new File(baseDirectory, "gwc-layers").mkdir();
 
-        XStream xStream =
-                XMLConfiguration.getConfiguredXStreamWithContext(
-                        new SecureXStream(), (WebApplicationContext) null, Context.PERSIST);
+        Supplier<XStream> xStream =
+                () ->
+                        XMLConfiguration.getConfiguredXStreamWithContext(
+                                new SecureXStream(), (WebApplicationContext) null, Context.PERSIST);
 
         catalog = new DefaultTileLayerCatalog(resourceLoader, xStream);
     }

--- a/src/main/src/main/java/org/geoserver/config/AsynchResourceIterator.java
+++ b/src/main/src/main/java/org/geoserver/config/AsynchResourceIterator.java
@@ -34,7 +34,7 @@ public class AsynchResourceIterator<T> implements Iterator<T>, Closeable {
 
     static final Logger LOGGER = Logging.getLogger(AsynchResourceIterator.class);
 
-    static final int ASYNCH_RESOURCE_THREADS;
+    public static final int ASYNCH_RESOURCE_THREADS;
 
     static {
         String value = GeoServerExtensions.getProperty("org.geoserver.catalog.loadingThreads");

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/AbstractParameterFilterSubform.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/AbstractParameterFilterSubform.java
@@ -6,9 +6,13 @@
 
 package org.geoserver.gwc.web.layer;
 
+import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.FormComponentPanel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.PropertyModel;
+import org.geowebcache.filter.parameters.CaseNormalizer;
+import org.geowebcache.filter.parameters.CaseNormalizingParameterFilter;
 import org.geowebcache.filter.parameters.ParameterFilter;
 
 /**
@@ -20,6 +24,8 @@ public abstract class AbstractParameterFilterSubform<T extends ParameterFilter>
         extends FormComponentPanel<T> {
 
     private static final long serialVersionUID = -213688039804104263L;
+
+    protected Component normalize;
 
     public AbstractParameterFilterSubform(String id, IModel<T> model) {
         super(id, model);
@@ -36,5 +42,41 @@ public abstract class AbstractParameterFilterSubform<T extends ParameterFilter>
                 });
         T filter = getModelObject();
         setConvertedInput(filter);
+    }
+
+    /**
+     * Adds the {@link CaseNormalizerSubform} component.
+     *
+     * @implNote Note we're calling {@code filter.setNormalize(filter.getNormalize());} to make the
+     *     {@link CaseNormalizer} instance variable explicitly set, because otherwise a new instance
+     *     is returned upon each invocation of {@link
+     *     CaseNormalizingParameterFilter#getNormalize()}. This is a workaround for a side effect of
+     *     an implementation detail in CaseNormalizingParameterFilter (super class of
+     *     StringParameterFilter and RegExParameterFilter) that makes this form's updated value not
+     *     to be set if a CaseNormalizer wasn't explicitly set before. Rationale being that before
+     *     GWC configuration objects properly implemented equals() and hashCode(),
+     *     CaseNormalizer.equals() always returned false, and hence
+     *     org.apache.wicket.Component.setDefaultModelObject() (from new
+     *     PropertyModel<CaseNormalizer>(model, "normalize") bellow) will always update the model.
+     *     With equals and hashCode properly implemented though, Component.setDefaultModelObject()
+     *     will not enter the {@code if (!getModelComparator().compare(this, object))} condition and
+     *     hence won't reach {@code model.setObject(object);}, since it will be comparing two
+     *     equivalent instances, product of CaseNormalizingParameterFilter.getNormalize() returning
+     *     a new CaseNormalizer instance when a value is not explicitly set.
+     *     <p>This workaround is side effect free since the net result of Filter having an explicit
+     *     value for its normalize instance variable is guaranteed anyways by the way the form
+     *     works.
+     *     <p>In the long run what should happen is that StringParameterFilter and CaseNormalizer
+     *     behave like simple POJOs instead of being clever about returning a new default value on
+     *     each accessor invocation.
+     *     <p>This same workaround is applied to RegExParameterFilterSubform
+     */
+    protected void addNormalize(IModel<? extends CaseNormalizingParameterFilter> model) {
+        CaseNormalizingParameterFilter filter = model.getObject();
+        filter.setNormalize(filter.getNormalize());
+        normalize =
+                new CaseNormalizerSubform(
+                        "normalize", new PropertyModel<CaseNormalizer>(model, "normalize"));
+        add(normalize);
     }
 }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/RegexParameterFilterSubform.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/RegexParameterFilterSubform.java
@@ -15,7 +15,6 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
-import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.RegexParameterFilter;
 
 /**
@@ -48,8 +47,6 @@ public class RegexParameterFilterSubform
     /** serialVersionUID */
     private static final long serialVersionUID = 1L;
 
-    private Component normalize;
-
     public RegexParameterFilterSubform(String id, IModel<RegexParameterFilter> model) {
         super(id, model);
 
@@ -68,9 +65,6 @@ public class RegexParameterFilterSubform
 
         add(regex);
 
-        normalize =
-                new CaseNormalizerSubform(
-                        "normalize", new PropertyModel<CaseNormalizer>(model, "normalize"));
-        add(normalize);
+        addNormalize(model);
     }
 }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/StringParameterFilterSubform.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/StringParameterFilterSubform.java
@@ -17,7 +17,6 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.util.convert.IConverter;
-import org.geowebcache.filter.parameters.CaseNormalizer;
 import org.geowebcache.filter.parameters.StringParameterFilter;
 
 /**
@@ -60,8 +59,6 @@ public class StringParameterFilterSubform
                 }
             };
 
-    private Component normalize;
-
     public StringParameterFilterSubform(String id, IModel<StringParameterFilter> model) {
         super(id, model);
 
@@ -91,9 +88,6 @@ public class StringParameterFilterSubform
         values.setConvertEmptyInputStringToNull(false);
         add(values);
 
-        normalize =
-                new CaseNormalizerSubform(
-                        "normalize", new PropertyModel<CaseNormalizer>(model, "normalize"));
-        add(normalize);
+        addNormalize(model);
     }
 }


### PR DESCRIPTION
See [GEOS-9385](https://osgeo-org.atlassian.net/browse/GEOS-9385) for a more in depth description of the issue and how this PR improves it.

* Avoid `DefaultTileLayerCatalog` initialization thrashing the filesystem `DefaultTileLayerCatalog.initialize()` loads `GeoServerTileLayerInfo` objects from the gwc-layers datadirectory sub folder concurrently, on the common pool, thrashing the file system if there are many cores.    
Instead of using `ForkJoinPool.commonPool()`, set up a short-lived `ForkJoinPool` with limited parallelism, and make it respect the `org.geoserver.catalog.loadingThreads` system property, following the same settings as `AsynchResourceIterator`.
* Reduce resource usage of `GWCInitializer`
* Overcome XStream poor concurrency at `DefaultTileLayerCatalog` parallel initialization by using one `XStream` instance per thread.
* Proper handling of DefaultTileLayerCatalog life cycle

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
