### PR TITLE
[GEOS-9738] Add possibility to customize attributeName separator for GeoJSON INSPIRE output

### DIFF
--- a/doc/en/user/source/community/features-templating/configuration.rst
+++ b/doc/en/user/source/community/features-templating/configuration.rst
@@ -307,7 +307,8 @@ The evaluation of a filter is handled by the module in the following way:
 Inspire GeoJSON Output
 ----------------------
 
-In order to provide a GeoJSON output encoded following INSPIRE rule for `alternative feature GeoJSON encoding <https://github.com/INSPIRE-MIF/2017.2/blob/master/GeoJSON/ads/simple-addresses.md>`_, it is possible to provide a VendorOption in the template file by adding the following attribute :code:`"$VendorOptions": "flat_output:true"`.
+In order to provide a GeoJSON output encoded following INSPIRE rule for `alternative feature GeoJSON encoding <https://github.com/INSPIRE-MIF/2017.2/blob/master/GeoJSON/ads/simple-addresses.md>`_ (`see also <https://github.com/INSPIRE-MIF/2017.2/blob/master/GeoJSON/efs/simple-environmental-monitoring-facilities.md>`_), it is possible to provide a VendorOption in the template file by adding the following attribute :code:`"$VendorOptions": "flat_output:true"`.
+Along with the :code:`flat_output` vendor option it is possible to specify a  :code:`separator` option, to customize the attribute name separator eg :code:`"$VendorOptions": "flat_output:true;separator:."`. Default is :code:`_`.
 Below an example configuration file for a Complex Feature type:
 
 .. code-block:: json
@@ -339,13 +340,13 @@ Below an example configuration file for a Complex Feature type:
                            "$source":"gsml:CompositionPart"
                         },
                         {
-                           "gsml:role.value":"$${strConcat('FeatureName: ', xpath('gsml:role'))}",
-                           "gsml:role.@codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
+                           "gsml:role_value":"$${strConcat('FeatureName: ', xpath('gsml:role'))}",
+                           "gsml:role_codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
                            "proportion":{
                               "$source":"gsml:proportion",
                               "@dataType":"CGI_ValueProperty",
-                              "CGI_TermValue.@dataType":"CGI_TermValue",
-                              "CGI_TermValue.value":"${gsml:CGI_TermValue}"
+                              "CGI-TermValue_@dataType":"CGI_TermValue",
+                              "CGI-TermValue_value":"${gsml:CGI_TermValue}"
                            },
                            "lithology":[
                               {

--- a/doc/en/user/source/community/features-templating/output.rst
+++ b/doc/en/user/source/community/features-templating/output.rst
@@ -294,19 +294,19 @@ While by using the flat_output VendorOption the output will be:
          },
          "properties":{
             "name":"FeatureName: MURRADUC BASALT",
-            "gsml:GeologicUnit.description":"Olivine basalt",
-            "gsml:GeologicUnit.gsml:geologicUnitType":"urn:ogc:def:nil:OGC::unknown",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.gsml:role.value":"FeatureName: interbedded component",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.gsml:role.@codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.@dataType":"CGI_ValueProperty",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.CGI_TermValue.@dataType":"CGI_TermValue",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.CGI_TermValue.value":"significant",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.name_1":"name_a",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.name_2":"name_b",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.name_3":"name_c",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.vocabulary":"@href:urn:ogc:def:nil:OGC::missing",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_2.name":"name_2",
-            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_2.vocabulary":"@href:urn:ogc:def:nil:OGC::missing"
+            "gsml:GeologicUnit_description":"Olivine basalt",
+            "gsml:GeologicUnit_gsml:geologicUnitType":"urn:ogc:def:nil:OGC::unknown",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_gsml:role_value":"FeatureName: interbedded component",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_gsml:role_@codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_@dataType":"CGI_ValueProperty",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_CGI-TermValue_@dataType":"CGI_TermValue",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_CGI-TermValue_value":"significant",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_name_1":"name_a",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_name_2":"name_b",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_name_3":"name_c",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_vocabulary":"@href:urn:ogc:def:nil:OGC::missing",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_2_name":"name_2",
+            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_2_vocabulary":"@href:urn:ogc:def:nil:OGC::missing"
          }
       }
    ]

