### PR TITLE
[GEOS-9355] implemented support to use params-extractor filter as a s…

### DIFF
--- a/doc/en/user/source/community/params-extractor/index.rst
+++ b/doc/en/user/source/community/params-extractor/index.rst
@@ -182,3 +182,30 @@ The rules and echo parameters can also be managed by means of a REST API found a
 ``geoserver/rest/params-extractor``. Documentation for it is available in 
 :api:`Swagger format <params-extractor.yaml>`
 
+Intercepting the security filters chain
+---------------------------------------
+By default, the params-extractor module does not interact with the security authentication filters.
+This is because the params-extractor filter is called later in the GeoServer filters chain.
+
+If you want params-extractor to work before the security filter chain, you have to configure it as
+a standard servlet filter in the GeoServer WEB-INF/web.xml file.
+
+This can be done adding the following to your current web.xml (immediately after the ``Set Character Encoding`` filter) and restarting GeoServer:
+
+    .. code-block:: xml
+
+        <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+        <web-app>
+            ...
+            <filter>
+             <filter-name>ExtractParams</filter-name>
+             <filter-class>org.geoserver.params.extractor.Filter</filter-class>
+            </filter>
+            ...
+            <filter-mapping>
+              <filter-name>ExtractParams</filter-name>
+              <url-pattern>/*</url-pattern>
+            </filter-mapping>
+            ...
+        </web-app>
+    

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
@@ -7,11 +7,16 @@ package org.geoserver.params.extractor;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
-import javax.servlet.*;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.filters.GeoServerFilter;
 import org.geoserver.platform.ExtensionPriority;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geotools.util.logging.Logging;
 
@@ -19,12 +24,34 @@ public final class Filter implements GeoServerFilter, ExtensionPriority {
 
     private static final Logger LOGGER = Logging.getLogger(Filter.class);
 
+    // this becomes true if the filter is initialized from the web container
+    // via web.xml, so that we know we should ignore the spring initialized filter
+    static boolean USE_AS_SERVLET_FILTER = false;
+
+    // marks the instance initialized via web.xml (if any) so that we can avoid
+    // duplicate filter application by the spring instance
+    private boolean servletInstance = false;
+
     private List<Rule> rules;
 
+    public Filter() {
+        // this is called if we initialize the filter in web.xml, so let's turn on the
+        // flags for this scenario
+        USE_AS_SERVLET_FILTER = true;
+        servletInstance = true;
+    }
+
     public Filter(GeoServerDataDirectory dataDirectory) {
-        Resource resource = dataDirectory.get(RulesDao.getRulesPath());
-        rules = RulesDao.getRules(resource.in());
-        resource.addListener(notify -> rules = RulesDao.getRules(resource.in()));
+        servletInstance = false;
+        initRules(dataDirectory);
+    }
+
+    private void initRules(GeoServerDataDirectory dataDirectory) {
+        if (dataDirectory != null) {
+            Resource resource = dataDirectory.get(RulesDao.getRulesPath());
+            rules = RulesDao.getRules(resource.in());
+            resource.addListener(notify -> rules = RulesDao.getRules(resource.in()));
+        }
     }
 
     @Override
@@ -32,33 +59,46 @@ public final class Filter implements GeoServerFilter, ExtensionPriority {
         return ExtensionPriority.HIGHEST;
     }
 
+    /**
+     * This method is called only when the Filter is used as a standard web container Filter. When
+     * this happens the related instance will be used instead of the one initialized by Spring.
+     */
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {}
+    public void init(FilterConfig filterConfig) throws ServletException {
+        GeoServerDataDirectory dataDirectory =
+                GeoServerExtensions.bean(GeoServerDataDirectory.class);
+
+        initRules(dataDirectory);
+    }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        if (httpServletRequest.getRequestURI().contains("web/wicket")
-                || httpServletRequest.getRequestURI().contains("geoserver/web")) {
-            chain.doFilter(request, response);
-            return;
+        if (isEnabled()) {
+            HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+            if (!httpServletRequest.getRequestURI().contains("web/wicket")
+                    && !httpServletRequest.getRequestURI().contains("geoserver/web")) {
+                UrlTransform urlTransform =
+                        new UrlTransform(
+                                httpServletRequest.getRequestURI(),
+                                httpServletRequest.getParameterMap());
+                String originalRequest = urlTransform.toString();
+                rules.forEach(rule -> rule.apply(urlTransform));
+                if (urlTransform.haveChanged()) {
+                    Utils.info(
+                            LOGGER,
+                            "Request '%s' transformed to '%s'.",
+                            originalRequest,
+                            urlTransform.toString());
+                    request = new RequestWrapper(urlTransform, httpServletRequest);
+                }
+            }
         }
-        UrlTransform urlTransform =
-                new UrlTransform(
-                        httpServletRequest.getRequestURI(), httpServletRequest.getParameterMap());
-        String originalRequest = urlTransform.toString();
-        rules.forEach(rule -> rule.apply(urlTransform));
-        if (urlTransform.haveChanged()) {
-            Utils.info(
-                    LOGGER,
-                    "Request '%s' transformed to '%s'.",
-                    originalRequest,
-                    urlTransform.toString());
-            chain.doFilter(new RequestWrapper(urlTransform, httpServletRequest), response);
-        } else {
-            chain.doFilter(request, response);
-        }
+        chain.doFilter(request, response);
+    }
+
+    boolean isEnabled() {
+        return !USE_AS_SERVLET_FILTER || servletInstance;
     }
 
     @Override

--- a/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/FilterTest.java
+++ b/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/FilterTest.java
@@ -1,0 +1,63 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.params.extractor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterConfig;
+
+public class FilterTest extends TestSupport {
+    FilterConfig filterConfig;
+
+    @Before
+    public void setUp() {
+        filterConfig = new MockFilterConfig();
+        Rule ruleA =
+                new RuleBuilder()
+                        .withId("0")
+                        .withActivated(true)
+                        .withPosition(3)
+                        .withParameter("cql_filter")
+                        .withTransform("CFCC='$2'")
+                        .build();
+        RulesDao.saveOrUpdateRule(ruleA);
+
+        Filter.USE_AS_SERVLET_FILTER = false;
+    }
+
+    @Test
+    public void testAsServletFilter() throws ServletException {
+        Filter filter = new Filter();
+        filter.init(filterConfig);
+        assertTrue(filter.isEnabled());
+    }
+
+    @Test
+    public void testAsSpringFilter() throws Exception {
+        GeoServerDataDirectory dataDirectory =
+                APPLICATION_CONTEXT.getBean(GeoServerDataDirectory.class);
+        Filter filter = new Filter(dataDirectory);
+        assertTrue(filter.isEnabled());
+    }
+
+    @Test
+    public void testServletFilterHasPriorityOverSpring() throws ServletException {
+        Filter servletFilter = new Filter();
+        servletFilter.init(filterConfig);
+
+        GeoServerDataDirectory dataDirectory =
+                APPLICATION_CONTEXT.getBean(GeoServerDataDirectory.class);
+        Filter springFilter = new Filter(dataDirectory);
+
+        assertTrue(servletFilter.isEnabled());
+        assertFalse(springFilter.isEnabled());
+    }
+}


### PR DESCRIPTION
…tandard servlet filter, to intercept the security filters chain - backport to 2.15.x

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
