### PR TITLE
[GEOS-9444]: SLDService rasterize service includes a wrong FeatureTypeName in produced SLD

### DIFF
--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/RasterizerController.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/RasterizerController.java
@@ -300,7 +300,7 @@ public class RasterizerController extends BaseSLDServiceController {
         }
 
         rasterSymbolizer.setColorMap(resampledColorMap);
-        Style style = sb.createStyle(layerName, rasterSymbolizer);
+        Style style = sb.createStyle("Feature", rasterSymbolizer);
 
         return style;
     }

--- a/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/RasterizerTest.java
+++ b/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/RasterizerTest.java
@@ -80,6 +80,22 @@ public class RasterizerTest extends SLDServiceBaseTest {
     }
 
     @Test
+    public void testRasterizeFeatureTypeName() throws Exception {
+        LayerInfo l = getCatalog().getLayerByName("wcs:World");
+        assertEquals("raster", l.getDefaultStyle().getName());
+        final String restPath =
+                RestBaseController.ROOT_PATH + "/sldservice/wcs:World/" + getServiceUrl() + ".xml";
+        MockHttpServletResponse response = getAsServletResponse(restPath);
+        assertTrue(response.getStatus() == 200);
+        Document dom = getAsDOM(restPath, 200);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        print(dom, baos);
+        assertTrue(
+                baos.toString().indexOf("<sld:FeatureTypeName>Feature</sld:FeatureTypeName>") > 0);
+        checkColorMap(baos.toString(), 100);
+    }
+
+    @Test
     public void testRasterizeOptions() throws Exception {
         LayerInfo l = getCatalog().getLayerByName("wcs:World");
         assertEquals("raster", l.getDefaultStyle().getName());


### PR DESCRIPTION
Fixes SLD produced by rasterize service, to include a generic FeatureTypeName with value Feature, instead of the original layer name, that is not correct for raster layer.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
