### PR TITLE
[2.16.x backport] [GEOS-9650] Update spring-security to 5.1.11 and spring-framework to 5.1.16

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1965,8 +1965,8 @@
   <gt.version>22-SNAPSHOT</gt.version>
   <gwc.version>1.16-SNAPSHOT</gwc.version>
   <jts.version>1.16.1</jts.version>
-  <spring.version>5.1.13.RELEASE</spring.version>
-  <spring.security.version>5.1.8.RELEASE</spring.security.version>
+  <spring.version>5.1.16.RELEASE</spring.version>
+  <spring.security.version>5.1.11.RELEASE</spring.security.version>
   <servlet-api.version>3.0.1</servlet-api.version>
   <jetty.version>9.4.18.v20190429</jetty.version>
   <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>


### PR DESCRIPTION
backports #4313

Update Spring Framework from 5.1.14 to 5.1.16 and update Spring Security from 5.1.9 to 5.1.11.

### Spring release notes:

- https://github.com/spring-projects/spring-framework/releases/tag/v5.1.16.RELEASE
- https://github.com/spring-projects/spring-framework/releases/tag/v5.1.15.RELEASE
- https://github.com/spring-projects/spring-security/releases/tag/5.1.11.RELEASE
- https://github.com/spring-projects/spring-security/releases/tag/5.1.10.RELEASE

## see also:
- https://osgeo-org.atlassian.net/browse/GEOS-9650
- https://github.com/GeoWebCache/geowebcache/pull/857
- https://tanzu.vmware.com/security/cve-2020-5408