### PR TITLE
[GEOS-9394] Cascaded WMS UI improvements

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/api/features/Queryable.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/api/features/Queryable.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.api.features;
 
-
 public class Queryable {
 
     String id;

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
@@ -92,8 +92,7 @@
             <input id="respectMetadataBBoxChkBox" type="checkbox" wicket:id="respectMetadataBBoxChkBox"></input>
             <label for="respectMetadataBBoxChkBox"><wicket:message key="respectMetadataBBoxLabel"> Do not send requests if requested map area is outside of the layer bounds</wicket:message></label>
           </li>
-        </ul>                  
-        
+        </ul>
       </fieldset>
      </li>
     </ul>  

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.html
@@ -69,23 +69,34 @@
             <label for="remoteFormatsPalette"><wicket:message key="remoteFormatsPaeletteLabel">Additional Remote Formats</wicket:message></label>
             <span wicket:id="remoteFormatsPalette"></span>
           </li>
-        </ul>
-        <ul id="metaDataCheckBoxContainer" wicket:id="metaDataCheckBoxContainer" class="choiceList">
-          <li>
-            <input id="minScale" type="text" wicket:id="minScale"></input>
-            <label for="minScale"><wicket:message key="minScaleLabel">Minimum Scale Denominator</wicket:message></label>
-            
-            <input id="maxScale" type="text" wicket:id="maxScale"></input>
-            <label for="maxScale"><wicket:message key="maxScaleLabel">Maximum Scale Denominator</wicket:message></label>
-          </li>        
-          <li>
-            <input id="respectMetadataBBoxChkBox" type="checkbox" wicket:id="respectMetadataBBoxChkBox"></input>
-            <label for="respectMetadataBBoxChkBox"><wicket:message key="respectMetadataBBoxLabel"> Do not send requests if requested Map Area is outside of the Layer bounds</wicket:message></label>
-          </li>          
-        </ul>   
+        </ul>        
       </fieldset>
     </li>
   </ul>
+  <ul>
+    <li>
+      <fieldset>
+        <legend><span><wicket:message key="MinMaxTitle">Minimum and Maximum Scale Denominators</wicket:message></span></legend>
+        <ul id="scaleDenominatorContainer" wicket:id="scaleDenominatorContainer">
+           <li>
+            <label for="minScale"><wicket:message key="minScaleLabel">Minimum</wicket:message></label>            
+            <input id="minScale" type="text" wicket:id="minScale"></input>            
+          </li>        
+          <li>
+            <label for="maxScale"><wicket:message key="maxScaleLabel">Maximum</wicket:message></label>
+            <input id="maxScale" type="text" wicket:id="maxScale"></input>            
+          </li>
+        </ul>        
+        <ul id="metaDataCheckBoxContainer" wicket:id="metaDataCheckBoxContainer"  class="choiceList">
+          <li>
+            <input id="respectMetadataBBoxChkBox" type="checkbox" wicket:id="respectMetadataBBoxChkBox"></input>
+            <label for="respectMetadataBBoxChkBox"><wicket:message key="respectMetadataBBoxLabel"> Do not send requests if requested map area is outside of the layer bounds</wicket:message></label>
+          </li>
+        </ul>                  
+        
+      </fieldset>
+     </li>
+    </ul>  
   </wicket:panel>
 </form>
 </body>

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
@@ -180,15 +180,19 @@ public class WMSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
         WebMarkupContainer remoteForamtsContainer = new WebMarkupContainer("remoteformats");
         WebMarkupContainer metaDataCheckBoxContainer =
                 new WebMarkupContainer("metaDataCheckBoxContainer");
+        WebMarkupContainer scaleDenominatorContainer =
+                new WebMarkupContainer("scaleDenominatorContainer");
 
         add(styleContainer);
         add(remoteForamtsContainer);
         add(metaDataCheckBoxContainer);
+        add(scaleDenominatorContainer);
 
         if (!(layerModel.getObject().getResource() instanceof WMSLayerInfo)) {
             styleContainer.setVisible(false);
             remoteForamtsContainer.setVisible(false);
             metaDataCheckBoxContainer.setVisible(false);
+            scaleDenominatorContainer.setVisible(false);
             return;
         }
 
@@ -261,13 +265,13 @@ public class WMSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
                         "minScale",
                         new PropertyModel<Boolean>(wmsLayerInfo, "minScale"),
                         Double.class);
-        metaDataCheckBoxContainer.add(minScale);
+        scaleDenominatorContainer.add(minScale);
         TextField<Double> maxScale =
                 new TextField(
                         "maxScale",
                         new PropertyModel<Boolean>(wmsLayerInfo, "maxScale"),
                         Double.class);
-        metaDataCheckBoxContainer.add(maxScale);
+        scaleDenominatorContainer.add(maxScale);
 
         minScale.add(new ScalesValidator(minScale, maxScale));
     }

--- a/src/web/wms/src/main/resources/GeoServerApplication.properties
+++ b/src/web/wms/src/main/resources/GeoServerApplication.properties
@@ -188,7 +188,8 @@ WMSLayerConfig.remoteFormatsDropDownLabel = Default Remote Format
 WMSLayerConfig.extraRemoteStylesLabel = Additional Remote Formats
 WMSLayerConfig.minScaleLabel = Minimum Scale Denominator
 WMSLayerConfig.maxScaleLabel = Maximum Scale Denominator
-WMSLayerConfig.respectMetadataBBoxLabel = Do not send requests if requested Map Area is outside of the Layer bounds
+WMSLayerConfig.respectMetadataBBoxLabel =  Do not send requests if requested map area is outside of the layer bounds
+WMSLayerConfig.MinMaxTitle = Minimum and Maximum Scale Denominators
 
 remoteFormatsPalette
 

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
@@ -230,13 +230,13 @@ public class WMSLayerConfigTest extends GeoServerWicketTestSupport {
         tester.assertVisible("form:panel:metaDataCheckBoxContainer");
 
         // min max scale UI fields
-        tester.assertVisible("form:panel:metaDataCheckBoxContainer:minScale");
-        tester.assertVisible("form:panel:metaDataCheckBoxContainer:maxScale");
+        tester.assertVisible("form:panel:scaleDenominatorContainer:minScale");
+        tester.assertVisible("form:panel:scaleDenominatorContainer:maxScale");
 
         // validation check, setting min scale above max
         FormTester ft = tester.newFormTester("form");
-        ft.setValue("panel:metaDataCheckBoxContainer:minScale", "100");
-        ft.setValue("panel:metaDataCheckBoxContainer:maxScale", "1");
+        ft.setValue("panel:scaleDenominatorContainer:minScale", "100");
+        ft.setValue("panel:scaleDenominatorContainer:maxScale", "1");
         ft.submit();
         // there should be an error
         tester.assertErrorMessages("Minimum Scale cannot be greater than Maximum Scale");


### PR DESCRIPTION
-added UI legends
-fixed indenting/formatting/descriptions

https://osgeo-org.atlassian.net/browse/GEOS-9394

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
