### PR TITLE
[GEOS-9656] JSON-LD validation will not try to validate the entire template

### DIFF
--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/JsonLdGenerator.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/JsonLdGenerator.java
@@ -106,7 +106,7 @@ public class JsonLdGenerator extends com.fasterxml.jackson.core.JsonGenerator {
             writeString(String.valueOf(result));
         } else if (result instanceof Date) {
             Date timeStamp = (Date) result;
-            DateFormat df = new SimpleDateFormat("YYYY/MM/DD hh:mm:ss");
+            DateFormat df = new SimpleDateFormat("yyyy/mm/dd hh:mm:ss");
             writeResult(df.format(timeStamp));
         } else if (result instanceof ComplexAttribute) {
             ComplexAttribute attr = (ComplexAttribute) result;
@@ -140,10 +140,6 @@ public class JsonLdGenerator extends com.fasterxml.jackson.core.JsonGenerator {
 
     public com.fasterxml.jackson.core.JsonGenerator getDelegate() {
         return delegate;
-    }
-
-    public void setDelegate(com.fasterxml.jackson.core.JsonGenerator delegate) {
-        this.delegate = delegate;
     }
 
     @Override
@@ -182,6 +178,7 @@ public class JsonLdGenerator extends com.fasterxml.jackson.core.JsonGenerator {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public com.fasterxml.jackson.core.JsonGenerator setFeatureMask(int i) {
         return delegate.setFeatureMask(i);
     }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/AbstractJsonBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/AbstractJsonBuilder.java
@@ -59,4 +59,8 @@ public abstract class AbstractJsonBuilder implements JsonBuilder {
         this.filter = cqlManager.getFilterFromString();
         this.filterContextPos = cqlManager.getContextPos();
     }
+
+    public int getFilterContextPos() {
+        return filterContextPos;
+    }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/SourceBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/SourceBuilder.java
@@ -25,7 +25,7 @@ public abstract class SourceBuilder extends AbstractJsonBuilder {
 
     public JsonBuilderContext evaluateSource(JsonBuilderContext context) {
 
-        if (source != null && !source.equals(context.getCurrentSource())) {
+        if (source != null && !source.getPropertyName().equals(context.getCurrentSource())) {
             Object o = evaluateSource(context.getCurrentObj());
             JsonBuilderContext newContext = new JsonBuilderContext(o, source.getPropertyName());
             newContext.setParent(context);

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/DynamicValueBuilder.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/builders/impl/DynamicValueBuilder.java
@@ -138,4 +138,8 @@ public class DynamicValueBuilder extends AbstractJsonBuilder {
     public NamespaceSupport getNamespaces() {
         return namespaces;
     }
+
+    public int getContextPos() {
+        return contextPos;
+    }
 }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdConfiguration.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdConfiguration.java
@@ -28,11 +28,11 @@ import org.xml.sax.helpers.NamespaceSupport;
 public class JsonLdConfiguration {
 
     private final LoadingCache<CacheKey, JsonLdTemplate> templateCache;
-    private GeoServerDataDirectory dd;
+    private GeoServerDataDirectory dataDirectory;
     public static final String JSON_LD_NAME = "json-ld-template.json";
 
     public JsonLdConfiguration(GeoServerDataDirectory dd) {
-        this.dd = dd;
+        this.dataDirectory = dd;
         templateCache =
                 CacheBuilder.newBuilder()
                         .maximumSize(100)
@@ -54,7 +54,8 @@ public class JsonLdConfiguration {
                                                             + e.getMessage());
                                         }
                                         Resource resource =
-                                                dd.get(key.getResource(), key.getPath());
+                                                getDataDirectory()
+                                                        .get(key.getResource(), key.getPath());
                                         JsonLdTemplate template =
                                                 new JsonLdTemplate(resource, namespaces);
                                         return template;
@@ -109,6 +110,10 @@ public class JsonLdConfiguration {
             }
         }
         return namespaceSupport;
+    }
+
+    GeoServerDataDirectory getDataDirectory() {
+        return dataDirectory;
     }
 
     private class CacheKey {

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdTemplateReader.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/configuration/JsonLdTemplateReader.java
@@ -7,11 +7,9 @@ package org.geoserver.jsonld.configuration;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.logging.Logger;
 import org.geoserver.jsonld.builders.*;
 import org.geoserver.jsonld.builders.impl.*;
 import org.geotools.filter.text.cql2.CQLException;
-import org.geotools.util.logging.Logging;
 import org.xml.sax.helpers.NamespaceSupport;
 
 /** Produce the builder tree starting from the evaluation of json-ld template file * */
@@ -24,8 +22,6 @@ public class JsonLdTemplateReader {
     public static final String FILTERKEY = "$filter";
 
     public static final String EXPRSTART = "${";
-
-    private static final Logger LOGGER = Logging.getLogger(JsonLdTemplateReader.class);
 
     private JsonNode template;
 

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdPathVisitor.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdPathVisitor.java
@@ -26,7 +26,6 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.BinaryExpression;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.PropertyName;
-import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * This visitor search for a Filter in {@link JsonBuilder} tree using the json-ld path provided as a
@@ -39,7 +38,6 @@ public class JsonLdPathVisitor extends DuplicatingFilterVisitor {
     static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
     static final Logger LOGGER = Logging.getLogger(JsonLdPathVisitor.class);
     boolean isSimple;
-    private NamespaceSupport namespaces;
 
     public JsonLdPathVisitor(FeatureType type) {
         this.isSimple = type instanceof SimpleFeatureType;
@@ -117,7 +115,6 @@ public class JsonLdPathVisitor extends DuplicatingFilterVisitor {
                         if (currentEl + 1 != eles.length) throw new ServiceException("error");
                         if (dvb.getXpath() != null) return super.visit(dvb.getXpath(), null);
                         else {
-                            this.namespaces = dvb.getNamespaces();
                             return super.visit(dvb.getCql(), null);
                         }
                     } else if (jb instanceof StaticBuilder) {

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdTemplateCallback.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/request/JsonLdTemplateCallback.java
@@ -29,12 +29,9 @@ public class JsonLdTemplateCallback extends AbstractDispatcherCallback {
 
     private Catalog catalog;
 
-    private GeoServer gs;
-
     private JsonLdConfiguration configuration;
 
     public JsonLdTemplateCallback(GeoServer gs, JsonLdConfiguration configuration) {
-        this.gs = gs;
         this.catalog = gs.getCatalog();
         this.configuration = configuration;
     }

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/response/JSONLDGetFeatureResponse.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/response/JSONLDGetFeatureResponse.java
@@ -43,12 +43,11 @@ public class JSONLDGetFeatureResponse extends WFSGetFeatureOutputFormat {
             throws ServiceException {
         FeatureTypeInfo info =
                 getFeatureType(GetFeatureRequest.adapt(getFeature.getParameters()[0]));
-        JsonLdGenerator writer = null;
-        try {
+        try (JsonLdGenerator writer =
+                new JsonLdGenerator(new JsonFactory().createGenerator(output, JsonEncoding.UTF8))) {
+
             RootBuilder rootBuilder = configuration.getTemplate(info);
-            writer =
-                    new JsonLdGenerator(
-                            new JsonFactory().createGenerator(output, JsonEncoding.UTF8));
+
             rootBuilder.startJsonLd(writer);
             for (FeatureCollection collection : featureCollection.getFeature()) {
                 FeatureIterator iterator = collection.features();
@@ -66,7 +65,6 @@ public class JSONLDGetFeatureResponse extends WFSGetFeatureOutputFormat {
             throw new ServiceException(e);
         } finally {
             try {
-                if (writer != null && !writer.isClosed()) writer.close();
                 output.close();
             } catch (IOException ioex) {
                 throw new ServiceException(ioex);

--- a/src/community/json-ld/src/main/java/org/geoserver/jsonld/validation/ValidateExpressionVisitor.java
+++ b/src/community/json-ld/src/main/java/org/geoserver/jsonld/validation/ValidateExpressionVisitor.java
@@ -16,8 +16,6 @@ import org.opengis.filter.expression.PropertyName;
  */
 public class ValidateExpressionVisitor extends DefaultFilterVisitor {
 
-    private int contextPos = 0;
-
     private JsonBuilderContext context;
 
     public ValidateExpressionVisitor(JsonBuilderContext context) {
@@ -38,5 +36,13 @@ public class ValidateExpressionVisitor extends DefaultFilterVisitor {
             result = context;
         }
         return result;
+    }
+
+    public JsonBuilderContext getContext() {
+        return context;
+    }
+
+    public void setContext(JsonBuilderContext context) {
+        this.context = context;
     }
 }

--- a/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDComplexTestSupport.java
+++ b/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDComplexTestSupport.java
@@ -26,6 +26,7 @@ public class JSONLDComplexTestSupport extends AbstractAppSchemaTestSupport {
     Catalog catalog;
     FeatureTypeInfo mappedFeature;
     FeatureTypeInfo geologicUnit;
+    FeatureTypeInfo parentFeature;
     GeoServerDataDirectory dd;
 
     @Before
@@ -34,18 +35,29 @@ public class JSONLDComplexTestSupport extends AbstractAppSchemaTestSupport {
 
         mappedFeature = catalog.getFeatureTypeByName("gsml", "MappedFeature");
         geologicUnit = catalog.getFeatureTypeByName("gsml", "GeologicUnit");
+        parentFeature = catalog.getFeatureTypeByName("ex", "FirstParentFeature");
         dd = (GeoServerDataDirectory) applicationContext.getBean("dataDirectory");
     }
 
     protected void setUpComplex() throws IOException {
-        setUpComplex("MappedFeature.json", mappedFeature);
+        setUpComplex("MappedFeature.json", "gsml", mappedFeature);
     }
 
     protected void setUpComplex(String templateFileName, FeatureTypeInfo ft) throws IOException {
+        setUpComplex(templateFileName, "gsml", ft);
+    }
+
+    protected void setUpComplex(String templateFileName, String workspace, FeatureTypeInfo ft)
+            throws IOException {
         File file =
                 dd.getResourceLoader()
                         .createFile(
-                                "workspaces/gsml/" + ft.getStore().getName() + "/" + ft.getName(),
+                                "workspaces/"
+                                        + workspace
+                                        + "/"
+                                        + ft.getStore().getName()
+                                        + "/"
+                                        + ft.getName(),
                                 JsonLdConfiguration.JSON_LD_NAME);
 
         dd.getResourceLoader().copyFromClassPath(templateFileName, file, getClass());
@@ -91,5 +103,16 @@ public class JSONLDComplexTestSupport extends AbstractAppSchemaTestSupport {
                                         + "/"
                                         + JsonLdConfiguration.JSON_LD_NAME);
         if (res2 != null) res2.delete();
+
+        Resource res3 =
+                dd.getResourceLoader()
+                        .get(
+                                "workspaces/ex/"
+                                        + parentFeature.getStore().getName()
+                                        + "/"
+                                        + parentFeature.getName()
+                                        + "/"
+                                        + JsonLdConfiguration.JSON_LD_NAME);
+        if (res3 != null) res3.delete();
     }
 }

--- a/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDGetComplexFeaturesResponseTest.java
+++ b/src/community/json-ld/src/test/java/org/geoserver/jsonld/response/JSONLDGetComplexFeaturesResponseTest.java
@@ -142,16 +142,32 @@ public class JSONLDGetComplexFeaturesResponseTest extends JSONLDComplexTestSuppo
 
     @Test
     public void testInvalidTemplateResponse() throws Exception {
-        setUpComplex("GeoLogicUnit_invalid.json", geologicUnit);
+        setUpComplex("FirstParentFeature_invalid.json", "ex", parentFeature);
         StringBuilder sb = new StringBuilder("wfs?request=GetFeature&version=2.0");
-        sb.append("&TYPENAME=gsml:GeologicUnit&outputFormat=");
+        sb.append("&TYPENAME=ex:FirstParentFeature&outputFormat=");
         sb.append("application%2Fld%2Bjson");
         MockHttpServletResponse response = getAsServletResponse(sb.toString());
         assertTrue(
                 response.getContentAsString()
                         .contains(
-                                "Failed to validate json-ld template for feature type GeologicUnit. "
+                                "Failed to validate json-ld template for feature type FirstParentFeature. "
                                         + "Failing attribute is Key: @id Value: &amp;quot;invalid/id&amp;quot;"));
+    }
+
+    @Test
+    public void testInvalidTemplateResponse2() throws Exception {
+        // check that validation fails for an invalid attribute down in the template
+        // the failing attribute also point to a previous context attribute (../)
+        setUpComplex("GeologicUnit_invalid.json", geologicUnit);
+        StringBuffer sb = new StringBuffer("wfs?request=GetFeature&version=2.0");
+        sb.append("&TYPENAME=gsml:GeologicUnit&outputFormat=");
+        sb.append("application%2Fld%2Bjson");
+        MockHttpServletResponse resp = getAsServletResponse(sb.toString());
+        assertTrue(
+                resp.getContentAsString()
+                        .contains(
+                                "Failed to validate json-ld template for feature type GeologicUnit. "
+                                        + "Failing attribute is Key: invalidAttr Value: &amp;quot;gsml:notExisting&amp;quot;"));
     }
 
     private void checkMappedFeatureJSON(JSONObject feature) {
@@ -162,9 +178,17 @@ public class JSONLDGetComplexFeaturesResponseTest extends JSONLDComplexTestSuppo
         assertEquals(String.valueOf(geom.get("@type")), "Polygon");
         assertNotNull(geom.get("wkt"));
         JSONObject geologicUnit = feature.getJSONObject("gsml:GeologicUnit");
+        String geologicUnitDescr = geologicUnit.getString("description");
+        assertNotNull(geologicUnitDescr);
         JSONArray composition = geologicUnit.getJSONArray("gsml:composition");
         assertTrue(composition.size() > 0);
         for (int i = 0; i < composition.size(); i++) {
+            JSONObject compositionObj = composition.getJSONObject(i);
+
+            String previousContextEl = compositionObj.getString("previousContextValue");
+            // check an ${../xpath} expression to be equal to the one
+            // acquired previously
+            assertEquals(geologicUnitDescr, previousContextEl);
             JSONArray compositionPart =
                     (JSONArray) ((JSONObject) composition.get(i)).get("gsml:compositionPart");
             assertTrue(compositionPart.size() > 0);

--- a/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/FirstParentFeature_invalid.json
+++ b/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/FirstParentFeature_invalid.json
@@ -1,0 +1,41 @@
+{
+  "@context": {
+    "gsp": "http://www.opengis.net/ont/geosparql#",
+    "sf": "http://www.opengis.net/ont/sf#",
+    "schema": "https://schema.org/",
+    "dc": "http://purl.org/dc/terms/",
+    "Feature": "gsp:Feature",
+    "FeatureCollection": "schema:Collection",
+    "Point": "sf:Point",
+    "wkt": "gsp:asWKT",
+    "features": {
+      "@container": "@set",
+      "@id": "schema:hasPart"
+    },
+    "geometry": "sf:geometry",
+    "description": "dc:description",
+    "title": "dc:title",
+    "name": "schema:name"
+  },
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "$source": "ex:FirstParentFeature"
+    },
+    {
+      "@id": "${invalid/id}",
+      "featureType": "FirstParentFeature",
+      "ex:nestedComponent": [
+        {
+          "$source": "ex:nestedFeature"
+        },
+        {
+          "ex.simpleContent": {
+            "SimpleContent": "${ex:SimpleContent}",
+            "anAttribute": "${ex:SimpleContent/ex:someAttribute}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/GeoLogicUnit_invalid.json
+++ b/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/GeoLogicUnit_invalid.json
@@ -22,22 +22,23 @@
     {
       "$source": "gsml:GeologicUnit"
     },
-    {"@id": "${invalid/id}",
-      "description": "${gml:description}",
+    {
+      "@id": "${@id}",
+      "description": "$filter{xpath('gml:description')='Olivine basalt'},${gml:description}",
       "gsml:geologicUnitType": "urn:ogc:def:nil:OGC::unknown",
       "gsml:composition": [
         {
           "$source": "gsml:composition"
         },
         {
-          "gmsl:compositionPart": [
+          "gsml:compositionPart": [
             {
               "$source": "gsml:CompositionPart"
             },
             {
               "gsml:role": {
                 "value": "${gsml:role}",
-                "@codeSpace": "urn:cgi:classifierScheme:Example:CompositionPartRole"
+                "@codeSpace": "$filter{xpath('../../gml:description')='Olivine basalt'},urn:cgi:classifierScheme:Example:CompositionPartRole"
               },
               "proportion": {
                 "$source": "gsml:proportion",
@@ -45,7 +46,7 @@
                 "CGI_TermValue": {
                   "@dataType": "CGI_TermValue",
                   "value": {
-                    "value": "${gsml:CGI_TermValue/gml:value}",
+                    "value": "${gsml:CGI_TermValue}",
                     "@codeSpace": "some:uri"
                   }
                 }
@@ -58,6 +59,7 @@
                   "@id": "${gsml:ControlledConcept/@id}",
                   "name": {
                     "value": "${gsml:ControlledConcept/gsml:name}",
+                    "invalidAttr": "${../gsml:notExisting}",
                     "@lang": "en"
                   },
                   "vocabulary": {

--- a/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/MappedFeature.json
+++ b/src/community/json-ld/src/test/resources/org/geoserver/jsonld/response/MappedFeature.json
@@ -44,6 +44,7 @@
             "$source": "gsml:composition"
           },
           {
+            "previousContextValue": "${../gml:description}",
             "gsml:compositionPart": [
               {
                 "$source": "gsml:CompositionPart"


### PR DESCRIPTION
JIRA Ticket https://osgeo-org.atlassian.net/browse/GEOS-9656

This pr fixes bugs on json-ld validation that prevent the validation process to consistely or entirely validate the json-ld template.
Moreover there are some fixes on qa failings highlighted during the attempted backport to 2.16.x of this pr https://github.com/geoserver/geoserver/pull/4248.
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
