### PR TITLE
[Backport-2.18.x][GEOS-9834] GetLegendGraphic results in java.lang.NegativeArraySizeException or OutOfMemory

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendGraphicBuilder.java
@@ -78,6 +78,7 @@ public abstract class LegendGraphicBuilder {
      */
     protected final double MINIMUM_SYMBOL_SIZE = 3.0;
 
+    double dpiScaleFactor;
     protected int w;
     protected int h;
     boolean forceLabelsOn = false;
@@ -96,6 +97,13 @@ public abstract class LegendGraphicBuilder {
         // width and height, we might have to rescale those in case of DPI usage
         w = request.getWidth();
         h = request.getHeight();
+        double dpi = RendererUtilities.getDpi(request.getLegendOptions());
+        double standardDpi = RendererUtilities.getDpi(Collections.emptyMap());
+        dpiScaleFactor = dpi / standardDpi;
+        if (dpiScaleFactor != 1.0) {
+            w = ((int) Math.round(request.getWidth() * dpiScaleFactor));
+            h = ((int) Math.round(request.getHeight() * dpiScaleFactor));
+        }
 
         if (request.getLegendOptions().get("forceLabels") instanceof String) {
             String forceLabelsOpt = (String) request.getLegendOptions().get("forceLabels");
@@ -149,13 +157,8 @@ public abstract class LegendGraphicBuilder {
     protected Style resizeForDPI(GetLegendGraphicRequest request, Style gt2Style) {
 
         // apply dpi rescale
-        double dpi = RendererUtilities.getDpi(request.getLegendOptions());
-        double standardDpi = RendererUtilities.getDpi(Collections.emptyMap());
-        if (dpi != standardDpi) {
-            double scaleFactor = dpi / standardDpi;
-            w = ((int) Math.round(w * scaleFactor));
-            h = ((int) Math.round(h * scaleFactor));
-            DpiRescaleStyleVisitor dpiVisitor = new DpiRescaleStyleVisitor(scaleFactor);
+        if (dpiScaleFactor != 1.0) {
+            DpiRescaleStyleVisitor dpiVisitor = new DpiRescaleStyleVisitor(dpiScaleFactor);
             dpiVisitor.visit(gt2Style);
             gt2Style = (Style) dpiVisitor.getCopy();
         }

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
@@ -1330,6 +1330,46 @@ public class BufferedImageLegendGraphicOutputFormatTest
         assertColorSimilar(Color.WHITE, colorOutsideCenter, 20);
     }
 
+    /** Tests that rescale due to dpi is done correctly. */
+    @org.junit.Test
+    public void testScaleDPI() throws Exception {
+        GetLegendGraphicRequest req = new GetLegendGraphicRequest(null);
+
+        req.setWidth(20);
+        req.setHeight(20);
+        FeatureTypeInfo ftInfo =
+                getCatalog()
+                        .getFeatureTypeByName(
+                                MockData.MPOINTS.getNamespaceURI(),
+                                MockData.MPOINTS.getLocalPart());
+
+        req.setLayer(ftInfo.getFeatureType());
+        Style sldStype = readSLD("line.sld");
+        req.setStyle(sldStype);
+
+        BufferedImage image = this.legendProducer.buildLegendGraphic(req);
+
+        assertEquals(20, this.legendProducer.w);
+        assertEquals(20, this.legendProducer.h);
+        assertEquals(20, image.getWidth());
+        assertEquals(20, image.getHeight());
+
+        // set dpi
+        HashMap<String, Object> legendOptions = new HashMap<>();
+        legendOptions.put("dpi", 300);
+        req.setLegendOptions(legendOptions);
+        image = this.legendProducer.buildLegendGraphic(req);
+        assertEquals(66, this.legendProducer.w);
+        assertEquals(66, this.legendProducer.h);
+        assertEquals(66, image.getWidth());
+        assertEquals(66, image.getHeight());
+
+        // and when we do it again this must not change the image size
+        this.legendProducer.resizeForDPI(req, sldStype);
+        assertEquals(66, this.legendProducer.w);
+        assertEquals(66, this.legendProducer.h);
+    }
+
     /** */
     private Style readSLD(String sldName) throws IOException {
         StyleFactory styleFactory = CommonFactoryFinder.getStyleFactory(null);


### PR DESCRIPTION
backporting #4606 fix for LegendGraphicBuilder style resizing issue [GEOS-9834]