### PR TITLE
Update flatgeobuf

### DIFF
--- a/src/community/flatgeobuf/pom.xml
+++ b/src/community/flatgeobuf/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.wololo</groupId>
       <artifactId>flatgeobuf</artifactId>
-      <version>2.2.0</version>
+      <version>3.0.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This is a breaking change for the flatgeobuf output (new specification v3). I have hopes this spec version will have a long life, or at least I aim to provide backwards compatibility from now on.

See https://github.com/bjornharrtell/flatgeobuf/releases/tag/3.0.0 for more info.