### PR TITLE
[2.17.x backport][GEOS-9680] WMTS othersSrs always add EPSG:4326 and shows wrong CRS c…

### DIFF
--- a/src/main/src/main/java/org/vfny/geoserver/util/DataStoreUtils.java
+++ b/src/main/src/main/java/org/vfny/geoserver/util/DataStoreUtils.java
@@ -269,9 +269,9 @@ public abstract class DataStoreUtils {
     // A utility method for retreiving supported SRS on WFS-NG resource
     public static List<String> getOtherSRSFromWfsNg(FeatureTypeInfo resourceInfo) {
         // do nothing when
-        if (resourceInfo.getStore().getType() == null) return Collections.EMPTY_LIST;
+        if (resourceInfo.getStore().getType() == null) return Collections.emptyList();
         else if (!resourceInfo.getStore().getType().equalsIgnoreCase("Web Feature Server (NG)"))
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         try {
             // featureType.
             FeatureTypeInfo featureType = resourceInfo;
@@ -292,7 +292,7 @@ public abstract class DataStoreUtils {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
 
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     // A utility method for retreiving supported SRS on WMSLayerInfo resource
@@ -304,7 +304,7 @@ public abstract class DataStoreUtils {
             Set<String> supportedSRS = wmsLayer.getSrs();
             // check if there are additional srs available
             // if not return an empty list for legacy behavior
-            if (supportedSRS.size() == 1) return Collections.EMPTY_LIST;
+            if (supportedSRS.size() == 1) return Collections.emptyList();
             // int index="EPSG:".length();
             List<String> otherSRS = supportedSRS.stream().collect(Collectors.toList());
             return otherSRS;
@@ -315,21 +315,18 @@ public abstract class DataStoreUtils {
                     e);
         }
         // default to legacy behavior on failure
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     // A utility method for retreiving supported SRS on WMTSLayerInfo resource
     public static List<String> getOtherSRSFromWMTSStore(WMTSLayerInfo wmtsLayerInfo) {
+        List<String> otherSRS = Collections.emptyList();
         try {
-
             Layer wmtsLayer = wmtsLayerInfo.getWMTSLayer(new NullProgressListener());
-
             Set<String> supportedSRS = wmtsLayer.getSrs();
-            // check if there are additional srs available
-            // if not return an empty list for legacy behavior
-            if (supportedSRS.size() == 1) return Collections.EMPTY_LIST;
-            List<String> otherSRS = supportedSRS.stream().collect(Collectors.toList());
-            return otherSRS;
+            // do we have additional srs?
+            if (!(supportedSRS.size() == 1))
+                otherSRS = supportedSRS.stream().collect(Collectors.toList());
         } catch (IOException e) {
             LOGGER.log(
                     Level.SEVERE,
@@ -337,6 +334,7 @@ public abstract class DataStoreUtils {
                             + wmtsLayerInfo.getNativeName(),
                     e);
         }
-        return Collections.EMPTY_LIST;
+
+        return otherSRS;
     }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/SRSProvider.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/SRSProvider.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.ReferencingFactoryFinder;
 import org.geotools.util.factory.Hints;
@@ -149,9 +148,14 @@ public class SRSProvider extends GeoServerDataProvider<SRSProvider.SRS> {
 
     // a constructor to pass custom list of SRS list
     public SRSProvider(List<String> srsList) {
-        int index = "EPSG:".length();
-        List<SRS> otherSRS =
-                srsList.stream().map(s -> new SRS(s.substring(index))).collect(Collectors.toList());
+        String epsg = "EPSG:";
+        List<SRS> otherSRS = new ArrayList<>();
+        for (String srs : srsList) {
+
+            if (srs.startsWith(epsg)) srs = srs.substring(epsg.length());
+
+            otherSRS.add(new SRS(srs));
+        }
         this.items = otherSRS;
     }
 

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
@@ -40,6 +40,7 @@ import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.repeater.data.DataView;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.catalog.*;
 import org.geoserver.catalog.impl.DataStoreInfoImpl;
@@ -489,7 +490,6 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
         storeInfo.setDateCreated(new Date());
         storeInfo.setDateModified(new Date());
         catalog.add(storeInfo);
-
         XStreamPersister xp = new XStreamPersisterFactory().createXMLPersister();
         WMTSLayerInfo wmtsInfo =
                 xp.load(getClass().getResourceAsStream("/wmtsLayerInfo.xml"), WMTSLayerInfo.class);
@@ -520,5 +520,69 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
                                 "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:srs")
                         .getDefaultModelObjectAsString();
         assertFalse(newNativeSRS.equalsIgnoreCase(actualNativeSRS));
+    }
+
+    @Test
+    public void testWMTSOtherCRSUrnFormat() throws IOException {
+        // SRSProvider constructor removes EPSG: from identifier
+        // to display only the code in otherSRS list. This test
+        // checks that CRS identified through urn format are properly
+        // displayed as well.
+        String baseURL = TestHttpClientProvider.MOCKSERVER;
+        MockHttpClient client = new MockHttpClient();
+        Catalog catalog = getCatalog();
+        URL descURL = new URL(baseURL + "/wmts?REQUEST=GetCapabilities&VERSION=1.0.0&SERVICE=WMTS");
+        client.expectGet(
+                descURL,
+                new MockHttpResponse(getClass().getResource("/wmts_getCaps.xml"), "text/xml"));
+
+        TestHttpClientProvider.bind(client, descURL);
+        WMTSStoreInfo storeInfo = new WMTSStoreInfoImpl(getCatalog());
+        storeInfo.setName("Another Mock WMTS Store");
+        storeInfo.setCapabilitiesURL(descURL.toString());
+        storeInfo.setConnectTimeout(60);
+        storeInfo.setMaxConnections(10);
+        storeInfo.setDateCreated(new Date());
+        storeInfo.setDateModified(new Date());
+        catalog.add(storeInfo);
+        CatalogBuilder builder = new CatalogBuilder(catalog);
+        builder.setStore(storeInfo);
+        WMTSLayerInfo wmtsLayerInfo = builder.buildWMTSLayer("bmapgrau");
+        LayerInfo layerInfo = builder.buildLayer(wmtsLayerInfo);
+
+        // page should show additional SRS in WMTS cap document
+        login();
+        tester.startPage(new ResourceConfigurationPage(layerInfo, true));
+        // click the FIND button next to open SRS selection popup
+        tester.clickLink(
+                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:find");
+
+        // verify Layer`s resource is updated with metadata
+        assertNotNull(layerInfo.getResource().getMetadata().get(FeatureTypeInfo.OTHER_SRS));
+
+        DataView epsgContainer =
+                (DataView)
+                        tester.getComponentFromLastRenderedPage(
+                                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items");
+
+        // we got two epsg in the otherSrs container
+        assertEquals(3, epsgContainer.size());
+
+        Component epsgComponent1 =
+                tester.getComponentFromLastRenderedPage(
+                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link:label");
+        Component epsgComponent2 =
+                tester.getComponentFromLastRenderedPage(
+                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:2:itemProperties:0:component:link:label");
+
+        Component epsgComponent3 =
+                tester.getComponentFromLastRenderedPage(
+                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:3:itemProperties:0:component:link:label");
+
+        // checks that they have been properly displayed with not urn format being cut
+
+        assertEquals("3857", epsgComponent1.getDefaultModel().getObject());
+        assertEquals("urn:ogc:def:crs:EPSG::900913", epsgComponent2.getDefaultModel().getObject());
+        assertEquals("urn:ogc:def:crs:EPSG::3857", epsgComponent3.getDefaultModel().getObject());
     }
 }


### PR DESCRIPTION
…ode (#4385)

* [GEOS-9680] WMTS othersSrs always add EPSG:4326 and shows wrong CRS code

* reviewer's suggestion applied

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
