### PR TITLE
[GEOS-9395] restconfig module for WMTS service configuration

### DIFF
--- a/doc/en/api/1.0.0/owsservices.yaml
+++ b/doc/en/api/1.0.0/owsservices.yaml
@@ -980,6 +980,233 @@ paths:
         200:
           description: OK
 
+  /services/wmts/settings:
+    get:
+      operationId: getWMTSSettings
+      description: Retrieves Web Map Tile Service settings globally for the server.
+      produces:
+        - application/xml
+        - application/json
+        - text/html
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/WMTSInfo"
+          examples:
+            application/xml: |
+              <wmts>
+                <enabled>true</enabled>
+                <name>WMTS</name>
+                <title>Web Map Tile Service</title>
+                <maintainer>http://geoserver.org/comm</maintainer>
+                <abstrct>This server implements the WMTS specification 1.0</abstrct>
+                <accessConstraints>NONE</accessConstraints>
+                <fees>NONE</fees>
+                <versions>
+                  <org.geotools.util.Version>
+                    <version>1.0.0</version>
+                  </org.geotools.util.Version>
+                </versions>
+                <keywords>
+                  <string>WMTS</string>
+                  <string>GEOSERVER</string>
+                </keywords>
+                <metadataLink>
+                  <type>undef</type>
+                  <about>http://geoserver.sourceforge.net/html/index.php</about>
+                  <metadataType>other</metadataType>
+                </metadataLink>
+                <citeCompliant>false</citeCompliant>
+                <onlineResource>http://geoserver.org</onlineResource>
+                <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
+                <verbose>false</verbose>
+              </wmts>
+
+            application/json: |
+              {
+                "wmts": {
+                  "enabled": true,
+                  "name": "WMTS",
+                  "title": "Web Map Tile Service",
+                  "maintainer": "http://geoserver.org/comm",
+                  "abstrct": "This server implements the WMTS specification 1.0",
+                  "accessConstraints": "NONE",
+                  "fees": "NONE",
+                  "versions": {
+                    "org.geotools.util.Version": [
+                      {
+                        "version": "1.0.0"
+                      }
+                    ]
+                  },
+                  "keywords": {
+                    "string": [
+                      "WMTS",
+                      "GEOSERVER"
+                    ]
+                  },
+                  "metadataLink": {
+                    "type": "undef",
+                    "about": "http://geoserver.sourceforge.net/html/index.php",
+                    "metadataType": "other"
+                  },
+                  "citeCompliant": false,
+                  "onlineResource": "http://geoserver.org",
+                  "schemaBaseURL": "http://schemas.opengis.net",
+                  "verbose": false
+                }
+              }
+    post:
+      operationId: postWMTSSettings
+      description: Invalid. Use PUT to edit a service setting.
+      responses:
+        405:
+          description: Method Not Allowed
+    put:
+      operationId: putWMTSSettings
+      description: Edits a global WMTS setting.
+      parameters:
+        - name: WMTSSettingsBody
+          in: body
+          description: Body of the WMTS settings
+          required: true
+          schema:
+            $ref: "#/definitions/WMTSInfo"
+      consumes:
+        - application/xml
+        - application/json
+      responses:
+        201:
+          description: Created
+
+    delete:
+      operationId: deleteWMTSSettings
+      description: Invalid. Use PUT to edit settings.
+      responses:
+        405:
+          description: Method Not Allowed
+
+
+  /services/wmts/workspaces/{workspace}/settings:
+    parameters:
+      - name: workspace
+        in: path
+        required: true
+        type: string
+        description: The workspace name
+    get:
+      operationId: getWMTSWorkspaceSettings
+      description: Retrieves Web Map Tile Service settings for a given workspace.
+      produces:
+        - application/xml
+        - application/json
+        - text/html
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/WMTSInfo"
+          examples:
+            application/xml: |
+              <wmts>
+                <workspace>
+                  <name>nurc</name>
+                </workspace>
+                <enabled>true</enabled>
+                <name>WMTS</name>
+                <title>Web Map Tile Service</title>
+                <maintainer>http://geoserver.org/comm</maintainer>
+                <abstrct>This server implements the WMTS specification 1.0</abstrct>
+                <accessConstraints>NONE</accessConstraints>
+                <fees>NONE</fees>
+                <versions>
+                  <org.geotools.util.Version>
+                    <version>1.0.0</version>
+                  </org.geotools.util.Version>
+                </versions>
+                <keywords>
+                  <string>WMTS</string>
+                  <string>GEOSERVER</string>
+                </keywords>
+                <metadataLink>
+                  <type>undef</type>
+                  <about>http://geoserver.sourceforge.net/html/index.php</about>
+                  <metadataType>other</metadataType>
+                </metadataLink>
+                <citeCompliant>false</citeCompliant>
+                <onlineResource>http://geoserver.org</onlineResource>
+                <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
+                <verbose>false</verbose>
+              </wmts>
+            application/json: |
+              {
+                "wmts": {
+                  "workspace": {
+                    "name": "nurc"
+                  },
+                  "enabled": true,
+                  "name": "WMTS",
+                  "title": "Web Map Tile Service",
+                  "maintainer": "http://geoserver.org/comm",
+                  "abstrct": "This server implements the WMTS specification 1.0",
+                  "accessConstraints": "NONE",
+                  "fees": "NONE",
+                  "versions": {
+                    "org.geotools.util.Version": [
+                      {
+                        "version": "1.0.0"
+                      }
+                    ]
+                  },
+                  "keywords": {
+                    "string": [
+                      "WMTS",
+                      "GEOSERVER"
+                    ]
+                  },
+                  "metadataLink": {
+                    "type": "undef",
+                    "about": "http://geoserver.sourceforge.net/html/index.php",
+                    "metadataType": "other"
+                  },
+                  "citeCompliant": false,
+                  "onlineResource": "http://geoserver.org",
+                  "schemaBaseURL": "http://schemas.opengis.net",
+                  "verbose": false
+                }
+              }
+
+
+    post:
+      operationId: postWMTSWorkspaceSettings
+      description: Invalid. Use PUT to edit a service setting.
+      responses:
+        405:
+          description: Method Not Allowed
+
+    put:
+      operationId: putWMTSWorkspaceSettings
+      description: Edits a workspace-specific WMTS setting.
+      parameters:
+        - name: WMTSSettingsBody
+          in: body
+          description: Body of the WMTS settings
+          required: true
+          schema:
+            $ref: "#/definitions/WMTSInfo"
+      consumes:
+        - application/xml
+        - application/json
+      responses:
+        201:
+          description: Created
+    delete:
+      operationId: deleteWMTSWorkspaceSettings
+      description: Deletes a workspace-specific WMTS setting.
+      responses:
+        200:
+          description: OK
 
 
 definitions:
