### PR TITLE
[2.16.x backport][Fixes GEOS-9435] [community - oauth2] Include basic auth header for …

### DIFF
--- a/src/community/security/oauth2-geonode/src/main/java/org/geoserver/security/oauth2/services/GeoNodeTokenServices.java
+++ b/src/community/security/oauth2-geonode/src/main/java/org/geoserver/security/oauth2/services/GeoNodeTokenServices.java
@@ -4,9 +4,14 @@
  */
 package org.geoserver.security.oauth2.services;
 
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
 import java.util.Map;
 import org.geoserver.security.oauth2.GeoServerAccessTokenConverter;
 import org.geoserver.security.oauth2.GeoServerOAuthRemoteTokenServices;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 /**
  * Remote Token Services for GeoNode token details.
@@ -19,9 +24,26 @@ public class GeoNodeTokenServices extends GeoServerOAuthRemoteTokenServices {
         super(new GeoServerAccessTokenConverter());
     }
 
+    protected Map<String, Object> checkToken(String accessToken) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("token", accessToken);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", getAuthorizationHeader(accessToken));
+        return postForMap(checkTokenEndpointUrl, formData, headers);
+    }
+
     protected void transformNonStandardValuesToStandardValues(Map<String, Object> map) {
         LOGGER.debug("Original map = " + map);
         map.put("user_name", map.get("issued_to")); // GeoNode sends 'client_id' as 'issued_to'
         LOGGER.debug("Transformed = " + map);
+    }
+
+    protected String getAuthorizationHeader(String accessToken) {
+        String creds = String.format("%s:%s", clientId, clientSecret);
+        try {
+            return "Basic " + new String(Base64.getEncoder().encode(creds.getBytes("UTF-8")));
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Could not convert String");
+        }
     }
 }


### PR DESCRIPTION
…Oauth2 token instrospection requests

(cherry picked from commit e3c96e7fd1e8aba4fbd1214725edef4e9b3f9731)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
