### PR TITLE
[GEOS-9703] Add support for StandardDeviation classification for vector data in SldService module [GEOS-9709] SldService, add an endpoint that returns supported classification methods

### DIFF
--- a/doc/en/user/source/extensions/sldservice/index.rst
+++ b/doc/en/user/source/extensions/sldservice/index.rst
@@ -110,7 +110,7 @@ Classify Raster and Vector Data
 
 The service can be used to create a set of SLD rules for the given vector
 layer, specifying the **attribute** used for classification, the  **classification 
-type** (equalInterval, uniqueInterval, quantile, jenks, equalArea) and one of the
+type** (equalInterval, uniqueInterval, quantile, jenks, equalArea, standardDeviation) and one of the
 **predefined color ranges** (red, blue, gray, jet, random, custom), together
 with some other optional parameters.
 
@@ -139,7 +139,7 @@ The parameters usable to customize the ColorMap are:
      - No default for vectors, "1" for rasters
    * - method
      - Classification method
-     - equalInterval, uniqueInterval, quantile, jenks, equalArea
+     - equalInterval, uniqueInterval, quantile, jenks, equalArea, standardDeviation (intervals above and below the mean of one standard deviation, available for vectors only)
      - equalInterval
    * - open
      - open or closed ranges

--- a/doc/en/user/source/extensions/sldservice/index.rst
+++ b/doc/en/user/source/extensions/sldservice/index.rst
@@ -634,3 +634,72 @@ A CUSTOM color ramp with 5 classes, with colors ranging from RED (0xFF0000) to B
         </sld:NamedLayer>
     </sld:StyledLayerDescriptor>
  
