### PR TITLE
[GEOS-9430] Integration Test involving app-schema MongoDB datasource …

### DIFF
--- a/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBSupport.java
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBSupport.java
@@ -231,6 +231,7 @@ public abstract class ComplexMongoDBSupport extends GeoServerSystemTestSupport {
                 "c",
                 "1482146935",
                 "25.0");
+        checkMeasurementNotExists(WFS11_XPATH_ENGINE, document, "station 3", "station3@mail.com");
     }
 
     @Test
@@ -428,10 +429,13 @@ public abstract class ComplexMongoDBSupport extends GeoServerSystemTestSupport {
         // insert stations data set in MongoDB
         File stationsFile1 = moveResourceToTempDir("/data/stations1.json", "stations1.json");
         File stationsFile2 = moveResourceToTempDir("/data/stations2.json", "stations2.json");
+        File stationsFile3 = moveResourceToTempDir("/data/stations3.json", "stations3.json");
         String stationsContent1 = new String(Files.readAllBytes(stationsFile1.toPath()));
         String stationsContent2 = new String(Files.readAllBytes(stationsFile2.toPath()));
+        String stationsContent3 = new String(Files.readAllBytes(stationsFile3.toPath()));
         insertJson(STATIONS_DATA_BASE_NAME, STATIONS_COLLECTION_NAME, stationsContent1);
         insertJson(STATIONS_DATA_BASE_NAME, STATIONS_COLLECTION_NAME, stationsContent2);
+        insertJson(STATIONS_DATA_BASE_NAME, STATIONS_COLLECTION_NAME, stationsContent3);
     }
 
     /** Load MongoDB connection properties. */
@@ -607,5 +611,26 @@ public abstract class ComplexMongoDBSupport extends GeoServerSystemTestSupport {
                         measurementUnit,
                         measurementTimestamp,
                         measurementValue));
+    }
+
+    private void checkMeasurementNotExists(
+            XpathEngine xpathEngine, Document document, String stationName, String stationMail) {
+        // check that the station metadata is correct
+        checkCount(
+                xpathEngine,
+                document,
+                1,
+                String.format(
+                        "/wfs:FeatureCollection/gml:featureMembers"
+                                + "/st:StationFeature[st:name='%s']/st:contact[st:mail='%s']",
+                        stationName, stationMail));
+        checkCount(
+                WFS11_XPATH_ENGINE,
+                document,
+                0,
+                String.format(
+                        "/wfs:FeatureCollection/gml:featureMembers"
+                                + "/st:StationFeature[st:name='%s']/st:measurement",
+                        stationName));
     }
 }

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBTest.java
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/java/org/geoserver/test/onlineTest/ComplexMongoDBTest.java
@@ -51,7 +51,7 @@ public class ComplexMongoDBTest extends ComplexMongoDBSupport {
         checkCount(
                 WFS11_XPATH_ENGINE,
                 document,
-                2,
+                3,
                 "/wfs:FeatureCollection/gml:featureMembers/st:StationFeature");
     }
 

--- a/src/extension/app-schema/app-schema-mongo-test/src/test/resources/data/stations3.json
+++ b/src/extension/app-schema/app-schema-mongo-test/src/test/resources/data/stations3.json
@@ -1,0 +1,24 @@
+{
+  "_id": { "$oid" : "58e5889ce4b02461ad5af082"},
+  "id": "3",
+  "name": "station 3",
+  "inferredAttribute": "ok",
+  "contact": {
+    "mail": "station3@mail.com"
+  },
+  "geometry": {
+    "coordinates": [
+      60,
+      70
+    ],
+    "type": "Point"
+  },
+  "measurements": [
+    {
+      "values": []
+    },
+    {
+      "values": []
+    }
+  ]
+}


### PR DESCRIPTION
…with empty list on MongoDB collections

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
