### PR TITLE
[GEOS-9644] Make LDAP testing use random port

### DIFF
--- a/doc/en/developer/source/release-guide/index.rst
+++ b/doc/en/developer/source/release-guide/index.rst
@@ -90,12 +90,6 @@ When creating the first release candidate of a series, there are some extra step
 
     git checkout master
     
-* Define a unque LDAP_SERVER_PORT in org.geoserver.security.ldap.LDAPTestUtils for each branch::
-  
-    public static final int LDAP_SERVER_PORT = 10389+18;
-  
-  The number `18` is chosen above for The GeoServer `1.18.x` branch.
-    
 * Update the version in all pom.xml files; for example, if changing master from ``2.17-SNAPSHOT`` to ``2.18-SNAPSHOT``.
   
   Edit :file:`build/rename.xml` to update GeoServer, GeoTools and GeoWebCache version numbers::

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPAuthenticationProviderTest.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPAuthenticationProviderTest.java
@@ -42,13 +42,7 @@ public class LDAPAuthenticationProviderTest extends LDAPBaseTest {
 
     @RunWith(FrameworkRunner.class)
     @CreateLdapServer(
-        transports = {
-            @CreateTransport(
-                protocol = "LDAP",
-                address = "localhost",
-                port = LDAPTestUtils.LDAP_SERVER_PORT
-            )
-        },
+        transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
         allowAnonymousAccess = true
     )
     @CreateDS(
@@ -291,13 +285,7 @@ public class LDAPAuthenticationProviderTest extends LDAPBaseTest {
 
     @RunWith(FrameworkRunner.class)
     @CreateLdapServer(
-        transports = {
-            @CreateTransport(
-                protocol = "LDAP",
-                address = "localhost",
-                port = LDAPTestUtils.LDAP_SERVER_PORT
-            )
-        },
+        transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
         allowAnonymousAccess = true
     )
     @CreateDS(

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPBaseTest.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPBaseTest.java
@@ -45,7 +45,7 @@ public abstract class LDAPBaseTest extends AbstractLdapTestUnit {
         securityProvider = new LDAPSecurityProvider(securityManager);
 
         createConfig();
-        config.setServerURL(ldapServerUrl + "/" + basePath);
+        config.setServerURL(ldapServerUrl + ":" + getLdapServer().getPort() + "/" + basePath);
         config.setGroupSearchBase("ou=Groups");
         config.setGroupSearchFilter("member=cn={1}");
         config.setUseTLS(false);

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPRoleServiceTest.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPRoleServiceTest.java
@@ -120,13 +120,7 @@ public class LDAPRoleServiceTest extends LDAPBaseTest {
 
     @RunWith(FrameworkRunner.class)
     @CreateLdapServer(
-        transports = {
-            @CreateTransport(
-                protocol = "LDAP",
-                address = "localhost",
-                port = LDAPTestUtils.LDAP_SERVER_PORT
-            )
-        },
+        transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
         allowAnonymousAccess = true
     )
     @CreateDS(
@@ -234,13 +228,7 @@ public class LDAPRoleServiceTest extends LDAPBaseTest {
 
     @RunWith(FrameworkRunner.class)
     @CreateLdapServer(
-        transports = {
-            @CreateTransport(
-                protocol = "LDAP",
-                address = "localhost",
-                port = LDAPTestUtils.LDAP_SERVER_PORT
-            )
-        },
+        transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
         allowAnonymousAccess = true
     )
     @CreateDS(
@@ -274,13 +262,7 @@ public class LDAPRoleServiceTest extends LDAPBaseTest {
 
     @RunWith(FrameworkRunner.class)
     @CreateLdapServer(
-        transports = {
-            @CreateTransport(
-                protocol = "LDAP",
-                address = "localhost",
-                port = LDAPTestUtils.LDAP_SERVER_PORT
-            )
-        },
+        transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
         allowAnonymousAccess = true
     )
     @CreateDS(

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPTestUtils.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPTestUtils.java
@@ -43,7 +43,7 @@ import org.springframework.ldap.support.LdapUtils;
  */
 public class LDAPTestUtils {
     public static final int LDAP_SERVER_PORT = 10389;
-    public static final String LDAP_SERVER_URL = "ldap://127.0.0.1:" + LDAP_SERVER_PORT;
+    public static final String LDAP_SERVER_URL = "ldap://127.0.0.1";
     public static final String LDAP_BASE_PATH = "dc=example,dc=com";
     public static final String DEFAULT_PRINCIPAL = "uid=admin,ou=system";
     public static final String DEFAULT_PASSWORD = "secret";

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPUserGroupServiceTest.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPUserGroupServiceTest.java
@@ -26,13 +26,7 @@ import org.junit.runner.RunWith;
 /** @author Niels Charlier */
 @RunWith(FrameworkRunner.class)
 @CreateLdapServer(
-    transports = {
-        @CreateTransport(
-            protocol = "LDAP",
-            address = "localhost",
-            port = LDAPTestUtils.LDAP_SERVER_PORT
-        )
-    },
+    transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
     allowAnonymousAccess = true
 )
 @CreateDS(

--- a/src/web/security/ldap/src/test/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanelTest.java
+++ b/src/web/security/ldap/src/test/java/org/geoserver/web/security/ldap/LDAPAuthProviderPanelTest.java
@@ -34,13 +34,7 @@ import org.junit.Test;
 
 /** @author "Mauro Bartolomeoli - mauro.bartolomeoli@geo-solutions.it" */
 @CreateLdapServer(
-    transports = {
-        @CreateTransport(
-            protocol = "LDAP",
-            address = "localhost",
-            port = LDAPTestUtils.LDAP_SERVER_PORT
-        )
-    },
+    transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
     allowAnonymousAccess = true
 )
 @CreateDS(
@@ -80,12 +74,16 @@ public class LDAPAuthProviderPanelTest extends AbstractSecurityWicketTestSupport
             String userGroupService) {
         config = new LDAPSecurityServiceConfig();
         config.setName("test");
-        config.setServerURL(ldapServerUrl + "/" + basePath);
+        config.setServerURL(getServerURL());
         config.setUserDnPattern(userDnPattern);
         config.setUserFilter(userFilter);
         config.setUserFormat(userFormat);
         config.setUserGroupServiceName(userGroupService);
         setupPanel(config);
+    }
+
+    private String getServerURL() {
+        return ldapServerUrl + ":" + serverRule.getLdapServer().getPort() + "/" + basePath;
     }
 
     @Override

--- a/src/web/security/ldap/src/test/java/org/geoserver/web/security/ldap/LDAPRoleServicePanelTest.java
+++ b/src/web/security/ldap/src/test/java/org/geoserver/web/security/ldap/LDAPRoleServicePanelTest.java
@@ -31,13 +31,7 @@ import org.junit.Test;
 
 /** @author "Mauro Bartolomeoli - mauro.bartolomeoli@geo-solutions.it" */
 @CreateLdapServer(
-    transports = {
-        @CreateTransport(
-            protocol = "LDAP",
-            address = "localhost",
-            port = LDAPTestUtils.LDAP_SERVER_PORT
-        )
-    },
+    transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
     allowAnonymousAccess = true
 )
 @CreateDS(
@@ -76,7 +70,7 @@ public class LDAPRoleServicePanelTest extends AbstractSecurityWicketTestSupport 
         config = new LDAPRoleServiceConfig();
         config.setName("test");
         if (setRequiredFields) {
-            config.setServerURL(ldapServerUrl + "/" + basePath);
+            config.setServerURL(getServerURL());
             config.setGroupSearchBase(GROUPS_BASE);
         }
         config.setBindBeforeGroupSearch(needsAuthentication);
@@ -84,6 +78,10 @@ public class LDAPRoleServicePanelTest extends AbstractSecurityWicketTestSupport 
         config.setUser(AUTH_USER);
         config.setPassword(AUTH_PASSWORD);
         setupPanel(config);
+    }
+
+    private String getServerURL() {
+        return ldapServerUrl + ":" + serverRule.getLdapServer().getPort() + "/" + basePath;
     }
 
     @Override
@@ -186,7 +184,7 @@ public class LDAPRoleServicePanelTest extends AbstractSecurityWicketTestSupport 
     }
 
     private void checkBaseConfig() {
-        tester.assertModelValue("form:panel:serverURL", ldapServerUrl + "/" + basePath);
+        tester.assertModelValue("form:panel:serverURL", getServerURL());
         tester.assertModelValue("form:panel:groupSearchBase", GROUPS_BASE);
         tester.assertModelValue("form:panel:groupSearchFilter", GROUP_SEARCH_FILTER);
         tester.assertModelValue(

--- a/src/web/security/ldap/src/test/java/org/geoserver/web/security/ldap/LDAPUserGroupServicePanelTest.java
+++ b/src/web/security/ldap/src/test/java/org/geoserver/web/security/ldap/LDAPUserGroupServicePanelTest.java
@@ -34,13 +34,7 @@ import org.junit.Test;
  * @author Niels Charlier
  */
 @CreateLdapServer(
-    transports = {
-        @CreateTransport(
-            protocol = "LDAP",
-            address = "localhost",
-            port = LDAPTestUtils.LDAP_SERVER_PORT
-        )
-    },
+    transports = {@CreateTransport(protocol = "LDAP", address = "localhost")},
     allowAnonymousAccess = true
 )
 @CreateDS(
@@ -81,7 +75,7 @@ public class LDAPUserGroupServicePanelTest extends AbstractSecurityWicketTestSup
         config = new LDAPUserGroupServiceConfig();
         config.setName("test");
         if (setRequiredFields) {
-            config.setServerURL(ldapServerUrl + "/" + basePath);
+            config.setServerURL(getServerURL());
             config.setGroupSearchBase(GROUPS_BASE);
             config.setUserSearchBase(USERS_BASE);
         }
@@ -90,6 +84,10 @@ public class LDAPUserGroupServicePanelTest extends AbstractSecurityWicketTestSup
         config.setUser(AUTH_USER);
         config.setPassword(AUTH_PASSWORD);
         setupPanel();
+    }
+
+    private String getServerURL() {
+        return ldapServerUrl + ":" + serverRule.getLdapServer().getPort() + "/" + basePath;
     }
 
     @Override
@@ -186,7 +184,7 @@ public class LDAPUserGroupServicePanelTest extends AbstractSecurityWicketTestSup
     }
 
     private void checkBaseConfig() {
-        tester.assertModelValue("form:panel:serverURL", ldapServerUrl + "/" + basePath);
+        tester.assertModelValue("form:panel:serverURL", getServerURL());
         tester.assertModelValue("form:panel:groupSearchBase", GROUPS_BASE);
         tester.assertModelValue("form:panel:groupSearchFilter", GROUP_SEARCH_FILTER);
         tester.assertModelValue(


### PR DESCRIPTION
This PR makes LDAP testing use a random port instead a fixed one.

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-9644

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
