### PR TITLE
[2.17.x backport] [GEOS-9646]: INSPIRE validation get errors of GetMapRequest parameters

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -243,11 +243,29 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         // set the raw params used to create the request
         getMap.setRawKvp(rawKvp);
 
+        boolean citeCompliant = wms.getServiceInfo().isCiteCompliant();
+
         // wms 1.3, srs changed to crs
         if (kvp.containsKey("crs")) {
             getMap.setSRS((String) kvp.get("crs"));
+        } else if (citeCompliant && WMS.VERSION_1_3_0.equals(WMS.version(getMap.getVersion()))) {
+            throw new ServiceException(
+                    "GetMap CRS parameter is missing, it is mandatory for CITE compliant mode");
         }
         // do some additional checks
+
+        if (citeCompliant && rawKvp != null && rawKvp.containsKey("transparent")) {
+            String trans = (String) rawKvp.get("transparent");
+
+            if (!trans.equalsIgnoreCase("false")
+                    && !trans.equalsIgnoreCase("true")
+                    && !trans.equalsIgnoreCase("0")
+                    && !trans.equalsIgnoreCase("1")) {
+                throw new Exception(
+                        "Invalid value of GetMap TRANSPARENT parameter, "
+                                + "choose between true or false for CITE compliant mode");
+            }
+        }
 
         // srs
         String epsgCode = getMap.getSRS();
@@ -288,6 +306,13 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         if (layerParam != null) {
             List<String> layerNames = KvpUtils.readFlat(layerParam);
             requestedLayerInfos.addAll(parseLayers(layerNames, remoteOwsUrl, remoteOwsType));
+        } else if (citeCompliant && getMap.getSldBody() == null && getMap.getSld() == null) {
+            // The SLD extensions to WMS allow a request not to have layers, as long as a full SLD
+            // is specified either using &sld or &sld_body. The error must not be thrown in these
+            // conditions (which are probably not what INSPIRE had in mind, but nonetheless a OGC
+            // specification.
+            throw new ServiceException(
+                    "GetMap LAYERS parameter is missing, it is mandatory for CITE compliant mode");
         }
 
         // raw styles parameter
@@ -295,6 +320,13 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         List<String> styleNameList = new ArrayList<String>();
         if (stylesParam != null) {
             styleNameList.addAll(KvpUtils.readFlat(stylesParam));
+        } else if (citeCompliant && getMap.getSldBody() == null && getMap.getSld() == null) {
+            // The SLD extensions to WMS allow a request not to have styles, as long as a full SLD
+            // is specified either using &sld or &sld_body. The error must not be thrown in these
+            // conditions (which are probably not what INSPIRE had in mind, but nonetheless a OGC
+            // specification.
+            throw new ServiceException(
+                    "GetMap STYLES parameter is missing, it is mandatory for CITE compliant mode");
         }
 
         // raw interpolations parameter


### PR DESCRIPTION
JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-9646

Backport to 2.17.x of https://github.com/geoserver/geoserver/pull/4300

The [INSPIRE validator](https://inspire.ec.europa.eu/validator) throws some errors testing GeoServer WMS Services. The GetMap validation report shows three errors, all of them about input parameters, we get these error messages:
- A GetMap was requested without mandatory parameter 'STYLES' and the service did not throw an exception.
- A GetMap was requested without mandatory parameter 'CRS' and the service did not throw an exception.
- A GetMap was requested using parameter 'TRANSPARENT' with an invalid value and the service did not throw an exception.

This code fixes all of them taking care of CITE compliant mode.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
