### PR TITLE
[2.16.x backport][GEOS-9483] Add testing for jdbc multi-value issue on empty collection

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NormalizedMultiValuesTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NormalizedMultiValuesTest.java
@@ -135,11 +135,12 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
         checkCount(
                 WFS11_XPATH_ENGINE,
                 document,
-                2,
+                3,
                 "/wfs:FeatureCollection/gml:featureMember/st_gml31:Station_gml31");
         // check that the expected stations and measurements are present
         checkStation1Gml31(document);
         checkStation2Gml31(document);
+        checkStation3Gml31(document);
     }
 
     @Test
@@ -156,12 +157,13 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
         checkCount(
                 WFS20_XPATH_ENGINE,
                 document,
-                2,
+                3,
                 "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32");
 
         // check that the expected stations and measurements are present
         checkStation1Gml32(document);
         checkStation2Gml32(document);
+        checkStation3Gml32(document);
     }
 
     @Test
@@ -294,6 +296,31 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
                         + "[ms_gml31:tag='pressure_tag']");
     }
 
+    /** Helper method that checks that station 3 is present in the provided document. */
+    private void checkStation3Gml31(Document document) {
+        String stationPath =
+                "/wfs:FeatureCollection/gml:featureMember/st_gml31:Station_gml31[@gml:id='st.3']";
+        // check station exists
+        checkCount(WFS11_XPATH_ENGINE, document, 1, stationPath);
+        // check stations tags
+        checkCount(WFS11_XPATH_ENGINE, document, 0, stationPath + "/st_gml31:tag");
+        // check measurements
+        checkCount(
+                WFS11_XPATH_ENGINE,
+                document,
+                1,
+                stationPath
+                        + "/st_gml31:measurements/ms_gml31:Measurement_gml31"
+                        + "[@gml:id='ms.4']");
+        checkCount(
+                WFS11_XPATH_ENGINE,
+                document,
+                0,
+                stationPath
+                        + "/st_gml31:measurements/ms_gml31:Measurement_gml31"
+                        + "[@gml:id='ms.4']/ms_gml31:tag");
+    }
+
     /** Helper method that checks that station 1 is present in the provided document. */
     private void checkStation1Gml32(Document document) {
         // check station exists
@@ -386,6 +413,31 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
                         + "/st_gml32:measurements/ms_gml32:Measurement_gml32"
                         + "[@gml:id='ms.3']"
                         + "[ms_gml32:tag='pressure_tag']");
+    }
+
+    /** Helper method that checks that station 3 is present in the provided document. */
+    private void checkStation3Gml32(Document document) {
+        final String stationPath =
+                "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32[@gml:id='st.3']";
+        // check station exists
+        checkCount(WFS20_XPATH_ENGINE, document, 1, stationPath);
+        // check stations tags
+        checkCount(WFS20_XPATH_ENGINE, document, 0, stationPath + "/st_gml32:tag");
+        // check measurements
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                1,
+                stationPath
+                        + "/st_gml32:measurements/ms_gml32:Measurement_gml32"
+                        + "[@gml:id='ms.4']");
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                0,
+                stationPath
+                        + "/st_gml32:measurements/ms_gml32:Measurement_gml32"
+                        + "[@gml:id='ms.4']/ms_gml32:tag");
     }
 
     /**

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/measurements.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/measurements.properties
@@ -2,3 +2,4 @@ _=ID:String,NAME:String,UNIT:String,STATION:String
 ms.1=ms.1|temperature|c|st.1
 ms.2=ms.2|wind|km/h|st.1
 ms.3=ms.3|pressure|atm|st.2
+ms.4=ms.4|wind|m/h|st.3

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.properties
@@ -1,3 +1,4 @@
 _=ID:String,NAME:String,PHONE:String,MAIL:String,LOCATION:Geometry:srid=4326
 st.1=st.1|station1|32154898|station1@stations.org|POINT(-1 1)
 st.2=st.2|station2|23754243|station2@stations.org|POINT(-2 -3)
+st.3=st.3|station3|66677788|station3@stations.org|POINT(0 0)


### PR DESCRIPTION
App-schema is getting "IllegalArgumentException: Could not find working property accessor for attribute" when it gets an empty collection on a 1..n cardinality attribute (jdbc multivalue).

This issue is replicated using Postgresql and a jdbc configuration following same steps and mappings as Geoserver documentation, but having no items for a root feature multivalue declared element:
https://docs.geoserver.org/stable/en/user/data/app-schema/mapping-file.html#attributes-with-cardinality-1-n

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-9483

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
