### PR TITLE
[2.17.x backport][GEOS-9840] Update Jackson 2 libraries from 2.10.1 to 2.10.5 / 2.10.5.1

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1080,7 +1080,7 @@
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
-     <version>${jackson2.version}</version>
+     <version>${jackson2.databind.version}</version>
    </dependency>
 
    <dependency>
@@ -1988,7 +1988,8 @@
   <git.commit.runOnlyOnce>true</git.commit.runOnlyOnce>
   <eclipse.emf.version>2.15.0</eclipse.emf.version>
   <jackson1.version>1.9.13</jackson1.version>
-  <jackson2.version>2.10.1</jackson2.version>
+  <jackson2.version>2.10.5</jackson2.version>
+  <jackson2.databind.version>2.10.5</jackson2.databind.version>
   <compress-lzf.version>1.0.3</compress-lzf.version>
   <marlin.version>0.9.3</marlin.version>
   <postgresql.jdbc.version>42.2.18</postgresql.jdbc.version>


### PR DESCRIPTION
In the Jackson project the following CVE was fixed CVE-2020-25649 , as well as various bugfixes in the used libs. See: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.10

backports #4607, resolves [GEOS-9840](https://osgeo-org.atlassian.net/browse/GEOS-9840) for 2.17.5

Related GeoTools PR: https://github.com/geotools/geotools/pull/3276