### PR TITLE
Run mvn jetty:run in test scope

### DIFF
--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -327,6 +327,7 @@
           -->
           <!-- Make sure it's not looking for annotations everywhere -->
           <contextXml>${project.build.testOutputDirectory}/jetty-context.xml</contextXml>
+          <useTestScope>true</useTestScope>
         </configuration>
       </plugin>
 	  <plugin>


### PR DESCRIPTION
This allows use of the cross-origin filter in web.xml. Without it you will get the error `java.lang.ClassNotFoundException: org.eclipse.jetty.servlets.CrossOriginFilter`.

