### PR TITLE
[GEOS-9191] (Fixed) FileSystemWatcher: 100% CPU usage while idle running on a large data directory

### DIFF
--- a/src/platform/pom.xml
+++ b/src/platform/pom.xml
@@ -98,5 +98,10 @@
     <artifactId>guava</artifactId>
     <scope>test</scope>
   </dependency>
+  <dependency>
+    <groupId>org.awaitility</groupId>
+    <artifactId>awaitility</artifactId>
+    <scope>test</scope>
+  </dependency>
  </dependencies>
 </project>

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemWatcher.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemWatcher.java
@@ -5,19 +5,33 @@
  */
 package org.geoserver.platform.resource;
 
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.geoserver.platform.resource.ResourceNotification.Kind;
+import org.geotools.util.logging.Logging;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
@@ -35,41 +49,45 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
  */
 public class FileSystemWatcher implements ResourceNotificationDispatcher, DisposableBean {
 
-    interface FileExtractor {
-        public File getFile(String path);
-    }
+    private static final Logger LOGGER = Logging.getLogger(FileSystemWatcher.class);
 
     /** Change to file system */
     static class Delta {
+        /** Watched directory where changes occurred */
         final File context;
 
         final Kind kind;
 
-        final List<File> created;
+        /** Paths relative to the context directory that have been created */
+        final List<String> created;
 
-        final List<File> removed;
+        /** Paths relative to the context directory that have been removed */
+        final List<String> removed;
 
-        final List<File> modified;
+        /** Paths relative to the context directory that have been modified */
+        final List<String> modified;
 
         public Delta(File context, Kind kind) {
             this.context = context;
             this.kind = kind;
-            this.created = null;
-            this.removed = null;
-            this.modified = null;
+            this.created = this.removed = this.modified = Collections.emptyList();
         }
 
         public Delta(
                 File context,
                 Kind kind,
-                List<File> created,
-                List<File> removed,
-                List<File> modified) {
+                List<String> created,
+                List<String> removed,
+                List<String> modified) {
             this.context = context;
             this.kind = Kind.ENTRY_MODIFY;
-            this.created = created != null ? created : (List<File>) Collections.EMPTY_LIST;
-            this.removed = removed != null ? removed : (List<File>) Collections.EMPTY_LIST;
-            this.modified = modified != null ? modified : (List<File>) Collections.EMPTY_LIST;
+            this.created = created == null ? Collections.emptyList() : created;
+            this.removed = removed == null ? Collections.emptyList() : removed;
+            this.modified = modified == null ? Collections.emptyList() : modified;
+        }
+
+        public int size() {
+            return created.size() + removed.size() + modified.size();
         }
 
         @Override
@@ -94,7 +112,7 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
         /** Path to use during notification */
         final String path;
 
-        List<ResourceListener> listeners = new CopyOnWriteArrayList<ResourceListener>();
+        final List<ResourceListener> listeners = new CopyOnWriteArrayList<ResourceListener>();
 
         /** When last notification was sent */
         long last = 0;
@@ -102,16 +120,33 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
         /** Used to track resource creation / deletion */
         boolean exsists;
 
-        File[] contents; // directory contents at last check
+        private Set<File> children = null;
+        private long childrenLastModifiedMax = 0L;
 
         public Watch(File file, String path) {
+            Objects.requireNonNull(file);
+            Objects.requireNonNull(path);
             this.file = file;
             this.path = path;
             this.exsists = file.exists();
             this.last = exsists ? file.lastModified() : 0;
             if (file.isDirectory()) {
-                contents = file.listFiles();
+                this.children = loadDirectoryContents(file);
+                this.childrenLastModifiedMax =
+                        this.children
+                                .parallelStream()
+                                .mapToLong(File::lastModified)
+                                .max()
+                                .orElse(0L);
             }
+        }
+
+        private Set<File> loadDirectoryContents(File directory) {
+            File[] files = directory.listFiles();
+            if (files == null) {
+                return new HashSet<>();
+            }
+            return Arrays.stream(files).collect(Collectors.toSet());
         }
 
         public void addListener(ResourceListener listener) {
@@ -134,24 +169,18 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
         public int hashCode() {
             final int prime = 31;
             int result = 1;
-            result = prime * result + ((file == null) ? 0 : file.hashCode());
-            result = prime * result + ((path == null) ? 0 : path.hashCode());
+            result = prime * result + file.hashCode();
+            result = prime * result + path.hashCode();
             return result;
         }
 
         @Override
         public boolean equals(Object obj) {
             if (this == obj) return true;
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
+            if (!(obj instanceof Watch)) return false;
+
             Watch other = (Watch) obj;
-            if (file == null) {
-                if (other.file != null) return false;
-            } else if (!file.equals(other.file)) return false;
-            if (path == null) {
-                if (other.path != null) return false;
-            } else if (!path.equals(other.path)) return false;
-            return true;
+            return file.equals(other.file) && path.equals(other.path);
         }
 
         @Override
@@ -172,115 +201,125 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
 
         public Delta changed(long now) {
             if (!file.exists()) {
-                if (exsists) {
-                    exsists = false;
-                    if (contents != null) {
-                        // delete directory
-                        List<File> deleted = Arrays.asList(contents);
-                        this.last = now;
-                        this.contents = null;
-                        return new Delta(file, Kind.ENTRY_DELETE, null, deleted, null);
-                    } else {
-                        // file has been deleted!
-                        this.last = now;
-                        return new Delta(file, Kind.ENTRY_DELETE);
-                    }
-                } else {
-                    return null; // no change file still deleted!
-                }
+                return watchedFileRemoved(now);
             }
             if (file.isFile()) {
-                long fileModified = file.lastModified();
-                if (fileModified > last || !exsists) {
-                    if (exsists) {
-                        this.last = fileModified;
-                        return new Delta(file, Kind.ENTRY_MODIFY);
-                    } else {
-                        exsists = true;
-                        this.last = fileModified;
-                        return new Delta(file, Kind.ENTRY_CREATE);
-                    }
-                } else {
-                    return null; // no change!
-                }
+                return simpleFileCheck();
             }
-            if (file.isDirectory()) {
-                Kind kind = null;
-                long fileModified = file.lastModified();
-                if (fileModified > last || !exsists) {
-                    kind = exsists ? Kind.ENTRY_MODIFY : Kind.ENTRY_CREATE;
-                    exsists = true;
-                }
-                File[] files = file.listFiles();
-                if (files == null) {
-                    return null;
-                }
+            return pollDirectory();
+        }
 
-                List<File> removed = new ArrayList<File>(files.length);
-                List<File> created = new ArrayList<File>(files.length);
-                List<File> modified = new ArrayList<File>(files.length);
-
-                removed.addAll(Arrays.asList(this.contents));
-                removed.removeAll(Arrays.asList(files));
-                if (!removed.isEmpty()) {
-                    fileModified = Math.max(fileModified, last + 1);
-                }
-
-                created.addAll(Arrays.asList(files));
-                created.removeAll(Arrays.asList(this.contents));
-                for (File check : created) {
-                    long checkModified = check.lastModified();
-                    fileModified = Math.max(fileModified, checkModified);
-                }
-                // check contents
-                List<File> review = new ArrayList<File>(files.length);
-                review.addAll(Arrays.asList(files));
-                review.removeAll(created); // no need to check these they are new
-                for (File check : review) {
-                    long checkModified = check.lastModified();
-                    if (checkModified > last) {
-                        modified.add(check);
-                        fileModified = Math.max(fileModified, checkModified);
-                    }
-                }
-                if (kind == null) {
-                    if (removed.isEmpty() && created.isEmpty() && modified.isEmpty()) {
-                        // win only check of directory contents
-                        return null; // no change to directory contents
-                    } else {
-                        kind = Kind.ENTRY_MODIFY;
-                    }
-                }
+        private Delta pollDirectory() {
+            Objects.requireNonNull(this.children);
+            final long fileModified = file.lastModified();
+            // REVISIT, with pollUpdatesOnly we could avoid scanning the directory
+            // (file.listFiles()) but then we'd miss added/deleted files that happened too
+            // fast for the directory's timestamp to be changed (given file.lastModified()
+            // generally lacks enough resolution)
+            // final boolean pollUpdatesOnly;
+            final Kind kind;
+            if (this.last == fileModified) {
+                // this.file is a directory and its utime hasn't changed. This means no child
+                // has been added or removed, but can't know if some child's been changed
+                // pollUpdatesOnly = true;
+                kind = Kind.ENTRY_MODIFY;
+            } else {
+                // pollUpdatesOnly = false;
+                kind = this.exsists ? Kind.ENTRY_MODIFY : Kind.ENTRY_CREATE;
                 this.last = fileModified;
-                this.contents = files;
-                return new Delta(file, kind, created, removed, modified);
+                this.exsists = true;
             }
-            return null; // no change
+
+            long childrenMaxLastModified = this.childrenLastModifiedMax;
+
+            final CompletableFuture<File[]> contentsFuture =
+                    CompletableFuture.supplyAsync(() -> this.file.listFiles());
+
+            final Map<Kind, List<String>> itemsByType = new EnumMap<>(Kind.class);
+            // check for updates. Fastest path, no need to list current directory contents
+            // nor check for removed files here
+            Iterator<File> it = this.children.iterator();
+            while (it.hasNext()) {
+                File child = it.next();
+                long lastModified = child.lastModified();
+                if (0L == lastModified) { // removed
+                    it.remove();
+                    itemsByType
+                            .computeIfAbsent(Kind.ENTRY_DELETE, k -> new ArrayList<>())
+                            .add(child.getName());
+                } else if (lastModified > this.childrenLastModifiedMax) {
+                    childrenMaxLastModified = lastModified;
+                    itemsByType
+                            .computeIfAbsent(Kind.ENTRY_MODIFY, k -> new ArrayList<>())
+                            .add(child.getName());
+                }
+            }
+
+            final File[] contents = contentsFuture.join();
+            if (null != contents) {
+                // find new
+                for (File child : contents) {
+                    if (this.children.add(child)) {
+                        childrenMaxLastModified =
+                                Math.max(childrenMaxLastModified, child.lastModified());
+                        itemsByType
+                                .computeIfAbsent(Kind.ENTRY_CREATE, k -> new ArrayList<>())
+                                .add(child.getName());
+                    }
+                }
+            }
+
+            if (itemsByType.isEmpty()) {
+                // win only check of directory contents
+                return null; // no change to directory contents
+            }
+            this.childrenLastModifiedMax = childrenMaxLastModified;
+            List<String> created = itemsByType.get(Kind.ENTRY_CREATE);
+            List<String> removed = itemsByType.get(Kind.ENTRY_DELETE);
+            List<String> modified = itemsByType.get(Kind.ENTRY_MODIFY);
+            Delta delta = new Delta(file, kind, created, removed, modified);
+            return delta;
+        }
+
+        private Delta simpleFileCheck() {
+            long fileModified = file.lastModified();
+            if (fileModified > last || !exsists) {
+                Kind kind = this.exsists ? Kind.ENTRY_MODIFY : Kind.ENTRY_CREATE;
+                this.exsists = true;
+                this.last = fileModified;
+                return new Delta(file, kind);
+            } else {
+                return null; // no change!
+            }
+        }
+
+        private Delta watchedFileRemoved(long now) {
+            Delta delta = null;
+            if (this.exsists) {
+                if (this.children == null) {
+                    // file has been deleted!
+                    delta = new Delta(file, Kind.ENTRY_DELETE);
+                } else {
+                    // delete directory
+                    List<String> deleted =
+                            this.children.stream().map(File::getName).collect(Collectors.toList());
+                    delta = new Delta(file, Kind.ENTRY_DELETE, null, deleted, null);
+                }
+                this.last = now;
+                this.exsists = false;
+                this.children = null;
+            }
+            return delta;
         }
 
         public boolean isMatch(File file, String path) {
-            if (this.file == null) {
-                if (file != null) {
-                    return false;
-                }
-            } else if (!this.file.equals(file)) {
-                return false;
-            }
-
-            if (this.path == null) {
-                if (path != null) {
-                    return false;
-                }
-            } else if (!this.path.equals(path)) {
-                return false;
-            }
-            return true;
+            return this.file.equals(file) && this.path.equals(path);
         }
     }
 
     private ScheduledExecutorService pool;
 
-    private FileExtractor fileExtractor;
+    private final Function<String, File> fileExtractor;
 
     protected long lastmodified;
 
@@ -301,36 +340,77 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
                             watchers.remove(watch);
                             continue;
                         }
-                        Delta delta = watch.changed(now);
+                        final boolean directory = watch.file.isDirectory();
+                        Level level = Level.FINER;
+                        long start = System.nanoTime();
+                        if (directory) LOGGER.log(level, "polling contents of " + watch.file);
+                        Delta delta;
+                        try {
+                            delta = watch.changed(now);
+                        } catch (RuntimeException e) {
+                            LOGGER.log(Level.WARNING, "Error polling contents of " + watch.file, e);
+                            return;
+                        }
+                        if (directory && LOGGER.isLoggable(level)) {
+                            long ellapsedMicros =
+                                    MICROSECONDS.convert(System.nanoTime() - start, NANOSECONDS);
+                            long ellapsedMillis =
+                                    MILLISECONDS.convert(ellapsedMicros, MICROSECONDS);
+                            String unit = ellapsedMillis == 0L ? "us" : "ms";
+                            long time = ellapsedMillis == 0L ? ellapsedMicros : ellapsedMillis;
+                            LOGGER.log(
+                                    level,
+                                    String.format(
+                                            "delta computed in %,d%s for %s",
+                                            time, unit, watch.file));
+                        }
                         if (delta != null) {
-
-                            /** Created based on created/removed/modified files */
-                            List<ResourceNotification.Event> events =
-                                    ResourceNotification.delta(
-                                            watch.file,
-                                            delta.created,
-                                            delta.removed,
-                                            delta.modified);
-
-                            ResourceNotification notify =
-                                    new ResourceNotification(
-                                            watch.getPath(), delta.kind, watch.last, events);
-
-                            for (ResourceListener listener : watch.getListeners()) {
-                                try {
-                                    listener.changed(notify);
-                                } catch (Throwable t) {
-                                    Logger logger =
-                                            Logger.getLogger(
-                                                    listener.getClass().getPackage().getName());
-                                    logger.log(
-                                            Level.FINE,
-                                            "Unable to notify " + watch + ":" + t.getMessage(),
-                                            t);
-                                }
-                            }
+                            notify(watch, delta);
                         }
                     }
+                }
+
+                private void notify(Watch watch, Delta delta) {
+                    if (LOGGER.isLoggable(Level.INFO)) {
+                        LOGGER.info(
+                                String.format(
+                                        "Notifying %s change on %s. Created: %,d, removed: %,d, modified: %,d",
+                                        delta.kind,
+                                        delta.context,
+                                        delta.created.size(),
+                                        delta.removed.size(),
+                                        delta.modified.size()));
+                    }
+                    // do not call listeners on the watch thread, they may take a
+                    // considerable amount of time to process the events
+                    CompletableFuture.runAsync(
+                            () -> {
+                                /** Created based on created/removed/modified files */
+                                List<ResourceNotification.Event> events =
+                                        ResourceNotification.delta(
+                                                watch.file,
+                                                delta.created,
+                                                delta.removed,
+                                                delta.modified);
+
+                                ResourceNotification notify =
+                                        new ResourceNotification(
+                                                watch.getPath(), delta.kind, watch.last, events);
+
+                                for (ResourceListener listener : watch.getListeners()) {
+                                    try {
+                                        listener.changed(notify);
+                                    } catch (Throwable t) {
+                                        Logger logger =
+                                                Logger.getLogger(
+                                                        listener.getClass().getPackage().getName());
+                                        logger.log(
+                                                Level.FINE,
+                                                "Unable to notify " + watch + ":" + t.getMessage(),
+                                                t);
+                                    }
+                                }
+                            });
                 }
             };
 
