### PR TITLE
[GEOS-9849] Convert collection .size() checks to isEmpty() where appropriate

### DIFF
--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -23,13 +23,8 @@ under the License.
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
 
     <description>
-        The default ruleset used by the Maven PMD Plugin, when no other ruleset is specified.
-        It contains the rules of the old (pre PMD 6.0.0) rulesets java-basic, java-empty, java-imports,
-        java-unnecessary, java-unusedcode.
-
-        This ruleset might be used as a starting point for an own customized ruleset [0].
-
-        [0] https://pmd.github.io/latest/pmd_userdocs_understanding_rulesets.html
+        The GeoServer ruleset used by the Maven PMD Plugin.
+        See https://pmd.github.io/latest/pmd_userdocs_understanding_rulesets.html
     </description>
 
     <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />
@@ -117,4 +112,5 @@ under the License.
         </property>
       </properties>
     </rule>
+    <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty" />
 </ruleset>

--- a/src/extension/authkey/src/main/java/org/geoserver/security/WebServiceBodyResponseUserGroupService.java
+++ b/src/extension/authkey/src/main/java/org/geoserver/security/WebServiceBodyResponseUserGroupService.java
@@ -155,7 +155,7 @@ public class WebServiceBodyResponseUserGroupService extends AbstractGeoServerSec
                 }
             }
         }
