### PR TITLE
[GEOS-9431] Integrated GWC does not kick in when making request not qualified by workspace

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -750,7 +750,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     public final ConveyorTile dispatch(
             final GetMapRequest request, StringBuilder requestMistmatchTarget) {
 
-        String layerName = request.getRawKvp().get("LAYERS");
+        final String layerName = request.getRawKvp().get("LAYERS");
         /*
          * This is a quick way of checking if the request was for a single layer. We can't really
          * use request.getLayers() because in the event that a layerGroup was requested, the request
@@ -761,19 +761,18 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             return null;
         }
 
-        if (!tld.layerExists(layerName)) {
-            // GEOS-9431-check in catalog also if not found TileLayerDispatcher
-            LayerInfo layerInfo = catalog.getLayerByName(layerName);
-            if (layerInfo != null) layerName = layerInfo.prefixedName();
-            else {
-                requestMistmatchTarget.append("not a tile layer");
-                return null;
-            }
+        // GEOS-9431 acquire prefixed name if not prefixed already
+        final String getPrefixedName =
+                (!layerName.contains(":")) ? getPrefixedName(layerName) : layerName;
+
+        if (!tld.layerExists(getPrefixedName)) {
+            requestMistmatchTarget.append("not a tile layer");
+            return null;
         }
 
         final TileLayer tileLayer;
         try {
-            tileLayer = this.tld.getTileLayer(layerName);
+            tileLayer = this.tld.getTileLayer(getPrefixedName);
         } catch (GeoWebCacheException e) {
             throw new RuntimeException(e);
         }
@@ -818,6 +817,14 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             log.log(Level.INFO, "Error dispatching tile request to GeoServer", e);
         }
         return tileResp;
+    }
+
+    private String getPrefixedName(String layerName) {
+        PublishedInfo info = catalog.getLayerByName(layerName);
+        if (info == null) info = catalog.getLayerGroupByName(layerName);
+        if (info != null) return info.prefixedName();
+        if (log.isLoggable(Level.INFO)) log.info("Unable to find a prefix for : " + layerName);
+        return layerName;
     }
 
     ConveyorTile prepareRequest(

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -750,7 +750,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     public final ConveyorTile dispatch(
             final GetMapRequest request, StringBuilder requestMistmatchTarget) {
 
-        final String layerName = request.getRawKvp().get("LAYERS");
+        String layerName = request.getRawKvp().get("LAYERS");
         /*
          * This is a quick way of checking if the request was for a single layer. We can't really
          * use request.getLayers() because in the event that a layerGroup was requested, the request
@@ -762,8 +762,13 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         }
 
         if (!tld.layerExists(layerName)) {
-            requestMistmatchTarget.append("not a tile layer");
-            return null;
+            // GEOS-9431-check in catalog also if not found TileLayerDispatcher
+            LayerInfo layerInfo = catalog.getLayerByName(layerName);
+            if (layerInfo != null) layerName = layerInfo.prefixedName();
+            else {
+                requestMistmatchTarget.append("not a tile layer");
+                return null;
+            }
         }
 
         final TileLayer tileLayer;

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -159,7 +159,6 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
     private void prepareDataDirectory(SystemTestData testData) throws Exception {
         Catalog catalog = getCatalog();
-        catalog.setDefaultWorkspace(getCatalog().getWorkspaceByName(BASIC_POLYGONS.getPrefix()));
         testData.addWorkspace(TEST_WORKSPACE_NAME, TEST_WORKSPACE_URI, catalog);
         WorkspaceInfo wi = catalog.getWorkspaceByName(TEST_WORKSPACE_NAME);
         testData.addStyle(
@@ -2090,7 +2089,7 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
     /**
      * Test verifying that GWC integration will work when layer belongs to default workspace and
-     * layer name is passed without workspace being part of layer name or OWS request itself
+     * layer name is passed without workspace being part of layer name or OWS request itself.
      */
     @Test
     public void testDirectDefaultWorkspaceWMSIntegration() throws Exception {
@@ -2102,6 +2101,58 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
                 "wms?service=WMS&request=GetMap&version=1.1.1&format=image/png"
                         + "&layers="
                         + layerName
+                        + "&srs=EPSG:4326&width=256&height=256&styles="
+                        + "&bbox=-180.0,-90.0,0.0,90.0&tiled=true";
+        MockHttpServletResponse response = getAsServletResponse(request);
+
+        response = getAsServletResponse(request);
+
+        assertEquals(200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+        assertNotNull(response.getHeader("geowebcache-tile-index"));
+        assertTrue(response.getHeader("geowebcache-cache-result").equalsIgnoreCase("HIT"));
+
+        // with virtual services
+        request =
+                MockData.CITE_PREFIX
+                        + "/wms?service=WMS&request=GetMap&version=1.1.1&format=image/png"
+                        + "&layers="
+                        + layerName
+                        + "&srs=EPSG:4326&width=256&height=256&styles="
+                        + "&bbox=-180.0,-90.0,0.0,90.0&tiled=true";
+        response = getAsServletResponse(request);
+
+        response = getAsServletResponse(request);
+
+        assertEquals(200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+        assertNotNull(response.getHeader("geowebcache-tile-index"));
+        assertTrue(response.getHeader("geowebcache-cache-result").equalsIgnoreCase("HIT"));
+    }
+
+    @Test
+    public void testDirectDefaultWorkspaceWMSIntegrationLayerGroup() throws Exception {
+        final GWC gwc = GWC.get();
+        gwc.getConfig().setDirectWMSIntegrationEnabled(true);
+        // build a layer group in the test workspace
+        LayerGroupInfo lg = getCatalog().getFactory().createLayerGroup();
+        lg.setName(WORKSPACED_LAYER_GROUP);
+        String bpLayerId = getLayerId(MockData.BASIC_POLYGONS);
+        String mpLayerId = getLayerId(MockData.LAKES);
+        lg.getLayers().add(getCatalog().getLayerByName(bpLayerId));
+        lg.getLayers().add(getCatalog().getLayerByName(mpLayerId));
+        lg.getStyles().add(null);
+        lg.getStyles().add(null);
+
+        lg.setWorkspace(getCatalog().getWorkspaceByName(MockData.BASIC_POLYGONS.getPrefix()));
+        new CatalogBuilder(getCatalog()).calculateLayerGroupBounds(lg);
+        getCatalog().add(lg);
+
+        String request =
+                MockData.BASIC_POLYGONS.getPrefix()
+                        + "/wms?service=WMS&request=GetMap&version=1.1.1&format=image/png"
+                        + "&layers="
+                        + WORKSPACED_LAYER_GROUP
                         + "&srs=EPSG:4326&width=256&height=256&styles="
                         + "&bbox=-180.0,-90.0,0.0,90.0&tiled=true";
         MockHttpServletResponse response = getAsServletResponse(request);


### PR DESCRIPTION
Integrated WMS requests not qualified for any workspace get ignored by Integrated GWC, since it expects layers to be always prefixed with workspace. The bug has been fixed and GWC will fall back to catalog if it is unable to find a layer in TileLayerDispatcher on first attempt.

JIRA:https://osgeo-org.atlassian.net/browse/GEOS-9431

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
