### PR TITLE
[Backport 2.16.x] [GEOS-9190]: Unable to create feature type through REST if two stores on different workspaces have the same name

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
@@ -171,7 +171,7 @@ public class FeatureTypeController extends AbstractCatalogController {
             UriComponentsBuilder builder)
             throws Exception {
 
-        DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
+        final DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
         // ensure the store matches up
         if (ftInfo.getStore() != null && storeName != null) {
             if (!storeName.equals(ftInfo.getStore().getName())) {
@@ -182,7 +182,10 @@ public class FeatureTypeController extends AbstractCatalogController {
                                 + ftInfo.getStore().getName(),
                         HttpStatus.FORBIDDEN);
             }
-            dsInfo = ftInfo.getStore();
+            // HACK: override the StoreInfo in case there's a store named the same on a
+            // different workspace. The FeatureTypeInfo deserialization doesn't know how to
+            // disambiguate to ftInfo may come in with the wrong Store
+            ftInfo.setStore(dsInfo);
         } else {
             ftInfo.setStore(dsInfo);
         }

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
@@ -69,7 +69,35 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
                 dom.getElementsByTagName("featureType").getLength());
     }
 
+    @Test // GEOS-9190
+    public void testCreateFeatureTypeSameStoreNameDifferentWorkspace() throws Exception {
+        final boolean configureFeatureType = false;
+        final String ws1 = "gs";
+        final String ws2 = "sf";
+        // create two stores named "pds" on different workspaces
+        addPropertyDataStore(ws1, configureFeatureType);
+        addPropertyDataStore(ws2, configureFeatureType);
+
+        String xml = "<featureType><name>pdsa</name><store>pds</store></featureType>";
+
+        MockHttpServletResponse response;
+        String ws1FetureTypesPath =
+                BASEPATH + "/workspaces/" + ws1 + "/datastores/pds/featuretypes";
+        String ws2FeatureTypesPath =
+                BASEPATH + "/workspaces/" + ws2 + "/datastores/pds/featuretypes";
+
+        response = postAsServletResponse(ws1FetureTypesPath, xml, "text/xml");
+        assertEquals(201, response.getStatus());
+
+        response = postAsServletResponse(ws2FeatureTypesPath, xml, "text/xml");
+        assertEquals(201, response.getStatus());
+    }
+
     void addPropertyDataStore(boolean configureFeatureType) throws Exception {
+        addPropertyDataStore("gs", configureFeatureType);
+    }
+
+    void addPropertyDataStore(String workspace, boolean configureFeatureType) throws Exception {
         ByteArrayOutputStream zbytes = new ByteArrayOutputStream();
         ZipOutputStream zout = new ZipOutputStream(zbytes);
 
@@ -95,10 +123,16 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
         zout.close();
 
         String q = "configure=" + (configureFeatureType ? "all" : "none");
-        put(
-                BASEPATH + "/workspaces/gs/datastores/pds/file.properties?" + q,
-                zbytes.toByteArray(),
-                "application/zip");
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        BASEPATH
+                                + "/workspaces/"
+                                + workspace
+                                + "/datastores/pds/file.properties?"
+                                + q,
+                        zbytes.toByteArray(),
+                        "application/zip");
+        assertEquals(201, response.getStatus());
     }
 
     void addGeomlessPropertyDataStore(boolean configureFeatureType) throws Exception {


### PR DESCRIPTION
Backport #3794, for some reason missed to backport to 2.16.x at the time, and backported only to 2.15.x, and missed the 2.16.2 release timeframe. Adding for completeness.
