### PR TITLE
ci: split linux build into separate jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: Docs CI
+
+on: [pull_request]
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
+
+jobs:
+  docs:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+    - uses: BSFishy/pip-action@v1
+      with:
+        packages: |
+          sphinx
+          requests
+    - name: Build docs
+      run: mvn -f doc/en install

--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -1,10 +1,9 @@
-name: Linux GitHub CI
+name: Linux JDK 11 GitHub CI
 
 on: [pull_request]
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
-  TAKARI_SMART_BUILDER_VERSION: 0.6.1
 
 jobs:
   build:
@@ -12,8 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
-            jdk: 8
           - os: ubuntu-20.04
             jdk: 11
     steps:
@@ -21,7 +18,7 @@ jobs:
       with:
         # 500 commits, set to 0 to get all
         fetch-depth: 500
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.jdk }}
@@ -48,45 +45,3 @@ jobs:
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
 
-  QA:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        # 500 commits, set to 0 to get all
-        fetch-depth: 500
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@v4
-      with:
-        maven-version: 3.6.3
-    - name: Maven repository caching
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: gs-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          gs-${{ runner.os }}-maven-
-    - name: Build with Maven
-      run: mvn -B -U -T3 -fae -Dfmt.action=check -Dqa -DskipTests=true -Prelease -f src/pom.xml clean install
-    - name: Build community modules
-      run: mvn -nsu -B -U -T4 -fae -Dfmt.action=check -DskipTests -Prelease -PcommunityRelease -f src/community/pom.xml clean install
-    - name: Remove SNAPSHOT jars from repository
-      run: |
-        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-
-  docs:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
-    - uses: BSFishy/pip-action@v1
-      with:
-        packages: |
-          sphinx
-          requests
-    - name: Build docs
-      run: mvn -f doc/en install

--- a/.github/workflows/linux_jdk8.yml
+++ b/.github/workflows/linux_jdk8.yml
@@ -1,0 +1,47 @@
+name: Linux JDK 8 GitHub CI
+
+on: [pull_request]
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            jdk: 8
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # 500 commits, set to 0 to get all
+        fetch-depth: 500
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jdk }}
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.6.3
+    - name: Maven repository caching
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: gs-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          gs-${{ runner.os }}-maven-
+    - name: Build with Maven
+      run: mvn -B -U -T3 -fae -Dfmt.skip=true -Prelease -f src/pom.xml clean install
+    - name: Build community modules
+      run: mvn -nsu -B -U -T4 -fae -Dfmt.skip=true -DskipTests -Prelease -PcommunityRelease -f src/community/pom.xml clean install
+    - name: Package
+      run: mvn -f src/pom.xml assembly:single -nsu -N
+    - name: Package community modules
+      run:  mvn -f src/community/pom.xml assembly:single -nsu -N
+    - name: Remove SNAPSHOT jars from repository
+      run: |
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
+

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,38 @@
+name: QA GitHub CI
+
+on: [pull_request]
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
+
+jobs:
+  QA:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # 500 commits, set to 0 to get all
+        fetch-depth: 500
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.6.3
+    - name: Maven repository caching
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: gs-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          gs-${{ runner.os }}-maven-
+    - name: Build with Maven
+      run: mvn -B -U -T3 -fae -Dfmt.action=check -Dqa -DskipTests=true -Prelease -f src/pom.xml clean install
+    - name: Build community modules
+      run: mvn -nsu -B -U -T4 -fae -Dfmt.action=check -DskipTests -Prelease -PcommunityRelease -f src/community/pom.xml clean install
+    - name: Remove SNAPSHOT jars from repository
+      run: |
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
+


### PR DESCRIPTION
When migrating from Travis to GH actions, the Linux build was four jobs. However when one of those jobs fails for a transient issue (like a transfer problem from repo), all four jobs need to be restarted - you can't do just the failing one. That is annoying, but also runs the risk of using up more build time than we need to.

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [N/A] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [N/A] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [N/A] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
