### PR TITLE
[GEOS-9758] CRS Panel overrides URN SRS format with EPSG:XXXX format

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/BasicResourceConfig.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/BasicResourceConfig.java
@@ -396,7 +396,8 @@ public class BasicResourceConfig extends ResourceConfigurationPanel {
                 new CRSPanel(
                         "nativeSRS",
                         new PropertyModel<CoordinateReferenceSystem>(model, "nativeCRS"),
-                        otherSRS) {
+                        otherSRS,
+                        !otherSRS.isEmpty()) {
 
                     /** serialVersionUID */
                     private static final long serialVersionUID = -7725670382699858126L;

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
@@ -459,6 +459,7 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
                                 "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:srs")
                         .getDefaultModelObjectAsString();
         assertFalse(newNativeSRS.equalsIgnoreCase(actualNativeSRS));
+        assertTrue(newNativeSRS.equalsIgnoreCase("urn:ogc:def:crs:EPSG::4326"));
 
         // click submit and go back to LayerPage
         FormTester ft = tester.newFormTester("publishedinfo");

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
@@ -448,12 +448,12 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
         // verify Layer`s resource is updated with metadata
         assertNotNull(layerInfo.getResource().getMetadata().get(FeatureTypeInfo.OTHER_SRS));
 
-        // click first item in SRS (4326)
+        // click first item in SRS (urn:ogc:def:crs:EPSG::4326)
         tester.clickLink(
                 "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link",
                 true);
 
-        // assert that native SRS has changed from EPSG:26713 to EPSG:4326
+        // assert that native SRS has changed from EPSG:26713 to urn:ogc:def:crs:EPSG::4326
         String newNativeSRS =
                 tester.getComponentFromLastRenderedPage(
                                 "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:srs")

--- a/src/web/core/src/test/resources/wfs_cap_110.xml
+++ b/src/web/core/src/test/resources/wfs_cap_110.xml
@@ -191,7 +191,7 @@
 				<ows:Keyword>roads</ows:Keyword>
 			</ows:Keywords>
 			<DefaultSRS>EPSG:26713</DefaultSRS>
-			<OtherSRS>EPSG:4326</OtherSRS>
+			<OtherSRS>urn:ogc:def:crs:EPSG::4326</OtherSRS>
 			<OtherSRS>EPSG:3857</OtherSRS>
 			<ows:WGS84BoundingBox>
 				<ows:LowerCorner>-103.87779468316292 44.37288961726252</ows:LowerCorner>


### PR DESCRIPTION
JIRA : https://osgeo-org.atlassian.net/browse/GEOS-9758

- updated CRS panel class with new flag and constructor
- flag will bind the text field to SRS literals known to CRSPanel only
- updated existing unit test

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
