### PR TITLE
[GEOS-9417] Monitoring plugin fails when a WMS GetLegendGraphic is is…

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/LegendGraphicAjaxUpdater.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/LegendGraphicAjaxUpdater.java
@@ -12,6 +12,7 @@ import org.apache.wicket.markup.html.image.Image;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.geoserver.catalog.StyleInfo;
+import org.opengis.feature.type.Name;
 
 /**
  * Helper class for a wicket ajax behavior that updates the {@code src} attribute of an {@link
@@ -32,16 +33,19 @@ class LegendGraphicAjaxUpdater implements Serializable {
     private String wmsURL;
 
     public LegendGraphicAjaxUpdater(
-            final String wmsURL, final Image image, final IModel<StyleInfo> styleInfoModel) {
+            final String wmsURL,
+            final Image image,
+            final IModel<StyleInfo> styleInfoModel,
+            Name layerName) {
         this.wmsURL = wmsURL;
         this.image = image;
         this.styleInfoModel = styleInfoModel;
         this.urlModel = new Model<String>(wmsURL);
         this.image.add(new AttributeModifier("src", urlModel));
-        updateStyleImage(null);
+        updateStyleImage(null, layerName);
     }
 
-    public void updateStyleImage(AjaxRequestTarget target) {
+    public void updateStyleImage(AjaxRequestTarget target, Name layerName) {
         String url =
                 wmsURL
                         + "REQUEST=GetLegendGraphic&VERSION=1.0.0&FORMAT=image/png&WIDTH=20&HEIGHT=20&STRICT=false&style=";
@@ -49,6 +53,11 @@ class LegendGraphicAjaxUpdater implements Serializable {
         if (styleInfo != null) {
             String style = styleInfo.prefixedName();
             url += style;
+            url +=
+                    "&layer="
+                            + layerName.getNamespaceURI()
+                            + layerName.getSeparator()
+                            + layerName.getLocalPart();
             urlModel.setObject(url);
             if (target != null) {
                 target.add(image);

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
@@ -141,6 +141,8 @@ public class WMSLayerConfigTest extends GeoServerWicketTestSupport {
         AttributeModifier mod = (AttributeModifier) img.getBehaviors().get(0);
         assertTrue(mod.toString().contains("wms?REQUEST=GetLegendGraphic"));
         assertTrue(mod.toString().contains("style=cite:Ponds"));
+        String ft = layer.getResource().getNamespace().getPrefix() + ":" + layer.getName();
+        assertTrue(mod.toString().contains("layer=" + ft));
     }
 
     @Test


### PR DESCRIPTION
…sued

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
