### PR TITLE
update conformance statements

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/api/ConformanceClass.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/api/ConformanceClass.java
@@ -1,0 +1,13 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.api;
+
+/** Conformance statements for the conformance page. */
+public class ConformanceClass {
+    public static final String CORE = "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core";
+
+    public static final String COLLECTIONS =
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections";
+}

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/api/images/ImagesService.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/api/images/ImagesService.java
@@ -142,7 +142,12 @@ public class ImagesService implements ApplicationContextAware {
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
     public ConformanceDocument conformance() {
-        List<String> classes = Arrays.asList(ConformanceClass.CORE, ConformanceClass.COLLECTIONS, IMAGES_CORE, IMAGES_TRANSACTIONAL);
+        List<String> classes =
+                Arrays.asList(
+                        ConformanceClass.CORE,
+                        ConformanceClass.COLLECTIONS,
+                        IMAGES_CORE,
+                        IMAGES_TRANSACTIONAL);
         return new ConformanceDocument(classes);
     }
 

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/api/images/ImagesService.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/api/images/ImagesService.java
@@ -33,6 +33,7 @@ import org.geoserver.api.APIDispatcher;
 import org.geoserver.api.APIException;
 import org.geoserver.api.APIRequestInfo;
 import org.geoserver.api.APIService;
+import org.geoserver.api.ConformanceClass;
 import org.geoserver.api.ConformanceDocument;
 import org.geoserver.api.HTMLResponseBody;
 import org.geoserver.api.OpenAPIMessageConverter;
@@ -102,9 +103,6 @@ public class ImagesService implements ApplicationContextAware {
 
     static final Logger LOGGER = Logging.getLogger(ImagesService.class);
 
-    static final String CORE = "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core";
-    static final String COLLECTIONS =
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/collections";
     static final String IMAGES_CORE = "http://www.opengis.net/spec/ogcapi-images-1/1.0/req/core";
     static final String IMAGES_TRANSACTIONAL =
             "http://www.opengis.net/spec/ogcapi-images-1/1.0/req/transactional";
@@ -144,7 +142,7 @@ public class ImagesService implements ApplicationContextAware {
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
     public ConformanceDocument conformance() {
-        List<String> classes = Arrays.asList(CORE, COLLECTIONS, IMAGES_CORE, IMAGES_TRANSACTIONAL);
+        List<String> classes = Arrays.asList(ConformanceClass.CORE, ConformanceClass.COLLECTIONS, IMAGES_CORE, IMAGES_TRANSACTIONAL);
         return new ConformanceDocument(classes);
     }
 

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/api/images/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/api/images/ConformanceTest.java
@@ -7,6 +7,7 @@ package org.geoserver.api.images;
 import static org.junit.Assert.assertEquals;
 
 import com.jayway.jsonpath.DocumentContext;
+import org.geoserver.api.ConformanceClass;
 import org.junit.Test;
 
 public class ConformanceTest extends ImagesTestSupport {
@@ -18,8 +19,8 @@ public class ConformanceTest extends ImagesTestSupport {
     }
 
     private void checkConformance(DocumentContext json) {
-        assertEquals(ImagesService.CORE, json.read("$.conformsTo[0]", String.class));
-        assertEquals(ImagesService.COLLECTIONS, json.read("$.conformsTo[1]", String.class));
+        assertEquals(ConformanceClass.CORE, json.read("$.conformsTo[0]", String.class));
+        assertEquals(ConformanceClass.COLLECTIONS, json.read("$.conformsTo[1]", String.class));
         assertEquals(ImagesService.IMAGES_CORE, json.read("$.conformsTo[2]", String.class));
         assertEquals(
                 ImagesService.IMAGES_TRANSACTIONAL, json.read("$.conformsTo[3]", String.class));

--- a/src/community/ogcapi/ogcapi-tiled-features/src/main/java/org/geoserver/api/features/tiled/TiledFeaturesExtension.java
+++ b/src/community/ogcapi/ogcapi-tiled-features/src/main/java/org/geoserver/api/features/tiled/TiledFeaturesExtension.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import org.geoserver.api.AbstractDocument;
 import org.geoserver.api.AbstractLandingPageDocument;
+import org.geoserver.api.ConformanceClass;
 import org.geoserver.api.ConformanceDocument;
 import org.geoserver.api.DocumentCallback;
 import org.geoserver.api.FreemarkerTemplateSupport;
@@ -24,7 +25,6 @@ import org.geoserver.api.features.FeaturesLandingPage;
 import org.geoserver.api.tiles.TileMatrixSets;
 import org.geoserver.api.tiles.TilesDocument;
 import org.geoserver.api.tiles.TilesLandingPage;
-import org.geoserver.api.tiles.TilesService;
 import org.geoserver.ows.Request;
 import org.geoserver.ows.util.ResponseUtils;
 import org.springframework.context.ApplicationListener;
@@ -151,7 +151,7 @@ public class TiledFeaturesExtension
     }
 
     public void extendConformanceClasses(ConformanceDocument conformance) {
-        conformance.getConformsTo().add(TilesService.CC_CORE);
+        conformance.getConformsTo().add(ConformanceClass.CORE);
     }
 
     private void extendCollectionDocument(CollectionDocument collection) {

--- a/src/community/ogcapi/ogcapi-tiled-features/src/test/java/org/geoserver/api/features/tiled/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-tiled-features/src/test/java/org/geoserver/api/features/tiled/ConformanceTest.java
@@ -7,8 +7,8 @@ package org.geoserver.api.features.tiled;
 import static org.junit.Assert.assertEquals;
 
 import com.jayway.jsonpath.DocumentContext;
+import org.geoserver.api.ConformanceClass;
 import org.geoserver.api.features.FeatureService;
-import org.geoserver.api.tiles.TilesService;
 import org.junit.Test;
 
 public class ConformanceTest extends TiledFeaturesTestSupport {
@@ -23,6 +23,6 @@ public class ConformanceTest extends TiledFeaturesTestSupport {
         assertEquals(FeatureService.GMLSF0, json.read("$.conformsTo[4]", String.class));
         assertEquals(FeatureService.CQL_TEXT, json.read("$.conformsTo[5]", String.class));
         // check the document got extended
-        assertEquals(TilesService.CC_CORE, json.read("$.conformsTo[6]", String.class));
+        assertEquals(ConformanceClass.CORE, json.read("$.conformsTo[6]", String.class));
     }
 }

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/api/tiles/TilesService.java
@@ -26,6 +26,7 @@ import org.geoserver.api.APIException;
 import org.geoserver.api.APIFilterParser;
 import org.geoserver.api.APIRequestInfo;
 import org.geoserver.api.APIService;
+import org.geoserver.api.ConformanceClass;
 import org.geoserver.api.ConformanceDocument;
 import org.geoserver.api.HTMLResponseBody;
 import org.geoserver.api.InvalidParameterValueException;
@@ -77,10 +78,11 @@ public class TilesService {
 
     static final Logger LOGGER = Logging.getLogger(TilesService.class);
 
-    public static final String CC_CORE = "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/core";
-    public static final String CC_MULTITILE =
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/multitile";
-    public static final String CC_INFO = "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/info";
+    public static final String CC_TILESET =
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset";
+    public static final String CC_MULTITILES =
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/multitiles";
+    public static final String CC_INFO = "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/info";
 
     private final GeoServer geoServer;
     private final GWC gwc;
@@ -133,7 +135,13 @@ public class TilesService {
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
     public ConformanceDocument conformance() {
-        List<String> classes = Arrays.asList(CC_CORE, CC_MULTITILE, CC_INFO);
+        List<String> classes =
+                Arrays.asList(
+                        ConformanceClass.CORE,
+                        ConformanceClass.COLLECTIONS,
+                        CC_TILESET,
+                        CC_MULTITILES,
+                        CC_INFO);
         return new ConformanceDocument(classes);
     }
 

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/ConformanceTest.java
@@ -7,6 +7,7 @@ package org.geoserver.api.tiles;
 import static org.junit.Assert.assertEquals;
 
 import com.jayway.jsonpath.DocumentContext;
+import org.geoserver.api.ConformanceClass;
 import org.junit.Test;
 
 public class ConformanceTest extends TilesTestSupport {
@@ -18,9 +19,11 @@ public class ConformanceTest extends TilesTestSupport {
     }
 
     private void checkConformance(DocumentContext json) {
-        assertEquals(TilesService.CC_CORE, json.read("$.conformsTo[0]", String.class));
-        assertEquals(TilesService.CC_MULTITILE, json.read("$.conformsTo[1]", String.class));
-        assertEquals(TilesService.CC_INFO, json.read("$.conformsTo[2]", String.class));
+        assertEquals(ConformanceClass.CORE, json.read("$.conformsTo[0]", String.class));
+        assertEquals(ConformanceClass.COLLECTIONS, json.read("$.conformsTo[1]", String.class));
+        assertEquals(TilesService.CC_TILESET, json.read("$.conformsTo[2]", String.class));
+        assertEquals(TilesService.CC_MULTITILES, json.read("$.conformsTo[3]", String.class));
+        assertEquals(TilesService.CC_INFO, json.read("$.conformsTo[4]", String.class));
         // check the others as they get implemented
     }
 

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/GetTileTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/api/tiles/GetTileTest.java
@@ -382,7 +382,7 @@ public class GetTileTest extends TilesTestSupport {
                                 + "/map/_/tiles/EPSG:900913/EPSG:900913:16/32768/32768?f=image/png",
                         "image/png");
         File expected = new File("src/test/resources/org/geoserver/api/tiles/nature_tile_16.png");
-        ImageAssert.assertEquals(expected, image, 100);
+        ImageAssert.assertEquals(expected, image, 120);
     }
 
     @Test


### PR DESCRIPTION
The OGC API specs are pretty fluid, but it looks (from https://github.com/opengeospatial/ogcapi-tiles/issues/20 and https://github.com/opengeospatial/ogcapi-tiles/pull/24 amongst other places) like the conformance classes have `conf` rather than `req`. This PR updates the implementation to refer to common correctly.

I also had to add a bit of pixel tolerance to one test.

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
