### PR TITLE
[GEOS-9649] NullPointerException for geoJSON output format with Compl…

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GeoJsonOutputFormatWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GeoJsonOutputFormatWfsTest.java
@@ -113,6 +113,21 @@ public final class GeoJsonOutputFormatWfsTest extends AbstractAppSchemaTestSuppo
         assertEquals("http://www.geoserver.org/featureC", featureLinkC.getString("@href"));
     }
 
+    @Test
+    public void testGetGeoJsonResponseWfs20WithNullGeometryAttribute() throws Exception {
+        // tests that with a null geometry value and minOccurs 0 in mappings
+        // conf, ComplexGeoJSONWriter doesn't throw npe but encode a geometry:null attribute
+        JSON response =
+                getAsJSON(
+                        "wfs?request=GetFeature&version=2.0"
+                                + "&typenames=st_gml32:Station_gml32&outputFormat=application/json");
+        // validate the obtained response
+        checkStation1Exists(response);
+        JSONObject station = getFeaturePropertiesById(response, "st.3");
+        // check we got the null geometry value encoded
+        assertEquals(station.get("geometry"), null);
+    }
+
     /** Helper method that station 1 exists and was correctly encoded in the GeoJSON response. */
     private void checkStation1Exists(JSON geoJson) {
         // get the station from the response

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GeoJsonOutputFormatWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GeoJsonOutputFormatWfsTest.java
@@ -7,9 +7,7 @@ package org.geoserver.test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
@@ -123,9 +121,13 @@ public final class GeoJsonOutputFormatWfsTest extends AbstractAppSchemaTestSuppo
                                 + "&typenames=st_gml32:Station_gml32&outputFormat=application/json");
         // validate the obtained response
         checkStation1Exists(response);
-        JSONObject station = getFeaturePropertiesById(response, "st.3");
+        // get station number 3 which should have null geometry value
+        JSONObject station3 = (JSONObject) ((JSONObject) response).getJSONArray("features").get(2);
+        JSONObject geometry = station3.getJSONObject("geometry");
+        // check we got the geometry key encoded
+        assertTrue(station3.containsKey("geometry"));
         // check we got the null geometry value encoded
-        assertEquals(station.get("geometry"), null);
+        assertTrue(geometry.isNullObject());
     }
 
     /** Helper method that station 1 exists and was correctly encoded in the GeoJSON response. */

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/geoJson/stations.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/geoJson/stations.properties
@@ -1,3 +1,4 @@
 _=ID:String,NAME:String,CODE:String,PHONE:Integer,TIMEZONE:String,MAIL:String,LOCATION:Geometry:srid=4326
 st.1=st.1|station1|st1|95482156|CET|st1@stations.org|POINT(-1 1)
 st.2=st.2|station2|st2|||st2@stations.org|POINT(-2 -3)
+st.3=st.3|station3|st3|||st3@stations.org|null

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/geoJson/stations.xsd
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/geoJson/stations.xsd
@@ -16,7 +16,7 @@
                             </xs:simpleContent>
                         </xs:complexType>
                     </xs:element>
-                    <xs:element name="location" type="gml:GeometryPropertyType"/>
+                    <xs:element name="location" type="gml:GeometryPropertyType" minOccurs="0"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="measurements"
                                 type="st:MeasurementPropertyType"/>
                     <xs:element name="featureLinkA" type="gml:FeaturePropertyType" maxOccurs="unbounded" nillable="true"/>

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
@@ -176,7 +176,7 @@ class ComplexGeoJsonWriter {
             }
             // store the attribute name and geometry value of the current feature
             geometryAttribute = feature.getProperty(geometryType.getName());
-            geometry = (Geometry) geometryAttribute.getValue();
+            geometry = geometryAttribute != null ? (Geometry) geometryAttribute.getValue() : null;
         } else {
             // this feature seems to not have a geometry, write the default axis order
             jsonWriter.setAxisOrder(CRS.AxisOrder.EAST_NORTH);


### PR DESCRIPTION
…exFeatures if some feature misses geometry value

JIRA ticket https://osgeo-org.atlassian.net/browse/GEOS-9649

This pr fixes a NPE when requesting ComplexFeatures in a geoJSON format and the following condition are met:

- a geometry attribute is null for some of the features;
- the geometry attribute has minOccurs = 0 or encodeIfEmpty is set to false.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
