### PR TITLE
[GEOS-9650] Update spring-security to 5.1.11 and spring-framework to 5.1.16

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1977,8 +1977,8 @@
   <gt.version>24-SNAPSHOT</gt.version>
   <gwc.version>1.18-SNAPSHOT</gwc.version>
   <jts.version>1.16.1</jts.version>
-  <spring.version>5.1.14.RELEASE</spring.version>
-  <spring.security.version>5.1.9.RELEASE</spring.security.version>
+  <spring.version>5.1.16.RELEASE</spring.version>
+  <spring.security.version>5.1.11.RELEASE</spring.security.version>
   <servlet-api.version>3.0.1</servlet-api.version>
   <jetty.version>9.4.18.v20190429</jetty.version>
   <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>


### PR DESCRIPTION
Update Spring Framework from 5.1.14 to 5.1.16 and update Spring Security from 5.1.9 to 5.1.11.

Resolves CVE-2020-5408: Dictionary attack with Spring Security queryable text encryptor .Geoserver seems not te be vulnerable as there is no use of `Encryptors#queryableText(CharSequence, CharSequence)`

### Spring release notes:

- https://github.com/spring-projects/spring-framework/releases/tag/v5.1.16.RELEASE
- https://github.com/spring-projects/spring-framework/releases/tag/v5.1.15.RELEASE
- https://github.com/spring-projects/spring-security/releases/tag/5.1.11.RELEASE
- https://github.com/spring-projects/spring-security/releases/tag/5.1.10.RELEASE

## see also:
- https://osgeo-org.atlassian.net/browse/GEOS-9650
- https://github.com/GeoWebCache/geowebcache/pull/857
- https://tanzu.vmware.com/security/cve-2020-5408

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
