### PR TITLE
[backport 2.18.x][GEOS-9309] Bump commons-beanutils from 1.9.2 to 1.9.4

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -48,7 +48,6 @@
   <dependency>
    <groupId>commons-beanutils</groupId>
    <artifactId>commons-beanutils</artifactId>
-   <classifier>noclassprop</classifier>
   </dependency>
   <dependency>
    <groupId>commons-fileupload</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -712,14 +712,7 @@
    <dependency>
     <groupId>commons-beanutils</groupId>
     <artifactId>commons-beanutils</artifactId>
-    <version>1.9.2</version>
-    <classifier>noclassprop</classifier>
-   </dependency>
-   <dependency>
-    <groupId>commons-beanutils</groupId>
-    <artifactId>commons-beanutils</artifactId>
-    <version>1.9.2</version>
-    <scope>provided</scope>
+    <version>1.9.4</version>
    </dependency>
    <dependency>
     <groupId>commons-digester</groupId>


### PR DESCRIPTION
backports #4473 to 2.18.x

see also https://github.com/geotools/geotools/pull/3145