@@ -1295,3 +1522,66 @@ definitions:
         type: boolean
         description: ""
 
+  WMTSInfo:
+    type: object
+    xml:
+      name: wmts
+    properties:
+      enabled:
+        type: boolean
+        description: Status of the service
+      name:
+        type: string
+        description: Name of the service. This value is unique among all instances of ServiceInfo and can be used as an identifier.
+      title:
+        type: string
+        description: Title of the service
+      maintainer:
+        type: string
+        description: Maintainer of the service
+      abstrct:
+        type: string
+        description: Description of the service
+      accessConstraints:
+        type: string
+        description: Access constraints
+      fees:
+        type: string
+        description: Any fees associated with the service
+      versions:
+        type: object
+        description: The versions of the service that are available.
+        properties:
+          org.geotools.util.Version:
+            type: array
+            items:
+              type: string
+              description: version number
+      keywords:
+        type: array
+        description: Keywords associated with the service.
+        items:
+          type: string
+      metadataLink:
+        type: array
+        items:
+          type: object
+          properties:
+            "@key":
+              type: string
+              description: Metadata key
+            text:
+              type: string
+              description: Metadata value
+      citeCompliant:
+        type: boolean
+        description: Status of service CITE compliance
+      onlineResource:
+        type: string
+        description: URL resource
+      schemaBaseURL:
+        type: string 
+        description: Base URL for the schemas describing the service
+      verbose:
+        type: boolean
+        description: Flag indicating if the service should be verbose

