### PR TITLE
[2.16.x backport][GEOS-9369] Fix declared CRS reprojection on AppSchema complex features

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -27,6 +27,7 @@ import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.Predicates;
+import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.catalog.ResourcePool;
 import org.geoserver.feature.TypeNameExtractingVisitor;
 import org.geoserver.ows.Dispatcher;
@@ -1222,30 +1223,25 @@ public class GetFeature {
         CoordinateReferenceSystem crs = source.getSchema().getCoordinateReferenceSystem();
 
         // gather declared CRS
+        final FeatureTypeInfo featureTypeInfo =
+                catalog.getFeatureTypeByName(
+                        primaryTypeName.getPrefix(), primaryTypeName.getLocalPart());
         CoordinateReferenceSystem declaredCRS = WFSReprojectionUtil.getDeclaredCrs(crs, wfsVersion);
 
         // make sure every bbox and geometry that does not have an attached crs will use
         // the declared crs, and then reproject it to the native crs
         Filter transformedFilter = filter;
+
         if (declaredCRS != null) {
             transformedFilter =
                     WFSReprojectionUtil.normalizeFilterCRS(filter, source.getSchema(), declaredCRS);
         } else {
             // this may happen with complex features, let's try to use the feature type info CRS
-            FeatureTypeInfo featureTypeInfo =
-                    catalog.getFeatureTypeByName(
-                            primaryTypeName.getPrefix(), primaryTypeName.getLocalPart());
-            if (featureTypeInfo != null && featureTypeInfo.getCRS() != null) {
-                // the feature type info has a CRS defined, so let's use it
-                transformedFilter =
-                        WFSReprojectionUtil.normalizeFilterCRS(
-                                filter,
-                                source.getSchema(),
-                                WFSReprojectionUtil.getDeclaredCrs(
-                                        featureTypeInfo.getCRS(), wfsVersion),
-                                featureTypeInfo.getCRS());
-            }
+            transformedFilter = buildFilterCRSFromInfo(filter, primaryTypeName, source, wfsVersion);
         }
+        // evaluate reprojection on complex features case
+        declaredCRS =
+                replaceCRSIfComplexFeatures(source, wfsVersion, crs, featureTypeInfo, declaredCRS);
 
         // replace gml:boundedBy with an expression
         transformedFilter =
@@ -1397,6 +1393,28 @@ public class GetFeature {
         dataQuery.setHints(hints);
 
         return dataQuery;
+    }
+
+    private CoordinateReferenceSystem replaceCRSIfComplexFeatures(
+            FeatureSource<? extends FeatureType, ? extends Feature> source,
+            String wfsVersion,
+            CoordinateReferenceSystem crs,
+            final FeatureTypeInfo featureTypeInfo,
+            CoordinateReferenceSystem formerCrs) {
+        // if not complex features
+        if (source.getSchema() instanceof SimpleFeatureType) {
+            return formerCrs;
+        } else {
+            // they are complex features, proceed with projection logic
+            final ProjectionPolicy projectionPolicy = featureTypeInfo.getProjectionPolicy();
+            switch (projectionPolicy) {
+                case REPROJECT_TO_DECLARED:
+                case FORCE_DECLARED:
+                    return WFSReprojectionUtil.getDeclaredCrs(featureTypeInfo.getCRS(), wfsVersion);
+                default:
+                    return WFSReprojectionUtil.getDeclaredCrs(crs, wfsVersion);
+            }
+        }
     }
 
     static Integer traverseXlinkDepth(String raw) {
@@ -1679,6 +1697,26 @@ public class GetFeature {
         }
 
         return properties;
+    }
+
+    private Filter buildFilterCRSFromInfo(
+            Filter filter,
+            QName primaryTypeName,
+            FeatureSource<? extends FeatureType, ? extends Feature> source,
+            String wfsVersion) {
+        FeatureTypeInfo featureTypeInfo =
+                catalog.getFeatureTypeByName(
+                        primaryTypeName.getPrefix(), primaryTypeName.getLocalPart());
+        if (featureTypeInfo != null && featureTypeInfo.getCRS() != null) {
+            // the feature type info has a CRS defined, so let's use it
+            return WFSReprojectionUtil.normalizeFilterCRS(
+                    filter,
+                    source.getSchema(),
+                    WFSReprojectionUtil.getDeclaredCrs(featureTypeInfo.getCRS(), wfsVersion),
+                    featureTypeInfo.getCRS());
+        } else {
+            return filter;
+        }
     }
 
     private static class CiteBBOXValidator extends AbstractFilterVisitor {


### PR DESCRIPTION
Fixes declared CRS reprojection support for AppSchema complex features, on WFS GetFeature requests.

https://osgeo-org.atlassian.net/browse/GEOS-9369

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
