### PR TITLE
[GEOS-9700] Use EMF and XSD via GeoTools dependencies

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1057,28 +1057,8 @@
     <artifactId>jt-concurrent-tile-cache</artifactId>
     <version>${jaiext.version}</version>
    </dependency>
-   <!-- EMF -->
 
-   <dependency>
-    <groupId>org.eclipse.emf</groupId>
-    <artifactId>org.eclipse.emf.common</artifactId>
-    <version>${eclipse.emf.version}</version>
-   </dependency>
-   <dependency>
-    <groupId>org.eclipse.emf</groupId>
-    <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-    <version>${eclipse.emf.version}</version>
-   </dependency>
-   <dependency>
-    <groupId>org.eclipse.emf</groupId>
-    <artifactId>org.eclipse.emf.ecore</artifactId>
-    <version>${eclipse.emf.version}</version>
-   </dependency>
-   <dependency>
-    <groupId>org.eclipse.emf</groupId>
-    <artifactId>org.eclipse.xsd</artifactId>
-    <version>${eclipse.emf.version}</version>
-   </dependency>
+   <!-- Text -->
    <dependency>
     <groupId>org.freemarker</groupId>
     <artifactId>freemarker</artifactId>


### PR DESCRIPTION
Reverting change so `xsd` is used as a library, simplify to accept transitive dependences from GeoTools `gt-xsd-core` (so we do not have the challenge of keeping these in sync over time resolving the original GEOS-9700 issue).

Modified https://github.com/geoserver/geoserver/pull/4419

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
