### PR TITLE
[Backport 2.16.x] Bump dependency-check-maven plugin to 5.3.1

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -2224,7 +2224,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>3.2.1</version>
+            <version>5.3.1</version>
             <configuration>
               <failBuildOnCVSS>8</failBuildOnCVSS>
               <suppressionFile>${geoserverBaseDir}/../build/qa/dependency-check-suppression.xml</suppressionFile>


### PR DESCRIPTION
backports #4117 to 2.16.x