### PR TITLE
[2.17.x backport][GEOS-9482] Nearest Match NPE if source database table is empty

### DIFF
--- a/src/main/src/main/java/org/geoserver/util/NearestMatchFinder.java
+++ b/src/main/src/main/java/org/geoserver/util/NearestMatchFinder.java
@@ -166,6 +166,7 @@ public abstract class NearestMatchFinder {
      *     HTTP warning head)
      */
     public Object getNearest(Object value) throws IOException {
+        if (value == null) return null;
         // simple point vs point comparison?
         if (endAttribute == null
                 && (!(value instanceof Range)

--- a/src/wms/src/test/resources/org/geoserver/wms/dimension/TimeElevationTruncated.properties
+++ b/src/wms/src/test/resources/org/geoserver/wms/dimension/TimeElevationTruncated.properties
@@ -1,0 +1,1 @@
+_=geom:Polygon:srid=4326,time:java.sql.Date,elevation:double,referenceTime:java.sql.Date,scanningAngle:double


### PR DESCRIPTION
This PR introduces a fix for a NullPointerException got when using Nearest Match on time dimension.

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9482

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
