### PR TITLE
[GEOS-9397] Cached layers page may take minutes to show up (when backing stores are not responsive)

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -100,7 +100,6 @@ import org.geotools.util.logging.Logging;
 import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
-import org.geowebcache.config.BaseConfiguration;
 import org.geowebcache.config.BlobStoreInfo;
 import org.geowebcache.config.ConfigurationException;
 import org.geowebcache.config.ConfigurationPersistenceException;
@@ -2212,13 +2211,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         } else {
             return false;
         }
-        BaseConfiguration configuration;
-        try {
-            configuration = tld.getConfiguration(tileLayerName);
-        } catch (IllegalArgumentException notFound) {
-            return false;
-        }
-        return configuration instanceof CatalogConfiguration;
+        return tld.layerExists(tileLayerName);
     }
 
     /**

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
@@ -225,9 +225,8 @@ public class CatalogConfiguration implements TileLayerConfiguration {
             if (pendingDeletes.contains(layerName)) {
                 return false;
             }
-            Set<String> layerNames = tileLayerCatalog.getLayerNames();
-            boolean hasLayer = layerNames.contains(layerName);
-            return hasLayer;
+            String layerId = tileLayerCatalog.getLayerId(layerName);
+            return layerId != null;
         } finally {
             lock.releaseReadLock();
         }

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.AttributeAppender;
@@ -33,6 +34,7 @@ import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.request.resource.DynamicImageResource;
 import org.geoserver.catalog.PublishedType;
 import org.geoserver.config.GeoServer;
 import org.geoserver.ows.util.ResponseUtils;
@@ -300,6 +302,26 @@ public class MapPreviewPage extends GeoServerBasePage {
             String t1 = translateFormat(prefix, f1);
             String t2 = translateFormat(prefix, f2);
             return t1.compareTo(t2);
+        }
+    }
+
+    private static class DelayedImageResource extends DynamicImageResource {
+        private final IModel<PreviewLayer> itemModel;
+
+        public DelayedImageResource(IModel<PreviewLayer> itemModel) {
+            super("image/png");
+            this.itemModel = itemModel;
+        }
+
+        @Override
+        protected byte[] getImageData(Attributes attributes) {
+            PreviewLayer layer = (PreviewLayer) itemModel.getObject();
+            try {
+                return IOUtils.toByteArray(
+                        layer.getIcon().getResource().getResourceStream().getInputStream());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/GWCIconFactory.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/GWCIconFactory.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.PublishedType;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.web.CatalogIconFactory;
 import org.geoserver.web.GeoServerBasePage;
@@ -40,8 +41,50 @@ public class GWCIconFactory implements Serializable {
     public static final PackageResourceReference GWC =
             new PackageResourceReference(GWCSettingsPage.class, "geowebcache-16.png");
 
+    /**
+     * Enum of tile layer type to aid in presenting a type column in the UI without incurring in
+     * heavy resource lookups such as loading feature types from the geoserver catalog.
+     */
+    public static enum CachedLayerType {
+        VECTOR(PublishedType.VECTOR.getCode()),
+        RASTER(PublishedType.RASTER.getCode()),
+        REMOTE(PublishedType.REMOTE.getCode()),
+        WMS(PublishedType.WMS.getCode()),
+        GROUP(PublishedType.GROUP.getCode()),
+        WMTS(PublishedType.WMTS.getCode()),
+        GWC(-1),
+        UNKNOWN(-2);
+
+        private final Integer code;
+
+        CachedLayerType(Integer code) {
+            this.code = code;
+        }
+
+        public Integer getCode() {
+            return code;
+        }
+
+        public static CachedLayerType valueOf(Integer code) {
+            return values()[code.intValue()];
+        }
+    }
+
     private GWCIconFactory() {
         // private constructor, this is a singleton
+    }
+
+    public static CachedLayerType getCachedLayerType(final TileLayer layer) {
+        if (layer instanceof GeoServerTileLayer) {
+            GeoServerTileLayer gsTileLayer = (GeoServerTileLayer) layer;
+            PublishedInfo published = gsTileLayer.getPublishedInfo();
+            PublishedType publishedType = published.getType();
+            return CachedLayerType.valueOf(publishedType.getCode());
+        }
+        if (layer instanceof WMSLayer) {
+            return CachedLayerType.GWC;
+        }
+        return CachedLayerType.UNKNOWN;
     }
 
     /**

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayerProvider.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayerProvider.java
@@ -17,9 +17,9 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.request.resource.PackageResourceReference;
 import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.web.GWCIconFactory;
+import org.geoserver.gwc.web.GWCIconFactory.CachedLayerType;
 import org.geoserver.web.wicket.GeoServerDataProvider;
 import org.geowebcache.layer.TileLayer;
 
@@ -32,15 +32,14 @@ import org.geowebcache.layer.TileLayer;
 class CachedLayerProvider extends GeoServerDataProvider<TileLayer> {
 
     private static final long serialVersionUID = -8599398086587516574L;
-
     static final Property<TileLayer> TYPE =
             new AbstractProperty<TileLayer>("type") {
 
                 private static final long serialVersionUID = 3215255763580377079L;
 
                 @Override
-                public PackageResourceReference getPropertyValue(TileLayer item) {
-                    return GWCIconFactory.getSpecificLayerIcon(item);
+                public GWCIconFactory.CachedLayerType getPropertyValue(TileLayer item) {
+                    return GWCIconFactory.getCachedLayerType(item);
                 }
 
                 @Override
@@ -48,9 +47,9 @@ class CachedLayerProvider extends GeoServerDataProvider<TileLayer> {
                     return new Comparator<TileLayer>() {
                         @Override
                         public int compare(TileLayer o1, TileLayer o2) {
-                            PackageResourceReference r1 = getPropertyValue(o1);
-                            PackageResourceReference r2 = getPropertyValue(o2);
-                            return r1.getName().compareTo(r2.getName());
+                            CachedLayerType r1 = getPropertyValue(o1);
+                            CachedLayerType r2 = getPropertyValue(o2);
+                            return r1.compareTo(r2);
                         }
                     };
                 }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayersPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayersPage.java
@@ -328,6 +328,7 @@ public class CachedLayersPage extends GeoServerSecuredPage {
     }
 
     private static class DelayedImageResource extends DynamicImageResource {
+        private static final long serialVersionUID = 657353636149402818L;
         private final IModel<TileLayer> itemModel;
         private final Property<TileLayer> property;
 
@@ -340,8 +341,7 @@ public class CachedLayersPage extends GeoServerSecuredPage {
         @Override
         protected byte[] getImageData(Attributes attributes) {
             TileLayer layer = (TileLayer) itemModel.getObject();
-            PackageResourceReference layerIcon =
-                    (PackageResourceReference) property.getPropertyValue(layer);
+            PackageResourceReference layerIcon = GWCIconFactory.getSpecificLayerIcon(layer);
             try {
                 return IOUtils.toByteArray(
                         layerIcon.getResource().getResourceStream().getInputStream());

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/NewCachedLayerPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/NewCachedLayerPage.java
@@ -70,7 +70,7 @@ public class NewCachedLayerPage extends GeoServerSecuredPage {
                             Fragment f = new Fragment(id, "iconFragment", NewCachedLayerPage.this);
                             TileLayer layer = (TileLayer) itemModel.getObject();
                             PackageResourceReference layerIcon =
-                                    (PackageResourceReference) property.getPropertyValue(layer);
+                                    GWCIconFactory.getSpecificLayerIcon(layer);
                             f.add(new Image("layerIcon", layerIcon));
                             return f;
                         } else if (property == NAME) {

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/UnconfiguredCachedLayersProvider.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/UnconfiguredCachedLayersProvider.java
@@ -15,7 +15,7 @@ import java.util.List;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
-import org.apache.wicket.request.resource.PackageResourceReference;
+import org.apache.wicket.request.resource.ResourceReference;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -38,7 +38,7 @@ class UnconfiguredCachedLayersProvider extends GeoServerDataProvider<TileLayer> 
                 private static final long serialVersionUID = 3215255763580377079L;
 
                 @Override
-                public PackageResourceReference getPropertyValue(TileLayer item) {
+                public ResourceReference getPropertyValue(TileLayer item) {
                     return GWCIconFactory.getSpecificLayerIcon(item);
                 }
 
@@ -47,8 +47,8 @@ class UnconfiguredCachedLayersProvider extends GeoServerDataProvider<TileLayer> 
                     return new Comparator<TileLayer>() {
                         @Override
                         public int compare(TileLayer o1, TileLayer o2) {
-                            PackageResourceReference r1 = getPropertyValue(o1);
-                            PackageResourceReference r2 = getPropertyValue(o2);
+                            ResourceReference r1 = getPropertyValue(o1);
+                            ResourceReference r2 = getPropertyValue(o2);
                             return r1.getName().compareTo(r2.getName());
                         }
                     };


### PR DESCRIPTION
Could not find a way to write a test for it, the wicket Image class does not allow inspection of its image resource...

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
