### PR TITLE
[GEOS-9739] Features-templating backwards mapping not working for geoJSON INSPIRE format with "_" separator

### DIFF
--- a/doc/en/user/source/community/features-templating/querying.rst
+++ b/doc/en/user/source/community/features-templating/querying.rst
@@ -125,8 +125,8 @@ The following are example of valid CQL filters:
 * features.gsml:GeologicUnit.description = 'some string value'
 * features."@id" = "3245"
 * features.name in ("MERCIA MUDSTONE", "UKNOWN")
-* features.gsml:positionalAccuracy.valueArray_1 = "100"
+* features.gsml:positionalAccuracy.valueArray1 = "100"
 
-As the last example shows, to refer to elements in arrays listing simple attributes, the index of the attribute is needed, starting from 1, in the form ``{attributeName}_{index}``, as in ``features.gsml:positionalAccuracy.valueArray_1.``
+As the last example shows, to refer to elements in arrays listing simple attributes, the index of the attribute is needed, starting from 1, in the form ``{attributeName}{index}``, as in ``features.gsml:positionalAccuracy.valueArray1.``
 
 Is worth mentioning that, as demonstrated in the examples above, ``""`` can be used to escape the attributes path components.

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/AttributeNameHelper.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/AttributeNameHelper.java
@@ -47,9 +47,9 @@ class AttributeNameHelper {
         String parentKey = this.parentKey;
         if (parentKey != null && !parentKey.equals(PROPERTIES_KEY))
             key = parentKey + separator + key;
-        if (separator != "_") key = replaceDefaultSeparatorWithCustom(key, separator);
+        key = replaceDefaultSeparatorWithCustom(key, separator);
         String itKey;
-        if (elementsSize > 0) itKey = key + "_" + (index + 1);
+        if (elementsSize > 0) itKey = key + separator + (index + 1);
         else itKey = key;
         return itKey;
     }

--- a/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/FlatGeoJSONComplexFeaturesResponseTest.java
+++ b/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/FlatGeoJSONComplexFeaturesResponseTest.java
@@ -58,7 +58,7 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
                         .append("&TYPENAME=gsml:MappedFeature&outputFormat=")
                         .append("application/json")
                         .append(
-                                "&cql_filter=features.properties.gsml:GeologicUnit.description = 'Olivine basalt'");
+                                "&cql_filter=features.properties.gsml:GeologicUnit_description = 'Olivine basalt'");
         JSONObject result = (JSONObject) getJson(sb.toString());
         JSONArray features = (JSONArray) result.get("features");
         assertTrue(features.size() == 1);
@@ -76,7 +76,7 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
                         .append("/items?f=application%2Fgeo%2Bjson")
                         .append("&filter-lang=cql-text")
                         .append(
-                                "&filter= features.properties.gsml:GeologicUnit.gsml:composition.gsml:compositionPart.lithology.name")
+                                "&filter= features.properties.gsml:GeologicUnit_gsml:composition.gsml:compositionPart.lithology.name")
                         .append(" = 'name_2' ");
         JSONObject result = (JSONObject) getJson(sb.toString());
         JSONArray features = (JSONArray) result.get("features");
@@ -120,7 +120,7 @@ public class FlatGeoJSONComplexFeaturesResponseTest extends TemplateJSONComplexT
                         .append(" <wfs:Query typeName=\"gsml:MappedFeature\">")
                         .append(" <ogc:Filter><ogc:PropertyIsEqualTo> ")
                         .append(
-                                "<ogc:PropertyName>features.properties.gsml:GeologicUnit.description</ogc:PropertyName>")
+                                "<ogc:PropertyName>features.properties.gsml:GeologicUnit_description</ogc:PropertyName>")
                         .append("<ogc:Literal>Olivine basalt</ogc:Literal>")
                         .append("</ogc:PropertyIsEqualTo></ogc:Filter></wfs:Query>")
                         .append("</wfs:GetFeature>");

--- a/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/JSONLDGetComplexFeaturesResponseTest.java
+++ b/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/JSONLDGetComplexFeaturesResponseTest.java
@@ -301,7 +301,7 @@ public class JSONLDGetComplexFeaturesResponseTest extends TemplateJSONComplexTes
                         .append("gsml:MappedFeature")
                         .append("/items?f=application%2Fld%2Bjson")
                         .append("&filter-lang=cql-text")
-                        .append("&filter= features.gsml:positionalAccuracy.valueArray_1 > 120");
+                        .append("&filter= features.gsml:positionalAccuracy.valueArray1 > 120");
         JSONObject result = (JSONObject) getJsonLd(sb.toString());
         JSONArray features = result.getJSONArray("features");
         assertEquals(features.size(), 2);

--- a/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FlatGeoJSONMappedFeature.json
+++ b/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FlatGeoJSONMappedFeature.json
@@ -10,13 +10,11 @@
       "geometry":"${gsml:shape}",
       "properties":{
         "name":"$${strConcat('FeatureName: ', xpath('gml:name'))}",
-        "gsml:GeologicUnit":{
-          "$source":"gsml:specification/gsml:GeologicUnit",
-          "description":"${gml:description}",
-          "gsml:geologicUnitType":"urn:ogc:def:nil:OGC::unknown",
-          "gsml:composition":[
+        "gsml:GeologicUnit_description":"${gsml:specification/gsml:GeologicUnit/gml:description}",
+        "gsml:GeologicUnit_gsml:geologicUnitType":"urn:ogc:def:nil:OGC::unknown",
+        "gsml:GeologicUnit_gsml:composition":[
             {
-              "$source":"gsml:composition"
+              "$source":"gsml:specification/gsml:GeologicUnit/gsml:composition"
             },
             {
               "gsml:compositionPart":[
@@ -46,7 +44,6 @@
             }
           ]
         }
-      }
     }
   ]
 }


### PR DESCRIPTION
This pr fixes an issue regarding backward mapping failure when a geoJSON template has a "_" separator in attribute names

JIRA ticket https://osgeo-org.atlassian.net/browse/GEOS-9739
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
