### PR TITLE
Startup.bat: detect java from "Program Files"

### DIFF
--- a/src/release/bin/startup.bat
+++ b/src/release/bin/startup.bat
@@ -30,7 +30,7 @@ goto checkDataDir
 
 :trySystemJava
   echo The JAVA_HOME environment variable is not defined, trying to use System Java
-for /f %%i in ('where java') do set RUN_JAVA=%%i
+for /f "tokens=*" %%i in ('where java') do set RUN_JAVA=%%i
 rem --- we might be on amd64 having only x86 jre installed ---
 if "%RUN_JAVA%"=="" if DEFINED ProgramFiles(x86) if NOT "%PROCESSOR_ARCHITECTURE%"=="x86" (
     rem --- restart the batch in x86 mode---


### PR DESCRIPTION
See mailing list topic https://sourceforge.net/p/geoserver/mailman/message/37027845/.

Fix works for me with system java located at:
   C:\Program Files\AdoptOpenJDK\jdk-11.0.5.10-hotspot\bin\java.exe

Should be safe to backport into 2.17.1 release.