+
+Capabilities
+------------
+``/capabilities[.<format>]``
+
+.. list-table::
+   :header-rows: 1
+
+   * - Method
+     - Action
+     - Status code
+     - Formats
+     - Default Format
+   * - GET
+     - Returns the supported classification's methods for rasters and vectors
+     - 200
+     - JSON, XML
+     - JSON
+
+The service can be used to retrieve the capabilities of the SldService plugin. At the time of writing the endoint
+will simply return a list of supported classification's methods for both raster and vector data. It can be usefull i.e. for clients who might be dealing with different GeoServer versions to know which classification methods is available to be used.
+Follow the service's outputs in json and xml format:
+
+.. code-block:: json
+
+    {
+    "capabilities": {
+        "vector": {
+            "classifications": [
+                "quantile",
+                "jenks",
+                "equalArea",
+                "equalInterval",
+                "uniqueInterval",
+                "standardDeviation"
+            ]
+        },
+        "raster": {
+            "classifications": [
+                "quantile",
+                "jenks",
+                "equalArea",
+                "equalInterval",
+                "uniqueInterval"
+            ]
+        }
+    }
+ }
+
+
+.. code-block:: xml
+
+  <capabilities>
+    <vector>
+        <classifications>quantile</classifications>
+        <classifications>jenks</classifications>
+        <classifications>equalArea</classifications>
+        <classifications>equalInterval</classifications>
+        <classifications>uniqueInterval</classifications>
+        <classifications>standardDeviation</classifications>
+    </vector>
+    <raster>
+        <classifications>quantile</classifications>
+        <classifications>jenks</classifications>
+        <classifications>equalArea</classifications>
+        <classifications>equalInterval</classifications>
+        <classifications>uniqueInterval</classifications>
+    </raster>
+ </capabilities>

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/CapabilitiesController.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/CapabilitiesController.java
@@ -1,0 +1,90 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.sldservice.rest;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.converters.XStreamMessageConverter;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** CapabilitiesController. */
+@RestController
+@ControllerAdvice
+@RequestMapping(path = RestBaseController.ROOT_PATH + "/sldservice")
+public class CapabilitiesController extends BaseSLDServiceController {
+
+    public CapabilitiesController(Catalog catalog) {
+        super(catalog);
+    }
+
+    @GetMapping(
+        path = "/capabilities",
+        produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE}
+    )
+    public Object classificationCapabilities() {
+        return wrapObject(new SldServiceCapabilities(), SldServiceCapabilities.class);
+    }
+
+    @Override
+    public void configurePersister(XStreamPersister persister, XStreamMessageConverter converter) {
+        XStream xstream = persister.getXStream();
+        xstream.alias("capabilities", SldServiceCapabilities.class);
+        xstream.registerConverter(new CapabilitiesConverter());
+        xstream.allowTypes(new Class[] {SldServiceCapabilities.class});
+    }
+
+    class CapabilitiesConverter implements Converter {
+
+        @Override
+        public void marshal(
+                Object o,
+                HierarchicalStreamWriter hierarchicalStreamWriter,
+                MarshallingContext marshallingContext) {
+            SldServiceCapabilities caps = (SldServiceCapabilities) o;
+            List<String> vectorMethods = caps.getVectorClassifications();
+            hierarchicalStreamWriter.startNode("vector");
+            encodeMethods(vectorMethods, hierarchicalStreamWriter);
+            hierarchicalStreamWriter.endNode();
+            List<String> rasterMethods = caps.getRasterClassifications();
+            hierarchicalStreamWriter.startNode("raster");
+
+            encodeMethods(rasterMethods, hierarchicalStreamWriter);
+            hierarchicalStreamWriter.endNode();
+        }
+
+        private void encodeMethods(List<String> methods, HierarchicalStreamWriter writer) {
+            for (String method : methods) {
+                writer.startNode("classifications");
+                writer.setValue(method);
+                writer.endNode();
+            }
+        }
+
+        @Override
+        public Object unmarshal(
+                HierarchicalStreamReader hierarchicalStreamReader,
+                UnmarshallingContext unmarshallingContext) {
+            return null;
+        }
+
+        @Override
+        public boolean canConvert(Class aClass) {
+            return SldServiceCapabilities.class.isAssignableFrom(aClass);
+        }
+    }
+}

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ClassifierController.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ClassifierController.java
@@ -625,6 +625,10 @@ public class ClassifierController extends BaseSLDServiceController {
                 rules =
                         builder.equalAreaClassification(
                                 ftCollection, property, propertyType, intervals, open, normalize);
+            } else if ("standardDeviation".equals(method)) {
+                rules =
+                        builder.standardDeviationClassification(
+                                ftCollection, property, propertyType, intervals, open, normalize);
             } else {
                 throw new RestException(
                         "Unknown classification method " + method, HttpStatus.BAD_REQUEST);

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/SldServiceCapabilities.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/SldServiceCapabilities.java
@@ -1,0 +1,36 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.sldservice.rest;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class represents sldService capabilities. At the moment holds only raster and vector
+ * supported classification's methods.
+ */
+class SldServiceCapabilities {
+
+    private final List<String> vectorClassifications =
+            Arrays.asList(
+                    "quantile",
+                    "jenks",
+                    "equalArea",
+                    "equalInterval",
+                    "uniqueInterval",
+                    "standardDeviation");
+
+    private final List<String> rasterClassifications =
+            Arrays.asList("quantile", "jenks", "equalArea", "equalInterval", "uniqueInterval");
+
+    List<String> getVectorClassifications() {
+        return vectorClassifications;
+    }
+
+    List<String> getRasterClassifications() {
+        return rasterClassifications;
+    }
+}

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/utils/classifier/RulesBuilder.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/utils/classifier/RulesBuilder.java
@@ -35,7 +35,7 @@ import org.opengis.filter.expression.PropertyName;
 
 /**
  * Creates a List of Rule using different classification methods Sets up only filter not Symbolyzer
- * Available Classification: Quantile,Unique Interval & Equal Interval
+ * Available Classification: Quantile,Unique Interval, Equal Interval & Standard Deviation
  *
  * @author kappu
  */
@@ -162,6 +162,17 @@ public class RulesBuilder {
             boolean normalize) {
         return getRules(
                 features, property, propertyType, intervals, open, normalize, "EqualInterval");
+    }
+
+    public List<Rule> standardDeviationClassification(
+            FeatureCollection features,
+            String property,
+            Class<?> propertyType,
+            int intervals,
+            boolean open,
+            boolean normalize) {
+        return getRules(
+                features, property, propertyType, intervals, open, normalize, "StandardDeviation");
     }
 
     /**
@@ -346,22 +357,27 @@ public class RulesBuilder {
         try {
             /* First class */
             r = SF.createRule();
-            if (groups.getMin(0).equals(groups.getMax(0))) {
-                f = FF.equals(att, FF.literal(groups.getMin(0)));
-                r.getDescription().setTitle((FF.literal(groups.getMin(0)).toString()));
+            Object min = groups.getMin(0);
+            Object max = groups.getMax(0);
+
+            if (min != null && min.equals(max)) {
+                f = FF.equals(att, FF.literal(min));
+                r.getDescription().setTitle((FF.literal(min).toString()));
             } else {
-                f = FF.less(att, FF.literal(groups.getMax(0)));
-                r.getDescription().setTitle(" < " + FF.literal(groups.getMax(0)));
+                f = FF.less(att, FF.literal(max));
+                r.getDescription().setTitle(" < " + FF.literal(max));
             }
             r.setFilter(f);
             list.add(r);
             percMan.collectRulePercentage(0);
             for (int i = 1; i < groups.getSize() - 1; i++) {
                 r = SF.createRule();
-                if (groups.getMin(i).equals(groups.getMax(i))) {
-                    f = FF.equals(att, FF.literal(groups.getMax(i)));
+                min = groups.getMin(i);
+                max = groups.getMax(i);
+                if (min.equals(max)) {
+                    f = FF.equals(att, FF.literal(max));
                     if (!isDuplicatedClass(list, f, percMan, i)) {
-                        r.getDescription().setTitle((FF.literal(groups.getMin(i)).toString()));
+                        r.getDescription().setTitle((FF.literal(min).toString()));
                         r.setFilter(f);
                         list.add(r);
                         percMan.collectRulePercentage(i);
@@ -370,14 +386,10 @@ public class RulesBuilder {
                     f =
                             FF.and(
                                     getNotOverlappingFilter(i, groups, att),
-                                    FF.less(att, FF.literal(groups.getMax(i))));
+                                    FF.less(att, FF.literal(max)));
                     if (!isDuplicatedClass(list, f, percMan, i)) {
                         r.getDescription()
-                                .setTitle(
-                                        (" >= "
-                                                + FF.literal(groups.getMin(i))
-                                                + " AND < "
-                                                + FF.literal(groups.getMax(i))));
+                                .setTitle((" >= " + FF.literal(min) + " AND < " + FF.literal(max)));
                         r.setFilter(f);
                         list.add(r);
                         percMan.collectRulePercentage(i);
@@ -386,9 +398,15 @@ public class RulesBuilder {
             }
             /* Last class */
             r = SF.createRule();
-            f = getNotOverlappingFilter(groups.getSize() - 1, groups, att);
+            int currentIdx = groups.getSize() - 1;
+            Object currMin = groups.getMin(currentIdx);
+            if (groups.getMax(currentIdx) == null) {
+                f = FF.greaterOrEqual(att, FF.literal(currMin));
+            } else {
+                f = getNotOverlappingFilter(currentIdx, groups, att);
+            }
             r.setFilter(f);
-            r.getDescription().setTitle((" >= " + FF.literal(groups.getMin(groups.getSize() - 1))));
+            r.getDescription().setTitle((" >= " + FF.literal(currMin)));
             list.add(r);
             percMan.collectRulePercentage(groups.getSize() - 1);
             percMan.appendPercentagesToLabels(list);
@@ -425,36 +443,50 @@ public class RulesBuilder {
         percMan = new PercentagesManager(groups.getPercentages());
         try {
             /* First class */
-            r = SF.createRule();
             for (int i = 0; i < groups.getSize(); i++) {
                 r = SF.createRule();
-                if (groups.getMin(i).equals(groups.getMax(i))) {
-                    f = FF.equals(att, FF.literal(groups.getMin(i)));
-                    if (!isDuplicatedClass(list, f, percMan, i)) {
-                        r.getDescription().setTitle((FF.literal(groups.getMin(i)).toString()));
-                        r.setFilter(f);
-                        list.add(r);
-                        percMan.collectRulePercentage(i);
+                Object min = groups.getMin(i);
+                Object max = groups.getMax(i);
+                boolean isDuplicated = false;
+
+                // stddev classification return null min for the first breaks since
+                // and null max for the last breaks since the computation add only 1 stddev below
+                // or above the mean till the number of requested class is reached,
+                // without knowing the min or max value.
+                if (min == null) {
+                    f = FF.less(att, FF.literal(max));
+                    r.getDescription().setTitle(" < " + FF.literal(max));
+                } else if (max == null) {
+                    f = FF.greaterOrEqual(att, FF.literal(min));
+                    r.getDescription().setTitle(" >= " + FF.literal(min));
+                } else if (min.equals(max)) {
+                    f = FF.equals(att, FF.literal(min));
+                    isDuplicated = isDuplicatedClass(list, f, percMan, i);
+                    if (!isDuplicated) {
+                        r.getDescription().setTitle((FF.literal(min).toString()));
                     }
                 } else {
                     f =
                             FF.and(
                                     getNotOverlappingFilter(i, groups, att),
                                     i == (groups.getSize() - 1)
-                                            ? FF.lessOrEqual(att, FF.literal(groups.getMax(i)))
-                                            : FF.less(att, FF.literal(groups.getMax(i))));
-                    if (!isDuplicatedClass(list, f, percMan, i)) {
+                                            ? FF.lessOrEqual(att, FF.literal(max))
+                                            : FF.less(att, FF.literal(max)));
+                    isDuplicated = isDuplicatedClass(list, f, percMan, i);
+                    if (!isDuplicated) {
                         r.getDescription()
                                 .setTitle(
                                         (" >= "
-                                                + FF.literal(groups.getMin(i))
+                                                + FF.literal(min)
                                                 + " AND "
                                                 + (i == (groups.getSize() - 1) ? "<=" : "<")
-                                                + FF.literal(groups.getMax(i))));
-                        r.setFilter(f);
-                        list.add(r);
-                        percMan.collectRulePercentage(i);
+                                                + FF.literal(max)));
                     }
+                }
+                if (!isDuplicated) {
+                    r.setFilter(f);
+                    list.add(r);
+                    percMan.collectRulePercentage(i);
                 }
             }
             percMan.appendPercentagesToLabels(list);
@@ -590,14 +622,14 @@ public class RulesBuilder {
     private Filter getNotOverlappingFilter(
             int currentIdx, RangedClassifier groups, Expression att) {
         Filter f;
+        Object currMin = groups.getMin(currentIdx);
         if (currentIdx > 0) {
-            Object currMin = groups.getMin(currentIdx);
             Object prevMin = groups.getMin(currentIdx - 1);
-            if (!prevMin.equals(currMin))
-                f = FF.greaterOrEqual(att, FF.literal(groups.getMin(currentIdx)));
-            else f = FF.greater(att, FF.literal(groups.getMin(currentIdx)));
+            if (prevMin == null || !prevMin.equals(currMin))
+                f = FF.greaterOrEqual(att, FF.literal(currMin));
+            else f = FF.greater(att, FF.literal(currMin));
         } else {
-            f = FF.greaterOrEqual(att, FF.literal(groups.getMin(currentIdx)));
+            f = FF.greaterOrEqual(att, FF.literal(currMin));
         }
 
         return f;

--- a/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/CapabilitiesTest.java
+++ b/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/CapabilitiesTest.java
@@ -1,0 +1,48 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.sldservice.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.geoserver.rest.RestBaseController;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class CapabilitiesTest extends SLDServiceBaseTest {
+
+    @Test
+    public void testClassifyForFeatureDefault() throws Exception {
+        final String restPath =
+                RestBaseController.ROOT_PATH + "/sldservice/" + getServiceUrl() + ".json";
+        MockHttpServletResponse response = getAsServletResponse(restPath);
+        assertTrue(response.getStatus() == 200);
+        JSONObject json = (JSONObject) getAsJSON(restPath, 200);
+        JSONObject vector = json.getJSONObject("capabilities").getJSONObject("vector");
+        JSONObject raster = json.getJSONObject("capabilities").getJSONObject("raster");
+        JSONArray vClassifications = vector.getJSONArray("classifications");
+        JSONArray rClassifications = raster.getJSONArray("classifications");
+        SldServiceCapabilities capabilities = new SldServiceCapabilities();
+        for (int i = 0; i < vClassifications.size(); i++) {
+            assertTrue(
+                    capabilities
+                            .getVectorClassifications()
+                            .contains(vClassifications.getString(i)));
+        }
+
+        for (int i = 0; i < rClassifications.size(); i++) {
+            assertTrue(
+                    capabilities
+                            .getRasterClassifications()
+                            .contains(vClassifications.getString(i)));
+        }
+    }
+
+    @Override
+    protected String getServiceUrl() {
+        return "capabilities";
+    }
+}


### PR DESCRIPTION
Jira tickets:
 https://osgeo-org.atlassian.net/browse/GEOS-9703
 https://osgeo-org.atlassian.net/browse/GEOS-9709


This pull request add standardDeviation classification support in the sldService module and an endpoint to retrieve supported classification's methods for raster and vector.

blocked by https://github.com/geotools/geotools/pull/3078.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
