### PR TITLE
[GEOS-6903] Unwanted dependency on HSQLDB in gs-web-wps

### DIFF
--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSExecuteTransformer.java
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSExecuteTransformer.java
@@ -5,11 +5,14 @@
  */
 package org.geoserver.wps.web;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.apache.xml.serializer.TreeWalker;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
@@ -27,7 +30,6 @@ import org.geotools.wps.WPS;
 import org.geotools.xlink.XLINK;
 import org.geotools.xml.transform.TransformerBase;
 import org.geotools.xml.transform.Translator;
-import org.hsqldb.lib.StringInputStream;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.w3c.dom.Document;
 import org.xml.sax.ContentHandler;
@@ -391,8 +393,8 @@ class WPSExecuteTransformer extends TransformerBase {
                 if (!data.startsWith("<?xml")) {
                     data = "<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n" + data;
                 }
-                return builder.parse(new StringInputStream(data));
-            } catch (Throwable t) {
+                return builder.parse(new ByteArrayInputStream(data.getBytes()));
+            } catch (IOException | ParserConfigurationException | SAXException t) {
                 LOGGER.log(Level.FINE, "Failed to parse XML, assuming it's plain text", t);
                 return null;
             }


### PR DESCRIPTION
Cleanup of old code (ticket picked at random).

See https://osgeo-org.atlassian.net/browse/GEOS-6903

Note that there is still a dependency on hsqldb in wps-core (because of https://github.com/geoserver/geoserver/blob/master/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/validator/MultiplicityValidator.java#L7). Happy to take hints on fixing that as a subsequent ticket - this only deals with web-wps.

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [N/A] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
