### PR TITLE
[2.17.x backport][GEOS-9791] GeoJSON bounding box axis order wrongly encoded when CRS axis order is NORTH-EAST

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -40,6 +40,7 @@ import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.ReferenceIdentifier;
@@ -250,9 +251,13 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
             boolean hasGeom) {
         // Bounding box for featurecollection
         if (hasGeom && featureBounding) {
+            CoordinateReferenceSystem crs = null;
             ReferencedEnvelope e = null;
             for (int i = 0; i < resultsList.size(); i++) {
                 FeatureCollection collection = resultsList.get(i);
+                FeatureType schema = collection.getSchema();
+                if (crs == null && schema.getGeometryDescriptor() != null)
+                    crs = schema.getGeometryDescriptor().getCoordinateReferenceSystem();
                 if (e == null) {
                     e = collection.getBounds();
                 } else {
@@ -261,7 +266,7 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
             }
 
             if (e != null) {
-                jsonWriter.setAxisOrder(CRS.getAxisOrder(e.getCoordinateReferenceSystem()));
+                jsonWriter.setAxisOrder(CRS.getAxisOrder(crs));
                 jsonWriter.writeBoundingBox(e);
             }
         }

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONTest.java
@@ -935,6 +935,36 @@ public class GeoJSONTest extends WFSTestSupport {
         assertEquals("Infinity", getProperty(f3, "f"));
     }
 
+    @Test
+    public void testBoundingBoxAxisOrderInWfs10AndWfs11() throws Exception {
+        // test that AxisOrder of bbox coordinates are switched to EAST-NORTH,
+        // as for the other coordinates array in the json features, when the CRS
+        // has NORTH-EAST axis order
+        JSONObject rootObject =
+                (JSONObject)
+                        getAsJSON(
+                                "wfs?request=GetFeature&version=1.0.0&typename="
+                                        + getLayerId(POINT_LATLON)
+                                        + "&outputformat="
+                                        + JSONType.json);
+
+        JSONArray bbox = rootObject.getJSONArray("bbox");
+
+        JSONObject rootObjectRep =
+                (JSONObject)
+                        getAsJSON(
+                                "wfs?request=GetFeature&version=1.1.0&typename="
+                                        + getLayerId(POINT_LATLON)
+                                        + "&outputformat="
+                                        + JSONType.json
+                                        + "&srsName=urn:x-ogc:def:crs:EPSG:4326");
+
+        JSONArray bboxRep = rootObjectRep.getJSONArray("bbox");
+        // bbox should be equal since the NORTH-EAST axis order in the wfs 1.1.0
+        // should have been ignored and kept to EAST-NORTH
+        assertTrue(bboxRep.equals(bbox));
+    }
+
     private Object getProperty(JSONObject feature, String propertyName) {
         return feature.getJSONObject("properties").get(propertyName);
     }


### PR DESCRIPTION

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
