### PR TITLE
a script that replaces the tile size (or other parameter) on all the layers of a selected workspace

### DIFF
--- a/src/community/script/py/src/misc/xml_values_replacer.py
+++ b/src/community/script/py/src/misc/xml_values_replacer.py
@@ -1,0 +1,87 @@
+# (c) 2020 Open Source Geospatial Foundation - all rights reserved
+# This code is licensed under the GPL 2.0 license, available at the root application directory.
+# Written by Idan Miara <idan@miara.com>
+'''
+This script replaces the tile size (or other parameter) on all the layers of a selected workspace
+usage: set data_dir path and workspace name at the bottom line, run.the script and restart geoserver
+'''
+
+import os
+from pathlib import Path
+import re
+
+def change_pattern_in_file(filename, key, pattern, new_value, make_backup=True):
+    # I could use proper read/write xml, but it seems like an overkill for this task
+    print(filename)
+    filename = Path(filename).resolve()
+    if not filename.exists():
+        raise Exception('filename {} does not exist'.format(filename))
+    lines = open(str(filename), "r").readlines()
+    line_i = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == key:
+            line_i = i+1
+            break
+    if line_i:
+        old_line = lines[line_i]
+        new_line = pattern.sub(new_value, old_line)
+        if old_line == new_line:
+            print('pattern was not replaced!')
+            return False
+        lines[line_i] = new_line
+    else:
+        print('key not found')
+        return False
+    if make_backup:
+        backup_name = filename.with_suffix('.bak')
+        if backup_name.exists():
+            print('backup file exists {}'.format(backup_name))
+        else:
+            os.rename(str(filename), str(backup_name))
+    open(str(filename), "w").writelines(lines)
+    return True
+
+
+def change_pattern_glob(root: Path, file_pattern: str, **kwargs):
+    result = 0
+    total = 0
+    for filename in root.glob(file_pattern):
+        total += 1
+        if change_pattern_in_file(filename=filename, **kwargs):
+            result += 1
+    return total, result
+
+
+# <coverage>
+# ...
+#   <parameters>
+# ...
+#     <entry>
+#       <string>SUGGESTED_TILE_SIZE</string>
+#       <string>512,512</string>
+#     </entry>
+# ...
+#   </parameters>
+# ...
+# </coverage>
+
+
+def geoserver_tilesize_change(data_dir, workspace):
+    key = '<string>SUGGESTED_TILE_SIZE</string>'
+    pattern = r'<string>{}</string>'
+    p = re.compile(pattern.format('.*'))
+    # new_value = r'<string>256,256</string>'
+    new_value = pattern.format('256,256')
+    root = Path(data_dir) / 'workspaces' / workspace
+    file_pattern = '**/**/coverage.xml'
+    make_backup = True
+
+    total, success = change_pattern_glob(
+        root=root, file_pattern=file_pattern,
+        key=key, pattern=p, new_value=new_value, make_backup=make_backup)
+    print('files processed {}/{}'.format(success, total))
+
+
+if __name__ == '__main__':
+    geoserver_tilesize_change(data_dir=r'c:\geoserver\data_dir', workspace='my_workspace')


### PR DESCRIPTION
xml_values_replacer.py - This script replaces the tile size (or other parameter) on all the layers of a selected workspace

I wrote it to workaround this bug: https://github.com/CesiumGS/cesium/issues/7994 but I guess it can be used for other purposes.

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
