### PR TITLE
[2.17.x backport][GEOS-9621] Wps download raster preserve native resolution when repro…

### DIFF
--- a/doc/en/user/source/community/wps-download/rawDownload.rst
+++ b/doc/en/user/source/community/wps-download/rawDownload.rst
@@ -37,6 +37,14 @@ The parameters to set are
  * ``writeParameters`` : a set of writing parameters (optional, applies for raster input only). See :ref:`writing_params` below section for more details on writing parameters defintion.
  * ``minimizeReprojections`` : since 2.17, parameter to control CRS management when dealing with heterogeneous CRS's coverages, in order to minimize reprojections when granules in ROI match the TargetCRS. See :ref:`heterogeneous_imagemosaic` below section for more details on this param.
  * ``bestResolutionOnMatchingCRS`` : since 2.17, parameter to control CRS and resolution management when dealing with heterogeneous CRS's coverages. See :ref:`heterogeneous_imagemosaic` below section for more details on this param.
+ * ``resolutionsDifferenceTolerance`` : the parameter allows to specify a tolerance value to control the use of native resolution of the data, when no target size has been specified and granules are reprojected. If
+
+   * the percentage difference between original and reprojected coverages resolutions is below the specified tolerance value, 
+   * native resolution is the same for all the requested granules,
+   * the unit of measure is the same for native and target CRS,
+
+  the reprojected coverage will be forced to use native resolutions.
+  For example by specifying a value of 5.0, if the percentage difference between native and reprojected data is below 5%, assuming that also the other two conditions are respected, the native resolutions will be preserved. Default values is 0.
 
 The ``targetCRS`` and ``RoiCRS`` parameters are using EPSG code terminology, so, valid parameters are literals like ``EPSG:4326`` (if we are referring to a the  Geogaphic WGS84 CRS), ``EPSG:3857`` (for WGS84 Web Mercator CRS), etc.
 

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/CRSRequestHandler.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/CRSRequestHandler.java
@@ -100,6 +100,8 @@ class CRSRequestHandler {
 
     private String crsAttribute;
 
+    private double resolutionsDifferenceTolerance;
+
     public CRSRequestHandler(
             GridCoverage2DReader reader,
             Catalog catalog,
@@ -350,5 +352,13 @@ class CRSRequestHandler {
             // Reproject the granule geometry to the requested CRS
             return JTS.bounds(geom, schemaCRS).transform(targetCRS, true);
         }
+    }
+
+    public double getResolutionsDifferenceTolerance() {
+        return resolutionsDifferenceTolerance;
+    }
+
+    public void setResolutionsDifferenceTolerance(double resolutionsDifferenceTolerance) {
+        this.resolutionsDifferenceTolerance = resolutionsDifferenceTolerance;
     }
 }

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadProcess.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadProcess.java
@@ -107,6 +107,15 @@ public class DownloadProcess implements GeoServerProcess, ApplicationContextAwar
      * @param bestResolutionOnMatchingCRS When dealing with a Heterogeneous CRS mosaic, given a ROI
      *     and a TargetCRS, with no target size being specified, get the best resolution of data
      *     having nativeCrs matching the TargetCRS
+     * @param resolutionsDifferenceTolerance the parameter allows to specify a tolerance value to
+     *     control the use of native resolution of the data, when no target size has been specified
+     *     and granules are reprojected. If the percentage difference between original and
+     *     reprojected coverages resolutions is below the specified tolerance value, native
+     *     resolution is the same for all the requested granules, the unit of measure is the same
+     *     for native and target CRS, the reprojected coverage will be forced to use native
+     *     resolutions. i.e. by specifying a value of 5.0, if the percentage difference between
+     *     native and reprojected data is below 5%, assuming that also the other two conditions are
+     *     respected, the native resolutions will be preserved. Default values is 0.
      * @param progressListener the progress listener
      * @return the file
      * @throws ProcessException the process exception
