### PR TITLE
[GSIP-190] assume +0 vote after 10 days

### DIFF
--- a/doc/en/developer/source/policies/gsip.rst
+++ b/doc/en/developer/source/policies/gsip.rst
@@ -3,8 +3,7 @@
 GeoServer Improvement Proposals
 ===============================
 
-GeoServer Improvements Proposals (GSIP) are the formal mechanism used to manage major changes to GeoServer in a responsible fashion. Examples of changes which are managed by
-the GSIP process include:
+GeoServer Improvements Proposals (GSIP) are the formal mechanism used to manage major changes to GeoServer in a responsible fashion. Examples of changes which are managed by the GSIP process include:
 
 * major features
 * code re-architecture
@@ -17,12 +16,12 @@ How a GSIP works
 
 The typical life cycle of a GSIP is as follows:
 
-#. Developer has an intent to perform a major change
-#. Developer communicates with the community about the change
-#. Developer goes off and implements the change
-#. Developer writes a GSIP and presents it to the community for feedback
-#. The PSC votes on the GSIP
-#. Developer commits changes upon receiving a positive vote
+#. Developer has an intent to perform a major change.
+#. Developer communicates with the community about the change.
+#. Developer goes off and implements the change.
+#. Developer writes a GSIP and presents it to the community for feedback.
+#. The PSC votes on the GSIP.
+#. Developer commits changes upon receiving a positive vote.
 
 Writing a GSIP
 --------------
@@ -34,64 +33,36 @@ If you have write access login and follow the steps below. If you do not have wr
 
 To make a GSIP:
 
-#. Navigate to the wiki: https://github.com/geoserver/geoserver/wiki/
-#. Select and copy the proposal template to your clipboard. (Template is available `here <https://github.com/geoserver/geoserver/wiki/GSIP-XXXX>`_)
-#. Navigate to the proposals page: https://github.com/geoserver/geoserver/wiki/Proposals
+#. Navigate to the wiki `proposals page <https://github.com/geoserver/geoserver/wiki/Proposals>`__
 #. Edit the page with a new link under *Proposals Under Discussion*:
    
-   ```
-   [GSIP 116 - Use Apache Style Contributor Agreement](GSIP 116)
-   ```
- 
-   #. The number should be the next "available" GSIP number.
-   #. The title should be short and descriptive
+   .. code-block:: text
+      
+      [GSIP 200 - Title](GSIP-200)
+   
+   * The number should be the next "available" GSIP number on the proposal page.
+   * The title should be short and descriptive.
 
-#. Save your change to the *Proposal* page, and click on your new link to create a new page.
-#. Click on your new link to create the page, fill in the page contents by pasting the proposal page template from your clipboard.
+#. Save your change to the *Proposal* page.
+
+#. Click on your new link to create the page, fill in the page contents by copy and pasting the following proposal page template.
+   
+   GSIP :download:`template <gsip_template.txt>`:
+
+   .. literalinclude:: gsip_template.txt
+      :language: text
+      :emphasize-lines: 1
+
 #. Fill in the information in the page template, and click ``Save`` when
    complete.
    
 Voting on a GSIP
 ----------------
 
-One of the duties of the GeoServer Project Steering Committee is to vote on 
+One of the duties of the :doc:`GeoServer Project Steering Committee <psc>` is to vote on 
 GSIPs. The voting process works as follows:
 
-* Each active PSC member gets a single vote, which can be one of "+1", "+0", "0", "-0", or "-1":
-
-    * A vote of "+1" means support for a proposal
-
-    * The neutral votes "+0", "0", and "-0" all count the same as "0" but permit PSC members
-      to indicate a slight tendency for, neutral, or against a proposal respectively
-
-    * A vote of "-1" means opposition to  a proposal
-
-* Voting remains open for seven days or until all active PSC members have cast their vote
-
-* Any active PSC member can during these seven days request an extension of voting for
-  an additional seven days; the voting period can only be extended once
-
-* Any PSC member who votes "-1" against a proposal must provide a
-  reasonable explanation as to why
-
-* Any PSC member who votes "-1" against a proposal has a limited time to
-  provide constructive feedback as to how the vote can be turned
-
-* The GSIP author must incorporate any reasonable feedback into the proposal
-
-* PSC members who voted "-1" consider whether their feedback has been addressed
-  and whether they wish to change their vote
-
-* Only active PSC members are counted for determining vote percentages
-
-* A GSIP is accepted if it receives:
-
-    * at least 30% "+1" votes, and
-
-    * a quorum of at least 50% "+1"/"+0"/"0"/"-0" votes, and
-
-    * no "-1" votes (or all feedback from any "-1" votes has been addressed
-      and any "-1" voters have changed their votes)
+.. include:: gsip_voting.txt
 
 GSIP FAQ
 --------

