### PR TITLE
GSIP-188: Add extension point for ResourcePool to convert coverage in…

### DIFF
--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -314,5 +314,9 @@
   	<constructor-arg ref="catalog"/>
   </bean>
 
-    <bean id="nearestMatchWarningAppender" class="org.geoserver.util.NearestMatchWarningAppender"/>
+  <bean id="nearestMatchWarningAppender" class="org.geoserver.util.NearestMatchWarningAppender"/>
+
+  <bean id="coverageReaderFileConverter" class="org.geoserver.catalog.CoverageReaderFileConverter">
+    <constructor-arg ref="catalog"/>
+  </bean>
 </beans>

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
@@ -1,0 +1,80 @@
+/* (c) 2014 - 2020 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+import org.geotools.util.factory.Hints;
+import org.opengis.coverage.grid.GridCoverageReader;
+
+/**
+ * Attempts to convert the source input object for a {@link GridCoverageReader} to {@link File}.
+ *
+ * @author joshfix Created on 2/25/20
+ */
+public class CoverageReaderFileConverter implements CoverageReaderInputObjectConverter<File> {
+
+    private final Catalog catalog;
+
+    public CoverageReaderFileConverter(Catalog catalog) {
+        this.catalog = catalog;
+    }
+
+    /**
+     * Performs the conversion of the input object to a file object. If this converter is not able
+     * to convert the input to a File, an empty {@link Optional} will be returned.
+     *
+     * @param input The input object.
+     * @param coverageInfo The grid coverage metadata, may be <code>null</code>.
+     * @param hints Hints to use when loading the coverage, may be <code>null</code>.
+     * @return
+     */
+    @Override
+    public Optional<File> convert(
+            Object input, @Nullable CoverageInfo coverageInfo, @Nullable Hints hints) {
+        if (!(input instanceof String)) {
+            return Optional.empty();
+        }
+        String urlString = (String) input;
+        return canConvert(urlString) ? convertFile(urlString) : Optional.empty();
+    }
+
+    /**
+     * Checks to see if the input string is a file URI.
+     *
+     * @param input The input string.
+     * @return Value representing whether or not this converter is able to convert the provided
+     *     input to File.
+     */
+    protected boolean canConvert(String input) {
+        // Check to see if our "url" points to a file or not, otherwise we use the string itself for
+        // reading
+        try {
+            URI uri = new URI(input);
+            return uri.getScheme() != null && "file".equalsIgnoreCase(uri.getScheme());
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Performs the conversion to File.
+     *
+     * @param input The input string.
+     * @return The Optional object containing the File
+     */
+    protected Optional<File> convertFile(String input) {
+        Resource resource = Files.asResource(catalog.getResourceLoader().getBaseDirectory());
+        final File readerFile = Resources.find(Resources.fromURL(resource, input), true);
+        return (readerFile != null) ? Optional.of(readerFile) : Optional.empty();
+    }
+}

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
@@ -59,7 +59,7 @@ public class CoverageReaderFileConverter implements CoverageReaderInputObjectCon
         // reading
         try {
             URI uri = new URI(input);
-            return uri.getScheme() != null && "file".equalsIgnoreCase(uri.getScheme());
+            return uri.getScheme() == null || "file".equalsIgnoreCase(uri.getScheme());
         } catch (URISyntaxException e) {
             return false;
         }

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
@@ -1,5 +1,4 @@
 /* (c) 2014 - 2020 Open Source Geospatial Foundation - all rights reserved
- * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageReaderInputObjectConverter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageReaderInputObjectConverter.java
@@ -1,0 +1,38 @@
+/* (c) 2014 - 2020 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.geotools.util.factory.Hints;
+import org.opengis.coverage.grid.GridCoverageReader;
+
+/**
+ * Extension point for {@link ResourcePool} that enables custom input object types when creating
+ * {@link GridCoverageReader}s. Implementations may return any custom Object which can in turn be
+ * used by {@link org.geotools.coverage.grid.io.AbstractGridFormat#getReader(Object)}
+ * implementations to instantiate the appropriate GridCoverageReader and by {@link
+ * javax.imageio.spi.ImageInputStreamSpi#getInputClass()} implementations to support the accurate
+ * selection of {@link javax.imageio.stream.ImageInputStream} implementations.
+ *
+ * @author joshfix Created on 2/13/20
+ */
+@FunctionalInterface
+public interface CoverageReaderInputObjectConverter<T> {
+
+    /**
+     * This method inspects the provided input object in an attempt to convert it to a custom class.
+     * Any of the accompanying method parameters may optionally be used to better inform the
+     * decision making logic. If an implementation does not support conversion for the given input
+     * object, the method should return an empty {@link Optional}.
+     *
+     * @param input The input object.
+     * @param coverageInfo The grid coverage metadata, may be <code>null</code>.
+     * @param hints Hints to use when loading the coverage, may be <code>null</code>.
+     * @return an {@link Optional} containing the converted value.
+     */
+    Optional<T> convert(Object input, @Nullable CoverageInfo coverageInfo, @Nullable Hints hints);
+}

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageReaderInputObjectConverter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageReaderInputObjectConverter.java
@@ -1,5 +1,4 @@
 /* (c) 2014 - 2020 Open Source Geospatial Foundation - all rights reserved
- * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -1,5 +1,4 @@
 /* (c) 2014 - 2020 Open Source Geospatial Foundation - all rights reserved
- * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -854,8 +854,8 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
     }
 
     /**
-     * Tests the ability for the ResourcePool to convert input objects for getting a specific GridCoverageReader
-     * using the CoverageReaderInputObjectConverter extension point.
+     * Tests the ability for the ResourcePool to convert input objects for getting a specific
+     * GridCoverageReader using the CoverageReaderInputObjectConverter extension point.
      *
      * @throws IOException
      */

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014-2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014-2020 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -852,5 +852,28 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
         assertNotNull(featureDefaultGeometry);
         assertEquals("pointProperty", schemaDefaultGeometry.getLocalName());
         assertEquals(schemaDefaultGeometry, featureDefaultGeometry);
+    }
+
+    /**
+     * Tests the ability for the ResourcePool to convert input objects for getting a specific GridCoverageReader
+     * using the CoverageReaderInputObjectConverter extension point.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testCoverageReaderInputConverter() throws IOException {
+        Catalog catalog = getCatalog();
+        ResourcePool pool = new ResourcePool(catalog);
+
+        CoverageStoreInfo info = catalog.getFactory().createCoverageStore();
+        info.setType("ImagePyramid");
+        info.setURL(
+                "file://./src/test/resources/data_dir/nested_layer_groups/data/pyramid%20with%20space");
+
+        GridCoverageReader reader = pool.getGridCoverageReader(info, null);
+
+        // the CoverageReaderFileConverter should have successfully converted the URL string to a
+        // File object
+        assertTrue(reader.getSource() instanceof File);
     }
 }

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -1,5 +1,4 @@
 /* (c) 2014-2020 Open Source Geospatial Foundation - all rights reserved
- * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */


### PR DESCRIPTION
https://github.com/geoserver/geoserver/wiki/GSIP-188
https://osgeo-org.atlassian.net/browse/GEOS-9563
​
ImageInputStreamSpi implementations advertise an inputClass. When utilities like GeoTools' ImageIOExt.getImageInputStreamSPI() are invoked, they try to match the provided input object class to the advertised inputClass of the ImageInputStreamSpi. When creating a GridCoverageReader in the ResourcePool, GeoServer only supplies the GridCoverageReaders with URLs in the form of Strings, with one exception. There is a single method to check if the input String represents a File URL, and if so, it converts the input String to a File.​

This input object is eventually used by ImageIO to determine which ImageInputStream to use by comparing the input class to the advertised inputClass as previously mentioned. The power of being able to advertise an input class is severely crippled by GeoServer’s inability to create readers with alternative input classes. Creating new reader implementations becomes difficult because there are already specific ImageInputStreamSpis to support String, URL, File, InputStream, etc. Ambiguity is introduced when more than one reader advertises the same inputClass. For example, S3ImageInputStreamImplSpi and StringImageInputStreamSpi both advertise the input class as String. This results in the ImageIO createImageInputStream method selecting the first SPI it comes across that supports String.​

This proposal seeks to implement a new extension point that will allow the ResourcePool to supply configurable input objects that extend beyond String/File. This enhancement ensures the specific, desired ImageInputStreamSpi implementation is able to be identified and selected.​

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [n/a] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [n/a] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
