### PR TITLE
[GEOS-9657] Allow static method calls in GetFeatureInfo templates

### DIFF
--- a/doc/en/user/source/tutorials/GetFeatureInfo/html.rst
+++ b/doc/en/user/source/tutorials/GetFeatureInfo/html.rst
@@ -161,3 +161,42 @@ As you can see, roads are still using the generic template, whilst POI is using 
 Advanced Formating
 ``````````````````
 The ``value`` property of Feature attribute values are given by geoserver in ``String`` form, using a sensible default depending on the actual type of the attribute value.  If you need to access the raw attribute value in order to apply a custom format (for example, to output ``"Enabled"`` or ``"Disabled"`` for a given boolean property, instead of the default ``true/false``, you can just use the ``rawValue`` property instead of ``value``.  For example: ``${attribute.rawValue?string("Enabled", "Disabled")}`` instead of just ``${attribute.value}``.
+
+Accessing static methods
+````````````````````````
+It is possible to call static methods and variables from within Freemarker templates to enable more sophisticated templates. 
+But please be aware that generally static method calls are a security liability, which can be used to make harmful things, especially when template authors can not be fully trusted. So by default this feature is disabled. The configuration parameter ``org.geoserver.htmlTemplates.staticMemberAccess`` has to specified to enabled it, for example as system property. The parameter takes a comma separated list of fully qualified class names. GeoServer allows access to static member of these classes from within templates using their simple, unqualified class name as the example below demonstrates.
+
+The following system property enables selective access::
+
+	-Dorg.geoserver.htmlTemplates.staticMemberAccess=java.lang.String
+
+This exposes the static members of ``java.lang.String`` using the variable name ``String`` in the template, which can be used in templates as follows::
+
+	<ul>
+	<#list features as feature>
+	  <li>${feature.NAME.value}: ${String.format("%.2f €", feature.AMOUNT.rawValue)}
+	  </li>
+	</#list>
+	</ul>
+
+In case of granting access to multiple classes with the same simple name, the later specified classes will be exposed with a number suffix. For example when specifying ``-Dorg.geoserver.htmlTemplates.staticMemberAccess=java.lang.String,com.acme.String``, the statics of ``java.lang.String`` will be exposed as ``String`` while the statics of ``com.acme.String`` will be exposed as ``String2`` and so on.
+
+You can also enable unrestricted access by specifying a ``*`` as the next example demonstrates.
+
+The following system property enables unrestricted access::
+
+	-Dorg.geoserver.htmlTemplates.staticMemberAccess=*
+
+In this case GeoServer exposes a ``statics`` variable you can use in templates to access static members as follows::
+
+	<#assign String=statics['java.lang.String']>
+	<ul>
+	<#list features as feature>
+	  <li>${feature.NAME.value}: ${String.format("%.2f €", feature.AMOUNT.rawValue)}
+	  </li>
+	</#list>
+	</ul>
+
+.. note::
+	Unrestricted access as shown above is only recommended if you can fully trust your template authors.

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
@@ -5,12 +5,21 @@
 package org.geoserver.wms.featureinfo;
 
 import static org.geoserver.wms.featureinfo.FreemarkerStaticsAccessRule.fromPattern;
+
+import freemarker.template.Configuration;
+import freemarker.template.SimpleHash;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateHashModel;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.List;
+import net.opengis.wfs.FeatureCollectionType;
 import org.apache.log4j.Logger;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.ows.Dispatcher;
@@ -26,14 +35,6 @@ import org.geoserver.wms.WMS;
 import org.geoserver.wms.featureinfo.FreemarkerStaticsAccessRule.RuleItem;
 import org.geotools.feature.FeatureCollection;
 import org.opengis.feature.simple.SimpleFeatureType;
-import freemarker.template.Configuration;
-import freemarker.template.SimpleHash;
-import freemarker.template.Template;
-import freemarker.template.TemplateException;
-import freemarker.template.TemplateHashModel;
-import freemarker.template.TemplateModel;
-import freemarker.template.TemplateModelException;
-import net.opengis.wfs.FeatureCollectionType;
 
 /**
  * Abstract class to manage free marker templates used to customize getFeatureInfo output format. It
@@ -66,22 +67,27 @@ public abstract class FreeMarkerTemplateManager {
 
     private static Logger logger = Logger.getLogger(FreeMarkerTemplateManager.class);
     private static FreemarkerStaticsAccessRule staticsAccessRule;
-    
-    /**
-     * Initializes the {@link #staticsAccessRule}.
-     */
+
+    /** Initializes the {@link #staticsAccessRule}. */
     static void initStaticsAccessRule() {
         String tmpAccessPattern = GeoServerExtensions.getProperty(KEY_STATIC_MEMBER_ACCESS);
         FreemarkerStaticsAccessRule tmpRule = fromPattern(tmpAccessPattern);
-        logger.debug("Initializing with "+tmpRule);
+        logger.debug("Initializing with " + tmpRule);
         for (RuleItem tmpItem : tmpRule.getAllowedItems()) {
             if (tmpItem.isNumberedAlias()) {
-                logger.warn("Granting access to static members of " + tmpItem.getClassName()
-                        + " using the variable name " + tmpItem.getAlias()
-                        + " to keep names unique.");
+                logger.warn(
+                        "Granting access to static members of "
+                                + tmpItem.getClassName()
+                                + " using the variable name "
+                                + tmpItem.getAlias()
+                                + " to keep names unique.");
             } else if (logger.isDebugEnabled()) {
-                logger.debug("Granting access to static members of " + tmpItem.getClassName()
-                        + " using the variable name " + tmpItem.getAlias() + ".");
+                logger.debug(
+                        "Granting access to static members of "
+                                + tmpItem.getClassName()
+                                + " using the variable name "
+                                + tmpItem.getAlias()
+                                + ".");
             }
         }
         staticsAccessRule = tmpRule;

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
@@ -1,6 +1,6 @@
-/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
  */
 package org.geoserver.wms.featureinfo;
 
@@ -53,10 +53,11 @@ class FreemarkerStaticsAccessRule {
 
     /** Instance signals unrestricted access */
     private static final FreemarkerStaticsAccessRule UNRESTRICTED =
-            new FreemarkerStaticsAccessRule();
+            new FreemarkerStaticsAccessRule(true);
 
     /** Instance signals access is disabled */
-    private static final FreemarkerStaticsAccessRule DISABLED = new FreemarkerStaticsAccessRule();
+    private static final FreemarkerStaticsAccessRule DISABLED =
+            new FreemarkerStaticsAccessRule(false);
 
     public static FreemarkerStaticsAccessRule fromPattern(String aPattern) {
         if (aPattern == null || aPattern.trim().isEmpty()) {
@@ -67,23 +68,19 @@ class FreemarkerStaticsAccessRule {
 
         // check for validity
         List<Class<?>> tmpClasses = new ArrayList<>();
-        for (StringTokenizer tmpTokenizer = new StringTokenizer(aPattern, ",");
-                tmpTokenizer.hasMoreTokens(); ) {
+        for (StringTokenizer tmpTokenizer = new StringTokenizer(aPattern, ","); tmpTokenizer
+                .hasMoreTokens();) {
             String tmpCandidate = tmpTokenizer.nextToken().trim();
             if (SourceVersion.isName(tmpCandidate)) {
                 try {
                     tmpClasses.add(Class.forName(tmpCandidate));
                 } catch (ClassNotFoundException e) {
-                    logger.warn(
-                            "Denying access to static members of '"
-                                    + tmpCandidate
-                                    + "': Class not found.");
+                    logger.warn("Denying access to static members of '" + tmpCandidate
+                            + "': Class not found.");
                 }
             } else {
-                logger.warn(
-                        "Denying access to static members of '"
-                                + tmpCandidate
-                                + "': Not a valid class name.");
+                logger.warn("Denying access to static members of '" + tmpCandidate
+                        + "': Not a valid class name.");
             }
         }
         if (tmpClasses.isEmpty()) {
@@ -111,15 +108,20 @@ class FreemarkerStaticsAccessRule {
 
     private static Logger logger = Logger.getLogger(FreemarkerStaticsAccessRule.class);
 
+    /**
+     * "true" for rules representing unrestricted access
+     */
+    private boolean unrestricted;
+
     /** Classes allowed to be accessed */
     private List<RuleItem> rulesItems = Collections.emptyList();
 
-    public FreemarkerStaticsAccessRule() {
-        super();
+    public FreemarkerStaticsAccessRule(boolean anUnRestricted) {
+        unrestricted = anUnRestricted;
     }
 
     public FreemarkerStaticsAccessRule(List<RuleItem> someItems) {
-        super();
+        this(false);
         rulesItems = someItems;
     }
 
@@ -130,6 +132,12 @@ class FreemarkerStaticsAccessRule {
 
     /** @return true, if unrestricted access to static members is allowed. */
     public boolean isUnrestricted() {
-        return this == UNRESTRICTED;
+        return unrestricted;
+    }
+
+    @Override
+    public String toString() {
+        return "FreemarkerStaticsAccessRule [unrestricted=" + unrestricted + ", rulesItems="
+                + rulesItems + "]";
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
@@ -1,6 +1,6 @@
-/*
- * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
- * GPL 2.0 license, available at the root application directory.
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
  */
 package org.geoserver.wms.featureinfo;
 
@@ -68,19 +68,23 @@ class FreemarkerStaticsAccessRule {
 
         // check for validity
         List<Class<?>> tmpClasses = new ArrayList<>();
-        for (StringTokenizer tmpTokenizer = new StringTokenizer(aPattern, ","); tmpTokenizer
-                .hasMoreTokens();) {
+        for (StringTokenizer tmpTokenizer = new StringTokenizer(aPattern, ",");
+                tmpTokenizer.hasMoreTokens(); ) {
             String tmpCandidate = tmpTokenizer.nextToken().trim();
             if (SourceVersion.isName(tmpCandidate)) {
                 try {
                     tmpClasses.add(Class.forName(tmpCandidate));
                 } catch (ClassNotFoundException e) {
-                    logger.warn("Denying access to static members of '" + tmpCandidate
-                            + "': Class not found.");
+                    logger.warn(
+                            "Denying access to static members of '"
+                                    + tmpCandidate
+                                    + "': Class not found.");
                 }
             } else {
-                logger.warn("Denying access to static members of '" + tmpCandidate
-                        + "': Not a valid class name.");
+                logger.warn(
+                        "Denying access to static members of '"
+                                + tmpCandidate
+                                + "': Not a valid class name.");
             }
         }
         if (tmpClasses.isEmpty()) {
@@ -108,9 +112,7 @@ class FreemarkerStaticsAccessRule {
 
     private static Logger logger = Logger.getLogger(FreemarkerStaticsAccessRule.class);
 
-    /**
-     * "true" for rules representing unrestricted access
-     */
+    /** "true" for rules representing unrestricted access */
     private boolean unrestricted;
 
     /** Classes allowed to be accessed */
@@ -137,7 +139,10 @@ class FreemarkerStaticsAccessRule {
 
     @Override
     public String toString() {
-        return "FreemarkerStaticsAccessRule [unrestricted=" + unrestricted + ", rulesItems="
-                + rulesItems + "]";
+        return "FreemarkerStaticsAccessRule [unrestricted="
+                + unrestricted
+                + ", rulesItems="
+                + rulesItems
+                + "]";
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
@@ -1,0 +1,135 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.featureinfo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import javax.lang.model.SourceVersion;
+import org.apache.log4j.Logger;
+
+/**
+ * Represents the rules for accessing static members from within Freemarker templates.
+ *
+ * @author awaterme
+ */
+class FreemarkerStaticsAccessRule {
+
+    public static final class RuleItem {
+        /** the class to allow access to */
+        private Class<?> clazz;
+        /** the alias (variable name) used to expose the statics of the class */
+        private String alias;
+        /**
+         * true, in case an number prefix was appended to keep the names distinct. Unlikely to occur
+         * in real world
+         */
+        private boolean numberedAlias;
+
+        public RuleItem(Class<?> clazz, String alias, boolean numberedAlias) {
+            super();
+            this.clazz = clazz;
+            this.alias = alias;
+            this.numberedAlias = numberedAlias;
+        }
+
+        public String getClassName() {
+            return clazz.getName();
+        }
+
+        public String getAlias() {
+            return alias;
+        }
+
+        public boolean isNumberedAlias() {
+            return numberedAlias;
+        }
+    }
+
+    /** Instance signals unrestricted access */
+    private static final FreemarkerStaticsAccessRule UNRESTRICTED =
+            new FreemarkerStaticsAccessRule();
+
+    /** Instance signals access is disabled */
+    private static final FreemarkerStaticsAccessRule DISABLED = new FreemarkerStaticsAccessRule();
+
+    public static FreemarkerStaticsAccessRule fromPattern(String aPattern) {
+        if (aPattern == null || aPattern.trim().isEmpty()) {
+            return DISABLED;
+        } else if ("*".equals(aPattern)) {
+            return UNRESTRICTED;
+        }
+
+        // check for validity
+        List<Class<?>> tmpClasses = new ArrayList<>();
+        for (StringTokenizer tmpTokenizer = new StringTokenizer(aPattern, ",");
+                tmpTokenizer.hasMoreTokens(); ) {
+            String tmpCandidate = tmpTokenizer.nextToken().trim();
+            if (SourceVersion.isName(tmpCandidate)) {
+                try {
+                    tmpClasses.add(Class.forName(tmpCandidate));
+                } catch (ClassNotFoundException e) {
+                    logger.warn(
+                            "Denying access to static members of '"
+                                    + tmpCandidate
+                                    + "': Class not found.");
+                }
+            } else {
+                logger.warn(
+                        "Denying access to static members of '"
+                                + tmpCandidate
+                                + "': Not a valid class name.");
+            }
+        }
+        if (tmpClasses.isEmpty()) {
+            return DISABLED;
+        }
+
+        // determine alias names (=variable names for template) and detect duplicates
+        List<RuleItem> tmpItems = new ArrayList<>();
+        Map<String, Integer> tmpCounts = new HashMap<>();
+        for (Class<?> tmpTarget : tmpClasses) {
+            String tmpSimpleAlias = tmpTarget.getSimpleName();
+            Integer tmpCount = tmpCounts.get(tmpSimpleAlias);
+
+            if (tmpCount == null) {
+                tmpCount = 1;
+                tmpItems.add(new RuleItem(tmpTarget, tmpTarget.getSimpleName(), false));
+            } else {
+                tmpCount += 1;
+                tmpItems.add(new RuleItem(tmpTarget, tmpTarget.getSimpleName() + tmpCount, true));
+            }
+            tmpCounts.put(tmpSimpleAlias, tmpCount);
+        }
+        return new FreemarkerStaticsAccessRule(tmpItems);
+    }
+
+    private static Logger logger = Logger.getLogger(FreemarkerStaticsAccessRule.class);
+
+    /** Classes allowed to be accessed */
+    private List<RuleItem> rulesItems = Collections.emptyList();
+
+    public FreemarkerStaticsAccessRule() {
+        super();
+    }
+
+    public FreemarkerStaticsAccessRule(List<RuleItem> someItems) {
+        super();
+        rulesItems = someItems;
+    }
+
+    /** @return the classes allowed to be accessed */
+    public List<RuleItem> getAllowedItems() {
+        return rulesItems;
+    }
+
+    /** @return true, if unrestricted access to static members is allowed. */
+    public boolean isUnrestricted() {
+        return this == UNRESTRICTED;
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRuleTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRuleTest.java
@@ -1,0 +1,141 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.featureinfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link FreemarkerStaticsAccessRule}
+ *
+ * @author awaterme
+ */
+public class FreemarkerStaticsAccessRuleTest {
+    // used for testing inner classes
+    public static final class Dummy {
+        public static final class String {};
+    }
+
+    public static final class String {};
+
+    /** Tests most common case: no value set */
+    @Test
+    public void testNullEmpty() {
+        FreemarkerStaticsAccessRule tmpRule = FreemarkerStaticsAccessRule.fromPattern(null);
+        assertDisabled(tmpRule);
+
+        tmpRule = FreemarkerStaticsAccessRule.fromPattern("");
+        assertDisabled(tmpRule);
+
+        tmpRule = FreemarkerStaticsAccessRule.fromPattern(" , ");
+        assertDisabled(tmpRule);
+    }
+
+    /** Tests case with unrestricted access */
+    @Test
+    public void testUnrestricted() {
+        FreemarkerStaticsAccessRule tmpRule = FreemarkerStaticsAccessRule.fromPattern("*");
+        assertTrue(tmpRule.isUnrestricted());
+    }
+
+    /** tests invalid input */
+    @Test
+    public void testInvalid() {
+        FreemarkerStaticsAccessRule tmpRule = FreemarkerStaticsAccessRule.fromPattern("a.b.C");
+        assertDisabled(tmpRule);
+
+        tmpRule = FreemarkerStaticsAccessRule.fromPattern("a.b.C, ..., .a.b,;");
+        assertDisabled(tmpRule);
+
+        tmpRule = FreemarkerStaticsAccessRule.fromPattern("true");
+        assertDisabled(tmpRule);
+
+        tmpRule = FreemarkerStaticsAccessRule.fromPattern("false");
+        assertDisabled(tmpRule);
+    }
+
+    /** Tests valid input */
+    @Test
+    public void testValid() {
+        // most simple
+        FreemarkerStaticsAccessRule tmpRule =
+                FreemarkerStaticsAccessRule.fromPattern("java.lang.String");
+        assertFalse(tmpRule.isUnrestricted());
+        assertEquals(1, tmpRule.getAllowedItems().size());
+        assertEquals("java.lang.String", tmpRule.getAllowedItems().get(0).getClassName());
+
+        // multiple, JDK and other
+        tmpRule =
+                FreemarkerStaticsAccessRule.fromPattern(
+                        " java.lang.String  ,java.text.DecimalFormat  , "
+                                + FeatureTemplate.class.getName());
+        assertFalse(tmpRule.isUnrestricted());
+        assertEquals(3, tmpRule.getAllowedItems().size());
+        assertEquals("java.lang.String", tmpRule.getAllowedItems().get(0).getClassName());
+        assertEquals("java.text.DecimalFormat", tmpRule.getAllowedItems().get(1).getClassName());
+        assertEquals(
+                FeatureTemplate.class.getName(), tmpRule.getAllowedItems().get(2).getClassName());
+
+        // inner classes
+        tmpRule =
+                FreemarkerStaticsAccessRule.fromPattern(
+                        getClass().getName() + "$" + Dummy.class.getSimpleName());
+        assertFalse(tmpRule.isUnrestricted());
+        assertEquals(1, tmpRule.getAllowedItems().size());
+        assertEquals(Dummy.class.getName(), tmpRule.getAllowedItems().get(0).getClassName());
+
+        // partially broken
+        tmpRule =
+                FreemarkerStaticsAccessRule.fromPattern(
+                        " java.lang.String, not.existing.Class ,java.text.DecimalFormat");
+        assertFalse(tmpRule.isUnrestricted());
+        assertEquals(2, tmpRule.getAllowedItems().size());
+        assertEquals("java.lang.String", tmpRule.getAllowedItems().get(0).getClassName());
+        assertEquals("java.text.DecimalFormat", tmpRule.getAllowedItems().get(1).getClassName());
+    }
+
+    /** Tests number suffixes are consistent */
+    @Test
+    public void testNumberPostfixes() {
+        java.lang.String lName1 = String.class.getName();
+        java.lang.String lName2 = FreemarkerStaticsAccessRuleTest.String.class.getName();
+        java.lang.String lName3 = FreemarkerStaticsAccessRuleTest.Dummy.String.class.getName();
+
+        assertSuffixes(lName1, lName2, lName3);
+
+        lName1 = FreemarkerStaticsAccessRuleTest.Dummy.String.class.getName();
+        lName2 = FreemarkerStaticsAccessRuleTest.String.class.getName();
+        lName3 = String.class.getName();
+
+        assertSuffixes(lName1, lName2, lName3);
+    }
+
+    private void assertSuffixes(
+            java.lang.String aName1, java.lang.String aName2, java.lang.String aName3) {
+
+        FreemarkerStaticsAccessRule tmpRule =
+                FreemarkerStaticsAccessRule.fromPattern(aName1 + "," + aName2 + "," + aName3);
+
+        assertFalse(tmpRule.isUnrestricted());
+        assertEquals(3, tmpRule.getAllowedItems().size());
+
+        assertEquals("String", tmpRule.getAllowedItems().get(0).getAlias());
+        assertEquals(aName1, tmpRule.getAllowedItems().get(0).getClassName());
+
+        assertEquals("String2", tmpRule.getAllowedItems().get(1).getAlias());
+        assertEquals(aName2, tmpRule.getAllowedItems().get(1).getClassName());
+
+        assertEquals("String3", tmpRule.getAllowedItems().get(2).getAlias());
+        assertEquals(aName3, tmpRule.getAllowedItems().get(2).getClassName());
+    }
+
+    private void assertDisabled(FreemarkerStaticsAccessRule aRule) {
+        assertFalse(aRule.isUnrestricted());
+        assertTrue(aRule.getAllowedItems().isEmpty());
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
@@ -51,6 +51,7 @@ import org.geotools.data.DataUtilities;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -349,5 +350,50 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
         outputFormat.write(fcType, getFeatureInfoRequest, outStream);
         String result = new String(outStream.toByteArray());
         assertEquals(String.valueOf(Math.max(10, 100)), result);
+    }
+
+    /** Verifies calls to static methods are possible in unrestricted case. */
+    @Test
+    public void testStaticMethodsUnrestrictedInTemplate() throws IOException {
+        System.setProperty(FreeMarkerTemplateManager.KEY_STATIC_MEMBER_ACCESS, "*");
+        currentTemplate = "test_custom_static_content.ftl";
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        outputFormat.write(fcType, getFeatureInfoRequest, outStream);
+        String result = new String(outStream.toByteArray());
+        assertEquals(String.format("Amount: %.2f €", 47.11), result);
+    }
+
+    /** Verifies calls to static methods are disabled by default. */
+    @Test(expected = IOException.class)
+    public void testStaticMethodsDisabledInTemplate() throws IOException {
+        System.clearProperty(FreeMarkerTemplateManager.KEY_STATIC_MEMBER_ACCESS);
+        currentTemplate = "test_custom_static_content.ftl";
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        outputFormat.write(fcType, getFeatureInfoRequest, outStream);
+    }
+
+    // for test below: Name has to be duplicate of existing class
+    public static final class Locale {
+        public static String m() {
+            return "Hello world";
+        }
+    }
+
+    /** Verifies calls to static methods for are enabled for specified classes. */
+    @Test(expected = IOException.class)
+    public void testSpecifiedStaticMethodsInTemplateAvailable() throws IOException {
+        System.setProperty(
+                FreeMarkerTemplateManager.KEY_STATIC_MEMBER_ACCESS,
+                java.util.Locale.class.getName() + "," + Locale.class.getName());
+        currentTemplate = "test_custom_static_content_specified.ftl";
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        outputFormat.write(fcType, getFeatureInfoRequest, outStream);
+        String result = new String(outStream.toByteArray());
+        assertEquals("Hello world from de", result);
+    }
+
+    @After
+    public void tearDownStaticAccessKey() {
+        System.clearProperty(FreeMarkerTemplateManager.KEY_STATIC_MEMBER_ACCESS);
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/HTMLFeatureInfoOutputFormatTest.java
@@ -12,6 +12,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+
+import freemarker.template.TemplateException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +27,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import net.opengis.wfs.FeatureCollectionType;
+import net.opengis.wfs.WfsFactory;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.Keyword;
 import org.geoserver.catalog.LayerInfo;
@@ -55,9 +59,6 @@ import org.junit.rules.ExpectedException;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
-import freemarker.template.TemplateException;
-import net.opengis.wfs.FeatureCollectionType;
-import net.opengis.wfs.WfsFactory;
 
 public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
     private HTMLFeatureInfoOutputFormat outputFormat;
@@ -397,15 +398,15 @@ public class HTMLFeatureInfoOutputFormatTest extends WMSTestSupport {
     }
 
     /**
-     * Activates the rule for the given pattern by re-initializing the
-     * {@link FreeMarkerTemplateManager}.
-     * 
+     * Activates the rule for the given pattern by re-initializing the {@link
+     * FreeMarkerTemplateManager}.
+     *
      * @param aPattern
      */
     private void activateStaticsAccessRules(String aPattern) {
-        if(aPattern == null) {
+        if (aPattern == null) {
             System.clearProperty(FreeMarkerTemplateManager.KEY_STATIC_MEMBER_ACCESS);
-        }else {
+        } else {
             System.setProperty(FreeMarkerTemplateManager.KEY_STATIC_MEMBER_ACCESS, aPattern);
         }
         FreeMarkerTemplateManager.initStaticsAccessRule();

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_custom_static_content.ftl
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_custom_static_content.ftl
@@ -1,0 +1,2 @@
+<#assign String=statics['java.lang.String']>
+${String.format("Amount: %.2f €", 47.11)}

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_custom_static_content_specified.ftl
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/test_custom_static_content_specified.ftl
@@ -1,0 +1,1 @@
+${Locale2.m()} from ${Locale.GERMAN.getLanguage()}


### PR DESCRIPTION
PR enable the usage of static methods in GetFeatureInfo HTML templates as requested by [GEOS-9657](https://osgeo-org.atlassian.net/browse/GEOS-9657).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [X] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [X] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
