### PR TITLE
[backport-2.15.x] [GEOS-9458] Fix WFS 2.0 join queries with unqualified typenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 cache:
   directories:
     - "$HOME/.m2"
+    - downloads
 language: java
 before_install:
   - rm ~/.m2/settings.xml
@@ -10,23 +11,25 @@ before_install:
 env:
   global:
     - MAVEN_OPTS=-Xmx512m
+    - MAVEN_VERSION=3.6.3
+    - TAKARI_SMART_BUILDER_VERSION=0.6.1
+before_script:
+  - mkdir -p downloads
+  - export MAVEN_ZIP=apache-maven-$MAVEN_VERSION-bin.zip
+  - |
+    if [ ! -f downloads/$MAVEN_ZIP ]; then
+      wget -P downloads https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/$MAVEN_ZIP
+    fi
+  - export SMART_JAR=takari-smart-builder-$TAKARI_SMART_BUILDER_VERSION.jar
+  - |
+    if [ ! -f downloads/$SMART_JAR ]; then
+      wget -P downloads https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/$TAKARI_SMART_BUILDER_VERSION/$SMART_JAR
+    fi
+  - unzip downloads/$MAVEN_ZIP
+  - export M2_HOME=$PWD/apache-maven-$MAVEN_VERSION
+  - cp downloads/$SMART_JAR $M2_HOME/lib/ext
+  - export PATH=$M2_HOME/bin:$PATH
+  - mvn --version
 script:
   - mvn -f src/pom.xml -B -U -T3 -fae -Prelease clean install $ARGS && mvn -f src/community/pom.xml -B -U -T4 -fae -DskipTests -Prelease -PcommunityRelease clean install $COMMUNITY_ARGS
   - grep -H "<testsuite" `find . -iname "TEST-*.xml"` | sed 's/.\/\(.*\)\/target.*:<testsuite .* name="\(.*\)" time="\([^"]*\)" .*/\3\t\2\t\1/' | sort -nr | head -50
-before-caching:
-  - rm -rf $HOME/.m2/repository/org/geotools
-  - rm -rf $HOME/.m2/repository/org/geowebcache
-  - rm -rf $HOME/.m2/repository/org/geoserver
-notifications:
-  email:
-    on_success: never
-    on_failure: never
-matrix:
-  include:
-    - jdk: oraclejdk8
-      env: ARGS="-Dfmt.skip=true" COMMUNITY_ARGS=$ARGS
-    - jdk: openjdk11
-      env: ARGS="-Dfmt.skip=true" COMMUNITY_ARGS=$ARGS
-    - jdk: openjdk11
-      env: ARGS="-Dfmt.action=check -Ppmd -Perrorprone -DskipTests=true" COMMUNITY_ARGS="-Dfmt.action=check -DskipTests=true"
-


### PR DESCRIPTION
Backport of #3971

Improve org.geoserver.wfs.WFSWorkspaceQualifier to resolve
typenames on the local workspace when a WFS request with
multiple elements in the 'typeNames' (not 'typeName') parameter
are specified.

checkOriginallyUnqualified() was only looking at TYPENAME (WFS 1.0),
and not TYPENAMES (2.0).

Since by the time TypeNameKvpParser resolves the requested type names,
the LocalWorkspace is not set, it may either resolve to an unqualified
QName, or one on any other workspace than the requested one (due to the
lenient resolution in TypeNameKvpParser.parseToken() calling
Catalog.getFeatureTypeByName(String), which in turns returns a feature
type in the default workspace or any other workspace if none is found).
This lead to either trying to use the wrong FeatureType or not finding
it at all.

Also improve the readability of WFSWorkspaceQualifier.qualifyRequest(
 WorkspaceInfo, PublishedInfo, Service, Request)
