### PR TITLE
[GEOS-9493] WFS GeoJSON complex features output issue on numeric typed xml attributes

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
@@ -379,14 +379,14 @@ class ComplexGeoJsonWriter {
     @SuppressWarnings("unchecked")
     private void encodeProperty(Property property) {
         // these extra attributes should be seen as XML attributes
-        Map<NameImpl, String> attributes =
-                (Map<NameImpl, String>) property.getUserData().get(Attributes.class);
+        Map<NameImpl, Object> attributes =
+                (Map<NameImpl, Object>) property.getUserData().get(Attributes.class);
         String attributeName = property.getName().getLocalPart();
         encodeProperty(attributeName, property, attributes);
     }
 
     private void encodeProperty(
-            String attributeName, Property property, Map<NameImpl, String> attributes) {
+            String attributeName, Property property, Map<NameImpl, Object> attributes) {
         if (property instanceof ComplexAttribute) {
             // check if we have a simple content
             ComplexAttribute complexAttribute = (ComplexAttribute) property;
@@ -401,9 +401,9 @@ class ComplexGeoJsonWriter {
                 if (isGMLPropertyType(complexAttribute)) {
                     Collection<? extends Property> value = complexAttribute.getValue();
                     Property nested = value.iterator().next();
-                    Map<NameImpl, String> nestedAttributes =
-                            (Map<NameImpl, String>) nested.getUserData().get(Attributes.class);
-                    Map<NameImpl, String> mergedAttributes =
+                    Map<NameImpl, Object> nestedAttributes =
+                            (Map<NameImpl, Object>) nested.getUserData().get(Attributes.class);
+                    Map<NameImpl, Object> mergedAttributes =
                             mergeMaps(attributes, nestedAttributes);
                     encodeProperty(attributeName, nested, mergedAttributes);
                 } else {
@@ -559,7 +559,7 @@ class ComplexGeoJsonWriter {
 
     /** Encode a complex attribute as a JSON object. */
     private void encodeComplexAttribute(
-            String name, ComplexAttribute attribute, Map<NameImpl, String> attributes) {
+            String name, ComplexAttribute attribute, Map<NameImpl, Object> attributes) {
         if (isFullFeature(attribute)) {
             jsonWriter.key(name);
             encodeFeature((Feature) attribute, false);
@@ -600,7 +600,7 @@ class ComplexGeoJsonWriter {
      * the value and attributes values.
      */
     private void encodeSimpleAttribute(
-            String name, Object value, Map<NameImpl, String> attributes) {
+            String name, Object value, Map<NameImpl, Object> attributes) {
         // let's see if we need to encode attributes or simple value
         if (attributes == null || attributes.isEmpty()) {
             // add a simple JSON attribute to the current object
@@ -623,7 +623,7 @@ class ComplexGeoJsonWriter {
      * attribute name local part will be used as the property name. Attributes with a NULL value
      * will not be encoded. This method assumes that it is already in an object context.
      */
-    private void encodeAttributes(Map<NameImpl, String> attributes) {
+    private void encodeAttributes(Map<NameImpl, Object> attributes) {
         attributes.forEach(
                 (name, value) -> {
                     if (value != null) {


### PR DESCRIPTION
When GeoJSON encoder tries to handle an xml attribute with other type than string, in this case an integer, Geoserver throws a class cast exception due to complex GeoJSON writer is handling all xml attributes as string.  On GML output this issue is not present and numeric typed attributes are encoded without exceptions.

This was reproduced using a app-schema jdbc multi value element with an integer typed attribute and executing a WFS GetFeature requesting GeoJSON output.
https://docs.geoserver.org/stable/en/user/data/app-schema/mapping-file.html#attributes-with-cardinality-1-n

This PR adds a fix for this issue.

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-9493

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