@@ -195,6 +204,18 @@ public class DownloadProcess implements GeoServerProcess, ApplicationContextAwar
                         min = 0
                     )
                     Boolean bestResolutionOnMatchingCRS,
+            @DescribeParameter(
+                        name = "resolutionsDifferenceTolerance",
+                        description =
+                                "the parameter allows to specify a tolerance value to control the use of native"
+                                        + " resolution of the data, when no target size has been specified and granules are reprojected. If "
+                                        + " the percentage difference between original and reprojected coverages resolutions is below the specified tolerance value,"
+                                        + " native resolutions is the same for all the requested granules,"
+                                        + " the unit of measure is the same for native and target CRS, "
+                                        + "the reprojected coverage will be forced to use native resolutions",
+                        min = 0
+                    )
+                    Double resolutionsDifferenceTolerance,
             final ProgressListener progressListener)
             throws ProcessException {
 
@@ -251,6 +272,13 @@ public class DownloadProcess implements GeoServerProcess, ApplicationContextAwar
                 minimizeReprojections = false;
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.log(Level.FINE, "Minimize reprojections is disabled");
+                }
+            }
+
+            if (resolutionsDifferenceTolerance == null) {
+                resolutionsDifferenceTolerance = 0d;
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, "Use native resolution is disabled");
                 }
             }
             //
@@ -347,7 +375,8 @@ public class DownloadProcess implements GeoServerProcess, ApplicationContextAwar
                                         bandIndices,
                                         writeParameters,
                                         minimizeReprojections,
-                                        bestResolutionOnMatchingCRS);
+                                        bestResolutionOnMatchingCRS,
+                                        resolutionsDifferenceTolerance);
             } else {
 
                 // wrong type

--- a/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/GridGeometryProvider.java
+++ b/src/community/wps-download/src/main/java/org/geoserver/wps/gs/download/GridGeometryProvider.java
@@ -9,15 +9,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.catalog.Predicates;
+import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
-import org.geotools.coverage.grid.io.DimensionDescriptor;
-import org.geotools.coverage.grid.io.GranuleSource;
-import org.geotools.coverage.grid.io.GridCoverage2DReader;
-import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
+import org.geotools.coverage.grid.io.*;
 import org.geotools.coverage.util.FeatureUtilities;
 import org.geotools.data.Query;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -26,6 +25,7 @@ import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.operation.matrix.XAffineTransform;
+import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.geotools.referencing.operation.transform.ProjectiveTransform;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
@@ -39,6 +39,7 @@ import org.opengis.geometry.BoundingBox;
 import org.opengis.metadata.spatial.PixelOrientation;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.cs.CoordinateSystem;
 import org.opengis.referencing.datum.PixelInCell;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.MathTransform2D;
@@ -265,6 +266,55 @@ class GridGeometryProvider {
                 resolution[1] = transformedDY;
             }
         }
