### PR TITLE
[2.16.x backport][GEOS-9575] Importer uses wrong datastore when more than one ws have …

### DIFF
--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportController.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportController.java
@@ -7,6 +7,7 @@ package org.geoserver.importer.rest;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.importer.ImportContext;
@@ -183,12 +184,11 @@ public class ImportController extends ImportBaseController {
             if (newContext != null) {
                 WorkspaceInfo targetWorkspace = newContext.getTargetWorkspace();
                 StoreInfo targetStore = newContext.getTargetStore();
-
+                Catalog cat = importer.getCatalog();
                 if (targetWorkspace != null) {
                     // resolve to the 'real' workspace
-                    WorkspaceInfo ws =
-                            importer.getCatalog()
-                                    .getWorkspaceByName(newContext.getTargetWorkspace().getName());
+
+                    WorkspaceInfo ws = cat.getWorkspaceByName(targetWorkspace.getName());
                     if (ws == null) {
                         throw new RestException(
                                 "Target workspace does not exist : "
@@ -198,10 +198,12 @@ public class ImportController extends ImportBaseController {
                     context.setTargetWorkspace(ws);
                 }
                 if (targetStore != null) {
-                    StoreInfo ts =
-                            importer.getCatalog()
-                                    .getStoreByName(
-                                            newContext.getTargetStore().getName(), StoreInfo.class);
+
+                    WorkspaceInfo ws = context.getTargetWorkspace();
+                    String storeName = targetStore.getName();
+                    StoreInfo ts;
+                    if (ws != null) ts = cat.getStoreByName(ws, storeName, StoreInfo.class);
+                    else ts = cat.getStoreByName(storeName, StoreInfo.class);
                     if (ts == null) {
                         throw new RestException(
                                 "Target store does not exist : "


### PR DESCRIPTION
…… (#4187)

* [GEOS-9575] Importer uses wrong datastore when more than one ws have a store with the same name

* reviewer's feedback applied

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
