### PR TITLE
[GEOS-9427] Fix authkey regex examples for capturing username

### DIFF
--- a/doc/en/user/source/extensions/authkey/index.rst
+++ b/doc/en/user/source/extensions/authkey/index.rst
@@ -72,7 +72,7 @@ This key provider calls an external URL to map the authentication key to the use
 GeoServer to integrate into an existing security infrastructure, where a session token is shared
 among applications and managed through dedicated web services.
 
-The web service URL and some other parameters can be specified to configure the mapper in details:
+The web service URL and some other parameters can be specified to configure the mapper in detail:
 
 .. list-table::
    :widths: 50 50
@@ -82,7 +82,7 @@ The web service URL and some other parameters can be specified to configure the 
    * - ``Web Service URL, with key placeholder``
      - the complete URL of the key mapping webservice, with a special placeholder ({key}) that will be replaced by the current authentication key
    * - ``Web Service Response User Search Regular Expression``
-     - a regular expression used to extract the username from the webservice response; the first matched group (the part included in parentheses) in the regular expression will be used as the user name; the default (^\\s*(.*)\\s*$) takes all the response text, trimming spaces at both ends
+     - a regular expression used to extract the username from the webservice response; the first matched group (the part included in parentheses) in the regular expression will be used as the username; the default (^\\s*(.*)\\s*$) takes all the response text, trimming spaces at both ends
    * - ``Connection Timeout``
      - timeout to connect to the webservice
    * - ``Read Timeout``
@@ -92,7 +92,7 @@ The mapper will call the webservice using an HTTP GET request (webservice requir
 supported yet), replacing the {key} placeholder in the configured URL with the actual authentication
 key.
 
-If a response is received, it is parsed using the configured regular expression to extract the user name 
+If a response is received, it is parsed using the configured regular expression to extract the username 
 from it. New lines are automatically stripped from the response. Some examples of regular expression 
 that can be used are:
 
@@ -101,9 +101,9 @@ that can be used are:
 
    * - **Regular Expression**
      - **Usage**
-   * - ``^\\s*(.*)\\s*$``
+   * - ``^\s*(.*)\s*$``
      - all text trimming spaces at both ends
-   * - ``^.*?\"user\"\\s*:\\s*\"([^\"]+)\".*$``
+   * - ``^.*?\"user\"\s*:\s*\"([^\"]+)\".*$``
      - json response where the username is contained in a property named **user**
    * - ``^.*?<username>(.*?)</username>.*$``
      - xml response where the username is contained in a tag named **username**
@@ -115,7 +115,7 @@ AuthKEY WebService Body Response UserGroup Service
 
 When using an external web service to get Auth details, it is possible to define a custom ``GeoServer UserGroup Service`` being able to fetch Authorities - aka user's Roles - from the HTTP Body Response.
 
-The rationale is mostly the same; that kind of ``GeoServer UserGroup Service`` will be apply a ``rolesRegex`` - Roles Regular Expression - to the body response - which can be either XML, JSON or Plain Text/HTML - in order to fetch the list of available Authorities.
+The rationale is mostly the same; that kind of ``GeoServer UserGroup Service`` will apply a ``rolesRegex`` - Roles Regular Expression - to the body response - which can be either XML, JSON or Plain Text/HTML - in order to fetch the list of available Authorities.
 
 In order to do this, it is possible to configure instances of **AuthKEY WebService Body Response** User Group Service.
 
@@ -172,7 +172,7 @@ Once the new ``GeoServer UserGroup Service`` has been configured, it can be easi
 
     Of course the role names are known only at runtime; nevertheless it is possible to **statically** specify associated ``GeoServer User Groups`` to be mapped later to other internal ``GeoServer User Roles``.
 
-    What does this means? A ``GeoServer User Group`` can be defined on the GeoServer Catalog and can be mapped by the active ``Role Services`` to one or more specific ``GeoServer User Roles``.
+    What does this mean? A ``GeoServer User Group`` can be defined on the GeoServer Catalog and can be mapped by the active ``Role Services`` to one or more specific ``GeoServer User Roles``.
 
     This mainly depends on the ``GeoServer Role Service`` you use. By default, the internal ``GeoServer Role Service`` can map Roles and Groups through static configuration stored on the GeoServer Data Dir.
     This is possible by editing ``GeoServer User Group`` details from the ``Users, Groups, and Roles`` panel
@@ -220,7 +220,7 @@ Configuration can be done using the administrator GUI. There is a new type of au
 named **authkey** offering the following options.
 
 #. URL parameter name. This the name of URL parameter used in client HTTP requests. Default is ``authkey``.
-#. Key Provider. GeoSever offers the providers described above.
+#. Key Provider. GeoServer offers the providers described above.
 #. User/group service to be used.
 
 Some of the key providers can require additional configuration parameter. These will appear under the 
@@ -251,7 +251,7 @@ to implement
    
    /**
     * 
-    * Maps a unique authentication key to a user name. Since user names are
+    * Maps a unique authentication key to a username. Since usernames are
     * unique within a {@link GeoServerUserGroupService} an individual mapper
     * is needed for each service offering this feature.
     * 


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-9427

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