+
+        /** Gets granules' resolution if it is equal for all the granules, otherwise returns null */
+        public double[] getGranulesNativeResolutionIfSame(GranuleSource granuleSource)
+                throws IOException, TransformException, FactoryException {
+
+            Query query = initQuery(granuleSource);
+            SimpleFeatureCollection granules = granuleSource.getGranules(query);
+            return getGranulesNativeResolutionIfSame(granules);
+        }
+
+        /** Gets granules' resolution if it is equal for all the granules, otherwise returns null */
+        public double[] getGranulesNativeResolutionIfSame(SimpleFeatureCollection granules) {
+            if (granules == null || granules.isEmpty()) return null;
+
+            SimpleFeatureIterator iterator = granules.features();
+            TreeSet<Double> resolutionsX = new TreeSet<>();
+            TreeSet<Double> resolutionsY = new TreeSet<>();
+            Map<String, DimensionDescriptor> descriptors = crsRequestHandler.getDescriptors();
+            DimensionDescriptor resDescriptor = descriptors.get(DimensionDescriptor.RESOLUTION);
+            DimensionDescriptor resXDescriptor = descriptors.get(DimensionDescriptor.RESOLUTION_X);
+            DimensionDescriptor resYDescriptor = descriptors.get(DimensionDescriptor.RESOLUTION_Y);
+            final String resXAttribute =
+                    hasBothResolutions
+                            ? resXDescriptor.getStartAttribute()
+                            : resDescriptor.getStartAttribute();
+            final String resYAttribute =
+                    hasBothResolutions
+                            ? resYDescriptor.getStartAttribute()
+                            : resDescriptor.getStartAttribute();
+            while (iterator.hasNext()) {
+                SimpleFeature feature = iterator.next();
+                resolutionsX.add((Double) feature.getAttribute(resXAttribute));
+                resolutionsY.add((Double) feature.getAttribute(resYAttribute));
+            }
+            if (resolutionsX.size() > 1 || resolutionsY.size() > 1) {
+                return null;
+            } else {
+                return new double[] {resolutionsX.first(), resolutionsY.first()};
+            }
+        }
+
+        public double[] getResolution(GridCoverage2D coverage2D) {
+            MathTransform2D gridToCRS2D = coverage2D.getGridGeometry().getGridToCRS2D();
+            if (!(gridToCRS2D instanceof AffineTransform2D)) {
+                return null;
+            }
+            AffineTransform2D at = (AffineTransform2D) gridToCRS2D;
+            return new double[] {Math.abs(at.getScaleX()), Math.abs(at.getScaleY())};
+        }
     }
 
     private CRSRequestHandler crsRequestHandler;
@@ -297,7 +347,6 @@ class GridGeometryProvider {
             String coverageName = structuredReader.getGridCoverageNames()[0];
 
             ResolutionProvider provider = new ResolutionProvider(crsRequestHandler);
-
             //
             // Do we have any resolution descriptor available?
             // if not, go to standard computation.
@@ -312,7 +361,8 @@ class GridGeometryProvider {
             }
 
             GranuleSource granules = structuredReader.getGranules(coverageName, true);
-
+            // Initialize resolution with infinite numbers
+            double[] resolution = new double[] {Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY};
             // Setup a query on top of ROI and input filter (if any)
             Query query = initQuery(granules);
             SimpleFeatureCollection features = granules.getGranules(query);
@@ -324,9 +374,42 @@ class GridGeometryProvider {
                 }
                 return getNativeResolutionGridGeometry();
             }
-            // Initialize resolution with infinite numbers
-            double[] resolution = new double[] {Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY};
-            ReferencedEnvelope envelope = provider.getBestResolution(features, resolution);
+            ReferencedEnvelope envelope = null;
+
+            double resolutionsDifferenceTolerance =
+                    crsRequestHandler.getResolutionsDifferenceTolerance();
+            boolean forceResolution = false;
+            if (crsRequestHandler.getReferenceFeatureForAlignment() == null
+                    && !crsRequestHandler.needsReprojection()
+                    && resolutionsDifferenceTolerance != 0d) {
+                // no reprojection but has been request to try to preserve native
+                // resolution if under tolerance value
+                resolution = provider.getGranulesNativeResolutionIfSame(features);
+                double[] testResolution =
+                        new double[] {Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY};
+                // get best resolution to have a reference
+                envelope = provider.getBestResolution(features, testResolution);
+                if (testResolution[0] != resolution[0] || testResolution[1] != resolution[1]) {
+                    // comparing resolutions
+                    double diffPercentageX =
+                            Math.abs((resolution[0] / testResolution[0]) - 1) * 100;
+                    double diffPercentageY =
+                            Math.abs((resolution[1] / testResolution[1]) - 1) * 100;
+                    if (!(diffPercentageX < resolutionsDifferenceTolerance
+                            && diffPercentageY < resolutionsDifferenceTolerance)) {
+                        // difference is beyond the tolerance limit
+                        // setting the best resolution
+                        resolution = testResolution;
+                    } else {
+                        forceResolution = true;
+                    }
+                }
+            }
+
+            if (envelope == null) {
+                envelope = provider.getBestResolution(features, resolution);
+            }
+
             AffineTransform at =
                     new AffineTransform(
                             resolution[0],
@@ -336,12 +419,81 @@ class GridGeometryProvider {
                             envelope.getMinX(),
                             envelope.getMaxY());
             MathTransform tx = ProjectiveTransform.create(at);
-            return computeGridGeometry2D(tx, envelope, resolution);
+            return computeGridGeometry2D(tx, envelope, resolution, forceResolution);
         }
     }
 
