### PR TITLE
[GEOS-9406] Data format issues on Custom vector dimensions GetCapabilities

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/dimension/AbstractDefaultValueSelectionStrategy.java
+++ b/src/wms/src/main/java/org/geoserver/wms/dimension/AbstractDefaultValueSelectionStrategy.java
@@ -44,8 +44,18 @@ public abstract class AbstractDefaultValueSelectionStrategy
             retval = numberValue.toString();
         } else {
             Object value = getDefaultValue(resource, dimensionName, dimensionInfo, Object.class);
-            retval = value.toString();
+            retval = stringRepresentation(value);
         }
         return retval;
+    }
+
+    private String stringRepresentation(Object value) {
+        if (value == null) return "";
+        if (value instanceof Date) {
+            Date dateValue = (Date) value;
+            return DateUtil.serializeDateTime(dateValue.getTime(), true);
+        } else {
+            return value.toString();
+        }
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorCapabilitiesTest.java
@@ -404,4 +404,19 @@ public class DimensionsVectorCapabilitiesTest extends WMSDimensionsTestSupport {
         assertXpathEvaluatesTo(
                 "0.0,1.0,2.0,3.0", "//Layer[Name='sf:TimeElevation']/Extent/text()", dom);
     }
+
+    @Test
+    public void testCustomContinuousDate() throws Exception {
+        setupVectorDimension(
+                "dim_custom",
+                "time",
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                UNITS,
+                UNIT_SYMBOL);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.0"), false);
+        assertXpathEvaluatesTo(
+                "2011-05-01T00:00:00Z", "//Layer[Name='sf:TimeElevation']/Extent/@default", dom);
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/DimensionsVectorCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/DimensionsVectorCapabilitiesTest.java
@@ -426,4 +426,41 @@ public class DimensionsVectorCapabilitiesTest extends WMSDimensionsTestSupport {
         assertXpathEvaluatesTo("0.0", "//wms:Layer/wms:Dimension/@default", dom);
         assertXpathEvaluatesTo("0.0/3.0/0", "//wms:Layer/wms:Dimension", dom);
     }
+
+    @Test
+    public void testCustomDiscreteInterval() throws Exception {
+        setupVectorDimension(
+                "dim_custom",
+                "lwidth",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                null,
+                UNITS,
+                UNIT_SYMBOL);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+        print(dom);
+
+        // check dimension has been declared
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("custom", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo(UNITS, "//wms:Layer/wms:Dimension/@units", dom);
+        assertXpathEvaluatesTo(UNIT_SYMBOL, "//wms:Layer/wms:Dimension/@unitSymbol", dom);
+        // check we have the extent
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("custom", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo("1", "//wms:Layer/wms:Dimension/@default", dom);
+        assertXpathEvaluatesTo("1/4/1", "//wms:Layer/wms:Dimension", dom);
+    }
+
+    @Test
+    public void testCustomContinuousDate() throws Exception {
+        setupVectorDimension(
+                "dim_custom", "time", DimensionPresentation.LIST, null, UNITS, UNIT_SYMBOL);
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+        assertXpathEvaluatesTo(
+                "2011-05-01T00:00:00Z",
+                "//wms:Layer[wms:Name/text() = \"sf:TimeElevation\"]/wms:Dimension/@default",
+                dom);
+        print(dom);
+    }
 }

--- a/src/wms/src/test/resources/org/geoserver/wms/TimeElevation.properties
+++ b/src/wms/src/test/resources/org/geoserver/wms/TimeElevation.properties
@@ -1,5 +1,5 @@
-_=geom:Polygon:srid=4326,time:java.util.Date,elevation:double,shared_key:String,enabled:Boolean
-TimeElevation.0=POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))|2011-05-01Z|0.0|str0|false
-TimeElevation.1=POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))|2011-05-02Z|1.0|str1|true
-TimeElevation.2=POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))|2011-05-03Z|2.0|str2|false
-TimeElevation.3=POLYGON((0 -90, 180 -90, 180 0, 0 0, 0 -90))|2011-05-04Z|3.0|str3|false
+_=geom:Polygon:srid=4326,time:java.util.Date,elevation:double,shared_key:String,enabled:Boolean,lwidth:int
+TimeElevation.0=POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))|2011-05-01Z|0.0|str0|false|1
+TimeElevation.1=POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))|2011-05-02Z|1.0|str1|true|4
+TimeElevation.2=POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))|2011-05-03Z|2.0|str2|false|3
+TimeElevation.3=POLYGON((0 -90, 180 -90, 180 0, 0 0, 0 -90))|2011-05-04Z|3.0|str3|false|2


### PR DESCRIPTION
There are data format issues on on Custom vector dimensions GetCapabilities response document, described as following:

1. Date format: Dates are displayed on Locale format instead ISO8601 format on default attribute.
2. Interval representation: The end point of the interval representation seems to be the start point (e.g., values 1,2,3,4 -> 1/1 instead of 1/4), also integer numbers are showed as doubles.

This PR introduces a fix for the GetCapabilities format issues.

JIRA ticket:
https://osgeo-org.atlassian.net/browse/GEOS-9406

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
