### PR TITLE
Add debug flag and vendor param to show imageprocessing chain

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
@@ -173,6 +173,12 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
     /** The lookup table used for data type transformation (it's really the identity one) */
     private static LookupTableJAI IDENTITY_TABLE = new LookupTableJAI(getTable());
 
+    /** Show Chain key */
+    public static final String RASTER_CHAIN_DEBUG_KEY = "wms.raster.enableRasterChainDebug";
+
+    /** Show Chain */
+    private static Boolean RASTER_CHAIN_DEBUG = Boolean.getBoolean(RASTER_CHAIN_DEBUG_KEY);
+
     private Function<WMSMapContent, LabelCache> labelCache = null;
 
     private static byte[] getTable() {
@@ -1520,6 +1526,12 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                     Level.FINE,
                     "Direct rendering path produced the following image chain:\n"
                             + RenderedImageBrowser.dumpChain(image));
+        }
+        Map<String, String> rawKvp = null;
+        if (RASTER_CHAIN_DEBUG
+                && ((rawKvp = mapContent.getRequest().getRawKvp()) != null)
+                && Boolean.valueOf(rawKvp.get("showchain"))) {
+            RenderedImageBrowser.showChain(image, true, true, "RenderedImageMapOutput", true);
         }
         return image;
     }


### PR DESCRIPTION
This PR simply add support for a wms.raster.showChain=true JAVA_OPT to be used in debugging/testing mode. It supports RenderedImageBrowser usage on RenderedImageMapOutputFormat when the wms request has an additional "&showchain=true" vendor param specified

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
