### PR TITLE
[GEOS-9625] Add filtering support in json-ld module

### DIFF
--- a/doc/en/user/source/community/json-ld/configuration.rst
+++ b/doc/en/user/source/community/json-ld/configuration.rst
@@ -207,13 +207,19 @@ attribute (static)
 
 
 
-As it is possible to see, in the array and object case the filter sintax expected an :code:`"$filter"` key followed by an attribute with the filter to evaluate. In the attribute case, instead, the filter is being specified inside the value as :code:`"$filter{...}"` separeted by the cql expression of by the static content from a :code:`,`.
+In the array and object case the filter sintax expected a :code:`"$filter"` key followed by an attribute with the filter to evaluate. In the attribute case, instead, the filter is being specified inside the value as :code:`"$filter{...}"`, followed by  the cql expression, or by the static content, with a comma separating the two.
 The evaluation of a filter is handled by the module in the following way:
 
 * if a :code:`"$filter": "cql"` attribute is present after the :code:`"$source"` attribute in an array or an object:
-  * in the array case, each of its element will be included in the output if the condition in the filter condition is true;
-  * in the object case, the entire object will be included in the output if the condition in the filter condition is true;
+  
+  * in the array case, each array element will be included in the output only if the condition in the filter is matched, otherwise it will be skipped;
+  
+  * in the object case, the entire object will be included in the output only if the condition in the filter is matched, otherwise the object will be skipped;
 
 * if a :code:`$filter{cql}` is present inside an attribute value before the expression or the static content, separated by it from a :code:`,`:
+  
   * in case of an expression attribute, the result of the expression will be included in the output if the filter condition is true;
+  
   * in case of a static content attribute, the static content will be included in the output if the filter condition is true.
+  
+  * in case the expression is not matched, the content, static or dynamic, will not be set, resulting in the attribute being skipped.

--- a/src/community/json-ld/pom.xml
+++ b/src/community/json-ld/pom.xml
@@ -155,6 +155,26 @@
         </dependency>
     </dependencies>
 
+    <build>
+    <plugins>
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.15</version>
+        <configuration>
+            <runOrder>alphabetical</runOrder>
+            <includes>
+                <include>**/*Test.java</include>
+            </includes>
+            <reuseForks>false</reuseForks>
+            <argLine>-Xmx${test.maxHeapSize}</argLine>
+            <enableAssertions>true</enableAssertions>
+            <printSummary>true</printSummary>
+        </configuration>
+    </plugin>
+    </plugins>
+    </build>
+
     <developers>
         <developer>
             <name>Marco Volpini</name>

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/JsonLdGenerator.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/JsonLdGenerator.java
@@ -133,6 +133,11 @@ public class JsonLdGenerator extends com.fasterxml.jackson.core.JsonGenerator {
         }
     }
 
+    public void writeString(String entryName, String value) throws IOException {
+        if (entryName != null && !entryName.equals("")) delegate.writeFieldName(entryName);
+        if (value != null && !value.equals("")) delegate.writeString(value);
+    }
+
     public com.fasterxml.jackson.core.JsonGenerator getDelegate() {
         return delegate;
     }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/AbstractJsonBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/AbstractJsonBuilder.java
@@ -7,10 +7,9 @@ package org.geoserver.jsonld.builders;
 import java.io.IOException;
 import org.geoserver.jsonld.JsonLdGenerator;
 import org.geoserver.jsonld.builders.impl.JsonBuilderContext;
-import org.geoserver.jsonld.expressions.JsonLdCqlManager;
+import org.geoserver.jsonld.expressions.JsonLdCQLManager;
 import org.geotools.filter.text.cql2.CQLException;
 import org.opengis.filter.Filter;
-import org.opengis.filter.expression.*;
 import org.xml.sax.helpers.NamespaceSupport;
 
 /** Abstract implementation of {@link JsonBuilder} who groups some common attributes and methods. */