+    /**
+     * Produces a GridGeometry from a reprojected coverage, having the resolution of the native
+     * granules. The conditions the method checks in order to return the coverage are:
+     *
+     * <ol>
+     *   <li>Granules have same resolution
+     *   <li>The involved CRSs have the same measurement's unit
+     *   <li>The percentage difference between the reprojected grid resolution and the original one
+     *       is less then the threshold value
+     * </ol>
+     *
+     * If the above conditions are not matched the method returns null
+     */
+    public GridGeometry2D getGridGeometryWithNativeResolution(
+            GridCoverage2D originalCoverage, GridCoverage2D testCoverage)
+            throws TransformException, IOException, FactoryException {
+        double resolutionsDifferenceTolerance =
+                crsRequestHandler.getResolutionsDifferenceTolerance();
+        if (!crsRequestHandler.hasStructuredReader()) return null;
+        ResolutionProvider resProvider = new ResolutionProvider(crsRequestHandler);
+        StructuredGridCoverage2DReader structured = crsRequestHandler.getStructuredReader();
+
+        GranuleSource source = structured.getGranules(originalCoverage.getName().toString(), true);
+        double[] resolution = resProvider.getGranulesNativeResolutionIfSame(source);
+        boolean canUseNative = resolution != null;
+        if (canUseNative) {
+            CoordinateSystem nativeCS =
+                    crsRequestHandler.getSelectedNativeCRS().getCoordinateSystem();
+            CoordinateSystem targetCS =
+                    crsRequestHandler.getSelectedTargetCRS().getCoordinateSystem();
+            int dimension = nativeCS.getDimension();
+            int targetDim = targetCS.getDimension();
+            if (dimension != targetDim) {
+                canUseNative = false;
+            } else {
+                for (int i = dimension; --i >= 0; ) {
+                    if (!nativeCS.getAxis(i).getUnit().equals(targetCS.getAxis(i).getUnit())) {
+                        canUseNative = false;
+                        break;
+                    }
+                }
+            }
+        }
+        if (canUseNative) {
+            double[] resolutionsResampled = resProvider.getResolution(testCoverage);
+            double diffPercentageX = Math.abs((resolution[0] / resolutionsResampled[0]) - 1) * 100;
+            double diffPercentageY = Math.abs((resolution[1] / resolutionsResampled[1]) - 1) * 100;
+            if (diffPercentageX < resolutionsDifferenceTolerance
+                    && diffPercentageY < resolutionsDifferenceTolerance) {
+                ReferencedEnvelope envelope =
+                        new ReferencedEnvelope(testCoverage.getGridGeometry().getEnvelope());
+                AffineTransform at =
+                        new AffineTransform(
+                                resolution[0],
+                                0,
+                                0,
+                                -resolution[1],
+                                envelope.getMinX(),
+                                envelope.getMaxY());
+                MathTransform tx = ProjectiveTransform.create(at);
+                return computeGridGeometry2D(tx, envelope, resolution, false);
+            }
+        }
+        return null;
+    }
+
     private GridGeometry2D computeGridGeometry2D(
-            MathTransform tx, ReferencedEnvelope envelope, double[] resolution)
+            MathTransform tx,
+            ReferencedEnvelope envelope,
+            double[] resolution,
+            boolean forceResolution)
             throws FactoryException, IOException, TransformException {
         GridGeometry2D gg2d =
                 new GridGeometry2D(
@@ -383,6 +535,7 @@ class GridGeometryProvider {
                                 PixelInCell.CELL_CORNER, tx, envelope, GeoTools.getDefaultHints());
             }
         }
