### PR TITLE
[GEOS-9753] Features-templating plug-in allows env parametrization on vendorOptions - [GEOS-9754] Not consistent array element enumeration in flat geojson output format

### DIFF
--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/AbstractTemplateBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/AbstractTemplateBuilder.java
@@ -6,7 +6,7 @@ package org.geoserver.featurestemplating.builders;
 
 import java.io.IOException;
 import org.geoserver.featurestemplating.builders.impl.TemplateBuilderContext;
-import org.geoserver.featurestemplating.expressions.JsonLdCQLManager;
+import org.geoserver.featurestemplating.expressions.TemplateCQLManager;
 import org.geoserver.featurestemplating.writers.TemplateOutputWriter;
 import org.geotools.filter.LiteralExpressionImpl;
 import org.geotools.filter.text.cql2.CQLException;
@@ -71,7 +71,7 @@ public abstract class AbstractTemplateBuilder implements TemplateBuilder {
      * @throws CQLException
      */
     public void setFilter(String filter) throws CQLException {
-        JsonLdCQLManager cqlManager = new JsonLdCQLManager(filter, namespaces);
+        TemplateCQLManager cqlManager = new TemplateCQLManager(filter, namespaces);
         this.filter = cqlManager.getFilterFromString();
         this.filterContextPos = cqlManager.getContextPos();
     }
@@ -106,7 +106,7 @@ public abstract class AbstractTemplateBuilder implements TemplateBuilder {
         Expression keyExpr;
         if (key != null) {
             if (key.startsWith("$${")) {
-                JsonLdCQLManager cqlManager = new JsonLdCQLManager(key, null);
+                TemplateCQLManager cqlManager = new TemplateCQLManager(key, null);
                 keyExpr = cqlManager.getExpressionFromString();
             } else {
                 keyExpr = new LiteralExpressionImpl(key);

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/SourceBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/SourceBuilder.java
@@ -7,7 +7,7 @@ package org.geoserver.featurestemplating.builders;
 import java.util.LinkedList;
 import java.util.List;
 import org.geoserver.featurestemplating.builders.impl.TemplateBuilderContext;
-import org.geoserver.featurestemplating.expressions.JsonLdCQLManager;
+import org.geoserver.featurestemplating.expressions.TemplateCQLManager;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
@@ -98,7 +98,7 @@ public abstract class SourceBuilder extends AbstractTemplateBuilder {
      * @param source the string source
      */
     public void setSource(String source) {
-        JsonLdCQLManager cqlManager = new JsonLdCQLManager(source, namespaces);
+        TemplateCQLManager cqlManager = new TemplateCQLManager(source, namespaces);
         Expression sourceExpr = cqlManager.getExpressionFromString();
         if (sourceExpr instanceof Literal)
             this.source =

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/AttributeNameHelper.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/AttributeNameHelper.java
@@ -4,24 +4,26 @@
  */
 package org.geoserver.featurestemplating.builders.flat;
 
+import org.opengis.filter.expression.Expression;
+
 /** An helper class to help creating attribute names when producing a flat geoJson output */
 class AttributeNameHelper {
 
-    private String key;
+    private Expression key;
     private String parentKey;
 
     private String separator;
 
     static final String PROPERTIES_KEY = "properties";
 
-    AttributeNameHelper(String key, String separator) {
+    AttributeNameHelper(Expression key, String separator) {
         this.key = key;
         this.separator = separator;
     }
 
     String getFinalAttributeName() {
         String parentKey = this.parentKey;
-        String key = this.key;
+        String key = this.key != null ? this.key.evaluate(null).toString() : null;
         if (parentKey != null && !parentKey.equals(PROPERTIES_KEY) && key != null)
             key = parentKey + separator + key;
         else if (key == null) key = parentKey;
@@ -32,7 +34,7 @@ class AttributeNameHelper {
 
     String getCompleteCompositeAttributeName() {
         String parentKey = this.parentKey;
-        String key = this.key;
+        String key = this.key != null ? this.key.evaluate(null).toString() : null;
         if (parentKey != null && !parentKey.equals(PROPERTIES_KEY)) {
             if (key != null && !key.equals(PROPERTIES_KEY)) key = parentKey + separator + key;
             else if (key == null || key.equals(PROPERTIES_KEY)) key = parentKey;
@@ -43,13 +45,13 @@ class AttributeNameHelper {
     }
 
     String getCompleteIteratingAttributeName(int elementsSize, int index) {
-        String key = this.key;
+        String key = this.key != null ? this.key.evaluate(null).toString() : null;
         String parentKey = this.parentKey;
         if (parentKey != null && !parentKey.equals(PROPERTIES_KEY))
             key = parentKey + separator + key;
         key = replaceDefaultSeparatorWithCustom(key, separator);
         String itKey;
-        if (elementsSize > 0) itKey = key + separator + (index + 1);
+        if (elementsSize > 0) itKey = key + separator + (index);
         else itKey = key;
         return itKey;
     }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatCompositeBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatCompositeBuilder.java
@@ -21,7 +21,7 @@ public class FlatCompositeBuilder extends CompositeBuilder implements FlatBuilde
 
     public FlatCompositeBuilder(String key, NamespaceSupport namespaces, String separator) {
         super(key, namespaces);
-        attributeNameHelper = new AttributeNameHelper(getKey(), separator);
+        attributeNameHelper = new AttributeNameHelper(this.key, separator);
     }
 
     @Override

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatDynamicBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatDynamicBuilder.java
@@ -18,7 +18,7 @@ public class FlatDynamicBuilder extends DynamicValueBuilder implements FlatBuild
     public FlatDynamicBuilder(
             String key, String expression, NamespaceSupport namespaces, String separator) {
         super(key, expression, namespaces);
-        nameHelper = new AttributeNameHelper(getKey(), separator);
+        nameHelper = new AttributeNameHelper(this.key, separator);
     }
 
     protected void writeValue(TemplateOutputWriter writer, Object value) throws IOException {

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatStaticBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/flat/FlatStaticBuilder.java
@@ -20,13 +20,13 @@ public class FlatStaticBuilder extends StaticBuilder implements FlatBuilder {
     public FlatStaticBuilder(
             String key, JsonNode value, NamespaceSupport namespaces, String separator) {
         super(key, value, namespaces);
-        nameHelper = new AttributeNameHelper(getKey(), separator);
+        nameHelper = new AttributeNameHelper(this.key, separator);
     }
 
     public FlatStaticBuilder(
             String key, String strValue, NamespaceSupport namespaces, String separator) {
         super(key, strValue, namespaces);
-        nameHelper = new AttributeNameHelper(getKey(), separator);
+        nameHelper = new AttributeNameHelper(this.key, separator);
     }
 
     @Override

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/geojson/GeoJsonRootBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/geojson/GeoJsonRootBuilder.java
@@ -7,6 +7,8 @@ package org.geoserver.featurestemplating.builders.geojson;
 import static org.geoserver.featurestemplating.builders.impl.RootBuilder.VendorOption.*;
 
 import java.util.Arrays;
+import org.geoserver.featurestemplating.builders.TemplateBuilder;
+import org.geoserver.featurestemplating.builders.flat.FlatBuilder;
 import org.geoserver.featurestemplating.builders.impl.RootBuilder;
 
 /** GeoJson root builder used to support flat_output vendor parameter */
@@ -15,5 +17,23 @@ public class GeoJsonRootBuilder extends RootBuilder {
     public GeoJsonRootBuilder() {
         supportedOptions.addAll(
                 Arrays.asList(FLAT_OUTPUT.getVendorOptionName(), SEPARATOR.getVendorOptionName()));
+    }
+
+    /**
+     * Check if a builder tree needs to be reloaded by checking if the flat output the matching of
+     * the vendor option flat_output value and the builder type. This due the fact that vendor
+     * options can be provided with env function.
+     *
+     * @return true if reload is needed otherwise false.
+     */
+    @Override
+    public boolean needsReload() {
+        TemplateBuilder aChild = getChildren().get(0);
+        boolean isCachedFlattened = aChild instanceof FlatBuilder;
+        String strFlat = getVendorOption(FLAT_OUTPUT.getVendorOptionName());
+        boolean isFlatOutput = strFlat != null ? Boolean.valueOf(strFlat) : false;
+        if (isCachedFlattened && !isFlatOutput) return true;
+        else if (!isCachedFlattened && isFlatOutput) return true;
+        else return false;
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicValueBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicValueBuilder.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.featurestemplating.builders.AbstractTemplateBuilder;
-import org.geoserver.featurestemplating.expressions.JsonLdCQLManager;
+import org.geoserver.featurestemplating.expressions.TemplateCQLManager;
 import org.geoserver.featurestemplating.writers.TemplateOutputWriter;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.util.logging.Logging;
@@ -31,7 +31,7 @@ public class DynamicValueBuilder extends AbstractTemplateBuilder {
     public DynamicValueBuilder(String key, String expression, NamespaceSupport namespaces) {
         super(key, namespaces);
         this.namespaces = namespaces;
-        JsonLdCQLManager cqlManager = new JsonLdCQLManager(expression, namespaces);
+        TemplateCQLManager cqlManager = new TemplateCQLManager(expression, namespaces);
         if (expression.startsWith("$${")) {
             this.cql = cqlManager.getExpressionFromString();
         } else if (expression.startsWith("${")) {

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/IteratingBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/IteratingBuilder.java
@@ -90,6 +90,29 @@ public class IteratingBuilder extends SourceBuilder {
     }
 
     protected boolean canWrite(TemplateBuilderContext context) {
-        return true;
+        Object o = context.getCurrentObj();
+        boolean result;
+        if (o instanceof List) {
+            result = canWriteList((List) o, context);
+        } else {
+            result = canWriteSingle(o, context);
+        }
+        return result;
+    }
+
+    private boolean canWriteList(List elements, TemplateBuilderContext context) {
+        for (Object el : elements) {
+            TemplateBuilderContext childContext = new TemplateBuilderContext(el);
+            childContext.setParent(context.getParent());
+            if (evaluateFilter(childContext)) return true;
+        }
+        return false;
+    }
+
+    private boolean canWriteSingle(Object element, TemplateBuilderContext context) {
+        TemplateBuilderContext childContext = new TemplateBuilderContext(element);
+        childContext.setParent(context.getParent());
+        if (evaluateFilter(childContext)) return true;
+        return false;
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/RootBuilder.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/builders/impl/RootBuilder.java
@@ -7,6 +7,7 @@ package org.geoserver.featurestemplating.builders.impl;
 import java.io.IOException;
 import java.util.*;
 import org.geoserver.featurestemplating.builders.TemplateBuilder;
+import org.geoserver.featurestemplating.expressions.TemplateCQLManager;
 import org.geoserver.featurestemplating.writers.TemplateOutputWriter;
 
 /** The root of the builders' tree. It triggers the evaluation process */
@@ -64,7 +65,12 @@ public class RootBuilder implements TemplateBuilder {
      * @return
      */
     public String getVendorOption(String optionName) {
-        return vendorOptions.get(optionName);
+        String optionValue = vendorOptions.get(optionName);
+        if (optionValue != null && optionValue.startsWith("$${")) {
+            TemplateCQLManager cqlManager = new TemplateCQLManager(optionValue, null);
+            return cqlManager.getExpressionFromString().evaluate(null).toString();
+        }
+        return optionValue;
     }
 
     /**
@@ -87,5 +93,9 @@ public class RootBuilder implements TemplateBuilder {
     protected boolean supportVendorOption(String vendorOptionName) {
         if (supportedOptions.contains(vendorOptionName)) return true;
         else return false;
+    }
+
+    public boolean needsReload() {
+        return false;
     }
 }

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/configuration/TemplateConfiguration.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/configuration/TemplateConfiguration.java
@@ -72,11 +72,17 @@ public class TemplateConfiguration {
         CacheKey key = new CacheKey(typeInfo, fileName);
         WFSTemplate template = templateCache.get(key);
         if (template.checkTemplate()) templateCache.put(key, template);
-        boolean isValid;
         RootBuilder root = template.getRootBuilder();
+        // check if reload is needed anyway and eventually reload the template
+        if (root != null && root.needsReload()) {
+            template.reloadTemplate();
+            templateCache.put(key, template);
+            root = template.getRootBuilder();
+        }
+
         if (root != null) {
             TemplateValidator validator = new TemplateValidator(typeInfo);
-            isValid = validator.validateTemplate(root);
+            boolean isValid = validator.validateTemplate(root);
             if (!isValid) {
                 throw new RuntimeException(
                         "Failed to validate template for feature type "

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/configuration/WFSTemplate.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/configuration/WFSTemplate.java
@@ -47,6 +47,7 @@ public class WFSTemplate {
                     try {
                         RootBuilder root = watcher.getTemplate();
                         this.builderTree = root;
+                        return true;
                     } catch (IOException ioe) {
                         throw new RuntimeException(ioe);
                     }
@@ -54,6 +55,19 @@ public class WFSTemplate {
             }
         }
         return false;
+    }
+
+    public void reloadTemplate() {
+        synchronized (this) {
+            if (watcher != null) {
+                try {
+                    RootBuilder root = watcher.getTemplate();
+                    this.builderTree = root;
+                } catch (IOException ioe) {
+                    throw new RuntimeException(ioe);
+                }
+            }
+        }
     }
 
     /**

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/expressions/TemplateCQLManager.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/expressions/TemplateCQLManager.java
@@ -30,7 +30,7 @@ import org.xml.sax.helpers.NamespaceSupport;
  * to extracts the xpath from the function as a literal, to substitute it after cql encoding
  * happened with an AttributeExpression.
  */
-public class JsonLdCQLManager {
+public class TemplateCQLManager {
 
     private String strCql;
 
@@ -38,7 +38,7 @@ public class JsonLdCQLManager {
 
     private NamespaceSupport namespaces;
 
-    public JsonLdCQLManager(String strCql, NamespaceSupport namespaces) {
+    public TemplateCQLManager(String strCql, NamespaceSupport namespaces) {
         this.strCql = strCql;
         this.namespaces = namespaces;
     }
@@ -349,7 +349,8 @@ public class JsonLdCQLManager {
      */
     public static String quoteXpathAttribute(String xpath) {
         int atIndex = xpath.indexOf("@");
-        if (atIndex != -1) {
+        int quotedAtIndex = xpath.indexOf("\"@\"");
+        if (atIndex != -1 && quotedAtIndex == -1) {
             Pattern pattern = Pattern.compile("[a-zA-Z()<>.\\-1-9*]");
             String substring = xpath.substring(atIndex + 1);
             StringBuilder xpathAttribute = new StringBuilder("@");

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/request/JsonPathVisitor.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/request/JsonPathVisitor.java
@@ -15,10 +15,8 @@ import org.geoserver.featurestemplating.builders.impl.CompositeBuilder;
 import org.geoserver.featurestemplating.builders.impl.DynamicValueBuilder;
 import org.geoserver.featurestemplating.builders.impl.IteratingBuilder;
 import org.geoserver.featurestemplating.builders.impl.StaticBuilder;
-import org.geoserver.featurestemplating.expressions.JsonLdCQLManager;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.AttributeExpressionImpl;
-import org.geotools.filter.text.cql2.CQL;
 import org.geotools.filter.visitor.DuplicatingFilterVisitor;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.FeatureType;
@@ -226,16 +224,13 @@ public class JsonPathVisitor extends DuplicatingFilterVisitor {
      */
     private String completeXPath(String xpath) {
         if (currentSource != null && !isSimple) xpath = currentSource + "/" + xpath;
-        return JsonLdCQLManager.quoteXpathAttribute(xpath);
+        return xpath;
     }
 
     private void addFilter(Filter filter) {
         if (filter != null) {
-            String f = CQL.toCQL(filter);
-            if (!f.contains("@")) {
-                filter = (Filter) findXpathArg(filter);
-                filters.add(filter);
-            }
+            filter = (Filter) findXpathArg(filter);
+            filters.add(filter);
         }
     }
 

--- a/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/request/JsonTemplateCallBackOGC.java
+++ b/src/community/features-templating/src/main/java/org/geoserver/featurestemplating/request/JsonTemplateCallBackOGC.java
@@ -18,7 +18,7 @@ import org.geoserver.featurestemplating.builders.impl.RootBuilder;
 import org.geoserver.featurestemplating.builders.jsonld.JsonLdRootBuilder;
 import org.geoserver.featurestemplating.configuration.TemplateConfiguration;
 import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
-import org.geoserver.featurestemplating.expressions.JsonLdCQLManager;
+import org.geoserver.featurestemplating.expressions.TemplateCQLManager;
 import org.geoserver.featurestemplating.response.GeoJsonTemplateGetFeatureResponse;
 import org.geoserver.ows.AbstractDispatcherCallback;
 import org.geoserver.ows.DispatcherCallback;
@@ -160,8 +160,8 @@ public class JsonTemplateCallBackOGC extends AbstractDispatcherCallback {
         }
         // Taking back a string from Function cause
         // OGC API get a string cql filter from query string
-        String newFilter = JsonLdCQLManager.removeQuotes(ECQL.toCQL(f)).replaceAll("/", ".");
-        newFilter = JsonLdCQLManager.quoteXpathAttribute(newFilter);
+        String newFilter = TemplateCQLManager.removeQuotes(ECQL.toCQL(f)).replaceAll("/", ".");
+        newFilter = TemplateCQLManager.quoteXpathAttribute(newFilter);
         for (int i = 0; i < operation.getParameters().length; i++) {
             Object p = operation.getParameters()[i];
             if (p != null && ((String.valueOf(p)).trim().equals(strFilter.trim()))) {

--- a/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/readers/JsonTemplateReaderTest.java
+++ b/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/readers/JsonTemplateReaderTest.java
@@ -1,0 +1,55 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.featurestemplating.readers;
+
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.geoserver.featurestemplating.builders.TemplateBuilder;
+import org.geoserver.featurestemplating.builders.flat.FlatBuilder;
+import org.geoserver.featurestemplating.builders.impl.RootBuilder;
+import org.geotools.filter.function.EnvFunction;
+import org.junit.Test;
+
+public class JsonTemplateReaderTest {
+
+    @Test
+    public void testVendorOptionWithEnvFunction() throws IOException {
+
+        RootBuilder root = getBuilderTree("FlatGeoJSONMappedFeature.json");
+        // flat_output option is true checking type is FlatBuilder
+        testBuildersType(root.getChildren(), b -> b instanceof FlatBuilder);
+        Map<String, Object> envValues = new HashMap<String, Object>();
+        envValues.put("flat_output", "false");
+        EnvFunction.setLocalValues(envValues);
+        root = getBuilderTree("FlatGeoJSONMappedFeature.json");
+        // if env parametrization on VendorOptions works flat_output should be false now
+        testBuildersType(root.getChildren(), b -> !(b instanceof FlatBuilder));
+    }
+
+    private RootBuilder getBuilderTree(String resourceName) throws IOException {
+        InputStream is = getClass().getResource(resourceName).openStream();
+        ObjectMapper mapper =
+                new ObjectMapper(new JsonFactory().enable(JsonParser.Feature.ALLOW_COMMENTS));
+        JsonTemplateReader templateReader = new JsonTemplateReader(mapper.readTree(is), null);
+        return templateReader.getRootBuilder();
+    }
+
+    private void testBuildersType(
+            List<TemplateBuilder> builders, Predicate<TemplateBuilder> predicate) {
+        for (TemplateBuilder builder : builders) {
+            assertTrue(predicate.test(builder));
+            if (builder.getChildren() != null) testBuildersType(builder.getChildren(), predicate);
+        }
+    }
+}

--- a/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/FilteringFlatGeoJSONComplexFeaturesResponseTest.java
+++ b/src/community/features-templating/src/test/java/org/geoserver/featurestemplating/response/FilteringFlatGeoJSONComplexFeaturesResponseTest.java
@@ -1,0 +1,45 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.featurestemplating.response;
+
+import static org.junit.Assert.*;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class FilteringFlatGeoJSONComplexFeaturesResponseTest
+        extends TemplateJSONComplexTestSupport {
+
+    @Test
+    public void testFilteredArraysIndex() throws Exception {
+        setUpMappedFeature("FilteringFlatGeoJSONMappedFeature.json");
+        StringBuffer sb = new StringBuffer("wfs?request=GetFeature&version=2.0");
+        sb.append("&TYPENAME=gsml:MappedFeature&outputFormat=");
+        sb.append("application/json");
+        JSONObject result = (JSONObject) getJson(sb.toString());
+        JSONArray features = (JSONArray) result.get("features");
+        assertEquals(4, features.size());
+        for (int i = 0; i < features.size(); i++) {
+            JSONObject feature = (JSONObject) features.get(i);
+            if (feature.getString("@id").equals("mf4")) {
+                JSONObject props = feature.getJSONObject("properties");
+                String id =
+                        props.getString(
+                                "gsml:GeologicUnit_gsml:composition_"
+                                        + "gsml:compositionPart_lithology_1_id");
+                assertEquals("cc.2", id);
+            }
+        }
+    }
+
+    @Override
+    protected String getTemplateFileName() {
+        return TemplateIdentifier.JSON.getFilename();
+    }
+}

--- a/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/readers/FlatGeoJSONMappedFeature.json
+++ b/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/readers/FlatGeoJSONMappedFeature.json
@@ -1,0 +1,52 @@
+{
+  "$VendorOptions": "flat_output:$${env('flat_output','true')}",
+  "type":"FeatureCollection",
+  "features":[
+    {
+      "$source":"gsml:MappedFeature"
+    },
+    {
+      "@id":"${@id}",
+      "geometry":"${gsml:shape}",
+      "properties":{
+        "name":"$${strConcat('FeatureName: ', xpath('gml:name'))}",
+        "gsml:GeologicUnit":{
+          "$source":"gsml:specification/gsml:GeologicUnit",
+          "description":"${gml:description}",
+          "gsml:geologicUnitType":"urn:ogc:def:nil:OGC::unknown",
+          "gsml:composition":[
+            {
+              "$source":"gsml:composition"
+            },
+            {
+              "gsml:compositionPart":[
+                {
+                  "$source":"gsml:CompositionPart"
+                },
+                {
+                  "gsml:role_value":"$${strConcat('FeatureName: ', xpath('gsml:role'))}",
+                  "gsml:role_@codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
+                  "proportion":{
+                    "$source":"gsml:proportion",
+                    "@dataType":"CGI_ValueProperty",
+                    "CGI_TermValue_@dataType":"CGI_TermValue",
+                    "CGI_TermValue_value":"${gsml:CGI_TermValue}"
+                  },
+                  "lithology":[
+                    {
+                      "$source":"gsml:lithology"
+                    },
+                    {
+                      "name":"${gsml:ControlledConcept/gsml:name}" ,
+                      "vocabulary":"@href:urn:ogc:def:nil:OGC::missing"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FilteringFlatGeoJSONMappedFeature.json
+++ b/src/community/features-templating/src/test/resources/org/geoserver/featurestemplating/response/FilteringFlatGeoJSONMappedFeature.json
@@ -1,0 +1,51 @@
+{
+  "$VendorOptions": "flat_output:true",
+  "type":"FeatureCollection",
+  "features":[
+    {
+      "$source":"gsml:MappedFeature"
+    },
+    {
+      "@id":"${@id}",
+      "geometry":"${gsml:shape}",
+      "properties":{
+        "name":"$${strConcat('FeatureName: ', xpath('gml:name'))}",
+        "gsml:GeologicUnit_description":"${gsml:specification/gsml:GeologicUnit/gml:description}",
+        "gsml:GeologicUnit_gsml:geologicUnitType":"urn:ogc:def:nil:OGC::unknown",
+        "gsml:GeologicUnit_gsml:composition":[
+            {
+              "$source":"gsml:specification/gsml:GeologicUnit/gsml:composition"
+            },
+            {
+              "gsml:compositionPart":[
+                {
+                  "$source":"gsml:CompositionPart"
+                },
+                {
+                  "gsml:role_value":"$${strConcat('FeatureName: ', xpath('gsml:role'))}",
+                  "gsml:role_@codeSpace":"urn:cgi:classifierScheme:Example:CompositionPartRole",
+                  "proportion":{
+                    "$source":"gsml:proportion",
+                    "@dataType":"CGI_ValueProperty",
+                    "CGI_TermValue_@dataType":"CGI_TermValue",
+                    "CGI_TermValue_value":"${gsml:CGI_TermValue}"
+                  },
+                  "lithology":[
+                    {
+                      "$source":"gsml:lithology",
+                      "$filter": "xpath('gsml:ControlledConcept/@id') = 'cc.2'"
+                    },
+                    {
+                      "id": "${gsml:ControlledConcept/@id}",
+                      "name":"${gsml:ControlledConcept/gsml:name}" ,
+                      "vocabulary":"@href:urn:ogc:def:nil:OGC::missing"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request provides the following fixes on features-templating plug-in:

- allowing the usage of env function inside the $VendorOptions directive;
- consistent array element enumeration when some array elements are filtered out by the $filter directive

Here the JIRA tickets https://osgeo-org.atlassian.net/browse/GEOS-9753
https://osgeo-org.atlassian.net/browse/GEOS-9754

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
