### PR TITLE
[GEOS-9646]: INSPIRE validation get errors of GetMapRequest parameters (2)

### DIFF
--- a/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
@@ -225,6 +225,9 @@ public class PreviewLayer {
         params.put("width", String.valueOf(request.getWidth()));
         params.put("height", String.valueOf(request.getHeight()));
         params.put("srs", String.valueOf(request.getSRS()));
+        params.put(
+                "styles",
+                request.getStyles().size() > 0 ? request.getStyles().get(0).getName() : "");
 
         return ResponseUtils.buildURL(getBaseURL(), getPath("wms", false), params, URLType.SERVICE);
     }

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
@@ -222,7 +222,7 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
                                             .getDefaultModelObject();
 
                     assertEquals(
-                            "http://localhost/context/cite/wms?service=WMS&amp;version=1.1.0&amp;request=GetMap&amp;layers=cite%3ALakes%20%2B%20a%20plus&amp;bbox=-180.0%2C-90.0%2C180.0%2C90.0&amp;width=768&amp;height=384&amp;srs=EPSG%3A4326&amp;format=application/openlayers",
+                            "http://localhost/context/cite/wms?service=WMS&amp;version=1.1.0&amp;request=GetMap&amp;layers=cite%3ALakes%20%2B%20a%20plus&amp;bbox=-180.0%2C-90.0%2C180.0%2C90.0&amp;width=768&amp;height=384&amp;srs=EPSG%3A4326&amp;styles=&amp;format=application/openlayers",
                             olLink.getDefaultModelObjectAsString());
                     assertThat(
                             gmlLink.getDefaultModelObjectAsString(),
@@ -242,7 +242,7 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
             assertThat(
                     onchange,
                     containsString(
-                            "http://localhost/context/cite/wms?service=WMS&version=1.1.0&request=GetMap&layers=cite%3ALakes%20%2B%20a%20plus&bbox=-180.0%2C-90.0%2C180.0%2C90.0&width=768&height=384&srs=EPSG%3A4326&format="));
+                            "http://localhost/context/cite/wms?service=WMS&version=1.1.0&request=GetMap&layers=cite%3ALakes%20%2B%20a%20plus&bbox=-180.0%2C-90.0%2C180.0%2C90.0&width=768&height=384&srs=EPSG%3A4326&styles=&format="));
             assertThat(
                     onchange,
                     containsString(

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/PreviewLayerProviderTest.java
@@ -8,11 +8,16 @@ package org.geoserver.web.demo;
 import static org.junit.Assert.*;
 
 import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class PreviewLayerProviderTest extends GeoServerWicketTestSupport {
@@ -35,6 +40,42 @@ public class PreviewLayerProviderTest extends GeoServerWicketTestSupport {
         } finally {
             layer.setAdvertised(true);
             getCatalog().save(layer);
+        }
+    }
+
+    @Test
+    public void testWmsLinkParametersOfLayer() throws Exception {
+        String layerId = getLayerId(MockData.BUILDINGS);
+
+        PreviewLayerProvider provider = new PreviewLayerProvider();
+        PreviewLayer pl = getPreviewLayer(provider, layerId);
+        assertNotNull(pl);
+
+        String wmsLink = pl.getWmsLink();
+        String[] wmsParams = wmsLink.substring(wmsLink.indexOf("?") + 1).split("&");
+        Set<String> wmsKeys = new HashSet<String>();
+
+        for (int i = 0; i < wmsParams.length; i++) {
+            String[] wmsParam = wmsParams[i].split("=");
+
+            if (wmsParam.length > 0) {
+                wmsKeys.add(wmsParam[0]);
+            }
+        }
+
+        List<String> keysToCheck =
+                Arrays.asList(
+                        "service", "version", "request", "layers", "bbox", "width", "height", "srs",
+                        "styles");
+
+        for (int i = 0; i < keysToCheck.size(); i++) {
+            String key = keysToCheck.get(i);
+
+            if (!wmsKeys.contains(key)) {
+                Assert.fail(
+                        String.format(
+                                "Parameter '%s' not specified in WmsLink URL of Layer.", key));
+            }
         }
     }
 


### PR DESCRIPTION
JIRA issue: https://osgeo-org.atlassian.net/browse/GEOS-9646

Fix to: https://github.com/geoserver/geoserver/pull/4300

This PR fixes a new issue caused by the [[GEOS-9646] PR](https://github.com/geoserver/geoserver/pull/4300). It adds to the PreviewLayer WMS GetMap link the mandatory STYLES parameter.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
