### PR TITLE
[GEOS-9361] Add Math support on freemarker template

### DIFF
--- a/doc/en/user/source/tutorials/freemarker.rst
+++ b/doc/en/user/source/tutorials/freemarker.rst
@@ -97,6 +97,9 @@ Allows accessing several environment variables, in particular those defined in:
  * OS environment variables
  * web.xml context parameters 
 
+**Math (map)**
+
+Allows accessing math functions.
 
 Examples
 ``````````````````
@@ -110,6 +113,9 @@ Examples
  * ${environment.GEOSERVER_DATA_DIR}
  * ${environment.WEB_SITE_URL}
 
+**Math**
+  
+ * ${Math.max(request.NUMBER1,request.NUMBER2)}
 
 
 

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormat.java
@@ -5,12 +5,7 @@
  */
 package org.geoserver.wms.featureinfo;
 
-import freemarker.template.Configuration;
-import freemarker.template.SimpleHash;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
+import freemarker.template.*;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -61,9 +56,15 @@ public class HTMLFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat {
                             SimpleHash map = (SimpleHash) super.wrap(object);
                             map.put("request", Dispatcher.REQUEST.get().getKvp());
                             map.put("environment", new EnvironmentVariablesTemplateModel());
+                            map.put("Math", getStaticModel("java.lang.Math"));
                             return map;
                         }
                         return super.wrap(object);
+                    }
+
+                    private TemplateHashModel getStaticModel(String path)
+                            throws TemplateModelException {
+                        return (TemplateHashModel) getStaticModels().get(path);
                     }
                 });
     }

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
@@ -110,6 +110,8 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
         Request request = new Request();
         parameters = new HashMap<String, Object>();
         parameters.put("LAYER", "testLayer");
+        parameters.put("NUMBER1", 10);
+        parameters.put("NUMBER2", 100);
         Map<String, String> env = new HashMap<String, String>();
         env.put("TEST1", "VALUE1");
         env.put("TEST2", "VALUE2");
@@ -342,5 +344,14 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
         } finally {
             executor.shutdown();
         }
+    }
+
+    @Test
+    public void testStaticMathMethodsAreEvaluatedInTemplate() throws IOException {
+        currentTemplate = "test_static_content.ftl";
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        outputFormat.write(fcType, getFeatureInfoRequest, outStream);
+        String result = new String(outStream.toByteArray());
+        assertEquals(String.valueOf(Math.max(10, 100)), result);
     }
 }

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_static_content.ftl
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_static_content.ftl
@@ -1,0 +1,2 @@
+<#assign val = Math.max(request.NUMBER1,request.NUMBER2)>
+${val}


### PR DESCRIPTION
Master PR:https://github.com/geoserver/geoserver/pull/3814
JIRA:https://osgeo-org.atlassian.net/browse/GEOS-9361


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
