### PR TITLE
[GEOS-9575] Importer uses wrong datastore when more than one ws have …

### DIFF
--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportController.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportController.java
@@ -7,6 +7,7 @@ package org.geoserver.importer.rest;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.importer.ImportContext;
@@ -183,11 +184,11 @@ public class ImportController extends ImportBaseController {
             if (newContext != null) {
                 WorkspaceInfo targetWorkspace = newContext.getTargetWorkspace();
                 StoreInfo targetStore = newContext.getTargetStore();
-
+                Catalog cat = importer.getCatalog();
                 if (targetWorkspace != null) {
                     // resolve to the 'real' workspace
                     WorkspaceInfo ws =
-                            importer.getCatalog().getWorkspaceByName(targetWorkspace.getName());
+                            cat.getWorkspaceByName(targetWorkspace.getName());
                     if (ws == null) {
                         throw new RestException(
                                 "Target workspace does not exist : " + targetWorkspace.getName(),
@@ -196,9 +197,16 @@ public class ImportController extends ImportBaseController {
                     context.setTargetWorkspace(ws);
                 }
                 if (targetStore != null) {
-                    StoreInfo ts =
-                            importer.getCatalog()
-                                    .getStoreByName(targetStore.getName(), StoreInfo.class);
+                    WorkspaceInfo ws = context.getTargetWorkspace();
+                    StoreInfo ts;
+                    if (ws != null)
+                        ts =
+                                cat.getStoreByName(
+                                        ws, newContext.getTargetStore().getName(), StoreInfo.class);
+                    else
+                        ts =
+                                cat.getStoreByName(
+                                        newContext.getTargetStore().getName(), StoreInfo.class);
                     if (ts == null) {
                         throw new RestException(
                                 "Target store does not exist : " + targetStore.getName(),

--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportController.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportController.java
@@ -187,8 +187,7 @@ public class ImportController extends ImportBaseController {
                 Catalog cat = importer.getCatalog();
                 if (targetWorkspace != null) {
                     // resolve to the 'real' workspace
-                    WorkspaceInfo ws =
-                            cat.getWorkspaceByName(targetWorkspace.getName());
+                    WorkspaceInfo ws = cat.getWorkspaceByName(targetWorkspace.getName());
                     if (ws == null) {
                         throw new RestException(
                                 "Target workspace does not exist : " + targetWorkspace.getName(),
@@ -198,15 +197,10 @@ public class ImportController extends ImportBaseController {
                 }
                 if (targetStore != null) {
                     WorkspaceInfo ws = context.getTargetWorkspace();
+                    String storeName = targetStore.getName();
                     StoreInfo ts;
-                    if (ws != null)
-                        ts =
-                                cat.getStoreByName(
-                                        ws, newContext.getTargetStore().getName(), StoreInfo.class);
-                    else
-                        ts =
-                                cat.getStoreByName(
-                                        newContext.getTargetStore().getName(), StoreInfo.class);
+                    if (ws != null) ts = cat.getStoreByName(ws, storeName, StoreInfo.class);
+                    else ts = cat.getStoreByName(storeName, StoreInfo.class);
                     if (ts == null) {
                         throw new RestException(
                                 "Target store does not exist : " + targetStore.getName(),

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportControllerTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportControllerTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.importer.Database;
 import org.geoserver.importer.Directory;
 import org.geoserver.importer.ImportContext;
@@ -48,6 +49,8 @@ public class ImportControllerTest extends ImporterTestSupport {
         dir = unpack("shape/archsites_no_crs.zip");
         this.thirdId =
                 importer.createContext(new SpatialFile(new File(dir, "archsites.shp"))).getId();
+        if (getCatalog().getStoreByName("gs", "skunkworks", DataStoreInfo.class) != null)
+            removeStore("gs", "skunkworks");
     }
 
     @After
@@ -481,6 +484,5 @@ public class ImportControllerTest extends ImporterTestSupport {
         assertEquals("skunkworks", ctx.getTargetStore().getName());
         resp = postAsServletResponse(RestBaseController.ROOT_PATH + "/imports/" + id, "");
         assertEquals(204, resp.getStatus());
-        removeStore("gs", "skunkworks");
     }
 }

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportControllerTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportControllerTest.java
@@ -404,4 +404,83 @@ public class ImportControllerTest extends ImporterTestSupport {
 
         assertTrue(layer.containsKey("bbox"));
     }
+
+    @Test
+    public void testPostTargetWithSameStoreNameTwoWs() throws Exception {
+        createH2DataStore("sf", "skunkworks");
+        // same store name in different ws, to check later that workspace is
+        // properly checked
+        createH2DataStore("gs", "skunkworks");
+
+        String json =
+                "{"
+                        + "\"import\": { "
+                        + "\"targetWorkspace\": {"
+                        + "\"workspace\": {"
+                        + "\"name\": \"sf\""
+                        + "}"
+                        + "},"
+                        + "\"targetStore\": {"
+                        + "\"dataStore\": {"
+                        + "\"name\": \"skunkworks\""
+                        + "}"
+                        + "}"
+                        + "}"
+                        + "}";
+
+        MockHttpServletResponse resp =
+                postAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/imports", json, "application/json");
+        assertEquals(201, resp.getStatus());
+        assertNotNull(resp.getHeader("Location"));
+
+        int id = lastId();
+        assertTrue(resp.getHeader("Location").endsWith("/imports/" + id));
+
+        ImportContext ctx = importer.getContext(id);
+        assertNotNull(ctx);
+        assertNotNull(ctx.getTargetWorkspace());
+        // check that the context got the right workspace
+        assertEquals("sf", ctx.getTargetWorkspace().getName());
+        assertNotNull(ctx.getTargetStore());
+        assertEquals("skunkworks", ctx.getTargetStore().getName());
+        resp = postAsServletResponse(RestBaseController.ROOT_PATH + "/imports/" + id, "");
+        assertEquals(204, resp.getStatus());
+
+        json =
+                "{"
+                        + "\"import\": { "
+                        + "\"targetWorkspace\": {"
+                        + "\"workspace\": {"
+                        + "\"name\": \"gs\""
+                        + "}"
+                        + "},"
+                        + "\"targetStore\": {"
+                        + "\"dataStore\": {"
+                        + "\"name\": \"skunkworks\""
+                        + "}"
+                        + "}"
+                        + "}"
+                        + "}";
+
+        resp =
+                postAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/imports", json, "application/json");
+        assertEquals(201, resp.getStatus());
+        assertNotNull(resp.getHeader("Location"));
+
+        id = lastId();
+        assertTrue(resp.getHeader("Location").endsWith("/imports/" + id));
+
+        ctx = importer.getContext(id);
+        assertNotNull(ctx);
+        assertNotNull(ctx.getTargetWorkspace());
+        // check that the context got the right workspace
+        assertEquals("gs", ctx.getTargetWorkspace().getName());
+        assertNotNull(ctx.getTargetStore());
+        assertEquals("skunkworks", ctx.getTargetStore().getName());
+        resp = postAsServletResponse(RestBaseController.ROOT_PATH + "/imports/" + id, "");
+        assertEquals(204, resp.getStatus());
+        removeStore("gs", "skunkworks");
+    }
 }


### PR DESCRIPTION
…a store with the same name

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
