### PR TITLE
[MapML Community Module] Use global proxyBaseUrl setting for base URL…

### DIFF
--- a/src/community/mapml/src/main/java/org/geoserver/mapml/MapMLController.java
+++ b/src/community/mapml/src/main/java/org/geoserver/mapml/MapMLController.java
@@ -50,6 +50,7 @@ import org.geoserver.mapml.xml.ProjType;
 import org.geoserver.mapml.xml.RelType;
 import org.geoserver.mapml.xml.Select;
 import org.geoserver.mapml.xml.UnitType;
+import org.geoserver.ows.URLMangler;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.wms.WMS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -137,7 +138,13 @@ public class MapMLController {
         final String workspace;
         String styleName = style.orElse("");
         String imageFormat = format.orElse("image/png");
-        String baseUrl = ResponseUtils.baseURL(request);
+        String proxyBaseUrl = geoServer.getSettings().getProxyBaseUrl();
+        String baseUrl =
+                ResponseUtils.buildURL(
+                        proxyBaseUrl != null ? proxyBaseUrl : ResponseUtils.baseURL(request),
+                        null,
+                        null,
+                        URLMangler.URLType.EXTERNAL);
         String baseUrlPattern = baseUrl;
         if (isLayerGroup) {
             layerGroupInfo = geoServer.getCatalog().getLayerGroupByName(layer);
@@ -476,8 +483,13 @@ public class MapMLController {
 
         String styleName = style.orElse("");
         String imageFormat = format.orElse("image/png");
-
-        String baseUrl = ResponseUtils.baseURL(request);
+        String proxyBaseUrl = geoServer.getSettings().getProxyBaseUrl();
+        String baseUrl =
+                ResponseUtils.buildURL(
+                        proxyBaseUrl != null ? proxyBaseUrl : ResponseUtils.baseURL(request),
+                        null,
+                        null,
+                        URLMangler.URLType.EXTERNAL);
         String baseUrlPattern = baseUrl;
 
         // handle shard config
@@ -503,7 +515,7 @@ public class MapMLController {
         HeadContent head = new HeadContent();
         head.setTitle(layerName);
         Base base = new Base();
-        base.setHref(baseUrl + "mapml");
+        base.setHref(ResponseUtils.buildURL(baseUrl, "mapml", null, URLMangler.URLType.EXTERNAL));
         head.setBase(base);
         List<Meta> metas = head.getMetas();
         Meta meta = new Meta();


### PR DESCRIPTION
… when set

In the MapML Community Module, I was not taking into account the Global Settings Proxy Base URL value, which the admin can use to set a base URL value to use that doesn't assume geoserver's context and port number i.e. how the outside world sees the service.  So, this value is conditionally used when set to a non-blank value.   

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
