### PR TITLE
[2.17.x backport] [GEOS-9731] Wfs-templating allow Iterating Builder to handle also json array without source

### DIFF
--- a/doc/en/user/source/community/wfs-templating/querying.rst
+++ b/doc/en/user/source/community/wfs-templating/querying.rst
@@ -36,8 +36,9 @@ Consider the following JSON-LD output example:
                 "http://vocabulary.odm2.org/samplingfeaturetype/mappedFeature"
             ],
             "name": "MERCIA MUDSTONE GROUP",
-            "gsml:positionalAccuracy": {
-                "value": "100.0"
+            "gsml:positionalAccuracy":{
+                "value":"100",
+                "valueArray": ["100","someStaticVal"]
             },
             "gsml:GeologicUnit": {
                 "@id": "gu.25678",
@@ -123,6 +124,9 @@ The following are example of valid CQL filters:
 
 * features.gsml:GeologicUnit.description = 'some string value'
 * features."@id" = "3245"
-* features.name in ("MERCIA MUDSTONE", "UKNOWN") AND features.gsml:positionalAccuracy.value = "100"
+* features.name in ("MERCIA MUDSTONE", "UKNOWN")
+* features.gsml:positionalAccuracy.valueArray_1 = "100"
+
+As the last example shows, to refer to elements in arrays listing simple attributes, the index of the attribute is needed, starting from 1, in the form ``{attributeName}_{index}``, as in ``features.gsml:positionalAccuracy.valueArray_1.``
 
 Is worth mentioning that, as demonstrated in the examples above, ``""`` can be used to escape the attributes path components.

--- a/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/builders/AbstractTemplateBuilder.java
+++ b/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/builders/AbstractTemplateBuilder.java
@@ -93,8 +93,9 @@ public abstract class AbstractTemplateBuilder implements TemplateBuilder {
      */
     protected void writeKey(TemplateOutputWriter writer) throws IOException {
         if (key != null && !key.evaluate(null).equals(""))
+            // key might be and EnvFunction or a Literal. In both cases
+            // no argument is needed for the evaluation thus passing null.
             writer.writeElementName(key.evaluate(null));
-        else throw new RuntimeException("Cannot write null key value");
     }
 
     public NamespaceSupport getNamespaces() {

--- a/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/readers/JsonTemplateReader.java
+++ b/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/readers/JsonTemplateReader.java
@@ -155,7 +155,7 @@ public class JsonTemplateReader implements TemplateReader {
                 } else if (childNode.isArray()) {
                     getBuilderFromJsonArray(nodeName, childNode, iteratingBuilder, factory);
                 } else {
-                    getBuilderFromJsonAttribute(nodeName, node, iteratingBuilder, factory);
+                    getBuilderFromJsonAttribute(null, childNode, iteratingBuilder, factory);
                 }
             }
         }

--- a/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/validation/TemplateValidator.java
+++ b/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/validation/TemplateValidator.java
@@ -10,7 +10,6 @@ import org.geoserver.wfstemplating.builders.AbstractTemplateBuilder;
 import org.geoserver.wfstemplating.builders.SourceBuilder;
 import org.geoserver.wfstemplating.builders.TemplateBuilder;
 import org.geoserver.wfstemplating.builders.impl.DynamicValueBuilder;
-import org.geoserver.wfstemplating.builders.impl.IteratingBuilder;
 import org.geoserver.wfstemplating.builders.impl.RootBuilder;
 import org.geoserver.wfstemplating.builders.impl.TemplateBuilderContext;
 import org.geoserver.wfstemplating.expressions.XpathFunction;
@@ -80,8 +79,6 @@ public class TemplateValidator {
                             siblingSource = pn.getPropertyName();
                         }
                     }
-                } else {
-                    if (sb instanceof IteratingBuilder) return false;
                 }
                 if (!validateExpressions(
                         jb, visitor, siblingSource != null ? siblingSource : source)) return false;

--- a/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/writers/CommonJsonWriter.java
+++ b/src/community/wfs-templating/src/main/java/org/geoserver/wfstemplating/writers/CommonJsonWriter.java
@@ -158,6 +158,9 @@ public abstract class CommonJsonWriter extends com.fasterxml.jackson.core.JsonGe
         } else if (result == null) {
             if (flatOutput) writeElementName(key);
             writeNull();
+        } else {
+            if (flatOutput) writeElementName(key);
+            writeValue(result.toString());
         }
     }
 

