### PR TITLE
GEOS-9457: Restore the usage instruction of Windows Installer (only add ref to dev manual)

### DIFF
--- a/doc/en/user/source/installation/index.rst
+++ b/doc/en/user/source/installation/index.rst
@@ -18,4 +18,4 @@ There are many ways to install GeoServer on your system. This section will discu
    war
    upgrade
 
-.. note:: At this time we no longer provide a Windows Installer, because the benefics do not outstand the costs (it's basically a wrapper around the win_binary). However if you realy need the Windows installer, you can create one following `the instruction on this site <../../developer/win-installer.html>`.
+.. note:: At this time, for several reasons, we no longer provide the Windows Installer. However if you realy need the Windows installer, you can create one following `the instruction on this site <../../developer/win-installer.html>`.

--- a/doc/en/user/source/installation/index.rst
+++ b/doc/en/user/source/installation/index.rst
@@ -17,3 +17,5 @@ There are many ways to install GeoServer on your system. This section will discu
    linux
    war
    upgrade
+
+.. note:: At this time we no longer provide a Windows Installer, because the benefics do not outstand the costs (it's basically a wrapper around the win_binary). However if you realy need the Windows installer, you can create one following `the instruction on this site <../../developer/win-installer.html>`.

--- a/doc/en/user/source/installation/index.rst
+++ b/doc/en/user/source/installation/index.rst
@@ -18,4 +18,4 @@ There are many ways to install GeoServer on your system. This section will discu
    war
    upgrade
 
-.. note:: At this time, for several reasons, we no longer provide the Windows Installer. However if you realy need the Windows installer, you can create one following `the instruction on this site <../../developer/win-installer.html>`.
+.. note:: At this time we no longer provide a Windows Installer, due to lack of a secure Windows machine where the installer can be built and signed. However if you realy need the Windows installer, you can create one following `the instruction on this site <../../developer/win-installer.html>`.


### PR DESCRIPTION
Below the list of available binaries, I added a note which:

- states GeoServer not longer provides the Windows Installers
- tells the user can create the Windows Installer themselves when needed

This way we hope to get fewer questions about the 'missing' Windows Installer in the download section.

## Checklist
- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
