### PR TITLE
[GEOS-9438] Serializer errors when using the Importer GUI

### DIFF
--- a/src/extension/importer/web/src/main/java/org/geoserver/importer/web/ImporterConfigPage.java
+++ b/src/extension/importer/web/src/main/java/org/geoserver/importer/web/ImporterConfigPage.java
@@ -69,7 +69,9 @@ public class ImporterConfigPage extends GeoServerSecuredPage {
                     @Override
                     public void onSubmit() {
                         try {
-                            importer.setConfiguration(info);
+                            Importer singleton =
+                                    getGeoServerApplication().getBeanOfType(Importer.class);
+                            singleton.setConfiguration(info);
                             doReturn();
                         } catch (Exception e) {
                             error(e);

--- a/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImporterConfigPageTest.java
+++ b/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImporterConfigPageTest.java
@@ -5,9 +5,11 @@
 package org.geoserver.importer.web;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import org.apache.wicket.serialize.java.JavaSerializer;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.importer.Importer;
@@ -51,5 +53,20 @@ public class ImporterConfigPageTest extends GeoServerWicketTestSupport {
         assertEquals(newUploadRoot, newConfiguration.getUploadRoot());
         assertEquals(2, newConfiguration.getMaxSynchronousImports());
         assertEquals(1, newConfiguration.getMaxAsynchronousImports());
+    }
+
+    @Test
+    public void testImporterConfigPageSerialization() {
+        // acquire wicket javaSerializer
+        JavaSerializer javaSeializer =
+                new JavaSerializer(getGeoServerApplication().getApplicationKey());
+
+        login();
+        // int the page
+        ImporterConfigPage page = tester.startPage(ImporterConfigPage.class);
+
+        // JavaSerializer logs an exception and returns null in case there are serialization errors
+        byte[] bytes = javaSeializer.serialize(page);
+        assertNotNull(bytes);
     }
 }


### PR DESCRIPTION
JIRA : https://osgeo-org.atlassian.net/browse/GEOS-9438

-fixed serialization
-added unit tests



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
