### PR TITLE
[Fixes GEOS-9398] [Community][wps-remote] Async Request Management Proposal

### DIFF
--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/RemoteProcessClient.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/RemoteProcessClient.java
@@ -82,9 +82,13 @@ public abstract class RemoteProcessClient implements DisposableBean, ExtensionPr
     protected List<RemoteMachineDescriptor> registeredProcessingMachines =
             Collections.synchronizedList(new ArrayList<RemoteMachineDescriptor>());
 
-    /** */
-    protected List<RemoteRequestDescriptor> pendingRequests =
+    /** Queue of WPS Requests GeoServer will test on Remote endpoints */
+    private List<RemoteRequestDescriptor> pendingRequests =
             Collections.synchronizedList(new LinkedList<RemoteRequestDescriptor>());
+
+    /** Execution Requests in charge from the RemoteProcessClient <pID; Request> */
+    private Map<String, RemoteRequestDescriptor> executingRequests =
+            new ConcurrentHashMap<String, RemoteRequestDescriptor>();
 
     /** */
     protected File certificateFile = null;
@@ -125,6 +129,16 @@ public abstract class RemoteProcessClient implements DisposableBean, ExtensionPr
     /** @return the remoteClientListeners */
     public Set<RemoteProcessClientListener> getRemoteClientListeners() {
         return remoteClientListeners;
+    }
+
+    /** @return the pendingRequests */
+    public List<RemoteRequestDescriptor> getPendingRequests() {
+        return pendingRequests;
+    }
+
+    /** @return the executingRequests */
+    public Map<String, RemoteRequestDescriptor> getExecutingRequests() {
+        return executingRequests;
     }
 
     /** @param enabled the enabled to set */

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPCannotExecuteMessage.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPCannotExecuteMessage.java
@@ -1,0 +1,49 @@
+/* (c) 2014 - 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps.remote.plugin;
+
+import java.util.Map;
+import java.util.logging.Level;
+import org.geoserver.wps.remote.RemoteRequestDescriptor;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.Packet;
+
+/**
+ * Listens for "CANTEXEC" messages from XMPP service channels and takes action accordingly.
+ *
+ * @author Alessio Fabiani, GeoSolutions
+ */
+public class XMPPCannotExecuteMessage extends XMPPOutputMessage {
+
+    public XMPPCannotExecuteMessage() {
+        super("cantexec");
+    }
+
+    @Override
+    public void handleSignal(
+            XMPPClient xmppClient, Packet packet, Message message, Map<String, String> signalArgs) {
+
+        final String serviceJID = (message != null ? message.getFrom() : packet.getFrom());
+        final String pID = signalArgs.get("id");
+        final String msg = signalArgs.get("message");
+        final String execId = signalArgs.get("exec_id");
+
+        if (pID != null
+                && pID.equalsIgnoreCase("master")
+                && msg != null
+                && msg.equals(this.topic)) {
+            if (xmppClient.getExecutingRequests().containsKey(execId)) {
+                RemoteRequestDescriptor request = xmppClient.getExecutingRequests().get(execId);
+                if (request != null && request.getMetadata().get("serviceJID").equals(serviceJID)) {
+                    // Cleanup the executing request
+                    xmppClient.getExecutingRequests().remove(execId);
+                    // Enqueuing the executing request
+                    xmppClient.getPendingRequests().add(request);
+                    LOGGER.log(Level.FINE, "Enqueuing Request [" + execId + "]...");
+                }
+            }
+        }
+    }
+}

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPCompletedMessage.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPCompletedMessage.java
@@ -96,6 +96,11 @@ public class XMPPCompletedMessage extends XMPPOutputMessage {
             } catch (IOException e) {
                 LOGGER.log(Level.FINER, e.getMessage(), e);
                 throw new IOException(e.getMessage(), e);
+            } finally {
+                // Cleanup the executing requests
+                if (xmppClient.getExecutingRequests().containsKey(pID)) {
+                    xmppClient.getExecutingRequests().remove(pID);
+                }
             }
         }
         // In any case stop the process by notifying the listeners ...

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPErrorMessage.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPErrorMessage.java
@@ -52,5 +52,10 @@ public class XMPPErrorMessage implements XMPPMessage {
             listener.exceptionOccurred(pID, cause, metadata);
             listener.progress(pID, listener.getProgress(pID));
         }
+
+        // Cleanup the executing requests
+        if (xmppClient.getExecutingRequests().containsKey(pID)) {
+            xmppClient.getExecutingRequests().remove(pID);
+        }
     }
 }

--- a/src/community/wps-remote/src/main/resources/applicationContext.xml
+++ b/src/community/wps-remote/src/main/resources/applicationContext.xml
@@ -118,6 +118,9 @@
 
 	<!-- LOADAVG Signal -->
 	<bean id="xmppLoadAverageMessage" class="org.geoserver.wps.remote.plugin.XMPPLoadAverageMessage" />
+
+	<!-- CANTEXEC Signal -->
+	<bean id="xmppCannotExecuteMessage" class="org.geoserver.wps.remote.plugin.XMPPCannotExecuteMessage" />
 	
 	<!-- ERROR Signal -->
 	<bean id="xmppErrorMessage" class="org.geoserver.wps.remote.plugin.XMPPErrorMessage" />


### PR DESCRIPTION
 - Fixes GEOS-9398 : [Community][wps-remote] Async Request Management Proposal

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
