### PR TITLE
CSW-iso (community module): fix gmd scheme

### DIFF
--- a/src/community/csw-iso/src/main/java/org/geoserver/csw/records/iso/MetaDataDescriptor.java
+++ b/src/community/csw-iso/src/main/java/org/geoserver/csw/records/iso/MetaDataDescriptor.java
@@ -88,8 +88,7 @@ public class MetaDataDescriptor extends AbstractRecordDescriptor {
         try {
             index =
                     reader.parse(
-                            new URL(
-                                    "http://schemas.opengis.net/iso/19139/20070417/gmd/metadataEntity.xsd"));
+                            new URL("http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"));
             indexGMX =
                     reader.parse(
                             new URL("http://schemas.opengis.net/iso/19139/20070417/gmx/gmx.xsd"));


### PR DESCRIPTION
The wrong xsd file is used to start parsing the gmd scheme, which causes issues when that same scheme is used by mapping files in app-schema, with elements missing.