--- a/src/community/wfs-templating/src/test/java/org/geoserver/wfstemplating/response/FlatGeoJSONComplexFeaturesResponseTest.java
+++ b/src/community/wfs-templating/src/test/java/org/geoserver/wfstemplating/response/FlatGeoJSONComplexFeaturesResponseTest.java
@@ -57,7 +57,7 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
                         .append("&TYPENAME=gsml:MappedFeature&outputFormat=")
                         .append("application/json")
                         .append(
-                                "&cql_filter=features.gsml:GeologicUnit.description = 'Olivine basalt'");
+                                "&cql_filter=features.properties.gsml:GeologicUnit.description = 'Olivine basalt'");
         JSONObject result = (JSONObject) getJson(sb.toString());
         JSONArray features = (JSONArray) result.get("features");
         assertTrue(features.size() == 1);
@@ -75,7 +75,7 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
                         .append("/items?f=application%2Fgeo%2Bjson")
                         .append("&filter-lang=cql-text")
                         .append(
-                                "&filter= features.gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology.name")
+                                "&filter= features.properties.gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology.name")
                         .append(" = 'name_2' ");
         JSONObject result = (JSONObject) getJson(sb.toString());
         JSONArray features = (JSONArray) result.get("features");
@@ -119,7 +119,7 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
                         .append(" <wfs:Query typeName=\"gsml:MappedFeature\">")
                         .append(" <ogc:Filter><ogc:PropertyIsEqualTo> ")
                         .append(
-                                "<ogc:PropertyName>features.gsml:GeologicUnit.description</ogc:PropertyName>")
+                                "<ogc:PropertyName>features.properties.gsml:GeologicUnit.description</ogc:PropertyName>")
                         .append("<ogc:Literal>Olivine basalt</ogc:Literal>")
                         .append("</ogc:PropertyIsEqualTo></ogc:Filter></wfs:Query>")
                         .append("</wfs:GetFeature>");

--- a/src/community/wfs-templating/src/test/java/org/geoserver/wfstemplating/writers/JsonWriterTest.java
+++ b/src/community/wfs-templating/src/test/java/org/geoserver/wfstemplating/writers/JsonWriterTest.java
@@ -1,0 +1,61 @@
+package org.geoserver.wfstemplating.writers;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.opengis.feature.Property;
+import org.opengis.feature.simple.SimpleFeature;
+
+public class JsonWriterTest {
+
+    private SimpleFeature createSimpleFeature() throws URISyntaxException {
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.add("geometry", Point.class);
+        tb.add("string", String.class);
+        tb.add("integer", Integer.class);
+        tb.add("double", Double.class);
+        tb.add("url", URI.class);
+        tb.setName("schema");
+        SimpleFeatureBuilder fb = new SimpleFeatureBuilder(tb.buildFeatureType());
+        GeometryFactory factory = new GeometryFactory();
+        Point point = factory.createPoint(new Coordinate(1, 1));
+        fb.set("geometry", point);
+        fb.set("string", "stringValue");
+        fb.set("integer", 1);
+        fb.set("double", 0.0);
+        fb.set("url", new URI("http://some/url/to.test"));
+        return fb.buildFeature("1");
+    }
+
+    @Test
+    public void testJsonWriterEncodesURL() throws URISyntaxException, IOException {
+        // test that values of URL types are correctly encoded
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleFeature f = createSimpleFeature();
+        JsonLdWriter writer =
+                new JsonLdWriter(new JsonFactory().createGenerator(baos, JsonEncoding.UTF8));
+        writer.writeStartObject();
+        for (Property prop : f.getProperties()) {
+            writer.writeFieldName(prop.getName().toString());
+            writer.writeValue(prop.getValue());
+        }
+        writer.endObject();
+        writer.close();
+        String jsonString = new String(baos.toByteArray());
+        JSONObject json = (JSONObject) JSONSerializer.toJSON(jsonString);
+        assertEquals(json.getString("url"), "http://some/url/to.test");
+    }
+}

--- a/src/community/wfs-templating/src/test/resources/org/geoserver/wfstemplating/response/MappedFeature.json
+++ b/src/community/wfs-templating/src/test/resources/org/geoserver/wfstemplating/response/MappedFeature.json
@@ -32,7 +32,8 @@
       "name": "${gml:name}",
       "gsml:positionalAccuracy": {
         "type": "$${env('positionalAccuracyType','CGI_NumericValue')}",
-        "value": "${gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue}"
+        "value": "${gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue}",
+        "valueArray": ["${gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue}","someStaticVal","$${strConcat('duplicated value: ', xpath('gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue'))}"]
       },
       "gsml:GeologicUnit": {
         "$source": "gsml:specification/gsml:GeologicUnit",


### PR DESCRIPTION

* [GEOS-9731] Wfs-templating allow Iterating Builder to handle also json array without source

* reviewer's suggestion applied

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
