### PR TITLE
[GEOS-9729] WMS XML Post request fails with Workspace qualifier in url

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/WMSWorkspaceQualifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSWorkspaceQualifier.java
@@ -24,7 +24,7 @@ public class WMSWorkspaceQualifier extends WorkspaceQualifyingCallback {
     @Override
     protected void qualifyRequest(
             WorkspaceInfo ws, PublishedInfo l, Service service, Request request) {
-        if (WebMapService.class.isInstance(service.getService())) {
+        if (WebMapService.class.isInstance(service.getService()) && request.getRawKvp() != null) {
             String layers = (String) request.getRawKvp().get("LAYERS");
             if (layers != null) {
                 request.getRawKvp().put("LAYERS", qualifyLayerNamesKVP(layers, ws));

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
@@ -853,6 +853,12 @@ public class GetMapIntegrationTest extends WMSTestSupport {
     }
 
     @Test
+    public void testXmlPostWithWorkSpaceQualifier() throws Exception {
+        MockHttpServletResponse response = postAsServletResponse("sf/wms?", STATES_GETMAP);
+        checkImage(response);
+    }
+
+    @Test
     public void testRemoteOWSGet() throws Exception {
         if (!RemoteOWSTestSupport.isRemoteWFSStatesAvailable(LOGGER)) return;
 


### PR DESCRIPTION
JIRA : https://osgeo-org.atlassian.net/browse/GEOS-9729

- added rawKvp null check in WMSWorkspaceQualifier.java
- added unit test to assert WMS POST request with workspace qualifier in post URL

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