--- a/doc/en/user/source/rest/api/services.rst
+++ b/doc/en/user/source/rest/api/services.rst
@@ -215,4 +215,74 @@ Controls Web Map Service settings for a given workspace.
      -
      -
 
+``/services/wmts/settings[.<format>]``
+--------------------------------------
+
+Controls Web Map Tile Service settings.
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Method
+     - Action
+     - Status code
+     - Formats
+     - Default Format
+   * - GET
+     - Return global WMTS settings
+     - 200
+     - HTML, XML, JSON
+     - HTML
+   * - POST
+     - 
+     - 405
+     -
+     -
+   * - PUT
+     - Modify global WMTS settings
+     - 200
+     - XML,JSON
+     - 
+   * - DELETE
+     - 
+     - 405
+     -
+     -
+
+
+``/services/wmts/workspaces/<ws>/settings[.<format>]``
+-------------------------------------------------------
+
+Controls Web Map Tile Service settings for a given workspace.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Method
+     - Action
+     - Status code
+     - Formats
+     - Default Format
+   * - GET
+     - Return WMTS settings for workspace ``ws``
+     - 200
+     - HTML, XML, JSON
+     - HTML
+   * - POST
+     - 
+     - 405
+     -
+     -
+   * - PUT
+     - Modify WMTS settings for workspace ``ws``
+     - 200
+     - XML,JSON
+     - 
+   * - DELETE
+     - Delete WMTS settings for workspace ``ws``
+     - 200
+     -
+     -
+
 .. todo:: WPS?

--- a/doc/en/user/source/rest/index.rst
+++ b/doc/en/user/source/rest/index.rst
@@ -26,7 +26,7 @@ The following links provide direct access to the GeoServer REST API documentatio
 * :api:`/layers <layers.yaml>`
 * :api:`/monitoring <monitoring.yaml>`
 * :api:`/namespaces <namespaces.yaml>`
-* :api:`/services/wms|wfs|wcs/settings <owsservices.yaml>`
+* :api:`/services/wms|wfs|wcs|wmts/settings <owsservices.yaml>`
 * :api:`/reload <reload.yaml>`
 * :api:`/resource <resource.yaml>`
 * :api:`/security <security.yaml>`

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1948,6 +1948,7 @@
   <module>restconfig-wcs</module>
   <module>restconfig-wfs</module>
   <module>restconfig-wms</module>
+  <module>restconfig-wmts</module>
   <module>web</module>
   <module>community</module>
   <module>extension</module>

