### PR TITLE
[GEOS-9867] Added missing dependency in community module, assembly descriptor

### DIFF
--- a/src/community/release/ext-cog.xml
+++ b/src/community/release/ext-cog.xml
@@ -16,6 +16,7 @@
         <include>http-client-spi-2*.jar</include>
         <include>http*-osgi*.jar</include>
         <include>imageio-ext-*rangereader*.jar</include>
+        <include>jackson-annotations*.jar</include>
         <include>jackson-core-asl*.jar</include>
         <include>jackson-data*.jar</include>
         <include>jackson-mapper-asl*.jar</include>


### PR DESCRIPTION
For some reason, the backport was missing that single dependency.
Fixing it.