### PR TITLE
[GEOS-9627] vector tiles - buffer around tile is too small

### DIFF
--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -114,13 +114,15 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
                                     paintArea,
                                     VectorMapRenderUtils.getMapScale(mapContent, renderingArea),
                                     (FeatureType) featureSource.getSchema()));
-            // buffer is in pixels (style pixels), need to convert to paint area pixels
-            buffer *=
-                    Math.max(
-                            Math.max(
-                                    this.tileBuilderFactory.getOversampleX(),
-                                    this.tileBuilderFactory.getOversampleY()),
-                            1); // if 0 (i.e. test case), don't expand
+            if (this.tileBuilderFactory.shouldOversampleScale()) {
+                // buffer is in pixels (style pixels), need to convert to paint area pixels
+                buffer *=
+                        Math.max(
+                                Math.max(
+                                        this.tileBuilderFactory.getOversampleX(),
+                                        this.tileBuilderFactory.getOversampleY()),
+                                1); // if 0 (i.e. test case), don't expand
+            }
             Pipeline pipeline =
                     getPipeline(mapContent, renderingArea, paintArea, sourceCrs, buffer);
 

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -114,6 +114,13 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
                                     paintArea,
                                     VectorMapRenderUtils.getMapScale(mapContent, renderingArea),
                                     (FeatureType) featureSource.getSchema()));
+            // buffer is in pixels (style pixels), need to convert to paint area pixels
+            buffer *=
+                    Math.max(
+                            Math.max(
+                                    this.tileBuilderFactory.getOversampleX(),
+                                    this.tileBuilderFactory.getOversampleY()),
+                            1); // if 0 (i.e. test case), don't expand
             Pipeline pipeline =
                     getPipeline(mapContent, renderingArea, paintArea, sourceCrs, buffer);
 

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
@@ -216,7 +216,7 @@ public class VectorTileMapOutputFormatTest {
 
         VectorTileMapOutputFormat vtof_spy = Mockito.spy(vtof);
 
-        // here's the test - the buffer (from style) is 32 bytes
+        // here's the test - the buffer (from style) is 32 pixels
         // however, since there is 16 * oversampling, it will really be a 512 pixel buffer
         int expectedBuffer = 32 * mbbf.getOversampleX();
 

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
@@ -27,6 +27,7 @@ import org.geoserver.wms.MapLayerInfo;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WebMap;
+import org.geoserver.wms.mapbox.MapBoxTileBuilderFactory;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.Query;
 import org.geotools.data.memory.MemoryDataStore;
@@ -48,6 +49,7 @@ import org.junit.Test;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
+import org.mockito.Mockito;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
@@ -199,6 +201,34 @@ public class VectorTileMapOutputFormatTest {
 
         q = getStyleQuery(scaleDependentPolygonLayer, mapContent);
         assertTrue(q.getFilter() == Filter.EXCLUDE);
+    }
+
+    // the calculated style buffer must account for oversampling
+    @Test
+    public void testBufferOversample() throws Exception {
+        ReferencedEnvelope mapBounds = new ReferencedEnvelope(-90, 90, 0, 180, WGS84);
+        Rectangle renderingArea = new Rectangle(256, 256);
+
+        WMSMapContent mapContent = createMapContent(mapBounds, renderingArea, 32, pointLayer);
+
+        MapBoxTileBuilderFactory mbbf = new MapBoxTileBuilderFactory();
+        VectorTileMapOutputFormat vtof = new VectorTileMapOutputFormat(mbbf);
+
+        VectorTileMapOutputFormat vtof_spy = Mockito.spy(vtof);
+
+        // here's the test - the buffer (from style) is 32 bytes
+        // however, since there is 16 * oversampling, it will really be a 512 pixel buffer
+        int expectedBuffer = 32 * mbbf.getOversampleX();
+
+        // verify that this buffer is send down to the Pipeline
+        vtof_spy.produceMap(mapContent);
+        Mockito.verify(vtof_spy)
+                .getPipeline(
+                        any(WMSMapContent.class),
+                        any(ReferencedEnvelope.class),
+                        any(Rectangle.class),
+                        any(CoordinateReferenceSystem.class),
+                        eq(expectedBuffer));
     }
 
     @Test


### PR DESCRIPTION
This fixes an issue with oversampling (default is 16*) and the "extra" buffer around the tile to account for "wide" styles.  Before, it wasn't taking into account the oversampling, which meant the buffer was too small.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
