### PR TITLE
[Backport 2.16.x][GEOS-9498] Add Backward compatibility on Layergroups with legacy Cascaded WMS Layers (#4047)

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/LayerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LayerInfoImpl.java
@@ -160,8 +160,8 @@ public class LayerInfoImpl implements LayerInfo {
             // will be null if remote capability document
             // does not have any Style tags
             if (remoteDefaultStyleInfo != null) return remoteDefaultStyleInfo;
-            else
-                LOGGER.warning(
+            else if (LOGGER.isLoggable(Level.FINE))
+                LOGGER.fine(
                         "No Default Style found on cascaded WMS Resource"
                                 + ((WMSLayerInfo) getResource()).getName());
         }
@@ -180,8 +180,8 @@ public class LayerInfoImpl implements LayerInfo {
             // will be null if remote capability document
             // does not have any Style tags
             if (remoteStyles != null) return remoteStyles;
-            else
-                LOGGER.warning(
+            else if (LOGGER.isLoggable(Level.FINE))
+                LOGGER.fine(
                         "No Default Styles found on cascaded WMS Resource"
                                 + ((WMSLayerInfo) getResource()).getName());
         }

--- a/src/wms/src/test/java/org/geoserver/wms/WMSCascadeTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSCascadeTestSupport.java
@@ -13,9 +13,12 @@ import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.TestHttpClientProvider;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.impl.LayerInfoImpl;
+import org.geoserver.data.test.CiteTestData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.test.http.MockHttpClient;
 import org.geoserver.test.http.MockHttpResponse;
@@ -232,6 +235,34 @@ public abstract class WMSCascadeTestSupport extends WMSTestSupport {
         wms13Client.expectGet(
                 new URL(mockURLWithSingleLayerInsideBounds),
                 new MockHttpResponse(pngRoadsImage, "image/png"));
+
+        WMSLayerInfo legacy_group_lyr = cb.buildWMSLayer("legacy_group_lyr_130");
+        legacy_group_lyr.setName("legacy_group_lyr_130");
+        getCatalog().add(legacy_group_lyr);
+
+        LayerInfoImpl legacy_lyr = (LayerInfoImpl) cb.buildLayer(legacy_group_lyr);
+        StyleInfo defaultRaster = getCatalog().getStyleByName(CiteTestData.DEFAULT_RASTER_STYLE);
+
+        legacy_lyr.setDefaultStyle(defaultRaster);
+        getCatalog().add(legacy_lyr);
+        LayerGroupInfo legacyCascadedGroup = getCatalog().getFactory().createLayerGroup();
+
+        legacyCascadedGroup.setName("cascaded_legacy_group_130");
+        legacyCascadedGroup.getLayers().add(legacy_lyr);
+
+        try {
+            cb.calculateLayerGroupBounds(legacyCascadedGroup);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+        getCatalog().add(legacyCascadedGroup);
+
+        String mockURLWithLegacyLayers =
+                wms13BaseURL
+                        + "?SERVICE=WMS&LAYERS=legacy_group_lyr_130&CRS=EPSG:4326&FORMAT=image/png&HEIGHT=90&TRANSPARENT=FALSE&BGCOLOR=0xFFFFFF&REQUEST=GetMap&BBOX=-90.0,-180.0,90.0,180.0&WIDTH=180&STYLES=&VERSION=1.3.0";
+        // we dont care about response, URL content is important
+        wms13Client.expectGet(
+                new URL(mockURLWithLegacyLayers), new MockHttpResponse(pngRoadsImage, "image/png"));
     }
 
     private void setupWMS110Layer() throws MalformedURLException, IOException {
@@ -408,6 +439,34 @@ public abstract class WMSCascadeTestSupport extends WMSTestSupport {
         wms11Client.expectGet(
                 new URL(mockURLWithSingleLayerInsideBounds),
                 new MockHttpResponse(pngRoadsImage, "image/png"));
+
+        WMSLayerInfo legacy_group_lyr = cb.buildWMSLayer("legacy_group_lyr");
+        legacy_group_lyr.setName("legacy_group_lyr");
+        getCatalog().add(legacy_group_lyr);
+
+        LayerInfoImpl legacy_lyr = (LayerInfoImpl) cb.buildLayer(legacy_group_lyr);
+        StyleInfo defaultRaster = getCatalog().getStyleByName(CiteTestData.DEFAULT_RASTER_STYLE);
+
+        legacy_lyr.setDefaultStyle(defaultRaster);
+        getCatalog().add(legacy_lyr);
+        LayerGroupInfo legacyCascadedGroup = getCatalog().getFactory().createLayerGroup();
+
+        legacyCascadedGroup.setName("cascaded_legacy_group");
+        legacyCascadedGroup.getLayers().add(legacy_lyr);
+
+        try {
+            cb.calculateLayerGroupBounds(legacyCascadedGroup);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+        getCatalog().add(legacyCascadedGroup);
+
+        String mockURLWithLegacyLayers =
+                wms11BaseURL
+                        + "?SERVICE=WMS&LAYERS=legacy_group_lyr&FORMAT=image%2Fpng&HEIGHT=90&TRANSPARENT=FALSE&BGCOLOR=0xFFFFFF&REQUEST=GetMap&BBOX=-180.0,-90.0,180.0,90.0&WIDTH=180&STYLES=&SRS=EPSG:4326&VERSION=1.1.1";
+        // we dont care about response, URL content is important
+        wms11Client.expectGet(
+                new URL(mockURLWithLegacyLayers), new MockHttpResponse(pngRoadsImage, "image/png"));
     }
 
     private void setupWMS110NfiLayer() throws MalformedURLException, IOException {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/WMSCascadeTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/WMSCascadeTest.java
@@ -215,6 +215,22 @@ public class WMSCascadeTest extends WMSCascadeTestSupport {
     }
 
     @Test
+    public void testLegacyCascadeLayerGroup() throws Exception {
+
+        String getMapRequest =
+                "wms?bbox=-180,-90,180,90"
+                        + "&styles=&layers=legacy_group_lyr"
+                        + "&Format=image/png&request=GetMap"
+                        + "&width=180&height=90&srs=EPSG:4326";
+
+        // the request should generate exepected remote WMS URL
+        // e.g default remote styles should empty in remote request
+        // For Mock URL check WMSCascadeTestSupport.setupWMS110Layer()
+        BufferedImage response = getAsImage(getMapRequest, "image/png");
+        assertNotNull(response);
+    }
+
+    @Test
     public void testCascadedBounds() throws Exception {
         LayerGroupInfo info = getCatalog().getLayerGroupByName("cascaded_group");
         LayerInfo groupLayer2 = getCatalog().getLayerByName("group_lyr_2");

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/WMSCascadeTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/WMSCascadeTest.java
@@ -311,7 +311,23 @@ public class WMSCascadeTest extends WMSCascadeTestSupport {
         // the request should generate exepected remote WMS URL
         // e.g default remote styles should include the forced remote style of one layer
         // and empty for second layer
-        // For Mock URL check WMSCascadeTestSupport.setupWMS110Layer()
+        // For Mock URL check WMSCascadeTestSupport.setupWMS130Layer()
+        BufferedImage response = getAsImage(getMapRequest, "image/png");
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testLegacyCascadeLayerGroup() throws Exception {
+
+        String getMapRequest =
+                "wms?bbox=-90,-180,90,180"
+                        + "&styles=&layers=cascaded_legacy_group_130"
+                        + "&Format=image/png&request=GetMap&version=1.3.0&service=wms"
+                        + "&width=180&height=90&crs=EPSG:4326";
+
+        // the request should generate exepected remote WMS URL
+        // e.g default remote styles should be empty in remote request
+        // For Mock URL check WMSCascadeTestSupport.setupWMS130Layer()
         BufferedImage response = getAsImage(getMapRequest, "image/png");
         assertNotNull(response);
     }

--- a/src/wms/src/test/resources/org/geoserver/wms/caps111.xml
+++ b/src/wms/src/test/resources/org/geoserver/wms/caps111.xml
@@ -178,6 +178,18 @@
               </LegendURL>
             </Style>        
       </Layer>    
+      <Layer queryable="1" opaque="1">
+            <Name>legacy_group_lyr</Name>
+            <Title>legacy_group_lyr</Title>
+            <Abstract/>
+            <KeywordList>
+              <Keyword>features</Keyword>
+              <Keyword>legacy_group_lyr</Keyword>
+            </KeywordList>
+            <SRS>EPSG:4326</SRS>
+            <LatLonBoundingBox minx="0" miny="0" maxx="20" maxy="20"/>
+            <BoundingBox SRS="EPSG:4326" minx="0" miny="0" maxx="20" maxy="20"/>
+      </Layer>    
     </Layer>
   </Capability>
 </WMT_MS_Capabilities>

--- a/src/wms/src/test/resources/org/geoserver/wms/caps130.xml
+++ b/src/wms/src/test/resources/org/geoserver/wms/caps130.xml
@@ -207,6 +207,23 @@
            </LegendURL>
        </Style>       
       </Layer>
+      <Layer queryable="1" opaque="0">
+        <Name>legacy_group_lyr_130</Name>
+        <Title>legacy_group_lyr_130</Title>
+        <Abstract/>
+        <KeywordList>
+            <Keyword>features</Keyword>
+            <Keyword>legacy_group_lyr_130</Keyword>
+        </KeywordList>
+       <CRS>EPSG:4326</CRS>       
+       <EX_GeographicBoundingBox>
+           <westBoundLongitude>0.0</westBoundLongitude>
+           <eastBoundLongitude>20.0</eastBoundLongitude>
+           <southBoundLatitude>0.0</southBoundLatitude>
+           <northBoundLatitude>20.0</northBoundLatitude>
+       </EX_GeographicBoundingBox>       
+       <BoundingBox minx="0" miny="0" maxx="20" maxy="20" CRS="EPSG:4326"/>
+      </Layer>
     </Layer>    
   </Capability>
 </WMS_Capabilities>


### PR DESCRIPTION
backport https://github.com/geoserver/geoserver/pull/4047

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Committs changing the REST API, or any configuration object, should check it the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
