### PR TITLE
fix caching key for GH workflows

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,12 +14,12 @@ jobs:
       with:
         java-version: 1.8
     - name: Maven repository caching
-      uses: actions/cache@v1
+      uses: actions/cache@v1.1.0
       with:
         path: ~/.m2/repository
         key: gs-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          gs-${{ runner.os }}-maven-
     - name: Build with Maven
       run: mvn -B clean install -T2 -Prelease --file src/pom.xml
     - name: Remove SNAPSHOT jars from repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,12 +14,12 @@ jobs:
       with:
         java-version: 1.8
     - name: Maven repository caching
-      uses: actions/cache@v1
+      uses: actions/cache@v1.1.0
       with:
         path: ~/.m2/repository
         key: gs-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          gs-${{ runner.os }}-maven-
     - name: Build with Maven
       run: mvn -B clean install -Dall -T2 -Prelease --file src/pom.xml
     - name: Remove SNAPSHOT jars from repository


### PR DESCRIPTION
As it is now the cache is only ever stored but never restored because the key used to save (`gs-${{ runne....`) is different to the key used to restore (`${{ runne....`), note the **gs-**

- fix caching key for GH MacOS workflow
- fix caching key for GH Windows workflow

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
