### PR TITLE
[GEOS-9603] JDBCConfig (community module): repopulate

### DIFF
--- a/doc/en/user/source/community/jdbcconfig/configuration.rst
+++ b/doc/en/user/source/community/jdbcconfig/configuration.rst
@@ -12,6 +12,8 @@ The following properties may be set:
 
 - ``import`` : The import configuration option tells GeoServer whether to import the current catalog from the file system to the database or not. If set to true, it will be imported and the config option will be set the value 'false' for the next start up to avoid trying to re-import the catalog  configuration.
 
+- ``repopulate``: The repopulate configuration option tells GeoServer to repopulate the queryable field values in the database. These are the fields of catalog objects jdbcconfig can query via the database, i.e. much faster than via post-filtering in memory. May be necessary after jdbcconfig upgrades or if someone manually adds queryable fields to the database. (In such cases, if the values were not properly repopulated, queries might give incorrect results.)
+
 - ``initScript``: Path to initialisation script .sql file. Only used if initdb = true.
 
 JNDI

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/JDBCGeoServerLoader.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/JDBCGeoServerLoader.java
@@ -91,6 +91,13 @@ public class JDBCGeoServerLoader extends DefaultGeoServerLoader {
             readCatalog(catalog, xp);
             decImportStep();
         }
+
+        if (!config.isInitDb() && !config.isImport() && config.isRepopulate()) {
+            ConfigDatabase configDatabase = ((JDBCCatalogFacade) catalogFacade).getConfigDatabase();
+            configDatabase.repopulateQueryableProperties();
+            config.setRepopulate(false);
+            config.save();
+        }
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbMappings.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbMappings.java
@@ -660,6 +660,14 @@ public class DbMappings {
         return changedProps;
     }
 
+    public Iterable<Property> allProperties(Info object) {
+        checkArgument(!(object instanceof Proxy));
+        final ClassMappings classMappings = ClassMappings.fromImpl(object.getClass());
+        checkNotNull(classMappings);
+
+        return properties(object, classMappings);
+    }
+
     private ImmutableSet<Property> properties(Info object, final ClassMappings classMappings) {
         final Class<? extends Info> type = classMappings.getInterface();
         final Integer typeId = getTypeId(type);

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/JDBCConfigProperties.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/JDBCConfigProperties.java
@@ -16,4 +16,11 @@ public class JDBCConfigProperties extends JDBCLoaderProperties {
 
     // jdbcconfig specific properties  may go here.
 
+    public boolean isRepopulate() {
+        return Boolean.parseBoolean(getProperty("repopulate", "false"));
+    }
+
+    public void setRepopulate(boolean initdb) {
+        setProperty("repopulate", String.valueOf(initdb));
+    }
 }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-9603

Adds a feature to jdbcconfig to repopulate all the queryable properties in the database.

This can be used if you want to manually add a queryable property to the database. For example, the metadata module allows any number of custom attributes to be added to layers. For efficiency reasons you might want to make one of them queryable.