@@ -338,7 +418,7 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
 
     private TimeUnit unit = TimeUnit.SECONDS;
 
-    private long delay = 10;
+    private long delay = 5;
 
     private static CustomizableThreadFactory tFactory;
 
@@ -352,25 +432,20 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
      *
      * <p>Internally a single threaded schedule executor is used to monitor files.
      */
-    FileSystemWatcher(FileExtractor fileExtractor) {
+    FileSystemWatcher(Function<String, File> fileExtractor) {
+        Objects.requireNonNull(fileExtractor);
         this.pool = Executors.newSingleThreadScheduledExecutor(tFactory);
         this.fileExtractor = fileExtractor;
     }
 
     FileSystemWatcher() {
-        this(
-                new FileExtractor() {
-                    @Override
-                    public File getFile(String path) {
-                        return new File(path.replace('/', File.separatorChar));
-                    }
-                });
+        this(path -> new File(path.replace('/', File.separatorChar)));
     }
 
     private Watch watch(File file, String path) {
-        if (file == null || path == null) {
-            return null;
-        }
+        Objects.requireNonNull(file);
+        Objects.requireNonNull(path);
+
         for (Watch watch : watchers) {
             if (watch.isMatch(file, path)) {
                 return watch;
@@ -380,13 +455,9 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
     }
 
     public synchronized void addListener(String path, ResourceListener listener) {
-        File file = fileExtractor.getFile(path);
-        if (file == null) {
-            throw new NullPointerException("File to watch is required");
-        }
-        if (path == null) {
-            throw new NullPointerException("Path for notification is required");
-        }
+        Objects.requireNonNull(path, "Path for notification is required");
+        File file = fileExtractor.apply(path);
+        Objects.requireNonNull(file, "File to watch is required");
         Watch watch = watch(file, path);
         if (watch == null) {
             watch = new Watch(file, path);
@@ -399,13 +470,10 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
     }
 
     public synchronized boolean removeListener(String path, ResourceListener listener) {
-        File file = fileExtractor.getFile(path);
-        if (file == null) {
-            throw new NullPointerException("File to watch is required");
-        }
-        if (path == null) {
-            throw new NullPointerException("Path for notification is required");
-        }
+        Objects.requireNonNull(path, "Path for notification is required");
+        File file = fileExtractor.apply(path);
+        Objects.requireNonNull(file, "File to watch is required");
+
         Watch watch = watch(file, path);
         boolean removed = false;
         if (watch != null) {
@@ -441,6 +509,7 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
     @Override
     public void destroy() throws Exception {
         pool.shutdown();
+        monitor = null;
     }
 
     @Override

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceTheoryTest.java
@@ -6,22 +6,26 @@ package org.geoserver.platform.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.geoserver.platform.resource.ResourceNotification.Event;
 import org.geoserver.platform.resource.ResourceNotification.Kind;
+import org.hamcrest.core.IsNull;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoints;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
@@ -29,6 +33,8 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
     FileSystemResourceStore store;
 
     @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @DataPoints
     public static String[] testPaths() {
@@ -60,14 +66,18 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
         store = new FileSystemResourceStore(folder.getRoot());
     }
 
+    @After
+    public void after() throws Exception {
+        if (store != null && store.watcher.get() != null) {
+            store.watcher.get().destroy();
+        }
+    }
+
     @Test
     public void invalid() {
-        try {
-            Resource resource = store.get("..");
-            assertNotNull(resource);
-            fail(".. invalid");
-        } catch (IllegalArgumentException expected) {
-        }
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Contains invalid .. path");
+        store.get("..");
     }
 
     @Test
@@ -77,13 +87,14 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
         AwaitResourceListener listener = new AwaitResourceListener();
 
         store.get("DirC/FileD").addListener(listener);
-        store.watcher.schedule(30, TimeUnit.MILLISECONDS);
+        ((FileSystemWatcher) store.getResourceNotificationDispatcher())
+                .schedule(30, TimeUnit.MILLISECONDS);
 
         long before = fileD.lastModified();
         long after = touch(fileD);
         assertTrue("touched", after > before);
 
-        ResourceNotification n = listener.await(5, TimeUnit.SECONDS);
+        ResourceNotification n = listener.await(1, TimeUnit.SECONDS);
         assertNotNull("detected event", n);
 
         assertEquals("file modified", Kind.ENTRY_MODIFY, n.getKind());
@@ -100,39 +111,42 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
         assertEquals("file created", Kind.ENTRY_CREATE, n.getKind());
         store.get("DirC/FileD").removeListener(listener);
     }
+
     /**
-     * Must delay long enough to match file system resolution (2 seconds).
+     * Changes the {@link File#lastModified() file.lastModified()} timestamp, making sure the result
+     * differs from its current timestamp; may delay long enough to match file system resolution.
      *
      * <p>Example: Linux systems expect around 1 second resolution for file modification.
      *
      * @param file
      * @return resulting value of lastmodified
-     * @throws InterruptedException
      */
-    private long touch(File file) throws InterruptedException {
+    private long touch(File file) {
         long origional = file.lastModified();
         if (origional == 0l) {
             return 0l; // cannot modify a file that does not exsist
         }
-        Thread.sleep(2000); // wait two seconds
-        long modifided = System.currentTimeMillis();
-        file.setLastModified(modifided);
-        for (modifided = file.lastModified();
-                (modifided - origional) < 2000;
-                modifided = file.lastModified()) {
+        long after = origional;
+        do {
             file.setLastModified(System.currentTimeMillis());
-            Thread.sleep(1000);
-        }
-        return modifided;
+        } while (origional == (after = file.lastModified()));
+        return after;
     }
 
     @Test
     public void eventNotification() throws InterruptedException {
         AwaitResourceListener listener = new AwaitResourceListener();
 
-        ResourceNotification n =
-                listener.await(5, TimeUnit.SECONDS); // expect timeout as no events will be sent!
-        assertNull("No events expected", n);
+        ResourceNotification notification =
+                new ResourceNotification(".", Kind.ENTRY_CREATE, 1_000_000L);
+        CompletableFuture.runAsync(() -> listener.changed(notification));
+
+        ResourceNotification n = listener.await(500, TimeUnit.MILLISECONDS);
+        assertSame(notification, n);
+
+        listener.reset();
+        expectedException.expect(ConditionTimeoutException.class);
+        listener.await(100, TimeUnit.MILLISECONDS); // expect timeout as no events will be sent!
     }
 
     @Test
@@ -145,12 +159,13 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
 
         AwaitResourceListener listener = new AwaitResourceListener();
         store.get(Paths.BASE).addListener(listener);
-        store.watcher.schedule(30, TimeUnit.MILLISECONDS);
+        ((FileSystemWatcher) store.getResourceNotificationDispatcher())
+                .schedule(100, TimeUnit.MILLISECONDS);
 
         long before = fileB.lastModified();
         long after = touch(fileB);
         assertTrue("touched", after > before);
-        ResourceNotification n = listener.await(5, TimeUnit.SECONDS);
+        ResourceNotification n = listener.await(500, TimeUnit.MILLISECONDS);
 
         assertEquals(Kind.ENTRY_MODIFY, n.getKind());
         assertEquals(Paths.BASE, n.getPath());
@@ -170,7 +185,7 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
 
         listener.reset();
         fileA.createNewFile();
-        n = listener.await(5, TimeUnit.SECONDS);
+        n = listener.await(2, TimeUnit.SECONDS);
         assertEquals(Kind.ENTRY_MODIFY, n.getKind());
         assertEquals(Paths.BASE, n.getPath());
         e = n.events().get(0);
@@ -181,87 +196,27 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
     }
 
     /** ResourceListener that traps the next ResourceNotification for testing */
-    static class AwaitResourceListener extends Await<ResourceNotification>
-            implements ResourceListener {
+    static class AwaitResourceListener implements ResourceListener {
+        private final AtomicReference<ResourceNotification> reference = new AtomicReference<>();
+
         @Override
         public void changed(ResourceNotification notify) {
-            notify(notify);
-        }
-    }
-    /**
-     * Support class to efficiently wait for event notification.
-     *
-     * @author Jody Garnett (Boundless)
-     * @param <T> Event Type
-     */
-    abstract static class Await<T> {
-
-        Lock lock = new ReentrantLock(true);
-
-        Condition condition = lock.newCondition();
-
-        private T event = null;
-
-        public void notify(T notification) {
-            // System.out.println("Arrived:"+notification);
-            lock.lock();
-            try {
-                if (this.event == null) {
-                    this.event = notification;
-                }
-                condition.signalAll(); // wake up your event is ready
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        public T await() throws InterruptedException {
-            return await(5, TimeUnit.SECONDS);
-        }
-        /**
-         * Wait for event notification.
-         *
-         * <p>If the event has arrived already this method will return immediately, if not we will
-         * wait for signal. If the event still has not arrived after five seconds null will be
-         * returned.
-         *
-         * @return Notification event, or null if it does not arrive within 5 seconds
-         * @throws InterruptedException
-         */
-        public T await(long howlong, TimeUnit unit) throws InterruptedException {
-            final long DELAY = unit.convert(howlong, TimeUnit.MILLISECONDS);
-            lock.lock();
-            try {
-                if (this.event == null) {
-                    long mark = System.currentTimeMillis();
-                    while (this.event == null) {
-                        long check = System.currentTimeMillis();
-                        if (mark + DELAY < check) {
-                            return null; // event did not show up!
-                        }
-                        boolean signal = condition.await(1, TimeUnit.SECONDS);
-                        // System.out.println("check wait="+signal+" time="+check+"
-                        // notify="+this.event);
-                    }
-                }
-            } finally {
-                lock.unlock();
-            }
-            return this.event;
+            reference.set(notify);
         }
 
         public void reset() {
-            lock.lock();
-            try {
-                this.event = null;
-            } finally {
-                lock.unlock();
-            }
+            this.reference.set(null);
         }
 
-        @Override
-        public String toString() {
-            return "Await [event=" + event + "]";
+        /**
+         * Awaits for {@link #changed} to be called for at most the given timeout before throwing a
+         * {@link ConditionTimeoutException}, returning the event in case it was received.
+         */
+        public ResourceNotification await(int timeout, TimeUnit unit) {
+            return Awaitility.await()
+                    .pollInterval(5, TimeUnit.MILLISECONDS)
+                    .atMost(timeout, unit)
+                    .untilAtomic(this.reference, IsNull.notNullValue());
         }
     }
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -617,6 +617,12 @@
     <scope>test</scope>
    </dependency>
    <dependency>
+     <groupId>org.awaitility</groupId>
+     <artifactId>awaitility</artifactId>
+     <version>4.0.1</version>
+     <scope>test</scope>
+   </dependency>
+   <dependency>
     <groupId>org.hamcrest</groupId>
     <artifactId>hamcrest-library</artifactId>
     <version>1.3</version>


### PR DESCRIPTION
re-applies #3860 fixing a bug that resulted in an NPE when the watched directory didn't exist at the time of registering a directory listener.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
