### PR TITLE
GEOS-9425 fix the bug: sync the style inside existing workspaces, the slave will cannot see the sld file.

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogStylesFileHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogStylesFileHandler.java
@@ -46,7 +46,7 @@ public class JMSCatalogStylesFileHandler extends DocumentFileHandler {
 
                 if (!Resources.exists(file)) {
                     final String styleAbsolutePath = event.getResourcePath();
-                    if (styleAbsolutePath.indexOf("workspaces") > 0) {
+                    if (styleAbsolutePath.contains("workspaces")) {
                         file =
                                 loader.get(
                                         styleAbsolutePath.substring(


### PR DESCRIPTION
During my debug, I found loader (an object of GeoServerResourceLoader) will return the relative path when the style inside existing workspaces, and will start with workspaces. This will result in styleAbsolutePath.indexOf("workspaces")==0, but the code on line 5 will ignore this situation. So that, the result is when sync the style inside existing workspaces, the sld file will be synced to the root directory of styles. Eventually it will cause that the slave cannot see the sld file.