### PR TITLE
REST FeatureType: use qualified name to get source

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
@@ -37,7 +37,6 @@ import org.geoserver.rest.wrapper.RestWrapper;
 import org.geotools.data.DataAccess;
 import org.geotools.data.DataStore;
 import org.geotools.data.FeatureSource;
-import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.util.logging.Logging;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -246,7 +245,7 @@ public class FeatureTypeController extends AbstractCatalogController {
         // attempt to fill in metadata from underlying feature source
         try {
             FeatureSource featureSource =
-                    dataAccess.getFeatureSource(new NameImpl(ftInfo.getNativeName()));
+                    dataAccess.getFeatureSource(ftInfo.getQualifiedNativeName());
             if (featureSource != null) {
                 cb.setupMetadata(ftInfo, featureSource);
             }


### PR DESCRIPTION
This is a very minor change, with only affect that there is no unnecessary stacktrace logged when you use REST to publish an app-schema layer.

Difficult to test, because effect is only in logging (it /does/ move on and work otherwise).

Didn't make jira issue because of how trivial this is / no new features or bug fixed.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

