### PR TITLE
Correct format option "antialising"->"antialias"

### DIFF
--- a/doc/en/user/source/services/wms/vendor.rst
+++ b/doc/en/user/source/services/wms/vendor.rst
@@ -135,7 +135,7 @@ The syntax is::
     
 The supported format options are:
 
-* ``antialiasing`` (values = ``on``, ``off``, ``text``): controls the use of antialiased rendering in raster output. 
+* ``antialias`` (values = ``on``, ``off``, ``text``): controls the use of antialiased rendering in raster output. 
 * ``callback``: specifies the callback function name for the jsonp response format (default is ``parseResponse``).
 * ``dpi``: sets the rendering DPI (dots-per-inch) for raster outputs. 
   The OGC standard output resolution is 90 DPI. 


### PR DESCRIPTION
See https://sourceforge.net/p/geoserver/mailman/message/37050631/

I do not know why Edit in GitHub also re-created the last line "Currently this parameter is ignored for layers with Complex features."