### PR TITLE
[2.18.x backport] [GEOS-9793] Update PostgreSQL (to 42.2.18) and Oracle (to 19.8.0.0) JDBC drivers

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1994,9 +1994,9 @@
   <jackson2.version>2.10.1</jackson2.version>
   <compress-lzf.version>1.0.3</compress-lzf.version>
   <marlin.version>0.9.3</marlin.version>
-  <postgresql.jdbc.version>42.2.14</postgresql.jdbc.version>
+  <postgresql.jdbc.version>42.2.18</postgresql.jdbc.version>
   <postgis.jdbc.version>1.3.3</postgis.jdbc.version>
-  <oracle.jdbc.version>19.7.0.0</oracle.jdbc.version>
+  <oracle.jdbc.version>19.8.0.0</oracle.jdbc.version>
   <solrj.version>7.2.1</solrj.version>
   <jacoco.version>0.8.1</jacoco.version>
   <hazelcast.version>3.11.1</hazelcast.version>


### PR DESCRIPTION
Both of these have had some patch releases, so they should be updated.
```
com.oracle.database.jdbc:ojdbc8 ................. 19.7.0.0 -> 19.8.0.0
org.postgresql:postgresql ......................... 42.2.14 -> 42.2.18
```

backports #4573 to 2.18.x

resolves [GEOS-9793](https://osgeo-org.atlassian.net/browse/GEOS-9793)

see also https://github.com/geotools/geotools/pull/3208 (geotools 24.x PR)
