### PR TITLE
WMS-Capabilities-LayerGroup : Adding a default Style in capabilities …

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
@@ -26,6 +26,12 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public final class CapabilityUtil {
 
+    protected static final String LAYER_GROUP_STYLE_NAME = "";
+    protected static final String LAYER_GROUP_STYLE_TITLE_PREFIX = "";
+    protected static final String LAYER_GROUP_STYLE_TITLE_SUFFIX = " style";
+    protected static final String LAYER_GROUP_STYLE_ABSTRACT_PREFIX = "Default style for ";
+    protected static final String LAYER_GROUP_STYLE_ABSTRACT_SUFFIX = " layer";
+
     private CapabilityUtil() {
         // utility class
     }


### PR DESCRIPTION
Hello,

It's a small add to WMS capabilities : 
As the GetLegendGraphic works for the layerGroups and some tools need the "Style" block, it add a standard block.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.


