### PR TITLE
[2.15.x backport][GEOS-9484] ADMIN_ROLE is assigned by default if no …

### DIFF
--- a/src/extension/authkey/src/main/java/org/geoserver/security/WebServiceBodyResponseUserGroupService.java
+++ b/src/extension/authkey/src/main/java/org/geoserver/security/WebServiceBodyResponseUserGroupService.java
@@ -155,11 +155,12 @@ public class WebServiceBodyResponseUserGroupService extends AbstractGeoServerSec
                     authorities.add(createAuthorityObject(roleName.trim()));
                 }
             }
-        } else {
+        }
+        if (authorities.size() == 0) {
             LOGGER.log(
                     Level.WARNING,
-                    "Error in WebServiceAuthenticationKeyMapper, cannot find any Role in response");
-            authorities.add(GeoServerRole.ADMIN_ROLE);
+                    "Error in WebServiceAuthenticationKeyMapper, cannot find any Role in response adding anonymous role");
+            authorities.add(GeoServerRole.ANONYMOUS_ROLE);
         }
 
         RoleCalculator calc = new RoleCalculator(this, getDefaultSecurityService());


### PR DESCRIPTION
…role is returned for a user inside WebService Body Response (#4027)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
