### PR TITLE
[GEOS-9684] Geowebcache layer preview memory issue

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerMetaTile.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerMetaTile.java
@@ -23,6 +23,7 @@ import org.geoserver.wms.WebMap;
 import org.geoserver.wms.map.RawMap;
 import org.geoserver.wms.map.RenderedImageMap;
 import org.geoserver.wms.map.RenderedImageMapResponse;
+import org.geoserver.wms.map.RenderedImageTimeDecorator;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.image.ImageWorker;
 import org.geotools.metadata.i18n.ErrorKeys;
@@ -238,6 +239,11 @@ public class GeoServerMetaTile extends MetaTile {
             metaTileMap.dispose();
             metaTileMap = null;
         }
+
+        if (metaTileImage instanceof RenderedImageTimeDecorator) {
+            metaTileImage = ((RenderedImageTimeDecorator) metaTileImage).getDelegate();
+        }
+
         super.dispose();
     }
 }


### PR DESCRIPTION
Fixes very similar memory issue to https://osgeo-org.atlassian.net/browse/GEOS-9667 occuring when previewing a layer using geowebcache. 

This issue originates from the gs-gwc package, where the metatile `ImageReader` is not being disposed and `InputStream` is not being closed when of type `RenderedImageTimeDecorator`.  

Code has been added to `GeoServerMetaTile` to check if the `metaTileImage` is of type `RenderedImageTimeDecorator`. If it is, it sets `metaTileImage` to the delegate `RenderedOp` image. Two unit tests have been added to test firstly if the reader is disposed and secondly if the input stream is closed. 

Another patch is also needed in geowebcache to add the reader `dispose()` call as part of the `Metatile` disposal method. See https://github.com/GeoWebCache/geowebcache/pull/869. Without this patch, it is expected that the test `testReaderDisposeCalledOnMetaTileImage` will fail within `GeoServerTileLayerTest`.

See https://osgeo-org.atlassian.net/browse/GEOS-9684

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
