### PR TITLE
[2.17.x backport][GEOS-9075] Fix jdbc multi value support on Oracle database

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NormalizedMultiValuesTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NormalizedMultiValuesTest.java
@@ -346,6 +346,42 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
         checkStation1Gml32(document);
     }
 
+    @Test
+    public void testGetFilteredAttributeMultiValuesWfs20() throws Exception {
+        // check if this is an online test with a JDBC based data store
+        if (notJdbcBased()) {
+            // not a JDBC online test
+            return;
+        }
+        // execute the WFS 2.0 request
+        String request = "wfs";
+        Document document =
+                postAsDOM(
+                        request,
+                        readResource(
+                                "/test-data/stations/multiValues/requests/station_tag_code_filter_wfs20.xml"));
+        // check that we got he correct station
+        checkStation1Gml32(document);
+    }
+
+    @Test
+    public void testGetFilteredAttributeMultiValuesWfs11() throws Exception {
+        // check if this is an online test with a JDBC based data store
+        if (notJdbcBased()) {
+            // not a JDBC online test
+            return;
+        }
+        // execute the WFS 1.1.0 request
+        String request = "wfs";
+        Document document =
+                postAsDOM(
+                        request,
+                        readResource(
+                                "/test-data/stations/multiValues/requests/station_tag_code_filter_wfs11.xml"));
+        // check that we got he correct station
+        checkStation1Gml31(document);
+    }
+
     /** Helper method that checks that station 1 is present in the provided document. */
     private void checkStation1Gml31(Document document) {
         // check station exists
@@ -506,6 +542,15 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
                         + "[@gml:id='ms.1']"
                         + "[ms_gml32:tag='temperature_tag']"
                         + "[ms_gml32:tag='desert_tag']");
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                1,
+                "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32"
+                        + "[@gml:id='st.1']"
+                        + "/st_gml32:measurements/ms_gml32:Measurement_gml32"
+                        + "[@gml:id='ms.1']"
+                        + "/ms_gml32:tag[@ms_gml32:code='8']");
         checkCount(
                 WFS20_XPATH_ENGINE,
                 document,

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/measurements.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/measurements.xml
@@ -50,6 +50,10 @@
             <targetColumn>OWNER</targetColumn>
             <targetValue>TAG</targetValue>
           </jdbcMultipleValue>
+          <ClientProperty>
+            <name>ms_${GML_PREFIX}:code</name>
+            <value>CODE</value>
+          </ClientProperty>
         </AttributeMapping>
         <AttributeMapping>
           <targetAttribute>FEATURE_LINK[1]</targetAttribute>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/measurements.xsd
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/measurements.xsd
@@ -19,10 +19,18 @@
         <xs:sequence>
           <xs:element name="name" type="xs:string"/>
           <xs:element name="unit" type="xs:string"/>
-          <xs:element name="tag" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+          <xs:element name="tag" minOccurs="0" maxOccurs="unbounded" type="ms:TagType"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
+  </xs:complexType>
+  
+  <xs:complexType name="TagType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="code" type="xs:integer"/>
+      </xs:extension>
+    </xs:simpleContent>
   </xs:complexType>
 
   <xs:element name="Measurement_${GML_PREFIX}" type="ms:MeasurementType" substitutionGroup="gml:AbstractFeature"/>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/requests/station_tag_code_filter_wfs11.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/requests/station_tag_code_filter_wfs11.xml
@@ -1,0 +1,18 @@
+<wfs:GetFeature
+        xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:st_gml31="http://www.stations_gml31.org/1.0"
+        xmlns:ms_gml31="http://www.measurements_gml31.org/1.0"
+        xmlns:wfs="http://www.opengis.net/wfs"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+    <wfs:Query typeName="st_gml31:Station_gml31">
+        <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>
+                    st_gml31:Station_gml31/st_gml31:tag/@st_gml31:code
+                </ogc:PropertyName>
+                <ogc:Literal>3</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+        </ogc:Filter>
+    </wfs:Query>
+</wfs:GetFeature>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/requests/station_tag_code_filter_wfs20.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/requests/station_tag_code_filter_wfs20.xml
@@ -1,0 +1,16 @@
+<wfs:GetFeature
+        service="WFS" version="2.0.0"
+        xmlns:fes="http://www.opengis.net/fes/2.0"
+        xmlns:st_gml32="http://www.stations_gml32.org/1.0"
+        xmlns:wfs="http://www.opengis.net/wfs/2.0">
+    <wfs:Query typeNames="st_gml32:Station_gml32">
+        <fes:Filter>
+            <fes:PropertyIsEqualTo>
+                <fes:ValueReference>
+                    st_gml32:Station_gml32/st_gml32:tag/@st_gml32:code
+                </fes:ValueReference>
+                <fes:Literal>3</fes:Literal>
+            </fes:PropertyIsEqualTo>
+        </fes:Filter>
+    </wfs:Query>
+</wfs:GetFeature>


### PR DESCRIPTION
This PR provides testing for the fixed issue on App-Schema module not supporting jdbcMultipleValue mappings on Oracle database.

Issue:
https://osgeo-org.atlassian.net/browse/GEOS-9075

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