@@ -36,11 +35,9 @@ public abstract class AbstractJsonBuilder implements JsonBuilder {
 
     protected boolean evaluateFilter(JsonBuilderContext context) {
         if (filter == null) return true;
-        int i = 0;
         JsonBuilderContext evaluationContenxt = context;
-        while (i < filterContextPos) {
+        for (int i = 0; i < filterContextPos; i++) {
             evaluationContenxt = evaluationContenxt.getParent();
-            i++;
         }
         return filter.evaluate(evaluationContenxt.getCurrentObj());
     }
@@ -58,7 +55,7 @@ public abstract class AbstractJsonBuilder implements JsonBuilder {
     }
 
     public void setFilter(String filter) throws CQLException {
-        JsonLdCqlManager cqlManager = new JsonLdCqlManager(filter, namespaces);
+        JsonLdCQLManager cqlManager = new JsonLdCQLManager(filter, namespaces);
         this.filter = cqlManager.getFilterFromString();
         this.filterContextPos = cqlManager.getContextPos();
     }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/AbstractJsonBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/AbstractJsonBuilder.java
@@ -6,19 +6,43 @@ package org.geoserver.jsonld.builders;
 
 import java.io.IOException;
 import org.geoserver.jsonld.JsonLdGenerator;
+import org.geoserver.jsonld.builders.impl.JsonBuilderContext;
+import org.geoserver.jsonld.expressions.JsonLdCqlManager;
+import org.geotools.filter.text.cql2.CQLException;
+import org.opengis.filter.Filter;
+import org.opengis.filter.expression.*;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /** Abstract implementation of {@link JsonBuilder} who groups some common attributes and methods. */
 public abstract class AbstractJsonBuilder implements JsonBuilder {
 
     protected String key;
 
-    public AbstractJsonBuilder(String key) {
+    protected Filter filter;
+
+    protected int filterContextPos = 0;
+
+    protected NamespaceSupport namespaces;
+
+    public AbstractJsonBuilder(String key, NamespaceSupport namespaces) {
         this.key = key;
+        this.namespaces = namespaces;
     }
 
     protected void writeKey(JsonLdGenerator writer) throws IOException {
         if (key != null && !key.equals("")) writer.writeFieldName(key);
         else throw new RuntimeException("Cannot write null key value");
+    }
+
+    protected boolean evaluateFilter(JsonBuilderContext context) {
+        if (filter == null) return true;
+        int i = 0;
+        JsonBuilderContext evaluationContenxt = context;
+        while (i < filterContextPos) {
+            evaluationContenxt = evaluationContenxt.getParent();
+            i++;
+        }
+        return filter.evaluate(evaluationContenxt.getCurrentObj());
     }
 
     public String getKey() {
@@ -27,5 +51,15 @@ public abstract class AbstractJsonBuilder implements JsonBuilder {
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    public Filter getFilter() {
+        return filter;
+    }
+
+    public void setFilter(String filter) throws CQLException {
+        JsonLdCqlManager cqlManager = new JsonLdCqlManager(filter, namespaces);
+        this.filter = cqlManager.getFilterFromString();
+        this.filterContextPos = cqlManager.getContextPos();
     }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/SourceBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/SourceBuilder.java
@@ -18,8 +18,8 @@ public abstract class SourceBuilder extends AbstractJsonBuilder {
 
     protected List<JsonBuilder> children;
 
-    public SourceBuilder(String key) {
-        super(key);
+    public SourceBuilder(String key, NamespaceSupport namespaces) {
+        super(key, namespaces);
         this.children = new LinkedList<JsonBuilder>();
     }
 
@@ -56,7 +56,7 @@ public abstract class SourceBuilder extends AbstractJsonBuilder {
         return source != null ? source.getPropertyName() : null;
     }
 
-    public void setSource(String source, NamespaceSupport namespaces) {
+    public void setSource(String source) {
         this.source = new AttributeExpressionImpl(source, namespaces);
     }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/CompositeBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/CompositeBuilder.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.geoserver.jsonld.JsonLdGenerator;
 import org.geoserver.jsonld.builders.JsonBuilder;
 import org.geoserver.jsonld.builders.SourceBuilder;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * Groups {@link StaticBuilder} and {@link DynamicValueBuilder}, invoke them and set, if found, the
@@ -20,15 +21,16 @@ public class CompositeBuilder extends SourceBuilder {
 
     private List<JsonBuilder> children;
 
-    public CompositeBuilder(String key) {
-        super(key);
+    public CompositeBuilder(String key, NamespaceSupport namespaces) {
+        super(key, namespaces);
         this.children = new LinkedList<>();
     }
 
     @Override
     public void evaluate(JsonLdGenerator writer, JsonBuilderContext context) throws IOException {
         context = evaluateSource(context);
-        if (context.getCurrentObj() != null && canWrite(context)) {
+        Object o = context.getCurrentObj();
+        if (o != null && evaluateFilter(context) && canWrite(context)) {
             writeKey(writer);
             writer.writeStartObject();
             for (JsonBuilder jb : children) {

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/DynamicValueBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/DynamicValueBuilder.java
@@ -4,20 +4,15 @@
  */
 package org.geoserver.jsonld.builders.impl;
 
-import static org.geoserver.jsonld.expressions.ExpressionsUtils.*;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.jsonld.JsonLdGenerator;
 import org.geoserver.jsonld.builders.AbstractJsonBuilder;
+import org.geoserver.jsonld.expressions.JsonLdCqlManager;
 import org.geotools.feature.ComplexAttributeImpl;
 import org.geotools.filter.AttributeExpressionImpl;
-import org.geotools.filter.FunctionExpression;
-import org.geotools.filter.MathExpressionImpl;
 import org.geotools.util.logging.Logging;
 import org.opengis.feature.Attribute;
 import org.opengis.feature.ComplexAttribute;
@@ -38,57 +33,34 @@ public class DynamicValueBuilder extends AbstractJsonBuilder {
     private static final Logger LOGGER = Logging.getLogger(DynamicValueBuilder.class);
 
     public DynamicValueBuilder(String key, String expression, NamespaceSupport namespaces) {
-        super(key);
+        super(key, namespaces);
         this.namespaces = namespaces;
+        JsonLdCqlManager cqlManager = new JsonLdCqlManager(expression, namespaces);
         if (expression.startsWith("$${")) {
-            strCqlToExpression(expression);
+            this.cql = cqlManager.getExpressionFromString();
+            // strCqlToExpression(expression);
         } else if (expression.startsWith("${")) {
-            strXpathToPropertyName(expression);
+            this.xpath = cqlManager.getAttributeExpressionFromString();
+            // strXpathToPropertyName(expression);
         }
-    }
-
-    /**
-     * Takes a str cql as $${cql} and makes all the necessary operation to convert it to a valid
-     * Expression
-     */
-    private void strCqlToExpression(String cql) {
-        // takes xpath fun from cql
-        String strXpathFun = extractXpathFromCQL(cql);
-        if (strXpathFun.indexOf(XPATH_FUN_START) != -1)
-            this.contextPos = determineContextPos(strXpathFun);
-        // takes the literal argument of xpathFun
-        String literalXpath = getLiteralXpath(strXpathFun);
-
-        // clean the function to obtain a cql expression without xpath() syntax
-        this.cql = extractCqlExpressions(cleanCQLExpression(cql, strXpathFun, literalXpath));
-        // replace the xpath literal inside the expression with a PropertyName
-        literalXpathToPropertyName(this.cql, removeBackDots(literalXpath));
-    }
-
-    /**
-     * Takes a str xpath as ${xpath} and makes all the necessary operation to produce a valid
-     * PropertyName
-     */
-    private void strXpathToPropertyName(String xpath) {
-        String strXpath = extractXpath(xpath);
-        this.contextPos = determineContextPos(strXpath);
-        strXpath = removeBackDots(strXpath);
-        this.xpath = new AttributeExpressionImpl(strXpath, namespaces);
+        this.contextPos = cqlManager.getContextPos();
     }
 
     @Override
     public void evaluate(JsonLdGenerator writer, JsonBuilderContext context) throws IOException {
         Object o = null;
-        if (xpath != null) {
+        if (evaluateFilter(context)) {
+            if (xpath != null) {
 
-            o = evaluateXPath(context);
+                o = evaluateXPath(context);
 
-        } else if (cql != null) {
-            o = evaluateExpressions(context);
-        }
-        if (canWriteValue(o)) {
-            writeKey(writer);
-            writer.writeResult(o);
+            } else if (cql != null) {
+                o = evaluateExpressions(context);
+            }
+            if (canWriteValue(o)) {
+                writeKey(writer);
+                writer.writeResult(o);
+            }
         }
     }
 
@@ -96,7 +68,7 @@ public class DynamicValueBuilder extends AbstractJsonBuilder {
         return cql;
     }
 
-    public Expression getXpath() {
+    public AttributeExpressionImpl getXpath() {
         return xpath;
     }
 
@@ -131,57 +103,6 @@ public class DynamicValueBuilder extends AbstractJsonBuilder {
             LOGGER.log(Level.INFO, "Unable to evaluate expression. Exception: {0}", e.getMessage());
         }
         return result;
-    }
-
-    /**
-     * Searches for one or more literal xpath inside the expression. If found, substitutes it/them
-     * with a ${@link PropertyName}
-     */
-    private void literalXpathToPropertyName(Expression expr, String literalXpath) {
-        List<Expression> params = null;
-        if (expr instanceof Function) {
-            params = ((Function) expr).getParameters();
-        } else if (expr instanceof BinaryExpression) {
-            params =
-                    Arrays.asList(
-                            ((BinaryExpression) expr).getExpression1(),
-                            ((BinaryExpression) expr).getExpression2());
-        }
-        if (params != null) {
-            int size = params.size();
-            List<Expression> newParams = new ArrayList<>(size);
-            if (size > 0) {
-                for (int i = 0; i < size; i++) {
-                    Expression e = params.get(i);
-                    if (e instanceof Literal) {
-                        e = xpathLiteralToPropertyName((Literal) e, literalXpath);
-                        newParams.add(i, e);
-                    } else if (e instanceof Function) {
-                        newParams.add(e);
-                        literalXpathToPropertyName(e, literalXpath);
-                    }
-                }
-            }
-            setParamsToExpression(expr, newParams);
-        }
-    }
-
-    private Expression xpathLiteralToPropertyName(Literal literal, String literalXpath) {
-        String unquoted = literalXpath.replaceAll("'", "");
-        if (String.valueOf(literal.getValue()).equals(unquoted)) {
-            return new AttributeExpressionImpl(unquoted, namespaces);
-        } else {
-            return literal;
-        }
-    }
-
-    private void setParamsToExpression(Expression expr, List<Expression> params) {
-        if (expr instanceof FunctionExpression) {
-            ((FunctionExpression) expr).setParameters(params);
-        } else if (expr instanceof MathExpressionImpl) {
-            ((MathExpressionImpl) expr).setExpression1(params.get(0));
-            ((MathExpressionImpl) expr).setExpression2(params.get(1));
-        }
     }
 
     /**

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/DynamicValueBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/DynamicValueBuilder.java
@@ -10,7 +10,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.jsonld.JsonLdGenerator;
 import org.geoserver.jsonld.builders.AbstractJsonBuilder;
-import org.geoserver.jsonld.expressions.JsonLdCqlManager;
+import org.geoserver.jsonld.expressions.JsonLdCQLManager;
 import org.geotools.feature.ComplexAttributeImpl;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.util.logging.Logging;
@@ -35,13 +35,11 @@ public class DynamicValueBuilder extends AbstractJsonBuilder {
     public DynamicValueBuilder(String key, String expression, NamespaceSupport namespaces) {
         super(key, namespaces);
         this.namespaces = namespaces;
-        JsonLdCqlManager cqlManager = new JsonLdCqlManager(expression, namespaces);
+        JsonLdCQLManager cqlManager = new JsonLdCQLManager(expression, namespaces);
         if (expression.startsWith("$${")) {
             this.cql = cqlManager.getExpressionFromString();
-            // strCqlToExpression(expression);
         } else if (expression.startsWith("${")) {
             this.xpath = cqlManager.getAttributeExpressionFromString();
-            // strXpathToPropertyName(expression);
         }
         this.contextPos = cqlManager.getContextPos();
     }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/IteratingBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/IteratingBuilder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.geoserver.jsonld.JsonLdGenerator;
 import org.geoserver.jsonld.builders.JsonBuilder;
 import org.geoserver.jsonld.builders.SourceBuilder;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * This builder handle the writing of a Json array by invoking its children builders and setting the
@@ -18,8 +19,8 @@ public class IteratingBuilder extends SourceBuilder {
 
     private boolean isFeaturesField;
 
-    public IteratingBuilder(String key) {
-        super(key);
+    public IteratingBuilder(String key, NamespaceSupport namespaces) {
+        super(key, namespaces);
         this.isFeaturesField = key != null && key.equalsIgnoreCase("features");
     }
 
@@ -52,8 +53,10 @@ public class IteratingBuilder extends SourceBuilder {
 
     private void evaluateInternal(JsonLdGenerator writer, JsonBuilderContext context)
             throws IOException {
-        for (JsonBuilder child : children) {
-            child.evaluate(writer, context);
+        if (evaluateFilter(context)) {
+            for (JsonBuilder child : children) {
+                child.evaluate(writer, context);
+            }
         }
     }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/RootBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/RootBuilder.java
@@ -24,7 +24,6 @@ public class RootBuilder implements JsonBuilder {
     private JsonNode contextHeader;
 
     public RootBuilder() {
-        super();
         this.children = new ArrayList<JsonBuilder>(2);
     }
 

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/StaticBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/StaticBuilder.java
@@ -8,25 +8,38 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import org.geoserver.jsonld.JsonLdGenerator;
 import org.geoserver.jsonld.builders.AbstractJsonBuilder;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /** This class provides functionality to write content from Json-ld template file as it is */
 public class StaticBuilder extends AbstractJsonBuilder {
 
     private JsonNode staticValue;
+    private String strValue;
 
-    public StaticBuilder(String key, JsonNode value) {
-        super(key);
+    public StaticBuilder(String key, JsonNode value, NamespaceSupport namespaces) {
+        super(key, namespaces);
         this.staticValue = value;
+    }
+
+    public StaticBuilder(String key, String strValue, NamespaceSupport namespaces) {
+        super(key, namespaces);
+        this.strValue = strValue;
     }
 
     @Override
     public void evaluate(JsonLdGenerator writer, JsonBuilderContext context) throws IOException {
-        if (staticValue.isObject()) {
-            writer.writeObjectNode(key, staticValue);
-        } else if (staticValue.isArray()) {
-            writer.writeArrayNode(key, staticValue);
-        } else {
-            writer.writeValueNode(key, staticValue);
+        if (evaluateFilter(context)) {
+            if (strValue != null) {
+                writer.writeString(key, strValue);
+            } else {
+                if (staticValue.isObject()) {
+                    writer.writeObjectNode(key, staticValue);
+                } else if (staticValue.isArray()) {
+                    writer.writeArrayNode(key, staticValue);
+                } else {
+                    writer.writeValueNode(key, staticValue);
+                }
+            }
         }
     }
 

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdConfiguration.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdConfiguration.java
@@ -8,15 +8,19 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.eclipse.emf.common.util.URI;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.jsonld.builders.impl.RootBuilder;
-import org.geoserver.jsonld.expressions.ExpressionsUtils;
 import org.geoserver.jsonld.validation.JsonLdValidator;
 import org.geoserver.platform.resource.Resource;
+import org.geotools.data.complex.feature.type.ComplexFeatureTypeImpl;
+import org.geotools.feature.type.Types;
 import org.opengis.feature.type.FeatureType;
 import org.xml.sax.helpers.NamespaceSupport;
 
@@ -41,7 +45,7 @@ public class JsonLdConfiguration {
                                         NamespaceSupport namespaces = null;
                                         try {
                                             FeatureType type = key.getResource().getFeatureType();
-                                            namespaces = ExpressionsUtils.declareNamespaces(type);
+                                            namespaces = declareNamespaces(type);
                                         } catch (IOException e) {
                                             throw new RuntimeException(
                                                     "Error retrieving FeatureType "
@@ -76,13 +80,35 @@ public class JsonLdConfiguration {
                         "Failed to validate json-ld template for feature type "
                                 + typeInfo.getName()
                                 + ". Failing attribute is "
-                                + validator.getFailingAttribute());
+                                + URI.decode(validator.getFailingAttribute()));
             }
         } else {
             throw new RuntimeException(
                     "No Json-Ld template found for feature type " + typeInfo.getName());
         }
         return root;
+    }
+
+    /**
+     * Extract Namespaces from given FeatureType
+     *
+     * @return Namespaces if found for the given FeatureType
+     */
+    private NamespaceSupport declareNamespaces(FeatureType type) {
+        NamespaceSupport namespaceSupport = null;
+        if (type instanceof ComplexFeatureTypeImpl) {
+            Map namespaces = (Map) type.getUserData().get(Types.DECLARED_NAMESPACES_MAP);
+            if (namespaces != null) {
+                namespaceSupport = new NamespaceSupport();
+                for (Iterator it = namespaces.entrySet().iterator(); it.hasNext(); ) {
+                    Map.Entry entry = (Map.Entry) it.next();
+                    String prefix = (String) entry.getKey();
+                    String namespace = (String) entry.getValue();
+                    namespaceSupport.declarePrefix(prefix, namespace);
+                }
+            }
+        }
+        return namespaceSupport;
     }
 
     private class CacheKey {

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdTemplateReader.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdTemplateReader.java
@@ -139,10 +139,13 @@ public class JsonLdTemplateReader {
         String strNode = node.asText();
         String filter = null;
         if (strNode.contains(FILTERKEY)) {
-            String[] arrNode = strNode.split(",");
+            strNode = strNode.replace(FILTERKEY + "{", "");
+            int sepIndex = strNode.indexOf('}') + 1;
+            String sep = String.valueOf(strNode.charAt(sepIndex));
+            String[] arrNode = strNode.split(sep);
             strNode = arrNode[1];
             filter = arrNode[0];
-            filter = filter.replace("$filter{", "").replace("}", "");
+            filter = filter.substring(0, filter.length() - 1);
         }
         if (node.toString().contains(EXPRSTART) && !node.asText().equals("FeatureCollection")) {
             DynamicValueBuilder dynamicBuilder =

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/expressions/JsonLdCQLManager.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/expressions/JsonLdCQLManager.java
@@ -27,7 +27,7 @@ import org.xml.sax.helpers.NamespaceSupport;
  * to extracts the xpath from the function as a literal, to substitute it after cql encoding
  * happened with an AttributeExpression.
  */
-public class JsonLdCqlManager {
+public class JsonLdCQLManager {
 
     private String strCql;
 
@@ -35,7 +35,7 @@ public class JsonLdCqlManager {
 
     private NamespaceSupport namespaces;
 
-    public JsonLdCqlManager(String strCql, NamespaceSupport namespaces) {
+    public JsonLdCQLManager(String strCql, NamespaceSupport namespaces) {
         this.strCql = strCql;
         this.namespaces = namespaces;
     }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/expressions/JsonLdCqlManager.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/expressions/JsonLdCqlManager.java
@@ -1,38 +1,125 @@
-/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
 package org.geoserver.jsonld.expressions;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.geoserver.jsonld.builders.impl.JsonBuilderContext;
-import org.geotools.data.complex.feature.type.ComplexFeatureTypeImpl;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.feature.type.Types;
+import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
-import org.opengis.feature.type.FeatureType;
+import org.geotools.filter.visitor.DuplicatingFilterVisitor;
+import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Literal;
 import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * Helper class that mainly allows the extraction of CQL and Xpath expressions out of a plain text
- * string using special separators. It also provides some Utility methods to handle namespaces and
- * xpath syntax
+ * string using special separators. Moreover, since JsonLd templates can declare an xpath('some
+ * xpath') function that has no real FunctionExpression implementation, this class provides methods
+ * to extracts the xpath from the function as a literal, to substitute it after cql encoding
+ * happened with an AttributeExpression.
  */
-public class ExpressionsUtils {
+public class JsonLdCqlManager {
+
+    private String strCql;
+
+    private int contextPos = 0;
+
+    private NamespaceSupport namespaces;
+
+    public JsonLdCqlManager(String strCql, NamespaceSupport namespaces) {
+        this.strCql = strCql;
+        this.namespaces = namespaces;
+    }
 
     static final FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
 
     public static final String XPATH_FUN_START = "xpath(";
 
-    public static String extractXpath(String xpath) {
+    /**
+     * Create a PropertyName from a String
+     *
+     * @return
+     */
+    public AttributeExpressionImpl getAttributeExpressionFromString() {
+        String strXpath = extractXpath(this.strCql);
+        this.contextPos = determineContextPos(strXpath);
+        strXpath = removeBackDots(strXpath);
+        return new AttributeExpressionImpl(strXpath, namespaces);
+    }
+
+    /**
+     * Create an expression from a string taking care of correctly handling the xpath() expression
+     *
+     * @return
+     */
+    public Expression getExpressionFromString() {
+        // takes xpath fun from cql
+        String strXpathFun = extractXpathFromCQL(this.strCql);
+        if (strXpathFun.indexOf(XPATH_FUN_START) != -1)
+            this.contextPos = determineContextPos(strXpathFun);
+        // takes the literal argument of xpathFun
+        String literalXpath = removeBackDots(toLiteralXpath(strXpathFun));
+
+        // clean the function to obtain a cql expression without xpath() syntax
+        Expression expression =
+                extractCqlExpressions(cleanCQL(this.strCql, strXpathFun, literalXpath));
+        // replace the xpath literal inside the expression with a PropertyName
+        return (Expression) setPropertyNameToCQL(expression, literalXpath.replaceAll("'", ""));
+    }
+
+    /**
+     * Create a filter from a string taking care of correctly handling the xpath() expression
+     *
+     * @return
+     * @throws CQLException
+     */
+    public Filter getFilterFromString() throws CQLException {
+        String xpathFunction = extractXpathFromCQL(this.strCql);
+        if (xpathFunction.indexOf(XPATH_FUN_START) != -1)
+            contextPos = determineContextPos(xpathFunction);
+        String literalXpath = removeBackDots(toLiteralXpath(xpathFunction));
+        String cleanedCql = cleanCQL(this.strCql, xpathFunction, literalXpath);
+        return (Filter)
+                setPropertyNameToCQL(ECQL.toFilter(cleanedCql), literalXpath.replaceAll("'", ""));
+    }
+
+    /**
+     * @param cql the cql filter or expression to which set the clean xpath as a PropertyName
+     * @param xpath
+     * @return
+     */
+    private Object setPropertyNameToCQL(Object cql, String xpath) {
+        DuplicatingFilterVisitor filterVisitor =
+                new DuplicatingFilterVisitor() {
+                    @Override
+                    public Object visit(Literal expression, Object extraData) {
+                        if (expression.getValue() instanceof String) {
+                            String strVal = (String) expression.getValue();
+                            if (strVal.endsWith(xpath))
+                                return new AttributeExpressionImpl(xpath, namespaces);
+                        }
+                        return super.visit(expression, extraData);
+                    }
+                };
+        Object result;
+        if (cql instanceof Expression) {
+            result = ((Expression) cql).accept(filterVisitor, null);
+        } else {
+            result = ((Filter) cql).accept(filterVisitor, null);
+        }
+        return result;
+    }
+
+    private String extractXpath(String xpath) {
         boolean inXpath = false;
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < xpath.length(); i++) {
@@ -81,7 +168,7 @@ public class ExpressionsUtils {
      * result of parsing each embedded cql expression and string literals in between the cql
      * expressions, in the order they appear in the original string
      */
-    static List<Expression> splitCqlExpressions(String expression) {
+    private List<Expression> splitCqlExpressions(String expression) {
         boolean inCqlExpression = false;
         List<Expression> result = new ArrayList<Expression>();
         StringBuilder sb = new StringBuilder();
@@ -163,7 +250,7 @@ public class ExpressionsUtils {
     }
 
     /** Given an expression list will create an expression concatenating them. */
-    static Expression catenateExpressions(List<Expression> expressions) {
+    private Expression catenateExpressions(List<Expression> expressions) {
         if (expressions == null || expressions.size() == 0)
             throw new IllegalArgumentException(
                     "You should provide at least one expression in the list");
@@ -179,8 +266,74 @@ public class ExpressionsUtils {
      * Builds a CQL expression equivalent to the specified string, see class javadocs for rules on
      * how to build the expression in string form
      */
-    public static Expression extractCqlExpressions(String expression) {
+    private Expression extractCqlExpressions(String expression) {
         return catenateExpressions(splitCqlExpressions(expression));
+    }
+
+    public static String removeQuotes(String cqlFilter) {
+        cqlFilter = cqlFilter.replaceFirst("\"", "");
+        StringBuilder strBuilder = new StringBuilder();
+        for (int i = 0; i < cqlFilter.length(); i++) {
+            char curr = cqlFilter.charAt(i);
+            if (curr != '\"') {
+                strBuilder.append(curr);
+            } else {
+                if (i != cqlFilter.length() && cqlFilter.charAt(i + 1) != ' ')
+                    strBuilder.append(curr);
+            }
+        }
+        return strBuilder.toString();
+    }
+
+    /**
+     * Clean a CQL from the xpath function syntax to make the xpath suitable to be encoded as a
+     * PropertyName
+     */
+    private String cleanCQL(String cql, String toReplace, String replacement) {
+        if (cql.indexOf(XPATH_FUN_START) != -1)
+            return cql.replace(toReplace, replacement).replaceAll("\\.\\./", "");
+        else return cql;
+    }
+
+    public static String removeBackDots(String xpath) {
+        if (xpath.indexOf("../") != -1) return xpath.replaceAll("\\.\\./", "");
+        return xpath;
+    }
+
+    /** Extract the xpath function from CQL Expression if present */
+    private String extractXpathFromCQL(String expression) {
+        int xpathI = expression.indexOf(XPATH_FUN_START);
+        if (xpathI != -1) {
+            int xpathI2 = expression.indexOf(")", xpathI);
+            String strXpath = expression.substring(xpathI, xpathI2 + 1);
+            return strXpath;
+        }
+        return expression;
+    }
+
+    /** Extract the literal argument from the xpath function */
+    private String toLiteralXpath(String strXpath) {
+        if (strXpath.indexOf(XPATH_FUN_START) != -1) {
+            return strXpath.replace(XPATH_FUN_START, "").replace(")", "");
+        }
+        return strXpath;
+    }
+
+    /**
+     * Determines how many times is needed to walk up {@link JsonBuilderContext} in order to execute
+     * xpath, and cleans it from ../ notation.
+     */
+    public static int determineContextPos(String xpath) {
+        int contextPos = 0;
+        while (xpath.contains("../")) {
+            contextPos++;
+            xpath = xpath.replaceFirst("\\.\\./", "");
+        }
+        return contextPos;
+    }
+
+    public int getContextPos() {
+        return contextPos;
     }
 
     /**
@@ -206,90 +359,5 @@ public class ExpressionsUtils {
                     xpathAttribute.toString(), "\"" + xpathAttribute.toString() + "\"");
         }
         return xpath;
-    }
-
-    /**
-     * Extract Namespaces from given FeatureType
-     *
-     * @return Namespaces if found for the given FeatureType
-     */
-    public static NamespaceSupport declareNamespaces(FeatureType type) {
-        NamespaceSupport namespaceSupport = null;
-        if (type instanceof ComplexFeatureTypeImpl) {
-            Map namespaces = (Map) type.getUserData().get(Types.DECLARED_NAMESPACES_MAP);
-            if (namespaces != null) {
-                namespaceSupport = new NamespaceSupport();
-                for (Iterator it = namespaces.entrySet().iterator(); it.hasNext(); ) {
-                    Map.Entry entry = (Map.Entry) it.next();
-                    String prefix = (String) entry.getKey();
-                    String namespace = (String) entry.getValue();
-                    namespaceSupport.declarePrefix(prefix, namespace);
-                }
-            }
-        }
-        return namespaceSupport;
-    }
-
-    public static String removeQuotes(String cqlFilter) {
-        cqlFilter = cqlFilter.replaceFirst("\"", "");
-        StringBuilder strBuilder = new StringBuilder();
-        for (int i = 0; i < cqlFilter.length(); i++) {
-            char curr = cqlFilter.charAt(i);
-            if (curr != '\"') {
-                strBuilder.append(curr);
-            } else {
-                if (i != cqlFilter.length() && cqlFilter.charAt(i + 1) != ' ')
-                    strBuilder.append(curr);
-            }
-        }
-        return strBuilder.toString();
-    }
-
-    /**
-     * Clean a CQL expression from the xpath function syntax to make the xpath suitable to be
-     * encoded as a PropertyName
-     */
-    public static String cleanCQLExpression(
-            String expression, String toReplace, String replacement) {
-        if (expression.indexOf(XPATH_FUN_START) != -1)
-            return expression.replace(toReplace, replacement).replaceAll("\\.\\./", "");
-        else return expression;
-    }
-
-    public static String removeBackDots(String xpath) {
-        if (xpath.indexOf("../") != -1) return xpath.replaceAll("\\.\\./", "");
-        return xpath;
-    }
-
-    /** Extract the xpath function from CQL Expression if present */
-    public static String extractXpathFromCQL(String expression) {
-        int xpathI = expression.indexOf(XPATH_FUN_START);
-        if (xpathI != -1) {
-            int xpathI2 = expression.indexOf(")", xpathI);
-            String strXpath = expression.substring(xpathI, xpathI2 + 1);
-            return strXpath;
-        }
-        return expression;
-    }
-
-    /** Extract the literal argument from the xpath function */
-    public static String getLiteralXpath(String strXpath) {
-        if (strXpath.indexOf(XPATH_FUN_START) != -1) {
-            return strXpath.replace(XPATH_FUN_START, "").replace(")", "");
-        }
-        return strXpath;
-    }
-
-    /**
-     * Determines how many times is needed to walk up {@link JsonBuilderContext} in order to execute
-     * xpath, and cleans it from ../ notation.
-     */
-    public static int determineContextPos(String xpath) {
-        int contextPos = 0;
-        while (xpath.contains("../")) {
-            contextPos++;
-            xpath = xpath.replaceFirst("\\.\\./", "");
-        }
-        return contextPos;
     }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdPathVisitor.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdPathVisitor.java
@@ -13,7 +13,7 @@ import org.geoserver.jsonld.builders.JsonBuilder;
 import org.geoserver.jsonld.builders.SourceBuilder;
 import org.geoserver.jsonld.builders.impl.DynamicValueBuilder;
 import org.geoserver.jsonld.builders.impl.StaticBuilder;
-import org.geoserver.jsonld.expressions.ExpressionsUtils;
+import org.geoserver.jsonld.expressions.JsonLdCqlManager;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.FunctionExpression;
@@ -155,6 +155,6 @@ public class JsonLdPathVisitor extends DuplicatingFilterVisitor {
      */
     private String completeXPath(String xpath) {
         if (currentSource != null && !isSimple) xpath = currentSource + "/" + xpath;
-        return ExpressionsUtils.quoteXpathAttribute(xpath);
+        return JsonLdCqlManager.quoteXpathAttribute(xpath);
     }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdPathVisitor.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdPathVisitor.java
@@ -13,7 +13,7 @@ import org.geoserver.jsonld.builders.JsonBuilder;
 import org.geoserver.jsonld.builders.SourceBuilder;
 import org.geoserver.jsonld.builders.impl.DynamicValueBuilder;
 import org.geoserver.jsonld.builders.impl.StaticBuilder;
-import org.geoserver.jsonld.expressions.JsonLdCqlManager;
+import org.geoserver.jsonld.expressions.JsonLdCQLManager;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.FunctionExpression;
@@ -155,6 +155,6 @@ public class JsonLdPathVisitor extends DuplicatingFilterVisitor {
      */
     private String completeXPath(String xpath) {
         if (currentSource != null && !isSimple) xpath = currentSource + "/" + xpath;
-        return JsonLdCqlManager.quoteXpathAttribute(xpath);
+        return JsonLdCQLManager.quoteXpathAttribute(xpath);
     }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdTemplateCallBackOGC.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdTemplateCallBackOGC.java
@@ -9,7 +9,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.jsonld.builders.impl.RootBuilder;
 import org.geoserver.jsonld.configuration.JsonLdConfiguration;
-import org.geoserver.jsonld.expressions.ExpressionsUtils;
+import org.geoserver.jsonld.expressions.JsonLdCqlManager;
 import org.geoserver.jsonld.response.JSONLDGetFeatureResponse;
 import org.geoserver.ows.AbstractDispatcherCallback;
 import org.geoserver.ows.DispatcherCallback;
@@ -85,8 +85,8 @@ public class JsonLdTemplateCallBackOGC extends AbstractDispatcherCallback {
                 // Taking back a string from Function cause
                 // OGC API get a string cql filter from query string
                 String newFilter =
-                        ExpressionsUtils.removeQuotes(ECQL.toCQL(f)).replaceAll("/", ".");
-                newFilter = ExpressionsUtils.quoteXpathAttribute(newFilter);
+                        JsonLdCqlManager.removeQuotes(ECQL.toCQL(f)).replaceAll("/", ".");
+                newFilter = JsonLdCqlManager.quoteXpathAttribute(newFilter);
                 for (int i = 0; i < operation.getParameters().length; i++) {
                     Object p = operation.getParameters()[i];
                     if (p != null && ((String.valueOf(p)).trim().equals(strFilter.trim()))) {

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdTemplateCallBackOGC.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdTemplateCallBackOGC.java
@@ -9,7 +9,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.jsonld.builders.impl.RootBuilder;
 import org.geoserver.jsonld.configuration.JsonLdConfiguration;
-import org.geoserver.jsonld.expressions.JsonLdCqlManager;
+import org.geoserver.jsonld.expressions.JsonLdCQLManager;
 import org.geoserver.jsonld.response.JSONLDGetFeatureResponse;
 import org.geoserver.ows.AbstractDispatcherCallback;
 import org.geoserver.ows.DispatcherCallback;
@@ -85,8 +85,8 @@ public class JsonLdTemplateCallBackOGC extends AbstractDispatcherCallback {
                 // Taking back a string from Function cause
                 // OGC API get a string cql filter from query string
                 String newFilter =
-                        JsonLdCqlManager.removeQuotes(ECQL.toCQL(f)).replaceAll("/", ".");
-                newFilter = JsonLdCqlManager.quoteXpathAttribute(newFilter);
+                        JsonLdCQLManager.removeQuotes(ECQL.toCQL(f)).replaceAll("/", ".");
+                newFilter = JsonLdCQLManager.quoteXpathAttribute(newFilter);
                 for (int i = 0; i < operation.getParameters().length; i++) {
                     Object p = operation.getParameters()[i];
                     if (p != null && ((String.valueOf(p)).trim().equals(strFilter.trim()))) {

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/validation/JsonLdValidator.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/validation/JsonLdValidator.java
@@ -6,14 +6,18 @@ package org.geoserver.jsonld.validation;
 
 import java.io.IOException;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.jsonld.builders.AbstractJsonBuilder;
 import org.geoserver.jsonld.builders.JsonBuilder;
 import org.geoserver.jsonld.builders.SourceBuilder;
 import org.geoserver.jsonld.builders.impl.DynamicValueBuilder;
 import org.geoserver.jsonld.builders.impl.IteratingBuilder;
 import org.geoserver.jsonld.builders.impl.JsonBuilderContext;
 import org.geoserver.jsonld.builders.impl.RootBuilder;
-import org.geotools.filter.FunctionExpression;
-import org.opengis.filter.expression.BinaryExpression;
+import org.geoserver.jsonld.expressions.JsonLdCqlManager;
+import org.geotools.filter.AttributeExpressionImpl;
+import org.geotools.filter.text.cql2.CQL;
+import org.geotools.filter.visitor.DuplicatingFilterVisitor;
+import org.opengis.filter.Filter;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.PropertyName;
 
@@ -23,45 +27,49 @@ import org.opengis.filter.expression.PropertyName;
  */
 public class JsonLdValidator {
 
-    private ValidateExpressionVisitor visitor;
-
     private FeatureTypeInfo type;
 
     private String failingAttribute;
 
+    private String source;
+
     public JsonLdValidator(FeatureTypeInfo type) {
-        visitor = new ValidateExpressionVisitor();
         this.type = type;
     }
 
     public boolean validateTemplate(RootBuilder root) {
         try {
-            return validateExpressions(root, new JsonBuilderContext(type.getFeatureType()));
+            ValidateExpressionVisitor validateVisitor =
+                    new ValidateExpressionVisitor(new JsonBuilderContext(type.getFeatureType()));
+            return validateExpressions(root, validateVisitor);
         } catch (IOException e) {
             e.printStackTrace();
         }
         return false;
     }
 
-    private boolean validateExpressions(JsonBuilder builder, JsonBuilderContext context) {
+    private boolean validateExpressions(JsonBuilder builder, ValidateExpressionVisitor visitor) {
         for (JsonBuilder jb : builder.getChildren()) {
             if (jb instanceof DynamicValueBuilder) {
                 DynamicValueBuilder djb = (DynamicValueBuilder) jb;
-                if (djb.getCql() != null) {
-                    if (!validateCQL(djb.getCql(), context, djb.getKey())) return false;
-                } else if (djb.getXpath() != null) {
-                    if (!validatePropertyName((PropertyName) djb.getXpath(), context, djb.getKey()))
+                Expression toValidate = getExpressionToValidate(djb);
+                if (validate(toValidate, visitor) == null)
+                    if (djb.getCql() != null) {
+                        this.failingAttribute =
+                                "Key: " + djb.getKey() + " Value: " + CQL.toCQL(djb.getCql());
                         return false;
-                }
+                    } else if (djb.getXpath() != null) {
+                        this.failingAttribute =
+                                "Key: " + djb.getKey() + " Value: " + CQL.toCQL(djb.getXpath());
+                        return false;
+                    }
             } else if (jb instanceof SourceBuilder) {
-                Object newType = null;
                 SourceBuilder sb = ((SourceBuilder) jb);
                 if (sb.getSource() != null) {
                     String typeName =
                             sb.getStrSource().substring(sb.getStrSource().indexOf(":") + 1);
                     if (!type.getName().contains(typeName)) {
-                        newType = sb.getSource().accept(visitor, context);
-                        if (newType == null) {
+                        if (validate(getSourceToValidate(sb), visitor) == null) {
                             failingAttribute = "Source: " + sb.getStrSource();
                             return false;
                         }
@@ -69,12 +77,12 @@ public class JsonLdValidator {
                 } else {
                     if (sb instanceof IteratingBuilder) return false;
                 }
-                if (newType != null) {
-                    JsonBuilderContext newContext = new JsonBuilderContext(newType);
-                    newContext.setParent(context);
-                    context = newContext;
+                return validateExpressions(jb, visitor);
+            } else {
+                Filter filter = getFilterToValidate((AbstractJsonBuilder) builder);
+                if (filter != null && validate(filter, visitor) == null) {
+                    return false;
                 }
-                return validateExpressions(jb, context);
             }
         }
         return true;
@@ -84,36 +92,81 @@ public class JsonLdValidator {
         return failingAttribute;
     }
 
-    private boolean validateCQL(Expression expression, JsonBuilderContext context, String key) {
-        PropertyName pn;
-        if (expression instanceof PropertyName) {
-            pn = (PropertyName) expression;
-            if (!validatePropertyName(pn, context, key)) return false;
-        } else if (expression instanceof FunctionExpression) {
-            FunctionExpression function = (FunctionExpression) expression;
-            if (function.getParameters().size() > 0) {
-                for (Expression ex : function.getParameters()) {
-                    if (!validateCQL(ex, context, key)) return false;
-                }
-            }
-        } else if (expression instanceof BinaryExpression) {
-            BinaryExpression binary = (BinaryExpression) expression;
-            if (!validateCQL(binary.getExpression1(), context, key)) return false;
-            if (!validateCQL(binary.getExpression2(), context, key)) return false;
+    public Object validate(Object toValidate, ValidateExpressionVisitor visitor) {
+        Object result = null;
+        if (toValidate instanceof Expression)
+            result = ((Expression) toValidate).accept(visitor, null);
+        else {
+            result = ((Filter) toValidate).accept(visitor, null);
         }
-        return true;
+        return result;
     }
 
-    private boolean validatePropertyName(PropertyName pn, JsonBuilderContext context, String key) {
-        try {
-            if (pn != null && pn.accept(visitor, context) == null) {
-                failingAttribute = "Key: " + key + " Value: " + pn.getPropertyName();
-                return false;
-            }
-        } catch (Exception e) {
-            failingAttribute = "Exception: " + e.getMessage();
-            return false;
+    /**
+     * Produce an AttributeExpressionImpl from the source attribute, suitable to be validated, eg.
+     * taking cares of handling properly changes of context
+     */
+    private AttributeExpressionImpl getSourceToValidate(SourceBuilder sb) {
+        AttributeExpressionImpl source = (AttributeExpressionImpl) sb.getSource();
+        if (this.source == null) this.source = sb.getStrSource();
+        else this.source += "/" + sb.getStrSource();
+        return new AttributeExpressionImpl(this.source, source.getNamespaceContext());
+    }
+
+    /**
+     * Produce a Filter from the filter attribute, suitable to be validated eg. taking cares of
+     * handling properly ../ and changes of context
+     */
+    private Filter getFilterToValidate(AbstractJsonBuilder ab) {
+        if (ab.getFilter() != null) return (Filter) completeXpathWithVisitor(ab.getFilter());
+        return null;
+    }
+
+    /**
+     * Produce an expression from the xpath or the cql expression hold by the DynamicBuilder,
+     * suitable to be validated, eg. taking care of handling properly ../ and changes of context
+     */
+    private Expression getExpressionToValidate(DynamicValueBuilder db) {
+        if (db.getXpath() != null) {
+            return completeXpathForValidation(db.getXpath());
+        } else {
+            return (Expression) completeXpathWithVisitor(db.getCql());
         }
-        return true;
+    }
+
+    private PropertyName completeXpathForValidation(PropertyName pn) {
+        if (pn instanceof AttributeExpressionImpl) {
+            AttributeExpressionImpl old = (AttributeExpressionImpl) pn;
+            String strXpath = old.getPropertyName();
+            int contextPos = JsonLdCqlManager.determineContextPos(strXpath);
+            int i = 0;
+            String newSource = source;
+            if (newSource != null) {
+                while (i < contextPos) {
+                    strXpath = strXpath.replaceFirst("\\.\\./", "");
+                    newSource = source.substring(0, source.lastIndexOf('/'));
+                }
+                return new AttributeExpressionImpl(
+                        newSource + "/" + old.getPropertyName(), old.getNamespaceContext());
+            } else {
+                return pn;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private Object completeXpathWithVisitor(Object cql) {
+        DuplicatingFilterVisitor visitor =
+                new DuplicatingFilterVisitor() {
+                    @Override
+                    public Object visit(PropertyName filter, Object extraData) {
+                        Object result = completeXpathForValidation(filter);
+                        if (result != null) return result;
+                        return super.visit(filter, extraData);
+                    }
+                };
+        if (cql instanceof Expression) return ((Expression) cql).accept(visitor, null);
+        else return ((Filter) cql).accept(visitor, null);
     }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/validation/JsonLdValidator.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/validation/JsonLdValidator.java
@@ -13,7 +13,7 @@ import org.geoserver.jsonld.builders.impl.DynamicValueBuilder;
 import org.geoserver.jsonld.builders.impl.IteratingBuilder;
 import org.geoserver.jsonld.builders.impl.JsonBuilderContext;
 import org.geoserver.jsonld.builders.impl.RootBuilder;
-import org.geoserver.jsonld.expressions.JsonLdCqlManager;
+import org.geoserver.jsonld.expressions.JsonLdCQLManager;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.text.cql2.CQL;
 import org.geotools.filter.visitor.DuplicatingFilterVisitor;
@@ -138,7 +138,7 @@ public class JsonLdValidator {
         if (pn instanceof AttributeExpressionImpl) {
             AttributeExpressionImpl old = (AttributeExpressionImpl) pn;
             String strXpath = old.getPropertyName();
-            int contextPos = JsonLdCqlManager.determineContextPos(strXpath);
+            int contextPos = JsonLdCQLManager.determineContextPos(strXpath);
             int i = 0;
             String newSource = source;
             if (newSource != null) {

--- a/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDComplexTestSupport.java
+++ b/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDComplexTestSupport.java
@@ -1,0 +1,95 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.jsonld.response;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import net.sf.json.JSON;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.jsonld.configuration.JsonLdConfiguration;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.test.AbstractAppSchemaMockData;
+import org.geoserver.test.AbstractAppSchemaTestSupport;
+import org.geoserver.test.FeatureChainingMockData;
+import org.junit.After;
+import org.junit.Before;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class JSONLDComplexTestSupport extends AbstractAppSchemaTestSupport {
+
+    Catalog catalog;
+    FeatureTypeInfo mappedFeature;
+    FeatureTypeInfo geologicUnit;
+    GeoServerDataDirectory dd;
+
+    @Before
+    public void before() {
+        catalog = getCatalog();
+
+        mappedFeature = catalog.getFeatureTypeByName("gsml", "MappedFeature");
+        geologicUnit = catalog.getFeatureTypeByName("gsml", "GeologicUnit");
+        dd = (GeoServerDataDirectory) applicationContext.getBean("dataDirectory");
+    }
+
+    protected void setUpComplex() throws IOException {
+        setUpComplex("MappedFeature.json", mappedFeature);
+    }
+
+    protected void setUpComplex(String templateFileName, FeatureTypeInfo ft) throws IOException {
+        File file =
+                dd.getResourceLoader()
+                        .createFile(
+                                "workspaces/gsml/" + ft.getStore().getName() + "/" + ft.getName(),
+                                JsonLdConfiguration.JSON_LD_NAME);
+
+        dd.getResourceLoader().copyFromClassPath(templateFileName, file, getClass());
+    }
+
+    protected JSON getJsonLd(String path) throws Exception {
+        MockHttpServletResponse response = getAsServletResponse(path);
+        assertEquals(response.getContentType(), "application/ld+json");
+        return json(response);
+    }
+
+    protected JSON postJsonLd(String xml) throws Exception {
+        MockHttpServletResponse response = postAsServletResponse("wfs", xml);
+        assertEquals(response.getContentType(), "application/ld+json");
+        return json(response);
+    }
+
+    @Override
+    protected AbstractAppSchemaMockData createTestData() {
+        return new FeatureChainingMockData();
+    }
+
+    @After
+    public void cleanup() {
+        Resource res =
+                dd.getResourceLoader()
+                        .get(
+                                "workspaces/gsml/"
+                                        + mappedFeature.getStore().getName()
+                                        + "/"
+                                        + mappedFeature.getName()
+                                        + "/"
+                                        + JsonLdConfiguration.JSON_LD_NAME);
+        if (res != null) res.delete();
+
+        Resource res2 =
+                dd.getResourceLoader()
+                        .get(
+                                "workspaces/gsml/"
+                                        + geologicUnit.getStore().getName()
+                                        + "/"
+                                        + geologicUnit.getName()
+                                        + "/"
+                                        + JsonLdConfiguration.JSON_LD_NAME);
+        if (res2 != null) res2.delete();
+    }
+}

--- a/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDGetComplexFeaturesResponseFilteringTest.java
+++ b/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDGetComplexFeaturesResponseFilteringTest.java
@@ -1,0 +1,100 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.jsonld.response;
+
+import static org.junit.Assert.*;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.junit.Test;
+
+public class JSONLDGetComplexFeaturesResponseFilteringTest extends JSONLDComplexTestSupport {
+
+    @Test
+    public void testJsonLdWithFilterOnIteratingAndComposite() throws Exception {
+        // test filter capabilities in json-ld template
+        // filter on composite "$filter": "xpath('gml:description') = 'Olivine basalt'"
+        // filter on iterating "$filter": "xpath('gsml:ControlledConcept/@id') = 'cc.2'"
+        setUpComplex("MappedFeatureIteratingAndCompositeFilter.json", mappedFeature);
+        StringBuilder sb =
+                new StringBuilder("wfs?request=GetFeature&version=2.0")
+                        .append("&TYPENAME=gsml:MappedFeature&outputFormat=")
+                        .append("application%2Fld%2Bjson");
+        JSONObject result = (JSONObject) getJsonLd(sb.toString());
+        JSONObject context = (JSONObject) result.get("@context");
+        assertNotNull(context);
+        JSONArray features = (JSONArray) result.get("features");
+        int size = features.size();
+        for (int i = 0; i < size; i++) {
+            JSONObject feature = features.getJSONObject(i);
+            if (i + 1 != size) {
+                assertEquals(feature.size(), 5);
+                assertNull(feature.get("gsml:GeologicUnit"));
+            } else {
+                // last feature is the one having the condition matched
+                // thus GeologicUnit got encoded.
+                assertEquals(feature.size(), 6);
+                Object geologicUnit = feature.get("gsml:GeologicUnit");
+                assertNotNull(feature.get("gsml:GeologicUnit"));
+
+                JSONArray lithologyAr =
+                        (JSONArray)
+                                ((JSONObject) geologicUnit)
+                                        .getJSONArray("gsml:composition")
+                                        .getJSONObject(0)
+                                        .getJSONArray("gsml:compositionPart")
+                                        .getJSONObject(0)
+                                        .get("lithology");
+                assertEquals(1, lithologyAr.size());
+                JSONObject lithology = lithologyAr.getJSONObject(0);
+                // lithology element with cc2.2 is the one matching the filter
+                assertEquals("cc.2", lithology.getString("@id"));
+                assertEquals("name_2", lithology.getJSONObject("name").getString("value"));
+            }
+        }
+    }
+
+    @Test
+    public void testJsonLdWithFilterOnStaticAndDynamic() throws Exception {
+        // filter on dynamic:
+        // "$filter{xpath('gml:description')='Olivine basalt'},${gml:description}"
+        // filter on static
+        //  "@codeSpace": "$filter{xpath('../../gml:description')='Olivine
+        // basalt'},urn:cgi:classifierScheme:Example:CompositionPartRole"
+        setUpComplex("GeologicUnitDynamicStaticFilter.json", geologicUnit);
+        StringBuilder sb =
+                new StringBuilder("wfs?request=GetFeature&version=2.0")
+                        .append("&TYPENAME=gsml:GeologicUnit&outputFormat=")
+                        .append("application%2Fld%2Bjson");
+        JSONObject result = (JSONObject) getJsonLd(sb.toString());
+        JSONObject context = (JSONObject) result.get("@context");
+        assertNotNull(context);
+        JSONArray features = (JSONArray) result.get("features");
+        int size = features.size();
+        assertEquals(3, size);
+        for (int i = 0; i < size; i++) {
+            JSONObject geologicUnit = features.getJSONObject(i);
+            Object description = geologicUnit.get("description");
+            // filter on dynamic
+            if (description != null) {
+                assertEquals("Olivine basalt", description);
+            }
+            JSONArray composition = geologicUnit.getJSONArray("gsml:composition");
+            for (int j = 0; j < composition.size(); j++) {
+                JSONArray compositionPart =
+                        (JSONArray) ((JSONObject) composition.get(j)).get("gsml:compositionPart");
+                assertTrue(compositionPart.size() > 0);
+                JSONObject role = compositionPart.getJSONObject(0).getJSONObject("gsml:role");
+                Object codeSpace = role.get("@codeSpace");
+                // check filter on the static value
+                if (description == null) {
+                    assertNull(codeSpace);
+                } else {
+                    assertNotNull(codeSpace);
+                }
+            }
+        }
+    }
+}

--- a/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/GeologicUnitDynamicStaticFilter.json
+++ b/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/GeologicUnitDynamicStaticFilter.json
@@ -1,0 +1,75 @@
+{
+  "@context": {
+    "gsp": "http://www.opengis.net/ont/geosparql#",
+    "sf": "http://www.opengis.net/ont/sf#",
+    "schema": "https://schema.org/",
+    "dc": "http://purl.org/dc/terms/",
+    "Feature": "gsp:Feature",
+    "FeatureCollection": "schema:Collection",
+    "Point": "sf:Point",
+    "wkt": "gsp:asWKT",
+    "features": {
+      "@container": "@set",
+      "@id": "schema:hasPart"
+    },
+    "geometry": "sf:geometry",
+    "description": "dc:description",
+    "title": "dc:title",
+    "name": "schema:name"
+  },
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "$source": "gsml:GeologicUnit"
+    },
+    {
+        "@id": "${@id}",
+        "description": "$filter{xpath('gml:description')='Olivine basalt'},${gml:description}",
+        "gsml:geologicUnitType": "urn:ogc:def:nil:OGC::unknown",
+        "gsml:composition": [
+          {
+            "$source": "gsml:composition"
+          },
+          {
+            "gsml:compositionPart": [
+              {
+                "$source": "gsml:CompositionPart"
+              },
+              {
+                "gsml:role": {
+                  "value": "${gsml:role}",
+                  "@codeSpace": "$filter{xpath('../../gml:description')='Olivine basalt'},urn:cgi:classifierScheme:Example:CompositionPartRole"
+                },
+                "proportion": {
+                  "$source": "gsml:proportion",
+                  "@dataType": "CGI_ValueProperty",
+                  "CGI_TermValue": {
+                    "@dataType": "CGI_TermValue",
+                    "value": {
+                      "value": "${gsml:CGI_TermValue}",
+                      "@codeSpace": "some:uri"
+                    }
+                  }
+                },
+                "lithology": [
+                  {
+                    "$source": "gsml:lithology"
+                  },
+                  {
+                    "@id": "${gsml:ControlledConcept/@id}",
+                    "name": {
+                      "value": "${gsml:ControlledConcept/gsml:name}",
+                      "@lang": "en"
+                    },
+                    "vocabulary": {
+                      "@href": "urn:ogc:def:nil:OGC::missing"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+    }
+  ]
+}

--- a/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/MappedFeatureIteratingAndCompositeFilter.json
+++ b/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/MappedFeatureIteratingAndCompositeFilter.json
@@ -1,0 +1,95 @@
+{
+  "@context": {
+    "gsp": "http://www.opengis.net/ont/geosparql#",
+    "sf": "http://www.opengis.net/ont/sf#",
+    "schema": "https://schema.org/",
+    "dc": "http://purl.org/dc/terms/",
+    "Feature": "gsp:Feature",
+    "FeatureCollection": "schema:Collection",
+    "Point": "sf:Point",
+    "wkt": "gsp:asWKT",
+    "features": {
+      "@container": "@set",
+      "@id": "schema:hasPart"
+    },
+    "geometry": "sf:geometry",
+    "description": "dc:description",
+    "title": "dc:title",
+    "name": "schema:name"
+  },
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "$source": "gsml:MappedFeature"
+    },
+    {
+      "@id": "${@id}",
+      "@type": [
+        "Feature",
+        "gsml:MappedFeature",
+        "http://vocabulary.odm2.org/samplingfeaturetype/mappedFeature"
+      ],
+      "name": "${gml:name}",
+      "gsml:positionalAccuracy": {
+        "type": "gsml:CGI_NumericValue",
+        "value": "${gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue}"
+      },
+      "gsml:GeologicUnit": {
+        "$source": "gsml:specification/gsml:GeologicUnit",
+        "$filter": "xpath('gml:description') = 'Olivine basalt'",
+        "@id": "${@id}",
+        "description": "${gml:description}",
+        "gsml:geologicUnitType": "urn:ogc:def:nil:OGC::unknown",
+        "gsml:composition": [
+          {
+            "$source": "gsml:composition"
+          },
+          {
+            "gsml:compositionPart": [
+              {
+                "$source": "gsml:CompositionPart"
+              },
+              {
+                "gsml:role": {
+                  "value": "${gsml:role}",
+                  "@codeSpace": "urn:cgi:classifierScheme:Example:CompositionPartRole"
+                },
+                "proportion": {
+                  "$source": "gsml:proportion",
+                  "@dataType": "CGI_ValueProperty",
+                  "CGI_TermValue": {
+                    "@dataType": "CGI_TermValue",
+                    "value": {
+                      "value": "${gsml:CGI_TermValue}",
+                      "@codeSpace": "some:uri"
+                    }
+                  }
+                },
+                "lithology": [
+                  {
+                    "$source": "gsml:lithology",
+                    "$filter": "xpath('gsml:ControlledConcept/@id') = 'cc.2'"
+                  },
+                  {
+                    "@id": "${gsml:ControlledConcept/@id}",
+                    "name": {
+                      "value": "${gsml:ControlledConcept/gsml:name}",
+                      "@lang": "en"
+                    },
+                    "vocabulary": {
+                      "@href": "urn:ogc:def:nil:OGC::missing"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "geometry": {
+        "@type": "Polygon",
+        "wkt": "$${toWKT(xpath('gsml:shape'))}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Jira ticket https://osgeo-org.atlassian.net/browse/GEOS-9625

This pull request add filtering capabilities in the Json-ld  module to have control over the final output.
Supported syntax is the following:

- Arrays below the source attribute, `"$filter":"{some filter}"`
- Object below the source attribute, `"$filter":"{some filter}"`
- Attribute before the static or dynamic attribute: `"key": "$filter{some filter},"static value or expression"`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
