### PR TITLE
[GEOS-6467] UI bug in disabling tile caching for layers

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/LayerEditCacheOptionsTabPanelInfo.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/LayerEditCacheOptionsTabPanelInfo.java
@@ -41,8 +41,7 @@ public class LayerEditCacheOptionsTabPanelInfo extends CommonPublishedEditTabPan
             GeoServerTileLayerInfo info = ((GeoServerTileLayer) tileLayer).getInfo();
             tileLayerInfo = info.clone();
         }
-
-        tileLayerInfo.setEnabled(true);
+        if (isNew) tileLayerInfo.setEnabled(true);
         final boolean initWithTileLayer =
                 (isNew && defaultSettings.isCacheLayersByDefault()) || tileLayer != null;
 

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerEditCacheOptionsTabPanelInfoTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerEditCacheOptionsTabPanelInfoTest.java
@@ -96,4 +96,27 @@ public class LayerEditCacheOptionsTabPanelInfoTest {
         ownModel = panelInfo.createOwnModel(layerModel, isNew);
         assertEquals(expected, ownModel.getObject());
     }
+
+    @Test
+    public void testCreateOwnModelExistingWithEnabledFalse() {
+
+        // test that if a layer is existing and has enable caching set to false
+        // enable value is not replaced with true
+        final boolean isNew = false;
+
+        IModel<GeoServerTileLayerInfo> ownModel;
+        ownModel = panelInfo.createOwnModel(layerModel, isNew);
+        assertNotNull(ownModel);
+        GeoServerTileLayerInfo expected = TileLayerInfoUtil.loadOrCreate(layer, defaults);
+        assertEquals(expected, ownModel.getObject());
+
+        GeoServerTileLayer tileLayer = mock(GeoServerTileLayer.class);
+        expected = new GeoServerTileLayerInfoImpl();
+        expected.setEnabled(false);
+        when(tileLayer.getInfo()).thenReturn(expected);
+        when(gwc.getTileLayer(same(layer))).thenReturn(tileLayer);
+
+        ownModel = panelInfo.createOwnModel(layerModel, isNew);
+        assertEquals(expected, ownModel.getObject());
+    }
 }


### PR DESCRIPTION
Jira ticket https://osgeo-org.atlassian.net/browse/GEOS-6467

This pr fixes a bug caused by wicket model creation overriding caching enable parameter with true, everytime layer configuration page is accesed.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
