### PR TITLE
[GEOS-9840] Update Jackson 2 libraries from 2.10.1 to 2.10.5 / 2.10.5.1

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1090,7 +1090,7 @@
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
-     <version>${jackson2.version}</version>
+     <version>${jackson2.databind.version}</version>
    </dependency>
 
    <dependency>
@@ -1996,7 +1996,8 @@
   <git.commit.runOnlyOnce>true</git.commit.runOnlyOnce>
   <eclipse.emf.version>2.15.0</eclipse.emf.version>
   <jackson1.version>1.9.13</jackson1.version>
-  <jackson2.version>2.10.1</jackson2.version>
+  <jackson2.version>2.10.5</jackson2.version>
+  <jackson2.databind.version>2.10.5</jackson2.databind.version>
   <compress-lzf.version>1.0.3</compress-lzf.version>
   <marlin.version>0.9.3</marlin.version>
   <postgresql.jdbc.version>42.2.18</postgresql.jdbc.version>


### PR DESCRIPTION
In the Jackson project the following CVE was fixed CVE-2020-25649 , as well as various bugfixes in the used libs. See: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.10

resolves [GEOS-9840](https://osgeo-org.atlassian.net/browse/GEOS-9840)

Related GeoTools PR: https://github.com/geotools/geotools/pull/3266

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
