### PR TITLE
[GEOS-9834] GetLegendGraphic results in java.lang.NegativeArraySizeException or OutOfMemory

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendGraphicBuilder.java
@@ -78,6 +78,7 @@ public abstract class LegendGraphicBuilder {
      */
     protected final double MINIMUM_SYMBOL_SIZE = 3.0;
 
+    double dpiScaleFactor;
     protected int w;
     protected int h;
     boolean forceLabelsOn = false;
@@ -96,6 +97,13 @@ public abstract class LegendGraphicBuilder {
         // width and height, we might have to rescale those in case of DPI usage
         w = request.getWidth();
         h = request.getHeight();
+        double dpi = RendererUtilities.getDpi(request.getLegendOptions());
+        double standardDpi = RendererUtilities.getDpi(Collections.emptyMap());
+        dpiScaleFactor = dpi / standardDpi;
+        if (dpiScaleFactor != 1.0) {
+            w = ((int) Math.round(request.getWidth() * dpiScaleFactor));
+            h = ((int) Math.round(request.getHeight() * dpiScaleFactor));
+        }
 
         if (request.getLegendOptions().get("forceLabels") instanceof String) {
             String forceLabelsOpt = (String) request.getLegendOptions().get("forceLabels");
@@ -149,13 +157,8 @@ public abstract class LegendGraphicBuilder {
     protected Style resizeForDPI(GetLegendGraphicRequest request, Style gt2Style) {
 
         // apply dpi rescale
-        double dpi = RendererUtilities.getDpi(request.getLegendOptions());
-        double standardDpi = RendererUtilities.getDpi(Collections.emptyMap());
-        if (dpi != standardDpi) {
-            double scaleFactor = dpi / standardDpi;
-            w = ((int) Math.round(request.getWidth() * scaleFactor));
-            h = ((int) Math.round(request.getHeight() * scaleFactor));
-            DpiRescaleStyleVisitor dpiVisitor = new DpiRescaleStyleVisitor(scaleFactor);
+        if (dpiScaleFactor != 1.0) {
+            DpiRescaleStyleVisitor dpiVisitor = new DpiRescaleStyleVisitor(dpiScaleFactor);
             dpiVisitor.visit(gt2Style);
             gt2Style = (Style) dpiVisitor.getCopy();
         }

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendGraphicBuilder.java
@@ -153,8 +153,8 @@ public abstract class LegendGraphicBuilder {
         double standardDpi = RendererUtilities.getDpi(Collections.emptyMap());
         if (dpi != standardDpi) {
             double scaleFactor = dpi / standardDpi;
-            w = ((int) Math.round(w * scaleFactor));
-            h = ((int) Math.round(h * scaleFactor));
+            w = ((int) Math.round(request.getWidth() * scaleFactor));
+            h = ((int) Math.round(request.getHeight() * scaleFactor));
             DpiRescaleStyleVisitor dpiVisitor = new DpiRescaleStyleVisitor(scaleFactor);
             dpiVisitor.visit(gt2Style);
             gt2Style = (Style) dpiVisitor.getCopy();

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
@@ -1330,6 +1330,48 @@ public class BufferedImageLegendGraphicOutputFormatTest
         assertColorSimilar(Color.WHITE, colorOutsideCenter, 20);
     }
 
+    /** Tests that rescale due to dpi is done correctly. */
+    @org.junit.Test
+    public void testScaleDPI() throws Exception {
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest(null);
+        ;
+        req.setWidth(20);
+        req.setHeight(20);
+        FeatureTypeInfo ftInfo =
+                getCatalog()
+                        .getFeatureTypeByName(
+                                MockData.MPOINTS.getNamespaceURI(),
+                                MockData.MPOINTS.getLocalPart());
+
+        req.setLayer(ftInfo.getFeatureType());
+        Style sldStype = readSLD("line.sld");
+        req.setStyle(sldStype);
+
+        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+
+        assertEquals(20, this.legendProducer.w);
+        assertEquals(20, this.legendProducer.h);
+        assertEquals(20, image.getWidth());
+        assertEquals(20, image.getHeight());
+
+        // set dpi
+        HashMap<String, Object> legendOptions = new HashMap<>();
+        legendOptions.put("dpi", 300);
+        req.setLegendOptions(legendOptions);
+        image = this.legendProducer.buildLegendGraphic(req);
+        assertEquals(66, this.legendProducer.w);
+        assertEquals(66, this.legendProducer.h);
+        assertEquals(66, image.getWidth());
+        assertEquals(66, image.getHeight());
+
+
+        // and when we do it again this must not change the image size
+        this.legendProducer.resizeForDPI(req, sldStype);
+        assertEquals(66, this.legendProducer.w);
+        assertEquals(66, this.legendProducer.h);
+
+    }
+
     /** */
     private Style readSLD(String sldName) throws IOException {
         StyleFactory styleFactory = CommonFactoryFinder.getStyleFactory(null);

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
@@ -70,12 +70,14 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  */
 public class BufferedImageLegendGraphicOutputFormatTest
         extends BaseLegendTest<BufferedImageLegendGraphicBuilder> {
+
     @Before
     public void setLegendProducer() throws Exception {
         this.legendProducer = new BufferedImageLegendGraphicBuilder();
 
         service = new GetLegendGraphic(getWMS());
     }
+
     /**
      * Tests that a legend is produced for the explicitly specified rule, when the FeatureTypeStyle
      * has more than one rule, and one of them is requested by the RULE parameter.
@@ -201,6 +203,7 @@ public class BufferedImageLegendGraphicOutputFormatTest
         // was the legend painted?
         assertNotBlank("testRainfall", image, LegendUtils.DEFAULT_BG_COLOR);
     }
+
     /** Tests that the legend graphic is produced for multiple layers */
     @org.junit.Test
     public void testMultipleLayers() throws Exception {
@@ -1364,12 +1367,10 @@ public class BufferedImageLegendGraphicOutputFormatTest
         assertEquals(66, image.getWidth());
         assertEquals(66, image.getHeight());
 
-
         // and when we do it again this must not change the image size
         this.legendProducer.resizeForDPI(req, sldStype);
         assertEquals(66, this.legendProducer.w);
         assertEquals(66, this.legendProducer.h);
-
     }
 
     /** */

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
@@ -70,14 +70,12 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  */
 public class BufferedImageLegendGraphicOutputFormatTest
         extends BaseLegendTest<BufferedImageLegendGraphicBuilder> {
-
     @Before
     public void setLegendProducer() throws Exception {
         this.legendProducer = new BufferedImageLegendGraphicBuilder();
 
         service = new GetLegendGraphic(getWMS());
     }
-
     /**
      * Tests that a legend is produced for the explicitly specified rule, when the FeatureTypeStyle
      * has more than one rule, and one of them is requested by the RULE parameter.
@@ -203,7 +201,6 @@ public class BufferedImageLegendGraphicOutputFormatTest
         // was the legend painted?
         assertNotBlank("testRainfall", image, LegendUtils.DEFAULT_BG_COLOR);
     }
-
     /** Tests that the legend graphic is produced for multiple layers */
     @org.junit.Test
     public void testMultipleLayers() throws Exception {
@@ -1337,7 +1334,7 @@ public class BufferedImageLegendGraphicOutputFormatTest
     @org.junit.Test
     public void testScaleDPI() throws Exception {
         GetLegendGraphicRequest req = new GetLegendGraphicRequest(null);
-        ;
+
         req.setWidth(20);
         req.setHeight(20);
         FeatureTypeInfo ftInfo =


### PR DESCRIPTION
According to my bug report [GEOS-9834](https://osgeo-org.atlassian.net/browse/GEOS-9834) I opened this pr to fix the scaling of the image.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
