### PR TITLE
[2.16.x backport][GEOS-9658] SecuredFeatureSource incorrectly logs when requesting Com…

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureSource.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureSource.java
@@ -89,12 +89,18 @@ public class SecuredFeatureSource<T extends FeatureType, F extends Feature>
                     ReTypingFeatureCollection retyped = new ReTypingFeatureCollection(sfc, target);
                     return (FeatureCollection) SecuredObjects.secure(retyped, policy);
                 } else {
-                    // complex feature store eh? No way to fix it at least warn the admin
-                    LOGGER.log(
-                            Level.SEVERE,
-                            "Complex store returned more properties than allowed "
-                                    + "by security (because they are required by the schema). "
-                                    + "Either the security setup is broken or you have a security breach");
+                    List<PropertyName> readProps = readQuery.getProperties();
+                    List<PropertyName> queryProps = query.getProperties();
+                    // logs only if properties have been limited by the security subsystem
+                    if (readProps != null
+                            && (queryProps == null || !readProps.containsAll(queryProps))) {
+                        // complex feature store eh? No way to fix it at least warn the admin
+                        LOGGER.log(
+                                Level.SEVERE,
+                                "Complex store returned more properties than allowed "
+                                        + "by security (because they are required by the schema). "
+                                        + "Either the security setup is broken or you have a security breach");
+                    }
                     return (FeatureCollection) SecuredObjects.secure(fc, policy);
                 }
             } else {

--- a/src/security/security-tests/src/test/java/org/geoserver/security/decorators/SecuredFeatureSourceTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/decorators/SecuredFeatureSourceTest.java
@@ -6,17 +6,25 @@
 package org.geoserver.security.decorators;
 
 import static org.easymock.EasyMock.*;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.*;
 import org.geoserver.security.WrapperPolicy;
 import org.geoserver.security.impl.SecureObjectsTest;
 import org.geotools.data.*;
+import org.geotools.data.complex.feature.type.ComplexFeatureTypeImpl;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.NameImpl;
+import org.geotools.util.logging.Logging;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.PropertyName;
 
 public class SecuredFeatureSourceTest extends SecureObjectsTest {
 
@@ -73,5 +81,64 @@ public class SecuredFeatureSourceTest extends SecureObjectsTest {
         SecuredFeatureSource ro =
                 new SecuredFeatureSource(fs, WrapperPolicy.readOnlyChallenge(null));
         assertTrue(ro.getDataStore() instanceof ReadOnlyDataAccess);
+    }
+
+    @Test
+    public void testSecuredFeatureSourceLoggingWithComplex() throws Exception {
+        // build up the mock
+        ComplexFeatureTypeImpl schema = createNiceMock(ComplexFeatureTypeImpl.class);
+        expect(schema.getName()).andReturn(new NameImpl("testComplexFt"));
+        List<PropertyDescriptor> descriptors = createNiceMock(List.class);
+        expect(descriptors.size()).andReturn(3).anyTimes();
+        replay(descriptors);
+        expect(schema.getDescriptors()).andReturn(descriptors).anyTimes();
+        replay(schema);
+        DataStore store = createNiceMock(DataStore.class);
+        replay(store);
+        FeatureStore fStore = createNiceMock(FeatureStore.class);
+        expect(fStore.getSchema()).andReturn(schema).anyTimes();
+        FeatureCollection fc = createNiceMock(FeatureCollection.class);
+        expect(fStore.getDataStore()).andReturn(store);
+        expect(fStore.getFeatures()).andReturn(fc).anyTimes();
+        expect(fStore.getFeatures((Filter) anyObject())).andReturn(fc).anyTimes();
+        expect(fStore.getFeatures((Query) anyObject())).andReturn(fc).anyTimes();
+        expect(fc.getSchema()).andReturn(schema).anyTimes();
+        replay(fStore);
+        replay(fc);
+
+        // custom LogHandler to intercept log messages
+        class LogHandler extends Handler {
+            List<String> messages = new ArrayList<>();
+
+            public void publish(LogRecord record) {
+                messages.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() throws SecurityException {}
+        }
+        Logger logger = Logging.getLogger(SecuredFeatureSource.class);
+        LogHandler customLogHandler = new LogHandler();
+        logger.addHandler(customLogHandler);
+        customLogHandler.setLevel(Level.SEVERE);
+        logger.addHandler(customLogHandler);
+        try {
+            SecuredFeatureStore ro =
+                    new SecuredFeatureStore(fStore, WrapperPolicy.readOnlyHide(null));
+            Query q = new Query("testComplextFt");
+            List<PropertyName> pnames = new ArrayList<PropertyName>(1);
+            FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+            pnames.add(ff.property("someProperty"));
+            q.setProperties(pnames);
+            ro.getFeatures(q);
+            String notExpectedMessage =
+                    "Complex store returned more properties than allowed by security (because they are required by the schema). Either the security setup is broken or you have a security breach";
+            assertFalse(customLogHandler.messages.contains(notExpectedMessage));
+        } finally {
+            logger.removeHandler(customLogHandler);
+        }
     }
 }


### PR DESCRIPTION
…… (#4324)

* [GEOS-9658] SecuredFeatureSource incorrectly logs when requesting ComplexFeatures with a sld style

* reviewer's suggestions applied

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