--- a/src/restconfig-wmts/pom.xml
+++ b/src/restconfig-wmts/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>geoserver</artifactId>
+    <groupId>org.geoserver</groupId>
+    <version>2.17-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.geoserver</groupId>
+  <artifactId>gs-restconfig-wmts</artifactId>
+  <name>WMTS REST configuration</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-restconfig</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-restconfig</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/restconfig-wmts/src/main/java/org/geoserver/rest/service/WMTSSettingsController.java
+++ b/src/restconfig-wmts/src/main/java/org/geoserver/rest/service/WMTSSettingsController.java
@@ -1,0 +1,103 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.service;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.gwc.wmts.WMTSInfo;
+import org.geoserver.gwc.wmts.WMTSInfoImpl;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.converters.XStreamMessageConverter;
+import org.geoserver.rest.util.MediaTypeExtensions;
+import org.geoserver.wms.WMSXStreamLoader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** WTMS Settings controller */
+@RestController
+@ControllerAdvice
+@RequestMapping(
+    path = RestBaseController.ROOT_PATH + "/services/wmts",
+    produces = {
+        MediaType.APPLICATION_JSON_VALUE,
+        MediaType.APPLICATION_XML_VALUE,
+        MediaType.TEXT_HTML_VALUE
+    }
+)
+public class WMTSSettingsController extends ServiceSettingsController {
+
+    @Autowired
+    public WMTSSettingsController(GeoServer geoServer) {
+        super(geoServer, WMTSInfo.class);
+    }
+
+    @PutMapping(
+        value = {"/settings", "/workspaces/{workspaceName}/settings"},
+        consumes = {
+            MediaType.APPLICATION_JSON_VALUE,
+            MediaTypeExtensions.TEXT_JSON_VALUE,
+            MediaType.APPLICATION_XML_VALUE,
+            MediaType.TEXT_XML_VALUE
+        }
+    )
+    public void serviceSettingsPut(
+            @RequestBody WMTSInfo info, @PathVariable(required = false) String workspaceName) {
+
+        super.serviceSettingsPut(info, workspaceName);
+    }
+
+    @Override
+    public String getTemplateName(Object object) {
+        return "wmtsSettings";
+    }
+
+    @Override
+    public boolean supports(
+            MethodParameter methodParameter,
+            Type targetType,
+            Class<? extends HttpMessageConverter<?>> converterType) {
+        return WMTSInfo.class.isAssignableFrom(methodParameter.getParameterType());
+    }
+
+    @Override
+    public void configurePersister(XStreamPersister persister, XStreamMessageConverter converter) {
+        persister.setHideFeatureTypeAttributes();
+        persister.getClassAliasingMapper().addClassAlias("wmts", WMTSInfoImpl.class);
+        persister.setCallback(
+                new XStreamPersister.Callback() {
+                    @Override
+                    protected ServiceInfo getServiceObject() {
+                        Map<String, String> uriTemplateVars = getURITemplateVariables();
+                        String workspace = uriTemplateVars.get("workspaceName");
+                        ServiceInfo service;
+                        if (workspace != null) {
+                            WorkspaceInfo ws = geoServer.getCatalog().getWorkspaceByName(workspace);
+                            service = geoServer.getService(ws, WMTSInfo.class);
+                        } else {
+                            service = geoServer.getService(WMTSInfo.class);
+                        }
+                        return service;
+                    }
+
+                    @Override
+                    protected Class<WMTSInfo> getObjectClass() {
+                        return WMTSInfo.class;
+                    }
+                });
+        WMSXStreamLoader.initXStreamPersister(persister);
+    }
+}

--- a/src/restconfig-wmts/src/main/java/org/geoserver/rest/service/ftl-templates/wmtsSettings.ftl
+++ b/src/restconfig-wmts/src/main/java/org/geoserver/rest/service/ftl-templates/wmtsSettings.ftl
@@ -1,0 +1,39 @@
+<#include "head.ftl">
+
+<#if properties.workspace.name??>
+    Workspace Name:  "${properties.workspace.name}"
+</#if>
+
+<h4>Service Metadata</h4>
+
+<ul>
+  <li>WMTS Enabled:  "${properties.enabled!}"</li>
+  <li>Strict CITE compliance:  "${properties.citeCompliant!}"</li>
+  <li>Maintainer:  "${properties.maintainer!}"</li>
+  <li>Online Resource:  "${properties.onlineResource!}"</li>
+  <li>Title:  "${properties.title!}"</li>
+  <li>Abstract:  "${properties.abstract!}"</li>
+  <li>Fees:  "${properties.fees!}"</li>
+  <li>Access Constraints:  "${properties.accessConstraints!}"</li>
+  <#if properties.keywords?is_enumerable>
+    <li>Keywords: "
+        <#list properties.keywords as el>
+            ${el.value!}
+            <#if el.language??>(${el.language!}) </#if>
+            <#if el.vocabulary??>[${el.vocabulary!}] </#if>
+        <#if el_has_next>, </#if></#list>
+    "</li>
+  <#else>
+    <li>Keywords: ""</li>
+  </#if>
+  <li>Name:  "${properties.name!}"</li>
+  <#if properties.versions?is_enumerable>
+    <li>Versions:  "${properties.versions!}"</li>
+  <#else>
+    <li>Versions: ""</li>
+  </#if>
+  <li>Schema Base URL:  "${properties.schemaBaseURL!}"</li>
+  <li>Verbose Messages:  "${properties.verbose!}"</li>
+</ul>
+
+<#include "tail.ftl">

