### PR TITLE
MapPreviewPage performance improvement with less catalog queries

### DIFF
--- a/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
@@ -339,10 +339,9 @@ public class PreviewLayer {
      * @param serviceName "WFS" or "WMS"
      */
     public boolean hasServiceSupport(String serviceName) {
-        LayerInfo linfo = GeoServerApplication.get().getCatalog().getLayerByName(this.getName());
-        if (linfo != null && linfo.getResource() != null && serviceName != null) {
+        if (layerInfo != null && layerInfo.getResource() != null && serviceName != null) {
             List<String> disabledServices =
-                    DisabledServiceResourceFilter.disabledServices(linfo.getResource());
+                    DisabledServiceResourceFilter.disabledServices(layerInfo.getResource());
             return disabledServices.stream().noneMatch(d -> d.equalsIgnoreCase(serviceName));
         }
         // layer group and backward compatibility


### PR DESCRIPTION
Use the held reference to `LayerInfo` inside `PreviewLayer.hasServiceSupport(String serviceName)` instead of re-loading
the layer from the `Catalog` on each call.

With 25 rows per page and 3 `CommonFormatLink` implementations available, it's 75 less queries to the Catalog.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
