### PR TITLE
Default spatial CQL filters to WGS84 unless otherwise specified, following OGC API guidance

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/api/APIFilterParser.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/api/APIFilterParser.java
@@ -4,15 +4,24 @@
  */
 package org.geoserver.api;
 
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.spatial.DefaultCRSFilterVisitor;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
 
 /** Centralizes filter/filter-lang handling. */
 public class APIFilterParser {
 
+    private static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
     public static String CQL_TEXT = "cql-text";
 
+    /**
+     * Parses the filter over the supported filter languages (right now, only {@link #CQL_TEXT}) and
+     * defaults the geometry liters in spatial filters to CRS84
+     */
     public Filter parse(String filter, String filterLang) {
         if (filter == null) {
             return null;
@@ -31,7 +40,12 @@ public class APIFilterParser {
         }
 
         try {
-            return ECQL.toFilter(filter);
+            Filter parsedFilter = ECQL.toFilter(filter);
+            // in OGC APIs assume CRS84 as the default, but the underlying machinery may default to
+            // the native CRS in EPSG axis order instead, best making the CRS explicit instead
+            DefaultCRSFilterVisitor crsDefaulter =
+                    new DefaultCRSFilterVisitor(FF, DefaultGeographicCRS.WGS84);
+            return (Filter) parsedFilter.accept(crsDefaulter, null);
         } catch (CQLException e) {
             throw new InvalidParameterValueException(e.getMessage(), e);
         }

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/api/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/api/features/FeatureService.java
@@ -281,7 +281,8 @@ public class FeatureService {
             filters.add(FF.id(FF.featureId(itemId)));
         }
         if (filter != null) {
-            filters.add(filterParser.parse(filter, filterLanguage));
+            Filter parsedFilter = filterParser.parse(filter, filterLanguage);
+            filters.add(parsedFilter);
         }
         query.setFilter(mergeFiltersAnd(filters));
         if (crs != null) {

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/api/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/api/features/FeatureTest.java
@@ -220,6 +220,22 @@ public class FeatureTest extends FeaturesTestSupport {
     }
 
     @Test
+    public void testCqlSpatialFilter() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/collections/"
+                                + roadSegments
+                                + "/items?filter=BBOX(pointProperty,38,1,40,3)&filter-lang=cql-text",
+                        200);
+        assertEquals("FeatureCollection", json.read("type", String.class));
+        // should return only f001
+        assertEquals(1, (int) json.read("features.length()", Integer.class));
+        assertEquals(
+                1, json.read("features[?(@.id == 'PrimitiveGeoFeature.f001')]", List.class).size());
+    }
+
+    @Test
     public void testCqlFilterInvalidLanguage() throws Exception {
         String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =


### PR DESCRIPTION
Right now it was left to the wrapped service, which would have ended up using native CRS, eventually in EPSG native order.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