+
         if (crsRequestHandler.needsReprojection()) {
             // Apply padding to read extra pixels.
             MathTransform2D worldToScreen = gg2d.getCRSToGrid2D(PixelOrientation.UPPER_LEFT);
@@ -398,6 +551,19 @@ class GridGeometryProvider {
                                 gridRange,
                                 PixelInCell.CELL_CORNER,
                                 worldToScreen.inverse(),
+                                gg2d.getCoordinateReferenceSystem2D(),
+                                null);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else if (forceResolution) {
+            GridEnvelope2D gridRange = gg2d.getGridRange2D();
+            try {
+                gg2d =
+                        new GridGeometry2D(
+                                gridRange,
+                                PixelInCell.CELL_CORNER,
+                                tx,
                                 gg2d.getCoordinateReferenceSystem2D(),
                                 null);
             } catch (Exception e) {

--- a/src/community/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
+++ b/src/community/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
@@ -279,6 +279,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -352,6 +353,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                             null, // Writing params
                             false,
                             false,
+                            0d,
                             new NullProgressListener() // progressListener
                             );
 
@@ -417,6 +419,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -449,6 +452,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -517,6 +521,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -581,6 +586,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -654,6 +660,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -725,6 +732,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -842,6 +850,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         parameters, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -954,6 +963,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -1045,6 +1055,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -1123,6 +1134,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -1187,6 +1199,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -1245,6 +1258,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -1316,6 +1330,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -1368,6 +1383,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -1445,6 +1461,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                             parameters, // Writing params
                             true,
                             false,
+                            0d,
                             new NullProgressListener() // progressListener
                             );
 
@@ -1529,6 +1546,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                             parameters, // Writing params
                             true,
                             true,
+                            0d,
                             new NullProgressListener() // progressListener
                             );
 
@@ -1628,6 +1646,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                             parameters, // Writing params
                             true,
                             true,
+                            0d,
                             new NullProgressListener() // progressListener
                             );
 
@@ -1720,6 +1739,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                             parameters, // Writing params
                             true,
                             true,
+                            0d,
                             new NullProgressListener() // progressListener
                             );
 
@@ -1813,6 +1833,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                             parameters, // Writing params
                             true,
                             true,
+                            0d,
                             new NullProgressListener() // progressListener
                             );
 