--- a/src/restconfig-wmts/src/test/java/org/geoserver/rest/service/LocalWMTSSettingsControllerTest.java
+++ b/src/restconfig-wmts/src/test/java/org/geoserver/rest/service/LocalWMTSSettingsControllerTest.java
@@ -1,0 +1,222 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.service;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import net.sf.json.JSON;
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.gwc.wmts.WMTSInfo;
+import org.geoserver.ows.LocalWorkspace;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.catalog.CatalogRESTTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+
+public class LocalWMTSSettingsControllerTest extends CatalogRESTTestSupport {
+
+    @After
+    public void clearLocalWorkspace() throws Exception {
+        LocalWorkspace.remove();
+        revertService(WMTSInfo.class, "sf");
+    }
+
+    @Before
+    public void initLocalWMTS() throws Exception {
+        GeoServer geoServer = getGeoServer();
+        WorkspaceInfo ws = geoServer.getCatalog().getWorkspaceByName("sf");
+        WMTSInfo wmtsInfo = geoServer.getService(ws, WMTSInfo.class);
+        if (wmtsInfo != null) {
+            geoServer.remove(wmtsInfo);
+        }
+        wmtsInfo = geoServer.getFactory().create(WMTSInfo.class);
+
+        wmtsInfo.setName("WMTS");
+        wmtsInfo.setWorkspace(ws);
+        geoServer.add(wmtsInfo);
+    }
+
+    @Test
+    public void testGetAsJSON() throws Exception {
+        JSON json =
+                getAsJSON(
+                        RestBaseController.ROOT_PATH
+                                + "/services/wmts/workspaces/sf/settings.json");
+        JSONObject jsonObject = (JSONObject) json;
+        assertNotNull(jsonObject);
+        JSONObject wmtsinfo = (JSONObject) jsonObject.get("wmts");
+        // assertEquals("wmts", wmtsinfo.get("id"));
+        assertEquals("WMTS", wmtsinfo.get("name"));
+        JSONObject workspace = (JSONObject) wmtsinfo.get("workspace");
+        assertNotNull(workspace);
+        assertEquals("sf", workspace.get("name"));
+    }
+
+    @Test
+    public void testGetAsXML() throws Exception {
+        Document dom =
+                getAsDOM(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings.xml");
+        assertEquals("wmts", dom.getDocumentElement().getLocalName());
+        assertXpathEvaluatesTo("true", "/wmts/enabled", dom);
+        assertXpathEvaluatesTo("sf", "/wmts/workspace/name", dom);
+        assertXpathEvaluatesTo("WMTS", "/wmts/name", dom);
+    }
+
+    @Test
+    public void testGetAsHTML() throws Exception {
+        getAsDOM(RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings.html");
+    }
+
+    @Test
+    public void testCreateAsJSON() throws Exception {
+        removeLocalWorkspace();
+        String input =
+                "{'wmts': {'id' : 'wmts_sf', 'workspace':{'name':'sf'},'name' : 'WMTS', 'enabled': 'true'}}";
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings/",
+                        input,
+                        "text/json");
+        assertEquals(200, response.getStatus());
+        JSON json =
+                getAsJSON(
+                        RestBaseController.ROOT_PATH
+                                + "/services/wmts/workspaces/sf/settings.json");
+        JSONObject jsonObject = (JSONObject) json;
+        assertNotNull(jsonObject);
+        JSONObject wmtsinfo = (JSONObject) jsonObject.get("wmts");
+        assertEquals("WMTS", wmtsinfo.get("name"));
+        assertEquals("true", wmtsinfo.get("enabled").toString().trim());
+        JSONObject workspace = (JSONObject) wmtsinfo.get("workspace");
+        assertNotNull(workspace);
+        assertEquals("sf", workspace.get("name"));
+    }
+
+    @Test
+    public void testCreateAsXML() throws Exception {
+        removeLocalWorkspace();
+        String xml =
+                "<wmts>"
+                        + "<id>wmts_sf</id>"
+                        + "<workspace>"
+                        + "<name>sf</name>"
+                        + "</workspace>"
+                        + "<name>WMTS</name>"
+                        + "<enabled>false</enabled>"
+                        + "</wmts>";
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings",
+                        xml,
+                        "text/xml");
+        assertEquals(200, response.getStatus());
+
+        Document dom =
+                getAsDOM(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings.xml");
+        assertEquals("wmts", dom.getDocumentElement().getLocalName());
+        assertXpathEvaluatesTo("false", "/wmts/enabled", dom);
+        assertXpathEvaluatesTo("sf", "/wmts/workspace/name", dom);
+        assertXpathEvaluatesTo("WMTS", "/wmts/name", dom);
+    }
+
+    @Test
+    public void testPutAsJSON() throws Exception {
+        String json =
+                "{'wmts': {'id':'wmts','workspace':{'name':'sf'},'enabled':'false','name':'WMTS'}}";
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings/",
+                        json,
+                        "text/json");
+        assertEquals(200, response.getStatus());
+        JSON jsonMod =
+                getAsJSON(
+                        RestBaseController.ROOT_PATH
+                                + "/services/wmts/workspaces/sf/settings.json");
+        JSONObject jsonObject = (JSONObject) jsonMod;
+        assertNotNull(jsonObject);
+        JSONObject wmtsinfo = (JSONObject) jsonObject.get("wmts");
+        // assertEquals("wmts", wmtsinfo.get("id"));
+        assertEquals("false", wmtsinfo.get("enabled").toString().trim());
+    }
+
+    @Test
+    public void testPutAsXML() throws Exception {
+        String xml =
+                "<wmts>"
+                        + "<id>wmts</id>"
+                        + "<workspace>"
+                        + "<name>sf</name>"
+                        + "</workspace>"
+                        + "<enabled>false</enabled>"
+                        + "</wmts>";
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings",
+                        xml,
+                        "text/xml");
+        assertEquals(200, response.getStatus());
+        Document dom =
+                getAsDOM(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings.xml");
+        assertXpathEvaluatesTo("false", "/wmts/enabled", dom);
+    }
+
+    @Test
+    public void testPutFullAsXML() throws Exception {
+        String xml =
+                IOUtils.toString(
+                        LocalWMTSSettingsControllerTest.class.getResourceAsStream("wmts.xml"),
+                        "UTF-8");
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings",
+                        xml,
+                        "text/xml");
+        assertEquals(200, response.getStatus());
+        Document dom =
+                getAsDOM(
+                        RestBaseController.ROOT_PATH + "/services/wmts/workspaces/sf/settings.xml");
+        assertXpathEvaluatesTo("true", "/wmts/enabled", dom);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        assertEquals(
+                200,
+                deleteAsServletResponse(
+                                RestBaseController.ROOT_PATH
+                                        + "/services/wmts/workspaces/sf/settings")
+                        .getStatus());
+        boolean thrown = false;
+        try {
+            JSON json =
+                    getAsJSON(
+                            RestBaseController.ROOT_PATH
+                                    + "/services/wmts/workspaces/sf/settings.json");
+        } catch (JSONException e) {
+            thrown = true;
+        }
+        assertEquals(true, thrown);
+    }
+
+    private void removeLocalWorkspace() {
+        GeoServer geoServer = getGeoServer();
+        WorkspaceInfo ws = geoServer.getCatalog().getWorkspaceByName("sf");
+        WMTSInfo wmtsInfo = geoServer.getService(ws, WMTSInfo.class);
+        geoServer.remove(wmtsInfo);
+    }
+}

