### PR TITLE
[2.16.x backport] Fix a typo in before caching on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - if [ "$ACTION" == "build" ]; then grep -H "<testsuite" `find . -iname "TEST-*.xml"` | sed 's/.\/\(.*\)\/target.*:<testsuite .* name="\(.*\)" time="\([^"]*\)" .*/\3\t\2\t\1/' | sort -nr | head -50; fi
   - if [ "$ACTION" == "docs" ]; then mvn -f doc/en install; fi
   - if [ "$ACTION" == "package" ]; then mvn -f src/pom.xml -B -U -T3 -fae --builder smart -Prelease,communityRelease clean install -DskipTests; mvn -f src/pom.xml assembly:attached -nsu; mvn -f src/community/pom.xml assembly:attached -nsu; fi
-before-caching:
+before_cache:
   - rm -rf $HOME/.m2/repository/org/geotools
   - rm -rf $HOME/.m2/repository/org/geowebcache
   - rm -rf $HOME/.m2/repository/org/geoserver


### PR DESCRIPTION
There seems to be a typo here, assuming these directories should not be part of the cache which is why they are deleted

see also: https://docs.travis-ci.com/user/caching#before_cache-phase

backports #4320