### PR TITLE
Fix invalid cast to LayerInfoImpl

### DIFF
--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportTaskController.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportTaskController.java
@@ -519,12 +519,12 @@ public class ImportTaskController extends ImportBaseController {
         l.setResource(resource);
         // @hack workaround OWSUtils bug - trying to copy null collections
         // why these are null in the first place is a different question
-        LayerInfoImpl impl = (LayerInfoImpl) orig.getLayer();
-        if (impl.getAuthorityURLs() == null) {
-            impl.setAuthorityURLs(new ArrayList(1));
+        LayerInfo layerInfo = orig.getLayer();
+        if (layerInfo.getAuthorityURLs() == null) {
+            layerInfo.setAuthorityURLs(new ArrayList(1));
         }
-        if (impl.getIdentifiers() == null) {
-            impl.setIdentifiers(new ArrayList(1));
+        if (layerInfo.getIdentifiers() == null) {
+            layerInfo.setIdentifiers(new ArrayList(1));
         }
         // @endhack
         cb.updateLayer(orig.getLayer(), l);


### PR DESCRIPTION
When I try to upload layers to Geonode, I get a 500 response with this stack trace https://pastebin.com/yiLbJFTp

It's caused by a failed request from Geonode to Geoserver which gives us this error:

org.geoserver.security.decorators.SecuredLayerInfo cannot be cast to org.geoserver.catalog.impl.LayerInfoImpl

The full stack trace from the Geoserver log is in here https://pastebin.com/mq5BWFaf

I think this is because I reconfigured Geonode to use HTTPS. Maybe there's a deeper issue here but, just by looking at the hierarchy of superclasses/interfaces, it seems like no cast is needed here, we should just treat the object.

I'm having trouble building a WAR that contains all the plugins needed in my production environment, so I can't test this in the environment where I'm running into the issue. Would someone else be able to test passing a SecuredLayerInfo as `orig` here? Thanks

https://osgeo-org.atlassian.net/browse/GEO-283

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
