### PR TITLE
[GEOS-9478] Layer definition cql filter doesnt work for complex features

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/ConnectionUsageTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/ConnectionUsageTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.security.decorators.DecoratingFeatureSource;
 import org.geotools.appschema.filter.FilterFactoryImplNamespaceAware;
 import org.geotools.data.DefaultTransaction;
 import org.geotools.data.FeatureSource;
@@ -32,6 +33,7 @@ import org.geotools.jdbc.JDBCDataStore;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.PropertyIsEqualTo;
 
@@ -212,8 +214,14 @@ public class ConnectionUsageTest extends AbstractAppSchemaTestSupport {
         assertNotNull(typeInfo);
 
         FeatureSource fs = typeInfo.getFeatureSource(new NullProgressListener(), null);
-        assertTrue(fs instanceof MappingFeatureSource);
-        mappingFs = (MappingFeatureSource) fs;
+        if (fs instanceof DecoratingFeatureSource) {
+            mappingFs =
+                    ((DecoratingFeatureSource<FeatureType, Feature>) fs)
+                            .unwrap(MappingFeatureSource.class);
+        } else {
+            assertTrue(fs instanceof MappingFeatureSource);
+            mappingFs = (MappingFeatureSource) fs;
+        }
 
         FeatureSource sourceFs = mappingFs.getMapping().getSource();
 

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/StationsMockData.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/StationsMockData.java
@@ -425,21 +425,21 @@ public class StationsMockData extends AbstractAppSchemaMockData {
     }
 
     /**
-     * String of features to add to Stations feature type
+     * String of features to add to Stations feature type.
      *
      * @return Optional String of features
      */
     protected Optional<String> extraStationFeatures() {
-        return Optional.ofNullable(null);
+        return Optional.empty();
     }
 
     /**
-     * String of features to add to Measurements feature type
+     * String of features to add to Measurements feature type.
      *
      * @return Optional String of features
      */
     protected Optional<String> extraMeasurementFeatures() {
-        return Optional.ofNullable(null);
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -138,6 +138,7 @@ import org.opengis.referencing.operation.TransformException;
 import org.springframework.context.ApplicationContext;
 import org.vfny.geoserver.global.GeoServerFeatureLocking;
 import org.vfny.geoserver.global.GeoServerFeatureSource;
+import org.vfny.geoserver.global.GeoserverComplexFeatureSource;
 import org.vfny.geoserver.util.DataStoreUtils;
 import org.xml.sax.EntityResolver;
 import si.uom.NonSI;
@@ -1398,12 +1399,14 @@ public class ResourcePool {
      * type info on the provided data access. We will first search based on the published name
      * (layer name) and only if this search fails we will search based on the native name.
      */
+    @SuppressWarnings("unchecked")
     private FeatureSource<? extends FeatureType, ? extends Feature> getFeatureSource(
             DataAccess<? extends FeatureType, ? extends Feature> dataAccess, FeatureTypeInfo info)
             throws IOException {
+        FeatureSource<? extends FeatureType, ? extends Feature> featureSource;
         try {
             // first try to search based on the published name, to avoid any unexpected aliasing
-            return dataAccess.getFeatureSource(info.getQualifiedName());
+            featureSource = dataAccess.getFeatureSource(info.getQualifiedName());
         } catch (Exception exception) {
             LOGGER.log(
                     Level.FINE,
@@ -1411,8 +1414,12 @@ public class ResourcePool {
                             "Error retrieving feature type using published name '%s'.",
                             info.getQualifiedName()));
             // let's try now to search based on the native name
-            return dataAccess.getFeatureSource(info.getQualifiedNativeName());
+            featureSource = dataAccess.getFeatureSource(info.getQualifiedNativeName());
         }
+        // return a decorated feature source, capable of handling the layer definition default CQL
+        // filter
+        return new GeoserverComplexFeatureSource(
+                (FeatureSource<FeatureType, Feature>) featureSource, info);
     }
 
     private Double getTolerance(FeatureTypeInfo info) {

--- a/src/main/src/main/java/org/vfny/geoserver/global/GeoserverComplexFeatureSource.java
+++ b/src/main/src/main/java/org/vfny/geoserver/global/GeoserverComplexFeatureSource.java
@@ -1,0 +1,133 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.vfny.geoserver.global;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.security.decorators.DecoratingFeatureSource;
+import org.geotools.data.DataSourceException;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.Query;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+
+/**
+ * Geoserver wrapper for a complex features feature source.
+ *
+ * <p>Handles the final query build taking into account the definition query from the
+ * FeatureTypeInfo if exists.
+ *
+ * @author Fernando Miño - Geosolutions
+ */
+public class GeoserverComplexFeatureSource extends DecoratingFeatureSource<FeatureType, Feature> {
+    private static final long serialVersionUID = 1L;
+
+    protected static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2(null);
+    /** provided FeatureTypeInfo for getting the declared query and more */
+    private final FeatureTypeInfo ftypeInfo;
+
+    public GeoserverComplexFeatureSource(
+            FeatureSource<FeatureType, Feature> delegate, FeatureTypeInfo ftypeInfo)
+            throws DataSourceException {
+        super(delegate);
+        this.ftypeInfo = Objects.requireNonNull(ftypeInfo);
+    }
+
+    @Override
+    public FeatureCollection<FeatureType, Feature> getFeatures(Filter filter) throws IOException {
+        filter = buildFilter(filter);
+        return delegate.getFeatures(filter);
+    }
+
+    @Override
+    public FeatureCollection<FeatureType, Feature> getFeatures(Query query) throws IOException {
+        query = buildQuery(query);
+        return delegate.getFeatures(query);
+    }
+
+    @Override
+    public FeatureCollection<FeatureType, Feature> getFeatures() throws IOException {
+        return delegate.getFeatures(getDefaultQuery());
+    }
+
+    @Override
+    public ReferencedEnvelope getBounds() throws IOException {
+        return delegate.getBounds(getDefaultQuery());
+    }
+
+    /**
+     * Builds and return the default Query for this layer's featureType when no request query is
+     * provided.
+     */
+    protected Query getDefaultQuery() throws DataSourceException {
+        return new Query(
+                ftypeInfo.getQualifiedNativeName().getLocalPart(), buildFilter(Filter.INCLUDE));
+    }
+
+    @Override
+    public ReferencedEnvelope getBounds(Query query) throws IOException {
+        query = buildQuery(query);
+        return delegate.getBounds(query);
+    }
+
+    @Override
+    public int getCount(Query query) throws IOException {
+        query = buildQuery(query);
+        return delegate.getCount(query);
+    }
+
+    /**
+     * Builds the final query mixing the request query with the layer default configured query (if
+     * exists) with a conjunction (and operator).
+     *
+     * @param query the requested query.
+     * @return the final mixed query.
+     */
+    protected Query buildQuery(Query query) throws DataSourceException {
+        Filter filter = buildFilter(query.getFilter());
+        Query newQuery = new Query(query);
+        newQuery.setFilter(filter);
+        return newQuery;
+    }
+
+    /**
+     * Builds the final filter mixing the request filter with the layer default configured filter
+     * (if exists) with a conjunction (and operator).
+     *
+     * @param filter the requested filter.
+     * @return the final mixed filter.
+     */
+    private Filter buildFilter(Filter filter) throws DataSourceException {
+        filter = nullSafeCheck(filter);
+        Filter newFilter = filter;
+        try {
+            Filter definitionQuery = nullSafeCheck(ftypeInfo.filter());
+            if (definitionQuery == Filter.INCLUDE) return filter;
+            SimplifyingFilterVisitor visitor = new SimplifyingFilterVisitor();
+            Filter simplifiedDefinitionQuery = (Filter) definitionQuery.accept(visitor, null);
+            if (filter == Filter.INCLUDE) {
+                newFilter = simplifiedDefinitionQuery;
+            } else if (simplifiedDefinitionQuery != Filter.INCLUDE) {
+                newFilter = FF.and(simplifiedDefinitionQuery, filter);
+            }
+        } catch (Exception ex) {
+            throw new DataSourceException("Can't create the definition filter", ex);
+        }
+
+        return newFilter;
+    }
+
+    private Filter nullSafeCheck(Filter filter) {
+        if (filter == null) return Filter.INCLUDE;
+        return filter;
+    }
+}


### PR DESCRIPTION
This PR adds support for layer definition CQL filter on complex features data sources, in the same approach as simple features layers support it already.

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-9478

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
