### PR TITLE
[GEOS-9667] GDAL Store memory management

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/RasterCleaner.java
+++ b/src/wms/src/main/java/org/geoserver/wms/RasterCleaner.java
@@ -10,6 +10,7 @@ import java.awt.image.RenderedImage;
 import java.util.ArrayList;
 import java.util.List;
 import javax.media.jai.PlanarImage;
+import javax.media.jai.RenderedImageAdapter;
 import javax.media.jai.RenderedImageList;
 import org.geoserver.ows.AbstractDispatcherCallback;
 import org.geoserver.ows.Request;
@@ -62,6 +63,10 @@ public class RasterCleaner extends AbstractDispatcherCallback {
         if (list != null) {
             images.remove();
             for (RenderedImage image : list) {
+                if (image instanceof RenderedImageAdapter) {
+                    image = ((RenderedImageAdapter) image).getWrappedImage();
+                }
+
                 if (image instanceof RenderedImageTimeDecorator)
                     image = ((RenderedImageTimeDecorator) image).getDelegate();
 

--- a/src/wms/src/test/java/org/geoserver/wms/map/MetaTileOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/MetaTileOutputFormatTest.java
@@ -5,6 +5,7 @@
 package org.geoserver.wms.map;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.awt.Point;
 import java.awt.geom.Point2D;
@@ -14,8 +15,12 @@ import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
+import java.awt.image.renderable.ParameterBlock;
+import javax.imageio.ImageReader;
 import javax.media.jai.Interpolation;
 import javax.media.jai.PlanarImage;
+import javax.media.jai.RenderedImageAdapter;
+import javax.media.jai.RenderedOp;
 import javax.media.jai.TiledImage;
 import org.geoserver.wms.RasterCleaner;
 import org.geoserver.wms.map.QuickTileCache.MapKey;
@@ -72,5 +77,27 @@ public class MetaTileOutputFormatTest {
         // java.lang.ClassCastException: java.awt.image.Raster cannot be cast to
         // java.awt.image.WritableRaster
         MetatileMapOutputFormat.split(key, source);
+    }
+
+    @Test
+    public void testReaderDisposeIsCalledForRenderedImageAdapter() {
+        Object reader = mock(ImageReader.class);
+
+        ParameterBlock parameterBlock = new ParameterBlock();
+        parameterBlock.add(reader);
+
+        RenderedOp image = mock(RenderedOp.class);
+        when(image.getParameterBlock()).thenReturn(parameterBlock);
+
+        RenderedImageTimeDecorator metaTile = mock(RenderedImageTimeDecorator.class);
+        when(metaTile.getDelegate()).thenReturn(image);
+
+        RenderedImageAdapter metaTileWrapped = mock(RenderedImageAdapter.class);
+        when(metaTileWrapped.getWrappedImage()).thenReturn(metaTile);
+
+        RasterCleaner.addImage((RenderedImage) (PlanarImage) metaTileWrapped);
+        cleaner.finished(null);
+
+        verify((ImageReader) reader, times(1)).dispose();
     }
 }

--- a/src/wms/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/wms/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Fixes a memory issue when a `RenderedImageAdapter` image (output of `PlanarImage.wrapRenderedImage(metaTile)`) is added to the `RasterCleaner`. This results in the image reader `dispose()` method not being called in `ImageUtils` since the image will not be of type `RenderedOp`. A conditional has been added to extract the `RenderedImageTimeDecorator` from the wrapped image.

 A unit test has been added which shows that the reader is not being disposed when `RasterCleaner` is used with a `RenderedImageAdapter`.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
