### PR TITLE
Updating to imageio-ext 1.3.5

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1962,7 +1962,7 @@
   <poi.version>4.0.0</poi.version>
   <wicket.version>7.6.0</wicket.version>
   <ant.version>1.9.15</ant.version>
-  <imageio-ext.version>1.3.4</imageio-ext.version>
+  <imageio-ext.version>1.3.5</imageio-ext.version>
   <jaiext.version>1.1.18</jaiext.version>
   <java.awt.headless>true</java.awt.headless>
   <sun.java2d.d3d>true</sun.java2d.d3d>


### PR DESCRIPTION
Updating to imageio-ext 1.3.5 to get in a minor bug fix on COG urls parsing.