### PR TITLE
[GEOS-9633] Pregeneralized DataStore and Vector-tile

### DIFF
--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/GetFeatureMapboxOutputFormat.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/response/GetFeatureMapboxOutputFormat.java
@@ -159,7 +159,7 @@ public class GetFeatureMapboxOutputFormat extends WFSGetFeatureOutputFormat {
             pipeline =
                     builder.preprocess()
                             .transform(true)
-                            .simplify(true)
+                            .simplify(true, null, null)
                             .clip(true, true)
                             .collapseCollections()
                             .build();

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
@@ -7,9 +7,11 @@ package org.geoserver.wms.vector;
 import static org.geotools.renderer.lite.VectorMapRenderUtils.buildTransform;
 
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.geotools.data.util.ScreenMap;
 import org.geotools.geometry.jts.Decimator;
@@ -21,6 +23,7 @@ import org.geotools.referencing.operation.transform.ProjectiveTransform;
 import org.geotools.renderer.crs.ProjectionHandler;
 import org.geotools.renderer.crs.ProjectionHandlerFinder;
 import org.geotools.renderer.lite.RendererUtilities;
+import org.geotools.util.factory.Hints;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -63,6 +66,8 @@ public class PipelineBuilder {
         public CoordinateReferenceSystem sourceCrs; // data's CRS
 
         public AffineTransform worldToScreen;
+
+        public double sourceCRSSimplificationDistance;
 
         public double targetCRSSimplificationDistance;
 
@@ -119,6 +124,7 @@ public class PipelineBuilder {
         context.paintArea = paintArea;
         context.sourceCrs = sourceCrs;
         context.worldToScreen = RendererUtilities.worldToScreenTransform(mapArea, paintArea);
+
         context.queryBuffer = queryBuffer;
 
         final boolean wrap = false;
@@ -133,12 +139,12 @@ public class PipelineBuilder {
         double[] spans_sourceCRS;
         double[] spans_targetCRS;
         try {
-            MathTransform screenToWorld = context.sourceToScreen.inverse();
 
             // 0.8px is used to make sure the generalization isn't too much (doesn't make visible
             // changes)
             spans_sourceCRS =
-                    Decimator.computeGeneralizationDistances(screenToWorld, context.paintArea, 0.8);
+                    Decimator.computeGeneralizationDistances(
+                            context.sourceToScreen.inverse(), context.paintArea, 0.8);
 
             spans_targetCRS =
                     Decimator.computeGeneralizationDistances(
@@ -153,6 +159,10 @@ public class PipelineBuilder {
         }
 
         context.screenSimplificationDistance = PIXEL_BASE_SAMPLE_SIZE / overSampleFactor;
+
+        // use min so generalize "less" (if pixel is different size in X and Y)
+        context.sourceCRSSimplificationDistance = Math.min(spans_sourceCRS[0], spans_sourceCRS[1]);
+
         // use min so generalize "less" (if pixel is different size in X and Y)
         context.targetCRSSimplificationDistance =
                 Math.min(spans_targetCRS[0], spans_targetCRS[1]) / overSampleFactor;
@@ -268,8 +278,24 @@ public class PipelineBuilder {
      *
      * @param isTransformToScreenCoordinates Use screen coordinate space simplification tolerance
      */
-    public PipelineBuilder simplify(boolean isTransformToScreenCoordinates) {
+    public PipelineBuilder simplify(
+            boolean isTransformToScreenCoordinates,
+            final Set<RenderingHints.Key> fsHints,
+            final Hints qHints) {
 
+        if (fsHints != null && qHints != null) {
+            // if possible we let the datastore do the generalizations
+
+            // check for distance support
+            if (fsHints.contains(Hints.GEOMETRY_DISTANCE)) {
+
+                // the datastore supports distance based simplification,
+                // let's add the Hint to the query
+                qHints.put(Hints.GEOMETRY_DISTANCE, context.sourceCRSSimplificationDistance);
+
+                // do not return: we can still perform some in memory generalization ...
+            }
+        }
         double pixelDistance = context.screenSimplificationDistance;
         double simplificationDistance = context.targetCRSSimplificationDistance;
 

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/VectorTileMapOutputFormat.java
@@ -10,8 +10,10 @@ import static org.geotools.renderer.lite.VectorMapRenderUtils.getStyleQuery;
 
 import com.google.common.base.Stopwatch;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -92,8 +94,8 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
                             this.tileBuilderFactory.getOversampleY() * mapHeight);
         }
 
-        VectorTileBuilder vectorTileBuilder;
-        vectorTileBuilder = this.tileBuilderFactory.newBuilder(paintArea, renderingArea);
+        final VectorTileBuilder vectorTileBuilder =
+                this.tileBuilderFactory.newBuilder(paintArea, renderingArea);
 
         CoordinateReferenceSystem sourceCrs;
         for (Layer layer : mapContent.layers()) {
@@ -123,11 +125,21 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
                                         this.tileBuilderFactory.getOversampleY()),
                                 1); // if 0 (i.e. test case), don't expand
             }
-            Pipeline pipeline =
-                    getPipeline(mapContent, renderingArea, paintArea, sourceCrs, buffer);
 
             Query query = getStyleQuery(layer, mapContent);
-            query.getHints().remove(Hints.SCREENMAP);
+            Hints hints = query.getHints();
+
+            Pipeline pipeline =
+                    getPipeline(
+                            mapContent,
+                            renderingArea,
+                            paintArea,
+                            sourceCrs,
+                            featureSource.getSupportedHints(),
+                            hints,
+                            buffer);
+
+            hints.remove(Hints.SCREENMAP);
 
             FeatureCollection<?, ?> features = featureSource.getFeatures(query);
 
@@ -143,8 +155,10 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
             final ReferencedEnvelope renderingArea,
             final Rectangle paintArea,
             CoordinateReferenceSystem sourceCrs,
+            final Set<RenderingHints.Key> fsHints,
+            final Hints qHints,
             int buffer) {
-        Pipeline pipeline;
+        final Pipeline pipeline;
         try {
             final PipelineBuilder builder =
                     PipelineBuilder.newBuilder(
@@ -154,9 +168,10 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
                     builder.preprocess()
                             .transform(transformToScreenCoordinates)
                             .clip(clipToMapBounds, transformToScreenCoordinates)
-                            .simplify(transformToScreenCoordinates)
+                            .simplify(transformToScreenCoordinates, fsHints, qHints)
                             .collapseCollections()
                             .build();
+
         } catch (FactoryException e) {
             throw new ServiceException(e);
         }
@@ -205,14 +220,17 @@ public class VectorTileMapOutputFormat extends AbstractMapOutputFormat {
                 try {
                     finalGeom = pipeline.execute(originalGeom);
                 } catch (Exception processingException) {
-                    processingException.printStackTrace();
+                    LOGGER.log(
+                            Level.WARNING,
+                            processingException.getLocalizedMessage(),
+                            processingException);
                     continue;
                 }
                 if (finalGeom.isEmpty()) {
                     continue;
                 }
 
-                final String layerName = feature.getName().getLocalPart();
+                final String layerName = feature.getType().getName().getLocalPart();
                 final String featureId = feature.getIdentifier().toString();
                 final String geometryName = geometryDescriptor.getName().getLocalPart();
 

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMapOutputFormatTest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.wicket.spring.test.ApplicationContextMock;
 import org.geoserver.catalog.SLDHandler;
 import org.geoserver.config.GeoServerLoader;
@@ -31,6 +32,10 @@ import org.geoserver.wms.mapbox.MapBoxTileBuilderFactory;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.Query;
 import org.geotools.data.memory.MemoryDataStore;
+import org.geotools.data.memory.MemoryFeatureSource;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.data.store.ContentEntry;
+import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -42,7 +47,9 @@ import org.geotools.referencing.CRS;
 import org.geotools.styling.NamedLayer;
 import org.geotools.styling.Style;
 import org.geotools.styling.StyledLayerDescriptor;
+import org.geotools.util.factory.Hints;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -228,6 +235,8 @@ public class VectorTileMapOutputFormatTest {
                         any(ReferencedEnvelope.class),
                         any(Rectangle.class),
                         any(CoordinateReferenceSystem.class),
+                        any(Set.class),
+                        any(Hints.class),
                         eq(expectedBuffer));
     }
 
@@ -494,6 +503,84 @@ public class VectorTileMapOutputFormatTest {
         request.setRawKvp(new HashMap<String, String>());
         request.setBuffer(buffer);
         return request;
+    }
+
+    @Test
+    public void testPregeneralized() throws Exception {
+        /**
+         * Simple class to MOCK a Datastore supporting PreGeneralized features
+         */
+        final class PregenDataStore extends MemoryDataStore {
+
+            final class _FeatureSource extends MemoryFeatureSource {
+                public _FeatureSource(ContentEntry entry, Query q) {
+                    super(entry, q);
+                }
+
+                @Override
+                protected void addHints(Set<org.geotools.util.factory.Hints.Key> hints) {
+                    hints.add(Hints.GEOMETRY_DISTANCE);
+                }
+            }
+
+            /** Creates the new feature store. */
+            public PregenDataStore() throws IOException {
+                super();
+            }
+
+            @Override
+            protected ContentFeatureSource createFeatureSource(ContentEntry entry, Query query) {
+                return new _FeatureSource(entry, query);
+            }
+        }
+
+        final String polyTypeSpec = "sp:String,ip:Integer,geom:Polygon:srid=4326";
+        final SimpleFeatureType pregenPolyType =
+                DataUtilities.createType("pregenPolygon", polyTypeSpec);
+
+        final MemoryDataStore _ds = new PregenDataStore();
+        _ds.addFeature(
+                feature(
+                        pregenPolyType,
+                        "pregenPolygon1",
+                        "StringPropX_1",
+                        1000,
+                        "POLYGON ((1 1, 2 2, 3 3, 4 4, 1 1))"));
+
+        final SimpleFeatureSource fs = _ds.getFeatureSource("pregenPolygon");
+
+        final FeatureLayer pregeneralizedLayer = new FeatureLayer(fs, defaultPolygonStyle);
+
+        final ReferencedEnvelope mapBounds = new ReferencedEnvelope(-90, 90, 0, 180, WGS84);
+        final Rectangle renderingArea = new Rectangle(256, 256);
+
+        final WMSMapContent mapContent =
+                createMapContent(mapBounds, renderingArea, 0, pregeneralizedLayer);
+
+        // ensure that the FeatureSource supports GEOMETRY_DISTANCE
+        Assert.assertTrue(
+                pregeneralizedLayer
+                        .getSimpleFeatureSource()
+                        .getSupportedHints()
+                        .contains(Hints.GEOMETRY_DISTANCE));
+
+        MapBoxTileBuilderFactory mbbf = new MapBoxTileBuilderFactory();
+        VectorTileMapOutputFormat vtof = new VectorTileMapOutputFormat(mbbf);
+        VectorTileMapOutputFormat vtof_spy = Mockito.spy(vtof);
+
+        // lets produce a map
+        vtof_spy.produceMap(mapContent);
+
+        // verify that the Pipeline recognize the Hint support adding the hint to the query
+        Mockito.verify(vtof_spy)
+                .getPipeline(
+                        any(WMSMapContent.class),
+                        any(ReferencedEnvelope.class),
+                        any(Rectangle.class),
+                        any(CoordinateReferenceSystem.class),
+                        any(Set.class),
+                        argThat((Hints qH) -> qH.containsKey(Hints.GEOMETRY_DISTANCE)),
+                        any(Integer.class));
     }
 
     // @Test


### PR DESCRIPTION
Hi, 
 [following up the discussion from the users mailing list](http://osgeo-org.1560.x6.nabble.com/Pregeneralized-DataStore-and-Vector-tyle-td5437747.html)

The PR is a first draft just to show what is missing related to [GEOS-9633](https://osgeo-org.atlassian.net/browse/GEOS-9633?atlOrigin=eyJpIjoiMTA5YWFlMTBhN2MyNGNjNGI2NjM4YjE5NjJiNzE2ZTEiLCJwIjoiaiJ9) feel free to comment and share your thoughts.

I've started looking at org.geotools.renderer.lite.StreamingRenderer and most of the code comes from there, I've tryied to simplify it as much as possible removing features not strictly related to this feature.



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
