### PR TITLE
[2.16.x backport] [GEOS-9539] URLKvpParser encodes urls also when not needed + System variable for legacy behaviour

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/kvp/URLKvpParser.java
+++ b/src/ows/src/main/java/org/geoserver/ows/kvp/URLKvpParser.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.ows.kvp;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import org.geoserver.ows.KvpParser;
 
@@ -24,7 +25,11 @@ public class URLKvpParser extends KvpParser {
     }
 
     public Object parse(String value) throws Exception {
-        return new URL(fixURL(value));
+        try {
+            return new URL(value);
+        } catch (MalformedURLException e) {
+            return new URL(fixURL(value));
+        }
     }
 
     /**

--- a/src/ows/src/main/java/org/geoserver/ows/kvp/URLKvpParser.java
+++ b/src/ows/src/main/java/org/geoserver/ows/kvp/URLKvpParser.java
@@ -15,6 +15,8 @@ import org.geoserver.ows.KvpParser;
  * @author Justin Deoliveira, The Open Planning Project, jdeolive@openplans.org
  */
 public class URLKvpParser extends KvpParser {
+
+    private final Boolean FIX_URL_FIRST = Boolean.getBoolean("org.geoserver.kvp.urlfix");
     /**
      * Creates the parser specifying the name of the key to latch to.
      *
@@ -25,10 +27,13 @@ public class URLKvpParser extends KvpParser {
     }
 
     public Object parse(String value) throws Exception {
-        try {
-            return new URL(value);
-        } catch (MalformedURLException e) {
-            return new URL(fixURL(value));
+        if (FIX_URL_FIRST) return new URL(fixURL(value));
+        else {
+            try {
+                return new URL(value);
+            } catch (MalformedURLException e) {
+                return new URL(fixURL(value));
+            }
         }
     }
 

--- a/src/ows/src/test/java/org/geoserver/ows/kvp/URLKvpParserTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/kvp/URLKvpParserTest.java
@@ -1,0 +1,37 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows.kvp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+import java.net.URL;
+import org.junit.Before;
+import org.junit.Test;
+
+public class URLKvpParserTest {
+    URLKvpParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new URLKvpParser("url");
+    }
+
+    @Test
+    public void testValidUrl() {
+        try {
+            String validUrl =
+                    "http://localhost:8080/geoserver/rest/sldservice/topp:states/classify.xml?attribute=PERSONS&intervals=8&method=quantile&ramp=custom&colors=%23000000%2C%23240000%2C%23490000%2C%236d0000%2C%23920000%2C%23b60000%2C%23db0000%2C%23ff0000&open=false&strokeWeight=-1&strokeColor=%23ff0000&customClasses=1.1011%2C22.518%2C%23000000%3B22.518%2C48.445%2C%23240000%3B48.445%2C81.193%2C%23490000%3B81.193%2C118.905%2C%236D0000%3B118.905%2C168.246%2C%23920000%3B168.246%2C232.83%2C%23B60000%3B232.83%2C338.04%2C%23DB0000%3B338.04%2C16597.660000000003%2C%23FF0000&fullSLD=true";
+            URL url = (URL) parser.parse(validUrl);
+            assertEquals(
+                    "http://localhost:8080/geoserver/rest/sldservice/topp:states/classify.xml?attribute=PERSONS&intervals=8&method=quantile&ramp=custom&colors=%23000000%2C%23240000%2C%23490000%2C%236d0000%2C%23920000%2C%23b60000%2C%23db0000%2C%23ff0000&open=false&strokeWeight=-1&strokeColor=%23ff0000&customClasses=1.1011%2C22.518%2C%23000000%3B22.518%2C48.445%2C%23240000%3B48.445%2C81.193%2C%23490000%3B81.193%2C118.905%2C%236D0000%3B118.905%2C168.246%2C%23920000%3B168.246%2C232.83%2C%23B60000%3B232.83%2C338.04%2C%23DB0000%3B338.04%2C16597.660000000003%2C%23FF0000&fullSLD=true",
+                    url.toExternalForm());
+            assertNotEquals(URLKvpParser.fixURL(validUrl), url.toExternalForm());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+}

--- a/src/ows/src/test/java/org/geoserver/ows/kvp/URLKvpParserTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/kvp/URLKvpParserTest.java
@@ -34,4 +34,20 @@ public class URLKvpParserTest {
             fail();
         }
     }
+
+    @Test
+    public void testLegacyBehaviourUrl() {
+        try {
+            System.setProperty("org.geoserver.kvp.urlfix", "true");
+            URLKvpParser legacyParser = new URLKvpParser("url");
+            String validUrl =
+                    "http://localhost:8080/geoserver/rest/sldservice/topp:states/classify.xml?attribute=PERSONS&intervals=8&method=quantile&ramp=custom&colors=%23000000%2C%23240000%2C%23490000%2C%236d0000%2C%23920000%2C%23b60000%2C%23db0000%2C%23ff0000&open=false&strokeWeight=-1&strokeColor=%23ff0000&customClasses=1.1011%2C22.518%2C%23000000%3B22.518%2C48.445%2C%23240000%3B48.445%2C81.193%2C%23490000%3B81.193%2C118.905%2C%236D0000%3B118.905%2C168.246%2C%23920000%3B168.246%2C232.83%2C%23B60000%3B232.83%2C338.04%2C%23DB0000%3B338.04%2C16597.660000000003%2C%23FF0000&fullSLD=true";
+            URL legacyUrl = (URL) legacyParser.parse(validUrl);
+            assertEquals(legacyUrl.toExternalForm(), URLKvpParser.fixURL(validUrl));
+        } catch (Exception e) {
+            fail();
+        } finally {
+            System.setProperty("org.geoserver.kvp.urlfix", "false");
+        }
+    }
 }


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