--- a/doc/en/user/source/community/geopkg/output.rst
+++ b/doc/en/user/source/community/geopkg/output.rst
@@ -4,25 +4,25 @@ GeoPackage As Output
 GeoPackage WMS Output Format
 ----------------------------
 
-Any WMS :ref:`wms_getmap` request can be returned in the form of a Geopackage by specifying ``format=geopackage`` as output format (see :ref:`wms_output_formats`). \
+Any WMS :ref:`wms_getmap` request can be returned in the form of a GeoPackage by specifying ``format=geopackage`` as output format (see :ref:`wms_output_formats`). \
 The returned result will be a GeoPackage file with a single tile layer. 
 
 The following additional parameters can be passed on using :ref:`format_options`:
-  * ``tileset_name``: name to be used for tileset in geopackage file (default is name of layer(s)).
+  * ``tileset_name``: name to be used for tileset in GeoPackage file (default is name of layer(s)).
   * ``min_zoom``, ``max_zoom``, ``min_column``, ``max_column``, ``min_row``, ``max_row``: set the minimum and maximum zoom level, column, and rows
   * ``gridset``: name of gridset to use (otherwise default for CRS is used)
         
 GeoPackage WFS Output Format
 ----------------------------    
 
-Any WFS :ref:`wfs_getfeature` request can be returned as a Geopackage by specifying ``format=geopackage`` as output format (see :ref:`wfs_output_formats`). The returned result will be a GeoPackage file with a single features layer.
+Any WFS :ref:`wfs_getfeature` request can be returned as a GeoPackage by specifying ``format=geopackage`` as output format (see :ref:`wfs_output_formats`). The returned result will be a GeoPackage file with a single features layer.
 
 GeoPackage WPS Process
 ----------------------
 
 A custom GeoPackage can be created with any number of tiles and features layers using the ``GeoPackage`` WPS Process (see :ref:`wps_processes`).
 
-The WPS process takes in one parameter: ``contents`` which is an xml schema that represents the desired output.
+The WPS process takes in one parameter: ``contents`` which is an XML schema that represents the desired output.
 
 General outline of a ``contents`` scheme::
 
@@ -50,10 +50,10 @@ General outline of a ``contents`` scheme::
       </geopackage>
 
 
-Each geopackage has a mandatory ``name``, which will be the name of the file (with the extension .gpkg added).
+Each GeoPackage has a mandatory ``name``, which will be the name of the file (with the extension .gpkg added).
 Each layer (features or tiles) has the following properties:
 
-  * ``name`` (mandatory): the name of the layer in the geopackage;
+  * ``name`` (mandatory): the name of the layer in the GeoPackage;
   * ``identifier`` (optional): an identifier for the layer;
   * ``description`` (optional): a description for the layer;
   * ``srs`` ( mandatory for tiles, optional for features): coordinate reference system; for features the default is the SRS of the feature type;
@@ -109,8 +109,8 @@ Each tiles layer has the following properties:
   * ``layers`` (mandatory): comma-separated list of layers that will be included
   * ``styles``, ``sld``, and ``sldbody`` are mutually exclusive, having one is mandatory
       * ``styles``: list of comma-separated styles to be used
-      * ``sld``: path to sld style file
-      * ``sldbody``: inline sld style file
+      * ``sld``: path to SLD style file
+      * ``sldbody``: inline SLD style file
   * ``format`` (optional): mime-type of image format of tiles (image/png or image/jpeg)
   * ``bgcolor`` (optional): background colour as a six-digit hexadecimal RGB value
   * ``transparent`` (optional): transparency (true or false)