@@ -1846,6 +1867,172 @@ public class DownloadProcessTest extends WPSTestSupport {
             double yPixels = Math.abs(referenceLowerCorner[1] - lowerCorner[1]) / resY;
             assertTrue(Math.abs(xPixels - Math.round(xPixels)) < DELTA);
             assertTrue(Math.abs(yPixels - Math.round(yPixels)) < DELTA);
+
+        } finally {
+            if (gc != null) {
+                CoverageCleanerCallback.disposeCoverage(gc);
+            }
+            if (reader != null) {
+                reader.dispose();
+            }
+            if (referenceGc != null) {
+                CoverageCleanerCallback.disposeCoverage(referenceGc);
+            }
+            if (referenceReader != null) {
+                referenceReader.dispose();
+            }
+            // clean up process
+            resourceManager.finished(resourceManager.getExecutionId(true));
+        }
+    }
+
+    @Test
+    public void testDownloadGranuleHeterogeneousCRSUsingNativeResolutions() throws Exception {
+        // This test check that by specifying a resolutionDifferenceTolerance parameter
+        // after reprojection we got the native resolution.
+        final WPSResourceManager resourceManager = getResourceManager();
+
+        // Creates the new process for the download
+        DownloadProcess downloadProcess = createDefaultTestingDownloadProcess(resourceManager);
+
+        // Requesting an area containing a granule in native CRS and a granule in a different CRS
+        GeoTiffReader referenceReader = null;
+        GeoTiffReader reader = null;
+        GridCoverage2D referenceGc = null;
+        GridCoverage2D gc = null;
+        CoordinateReferenceSystem targetCRS = CRS.decode("EPSG:31256", true);
+        try {
+            String roiWkt =
+                    "POLYGON ((-102583.25 262175.25, -102332.25 262175.25, -102332.25 262042.25, -102583.25 262042.25, -102583.25 262175.25))";
+            Polygon bboxRoi = (Polygon) new WKTReader2().read(roiWkt);
+
+            Parameters parameters = new Parameters();
+            List<Parameter> parametersList = parameters.getParameters();
+            parametersList.add(new Parameter("writenodata", "false"));
+            File rasterZip =
+                    downloadProcess.execute(
+                            getLayerId(HETEROGENEOUS_CRS2), // layerName
+                            null, // filter
+                            "image/tiff", // outputFormat
+                            targetCRS, // targetCRS
+                            targetCRS,
+                            bboxRoi, // roi
+                            false, // cropToGeometry
+                            null, // interpolation
+                            null, // targetSizeX
+                            null, // targetSizeY
+                            null, // bandSelectIndices
+                            parameters, // Writing params
+                            false,
+                            false,
+                            10d,
+                            new NullProgressListener() // progressListener
+                            );
+
+            Assert.assertNotNull(rasterZip);
+            final File[] tiffFiles = extractFiles(rasterZip, "GTIFF");
+            reader = new GeoTiffReader(tiffFiles[0]);
+            gc = reader.read(null);
+            GridGeometry2D gc2d = gc.getGridGeometry();
+            AffineTransform transform = (AffineTransform) gc2d.getGridToCRS();
+
+            // Finally, get the original granule
+            final File file =
+                    new File(this.getTestData().getDataDirectoryRoot(), "hcrs2/31255.tif");
+            referenceReader = new GeoTiffReader(file);
+            referenceGc = referenceReader.read(null);
+            GridGeometry2D referenceGc2d = referenceGc.getGridGeometry();
+            AffineTransform referenceTransform = (AffineTransform) referenceGc2d.getGridToCRS();
+
+            // Checking that resolutions are equal
+            double resX = XAffineTransform.getScaleX0(referenceTransform);
+            double resY = XAffineTransform.getScaleY0(referenceTransform);
+            assertEquals(resX, XAffineTransform.getScaleX0(transform), 0d);
+            assertEquals(resY, XAffineTransform.getScaleY0(transform), 0d);
+
+        } finally {
+            if (gc != null) {
+                CoverageCleanerCallback.disposeCoverage(gc);
+            }
+            if (reader != null) {
+                reader.dispose();
+            }
+            if (referenceGc != null) {
+                CoverageCleanerCallback.disposeCoverage(referenceGc);
+            }
+            if (referenceReader != null) {
+                referenceReader.dispose();
+            }
+            // clean up process
+            resourceManager.finished(resourceManager.getExecutionId(true));
+        }
+    }
+
+    @Test
+    public void testDownloadGranuleUsingNativeResolutionsWithMinimizeReprojection()
+            throws Exception {
+        // This test check that by specifying a resolutionDifferenceTolerance parameter,
+        // even if minimize reprojection is enabled and no reprojection occurs since mosaic
+        // declared crs and target are same, we got the native granules resolution.
+        final WPSResourceManager resourceManager = getResourceManager();
+
+        // Creates the new process for the download
+        DownloadProcess downloadProcess = createDefaultTestingDownloadProcess(resourceManager);
+
+        // Requesting an area containing a granule in native CRS and a granule in a different CRS
+        GeoTiffReader referenceReader = null;
+        GeoTiffReader reader = null;
+        GridCoverage2D referenceGc = null;
+        GridCoverage2D gc = null;
+        CoordinateReferenceSystem targetCRS = CRS.decode("EPSG:31256", true);
+        try {
+            String roiWkt =
+                    "POLYGON ((-102583.25 262175.25, -102332.25 262175.25, -102332.25 262042.25, -102583.25 262042.25, -102583.25 262175.25))";
+            Polygon bboxRoi = (Polygon) new WKTReader2().read(roiWkt);
+
+            Parameters parameters = new Parameters();
+            List<Parameter> parametersList = parameters.getParameters();
+            parametersList.add(new Parameter("writenodata", "false"));
+            File rasterZip =
+                    downloadProcess.execute(
+                            getLayerId(HETEROGENEOUS_CRS2), // layerName
+                            null, // filter
+                            "image/tiff", // outputFormat
+                            targetCRS, // targetCRS
+                            targetCRS,
+                            bboxRoi, // roi
+                            false, // cropToGeometry
+                            null, // interpolation
+                            null, // targetSizeX
+                            null, // targetSizeY
+                            null, // bandSelectIndices
+                            parameters, // Writing params
+                            true,
+                            true,
+                            10d,
+                            new NullProgressListener() // progressListener
+                            );
+
+            Assert.assertNotNull(rasterZip);
+            final File[] tiffFiles = extractFiles(rasterZip, "GTIFF");
+            reader = new GeoTiffReader(tiffFiles[0]);
+            gc = reader.read(null);
+            GridGeometry2D gc2d = gc.getGridGeometry();
+            AffineTransform transform = (AffineTransform) gc2d.getGridToCRS();
+
+            // Finally, get the original granule
+            final File file =
+                    new File(this.getTestData().getDataDirectoryRoot(), "hcrs2/31255.tif");
+            referenceReader = new GeoTiffReader(file);
+            referenceGc = referenceReader.read(null);
+            GridGeometry2D referenceGc2d = referenceGc.getGridGeometry();
+            AffineTransform referenceTransform = (AffineTransform) referenceGc2d.getGridToCRS();
+
+            // Checking that resolutions are equal
+            double resX = XAffineTransform.getScaleX0(referenceTransform);
+            double resY = XAffineTransform.getScaleY0(referenceTransform);
+            assertEquals(resX, XAffineTransform.getScaleX0(transform), 0d);
+            assertEquals(resY, XAffineTransform.getScaleY0(transform), 0d);
 
         } finally {
             if (gc != null) {
@@ -1944,6 +2131,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -2013,6 +2201,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     new NullProgressListener() // progressListener
                     );
 
@@ -2074,6 +2263,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     new NullProgressListener() // progressListener
                     );
 
@@ -2128,6 +2318,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -2162,6 +2353,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     new NullProgressListener() // progressListener
                     );
 
@@ -2221,6 +2413,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                             null, // Writing params
                             false,
                             false,
+                            0d,
                             new NullProgressListener() // progressListener
                             );
 
@@ -2284,6 +2477,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     new NullProgressListener() // progressListener
                     );
 
@@ -2374,6 +2568,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     new NullProgressListener() // progressListener
                     );
 
@@ -2437,6 +2632,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     listener // progressListener
                     );
 
@@ -2498,6 +2694,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     listener // progressListener
                     );
 
@@ -2551,6 +2748,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                     null, // Writing params
                     false,
                     false,
+                    0d,
                     progressListener // progressListener
                     );
 
@@ -2635,6 +2833,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -2691,6 +2890,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 
@@ -2782,6 +2982,7 @@ public class DownloadProcessTest extends WPSTestSupport {
                         null, // Writing params
                         false,
                         false,
+                        0d,
                         new NullProgressListener() // progressListener
                         );
 


### PR DESCRIPTION
…… (#4244)

* [GEOS-9621] Wps download raster preserve native resolution when reprojection is requested with no target size

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
