### PR TITLE
Make geopkg community module tests pass again

### DIFF
--- a/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageMimeTypeTest.java
+++ b/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageMimeTypeTest.java
@@ -29,7 +29,7 @@ public class GeoPackageMimeTypeTest extends GeoServerWicketTestSupport {
         // Getting the wms outputformats available
         Component component =
                 tester.getComponentFromLastRenderedPage(
-                        "table:listContainer:items:1:itemProperties:4:component:menu:wmsFormats");
+                        "table:listContainer:items:1:itemProperties:4:component:menu:wms:wmsFormats");
         assertNotNull(component);
         assertTrue(component instanceof RepeatingView);
         // Get the list of all the format

--- a/src/community/geopkg/src/test/java/org/geoserver/geopkg/wps/gs/GeoPackageProcessTest.java
+++ b/src/community/geopkg/src/test/java/org/geoserver/geopkg/wps/gs/GeoPackageProcessTest.java
@@ -6,12 +6,18 @@ package org.geoserver.geopkg.wps.gs;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLUnit;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wps.WPSTestSupport;
 import org.geotools.data.simple.SimpleFeatureReader;
@@ -21,6 +27,7 @@ import org.geotools.geopkg.TileEntry;
 import org.geotools.geopkg.TileMatrix;
 import org.geotools.geopkg.TileReader;
 import org.geotools.util.URLs;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
@@ -31,6 +38,15 @@ public class GeoPackageProcessTest extends WPSTestSupport {
     protected void setUpTestData(SystemTestData testData) throws Exception {
         super.setUpTestData(testData);
         testData.setUpDefaultRasterLayers();
+    }
+
+    @Before
+    public void disableXXEDetection() {
+        // running tests in the IDE having also GeoTools loaded otherwise fails
+        GeoServer gs = getGeoServer();
+        GeoServerInfo global = gs.getGlobal();
+        global.setXmlExternalEntitiesEnabled(true);
+        gs.save(global);
     }
 
     @Test
@@ -250,6 +266,12 @@ public class GeoPackageProcessTest extends WPSTestSupport {
 
     @Test
     public void testGeoPackageProcessValidationXXE() throws Exception {
+        // for this one test we want the check on
+        GeoServer gs = getGeoServer();
+        GeoServerInfo global = gs.getGlobal();
+        global.setXmlExternalEntitiesEnabled(false);
+        gs.save(global);
+
         String xml =
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                         + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">"

--- a/src/wfs/src/main/java/org/geoserver/wfs/FeatureBoundsFeatureCollection.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/FeatureBoundsFeatureCollection.java
@@ -6,7 +6,9 @@
 package org.geoserver.wfs;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
@@ -17,6 +19,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.IllegalAttributeException;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.GeometryDescriptor;
 
 /**
@@ -115,6 +118,16 @@ class FeatureBoundsFeatureCollection extends AbstractFeatureCollection {
         public Object getAttribute(String path) {
             if (type.getDescriptor(path) == null) return null;
             return delegate.getAttribute(path);
+        }
+
+        @Override
+        public List<Object> getAttributes() {
+            List<Object> result = new ArrayList<>();
+            List<AttributeDescriptor> descriptors = type.getAttributeDescriptors();
+            for (int i = 0; i < descriptors.size(); i++) {
+                result.add(delegate.getAttribute(descriptors.get(i).getName()));
+            }
+            return result;
         }
 
         public Object[] getAttributes(Object[] attributes) {


### PR DESCRIPTION
A couple of tests are failing in the geopkg community module (hosting the WMS/WFS/WPS output formats generating GeoPackages). This PR restores the build in that module.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