@@ -135,7 +135,7 @@ where the ``name`` of a known gridset is specified; or a custom gridset may be d
 		      <matrixWidth>4</matrixWidth>
 		      <matrixHeight>4</matrixHeight>
 		      <pixelXSize>0.17</pixelXSize>
-		      <pixelYSize>0.17</pizelYSize>
+		      <pixelYSize>0.17</pixelYSize>
 		      </grid>
 		      <grid>...</grid>
 		      ...

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/BuilderFactory.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/BuilderFactory.java
@@ -26,6 +26,7 @@ public class BuilderFactory {
 
     private boolean isJsonLd;
     private boolean flatOutput;
+    private String separator = "_";
 
     public BuilderFactory(boolean isJsonLd) {
         this.isJsonLd = isJsonLd;
@@ -43,7 +44,7 @@ public class BuilderFactory {
         if (isJsonLd) {
             iterating = new JsonLdIteratingBuilder(key, namespaces);
         } else {
-            if (flatOutput) iterating = new FlatIteratingBuilder(key, namespaces);
+            if (flatOutput) iterating = new FlatIteratingBuilder(key, namespaces, separator);
             else iterating = new IteratingBuilder(key, namespaces);
         }
         return iterating;
@@ -61,7 +62,7 @@ public class BuilderFactory {
         if (isJsonLd) {
             composite = new JsonLdCompositeBuilder(key, namespaces);
         } else {
-            if (flatOutput) composite = new FlatCompositeBuilder(key, namespaces);
+            if (flatOutput) composite = new FlatCompositeBuilder(key, namespaces, separator);
             else composite = new CompositeBuilder(key, namespaces);
         }
         return composite;
@@ -81,7 +82,8 @@ public class BuilderFactory {
         if (isJsonLd) {
             dynamic = new JsonLdDynamicBuilder(key, expression, namespaces);
         } else {
-            if (flatOutput) dynamic = new FlatDynamicBuilder(key, expression, namespaces);
+            if (flatOutput)
+                dynamic = new FlatDynamicBuilder(key, expression, namespaces, separator);
             else dynamic = new DynamicValueBuilder(key, expression, namespaces);
         }
         return dynamic;
@@ -101,7 +103,8 @@ public class BuilderFactory {
         if (isJsonLd) {
             staticBuilder = new StaticBuilder(key, strValue, namespaces);
         } else {
-            if (flatOutput) staticBuilder = new FlatStaticBuilder(key, strValue, namespaces);
+            if (flatOutput)
+                staticBuilder = new FlatStaticBuilder(key, strValue, namespaces, separator);
             else staticBuilder = new StaticBuilder(key, strValue, namespaces);
         }
         return staticBuilder;
@@ -121,7 +124,8 @@ public class BuilderFactory {
         if (isJsonLd) {
             staticBuilder = new StaticBuilder(key, value, namespaces);
         } else {
-            if (flatOutput) staticBuilder = new FlatStaticBuilder(key, value, namespaces);
+            if (flatOutput)
+                staticBuilder = new FlatStaticBuilder(key, value, namespaces, separator);
             else staticBuilder = new StaticBuilder(key, value, namespaces);
         }
         return staticBuilder;
@@ -144,5 +148,9 @@ public class BuilderFactory {
      */
     public void setFlatOutput(boolean flatOutput) {
         this.flatOutput = flatOutput;
+    }
+
+    public void setSeparator(String separator) {
+        this.separator = separator;
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/AttributeNameHelper.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/AttributeNameHelper.java
@@ -10,19 +10,23 @@ class AttributeNameHelper {
     private String key;
     private String parentKey;
 
+    private String separator;
+
     static final String PROPERTIES_KEY = "properties";
 
-    AttributeNameHelper() {};
-
-    AttributeNameHelper(String key, String parentKey) {
+    AttributeNameHelper(String key, String separator) {
         this.key = key;
-        this.parentKey = parentKey;
+        this.separator = separator;
     }
 
     String getFinalAttributeName() {
         String parentKey = this.parentKey;
         String key = this.key;
-        if (parentKey != null && !parentKey.equals(PROPERTIES_KEY)) key = parentKey + "." + key;
+        if (parentKey != null && !parentKey.equals(PROPERTIES_KEY) && key != null)
+            key = parentKey + separator + key;
+        else if (key == null) key = parentKey;
+        if (separator != "_" && key != null)
+            key = replaceDefaultSeparatorWithCustom(key, separator);
         return key;
     }
 
@@ -30,19 +34,50 @@ class AttributeNameHelper {
         String parentKey = this.parentKey;
         String key = this.key;
         if (parentKey != null && !parentKey.equals(PROPERTIES_KEY)) {
-            if (key != null && !key.equals(PROPERTIES_KEY)) key = parentKey + "." + key;
+            if (key != null && !key.equals(PROPERTIES_KEY)) key = parentKey + separator + key;
             else if (key == null || key.equals(PROPERTIES_KEY)) key = parentKey;
         }
+        if (separator != "_" && key != null)
+            key = replaceDefaultSeparatorWithCustom(key, separator);
         return key;
     }
 
     String getCompleteIteratingAttributeName(int elementsSize, int index) {
         String key = this.key;
         String parentKey = this.parentKey;
-        if (parentKey != null && !parentKey.equals(PROPERTIES_KEY)) key = parentKey + "." + key;
+        if (parentKey != null && !parentKey.equals(PROPERTIES_KEY))
+            key = parentKey + separator + key;
+        if (separator != "_") key = replaceDefaultSeparatorWithCustom(key, separator);
         String itKey;
         if (elementsSize > 0) itKey = key + "_" + (index + 1);
         else itKey = key;
         return itKey;
+    }
+
+    private String replaceDefaultSeparatorWithCustom(String key, String separator) {
+        char[] charArr = key.toCharArray();
+        StringBuilder sb = new StringBuilder("");
+        for (int i = 0; i < charArr.length; i++) {
+            char next = ' ';
+            char curr = charArr[i];
+            if (curr == '_') {
+                if (i < charArr.length - 1) {
+                    next = charArr[i + 1];
+                }
+                if (!Character.isDigit(next)) sb.append(separator);
+                else sb.append(curr);
+            } else {
+                sb.append(curr);
+            }
+        }
+        return sb.toString();
+    }
+
+    void setParentKey(String parentKey) {
+        this.parentKey = parentKey;
+    }
+
+    public String getSeparator() {
+        return separator;
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatCompositeBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatCompositeBuilder.java
@@ -19,9 +19,9 @@ public class FlatCompositeBuilder extends CompositeBuilder implements FlatBuilde
 
     private AttributeNameHelper attributeNameHelper;
 
-    public FlatCompositeBuilder(String key, NamespaceSupport namespaces) {
+    public FlatCompositeBuilder(String key, NamespaceSupport namespaces, String separator) {
         super(key, namespaces);
-        attributeNameHelper = new AttributeNameHelper();
+        attributeNameHelper = new AttributeNameHelper(getKey(), separator);
     }
 
     @Override
@@ -41,6 +41,6 @@ public class FlatCompositeBuilder extends CompositeBuilder implements FlatBuilde
     }
 
     public void setParentKey(String parentKey) {
-        this.attributeNameHelper = new AttributeNameHelper(getKey(), parentKey);
+        this.attributeNameHelper.setParentKey(parentKey);
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatDynamicBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatDynamicBuilder.java
@@ -15,9 +15,10 @@ public class FlatDynamicBuilder extends DynamicValueBuilder implements FlatBuild
 
     private AttributeNameHelper nameHelper;
 
-    public FlatDynamicBuilder(String key, String expression, NamespaceSupport namespaces) {
+    public FlatDynamicBuilder(
+            String key, String expression, NamespaceSupport namespaces, String separator) {
         super(key, expression, namespaces);
-        nameHelper = new AttributeNameHelper();
+        nameHelper = new AttributeNameHelper(getKey(), separator);
     }
 
     protected void writeValue(TemplateOutputWriter writer, Object value) throws IOException {
@@ -28,6 +29,6 @@ public class FlatDynamicBuilder extends DynamicValueBuilder implements FlatBuild
 
     @Override
     public void setParentKey(String parentKey) {
-        this.nameHelper = new AttributeNameHelper(getKey(), parentKey);
+        this.nameHelper.setParentKey(parentKey);
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatIteratingBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatIteratingBuilder.java
@@ -20,8 +20,9 @@ public class FlatIteratingBuilder extends IteratingBuilder implements FlatBuilde
 
     private AttributeNameHelper nameHelper;
 
-    public FlatIteratingBuilder(String key, NamespaceSupport namespaces) {
+    public FlatIteratingBuilder(String key, NamespaceSupport namespaces, String separator) {
         super(key, namespaces);
+        nameHelper = new AttributeNameHelper(getKey(), separator);
     }
 
     @Override
@@ -76,6 +77,6 @@ public class FlatIteratingBuilder extends IteratingBuilder implements FlatBuilde
 
     @Override
     public void setParentKey(String parentKey) {
-        this.nameHelper = new AttributeNameHelper(getKey(), parentKey);
+        this.nameHelper.setParentKey(parentKey);
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatStaticBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatStaticBuilder.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import org.geoserver.featurestemplating.builders.impl.StaticBuilder;
 import org.geoserver.featurestemplating.builders.impl.TemplateBuilderContext;
+import org.geoserver.featurestemplating.writers.GeoJsonWriter;
 import org.geoserver.featurestemplating.writers.TemplateOutputWriter;
 import org.xml.sax.helpers.NamespaceSupport;
 
@@ -16,24 +17,31 @@ public class FlatStaticBuilder extends StaticBuilder implements FlatBuilder {
 
     private AttributeNameHelper nameHelper;
 
-    public FlatStaticBuilder(String key, JsonNode value, NamespaceSupport namespaces) {
+    public FlatStaticBuilder(
+            String key, JsonNode value, NamespaceSupport namespaces, String separator) {
         super(key, value, namespaces);
-        nameHelper = new AttributeNameHelper();
+        nameHelper = new AttributeNameHelper(getKey(), separator);
     }
 
-    public FlatStaticBuilder(String key, String strValue, NamespaceSupport namespaces) {
+    public FlatStaticBuilder(
+            String key, String strValue, NamespaceSupport namespaces, String separator) {
         super(key, strValue, namespaces);
+        nameHelper = new AttributeNameHelper(getKey(), separator);
     }
 
     @Override
     protected void evaluateInternal(TemplateOutputWriter writer, TemplateBuilderContext context)
             throws IOException {
+        GeoJsonWriter geoJsonWriter = (GeoJsonWriter) writer;
         if (strValue != null)
-            writer.writeStaticContent(nameHelper.getFinalAttributeName(), strValue);
-        else writer.writeStaticContent(nameHelper.getFinalAttributeName(), staticValue);
+            geoJsonWriter.writeStaticContent(
+                    nameHelper.getFinalAttributeName(), strValue, nameHelper.getSeparator());
+        else
+            geoJsonWriter.writeStaticContent(
+                    nameHelper.getFinalAttributeName(), staticValue, nameHelper.getSeparator());
     }
 
     public void setParentKey(String parentKey) {
-        this.nameHelper = new AttributeNameHelper(getKey(), parentKey);
+        this.nameHelper.setParentKey(parentKey);
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/geojson/GeoJsonRootBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/geojson/GeoJsonRootBuilder.java
@@ -4,14 +4,16 @@
  */
 package org.geoserver.featurestemplating.builders.geojson;
 
-import static org.geoserver.featurestemplating.builders.impl.RootBuilder.VendorOption.FLAT_OUTPUT;
+import static org.geoserver.featurestemplating.builders.impl.RootBuilder.VendorOption.*;
 
+import java.util.Arrays;
 import org.geoserver.featurestemplating.builders.impl.RootBuilder;
 
 /** GeoJson root builder used to support flat_output vendor parameter */
 public class GeoJsonRootBuilder extends RootBuilder {
 
     public GeoJsonRootBuilder() {
-        supportedOptions.add(FLAT_OUTPUT.getVendorOptionName());
+        supportedOptions.addAll(
+                Arrays.asList(FLAT_OUTPUT.getVendorOptionName(), SEPARATOR.getVendorOptionName()));
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/RootBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/RootBuilder.java
@@ -20,7 +20,8 @@ public class RootBuilder implements TemplateBuilder {
 
     /** Enum listing available vendor options */
     public enum VendorOption {
-        FLAT_OUTPUT("flat_output");
+        FLAT_OUTPUT("flat_output"),
+        SEPARATOR("separator");
 
         private String vendorOptionName;
 

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/readers/JsonTemplateReader.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/readers/JsonTemplateReader.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver.featurestemplating.readers;
 
-import static org.geoserver.featurestemplating.builders.impl.RootBuilder.VendorOption.FLAT_OUTPUT;
+import static org.geoserver.featurestemplating.builders.impl.RootBuilder.VendorOption.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Iterator;
@@ -221,7 +221,15 @@ public class JsonTemplateReader implements TemplateReader {
             builder.setVendorOptions(arrOp);
         }
         String strFlatOutput = builder.getVendorOption(FLAT_OUTPUT.getVendorOptionName());
-        if (strFlatOutput != null)
-            factory.setFlatOutput(Boolean.valueOf(strFlatOutput).booleanValue());
+        if (strFlatOutput != null) {
+            boolean flatOutput = Boolean.valueOf(strFlatOutput).booleanValue();
+            factory.setFlatOutput(flatOutput);
+            if (flatOutput) {
+                String delimiter = builder.getVendorOption(SEPARATOR.getVendorOptionName());
+                if (delimiter != null) {
+                    factory.setSeparator(delimiter);
+                }
+            }
+        }
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/writers/CommonJsonWriter.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/writers/CommonJsonWriter.java
@@ -110,7 +110,7 @@ public abstract class CommonJsonWriter extends com.fasterxml.jackson.core.JsonGe
 
     @Override
     public void writeElementName(Object elementName) throws IOException {
-        writeFieldName(elementName.toString());
+        if (elementName != null) writeFieldName(elementName.toString());
     }
 
     /**

--- a/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/FlatGeoJSONComplexFeaturesResponseTest.java
+++ b/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/FlatGeoJSONComplexFeaturesResponseTest.java
@@ -7,6 +7,7 @@ package org.geoserver.featurestemplating.response;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Set;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
@@ -24,7 +25,7 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
         sb.append("application/json");
         JSONObject result = (JSONObject) getJson(sb.toString());
         JSONArray features = (JSONArray) result.get("features");
-        assertEquals(features.size(), 4);
+        assertEquals(4, features.size());
         for (int i = 0; i < features.size(); i++) {
             JSONObject feature = (JSONObject) features.get(i);
             checkInspireMappedFeature(feature);
@@ -131,6 +132,33 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
         checkAdditionalInfo(result);
     }
 
+    @Test
+    public void testGeoJSONResponseWithCustomSeparator() throws Exception {
+        setUpComplex("FlatGeologicUnitWithSeparator.json", geologicUnit);
+        String path =
+                "ogc/features/collections/"
+                        + "gsml:GeologicUnit"
+                        + "/items?f=application%2Fgeo%2Bjson";
+        JSONObject result = (JSONObject) getJson(path);
+        JSONArray features = (JSONArray) result.get("features");
+        assertEquals(3, features.size());
+        for (int i = 0; i < features.size(); i++) {
+            JSONObject feature = (JSONObject) features.get(i);
+            JSONObject properties = feature.getJSONObject("properties");
+            Set<String> keys = properties.keySet();
+            for (String key : keys) {
+                boolean keyWithSep =
+                        !key.equals("@id")
+                                && !key.equals("description")
+                                && !key.equals("gsml:geologicUnitType");
+                if (keyWithSep) {
+                    String[] arKey = key.split("\\.");
+                    assertTrue(arKey.length > 0);
+                }
+            }
+        }
+    }
+
     private void checkInspireMappedFeature(JSONObject feature) {
         assertNotNull(feature);
         String id = feature.getString("@id");
@@ -142,107 +170,107 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
         JSONObject properties = feature.getJSONObject("properties");
         assertNotNull(properties);
         assertNotNull(properties.getString("name"));
-        assertNotNull(properties.getString("gsml:GeologicUnit.description"));
-        assertNotNull(properties.getString("gsml:GeologicUnit.gsml:geologicUnitType"));
+        assertNotNull(properties.getString("gsml:GeologicUnit_description"));
+        assertNotNull(properties.getString("gsml:GeologicUnit_gsml:geologicUnitType"));
         if (id.equals("mf1")) {
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.gsml:role.value"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_gsml:role_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.gsml:role.@codeSpace"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_gsml:role_@codeSpace"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.CGI_TermValue.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_CGI_TermValue_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.CGI_TermValue.value"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_CGI_TermValue_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology.name"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_name"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology.vocabulary"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_vocabulary"));
         } else if (id.equals("mf2") || id.equals("mf3")) {
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_1.gsml:compositionPart.gsml:role.value"));
+                            "gsml:GeologicUnit_gsml:composition_1_gsml:compositionPart_gsml:role_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_1.gsml:compositionPart.gsml:role.@codeSpace"));
+                            "gsml:GeologicUnit_gsml:composition_1_gsml:compositionPart_gsml:role_@codeSpace"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_1.gsml:compositionPart.proportion.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_1_gsml:compositionPart_proportion_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_1.gsml:compositionPart.proportion.CGI_TermValue.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_1_gsml:compositionPart_proportion_CGI_TermValue_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_1.gsml:compositionPart.proportion.CGI_TermValue.value"));
+                            "gsml:GeologicUnit_gsml:composition_1_gsml:compositionPart_proportion_CGI_TermValue_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_1.gsml:compositionPart.lithology.name"));
+                            "gsml:GeologicUnit_gsml:composition_1_gsml:compositionPart_lithology_name"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_1.gsml:compositionPart.lithology.vocabulary"));
+                            "gsml:GeologicUnit_gsml:composition_1_gsml:compositionPart_lithology_vocabulary"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_2.gsml:compositionPart.gsml:role.value"));
+                            "gsml:GeologicUnit_gsml:composition_2_gsml:compositionPart_gsml:role_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_2.gsml:compositionPart.gsml:role.@codeSpace"));
+                            "gsml:GeologicUnit_gsml:composition_2_gsml:compositionPart_gsml:role_@codeSpace"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_2.gsml:compositionPart.proportion.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_2_gsml:compositionPart_proportion_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_2.gsml:compositionPart.proportion.CGI_TermValue.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_2_gsml:compositionPart_proportion_CGI_TermValue_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_2.gsml:compositionPart.proportion.CGI_TermValue.value"));
+                            "gsml:GeologicUnit_gsml:composition_2_gsml:compositionPart_proportion_CGI_TermValue_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_2.gsml:compositionPart.lithology.name"));
+                            "gsml:GeologicUnit_gsml:composition_2_gsml:compositionPart_lithology_name"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition_2.gsml:compositionPart.lithology.vocabulary"));
+                            "gsml:GeologicUnit_gsml:composition_2_gsml:compositionPart_lithology_vocabulary"));
         } else if (id.equals("mf4")) {
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.gsml:role.value"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_gsml:role_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.gsml:role.@codeSpace"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_gsml:role_@codeSpace"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.CGI_TermValue.@dataType"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_CGI_TermValue_@dataType"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.proportion.CGI_TermValue.value"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_proportion_CGI_TermValue_value"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.name_1"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_name_1"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.name_2"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_name_2"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.name_3"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_name_3"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_1.vocabulary"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_1_vocabulary"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_2.name"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_2_name"));
             assertNotNull(
                     properties.getString(
-                            "gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology_2.vocabulary"));
+                            "gsml:GeologicUnit_gsml:composition_gsml:compositionPart_lithology_2_vocabulary"));
         }
     }
 

--- a/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FlatGeoJSONMappedFeature.json
+++ b/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FlatGeoJSONMappedFeature.json
@@ -24,13 +24,13 @@
                   "$source":"gsml:CompositionPart"
                 },
                 {
-                  "gsml:role.value":"$${strConcat('FeatureName: ', xpath('gsml:role'))}",
-                  "gsml:role.@codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
+                  "gsml:role_value":"$${strConcat('FeatureName: ', xpath('gsml:role'))}",
+                  "gsml:role_@codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
                   "proportion":{
                     "$source":"gsml:proportion",
                     "@dataType":"CGI_ValueProperty",
-                    "CGI_TermValue.@dataType":"CGI_TermValue",
-                    "CGI_TermValue.value":"${gsml:CGI_TermValue}"
+                    "CGI_TermValue_@dataType":"CGI_TermValue",
+                    "CGI_TermValue_value":"${gsml:CGI_TermValue}"
                   },
                   "lithology":[
                     {

--- a/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FlatGeologicUnitWIthSeparator.json
+++ b/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FlatGeologicUnitWIthSeparator.json
@@ -1,0 +1,50 @@
+{
+  "$VendorOptions": "flat_output:true;separator:.",
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "$source": "gsml:GeologicUnit"
+    },
+    {
+      "properties": {
+        "@id": "${@id}",
+        "description": "$filter{xpath('gml:description')='Olivine basalt'},${gml:description}",
+        "gsml:geologicUnitType": "urn:ogc:def:nil:OGC::unknown",
+        "gsml:composition": [
+          {
+            "$source": "gsml:composition"
+          },
+          {
+            "gsml:compositionPart": [
+              {
+                "$source": "gsml:CompositionPart"
+              },
+              {
+                "gsml:role_value": "${gsml:role}",
+                "gsml:role_codeSpace": "urn:cgi:classifierScheme:Example:CompositionPartRole",
+                "proportion_dataType": "CGI_ValueProperty",
+                "proportion_CGI_TermValue_dataType": "CGI_TermValue",
+                "proportion_CGI_TermValue_value": "${gsml:proportion/gsml:CGI_TermValue}",
+                "lithology": [
+                  {
+                    "$source": "gsml:lithology"
+                  },
+                  {
+                    "@id": "${gsml:ControlledConcept/@id}",
+                    "name": {
+                      "value": "${gsml:ControlledConcept/gsml:name}",
+                      "@lang": "en"
+                    },
+                    "vocabulary": {
+                      "@href": "urn:ogc:def:nil:OGC::missing"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -508,7 +508,7 @@
       <dependencies>
         <dependency>
             <groupId>org.geoserver.extension</groupId>
-            <artifactId>gs-app-schema-web</artifactId>
+            <artifactId>gs-app-schema-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pr add the possibilities to customize the separator for attribute names in geoJSON inspire output format, by means of a VendorOptions in the template file.

Jira ticket https://osgeo-org.atlassian.net/browse/GEOS-9738

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