--- a/src/restconfig-wmts/src/test/java/org/geoserver/rest/service/WMTSSettingsControllerTest.java
+++ b/src/restconfig-wmts/src/test/java/org/geoserver/rest/service/WMTSSettingsControllerTest.java
@@ -1,0 +1,173 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.service;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringWriter;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
+import org.geoserver.config.GeoServer;
+import org.geoserver.gwc.wmts.WMTSInfo;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.catalog.CatalogRESTTestSupport;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+
+public class WMTSSettingsControllerTest extends CatalogRESTTestSupport {
+
+    @After
+    public void revertChanges() {
+        revertService(WMTSInfo.class, null);
+    }
+
+    @Test
+    public void testGetASJSON() throws Exception {
+        JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/services/wmts/settings.json");
+        JSONObject jsonObject = (JSONObject) json;
+        assertNotNull(jsonObject);
+        JSONObject wmtsinfo = (JSONObject) jsonObject.get("wmts");
+        assertEquals("true", wmtsinfo.get("enabled").toString().trim());
+        assertEquals("WMTS", wmtsinfo.get("name"));
+    }
+
+    @Test
+    public void testGetAsXML() throws Exception {
+        Document dom = getAsDOM(RestBaseController.ROOT_PATH + "/services/wmts/settings.xml");
+        assertEquals("wmts", dom.getDocumentElement().getLocalName());
+        assertEquals(1, dom.getElementsByTagName("name").getLength());
+        assertXpathEvaluatesTo("true", "/wmts/enabled", dom);
+        assertXpathEvaluatesTo("WMTS", "/wmts/name", dom);
+    }
+
+    @Test
+    public void testGetAsHTML() throws Exception {
+        getAsDOM(RestBaseController.ROOT_PATH + "/services/wmts/settings.html");
+    }
+
+    @Test
+    public void testPutAsJSON() throws Exception {
+        String json =
+                "{'wmts': {'id':'wmts','enabled':'false','name':'WMTS', 'title':'New Title'}}";
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/settings/",
+                        json,
+                        "text/json");
+        assertEquals(200, response.getStatus());
+        JSON jsonMod = getAsJSON(RestBaseController.ROOT_PATH + "/services/wmts/settings.json");
+        JSONObject jsonObject = (JSONObject) jsonMod;
+        assertNotNull(jsonObject);
+        JSONObject wmtsinfo = (JSONObject) jsonObject.get("wmts");
+
+        assertEquals("false", wmtsinfo.get("enabled").toString().trim());
+        assertEquals("WMTS", wmtsinfo.get("name"));
+        assertEquals("New Title", wmtsinfo.get("title"));
+    }
+
+    @Test
+    public void testPutAsXML() throws Exception {
+        String xml =
+                "<wmts>"
+                        + "<id>wmts</id>"
+                        + "<enabled>false</enabled>"
+                        + "<name>WMTS</name>"
+                        + "<title>New Title</title>"
+                        + "<maintainer>http://geoserver.org/comm</maintainer>"
+                        + "</wmts>";
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/settings", xml, "text/xml");
+        assertEquals(200, response.getStatus());
+
+        Document dom = getAsDOM(RestBaseController.ROOT_PATH + "/services/wmts/settings.xml");
+        assertXpathEvaluatesTo("false", "/wmts/enabled", dom);
+        assertXpathEvaluatesTo("WMTS", "/wmts/name", dom);
+        assertXpathEvaluatesTo("New Title", "/wmts/title", dom);
+    }
+
+    @Test
+    public void testRoundTripJSON() throws Exception {
+        JSONObject original =
+                (JSONObject)
+                        getAsJSON(RestBaseController.ROOT_PATH + "/services/wmts/settings.json");
+        assertNotNull(original);
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/settings/",
+                        original.toString(),
+                        "text/json");
+        assertEquals(200, response.getStatus());
+        JSON updated = getAsJSON(RestBaseController.ROOT_PATH + "/services/wmts/settings.json");
+        assertEquals(original, updated);
+    }
+
+    @Test
+    public void testRoundTripXML() throws Exception {
+        Document original = getAsDOM(RestBaseController.ROOT_PATH + "/services/wmts/settings.xml");
+        assertEquals("wmts", original.getDocumentElement().getLocalName());
+        String originalString = documentToString(original);
+
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/settings",
+                        originalString,
+                        "text/xml");
+        assertEquals(200, response.getStatus());
+        Document updated = getAsDOM(RestBaseController.ROOT_PATH + "/services/wmts/settings.xml");
+        assertEquals(originalString, documentToString(updated));
+    }
+
+    private String documentToString(Document doc) throws Exception {
+        DOMSource domSource = new DOMSource(doc);
+        StringWriter writer = new StringWriter();
+        StreamResult result = new StreamResult(writer);
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        transformer.transform(domSource, result);
+        return writer.toString();
+    }
+
+    @Test
+    public void testPutNonDestructive() throws Exception {
+        GeoServer geoServer = getGeoServer();
+        WMTSInfo i = geoServer.getService(WMTSInfo.class);
+        i.setEnabled(true);
+        geoServer.save(i);
+        String xml =
+                "<wmts>"
+                        + "<id>wmts</id>"
+                        + "<name>WMTS</name><title>GeoServer Web Map Service</title>"
+                        + "<maintainer>http://geoserver.org/comm</maintainer>"
+                        + "</wmts>";
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/services/wmts/settings", xml, "text/xml");
+        assertEquals(200, response.getStatus());
+
+        Document dom = getAsDOM(RestBaseController.ROOT_PATH + "/services/wmts/settings.xml");
+        assertXpathEvaluatesTo("true", "/wmts/enabled", dom);
+        assertXpathEvaluatesTo("WMTS", "/wmts/name", dom);
+        i = geoServer.getService(WMTSInfo.class);
+        assertTrue(i.isEnabled());
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        assertEquals(
+                405,
+                deleteAsServletResponse(RestBaseController.ROOT_PATH + "/services/wmts/settings")
+                        .getStatus());
+    }
+}

