### PR TITLE
[2.17.x][GEOS-9545] Web Resource Page fails to load with WicketRuntimeException when a resource contains : or ~ in its name

### DIFF
--- a/src/extension/web-resource/src/main/java/org/geoserver/web/resources/ResourceNode.java
+++ b/src/extension/web-resource/src/main/java/org/geoserver/web/resources/ResourceNode.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.web.resources;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Set;
 import java.util.TreeSet;
 import org.apache.wicket.model.IModel;
@@ -24,9 +26,27 @@ public class ResourceNode implements TreeNode<Resource>, Comparable<ResourceNode
 
     private ResourceExpandedStates expandedStates;
 
+    private String uniqueId;
+
     public ResourceNode(Resource resource, ResourceExpandedStates expandedStates) {
         this.resource = Resources.serializable(resource);
         this.expandedStates = expandedStates;
+        this.uniqueId = getUniqueId(this.resource.path());
+    }
+
+    public static String getUniqueId(String path) {
+        if (path.isEmpty()) {
+            return "/";
+        } else if (!path.contains(":") && !path.contains("~")) {
+            // Helps prevent duplicate Wicket IDs if there is a filename that
+            // is the Base64 encoded path of a file that has to be encoded
+            // without having to unnecessarily encode everything.
+            return "/" + path;
+        }
+        // Base64 encode the file path to replace special characters that are
+        // not allowed in Wicket component IDs.
+        byte[] bytes = path.getBytes(StandardCharsets.UTF_8);
+        return Base64.getUrlEncoder().encodeToString(bytes);
     }
 
     @Override
@@ -78,12 +98,7 @@ public class ResourceNode implements TreeNode<Resource>, Comparable<ResourceNode
 
     @Override
     public String getUniqueId() {
-        String path = resource.path();
-        if (path.isEmpty()) {
-            return "/";
-        } else {
-            return path;
-        }
+        return uniqueId;
     }
 
     @Override

--- a/src/extension/web-resource/src/test/java/org/geoserver/web/resources/PageResourceBrowserTest.java
+++ b/src/extension/web-resource/src/test/java/org/geoserver/web/resources/PageResourceBrowserTest.java
@@ -19,14 +19,17 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.platform.resource.Resources;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.geoserver.web.treeview.TreeNode;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -37,6 +40,8 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
     protected final String PATH_DIR = "temp/dir";
     protected final String PATH_RES = "temp/dir/something";
     protected final String PATH_RES2 = "temp/dir/somethingelse";
+    protected final String DIR_FORBIDDEN_CHARS = "the:~dir";
+    protected final String FILE_FORBIDDEN_CHARS = "the:~file.txt";
     protected final String DATA = "foobar";
     protected final String DATA2 = "barfoo";
 
@@ -50,12 +55,20 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         resourceBrowser = new PageResourceBrowser();
 
-        try (OutputStream os = resourceBrowser.store().get(PATH_RES).out()) {
+        ResourceStore store = resourceBrowser.store();
+        try (OutputStream os = store.get(PATH_RES).out()) {
             os.write(DATA.getBytes());
         }
 
-        try (OutputStream os = resourceBrowser.store().get(PATH_RES2).out()) {
+        try (OutputStream os = store.get(PATH_RES2).out()) {
             os.write(DATA.getBytes());
+        }
+
+        if (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC_OSX) {
+            store.get(DIR_FORBIDDEN_CHARS).dir();
+            try (OutputStream os = store.get(FILE_FORBIDDEN_CHARS).out()) {
+                os.write(DATA.getBytes());
+            }
         }
 
         tester.startPage(resourceBrowser);
@@ -73,9 +86,9 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select dir
         tester.assertComponent(
-                "treeview:rootView:/:children:temp:children:temp/dir", Component.class);
+                "treeview:rootView:/:children:/temp:children:/temp/dir", Component.class);
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:label:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:label:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("cut").isEnabled());
         assertFalse(tester.getComponentFromLastRenderedPage("paste").isEnabled());
@@ -98,9 +111,9 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES)));
         assertTrue(Resources.exists(resourceBrowser.store().get("/temp/new_dir")));
         assertTrue(Resources.exists(resourceBrowser.store().get("/temp/new_dir/dir/something")));