--- a/doc/en/developer/source/policies/gsip_template.txt
+++ b/doc/en/developer/source/policies/gsip_template.txt
@@ -1,0 +1,47 @@
+# GSIP 1234 - Title
+
+## Overview
+
+### Proposed By
+
+John Doe
+
+### Assigned to Release
+
+This proposal is for GeoServer 2.15-beta.
+
+### State
+
+* [x] Under Discussion
+* [ ] In Progress
+* [ ] Completed
+* [ ] Rejected
+* [ ] Deferred
+
+### Motivation
+
+## Proposal
+
+### Backwards Compatibility
+
+## Feedback
+
+## Voting
+
+Project Steering Committee:
+
+* Alessio Fabiani:
+* Andrea Aime:
+* Ian Turton:
+* Jody Garnett:
+* Jukka Rahkonen:
+* Kevin Smith:
+* Simone Giannecchini:
+* Torben Barsballe:
+* Nuno Oliveira:
+
+## Links
+
+* [Email Discussion](http://osgeo-org.1560.x6.nabble.com/GSIP-1234-discussion-tt5135281.html)
+* [Pull Request 123](https://github.com/geoserver/geoserver/pull/123)
+* [GeoTools / GeoServer Meeting 2019-03-01 ](http://osgeo-org.1560.x6.nabble.com/GeoTools-GeoServer-Meeting-2019-03-02-tt5142734.html)

--- a/doc/en/developer/source/policies/gsip_voting.txt
+++ b/doc/en/developer/source/policies/gsip_voting.txt
@@ -1,0 +1,57 @@
+.. note:: Voting on GeoServer Improvement Proposal (GSIP)
+   
+   #. Proposals may be made by any interested party (PSC, Non-PSC, committer,user,etc...).
+   
+      All community members are encouraged to review proposals, and provide their support and feedback.
+   
+   #. Each PSC member may vote one of the following in support of the proposal:
+   
+      * +1 : For
+      * +0: Mildly for, but mostly indifferent
+      * -0: Mildly against, but mostly indifferent
+      * -1 : Against, accompanied with a detailed reason of being against
+   
+   #. Voting remains open for ten days or until all PSC members have cast their vote.
+   
+      * At the end of ten days time any remaining votes are assumed to be +0.
+      
+      * Any active PSC member can during ten days request an extension of voting for
+        an additional ten days; the voting period can only be extended once.
+
+      * Any PSC member who votes "-1" against a proposal must provide a
+        reasonable explanation as to why.
+        
+      * Any PSC member who votes "-1" against a proposal has a limited time to
+        provide constructive feedback as to how their -1 vote can be addressed.
+        
+        The GSIP author must incorporate any reasonable feedback into the proposal.
+
+        The PSC member who voted "-1" must consider whether their feedback has been
+        addressed and whether they wish to change their vote.
+           
+   #. Voting results:
+      
+      * A vote of "+1" means support for a proposal
+      * The neutral votes "+0", "0", and "-0" all count the same as "0" but permit PSC members
+        to indicate a slight tendency for, neutral, or against a proposal respectively
+      * A vote of "-1" means opposition to the proposal
+
+      A unanimous response is:
+      
+      * Successful: No -1 votes against it, or
+      * Unsuccessful: No +1 votes for it.
+   
+   #. A GSIP is accepted if it receives:
+
+      * at least 30% "+1" votes, and
+      * no "-1" votes (or all feedback from any "-1" votes has been addressed and any "-1" voters have changed their votes)
+   
+   #. In the event of an *successful non unanimous* vote, the following steps are taken:
+ 
+      * Each member who votes -1 *may* supply an alternative with which the original author can use to rework the proposal in order to satisfy that PSC member.
+      * If at least one -1 voting PSC member supplies some alternative criteria, the original author must rework the proposal and resubmit, and the voting process starts again from scratch.
+      * If no -1 voters are able to supply alternative criteria, the proposal is accepted.
+   
+   #. In the event of an *unsuccessful* vote, the author may choose to rework and submit.
+      
+      A proposal may not be resubmitted after being rejected three times.

--- a/doc/en/developer/source/policies/psc.rst
+++ b/doc/en/developer/source/policies/psc.rst
@@ -105,7 +105,7 @@ A GSIP proposal is NOT needed for:
 * an improvement that can go in a community module; or
 * a bug fix that doesn't rework anything substantially
 
-For minor decisions where feedback might be desired, the course of action to take is to consult the development list or raise it in a video meeting.  The GeoServer Project recognizes that it is run those who are actually doing the work, and thus we want to avoid high overhead for 'getting things done'.
+For minor decisions where feedback might be desired, consult the development list, or raise it in a video meeting (anyone not attending can follow up on the meeting minutes email).  The GeoServer Project recognizes that it is run those doing the work, and wish to avoid high overhead for 'getting things done'.
 
 For these *snap decisions* that are not official GSIP proposals, everyone 'available' (those in the video meeting or who respond to an email within 4 days) are given the power to vote and decide an issue.  The same voting procedure (+1,+0,-0,-1) is used, but any decision that receives a -1 from any party present (even a  new user), should go to a GSIP.
 

--- a/doc/en/developer/source/policies/psc.rst
+++ b/doc/en/developer/source/policies/psc.rst
@@ -61,7 +61,7 @@ PSC Chair is nominated following the same procedures as PSC members.
 Stepping Down
 ^^^^^^^^^^^^^
 
-If you find you cannot make meetings for a month or two, by all means step aside. Thank you so much for your time, if you want to groom a successor and then nominate them that is cool, but the nomination process still applies.  
+If you find you cannot make meetings for a month or two, or have been unable to vote on proposals, by all means step aside. Thank you so much for your time, if you want to groom a successor and then nominate them that is cool, but the nomination process still applies.  
 
 If we do not hear from you for six months we will assume you lost, send out a search party and nominate your replacement.  
 
@@ -84,49 +84,30 @@ Process
 
 The primary role of the PSC is to make decisions relating to project management. The following decision making process is used. It is based on the "Proposal-Vote" system.
 
- * Issues that require a decision are based on GeoServer Improvement Proposals (GSIPs). For more on making a proposal see :ref:`gsip`
- * Proposals may be made by any interested party (PSC, Non-PSC, committer,user,etc...)
- * Proposals should be addressed within one week of being submitted, votes take place at the subsequent IRC meeting.
- * Each PSC member may vote one of the following in support of the proposal:
-   
-   * +1 : For
-   * -1 : Against
-   * +0: Mildly for, but mostly indifferent
-   * -0: Mildly against, but mostly indifferent
+GeoServer Improvement Proposals
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
- * A -1 vote must be accompanied with a detailed reason of being against.
- * A vote is *successful* if there is a majority of positive votes.
- * A vote is *unanimous*, if there are either:
+A GeoServer Improvement Proposals (GSIPs) is needed for any action that:
 
-   #. No -1 votes against it, or
-   #. No +1 votes for it.
+  * Has a major effect on others in the GeoServer community; or
+  * Will break backwards compatibility; or
+  * Change core code
 
- * In the event of an *successful non unanimous* vote, the following steps are taken:
- 
-   * Each member who votes -1 _may_ supply an alternative with which the original author can use to rework the proposal in order to satisfy that PSC member.
-   * If at least one -1 voting PSC member supplies some alternative criteria, the original author must rework the proposal and resubmit, and the voting process starts again from scratch.
-   * If no -1 voters are able to supply alternative criteria, the proposal is accepted.
-   * In the event of an *unsuccessful* vote, the author may rework and submit. A proposal may not be resubmitted after being rejected three times.
-   * Note that a majority of positive votes does not need to be a majority of the full PSC, just a majority of the 'active' PSC - defined by those present at an IRC meeting or responding within 4 days on email.  PSC members need not sound in on every single motion, but are expected to be active - the section on stepping down details that if a PSC is not active for 2 months they will
+For more on making a proposal see :ref:`gsip`.
 
-When not to use the GSIP
-^^^^^^^^^^^^^^^^^^^^^^^^
+.. include:: gsip_voting.txt
 
-A GSIP is only needed for:
+Snap Decisions
+^^^^^^^^^^^^^^
 
-  * an action that has a major effect on others in the GeoServer community.
-  * If an action will break backwards compatibility, or change core code, a GSIP is recommended.
+A GSIP proposal is NOT needed for:
 
-A GSIP is NOT needed for:
+* an improvement that can go in a community module; or
+* a bug fix that doesn't rework anything substantially
 
-  * an improvement that can go in a community module; or
-  * a bug fix that doesn't rework anything substantially
+For minor decisions where feedback might be desired, the course of action to take is to consult the development list or raise it in a video meeting.  The GeoServer Project recognizes that it is run those who are actually doing the work, and thus we want to avoid high overhead for 'getting things done'.
 
-For minor decisions where feedback might be desired, the course of action to take is to consult the development list or raise it in an irc meeting.  The GeoServer Project recognizes that it is run those who are actually doing the work, and thus we want to avoid high overhead for 'getting things done'.
-
-.. note:: Snap Decisions
-
-   For all decisions that are not official GSIP proposals, those 'present' (those in the Skype meeting or who bother to respond to an email within 4 days) are given the power to vote and decide an issue.  The same voting procedures are used, but any vote that meets a -1 from any party present (even a  new user), should go to a GSIP.  
+For these *snap decisions* that are not official GSIP proposals, everyone 'available' (those in the video meeting or who respond to an email within 4 days) are given the power to vote and decide an issue.  The same voting procedure (+1,+0,-0,-1) is used, but any decision that receives a -1 from any party present (even a  new user), should go to a GSIP.
 
 Responsibilities
 ----------------
@@ -148,12 +129,23 @@ PSC members are expected to be active on both user and developer email lists, su
 *It is a requirement that all PSC members maintain good public visibility with respect to activity and management of the project. This cannot happen without a good frequency of email on the mailing lists.*
 
 .. note::
-
-   Biweekly Skype Meeting Attendance
-
-   PSC members are encouraged to attend one of biweekly Skype meetings. Of course this is not always possible due to various reasons. If known in advance that a member cannot attend a meeting it is polite to email the developer list in response to the meeting reminder. No reason need to be given for not attending the meeting.
    
-   Meetings are a chance to quickly discuss project activities, review difficult pull requests, and cut down on email.
+   Our community is subject to both a responsible disclosure policy and a code of conduct; this is the responsibility of all partipants and is not limited to the PSC.*
+
+**Biweekly Video Meeting Attendance**
+
+PSC members are encouraged to attend one of biweekly Skype meetings. Of course this is not always possible due to various reasons. If known in advance that a member cannot attend a meeting it is polite to email the developer list in response to the meeting reminder. No reason need to be given for not attending the meeting.
+   
+Meetings are a chance to quickly discuss project activities, review difficult pull requests, and cut down on email.
+
+**Community Commitments**
+
+As an Open Source Geospatial Foundation project we have a number of committments:
+
+* Code of Conduct
+* OSGeo Officer
+* OSGeo Annual Report
+* OSGeo Budget
 
 Planning
 ^^^^^^^^
@@ -171,7 +163,7 @@ Long term project management. Duties include:
 **Project Policies**
 
 The PSC is responsible for defining project policies and practiced. Examples include:
-
+ 
  * Development Practices
 
    * Code Reviews
@@ -185,4 +177,4 @@ The PSC is responsible for defining project policies and practiced. Examples inc
 
    * Frequency 
    * Version numbering
-   * Stable vs R&D
+   * Stable vs Maintenance vs R&D


### PR DESCRIPTION
See [GSIP-190](https://github.com/geoserver/geoserver/wiki/GSIP-190) for policy change:

> Assume +0 vote after 10 days

It has been some time since these pages were updated:

* [x] Combines the voting procedure from the gsip and psc pages into an include, and attempt to make them consistent.
* [x] Includs the markdown gsip template as part of the gsip page to save time
* [x] Changes irc meeting to video meeting
* [x] Consistently says 6 months, rather than 2 months, to consider PSC member inactive
* [x] Note OSGeo stuff (annual report, budget, officer, code of conduct)

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
