### PR TITLE
[GEOS-9696] Add documentation regarding JsonPointerFunction support

### DIFF
--- a/doc/en/user/source/data/database/postgis.rst
+++ b/doc/en/user/source/data/database/postgis.rst
@@ -248,18 +248,18 @@ To insert multi-line text (for use with labeling) remember to use escaped text::
 JsonPointer Function support
 ----------------------------
 
-GeoServer is able to translate a jsonPointer function to a query using PostgreSQL support for JSON types. 
+GeoServer is able to translate the ``jsonPointer`` function to a query using PostgreSQL support for JSON types. 
 The following are the main characteristics of the implementation:
 
-* the jsonPointer function syntax is like the following: ``jsonPointer(attributeName,'/path/to/json/attribute')``;
+* The jsonPointer function syntax is like the following: ``jsonPointer(attributeName,'/path/to/json/attribute')``.
 
-* the function is able to select attributes inside json arrays by specifying the index of the target element in the json path eg. ``'/path/to/array/element/0'``;
+* The function is able to select attributes inside json arrays by specifying the index of the target element in the json path eg. ``'/path/to/array/element/0'``.
 
-* when accessing a JSON property it is implicitly assumed that the same property will have the same type on all features, otherwise a cast exception will be thrown by the database;
+* When accessing a JSON property it is implicitly assumed that the same property will have the same type on all features, otherwise a cast exception will be thrown by the database.
 
-* GeoServer will perform a cast automatically to the expect type from the evaluation; the cast is completely delegated to the database;
+* GeoServer will perform a cast automatically to the expect type from the evaluation; the cast is completely delegated to the database.
 
-* if the property doesn't exists no errors will be issued, but the features that have that property will be excluded; hence the property we whish to query is not mandatory in all features
+* If the property doesn't exists no errors will be issued, but the features that have that property will be excluded; hence the property we whish to query is not mandatory in all features.
 
 Examples
 ````````
@@ -288,9 +288,9 @@ Having a json column storing jsonvalues like the following,
 
 and assuming an attribute name as ``city``, valid jsonPointer functions would be: 
 
-* ``jsonPointer(city, '/name')``, 
+* ``jsonPointer(city, '/name')``.
 
-* ``jsonPointer(city, '/population/average_age')``, 
+* ``jsonPointer(city, '/population/average_age')``.
 
 * ``jsonPointer(city, '/districts/0/name')``.
 
@@ -330,12 +330,12 @@ DataTypes
 
 PostgreSQL defines two JSON datatypes: 
 
- * ``json`` that stores an exact copy of the input text;
+ * ``json`` that stores an exact copy of the input text.
 
  * ``jsonb`` which store the value in a decomposed binary format.
 
 The jsonPointer function supports both, as well as the text format if it contains a valid json representation. 
-Anyway it is worth mentioning that, according to the PostgreSQL documentation, jsonb is the recommended type to be used since it is faster to process. 
+Anyways, the PostgreSQL documentation recommends usage of jsonb, as it is faster to process. 
 
 PostgreSQL supports also indexing on json types. And index on a specific json attribute can be created as follow:
 

--- a/doc/en/user/source/data/database/postgis.rst
+++ b/doc/en/user/source/data/database/postgis.rst
@@ -245,4 +245,106 @@ To insert multi-line text (for use with labeling) remember to use escaped text::
    INSERT INTO place VALUES (ST_GeomFromText('POINT(-71.060316 48.432044)', 4326), E'Westfield\nTower');
 
 
+JsonPointer Function support
+----------------------------
+
+GeoServer is able to translate a jsonPointer function to a query using PostgreSQL support for JSON types. 
+The following are the main characteristics of the implementation:
+
+* the jsonPointer function syntax is like the following: ``jsonPointer(attributeName,'/path/to/json/attribute')``;
+
+* the function is able to select attributes inside json arrays by specifying the index of the target element in the json path eg. ``'/path/to/array/element/0'``;
+
+* when accessing a JSON property it is implicitly assumed that the same property will have the same type on all features, otherwise a cast exception will be thrown by the database;
+
+* GeoServer will perform a cast automatically to the expect type from the evaluation; the cast is completely delegated to the database;
+
+* if the property doesn't exists no errors will be issued, but the features that have that property will be excluded; hence the property we whish to query is not mandatory in all features
+
+Examples
+````````
+
+Having a json column storing jsonvalues like the following,
+
+.. code-block :: json
+
+  { "name": "city name", 
+    "description": "the city description",
+    "districts": [
+      {
+       "name":"district1",
+       "population": 2000
+      },
+      {
+       "name":"district2",
+       "population": 5000
+      }
+    ]
+    "population":{
+      "average_age": 35,
+      "toal": 50000 
+    }
+  }
+
+and assuming an attribute name as ``city``, valid jsonPointer functions would be: 
+
+* ``jsonPointer(city, '/name')``, 
+
+* ``jsonPointer(city, '/population/average_age')``, 
+
+* ``jsonPointer(city, '/districts/0/name')``.
+
+An example cql_filter would then be ``jsonPointer(city, '/population/average_age') > 30``.
+
+While an example rule in a sld style sheet could be:
+
+.. code-block:: xml 
+
+   <Rule>
+     <Name>Cities</Name>
+        <ogc:Filter>
+          <ogc:PropertyIsEqualTo>
+            <ogc:Function name="jsonPointer">
+              <ogc:PropertyName>city</ogc:PropertyName>
+              <ogc:Literal>/population/average_age</ogc:Literal>
+            </ogc:Function>
+            <ogc:Literal>35</ogc:Literal>
+          </ogc:PropertyIsEqualTo>
+          </ogc:Filter>          
+        <PointSymbolizer>
+          <Graphic>
+            <Mark>
+              <WellKnownName>square</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+            </Mark>
+            <Size>16</Size>
+          </Graphic>
+       </PointSymbolizer>
+    </Rule>
+
+
+DataTypes
+`````````
+
+PostgreSQL defines two JSON datatypes: 
+
+ * ``json`` that stores an exact copy of the input text;
+
+ * ``jsonb`` which store the value in a decomposed binary format.
+
+The jsonPointer function supports both, as well as the text format if it contains a valid json representation. 
+Anyway it is worth mentioning that, according to the PostgreSQL documentation, jsonb is the recommended type to be used since it is faster to process. 
+
+PostgreSQL supports also indexing on json types. And index on a specific json attribute can be created as follow:
+
+``CREATE INDEX description_index ON table_name 
+((column_name -> path -> to ->> json_attribute ))``.
+
+Index can also be specified in partial way:
+
+``CREATE INDEX description_index ON table_name
+((column_name -> path -> to ->> json_attribute )) 
+WHERE (column_name -> path -> to ->> json_attribute) IS NOT NULL``.
 


### PR DESCRIPTION
Adds documentation regarding jsonPointer function encoding to postgreSQL query.

Jira ticket https://osgeo-org.atlassian.net/browse/GEOS-9696

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