--- a/src/restconfig-wmts/src/test/resources/org/geoserver/rest/service/wmts.xml
+++ b/src/restconfig-wmts/src/test/resources/org/geoserver/rest/service/wmts.xml
@@ -1,0 +1,28 @@
+<wmts>
+  <id>wmts-1</id>
+  <enabled>true</enabled>
+  <name>WMS</name>
+  <title>GeoServer Web Map Tile Service</title>
+  <maintainer>http://jira.codehaus.org/secure/BrowseProject.jspa?id=10311</maintainer>
+  <abstrct>A compliant implementation of WMTS service.</abstrct>
+  <accessConstraints>NONE</accessConstraints>
+  <fees>NONE</fees>
+  <versions>
+    <org.geotools.util.Version>
+      <version>1.0.0</version>
+    </org.geotools.util.Version>
+  </versions>
+  <keywords>
+    <string>WMTS</string>
+    <string>GEOSERVER</string>
+  </keywords>
+  <metadataLink/>
+  <citeCompliant>false</citeCompliant>
+  <onlineResource>http://geoserver.sourceforge.net/html/index.php</onlineResource>
+  <schemaBaseURL>http://schemas.opengis.net</schemaBaseURL>
+  <verbose>false</verbose>
+  <metadata>
+    <entry key="foo">bar</entry>
+    <entry key="metadata">unused</entry>
+  </metadata>
+</wmts>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -143,6 +143,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-restconfig-wmts</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver.security</groupId>
       <artifactId>gs-sec-jdbc</artifactId>
       <version>${project.version}</version>
@@ -1756,6 +1761,5 @@
         </dependency>
       </dependencies>
     </profile>
-
   </profiles>
 </project>


### PR DESCRIPTION
Core module (`restconfig-wmts`) to enable configuring basic WMTS service metadata (global and workspace-local) through the REST API just like it's done for WMS, WFS, and WCS.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
