### PR TITLE
CascadeDeleteVisitor.visit(WorkspaceInfo) small(ish) speed-up

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CascadeDeleteVisitor.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CascadeDeleteVisitor.java
@@ -38,6 +38,12 @@ public class CascadeDeleteVisitor implements CatalogVisitor {
     public void visit(Catalog catalog) {}
 
     public void visit(WorkspaceInfo workspace) {
+        // remove layer groups contained in this workspace. Do this first to speed up
+        // visit(LayerInfo) looking for related groups
+        for (LayerGroupInfo group : catalog.getLayerGroupsByWorkspace(workspace)) {
+            group.accept(this);
+        }
+
         // remove owned stores
         for (StoreInfo s : catalog.getStoresByWorkspace(workspace, StoreInfo.class)) {
             s.accept(this);
@@ -52,11 +58,6 @@ public class CascadeDeleteVisitor implements CatalogVisitor {
         // remove styles contained in this workspace
         for (StyleInfo style : catalog.getStylesByWorkspace(workspace)) {
             style.accept(this);
-        }
-
-        // remove layer groups contained in this workspace
-        for (LayerGroupInfo group : catalog.getLayerGroupsByWorkspace(workspace)) {
-            group.accept(this);
         }
 
         catalog.remove(workspace);


### PR DESCRIPTION
Delete LayerGroups first when deleting a WorkspaceInfo. Potentially
saves a bunch of unnecessary LayerGroup updates in the visitor chain
`Stores <- Resources <- Layers`, since `visit(LayerInfo layer)` will
update all the LayerGroups that reference the layer to then remove the
LayerGroup when `visit(WorkspaceInfo)` proceeds to it.

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
