### PR TITLE
[2.16.x backport][GEOS-9388] App-Schema WFS GetFeature includes namespaces for all workspaces on isolated workspace

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml30WfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml30WfsTest.java
@@ -8,6 +8,8 @@ package org.geoserver.test;
 
 import static org.junit.Assert.*;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.geotools.wfs.v2_0.WFS;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -104,7 +106,7 @@ public class Gsml30WfsTest extends AbstractAppSchemaTestSupport {
         assertXpathEvaluatesTo("unknown", "/wfs:FeatureCollection/@numberMatched", doc);
         assertXpathCount(2, "/wfs:FeatureCollection/wfs:member", doc);
         // test that all namespaces are present on the root element
-        for (String prefix : getNamespaces().keySet()) {
+        for (String prefix : getRequiredNamespaces().keySet()) {
             assertEquals(
                     getNamespace(prefix),
                     doc.getFirstChild()
@@ -115,5 +117,15 @@ public class Gsml30WfsTest extends AbstractAppSchemaTestSupport {
         // test that no namespaces are present on the wfs:member elements
         assertEquals(0, doc.getFirstChild().getChildNodes().item(0).getAttributes().getLength());
         assertEquals(0, doc.getFirstChild().getChildNodes().item(1).getAttributes().getLength());
+    }
+
+    private Map<String, String> getRequiredNamespaces() {
+        final Map<String, String> requiredNamespaces = new HashMap<>();
+        requiredNamespaces.put("gsml", "urn:cgi:xmlns:CGI:GeoSciML-Core:3.0.0");
+        requiredNamespaces.put("gmd", "http://www.isotc211.org/2005/gmd");
+        requiredNamespaces.put("gco", "http://www.isotc211.org/2005/gco");
+        requiredNamespaces.put("cgu", "urn:cgi:xmlns:CGI:Utilities:3.0.0");
+        requiredNamespaces.put("swe", "http://www.opengis.net/swe/1.0/gml32");
+        return requiredNamespaces;
     }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NamespacesWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NamespacesWfsTest.java
@@ -6,12 +6,16 @@ package org.geoserver.test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.StringReader;
 import java.util.Map;
 import net.opengis.wfs20.StoredQueryDescriptionType;
 import org.apache.commons.io.IOUtils;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.NamespaceInfoImpl;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.StoredQuery;
@@ -304,8 +308,8 @@ public final class NamespacesWfsTest extends StationsAppSchemaTestSupport {
         assertTrue(output.indexOf("null:Station_gml32") < 0);
         assertTrue(output.indexOf("ms_gml32:Measurement_gml32") > -1);
         assertTrue(output.indexOf("st_gml32:Station_gml32") > -1);
-        // check test1 namespace injected:
-        assertTrue(output.indexOf("xmlns:test1=\"http://www.test1.org/test1\"") >= 0);
+        // check test1 namespace not injected:
+        assertTrue(output.indexOf("xmlns:test1=\"http://www.test1.org/test1\"") == -1);
     }
 
     /**
@@ -339,8 +343,57 @@ public final class NamespacesWfsTest extends StationsAppSchemaTestSupport {
         assertTrue(output.indexOf("null:Station_gml31") < 0);
         assertTrue(output.indexOf("ms_gml31:Measurement_gml31") > -1);
         assertTrue(output.indexOf("st_gml31:Station_gml31") > -1);
-        // check test1 namespace injected:
-        assertTrue(output.indexOf("xmlns:test1=\"http://www.test1.org/test1\"") >= 0);
+        // check test1 namespace not injected:
+        assertTrue(output.indexOf("xmlns:test1=\"http://www.test1.org/test1\"") == -1);
+    }
+
+    @Test
+    public void testIsolatedWorkspaceGetFeatureNamespacesWfs11() throws Exception {
+        final Catalog catalog = getCatalog();
+        WorkspaceInfo workspaceInfo = catalog.getWorkspaceByName("st_gml31");
+        workspaceInfo.setIsolated(true);
+        catalog.save(workspaceInfo);
+        try {
+            Document document =
+                    getAsDOM(
+                            "st_gml31/wfs?request=GetFeature&version=1.1.0&typename=st_gml31:Station_gml31");
+            assertEquals(
+                    "http://www.measurements_gml31.org/1.0",
+                    document.getFirstChild()
+                            .getAttributes()
+                            .getNamedItemNS(XMLNS, "ms_gml31")
+                            .getTextContent());
+            assertNull(document.getFirstChild().getAttributes().getNamedItemNS(XMLNS, "test1"));
+        } finally {
+            workspaceInfo = catalog.getWorkspaceByName("st_gml31");
+            workspaceInfo.setIsolated(false);
+            catalog.save(workspaceInfo);
+        }
+    }
+
+    @Test
+    public void testIsolatedWorkspaceGetFeatureNamespacesWfs20() throws Exception {
+        final Catalog catalog = getCatalog();
+        WorkspaceInfo workspaceInfo = catalog.getWorkspaceByName("st_gml32");
+        workspaceInfo.setIsolated(true);
+        catalog.save(workspaceInfo);
+        try {
+            Document document =
+                    getAsDOM(
+                            "st_gml32/wfs?request=GetFeature&version=2.0.0&typename=st_gml32:Station_gml32");
+            // check should not return namespace:  xmlns:test1="http://www.test1.org/test1"
+            assertEquals(
+                    "http://www.measurements_gml32.org/1.0",
+                    document.getFirstChild()
+                            .getAttributes()
+                            .getNamedItemNS(XMLNS, "ms_gml32")
+                            .getTextContent());
+            assertNull(document.getFirstChild().getAttributes().getNamedItemNS(XMLNS, "test1"));
+        } finally {
+            workspaceInfo = catalog.getWorkspaceByName("st_gml32");
+            workspaceInfo.setIsolated(false);
+            catalog.save(workspaceInfo);
+        }
     }
 
     private void addTestNamespaceToCatalog() {

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NestedElementsFilteringTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NestedElementsFilteringTest.java
@@ -6,12 +6,17 @@ package org.geoserver.test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 /**
  * Validates the encoding of filters on nested properties with some advanced mappings and xpaths.
@@ -62,5 +67,20 @@ public final class NestedElementsFilteringTest extends AbstractAppSchemaTestSupp
         String content = response.getContentAsString();
         assertThat(content, containsString("gml:id=\"ins.1\""));
         assertThat(StringUtils.countMatches(content, "<wfs:member>"), is(1));
+    }
+
+    /** Checks for included types namespaces on output GML. */
+    @Test
+    public void testWfsIncludedNamespacesDeclaration() throws Exception {
+        // execute the WFS 2.0 request
+        Document doc =
+                postAsDOM(
+                        "wfs",
+                        readResource(
+                                "/test-data/stations/nestedElements/requests/wfs_get_feature_1.xml"));
+        Node perAttributeNode = doc.getFirstChild().getAttributes().getNamedItem("xmlns:per");
+        assertTrue(perAttributeNode instanceof Attr);
+        Attr perAttr = (Attr) perAttributeNode;
+        assertEquals("http://www.person.org/1.0", perAttr.getValue());
     }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/nestedElements/persons.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/nestedElements/persons.xml
@@ -11,6 +11,10 @@
             <prefix>xlink</prefix>
             <uri>http://www.w3.org/1999/xlink</uri>
         </Namespace>
+        <Namespace>
+            <prefix>per</prefix>
+            <uri>http://www.person.org/1.0</uri>
+        </Namespace>
     </namespaces>
     <sourceDataStores>
         <DataStore>

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
@@ -271,7 +271,7 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat {
             for (Iterator m = metas.iterator(); m.hasNext(); ) {
                 ResourceInfo ri = (ResourceInfo) m.next();
                 if (ri instanceof FeatureTypeInfo) {
-                    FeatureTypeInfo meta = (FeatureTypeInfo) ri;
+                    final FeatureTypeInfo meta = (FeatureTypeInfo) ri;
                     FeatureType featureType = meta.getFeatureType();
                     Object userSchemaLocation = featureType.getUserData().get("schemaURI");
                     if (userSchemaLocation != null && userSchemaLocation instanceof Map) {

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
@@ -47,6 +47,8 @@ public class WFSXmlUtils {
     public static final String ENTITY_EXPANSION_LIMIT =
             "org.geoserver.wfs.xml.entityExpansionLimit";
 
+    public static final String XLINK_DEFAULT_PREFIX = "xlink";
+
     public static void initRequestParser(Parser parser, WFSInfo wfs, GeoServer geoServer, Map kvp) {
         // check the strict flag to determine if we should validate or not
         Boolean strict = (Boolean) kvp.get("strict");


### PR DESCRIPTION
App-Schema WFS GetFeature GML 3.1 and 3.2 responses include namespaces from all workspaces on isolated workspace (virtual service) request. This PR fixes this issue.

Requires:
https://github.com/geotools/geotools/pull/2742

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-9388

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