-        tester.assertContainsNot("treeview:rootView:/:children:temp:children:temp/dir");
+        tester.assertContainsNot("treeview:rootView:/:children:/temp:children:/temp/dir");
         tester.assertComponent(
-                "treeview:rootView:/:children:temp:children:temp/new_dir", Component.class);
+                "treeview:rootView:/:children:/temp:children:/temp/new_dir", Component.class);
 
         // is selected
         assertEquals(
@@ -120,18 +133,18 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select dir
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:label:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:label:selectableLabel",
                 "click");
         assertFalse(tester.getComponentFromLastRenderedPage("copy").isEnabled());
         assertFalse(tester.getComponentFromLastRenderedPage("paste").isEnabled());
 
         // select two resources
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something:selectableLabel",
                 "click");
         tester.getRequest().addParameter("ctrl", "true");
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/somethingelse:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/somethingelse:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("copy").isEnabled());
         assertFalse(tester.getComponentFromLastRenderedPage("paste").isEnabled());
@@ -143,7 +156,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select dir
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:label:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:label:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("paste").isEnabled());
 
@@ -155,10 +168,10 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
         assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
 
         tester.assertComponent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something.1",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something.1",
                 Component.class);
         tester.assertComponent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/somethingelse.1",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/somethingelse.1",
                 Component.class);
 
         Resource copiedResource = resourceBrowser.store().get("temp/dir/something.1");
@@ -201,11 +214,11 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select resource
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something:selectableLabel",
                 "click");
         tester.getRequest().addParameter("ctrl", "true");
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/somethingelse:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/somethingelse:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("delete").isEnabled());
 
@@ -219,7 +232,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES)));
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES2)));
         tester.assertContainsNot(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something");
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something");
     }
 
     @Test
@@ -228,7 +241,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select resource
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("rename").isEnabled());
 
@@ -242,9 +255,9 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES)));
         tester.assertContainsNot(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something");
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something");
         tester.assertComponent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/anotherthing",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/anotherthing",
                 Component.class);
 
         Resource renamedResource = resourceBrowser.store().get("temp/dir/anotherthing");
@@ -268,7 +281,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select resource
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("download").isEnabled());
 
@@ -284,7 +297,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select resource
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:label:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:label:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("upload").isEnabled());
 
@@ -306,7 +319,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
         assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
 
         tester.assertComponent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/anewthing",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/anewthing",
                 Component.class);
 
         Resource uploadedResource = resourceBrowser.store().get("temp/dir/anewthing");
@@ -330,7 +343,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select resource
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:label:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:label:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("new").isEnabled());
 
@@ -344,7 +357,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
         assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
 
         tester.assertComponent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/anewthing",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/anewthing",
                 Component.class);
 
         Resource newResource = resourceBrowser.store().get("temp/dir/anewthing");
@@ -369,7 +382,7 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // select resource
         tester.executeAjaxEvent(
-                "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something:selectableLabel",
+                "treeview:rootView:/:children:/temp:children:/temp/dir:children:/temp/dir/something:selectableLabel",
                 "click");
         assertTrue(tester.getComponentFromLastRenderedPage("edit").isEnabled());
 
@@ -386,5 +399,30 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
             assertEquals(
                     DATA2 + System.lineSeparator(), IOUtils.toString(is, StandardCharsets.UTF_8));
         }
+    }
+
+    @Test
+    public void testForbiddenChars() throws Exception {
+        // the resources with invalid chars are created only on linux and OSX
+        Assume.assumeTrue(SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC_OSX);
+
+        // getting here is already a win, means it did not blow up unlike reported on
+        // https://osgeo-org.atlassian.net/browse/GEOS-9545
+
+        // go check the resources are there, the file
+        Component file =
+                tester.getComponentFromLastRenderedPage(
+                        "treeview:rootView:/:children:dGhlOn5maWxlLnR4dA==");
+        Resource fileResouce = ((ResourceNode) file.getDefaultModelObject()).getObject();
+        assertEquals(FILE_FORBIDDEN_CHARS, fileResouce.path());
+        assertEquals(Resource.Type.RESOURCE, fileResouce.getType());
+
+        // and the directory
+        Component dir =
+                tester.getComponentFromLastRenderedPage(
+                        "treeview:rootView:/:children:dGhlOn5kaXI=");
+        Resource dirResouce = ((ResourceNode) dir.getDefaultModelObject()).getObject();
+        assertEquals(DIR_FORBIDDEN_CHARS, dirResouce.path());
+        assertEquals(Resource.Type.DIRECTORY, dirResouce.getType());
     }
 }


### PR DESCRIPTION
2.17.x backport for [GEOS-9545] Web Resource Page fails to load with WicketRuntimeException when a resource contains : or ~ in its name

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
