### PR TITLE
[GEOS-9788] Keycloak-plugin wrong role mapping

### DIFF
--- a/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/GeoServerKeycloakFilter.java
+++ b/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/GeoServerKeycloakFilter.java
@@ -63,7 +63,9 @@ public class GeoServerKeycloakFilter extends GeoServerSecurityFilter
     public GeoServerKeycloakFilter() {
         this.adapterTokenStoreFactory = new SpringSecurityAdapterTokenStoreFactory();
         this.authenticationMapper = new KeycloakAuthenticationProvider();
-        authenticationMapper.setGrantedAuthoritiesMapper(new SimpleAuthorityMapper());
+        SimpleAuthorityMapper simpleAuthMapper = new SimpleAuthorityMapper();
+        simpleAuthMapper.setPrefix("");
+        authenticationMapper.setGrantedAuthoritiesMapper(simpleAuthMapper);
     }
 
     @Override

--- a/src/community/security/keycloak/src/test/java/org/geoserver/security/keycloak/GeoServerKeycloakFilterTest.java
+++ b/src/community/security/keycloak/src/test/java/org/geoserver/security/keycloak/GeoServerKeycloakFilterTest.java
@@ -237,7 +237,7 @@ public class GeoServerKeycloakFilterTest {
         assertTrue(authn instanceof UsernamePasswordAuthenticationToken);
         assertFalse(authn.getAuthorities().isEmpty());
         for (GrantedAuthority a : authn.getAuthorities()) {
-            assertTrue(a.getAuthority().startsWith("ROLE_"));
+            assertFalse(a.getAuthority().startsWith("ROLE_"));
         }
     }
 }


### PR DESCRIPTION
This issue is referencing to this GeoServer-dev-mailing-list-post: http://osgeo-org.1560.x6.nabble.com/Keycloak-plugin-wrong-role-mapping-td5449169.html 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
