### PR TITLE
[backport 2.16][GEOS-9348] Fix tools page to ignore external links without descriptionKey

### DIFF
--- a/doc/en/developer/source/quickstart/checkout.txt
+++ b/doc/en/developer/source/quickstart/checkout.txt
@@ -8,8 +8,8 @@ Check out the source code from the git repository.::
 To list the available branches.::
 
   % git branch
-     2.14.x
      2.15.x
+     2.16.x
    * master
 
 Choose ``master`` for the latest development.::
@@ -18,7 +18,7 @@ Choose ``master`` for the latest development.::
 
 Or chose a stable branch for versions less likely to change often::
 
-  % git checkout 2.14.x
+  % git checkout 2.16.x
 
 In this example we will pretend that your source code is in a directory
 called ``geoserver``, but a more descriptive name is recommended.

--- a/src/community/script/core/src/main/java/org/geoserver/script/ScriptManager.java
+++ b/src/community/script/core/src/main/java/org/geoserver/script/ScriptManager.java
@@ -409,7 +409,7 @@ public class ScriptManager implements InitializingBean {
 
     public boolean hasEngineForExtension(Resource ext) {
         for (ScriptEngineFactory f : engineMgr.getEngineFactories()) {
-            if (f.getExtensions().contains(ext)) {
+            if (f.getExtensions().contains(ext.name())) {
                 return true;
             }
         }

--- a/src/web/core/src/main/java/org/geoserver/web/ToolPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/ToolPage.java
@@ -19,8 +19,13 @@ public class ToolPage extends GeoServerSecuredPage {
     @SuppressWarnings("serial")
     public ToolPage() {
         List links = getGeoServerApplication().getBeansOfType(ToolLinkInfo.class);
-        links.addAll(getGeoServerApplication().getBeansOfType(ToolLinkExternalInfo.class));
-
+        for (ToolLinkExternalInfo link :
+                getGeoServerApplication().getBeansOfType(ToolLinkExternalInfo.class)) {
+            if (link.getDescriptionKey() == null) {
+                continue;
+            }
+            links.add(link);
+        }
         links = filterByAuth(links);
 
         add(

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
@@ -50,6 +50,14 @@ public class GeoServerSecuredPageTest extends GeoServerWicketTestSupport {
     }
 
     @Test
+    public void testToolPageAllowsAccessWhenLoggedIn() {
+        login();
+        tester.startPage(ToolPage.class);
+        tester.assertRenderedPage(ToolPage.class);
+        tester.assertNoErrorMessage();
+    }
+
+    @Test
     public void testSessionFixationAvoidance() throws Exception {
         tester.startPage(GeoServerHomePage.class);
         final WebSession session = WebSession.get();


### PR DESCRIPTION
Backport tools fix to 2.16.x