-        if (authorities.size() == 0) {
+        if (authorities.isEmpty()) {
             LOGGER.log(
                     Level.WARNING,
                     "Error in WebServiceAuthenticationKeyMapper, cannot find any Role in response adding anonymous role");
@@ -181,7 +181,7 @@ public class WebServiceBodyResponseUserGroupService extends AbstractGeoServerSec
         }
 
         // Check if Role Admin and Anonymous are present other than other roles
-        if (authorities.size() > 0) {
+        if (!authorities.isEmpty()) {
             for (GrantedAuthority authority : authorities) {
                 if (authority.equals(GeoServerRole.ADMIN_ROLE)
                         || authority.equals(GeoServerRole.GROUP_ADMIN_ROLE)

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/ControlFlowCallback.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/ControlFlowCallback.java
@@ -132,7 +132,7 @@ public class ControlFlowCallback extends AbstractDispatcherCallback
                         e);
                 return operation;
             }
-            if (controllers.size() == 0) {
+            if (controllers.isEmpty()) {
                 LOGGER.info("Control-flow inactive, there are no configured rules");
             } else {
                 if (LOGGER.isLoggable(Level.INFO)) {

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/DefaultFlowControllerProvider.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/DefaultFlowControllerProvider.java
@@ -48,7 +48,7 @@ public class DefaultFlowControllerProvider implements FlowControllerProvider {
 
     private void initControllers() {
         checkConfiguration();
-        if (controllers.size() == 0) {
+        if (controllers.isEmpty()) {
             LOGGER.info("Control-flow inactive, there are no configured rules");
         }
     }

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/DefaultWebCatalogService.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/DefaultWebCatalogService.java
@@ -135,7 +135,7 @@ public class DefaultWebCatalogService implements WebCatalogService, ApplicationC
         List<CatalogStore> storeCandidates =
                 GeoServerExtensions.extensions(CatalogStore.class, applicationContext);
 
-        if (storeCandidates != null && storeCandidates.size() > 0) {
+        if (storeCandidates != null && !storeCandidates.isEmpty()) {
             String defaultStore = System.getProperty("DefaultCatalogStore");
             if (defaultStore != null) {
                 for (CatalogStore store : storeCandidates) {

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/DescribeRecord.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/DescribeRecord.java
@@ -95,7 +95,7 @@ public class DescribeRecord {
 
                 // we could be left with some extra feature types, the spec says we should not
                 // complain and just return the ones we have (eventually an empty document)
-                if (requested.size() != 0) {
+                if (!requested.isEmpty()) {
                     LOGGER.log(
                             Level.FINE,
                             "Failed to locate feature types " + requested + ", ignoring them");

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/GetCapabilities.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/GetCapabilities.java
@@ -128,7 +128,7 @@ public class GetCapabilities {
 
             KeywordsType kw = null;
             List<KeywordInfo> keywords = csw.getKeywords();
-            if (keywords != null && keywords.size() > 0) {
+            if (keywords != null && !keywords.isEmpty()) {
                 kw = owsf.createKeywordsType();
                 for (KeywordInfo keyword : keywords) {
                     kw.getKeyword().add(keyword.getValue());
@@ -427,7 +427,7 @@ public class GetCapabilities {
             for (RecordDescriptor rd : store.getRecordDescriptors()) {
                 List<Name> queriables =
                         store.getCapabilities().getQueriables(rd.getFeatureDescriptor().getName());
-                if (queriables != null && queriables.size() > 0) {
+                if (queriables != null && !queriables.isEmpty()) {
                     DomainType dt = owsf.createDomainType();
                     dt.setName(rd.getQueryablesDescription());
                     NamespaceSupport nss = rd.getNamespaceSupport();
@@ -547,7 +547,7 @@ public class GetCapabilities {
                         store.getCapabilities()
                                 .getDomainQueriables(rd.getFeatureDescriptor().getName());
 
-                if (queriables != null && queriables.size() > 0) {
+                if (queriables != null && !queriables.isEmpty()) {
                     NamespaceSupport nss = rd.getNamespaceSupport();
                     for (Name q : queriables) {
                         String prefix = nss.getPrefix(q.getNamespaceURI());
@@ -559,7 +559,7 @@ public class GetCapabilities {
                 }
             }
 
-            if (summary.size() > 0) {
+            if (!summary.isEmpty()) {
                 List<String> sorted = new ArrayList<>(summary);
                 Collections.sort(sorted);
                 DomainType dt = owsf.createDomainType();

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/kvp/GetDomainKvpRequestReader.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/kvp/GetDomainKvpRequestReader.java
@@ -30,7 +30,7 @@ public class GetDomainKvpRequestReader extends CSWKvpRequestReader {
         Object propertyName = kvp.remove(PROPERTYNAME);
 
         if (propertyName != null) {
-            if (propertyName instanceof List && ((List) propertyName).size() > 0) {
+            if (propertyName instanceof List && !((List) propertyName).isEmpty()) {
                 Object property = null;
 
                 if (((List) propertyName).get(0) instanceof List) {

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/store/internal/CatalogStoreFeatureIterator.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/store/internal/CatalogStoreFeatureIterator.java
@@ -282,7 +282,7 @@ class CatalogStoreFeatureIterator implements Iterator<Feature> {
     }
 
     protected static List<Object> interpolate(Map<String, String> properties, Collection<?> value) {
-        if (value.size() > 0) {
+        if (!value.isEmpty()) {
             List<Object> elements = new ArrayList<>();
             for (Object element : value) {
                 Object result = null;

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -1026,7 +1026,7 @@ public class GeofenceAccessManager
             allowedStyles.addAll(rule.getAllowedStyles());
         }
 
-        if ((allowedStyles.size() > 0) && !allowedStyles.contains(styleName)) {
+        if ((!allowedStyles.isEmpty()) && !allowedStyles.contains(styleName)) {
             throw new ServiceException(
                     "The '" + styleName + "' style is not available on this layer");
         }

--- a/src/extension/imagemap/src/main/java/org/vfny/geoserver/wms/responses/map/htmlimagemap/holes/HolesRemover.java
+++ b/src/extension/imagemap/src/main/java/org/vfny/geoserver/wms/responses/map/htmlimagemap/holes/HolesRemover.java
@@ -195,7 +195,7 @@ public class HolesRemover {
 
         // if there are any interior reflex vertices, find the one that, when connected
         // to our rightMostHoleVertex, forms the line closest to Vector2.UnitX
-        if (interiorReflexVertices.size() > 0) {
+        if (!interiorReflexVertices.isEmpty()) {
             float closestDot = -1f;
             for (Vertex v : interiorReflexVertices) {
                 GVector n = new GVector(new double[] {v.getPosition().x, v.getPosition().y});

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/transform/GdalAddoTransform.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/transform/GdalAddoTransform.java
@@ -33,7 +33,7 @@ public class GdalAddoTransform extends AbstractCommandLinePreTransform implement
     public GdalAddoTransform(List<String> options, List<Integer> levels) {
         super(options);
         this.levels = levels;
-        if (levels == null || levels.size() == 0) {
+        if (levels == null || levels.isEmpty()) {
             throw new ValidationException("Levels is missing, must contain at least one value");
         } else {
             for (Integer level : levels) {

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/RequestData.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/RequestData.java
@@ -400,11 +400,11 @@ public class RequestData implements Serializable {
     }
 
     public String getResourcesList() {
-        if (resources != null && resources.size() > 0) {
+        if (resources == null || resources.isEmpty()) {
+            return null;
+        } else {
             String result = resources.toString();
             return result.substring(1, result.length() - 1);
-        } else {
-            return null;
         }
     }
 
@@ -528,11 +528,11 @@ public class RequestData implements Serializable {
     }
 
     public String getResourcesProcessingTimeList() {
-        if (resourcesProcessingTime != null && resourcesProcessingTime.size() > 0) {
+        if (resourcesProcessingTime == null || resourcesProcessingTime.isEmpty()) {
+            return null;
+        } else {
             String times = resourcesProcessingTime.toString();
             return times.substring(1, times.length() - 1);
-        } else {
-            return null;
         }
     }
 

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/wms/GetLegendGraphicHandler.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ows/wms/GetLegendGraphicHandler.java
@@ -22,13 +22,14 @@ public class GetLegendGraphicHandler extends RequestObjectHandler {
     protected List<String> getLayers(Object request) {
         @SuppressWarnings("unchecked")
         List<FeatureType> types = (List<FeatureType>) OwsUtils.get(request, "layers");
-        if (types != null && types.size() > 0) {
+        if (types == null || types.isEmpty()) {
+            return null;
+        } else {
             List<String> result = new ArrayList<>();
             for (FeatureType ft : types) {
                 result.add(ft.getName().toString());
             }
             return result;
         }
-        return null;
     }
 }

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/layer/NetCDFOutSettingsEditor.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/layer/NetCDFOutSettingsEditor.java
@@ -101,7 +101,7 @@ public class NetCDFOutSettingsEditor extends NetCDFPanel<NetCDFLayerSettingsCont
         if ((startUOM == null || startUOM.isEmpty()) && cinfo != null) {
             // Add the new value from the CoverageBand Details
             List<CoverageDimensionInfo> infos = cinfo.getObject().getDimensions();
-            if (infos != null && infos.size() > 0) {
+            if (infos != null && !infos.isEmpty()) {
                 CoverageDimensionInfo info = infos.get(0);
                 uom.setModelObject(info.getUnit());
             }

--- a/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrOutputFormat.java
+++ b/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrOutputFormat.java
@@ -158,7 +158,7 @@ public class Ogr2OgrOutputFormat extends WFSGetFeatureOutputFormat
     @Override
     public boolean canHandle(Operation operation) {
         // we can't handle anything if the ogr2ogr configuration failed
-        if (formats.size() == 0) {
+        if (formats.isEmpty()) {
             return false;
         } else {
             return super.canHandle(operation);

--- a/src/extension/querylayer/src/main/java/org/geoserver/filter/function/CollectGeometriesFunction.java
+++ b/src/extension/querylayer/src/main/java/org/geoserver/filter/function/CollectGeometriesFunction.java
@@ -43,7 +43,7 @@ public class CollectGeometriesFunction extends FunctionImpl {
 
     public Object evaluate(Object object) {
         List geometries = getParameters().get(0).evaluate(object, List.class);
-        if (geometries == null || geometries.size() == 0) {
+        if (geometries == null || geometries.isEmpty()) {
             return new GeometryCollection(null, new GeometryFactory());
         }
 

--- a/src/extension/querylayer/src/main/java/org/geoserver/filter/function/QueryFunction.java
+++ b/src/extension/querylayer/src/main/java/org/geoserver/filter/function/QueryFunction.java
@@ -134,7 +134,7 @@ public class QueryFunction extends FunctionImpl {
                 results.add(value);
             }
 
-            if (results.size() == 0) {
+            if (results.isEmpty()) {
                 return null;
             }
             if (maxResults > 0 && results.size() > maxResults && !single) {

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/vector/PipelineBuilder.java
@@ -460,7 +460,7 @@ public class PipelineBuilder {
                     result.add(clipped);
                 }
             }
-            if (result.size() == 0) {
+            if (result.isEmpty()) {
                 return null;
             }
             return new GeometryCollection(
@@ -478,7 +478,7 @@ public class PipelineBuilder {
             @SuppressWarnings("unchecked")
             List<Polygon> polys =
                     org.locationtech.jts.geom.util.PolygonExtracter.getPolygons(result);
-            if (polys.size() == 0) {
+            if (polys.isEmpty()) {
                 return null;
             }
             if (polys.size() == 1) {
@@ -500,7 +500,7 @@ public class PipelineBuilder {
             @SuppressWarnings("unchecked")
             List<LineString> lines =
                     org.locationtech.jts.geom.util.LineStringExtracter.getLines(result);
-            if (lines.size() == 0) {
+            if (lines.isEmpty()) {
                 return null;
             }
             if (lines.size() == 1) {
@@ -516,7 +516,7 @@ public class PipelineBuilder {
             }
             @SuppressWarnings("unchecked")
             List<Point> pts = org.locationtech.jts.geom.util.PointExtracter.getPoints(result);
-            if (pts.size() == 0) {
+            if (pts.isEmpty()) {
                 return null;
             }
             if (pts.size() == 1) {

--- a/src/extension/web-resource/src/main/java/org/geoserver/web/treeview/TreeNode.java
+++ b/src/extension/web-resource/src/main/java/org/geoserver/web/treeview/TreeNode.java
@@ -57,7 +57,7 @@ public interface TreeNode<T> extends Serializable {
      * @return true if the node is a leaf
      */
     default boolean isLeaf() {
-        return getChildren().size() == 0;
+        return getChildren().isEmpty();
     }
 
     /**

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/FilteredProcessesProvider.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/FilteredProcessesProvider.java
@@ -95,7 +95,7 @@ public class FilteredProcessesProvider
             ProcessInfo pai = new ProcessInfoImpl();
             pai.setName(getName());
             pai.setEnabled(getEnabled());
-            if (getRoles() != null && getRoles().size() > 0) {
+            if (getRoles() != null && !getRoles().isEmpty()) {
                 pai.getRoles().addAll(getRoles());
             }
             if (validators != null && validators.size() > 0) {

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/InputParameterValues.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/InputParameterValues.java
@@ -110,17 +110,17 @@ class InputParameterValues implements Serializable {
 
     public boolean isComplex() {
         List<ProcessParameterIO> ppios = getProcessParameterIO();
-        return ppios.size() > 0 && ppios.get(0) instanceof ComplexPPIO;
+        return !ppios.isEmpty() && ppios.get(0) instanceof ComplexPPIO;
     }
 
     public boolean isBoundingBox() {
         List<ProcessParameterIO> ppios = getProcessParameterIO();
-        return ppios.size() > 0 && ppios.get(0) instanceof BoundingBoxPPIO;
+        return !ppios.isEmpty() && ppios.get(0) instanceof BoundingBoxPPIO;
     }
 
     public boolean isCoordinateReferenceSystem() {
         List<ProcessParameterIO> ppios = getProcessParameterIO();
-        return ppios.size() > 0 && ppios.get(0) instanceof CoordinateReferenceSystemPPIO;
+        return !ppios.isEmpty() && ppios.get(0) instanceof CoordinateReferenceSystemPPIO;
     }
 
     List<ProcessParameterIO> getProcessParameterIO() {

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/OutputParameter.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/OutputParameter.java
@@ -56,7 +56,7 @@ class OutputParameter implements Serializable {
 
     public boolean isComplex() {
         List<ProcessParameterIO> ppios = getProcessParameterIO();
-        return ppios.size() > 0 && ppios.get(0) instanceof ComplexPPIO;
+        return !ppios.isEmpty() && ppios.get(0) instanceof ComplexPPIO;
     }
 
     List<ProcessParameterIO> getProcessParameterIO() {

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/ProcessStatusPage.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/ProcessStatusPage.java
@@ -98,7 +98,7 @@ public class ProcessStatusPage extends GeoServerSecuredPage {
         public void onClick(AjaxRequestTarget target) {
             // see if the user selected anything
             final List<ExecutionStatus> selection = table.getSelection();
-            if (selection.size() == 0) return;
+            if (selection.isEmpty()) return;
 
             dialog.setTitle(new ParamResourceModel("confirmDismissal", this));
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/executor/AbstractInputProvider.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/executor/AbstractInputProvider.java
@@ -112,7 +112,7 @@ public abstract class AbstractInputProvider implements InputProvider {
         KvpUtils.normalize(original);
         Map<String, Object> parsed = new KvpMap<>(original);
         List<Throwable> errors = KvpUtils.parse(parsed);
-        if (errors.size() > 0) {
+        if (!errors.isEmpty()) {
             throw new WPSException("Failed to parse KVP request", errors.get(0));
         }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/GeorectifyCoverage.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/GeorectifyCoverage.java
@@ -434,7 +434,7 @@ public class GeorectifyCoverage implements GeoServerProcess {
             final List<String> warpingParameters) {
         return new ArrayList<String>() {
             {
-                if (targetEnvelope != null && targetEnvelope.size() > 0) {
+                if (targetEnvelope != null && !targetEnvelope.isEmpty()) {
                     add("-te");
                     addAll(targetEnvelope);
                 }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
@@ -473,7 +473,7 @@ public class ImportProcess implements GeoServerProcess {
                         if (coverages.size() == 1) {
                             existing = coverages.get(0);
                         }
-                        if (coverages.size() == 0) {
+                        if (coverages.isEmpty()) {
                             // no coverages yet configured, change add flag and continue on
                             add = true;
                         } else {

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/kvp/ExecuteKvpRequestReader.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/kvp/ExecuteKvpRequestReader.java
@@ -326,7 +326,7 @@ public class ExecuteKvpRequestReader extends EMFKvpRequestReader
 
         List<IOParam> ioParams = parseIOParameters(rawOutputs);
 
-        if (ioParams.size() == 0) {
+        if (ioParams.isEmpty()) {
             return response;
         }
         if (ioParams.size() > 1) {

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/security/WpsAccessRuleDAO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/security/WpsAccessRuleDAO.java
@@ -104,7 +104,7 @@ public class WpsAccessRuleDAO extends ConfigurationListenerAdapter {
             }
         }
         // make sure the single basic rules if the set is empty
-        if (result.size() == 0) {
+        if (result.isEmpty()) {
             result.add(new WpsAccessRule(WpsAccessRule.EXECUTE_ALL));
         }
 

--- a/src/extension/xslt/src/main/java/org/geoserver/wfs/xslt/config/TransformRepository.java
+++ b/src/extension/xslt/src/main/java/org/geoserver/wfs/xslt/config/TransformRepository.java
@@ -113,7 +113,7 @@ public class TransformRepository {
                                 });
                         Templates template = tf.newTemplates(xslSource);
 
-                        if (errors.size() > 0) {
+                        if (!errors.isEmpty()) {
                             StringBuilder sb = new StringBuilder("Errors found in the template");
                             for (TransformerException e : errors) {
                                 sb.append("\n").append(e.getMessageAndLocation());

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -527,7 +527,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         final List<MimeType> mimeTypes;
         if (styleName == null) {
             styleNames = getCachedStyles(layerName);
-            if (styleNames.size() == 0) {
+            if (styleNames.isEmpty()) {
                 styleNames.add("");
             }
         } else {
@@ -929,13 +929,13 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         Map<String, ParameterFilter> filters;
         {
             List<ParameterFilter> parameterFilters = layer.getParameterFilters();
-            if (null != parameterFilters && parameterFilters.size() > 0) {
+            if (null == parameterFilters || parameterFilters.isEmpty()) {
+                filters = Collections.emptyMap();
+            } else {
                 filters = new HashMap<>();
                 for (ParameterFilter pf : parameterFilters) {
                     filters.put(pf.getKey().toUpperCase(), pf);
                 }
-            } else {
-                filters = Collections.emptyMap();
             }
         }
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWCTransactionListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWCTransactionListener.java
@@ -134,7 +134,7 @@ public class GWCTransactionListener implements TransactionCallback {
     private ReferencedEnvelope merge(
             final String tileLayerName, final List<ReferencedEnvelope> dirtyList)
             throws TransformException, FactoryException {
-        if (dirtyList.size() == 0) {
+        if (dirtyList.isEmpty()) {
             return null;
         }
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/dispatch/GwcResponseProxy.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/dispatch/GwcResponseProxy.java
@@ -35,7 +35,7 @@ public class GwcResponseProxy extends Response {
     public String[][] getHeaders(Object value, Operation operation) throws ServiceException {
         GwcOperationProxy op = (GwcOperationProxy) value;
         Map<String, String> responseHeaders = op.getResponseHeaders();
-        if (responseHeaders == null || responseHeaders.size() == 0) {
+        if (responseHeaders == null || responseHeaders.isEmpty()) {
             return null;
         }
         String[][] headers = new String[responseHeaders.size()][2];

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -940,7 +940,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
             throws ConfigurationException {
 
         Set<XMLGridSubset> cachedGridSets = info.getGridSubsets();
-        if (cachedGridSets.size() == 0) {
+        if (cachedGridSets.isEmpty()) {
             return Collections.emptyMap();
         }
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/LegacyTileLayerInfoLoader.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/LegacyTileLayerInfoLoader.java
@@ -223,10 +223,10 @@ public class LegacyTileLayerInfoLoader {
         metadata.put(CONFIG_KEY_AUTO_CACHE_STYLES, autoCacheStyles);
         metadata.put(CONFIG_KEY_IN_MEMORY_CACHED, inMemoryCached);
 
-        if (cachedStyles.size() > 0) {
-            metadata.put(CONFIG_KEY_CACHED_STYLES, marshalList(cachedStyles));
-        } else {
+        if (cachedStyles.isEmpty()) {
             metadata.remove(CONFIG_KEY_CACHED_STYLES);
+        } else {
+            metadata.put(CONFIG_KEY_CACHED_STYLES, marshalList(cachedStyles));
         }
     }
 }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/TileLayerInfoUtil.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/TileLayerInfoUtil.java
@@ -234,7 +234,7 @@ public class TileLayerInfoUtil {
 
         createParam |= tileLayerInfo.removeParameterFilter(paramKey);
 
-        if (createParam && allowedValues != null && allowedValues.size() > 0) {
+        if (createParam && allowedValues != null && !allowedValues.isEmpty()) {
             // make sure default value is among the list of allowed values
             Set<String> values = new TreeSet<>(allowedValues);
 

--- a/src/kml/src/main/java/org/geoserver/kml/KmlEncodingContext.java
+++ b/src/kml/src/main/java/org/geoserver/kml/KmlEncodingContext.java
@@ -268,7 +268,7 @@ public class KmlEncodingContext {
     /** Adds features to the folder own list */
     public void addFeatures(Folder folder, List<Feature> features) {
         List<Feature> originalFeatures = folder.getFeature();
-        if (originalFeatures == null || originalFeatures.size() == 0) {
+        if (originalFeatures == null || originalFeatures.isEmpty()) {
             folder.setFeature(features);
         } else {
             // in this case, compose the already existing features with the
@@ -280,7 +280,7 @@ public class KmlEncodingContext {
     /** Adds features to the document own list */
     public void addFeatures(Document document, List<Feature> features) {
         List<Feature> originalFeatures = document.getFeature();
-        if (originalFeatures == null || originalFeatures.size() == 0) {
+        if (originalFeatures == null || originalFeatures.isEmpty()) {
             document.setFeature(features);
         } else {
             // in this case, compose the already existing features with the

--- a/src/kml/src/main/java/org/geoserver/kml/builder/SuperOverlayNetworkLinkBuilder.java
+++ b/src/kml/src/main/java/org/geoserver/kml/builder/SuperOverlayNetworkLinkBuilder.java
@@ -508,13 +508,13 @@ public class SuperOverlayNetworkLinkBuilder extends AbstractNetworkLinkBuilder {
 
         // check there is no extra filtering applied to the layer
         List<Filter> filters = request.getFilter();
-        if (filters != null && filters.size() > 0 && filters.get(layerIndex) != Filter.INCLUDE) {
+        if (filters != null && !filters.isEmpty() && filters.get(layerIndex) != Filter.INCLUDE) {
             return false;
         }
 
         // no extra sorts
         List<List<SortBy>> sortBy = request.getSortBy();
-        if (sortBy != null && sortBy.size() > 0) {
+        if (sortBy != null && !sortBy.isEmpty()) {
             return false;
         }
 

--- a/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
@@ -80,13 +80,13 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
             Style style = pm.createAndAddStyle();
             List<Symbolizer> symbolizers = context.getCurrentSymbolizers();
             SimpleFeature sf = context.getCurrentFeature();
-            if (symbolizers.size() > 0 && sf.getDefaultGeometry() != null) {
+            if (!symbolizers.isEmpty() && sf.getDefaultGeometry() != null) {
                 // sort by point, text, line and polygon
                 Map<Class, List<Symbolizer>> classified = classifySymbolizers(symbolizers);
 
                 // if no point symbolizers, create a default one
                 List<Symbolizer> points = classified.get(PointSymbolizer.class);
-                if (points.size() == 0) {
+                if (points.isEmpty()) {
                     if (context.isDescriptionEnabled()) {
                         setDefaultIconStyle(style, sf, context);
                     }
@@ -99,7 +99,7 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
 
                 // handle label styles
                 List<Symbolizer> texts = classified.get(TextSymbolizer.class);
-                if (texts.size() == 0) {
+                if (texts.isEmpty()) {
                     if (context.isDescriptionEnabled()) {
                         setDefaultLabelStyle(style);
                     }
@@ -115,21 +115,21 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
                 List<Symbolizer> lines = classified.get(LineSymbolizer.class);
                 // the XML schema allows only one line style, follow painter's model
                 // and set the last one
-                if (lines.size() > 0) {
+                if (!lines.isEmpty()) {
                     LineSymbolizer lastLineSymbolizer =
                             (LineSymbolizer) lines.get(lines.size() - 1);
                     setLineStyle(style, sf, lastLineSymbolizer.getStroke());
                 }
 
                 // handle polygon styles
-                boolean forceOutiline = lines.size() == 0;
+                boolean forceOutline = lines.isEmpty();
                 List<Symbolizer> polygons = classified.get(PolygonSymbolizer.class);
-                if (polygons.size() > 0) {
+                if (!polygons.isEmpty()) {
                     // the XML schema allows only one polygon style, follow painter's model
                     // and set the last one
                     PolygonSymbolizer lastPolygonSymbolizer =
                             (PolygonSymbolizer) polygons.get(polygons.size() - 1);
-                    setPolygonStyle(style, sf, lastPolygonSymbolizer, forceOutiline);
+                    setPolygonStyle(style, sf, lastPolygonSymbolizer, forceOutline);
                 }
             }
 

--- a/src/kml/src/main/java/org/geoserver/kml/iterator/FeatureIteratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/iterator/FeatureIteratorFactory.java
@@ -122,7 +122,7 @@ public class FeatureIteratorFactory implements IteratorFactory<Feature> {
                     context.setCurrentFeature(sf);
 
                     List<Symbolizer> symbolizers = getSymbolizers(simplified, sf);
-                    if (symbolizers.size() == 0) {
+                    if (symbolizers.isEmpty()) {
                         // skip layers that have no active symbolizers
                         continue;
                     }

--- a/src/kml/src/main/java/org/geoserver/kml/regionate/CachedHierarchyRegionatingStrategy.java
+++ b/src/kml/src/main/java/org/geoserver/kml/regionate/CachedHierarchyRegionatingStrategy.java
@@ -160,7 +160,7 @@ public abstract class CachedHierarchyRegionatingStrategy implements RegionatingS
         }
 
         // This okay, just means the tile is empty
-        if (featuresInTile.size() == 0) {
+        if (featuresInTile.isEmpty()) {
             throw new HttpErrorCodeException(204);
         } else {
             FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
@@ -297,7 +297,7 @@ public abstract class CachedHierarchyRegionatingStrategy implements RegionatingS
             String stmt = "INSERT INTO TILECACHE VALUES (" + t.x + ", " + t.y + ", " + t.z + ", ?)";
             ps = conn.prepareStatement(stmt);
 
-            if (fids.size() == 0) {
+            if (fids.isEmpty()) {
                 // we just have to mark the tile as empty
                 ps.setString(1, null);
                 ps.execute();

--- a/src/kml/src/main/java/org/geoserver/kml/utils/KMLFeatureAccessor.java
+++ b/src/kml/src/main/java/org/geoserver/kml/utils/KMLFeatureAccessor.java
@@ -247,7 +247,7 @@ public class KMLFeatureAccessor {
         }
 
         GeometryDescriptor gd = schema.getGeometryDescriptor();
-        if (sourceEnvelopes.size() == 0) {
+        if (sourceEnvelopes.isEmpty()) {
             return Filter.INCLUDE;
         } else if (sourceEnvelopes.size() == 1) {
             ReferencedEnvelope se = sourceEnvelopes.get(0);

--- a/src/kml/src/main/java/org/geoserver/kml/utils/RuleFiltersCollector.java
+++ b/src/kml/src/main/java/org/geoserver/kml/utils/RuleFiltersCollector.java
@@ -43,7 +43,7 @@ public class RuleFiltersCollector extends AbstractStyleVisitor {
 
     /** Returns a filter that includes all the visited rules */
     Filter getSummaryFilter() {
-        if (filters.size() == 0) {
+        if (filters.isEmpty()) {
             return Filter.INCLUDE;
         } else if (filters.size() == 1) {
             return filters.get(0);

--- a/src/kml/src/main/java/org/geoserver/kml/utils/SymbolizerCollector.java
+++ b/src/kml/src/main/java/org/geoserver/kml/utils/SymbolizerCollector.java
@@ -39,7 +39,7 @@ public class SymbolizerCollector extends AbstractStyleVisitor {
 
     public List<Symbolizer> getSymbolizers() {
         // the else filters are activated only if the regular rules are not catching the style
-        if (symbolizers.size() == 0) {
+        if (symbolizers.isEmpty()) {
             return elseSymbolizers;
         } else {
             return symbolizers;

--- a/src/main/src/main/java/org/geoserver/catalog/CascadeRemovalReporter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CascadeRemovalReporter.java
@@ -263,7 +263,7 @@ public class CascadeRemovalReporter implements CatalogVisitor {
                 if (group.getLayers().contains(layerGroupToRemove)) {
                     final List<PublishedInfo> layers = new ArrayList<>(group.getLayers());
                     layers.removeAll(objects.keySet());
-                    if (layers.size() == 0) {
+                    if (layers.isEmpty()) {
                         visit(group);
                     } else {
                         add(group, ModificationType.GROUP_CHANGED);

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageDimensionCustomizerReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageDimensionCustomizerReader.java
@@ -306,7 +306,7 @@ public class CoverageDimensionCustomizerReader implements GridCoverage2DReader {
             List<CoverageDimensionInfo> storedDimensions,
             int[] bandIndexes) {
         GridSampleDimension[] wrappedDims = null;
-        if (storedDimensions != null && storedDimensions.size() > 0) {
+        if (storedDimensions != null && !storedDimensions.isEmpty()) {
             int i = 0;
             wrappedDims = new GridSampleDimension[dims.length];
             for (SampleDimension dim : dims) {
@@ -611,14 +611,14 @@ public class CoverageDimensionCustomizerReader implements GridCoverage2DReader {
             // custom null values
             final List<Double> nullValues = info.getNullValues();
             double[] configuredNoDataValues;
-            if (nullValues != null && nullValues.size() > 0) {
+            if (nullValues == null || nullValues.isEmpty()) {
+                configuredNoDataValues = sampleDim.getNoDataValues();
+            } else {
                 final int size = nullValues.size();
                 configuredNoDataValues = new double[size];
                 for (int i = 0; i < size; i++) {
                     configuredNoDataValues[i] = nullValues.get(i);
                 }
-            } else {
-                configuredNoDataValues = sampleDim.getNoDataValues();
             }
 
             // Check if the nodata has been configured

--- a/src/main/src/main/java/org/geoserver/catalog/LayerGroupVisibilityPolicy.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerGroupVisibilityPolicy.java
@@ -33,7 +33,7 @@ public interface LayerGroupVisibilityPolicy {
                 @Override
                 public boolean hideLayerGroup(
                         LayerGroupInfo group, List<PublishedInfo> filteredLayers) {
-                    return filteredLayers.size() == 0;
+                    return filteredLayers.isEmpty();
                 }
             };
 
@@ -43,7 +43,7 @@ public interface LayerGroupVisibilityPolicy {
                 @Override
                 public boolean hideLayerGroup(
                         LayerGroupInfo group, List<PublishedInfo> filteredLayers) {
-                    return filteredLayers.size() == 0 && group.getLayers().size() > 0;
+                    return filteredLayers.isEmpty() && group.getLayers().size() > 0;
                 }
             };
 }

--- a/src/main/src/main/java/org/geoserver/catalog/NamespaceWorkspaceConsistencyListener.java
+++ b/src/main/src/main/java/org/geoserver/catalog/NamespaceWorkspaceConsistencyListener.java
@@ -111,7 +111,7 @@ public class NamespaceWorkspaceConsistencyListener implements CatalogListener {
             WorkspaceInfo ws = catalog.getWorkspaceByName(ns.getPrefix());
             if (ws != null) {
                 List<DataStoreInfo> stores = catalog.getDataStoresByWorkspace(ws);
-                if (stores.size() > 0) {
+                if (!stores.isEmpty()) {
                     for (DataStoreInfo store : stores) {
                         String oldURI = (String) store.getConnectionParameters().get("namespace");
                         if (oldURI != null && !namespaceURI.equals(oldURI)) {

--- a/src/main/src/main/java/org/geoserver/catalog/Predicates.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Predicates.java
@@ -250,7 +250,7 @@ public class Predicates {
      * a false predicate is found.
      */
     public static Filter and(List<Filter> operands) {
-        if (operands.size() == 0) {
+        if (operands.isEmpty()) {
             return Filter.INCLUDE;
         } else if (operands.size() == 1) {
             return operands.get(0);
@@ -287,7 +287,7 @@ public class Predicates {
     }
 
     public static Filter or(List<Filter> operands) {
-        if (operands.size() == 0) {
+        if (operands.isEmpty()) {
             return Filter.EXCLUDE;
         } else if (operands.size() == 1) {
             return operands.get(0);

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -1010,7 +1010,7 @@ public class ResourcePool {
 
         List<Name> typeNames = dataAccess.getNames();
         String nsURI = null;
-        if (typeNames.size() > 0) {
+        if (!typeNames.isEmpty()) {
             nsURI = typeNames.get(0).getNamespaceURI();
         }
         do {

--- a/src/main/src/main/java/org/geoserver/catalog/StructuredCoverageViewReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/StructuredCoverageViewReader.java
@@ -139,7 +139,7 @@ public class StructuredCoverageViewReader extends CoverageViewReader
             }
             // aggregate and return
             SimpleFeatureCollection result;
-            if (collections.size() == 0) {
+            if (collections.isEmpty()) {
                 throw new IllegalStateException(
                         "Unexpected, there is not a single band in the definition?");
             } else {

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -895,7 +895,7 @@ public class CatalogImpl implements Catalog {
                         // validate style groups
                         StyledLayerDescriptor sld = styles.get(i).getSLD();
                         List<Exception> errors = SLDNamedLayerValidator.validate(this, sld);
-                        if (errors.size() > 0) {
+                        if (!errors.isEmpty()) {
                             throw new IllegalArgumentException(
                                     "Invalid style group: " + errors.get(0).getMessage(),
                                     errors.get(0));

--- a/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxyCloner.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxyCloner.java
@@ -182,7 +182,7 @@ class ModificationProxyCloner {
                     cis.add(cast);
                 }
             }
-            if (cis.size() == 0) {
+            if (cis.isEmpty()) {
                 result = null;
             } else if (cis.size() == 1) {
                 result = cis.get(0);

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -956,7 +956,7 @@ public class XStreamPersister {
                     Collections.sort(matches, comparator);
                 }
 
-                if (matches.size() > 0) {
+                if (!matches.isEmpty()) {
                     typeId = backwardBreifMap.get(matches.get(0));
                 }
             }

--- a/src/main/src/main/java/org/geoserver/data/DimensionFilterBuilder.java
+++ b/src/main/src/main/java/org/geoserver/data/DimensionFilterBuilder.java
@@ -32,7 +32,7 @@ public class DimensionFilterBuilder {
 
     public void appendFilters(
             String startAttributeName, String endAttributeName, List<Object> ranges) {
-        if (ranges == null || ranges.size() == 0) {
+        if (ranges == null || ranges.isEmpty()) {
             return;
         }
 

--- a/src/main/src/main/java/org/geoserver/filters/BufferedRequestWrapper.java
+++ b/src/main/src/main/java/org/geoserver/filters/BufferedRequestWrapper.java
@@ -73,9 +73,11 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
     public String getParameter(String name) {
         parseParameters();
         List<String> allValues = myParameterMap.get(name);
-        if (allValues != null && allValues.size() > 0) {
+        if (allValues == null || allValues.isEmpty()) {
+            return null;
+        } else {
             return allValues.get(0);
-        } else return null;
+        }
     }
 
     public Map<String, String[]> getParameterMap() {
@@ -97,9 +99,11 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
     public String[] getParameterValues(String name) {
         parseParameters();
         List<String> allValues = myParameterMap.get(name);
-        if (allValues != null && allValues.size() > 0) {
+        if (allValues == null || allValues.isEmpty()) {
+            return null;
+        } else {
             return allValues.toArray(new String[0]);
-        } else return null;
+        }
     }
 
     protected void parseParameters() {

--- a/src/main/src/main/java/org/geoserver/function/IsInstanceOf.java
+++ b/src/main/src/main/java/org/geoserver/function/IsInstanceOf.java
@@ -117,7 +117,7 @@ public class IsInstanceOf implements VolatileFunction, Function {
     @Override
     public String toString() {
         List<Expression> params = getParameters();
-        if (params == null || params.size() == 0) {
+        if (params == null || params.isEmpty()) {
             return "IsInstanceOf([INVALID])";
         } else {
             return "IsInstanceOf(" + params.get(0) + ")";

--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
@@ -1899,7 +1899,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
 
         String username = GeoServerUser.ADMIN_USERNAME;
         String masterPW = candidates.get(username);
-        if (masterPW == null && candidates.size() > 0) {
+        if (masterPW == null && !candidates.isEmpty()) {
             username = candidates.keySet().iterator().next();
             masterPW = candidates.get(username);
         }

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureSource.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureSource.java
@@ -153,7 +153,7 @@ public class SecuredFeatureSource<T extends FeatureType, F extends Feature>
 
         // check request attributes and use those ones only
         List<PropertyName> securityProperties = securityQuery.getProperties();
-        if (securityProperties != null && securityProperties.size() > 0) {
+        if (securityProperties != null && !securityProperties.isEmpty()) {
             List<PropertyName> userProperties = userQuery.getProperties();
             if (userProperties == null) {
                 result.setProperties(securityProperties);

--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerCompositeFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerCompositeFilter.java
@@ -82,7 +82,7 @@ public class GeoServerCompositeFilter extends GeoServerSecurityFilter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 
-        if (nestedFilters == null || nestedFilters.size() == 0) {
+        if (nestedFilters == null || nestedFilters.isEmpty()) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
@@ -102,7 +102,7 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         }
 
         // make sure the two basic rules if the set is empty
-        if (result.size() == 0) {
+        if (result.isEmpty()) {
             result.add(new DataAccessRule(DataAccessRule.READ_ALL));
             result.add(new DataAccessRule(DataAccessRule.WRITE_ALL));
         }

--- a/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
@@ -531,7 +531,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
                     }
                 }
             }
-            if (exceptions.size() == 0) {
+            if (exceptions.isEmpty()) {
                 return rootAccess ? Filter.INCLUDE : Filter.EXCLUDE;
             } else {
                 return rootAccess ? Predicates.and(exceptions) : Predicates.or(exceptions);
@@ -610,7 +610,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
                 }
             }
 
-            if (exceptions.size() == 0) {
+            if (exceptions.isEmpty()) {
                 return rootAccess ? Filter.INCLUDE : Filter.EXCLUDE;
             } else {
                 return rootAccess ? Predicates.and(exceptions) : Predicates.or(exceptions);
@@ -633,7 +633,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
                     }
                 }
             }
-            if (exceptions.size() == 0) {
+            if (exceptions.isEmpty()) {
                 return rootAccess ? Filter.INCLUDE : Filter.EXCLUDE;
             } else {
                 return rootAccess ? Predicates.and(exceptions) : Predicates.or(exceptions);

--- a/src/main/src/main/java/org/geoserver/security/impl/RoleHierarchyHelper.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/RoleHierarchyHelper.java
@@ -83,7 +83,7 @@ public class RoleHierarchyHelper {
 
     /** recursive method to fill the descendant list */
     protected void fillDescendents(List<String> children, Set<String> descendants) {
-        if (children == null || children.size() == 0) return; // end recursion
+        if (children == null || children.isEmpty()) return; // end recursion
         for (String childName : children) {
             if (descendants.contains(childName)) // cycle
             cycleDetected(childName, null);

--- a/src/main/src/main/java/org/geoserver/security/impl/ServiceAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/ServiceAccessRuleDAO.java
@@ -76,7 +76,7 @@ public class ServiceAccessRuleDAO extends AbstractAccessRuleDAO<ServiceAccessRul
         }
 
         // make sure to add the "all access alloed" rule if the set if empty
-        if (result.size() == 0) {
+        if (result.isEmpty()) {
             result.add(new ServiceAccessRule(new ServiceAccessRule()));
         }
 

--- a/src/main/src/main/java/org/geoserver/security/validation/RoleServiceValidationWrapper.java
+++ b/src/main/src/main/java/org/geoserver/security/validation/RoleServiceValidationWrapper.java
@@ -120,7 +120,7 @@ public class RoleServiceValidationWrapper extends AbstractSecurityValidator
                 secMgr.getDataAccessRuleDAO().getRulesAssociatedWithRole(role.getAuthority()))
             keys.add(rule.getKey());
 
-        if (keys.size() > 0) {
+        if (!keys.isEmpty()) {
             String ruleString = StringUtils.collectionToCommaDelimitedString(keys);
             throw createSecurityException(ROLE_IN_USE_$2, role.getAuthority(), ruleString);
         }

--- a/src/main/src/main/java/org/vfny/geoserver/global/xml/NameSpaceTranslator.java
+++ b/src/main/src/main/java/org/vfny/geoserver/global/xml/NameSpaceTranslator.java
@@ -287,7 +287,7 @@ public abstract class NameSpaceTranslator {
         Set posibilities = getElements(type);
 
         // System.out.println("getting default for type: " + type + " = " + posibilities);
-        if (posibilities.size() == 0) {
+        if (posibilities.isEmpty()) {
             return null;
         }
 
@@ -319,7 +319,7 @@ public abstract class NameSpaceTranslator {
 
         Set posibilities = getElements(type);
 
-        if (posibilities.size() == 0) {
+        if (posibilities.isEmpty()) {
             return null;
         }
 

--- a/src/main/src/main/java/org/vfny/geoserver/global/xml/WriterHelper.java
+++ b/src/main/src/main/java/org/vfny/geoserver/global/xml/WriterHelper.java
@@ -202,7 +202,7 @@ public class WriterHelper {
      */
     public void textTag(String tagName, Map attributes, String data) throws ConfigurationException {
         StringBuffer sb = new StringBuffer();
-        sb.append("<" + tagName + ((attributes.size() > 0) ? " " : ""));
+        sb.append("<" + tagName + ((attributes.isEmpty()) ? "" : " "));
 
         Iterator i = attributes.keySet().iterator();
 

--- a/src/main/src/main/java/org/vfny/geoserver/util/SLDValidator.java
+++ b/src/main/src/main/java/org/vfny/geoserver/util/SLDValidator.java
@@ -70,7 +70,7 @@ public class SLDValidator {
             int exceptionNum = 0;
 
             // check for lineNumber -1 errors  --> invalid XML
-            if (errors.size() > 0 && errors.get(0) instanceof SAXParseException) {
+            if (!errors.isEmpty() && errors.get(0) instanceof SAXParseException) {
                 SAXParseException sax = (SAXParseException) errors.get(0);
 
                 if (sax.getLineNumber() < 0) {

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -1462,7 +1462,7 @@ public class Dispatcher extends AbstractController {
                 Collections.sort(vmatches, comparator);
             }
 
-            if (vmatches.size() > 0) xmlReader = vmatches.get(vmatches.size() - 1);
+            if (!vmatches.isEmpty()) xmlReader = vmatches.get(vmatches.size() - 1);
         } else {
             // only a single match, that was easy
             xmlReader = matches.get(0);

--- a/src/ows/src/main/java/org/geoserver/ows/Ows11Util.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Ows11Util.java
@@ -49,7 +49,7 @@ public class Ows11Util {
 
     @SuppressWarnings("unchecked") // due to KeywordsType using raw collections
     public static KeywordsType keywords(List<String> keywords) {
-        if (keywords == null || keywords.size() == 0) {
+        if (keywords == null || keywords.isEmpty()) {
             return null;
         }
         KeywordsType kw = f.createKeywordsType();

--- a/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
@@ -320,7 +320,7 @@ public class KvpUtils {
                         normalized.add(v);
                     }
                 }
-                if (normalized.size() == 0) {
+                if (normalized.isEmpty()) {
                     value = null;
                 } else if (normalized.size() == 1) {
                     value = normalized.iterator().next();

--- a/src/platform/src/main/java/org/geoserver/platform/ModuleStatusImpl.java
+++ b/src/platform/src/main/java/org/geoserver/platform/ModuleStatusImpl.java
@@ -20,7 +20,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 /**
  * Bean used to register module installation in applicationContext.xml.
  *
- * <p>Bean completly defined by applicationContext.xml - no dynamic content.
+ * <p>Bean completely defined by applicationContext.xml - no dynamic content.
  *
  * <pre>
  * &lt!-- code example needed --&gt;>
@@ -199,7 +199,9 @@ public class ModuleStatusImpl implements ModuleStatus, Serializable {
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Error listing pom.properties", e);
         }
-        if (matches.size() >= 1) {
+        if (matches.isEmpty()) {
+            return null;
+        } else {
             if (matches.size() > 1) {
                 LOGGER.log(
                         Level.WARNING,
@@ -211,6 +213,5 @@ public class ModuleStatusImpl implements ModuleStatus, Serializable {
             }
             return matches.get(0).getProperty("version");
         }
-        return null;
     }
 }

--- a/src/platform/src/main/java/org/geoserver/platform/ServiceException.java
+++ b/src/platform/src/main/java/org/geoserver/platform/ServiceException.java
@@ -209,7 +209,7 @@ public class ServiceException extends RuntimeException {
     @Override
     public String toString() {
         String msg = super.toString();
-        if (exceptionText == null || exceptionText.size() == 0) return msg;
+        if (exceptionText == null || exceptionText.isEmpty()) return msg;
 
         StringBuffer sb = new StringBuffer(msg);
         for (String extraMessage : exceptionText) {

--- a/src/rest/src/main/java/org/geoserver/rest/EnviromentInjectionCallback.java
+++ b/src/rest/src/main/java/org/geoserver/rest/EnviromentInjectionCallback.java
@@ -36,7 +36,7 @@ public class EnviromentInjectionCallback extends DispatcherCallbackAdapter {
         }
 
         // set it into the EnvFunction
-        if (envVars.size() > 0) {
+        if (!envVars.isEmpty()) {
             EnvFunction.setLocalValues(envVars);
         }
     }

--- a/src/rest/src/main/java/org/geoserver/rest/RestConfiguration.java
+++ b/src/rest/src/main/java/org/geoserver/rest/RestConfiguration.java
@@ -79,7 +79,7 @@ public class RestConfiguration extends WebMvcConfigurationSupport {
                 if (!(strategy instanceof ContentNegotiationManager
                         || strategy instanceof DelegatingContentNegotiationStrategy)) {
                     mediaTypes = strategy.resolveMediaTypes(webRequest);
-                    if (mediaTypes.size() > 0) {
+                    if (!mediaTypes.isEmpty()) {
                         return mediaTypes;
                     }
                 }

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreFileController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreFileController.java
@@ -348,7 +348,7 @@ public class CoverageStoreFileController extends AbstractStoreUploadController {
                     existing = coverages.get(0);
                 }
                 // check if we have it or not
-                if (coverages.size() == 0) {
+                if (coverages.isEmpty()) {
                     // no coverages yet configured, change add flag and continue on
                     add = true;
                 } else {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/MapXMLConverter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/MapXMLConverter.java
@@ -86,8 +86,8 @@ public class MapXMLConverter extends BaseMessageConverter<Map<?, ?>> {
      */
     protected Object convert(Element elem) {
         List<?> children = elem.getChildren();
-        if (children.size() == 0) {
-            if (elem.getContent().size() == 0) {
+        if (children.isEmpty()) {
+            if (elem.getContent().isEmpty()) {
                 return null;
             } else {
                 return elem.getText();

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
@@ -506,7 +506,7 @@ public class StyleController extends AbstractCatalogController {
         // If there is more than one layer, assume this is a style group and validate accordingly.
         if (sld.getStyledLayers().length > 1) {
             List<Exception> validationErrors = SLDNamedLayerValidator.validate(catalog, sld);
-            if (validationErrors.size() > 0) {
+            if (!validationErrors.isEmpty()) {
                 throw validationErrors.get(0);
             }
         }

--- a/src/wcs/src/main/java/org/vfny/geoserver/util/WCSUtils.java
+++ b/src/wcs/src/main/java/org/vfny/geoserver/util/WCSUtils.java
@@ -256,7 +256,7 @@ public class WCSUtils {
                                 }
                             }
 
-                            if (selectedBands.size() == 0) {
+                            if (selectedBands.isEmpty()) {
                                 throw new Exception("WRONG PARAM VALUES.");
                             }
                         }
@@ -539,7 +539,7 @@ public class WCSUtils {
             filter = request.getKvp().get("CQL_FILTER");
             if (filter instanceof List) {
                 List list = (List) filter;
-                if (list.size() > 0) {
+                if (!list.isEmpty()) {
                     filter = list.get(0);
                 }
             }

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/DefaultWebCoverageService100.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/DefaultWebCoverageService100.java
@@ -177,12 +177,12 @@ public class DefaultWebCoverageService100 implements WebCoverageService100 {
             // spatial
             final SpatialSubsetType spatialSubset = domainSubset.getSpatialSubset();
             final EList grids = spatialSubset.getGrid();
-            if (grids.size() == 0)
+            if (grids.isEmpty())
                 throw new IllegalArgumentException(
                         "Invalid number of Grid for spatial subsetting was set:" + grids.size());
             final RectifiedGridType grid = (RectifiedGridType) grids.get(0);
             final List envelopes = spatialSubset.getEnvelope();
-            if (envelopes.size() == 0)
+            if (envelopes.isEmpty())
                 throw new IllegalArgumentException(
                         "Invalid number of Envelope for spatial subsetting was set:"
                                 + envelopes.size());
@@ -389,7 +389,7 @@ public class DefaultWebCoverageService100 implements WebCoverageService100 {
                 List axisSubset = null;
                 if (request.getRangeSubset() != null) {
                     axisSubset = request.getRangeSubset().getAxisSubset();
-                    if (axisSubset.size() > 0) {
+                    if (!axisSubset.isEmpty()) {
                         for (Object o : axisSubset) {
                             AxisSubsetType axis = (AxisSubsetType) o;
 

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/AxisSubsetKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/AxisSubsetKvpParser.java
@@ -60,7 +60,7 @@ public class AxisSubsetKvpParser extends KvpParser {
         } else {
             List<String> unparsed = KvpUtils.readFlat(value, KvpUtils.INNER_DELIMETER);
 
-            if (unparsed.size() == 0) {
+            if (unparsed.isEmpty()) {
                 throw new WcsException(
                         "Requested axis subset contains wrong number of values (should have at least 1): "
                                 + unparsed.size(),

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/CoverageKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/CoverageKvpParser.java
@@ -38,7 +38,7 @@ public class CoverageKvpParser extends KvpParser {
     public Object parse(String value) throws Exception {
         final List<String> coverages = new ArrayList<>();
         final List<String> identifiers = KvpUtils.readFlat(value);
-        if (identifiers == null || identifiers.size() == 0) {
+        if (identifiers == null || identifiers.isEmpty()) {
             throw new WcsException(
                     "Required paramer, coverage, missing",
                     WcsExceptionCode.MissingParameterValue,

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/SourceCoverageKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/SourceCoverageKvpParser.java
@@ -36,7 +36,7 @@ public class SourceCoverageKvpParser extends KvpParser {
     public Object parse(String value) throws Exception {
         List<String> coverages = new ArrayList<>();
         final List<String> identifiers = KvpUtils.readFlat(value);
-        if (identifiers == null || identifiers.size() == 0) {
+        if (identifiers == null || identifiers.isEmpty()) {
             throw new WcsException(
                     "Required paramer, sourcecoverage, missing",
                     WcsExceptionCode.MissingParameterValue,

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/Wcs10GetCoverageRequestReader.java
@@ -463,7 +463,7 @@ public class Wcs10GetCoverageRequestReader extends EMFKvpRequestReader {
                 } else {
                     List<String> unparsed = KvpUtils.readFlat(bands, KvpUtils.INNER_DELIMETER);
 
-                    if (unparsed.size() == 0) {
+                    if (unparsed.isEmpty()) {
                         throw new WcsException(
                                 "Requested axis subset contains wrong number of values (should have at least 1): "
                                         + unparsed.size(),

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/DefaultWebCoverageService111.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/DefaultWebCoverageService111.java
@@ -289,7 +289,7 @@ public class DefaultWebCoverageService111 implements WebCoverageService111 {
             final List<GeneralParameterDescriptor> parameterDescriptors =
                     readParametersDescriptor.getDescriptor().descriptors();
             ParameterValue time = null;
-            boolean hasTime = timeValues.size() > 0;
+            boolean hasTime = !timeValues.isEmpty();
 
             if (hasTime) {
                 for (GeneralParameterDescriptor pd : parameterDescriptors) {

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/DescribeCoverageKvpRequestReader.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/DescribeCoverageKvpRequestReader.java
@@ -40,7 +40,7 @@ public class DescribeCoverageKvpRequestReader extends EMFKvpRequestReader {
         // we need at least one coverage
         final String identifiersValue = (String) rawKvp.get("identifiers");
         final List identifiers = KvpUtils.readFlat(identifiersValue);
-        if (identifiers == null || identifiers.size() == 0) {
+        if (identifiers == null || identifiers.isEmpty()) {
             throw new WcsException(
                     "Required paramer, identifiers, missing",
                     WcsExceptionCode.MissingParameterValue,

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/DescribeCoverageTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/DescribeCoverageTransformer.java
@@ -361,7 +361,7 @@ public class DescribeCoverageTransformer extends TransformerBase {
                 if (nulls == null) return;
                 if (nulls.size() == 1) {
                     element("wcs:NullValue", nulls.get(0).toString());
-                } else if (nulls.size() >= 1) {
+                } else if (!nulls.isEmpty()) {
                     // the new specification allows only for a list of values,
                     // Can we assume min and max are two integer numbers and
                     // make up a list out of them? For the moment, just fail

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
@@ -318,7 +318,7 @@ public class WCSCapsTransformer extends TransformerBase {
 
         /** */
         protected void handleKeywords(List kwords) {
-            if (kwords != null && kwords.size() > 0) {
+            if (kwords != null && !kwords.isEmpty()) {
                 start("ows:Keywords");
 
                 if (kwords != null) {

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/GetCoverage.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/GetCoverage.java
@@ -705,7 +705,7 @@ public class GetCoverage {
     private ScalingType extractScaling(Map<String, ExtensionItemType> extensions) {
         ScalingType scaling = null;
         // look for a scaling extension
-        if (!(extensions == null || extensions.size() == 0 || !extensions.containsKey("Scaling"))) {
+        if (!(extensions == null || extensions.isEmpty() || !extensions.containsKey("Scaling"))) {
             final ExtensionItemType extensionItem = extensions.get("Scaling");
             assert extensionItem != null;
 
@@ -864,7 +864,7 @@ public class GetCoverage {
 
     private OverviewPolicy extractOverviewPolicy(Map<String, ExtensionItemType> extensions) {
         if (extensions == null
-                || extensions.size() == 0
+                || extensions.isEmpty()
                 || !extensions.containsKey(WCS20Const.OVERVIEW_POLICY_EXTENSION)) {
             // NO extension at hand
             return null;
@@ -1460,7 +1460,7 @@ public class GetCoverage {
         Utilities.ensureNonNull("defaultCRS", defaultCRS);
         final String identifier = isOutputCRS ? "outputCrs" : "subsettingCrs";
         // look for subsettingCRS Extension extension
-        if (extensions == null || extensions.size() == 0 || !extensions.containsKey(identifier)) {
+        if (extensions == null || extensions.isEmpty() || !extensions.containsKey(identifier)) {
             // NO extension at hand
             return defaultCRS;
         }
@@ -1603,7 +1603,7 @@ public class GetCoverage {
 
         // look for scaling extension
         if (extensions == null
-                || extensions.size() == 0
+                || extensions.isEmpty()
                 || !extensions.containsKey("Interpolation")) {
             // NO INTERPOLATION
             return returnValue;
@@ -1731,9 +1731,7 @@ public class GetCoverage {
         final List<String> returnValue = new ArrayList<>();
 
         // look for rangeSubset extension
-        if (extensions == null
-                || extensions.size() == 0
-                || !extensions.containsKey("rangeSubset")) {
+        if (extensions == null || extensions.isEmpty() || !extensions.containsKey("rangeSubset")) {
             // NO subsetting
             return coverage;
         }

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCapabilitiesTransformer.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCS20GetCapabilitiesTransformer.java
@@ -452,7 +452,7 @@ public class WCS20GetCapabilitiesTransformer extends TransformerBase {
             end("ows:AllowedValues");
             end("ows:Constraint");
 
-            if (extensions != null && extensions.size() > 0) {
+            if (extensions != null && !extensions.isEmpty()) {
                 try {
                     for (WCSExtendedCapabilitiesProvider provider : extensions) {
                         provider.encodeExtendedOperations(translator, wcs, request);
@@ -609,7 +609,7 @@ public class WCS20GetCapabilitiesTransformer extends TransformerBase {
                 }
             }
 
-            if (extensions != null && extensions.size() > 0) {
+            if (extensions != null && !extensions.isEmpty()) {
                 start("wcs:Extension");
                 try {
                     for (WCSExtendedCapabilitiesProvider provider : extensions) {

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDefaultValuesHelper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDefaultValuesHelper.java
@@ -400,7 +400,7 @@ public class WCSDefaultValuesHelper {
         if (additionalDimensions != null
                 && dimensionSubset != null
                 && additionalDimensions.size() != dimensionSubset.size()
-                && dimensionSubset.size() > 0) {
+                && !dimensionSubset.isEmpty()) {
 
             List<Filter> additionalDimensionFilterList = new ArrayList<>();
             Set<String> dimensionKeys = dimensionSubset.keySet();

--- a/src/web/core/src/main/java/org/geoserver/web/admin/GlobalSettingsPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/admin/GlobalSettingsPage.java
@@ -250,7 +250,7 @@ public class GlobalSettingsPage extends ServerAdminPage {
                     e);
         }
         // if none is found use the default set
-        if (logProfiles == null || logProfiles.size() == 0) logProfiles = DEFAULT_LOG_PROFILES;
+        if (logProfiles == null || logProfiles.isEmpty()) logProfiles = DEFAULT_LOG_PROFILES;
 
         form.add(
                 new ListChoice<>(

--- a/src/web/core/src/main/java/org/geoserver/web/data/ConfirmRemovalPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/ConfirmRemovalPanel.java
@@ -84,42 +84,42 @@ public class ConfirmRemovalPanel extends Panel {
             CatalogInfo catalogInfo = it.next();
             if (catalogInfo instanceof ResourceInfo) it.remove();
         }
-        removed.setVisible(cascaded.size() > 0);
+        removed.setVisible(!cascaded.isEmpty());
         add(removed);
 
         // removed workspaces
         WebMarkupContainer wsr = new WebMarkupContainer("workspacesRemoved");
         removed.add(wsr);
         List<WorkspaceInfo> workspaces = visitor.getObjects(WorkspaceInfo.class);
-        if (workspaces.size() == 0) wsr.setVisible(false);
+        if (workspaces.isEmpty()) wsr.setVisible(false);
         wsr.add(new Label("workspaces", names(workspaces)));
 
         // removed stores
         WebMarkupContainer str = new WebMarkupContainer("storesRemoved");
         removed.add(str);
         List<StoreInfo> stores = visitor.getObjects(StoreInfo.class);
-        if (stores.size() == 0) str.setVisible(false);
+        if (stores.isEmpty()) str.setVisible(false);
         str.add(new Label("stores", names(stores)));
 
         // removed layers
         WebMarkupContainer lar = new WebMarkupContainer("layersRemoved");
         removed.add(lar);
         List<LayerInfo> layers = visitor.getObjects(LayerInfo.class, DELETE);
-        if (layers.size() == 0) lar.setVisible(false);
+        if (layers.isEmpty()) lar.setVisible(false);
         lar.add(new Label("layers", names(layers)));
 
         // removed groups
         WebMarkupContainer grr = new WebMarkupContainer("groupsRemoved");
         removed.add(grr);
         List<LayerGroupInfo> groups = visitor.getObjects(LayerGroupInfo.class, DELETE);
-        if (groups.size() == 0) grr.setVisible(false);
+        if (groups.isEmpty()) grr.setVisible(false);
         grr.add(new Label("groups", names(groups)));
 
         // removed styles
         WebMarkupContainer syr = new WebMarkupContainer("stylesRemoved");
         removed.add(syr);
         List<StyleInfo> styles = visitor.getObjects(StyleInfo.class, DELETE);
-        if (styles.size() == 0) syr.setVisible(false);
+        if (styles.isEmpty()) syr.setVisible(false);
         syr.add(new Label("styles", names(styles)));
 
         // modified objects root (we show it if any modified object is on the list)
@@ -133,14 +133,14 @@ public class ConfirmRemovalPanel extends Panel {
         WebMarkupContainer lam = new WebMarkupContainer("layersModified");
         modified.add(lam);
         layers = visitor.getObjects(LayerInfo.class, STYLE_RESET, EXTRA_STYLE_REMOVED);
-        if (layers.size() == 0) lam.setVisible(false);
+        if (layers.isEmpty()) lam.setVisible(false);
         lam.add(new Label("layers", names(layers)));
 
         // groups modified
         WebMarkupContainer grm = new WebMarkupContainer("groupsModified");
         modified.add(grm);
         groups = visitor.getObjects(LayerGroupInfo.class, GROUP_CHANGED);
-        if (groups.size() == 0) grm.setVisible(false);
+        if (groups.isEmpty()) grm.setVisible(false);
         grm.add(new Label("groups", names(groups)));
     }
 

--- a/src/web/core/src/main/java/org/geoserver/web/data/SelectionRemovalLink.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/SelectionRemovalLink.java
@@ -42,7 +42,7 @@ public class SelectionRemovalLink extends AjaxLink<Void> {
     public void onClick(AjaxRequestTarget target) {
         // see if the user selected anything
         final List<? extends CatalogInfo> selection = catalogObjects.getSelection();
-        if (selection.size() == 0) return;
+        if (selection.isEmpty()) return;
 
         dialog.setTitle(new ParamResourceModel("confirmRemoval", this));
 

--- a/src/web/core/src/main/java/org/geoserver/web/data/importer/WMSLayerImporterPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/importer/WMSLayerImporterPage.java
@@ -160,7 +160,7 @@ public class WMSLayerImporterPage extends GeoServerSecuredPage {
                     List<LayerResource> selection = layers.getSelection();
 
                     // if nothing was selected we need to go back
-                    if (selection.size() == 0) {
+                    if (selection.isEmpty()) {
                         error(
                                 new ParamResourceModel("selectionEmpty", WMSLayerImporterPage.this)
                                         .getString());

--- a/src/web/core/src/main/java/org/geoserver/web/data/importer/WMTSLayerImporterPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/importer/WMTSLayerImporterPage.java
@@ -159,7 +159,7 @@ public class WMTSLayerImporterPage extends GeoServerSecuredPage {
                     List<LayerResource> selection = layers.getSelection();
 
                     // if nothing was selected we need to go back
-                    if (selection.size() == 0) {
+                    if (selection.isEmpty()) {
                         error(
                                 new ParamResourceModel("selectionEmpty", WMTSLayerImporterPage.this)
                                         .getString());

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
@@ -432,7 +432,7 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
         }
 
         // no geometries? Or, shall we not try to guess the geometries type and srid?
-        if (geometries.size() == 0 || !guessGeometrySrid) {
+        if (geometries.isEmpty() || !guessGeometrySrid) {
             return base;
         }
 

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAttributeProvider.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAttributeProvider.java
@@ -108,7 +108,7 @@ public class SQLViewAttributeProvider extends GeoServerDataProvider<SQLViewAttri
                 pks.add(att.getName());
             }
         }
-        if (pks.size() > 0) {
+        if (!pks.isEmpty()) {
             vt.setPrimaryKeyColumns(pks);
         }
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/CoverageResourceConfigurationPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/CoverageResourceConfigurationPanel.java
@@ -113,7 +113,7 @@ public class CoverageResourceConfigurationPanel extends ResourceConfigurationPan
         paramsList.setReuseItems(true);
         add(paramsList);
 
-        if (keys.size() == 0) setVisible(false);
+        if (keys.isEmpty()) setVisible(false);
     }
 
     /**

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceDimensionsTabPanelInfo.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/ResourceDimensionsTabPanelInfo.java
@@ -125,7 +125,7 @@ public class ResourceDimensionsTabPanelInfo extends PublishedEditTabPanel<LayerI
                     }
                 };
         add(customDimensionsEditor);
-        customDimensionsEditor.setVisible(customDimensionModels.size() > 0);
+        customDimensionsEditor.setVisible(!customDimensionModels.isEmpty());
 
         // vector custom dimensions panel
         buildVectorCustomDimensionsPanel(model, resource);

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
@@ -167,7 +167,7 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
             IModel<NamespaceInfo> namespaceModel = new NamespaceParamModel(paramsModel, paramName);
             IModel<String> paramLabelModel = new ResourceModel(paramLabel, paramLabel);
             parameterPanel = new NamespacePanel(componentId, namespaceModel, paramLabelModel, true);
-        } else if (options != null && options.size() > 0) {
+        } else if (options != null && !options.isEmpty()) {
 
             IModel<Serializable> valueModel = new MapModel<>(paramsModel, paramName);
             if (binding.isEnum()) {

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/ParamInfo.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/ParamInfo.java
@@ -75,7 +75,7 @@ public class ParamInfo implements Serializable {
         this.required = param.required;
         if (param.metadata != null) {
             List<Serializable> options = (List<Serializable>) param.metadata.get(Param.OPTIONS);
-            if (options != null && options.size() > 0) {
+            if (options != null && !options.isEmpty()) {
                 this.options = new ArrayList<>(options);
                 if (Comparable.class.isAssignableFrom(this.binding)) {
                     Collections.sort((List) options);

--- a/src/web/core/src/main/java/org/geoserver/web/security/AccessDataRuleInfoManager.java
+++ b/src/web/core/src/main/java/org/geoserver/web/security/AccessDataRuleInfoManager.java
@@ -204,7 +204,7 @@ public class AccessDataRuleInfoManager {
         }
         for (AccessMode key : modeRoleMap.keySet()) {
             Set<String> roles = modeRoleMap.get(key);
-            if (roles != null && roles.size() > 0) {
+            if (roles != null && !roles.isEmpty()) {
                 DataAccessRule rule = new DataAccessRule();
                 if (!globalLayerGroup) {
                     rule.setRoot(wsName);

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/SRSListTextArea.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/SRSListTextArea.java
@@ -79,7 +79,7 @@ public class SRSListTextArea extends TextArea<List<String>> {
                                 }
                             });
 
-            if (invalid.size() > 0) {
+            if (!invalid.isEmpty()) {
                 IValidationError err =
                         new ValidationError("SRSListTextArea.unknownEPSGCodes")
                                 .addKey("SRSListTextArea.unknownEPSGCodes")

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/blob/BlobStorePage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/blob/BlobStorePage.java
@@ -194,7 +194,7 @@ public class BlobStorePage extends GeoServerSecuredPage {
                         if (originalStore != null
                                 && originalStore.isEnabled()
                                 && !blobStore.isEnabled()
-                                && assignedLayers.size() > 0) {
+                                && !assignedLayers.isEmpty()) {
                             dialog.showOkCancel(
                                     target,
                                     new GeoServerDialog.DialogDelegate() {

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/GridSetsPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/GridSetsPage.java
@@ -169,7 +169,7 @@ public class GridSetsPage extends GeoServerSecuredPage {
         public void onClick(AjaxRequestTarget target) {
             // see if the user selected anything
             List<GridSet> selection = gridsets.getSelection();
-            if (selection.size() == 0) {
+            if (selection.isEmpty()) {
                 return;
             }
 

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/TileMatrixSetEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/TileMatrixSetEditor.java
@@ -62,7 +62,7 @@ public class TileMatrixSetEditor extends FormComponentPanel<List<Grid>> {
         @Override
         public void validate(IValidatable<List<Grid>> validatable) {
             List<Grid> grids = validatable.getValue();
-            if (grids == null || grids.size() == 0) {
+            if (grids == null || grids.isEmpty()) {
                 ValidationError error = new ValidationError();
                 error.setMessage(
                         new ResourceModel("TileMatrixSetEditor.validation.empty").getObject());
@@ -381,7 +381,7 @@ public class TileMatrixSetEditor extends FormComponentPanel<List<Grid>> {
     @Override
     public void convertInput() {
         List<Grid> info = grids.getModelObject();
-        if (info == null || info.size() == 0) {
+        if (info == null || info.isEmpty()) {
             setConvertedInput(new ArrayList<>(2));
             return;
         }

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
@@ -70,7 +70,7 @@ class GridSubsetsEditor extends FormComponentPanel<Set<XMLGridSubset>> {
                 return;
             }
             Set<XMLGridSubset> gridSubsets = validatable.getValue();
-            if (gridSubsets == null || gridSubsets.size() == 0) {
+            if (gridSubsets == null || gridSubsets.isEmpty()) {
                 error(validatable, "GridSubsetsEditor.validation.empty");
                 return;
             }

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/AbstractConfirmRemovalPanel.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/AbstractConfirmRemovalPanel.java
@@ -55,7 +55,7 @@ public abstract class AbstractConfirmRemovalPanel<T> extends Panel {
         // removed
         WebMarkupContainer rulesRemoved = new WebMarkupContainer("rulesRemoved");
         removed.add(rulesRemoved);
-        if (roots.size() == 0) removed.setVisible(false);
+        if (roots.isEmpty()) removed.setVisible(false);
         else {
             rulesRemoved.add(
                     new ListView<String>("rules", names(roots)) {
@@ -71,7 +71,7 @@ public abstract class AbstractConfirmRemovalPanel<T> extends Panel {
 
         WebMarkupContainer rulesNotRemoved = new WebMarkupContainer("rulesNotRemoved");
         problematic.add(rulesNotRemoved);
-        if (problems.size() == 0) problematic.setVisible(false);
+        if (problems.isEmpty()) problematic.setVisible(false);
         else {
             rulesNotRemoved.add(
                     new ListView<String>("problems", problems(problems)) {

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/data/SelectionDataRuleRemovalLink.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/data/SelectionDataRuleRemovalLink.java
@@ -35,7 +35,7 @@ public class SelectionDataRuleRemovalLink extends AjaxLink {
     @Override
     public void onClick(AjaxRequestTarget target) {
         final List<DataAccessRule> selection = rules.getSelection();
-        if (selection.size() == 0) return;
+        if (selection.isEmpty()) return;
 
         dialog.setTitle(new ParamResourceModel("confirmRemoval", this));
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/group/SelectionGroupRemovalLink.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/group/SelectionGroupRemovalLink.java
@@ -55,7 +55,7 @@ public class SelectionGroupRemovalLink extends AjaxLink<Object> {
     @Override
     public void onClick(AjaxRequestTarget target) {
         final List<GeoServerUserGroup> selection = groups.getSelection();
-        if (selection.size() == 0) return;
+        if (selection.isEmpty()) return;
 
         dialog.setTitle(new ParamResourceModel("confirmRemoval", this));
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/SelectionRoleRemovalLink.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/SelectionRoleRemovalLink.java
@@ -47,7 +47,7 @@ public class SelectionRoleRemovalLink extends AjaxLink<Object> {
     @Override
     public void onClick(AjaxRequestTarget target) {
         final List<GeoServerRole> selection = roles.getSelection();
-        if (selection.size() == 0) return;
+        if (selection.isEmpty()) return;
 
         dialog.setTitle(new ParamResourceModel("confirmRemoval", this));
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/service/SelectionServiceRemovalLink.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/service/SelectionServiceRemovalLink.java
@@ -35,7 +35,7 @@ public class SelectionServiceRemovalLink extends AjaxLink {
     @Override
     public void onClick(AjaxRequestTarget target) {
         final List<ServiceAccessRule> selection = services.getSelection();
-        if (selection.size() == 0) return;
+        if (selection.isEmpty()) return;
 
         dialog.setTitle(new ParamResourceModel("confirmRemoval", this));
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/user/SelectionUserRemovalLink.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/user/SelectionUserRemovalLink.java
@@ -57,7 +57,7 @@ public class SelectionUserRemovalLink extends AjaxLink<Object> {
     @Override
     public void onClick(AjaxRequestTarget target) {
         final List<GeoServerUser> selection = users.getSelection();
-        if (selection.size() == 0) return;
+        if (selection.isEmpty()) return;
 
         dialog.setTitle(new ParamResourceModel("confirmRemoval", this));
 

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -173,7 +173,7 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
         // Try getting the first layer associated with this style
         if (style != null) {
             layers = catalog.getLayers(style);
-            if (layers.size() > 0) {
+            if (!layers.isEmpty()) {
                 layerModel = new Model<>(layers.get(0));
                 return;
             }
@@ -188,7 +188,7 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
                         catalog.getResourcesByStore(defaultStore, ResourceInfo.class);
                 for (ResourceInfo resource : resources) {
                     layers = catalog.getLayers(resource);
-                    if (layers.size() > 0) {
+                    if (!layers.isEmpty()) {
                         layerModel = new Model<>(layers.get(0));
                         return;
                     }
@@ -198,7 +198,7 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
 
         // Try getting the first layer returned by the catalog
         layers = catalog.getLayers();
-        if (layers.size() > 0) {
+        if (!layers.isEmpty()) {
             layerModel = new Model<>(layers.get(0));
             return;
         }

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/AuthorityURLListEditor.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/AuthorityURLListEditor.java
@@ -152,7 +152,7 @@ public class AuthorityURLListEditor extends FormComponentPanel<List<AuthorityURL
 
     private void updateLinksVisibility() {
         List<AuthorityURLInfo> list = authorityURLs.getModelObject();
-        boolean anyLink = list.size() > 0;
+        boolean anyLink = !list.isEmpty();
         table.setVisible(anyLink);
         noMetadata.setVisible(!anyLink);
     }
@@ -160,7 +160,7 @@ public class AuthorityURLListEditor extends FormComponentPanel<List<AuthorityURL
     @Override
     public void convertInput() {
         List<AuthorityURLInfo> info = authorityURLs.getModelObject();
-        if (info == null || info.size() == 0) {
+        if (info == null || info.isEmpty()) {
             setConvertedInput(new ArrayList<>(2));
             return;
         }

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/LayerIdentifierListEditor.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/LayerIdentifierListEditor.java
@@ -211,7 +211,7 @@ public class LayerIdentifierListEditor extends FormComponentPanel<List<LayerIden
 
     private void updateLinksVisibility() {
         List<LayerIdentifierInfo> list = identifiers.getModelObject();
-        boolean anyLink = list.size() > 0;
+        boolean anyLink = !list.isEmpty();
         table.setVisible(anyLink);
         noMetadata.setVisible(!anyLink);
     }

--- a/src/wfs/src/main/java/org/geoserver/wfs/JoinExtractingVisitor.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/JoinExtractingVisitor.java
@@ -212,7 +212,7 @@ public class JoinExtractingVisitor extends FilterVisitorSupport {
             Set<String> localAttributes = fae.getAttributeNameSet();
             Set<String> localPrefixes = getPrefixes(localAttributes);
             if (!localPrefixes.isEmpty()) {
-                if (prefixes.size() == 0) {
+                if (prefixes.isEmpty()) {
                     // accumulate the prefixes, to see how many tables we're joining
                     prefixes.addAll(localPrefixes);
                 } else if (prefixes.size() > 1) {

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -540,7 +540,7 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
         if (crs != null) {
             Set<ReferenceIdentifier> ids = crs.getIdentifiers();
             // WKT defined crs might not have identifiers at all
-            if (ids != null && ids.size() > 0) {
+            if (ids != null && !ids.isEmpty()) {
                 NamedIdentifier namedIdent = (NamedIdentifier) ids.iterator().next();
                 String csStr = namedIdent.getCodeSpace().toUpperCase();
 

--- a/src/wfs/src/main/java/org/geoserver/wfs/kvp/GetFeatureKvpRequestReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/kvp/GetFeatureKvpRequestReader.java
@@ -140,7 +140,7 @@ public class GetFeatureKvpRequestReader extends BaseFeatureKvpRequestReader {
             @SuppressWarnings("unchecked")
             List<Map<String, String>> viewParams =
                     (List<Map<String, String>>) kvp.get("viewParams");
-            if (viewParams.size() > 0) {
+            if (!viewParams.isEmpty()) {
                 int layerCount = req.getQueries().size();
 
                 // if we have just one replicate over all layers

--- a/src/wfs/src/main/java/org/geoserver/wfs/request/Lock.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/request/Lock.java
@@ -55,7 +55,7 @@ public abstract class Lock extends RequestObject {
             if (typeNames != null) {
                 if (typeNames.size() == 1) {
                     return (QName) typeNames.get(0);
-                } else if (typeNames.size() > 0) {
+                } else if (!typeNames.isEmpty()) {
                     throw new IllegalArgumentException(
                             "Multiple type names on single lock not supported");
                 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/NameSpaceTranslator.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/NameSpaceTranslator.java
@@ -271,7 +271,7 @@ public abstract class NameSpaceTranslator {
         Set posibilities = getElements(type);
 
         // System.out.println("getting default for type: " + type + " = " + posibilities);
-        if (posibilities.size() == 0) {
+        if (posibilities.isEmpty()) {
             return null;
         }
 
@@ -303,7 +303,7 @@ public abstract class NameSpaceTranslator {
 
         Set posibilities = getElements(type);
 
-        if (posibilities.size() == 0) {
+        if (posibilities.isEmpty()) {
             return null;
         }
 

--- a/src/wms/src/main/java/org/geoserver/wms/FeatureInfoRequestParameters.java
+++ b/src/wms/src/main/java/org/geoserver/wms/FeatureInfoRequestParameters.java
@@ -212,7 +212,7 @@ public class FeatureInfoRequestParameters {
     /** The property names for the specified layer (if any, null otherwise) */
     public String[] getPropertyNames() {
         if (propertyNames == null
-                || propertyNames.size() == 0
+                || propertyNames.isEmpty()
                 || propertyNames.get(currentLayer) == null) {
             return Query.ALL_NAMES;
         } else {

--- a/src/wms/src/main/java/org/geoserver/wms/GetMap.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMap.java
@@ -234,7 +234,7 @@ public class GetMap {
             if (singleTimeRange) {
                 List<Object> expandTimeList =
                         expandTimeList((DateRange) times.get(0), request, maxAllowedFrames);
-                if (expandTimeList.size() == 0) {
+                if (expandTimeList.isEmpty()) {
                     return executeInternal(
                             mapContent, request, delegate, Arrays.asList(times.get(0)), elevations);
                 } else {
@@ -266,7 +266,7 @@ public class GetMap {
                 List<Object> expandElevationList =
                         expandElevationList(
                                 (NumberRange) elevations.get(0), request, maxAllowedFrames);
-                if (expandElevationList.size() == 0) {
+                if (expandElevationList.isEmpty()) {
                     map =
                             executeInternal(
                                     mapContent,
@@ -876,11 +876,11 @@ public class GetMap {
                     "MissingOrInvalidParameter");
         }
 
-        if (request.getLayers().size() == 0) {
+        if (request.getLayers().isEmpty()) {
             throw new ServiceException("No layers have been requested", "LayerNotDefined");
         }
 
-        if (request.getStyles().size() == 0) {
+        if (request.getStyles().isEmpty()) {
             throw new ServiceException("No styles have been requested", "StyleNotDefined");
         }
 
@@ -920,7 +920,7 @@ public class GetMap {
     private Filter[] buildLayersFilters(List<Filter> requestFilters, List<MapLayerInfo> layers) {
         final int nLayers = layers.size();
 
-        if (requestFilters == null || requestFilters.size() == 0) {
+        if (requestFilters == null || requestFilters.isEmpty()) {
             requestFilters = Collections.nCopies(layers.size(), Filter.INCLUDE);
         } else if (requestFilters.size() != nLayers) {
             throw new IllegalArgumentException(

--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -332,11 +332,11 @@ public class WMS implements ApplicationContextAware {
         WMSInfo serviceInfo = getServiceInfo();
         List<Version> versions = serviceInfo.getVersions();
         String version;
-        if (versions.size() > 0) {
-            version = versions.get(0).toString();
-        } else {
+        if (versions.isEmpty()) {
             // shouldn't a version be set?
             version = "1.1.1";
+        } else {
+            version = versions.get(0).toString();
         }
         return version;
     }
@@ -1319,7 +1319,7 @@ public class WMS implements ApplicationContextAware {
 
             @SuppressWarnings("unchecked")
             Set<Date> values = visitor.getUnique();
-            if (values.size() <= 0) {
+            if (values.isEmpty()) {
                 result = null;
             } else {
                 // we might get null values out of the visitor, strip them
@@ -1398,7 +1398,7 @@ public class WMS implements ApplicationContextAware {
 
             @SuppressWarnings("unchecked")
             Set<Object> values = visitor.getUnique();
-            if (values.size() <= 0) {
+            if (values.isEmpty()) {
                 result = null;
             } else {
                 for (Object value : values) {

--- a/src/wms/src/main/java/org/geoserver/wms/WMSMapContent.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSMapContent.java
@@ -212,10 +212,10 @@ public class WMSMapContent extends MapContent {
             }
         }
 
-        if (filtered.size() > 0) {
-            return super.addLayers(filtered);
-        } else {
+        if (filtered.isEmpty()) {
             return 0;
+        } else {
+            return super.addLayers(filtered);
         }
     }
 

--- a/src/wms/src/main/java/org/geoserver/wms/WebMap.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WebMap.java
@@ -67,7 +67,7 @@ public abstract class WebMap {
     }
 
     public String[][] getResponseHeaders() {
-        if (responseHeaders == null || responseHeaders.size() == 0) {
+        if (responseHeaders == null || responseHeaders.isEmpty()) {
             return null;
         }
         String[][] headers = new String[responseHeaders.size()][2];

--- a/src/wms/src/main/java/org/geoserver/wms/animate/FrameCatalogVisitor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/animate/FrameCatalogVisitor.java
@@ -105,7 +105,7 @@ public class FrameCatalogVisitor {
             images.add(image);
         }
 
-        if (images == null || images.size() == 0) {
+        if (images == null || images.isEmpty()) {
             dispose();
             throw new IOException("Empty list of frames.");
         }

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -745,16 +745,16 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
 
                 end("Layer");
             } else {
-                if (layerGroups.size() > 0) {
+                if (layerGroups.isEmpty()) {
+                    // now encode the single layer
+                    handleLayerTree(layers, layersAlreadyProcessed, true);
+                } else {
                     try {
                         handleLayerGroups(new ArrayList<>(layerGroups), true);
                     } catch (Exception e) {
                         throw new RuntimeException(
                                 "Can't obtain Envelope of Layer-Groups: " + e.getMessage(), e);
                     }
-                } else {
-                    // now encode the single layer
-                    handleLayerTree(layers, layersAlreadyProcessed, true);
                 }
             }
         }
@@ -806,10 +806,10 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                             .filter(layer -> includeLayer(layersAlreadyProcessed, layer))
                             .collect(Collectors.toList());
             List<LayerGroupInfo> rootGroups = filterNestedGroups(layerGroups);
-            if (rootLayers.size() == 1 && rootGroups.size() == 0) {
+            if (rootLayers.size() == 1 && rootGroups.isEmpty()) {
                 return rootLayers.get(0);
             }
-            if (rootLayers.size() == 0 && rootGroups.size() == 1) {
+            if (rootLayers.isEmpty() && rootGroups.size() == 1) {
                 return rootGroups.get(0);
             }
             return null;
@@ -1256,7 +1256,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
         protected Set<LayerInfo> getLayersInGroups(List<LayerGroupInfo> layerGroups) {
             Set<LayerInfo> layersAlreadyProcessed = new HashSet<>();
 
-            if (layerGroups == null || layerGroups.size() == 0) {
+            if (layerGroups == null || layerGroups.isEmpty()) {
                 return layersAlreadyProcessed;
             }
 

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesResponse.java
@@ -219,7 +219,7 @@ public class GetCapabilitiesResponse extends BaseCapabilitiesResponse {
 
         for (ExtendedCapabilitiesProvider provider : providers) {
             List<String> roots = provider.getVendorSpecificCapabilitiesRoots(request);
-            if (roots != null && roots.size() > 0) {
+            if (roots != null && !roots.isEmpty()) {
                 for (String vendorRoot : roots) {
                     numRoots++;
                     if (numRoots > 1) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -722,17 +722,17 @@ public class GetCapabilitiesTransformer extends TransformerBase {
 
                 end("Layer");
             } else {
-                if (layerGroups.size() > 0) {
+                if (layerGroups.isEmpty()) {
+                    // now encode the single layer
+                    LayerTree featuresLayerTree = new LayerTree(layers);
+                    handleLayerTree(featuresLayerTree, layersAlreadyProcessed, true);
+                } else {
                     try {
                         handleLayerGroups(new ArrayList<>(layerGroups), true);
                     } catch (Exception e) {
                         throw new RuntimeException(
                                 "Can't obtain Envelope of Layer-Groups: " + e.getMessage(), e);
                     }
-                } else {
-                    // now encode the single layer
-                    LayerTree featuresLayerTree = new LayerTree(layers);
-                    handleLayerTree(featuresLayerTree, layersAlreadyProcessed, true);
                 }
             }
         }
@@ -772,10 +772,10 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                             .filter(layer -> includeLayer(layersAlreadyProcessed, layer))
                             .collect(Collectors.toList());
             List<LayerGroupInfo> rootGroups = filterNestedGroups(layerGroups);
-            if (rootLayers.size() == 1 && rootGroups.size() == 0) {
+            if (rootLayers.size() == 1 && rootGroups.isEmpty()) {
                 return rootLayers.get(0);
             }
-            if (rootLayers.size() == 0 && rootGroups.size() == 1) {
+            if (rootLayers.isEmpty() && rootGroups.size() == 1) {
                 return rootGroups.get(0);
             }
             return null;
@@ -1289,7 +1289,7 @@ public class GetCapabilitiesTransformer extends TransformerBase {
         protected Set<LayerInfo> getLayersInGroups(List<LayerGroupInfo> layerGroups) {
             Set<LayerInfo> layersAlreadyProcessed = new HashSet<>();
 
-            if (layerGroups == null || layerGroups.size() == 0) {
+            if (layerGroups == null || layerGroups.isEmpty()) {
                 return layersAlreadyProcessed;
             }
 

--- a/src/wms/src/main/java/org/geoserver/wms/describelayer/DescribeLayerKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/describelayer/DescribeLayerKvpRequestReader.java
@@ -63,7 +63,7 @@ public class DescribeLayerKvpRequestReader extends KvpRequestReader {
         List<MapLayerInfo> layers =
                 new MapLayerInfoKvpParser("LAYERS", wms).parse((String) rawKvp.get("LAYERS"));
         request.setLayers(layers);
-        if (layers == null || layers.size() == 0) {
+        if (layers == null || layers.isEmpty()) {
             throw new ServiceException(
                     "No LAYERS has been requested", "NoLayerRequested", getClass().getName());
         }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/DynamicSizeStyleExtractor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/DynamicSizeStyleExtractor.java
@@ -56,7 +56,7 @@ class DynamicSizeStyleExtractor extends DuplicatingStyleVisitor {
             }
         }
 
-        if (nonNullCopies.size() == 0) {
+        if (nonNullCopies.isEmpty()) {
             pages.pop();
             pages.push(null);
         } else {
@@ -87,7 +87,7 @@ class DynamicSizeStyleExtractor extends DuplicatingStyleVisitor {
             }
         }
 
-        if (nonNullCopies.size() == 0) {
+        if (nonNullCopies.isEmpty()) {
             pages.pop();
             pages.push(null);
         } else {
@@ -107,7 +107,7 @@ class DynamicSizeStyleExtractor extends DuplicatingStyleVisitor {
             }
         }
 
-        if (nonNullCopies.size() == 0) {
+        if (nonNullCopies.isEmpty()) {
             pages.pop();
             pages.push(null);
         } else {

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
@@ -191,7 +191,7 @@ class FeatureInfoStylePreprocessor extends SymbolizerFilteringVisitor {
     public void visit(FeatureTypeStyle fts) {
         extraRules.clear();
         super.visit(fts);
-        if (extraRules.size() > 0) {
+        if (!extraRules.isEmpty()) {
             FeatureTypeStyle copy = (FeatureTypeStyle) pages.peek();
             copy.rules().addAll(extraRules);
         }
@@ -314,7 +314,7 @@ class FeatureInfoStylePreprocessor extends SymbolizerFilteringVisitor {
         if (stroke != null) {
             List<Expression> dashArray = stroke.dashArray();
             Graphic graphicStroke = stroke.getGraphicStroke();
-            if (graphicStroke != null || dashArray != null && dashArray.size() > 0) {
+            if (graphicStroke != null || dashArray != null && !dashArray.isEmpty()) {
                 addSolidLineSymbolier = true;
             }
         }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/GetFeatureInfoKvpReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/GetFeatureInfoKvpReader.java
@@ -172,7 +172,7 @@ public class GetFeatureInfoKvpReader extends KvpRequestReader {
         // make sure they are a subset of layers
         List<MapLayerInfo> queryLayers = new ArrayList<>(request.getQueryLayers());
         queryLayers.removeAll(getMapLayers);
-        if (queryLayers.size() > 0) {
+        if (!queryLayers.isEmpty()) {
             // we've already expanded base layers so let's avoid list the names, they are not
             // the original ones anymore
             throw new ServiceException(

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorBasicLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorBasicLayerIdentifier.java
@@ -71,7 +71,7 @@ public class VectorBasicLayerIdentifier extends AbstractVectorLayerIdentifier {
         final Style style = params.getStyle();
         // ok, internally rendered layer then, we check the style to see what's active
         final List<Rule> rules = getActiveRules(style, params.getScaleDenominator());
-        if (rules.size() == 0) {
+        if (rules.isEmpty()) {
             return null;
         }
 
@@ -148,7 +148,7 @@ public class VectorBasicLayerIdentifier extends AbstractVectorLayerIdentifier {
 
         // handle sql view params
         final Map<String, String> viewParams = params.getViewParams();
-        if (viewParams != null && viewParams.size() > 0) {
+        if (viewParams != null && !viewParams.isEmpty()) {
             q.setHints(new Hints(Hints.VIRTUAL_TABLE_PARAMETERS, viewParams));
         }
 

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorRenderingLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorRenderingLayerIdentifier.java
@@ -149,7 +149,7 @@ public class VectorRenderingLayerIdentifier extends AbstractVectorLayerIdentifie
 
         // check the style to see what's active
         final List<Rule> rules = getActiveRules(style, params.getScaleDenominator());
-        if (rules.size() == 0) {
+        if (rules.isEmpty()) {
             return null;
         }
         GetMapRequest getMap = params.getGetMapRequest();
@@ -469,7 +469,7 @@ public class VectorRenderingLayerIdentifier extends AbstractVectorLayerIdentifie
 
             // this can happen, the meta buffer estimator can get tripped by
             // graphic fills using dynamic sizes for their strokes
-            if (dynamicRules.size() == 0) {
+            if (dynamicRules.isEmpty()) {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine(
                             "No dynamic rules found, even if the estimator initially though so, "

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
@@ -485,7 +485,7 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
             }
             addStylesFrom(sldStyles, styleNames, parseSldBody(sldBody));
 
-        } else if (styleNames.size() > 0) {
+        } else if (!styleNames.isEmpty()) {
             if (LOGGER.isLoggable(Level.FINER)) {
                 LOGGER.finer("taking style from STYLE parameter");
             }
@@ -607,7 +607,7 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
      * @param source list of styles from a given source
      */
     private void addStylesFrom(List<Style> sldStyles, List<String> styleNames, Style[] source) {
-        if (styleNames.size() == 0) {
+        if (styleNames.isEmpty()) {
             sldStyles.add(findStyle(null, source));
         } else {
             for (String styleName : styleNames) {

--- a/src/wms/src/main/java/org/geoserver/wms/map/AbstractMapResponse.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/AbstractMapResponse.java
@@ -105,7 +105,7 @@ public abstract class AbstractMapResponse extends Response {
             return false;
         }
         Set<String> outputFormats = getOutputFormats();
-        if (outputFormats.size() == 0) {
+        if (outputFormats.isEmpty()) {
             // rely only on response binding
             return true;
         }

--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -394,7 +394,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         }
         getMap.setLayers(newLayers);
 
-        if (interpolationList.size() > 0) {
+        if (!interpolationList.isEmpty()) {
             getMap.setInterpolations(parseInterpolations(requestedLayerInfos, interpolationList));
         }
 
@@ -418,7 +418,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                 try (StringReader reader = new StringReader(getMap.getSldBody())) {
                     List<Exception> errors = validateStyle(reader, getMap);
 
-                    if (errors.size() != 0) {
+                    if (!errors.isEmpty()) {
                         throw new ServiceException(
                                 SLDValidator.getErrorMessage(
                                         new StringReader(getMap.getSldBody()), errors));
@@ -459,7 +459,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                 try (InputStreamReader reader = new InputStreamReader(input)) {
                     if (getMap.getValidateSchema().booleanValue()) {
                         List<Exception> errors = validateStyle(input, getMap);
-                        if ((errors != null) && (errors.size() != 0)) {
+                        if ((errors != null) && (!errors.isEmpty())) {
                             throw new ServiceException(SLDValidator.getErrorMessage(input, errors));
                         }
                     }
@@ -497,13 +497,13 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
             }
 
             // ok, parse the styles parameter in isolation
-            if (styleNameList.size() > 0) {
+            if (!styleNameList.isEmpty()) {
                 List<Style> parseStyles = parseStyles(styleNameList, requestedLayerInfos);
                 getMap.setStyles(parseStyles);
             }
 
             // first, expand base layers and default styles
-            if (isParseStyle() && requestedLayerInfos.size() > 0) {
+            if (isParseStyle() && !requestedLayerInfos.isEmpty()) {
                 List<Style> oldStyles =
                         getMap.getStyles() != null
                                 ? new ArrayList<>(getMap.getStyles())
@@ -542,7 +542,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                         }
 
                     } else if (o instanceof LayerInfo) {
-                        style = oldStyles.size() > 0 ? oldStyles.get(i) : null;
+                        style = oldStyles.isEmpty() ? null : oldStyles.get(i);
                         if (style != null) {
                             newStyles.add(style);
                         } else {
@@ -557,7 +557,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                             newSortBy.add(getSortBy(sortBy, i));
                         }
                     } else if (o instanceof MapLayerInfo) {
-                        style = oldStyles.size() > 0 ? oldStyles.get(i) : null;
+                        style = oldStyles.isEmpty() ? null : oldStyles.get(i);
                         if (style != null) {
                             newStyles.add(style);
                         } else {
@@ -581,7 +581,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
 
             // then proceed with standard processing
             List<MapLayerInfo> layers = getMap.getLayers();
-            if (isParseStyle() && (layers != null) && (layers.size() > 0)) {
+            if (isParseStyle() && (layers != null) && (!layers.isEmpty())) {
                 final List styles = getMap.getStyles();
 
                 if (layers.size() != styles.size()) {
@@ -638,7 +638,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
 
         // check the view params
         List<Map<String, String>> viewParams = getMap.getViewParams();
-        if (viewParams != null && viewParams.size() > 0) {
+        if (viewParams != null && !viewParams.isEmpty()) {
             int layerCount = getMap.getLayers().size();
 
             // if we have just one replicate over all layers
@@ -907,7 +907,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         }
 
         // return null in case we found no filters
-        if (filters.size() == 0) {
+        if (filters.isEmpty()) {
             filters = null;
         }
         return filters;
@@ -951,7 +951,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
             final StyledLayerDescriptor sld,
             final List<String> styleNames)
             throws ServiceException, IOException {
-        if (requestedLayers.size() == 0) {
+        if (requestedLayers.isEmpty()) {
             sld.accept(new ProcessStandaloneSLDVisitor(wms, request));
         } else {
             processLibrarySld(request, sld, requestedLayers, styleNames);
@@ -1003,7 +1003,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         String styleName = null;
 
         for (int i = 0; i < requestedLayers.size(); i++) {
-            if (styleNames != null && styleNames.size() > 0) {
+            if (styleNames != null && !styleNames.isEmpty()) {
                 styleName = styleNames.get(i);
             }
             Object o = requestedLayers.get(i);
@@ -1387,7 +1387,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         // }
         // }
 
-        if (layersOrGroups.size() == 0) {
+        if (layersOrGroups.isEmpty()) {
             throw new ServiceException("No LAYERS has been requested", getClass().getName());
         }
         return layersOrGroups;

--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapXmlReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapXmlReader.java
@@ -733,7 +733,7 @@ public class GetMapXmlReader extends org.geoserver.ows.XmlRequestReader {
                 }
             }
 
-            if (errors.size() != 0) {
+            if (!errors.isEmpty()) {
                 in = new FileInputStream(f);
                 throw new ServiceException(SLDValidator.getErrorMessage(in, errors));
             }
@@ -766,7 +766,7 @@ public class GetMapXmlReader extends org.geoserver.ows.XmlRequestReader {
                 }
             }
 
-            if (errors.size() != 0) {
+            if (!errors.isEmpty()) {
                 in = new FileInputStream(f);
                 throw new ServiceException(GETMAPValidator.getErrorMessage(in, errors));
             }

--- a/src/wms/src/main/java/org/geoserver/wms/map/PaletteExtractor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/PaletteExtractor.java
@@ -87,7 +87,7 @@ public class PaletteExtractor extends FilterAttributeExtractor implements StyleV
             return false;
 
         // impossible to devise a palette (0 shuold never happen, but you never know...)
-        if (colors.size() == 0 || colors.size() > 256) return false;
+        if (colors.isEmpty() || colors.size() > 256) return false;
 
         return true;
     }

--- a/src/wms/src/main/java/org/geoserver/wms/svg/SVGWriter.java
+++ b/src/wms/src/main/java/org/geoserver/wms/svg/SVGWriter.java
@@ -264,7 +264,7 @@ class SVGWriter extends OutputStreamWriter {
                 LOGGER.finer("Added BOUNDS handler decorator");
             }
 
-            if (atts.size() > 0) {
+            if (!atts.isEmpty()) {
                 this.writerHandler = new AttributesSVGHandler(this.writerHandler);
                 LOGGER.finer("Added ATTRIBUTES handler decorator");
             }


### PR DESCRIPTION
Includes PMD QA check to verify this.

Resolves https://osgeo-org.atlassian.net/browse/GEOS-9849

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [N/A] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
