### PR TITLE
[Backport-2.18.x][GEOT-6789]:Follow up on documentation for max oversampling (#4647)

### DIFF
--- a/doc/en/user/source/configuration/raster_access.rst
+++ b/doc/en/user/source/configuration/raster_access.rst
@@ -42,3 +42,23 @@ Using an `unbounded` queue is recommended which allows to queue all the pending 
 .. note:: If the pool currently has more than `corePoolSize` threads, excess threads will be terminated if they have been idle for more than the `keepAliveTime`.
 .. note:: If a new task is submitted to the list of tasks to be executed and there are more than `corePoolSize` but less than `maximumPoolSize` threads running, a new thread will be created only if the queue is full. This means that when using an `Unbounded` queue, no more threads than `corePoolSize` will be running and `keepAliveTime` has no influence.
 .. note:: If `corePoolSize` and `maximumPoolSize` are the same, a fixed-size thread pool is used.
+
+System Properties Configuration
+===============================
+There are some additional global configuration parameters involved in raster access which can be specified through System properties.
+
+Max Oversampling Factor
+-----------------------
+When dealing with reprojection, the underlying raster read operation might do some oversampling in order to provide the requested output resolution. Depending on the reprojection and the requested area, the oversampling factor might be high.
+
+Consider an untiled whole world request of an EPSG:4326 raster, towards EPSG:3857, filling a 1024x768 image. Due to the big distortion introduced by the Mercator Projection at high latitudes, the underlying read operation may result in actually reading 20000x8000 pixels, in other words, an oversampling factor of almost 20. Image processing operations will work on that big input image before returning back the desired 1024x768 image.
+
+This can be very time consuming (you may notice long rendering time for that). It's possible to put a limit on the maximum oversampling factor by adding the following java option to GeoServer startup script and restart it:
+
+    .. code-block:: xml
+	
+	-Dorg.geotools.coverage.max.oversample=N
+   
+
+
+With N a number representing the maximum oversampling factor. By this way, the underlying read operation will use a reading resolution within that limit, making the rendering faster. The speed gain has however a penalty, output quality decrease at the poles. So you may want to play a bit with this value to find the optimal trade-off between speed and quality. For example, you could start trying with a value of 3 and check the results, and then slowly increase it until the output matches the desired quality within an acceptable rendering time.


### PR DESCRIPTION
backporting documentation for max oversampling [GEOT-6789]:
