### PR TITLE
Fix tools page (GEOS-9348)

### DIFF
--- a/doc/en/developer/source/quickstart/checkout.txt
+++ b/doc/en/developer/source/quickstart/checkout.txt
@@ -8,8 +8,8 @@ Check out the source code from the git repository.::
 To list the available branches.::
 
   % git branch
-     2.14.x
      2.15.x
+     2.16.x
    * master
 
 Choose ``master`` for the latest development.::
@@ -18,7 +18,7 @@ Choose ``master`` for the latest development.::
 
 Or chose a stable branch for versions less likely to change often::
 
-  % git checkout 2.14.x
+  % git checkout 2.16.x
 
 In this example we will pretend that your source code is in a directory
 called ``geoserver``, but a more descriptive name is recommended.

--- a/src/community/script/core/src/main/java/org/geoserver/script/ScriptManager.java
+++ b/src/community/script/core/src/main/java/org/geoserver/script/ScriptManager.java
@@ -409,7 +409,7 @@ public class ScriptManager implements InitializingBean {
 
     public boolean hasEngineForExtension(Resource ext) {
         for (ScriptEngineFactory f : engineMgr.getEngineFactories()) {
-            if (f.getExtensions().contains(ext)) {
+            if (f.getExtensions().contains(ext.name())) {
                 return true;
             }
         }

--- a/src/web/core/src/main/java/org/geoserver/web/ToolPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/ToolPage.java
@@ -19,8 +19,13 @@ public class ToolPage extends GeoServerSecuredPage {
     @SuppressWarnings("serial")
     public ToolPage() {
         List links = getGeoServerApplication().getBeansOfType(ToolLinkInfo.class);
-        links.addAll(getGeoServerApplication().getBeansOfType(ToolLinkExternalInfo.class));
-
+        for (ToolLinkExternalInfo link :
+                getGeoServerApplication().getBeansOfType(ToolLinkExternalInfo.class)) {
+            if (link.getDescriptionKey() == null) {
+                continue;
+            }
+            links.add(link);
+        }
         links = filterByAuth(links);
 
         add(

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
@@ -50,6 +50,14 @@ public class GeoServerSecuredPageTest extends GeoServerWicketTestSupport {
     }
 
     @Test
+    public void testToolPageAllowsAccessWhenLoggedIn() {
+        login();
+        tester.startPage(ToolPage.class);
+        tester.assertRenderedPage(ToolPage.class);
+        tester.assertNoErrorMessage();
+    }
+
+    @Test
     public void testSessionFixationAvoidance() throws Exception {
         tester.startPage(GeoServerHomePage.class);
         final WebSession session = WebSession.get();


### PR DESCRIPTION
The tools page lists all instances of ToolLinkExternalInfo, some recent work to make the Layer Preview page extendable reused this as a base class without testing the tools page.

This patch double checks that an instance has a description before including it in the tools page, this has the effect of filtering out all the CommonFormatLink instances.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] Will merge as a single commit for ease of backporting
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
