### PR TITLE
ogcapi: fix deprecated usage, unchecked warnings, minor typos

### DIFF
--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/CollectionDocument.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/CollectionDocument.java
@@ -38,7 +38,7 @@ import org.springframework.http.MediaType;
 
 /** Description of a single collection, that will be serialized to JSON/XML/HTML */
 @JsonPropertyOrder({"id", "title", "description", "extent", "dggs-id", "resolutions", "links"})
-public class CollectionDocument extends AbstractCollectionDocument {
+public class CollectionDocument extends AbstractCollectionDocument<FeatureTypeInfo> {
     static final Logger LOGGER = Logging.getLogger(CollectionDocument.class);
     private final DGGSFeatureSource fs;
 

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIDispatcher.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIDispatcher.java
@@ -342,7 +342,7 @@ public class APIDispatcher extends AbstractController {
      * @return The first {@link APIService} found walking up the inheritance hierarchy, or null if
      *     not found
      */
-    static APIService getApiServiceAnnotation(Class clazz) {
+    static APIService getApiServiceAnnotation(Class<?> clazz) {
         APIService annotation = null;
         while (annotation == null && clazz != null) {
             annotation = (APIService) clazz.getAnnotation(APIService.class);
@@ -469,14 +469,14 @@ public class APIDispatcher extends AbstractController {
         // most likely...
 
         // unparsed kvp set
-        Map kvp = request.getHttpRequest().getParameterMap();
+        Map<String, String[]> kvp = request.getHttpRequest().getParameterMap();
 
         if (kvp == null || kvp.isEmpty()) {
-            request.setKvp(new HashMap());
-            request.setRawKvp(new HashMap());
+            request.setKvp(new HashMap<>());
+            request.setRawKvp(new HashMap<>());
         } else {
             // track parsed kvp and unparsd
-            Map parsedKvp = KvpUtils.normalize(kvp);
+            Map<String, Object> parsedKvp = KvpUtils.normalize(kvp);
             Map rawKvp = new KvpMap(parsedKvp);
 
             request.setKvp(parsedKvp);

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractCollectionDocument.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractCollectionDocument.java
@@ -11,13 +11,10 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
-import org.geotools.util.logging.Logging;
 
 /** Description of a single collection, that will be serialized to JSON/XML/HTML */
 @JsonPropertyOrder({"id", "title", "description", "extent", "links"})
 public class AbstractCollectionDocument<T> extends AbstractDocument {
-    static final Logger LOGGER = Logging.getLogger(AbstractCollectionDocument.class);
 
     protected String title;
     protected String description;

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractDocument.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractDocument.java
@@ -14,18 +14,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.geoserver.ows.URLMangler;
 import org.geoserver.ows.util.ResponseUtils;
-import org.geotools.util.logging.Logging;
 import org.springframework.http.MediaType;
 
 /** Base OGC API document class with shared link generation facilities */
 public class AbstractDocument {
-    protected static final Logger LOGGER = Logging.getLogger(AbstractDocument.class);
 
     protected String id;
     protected String htmlTitle;

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractHTMLMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractHTMLMessageConverter.java
@@ -36,7 +36,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
  */
 public abstract class AbstractHTMLMessageConverter<T> extends AbstractHttpMessageConverter<T> {
 
-    protected final Class binding;
+    protected final Class<?> binding;
     protected final GeoServer geoServer;
     protected final FreemarkerTemplateSupport templateSupport;
     protected final Class<? extends ServiceInfo> serviceConfigurationClass;
@@ -50,7 +50,7 @@ public abstract class AbstractHTMLMessageConverter<T> extends AbstractHttpMessag
      * @param geoServer The
      */
     public AbstractHTMLMessageConverter(
-            Class binding,
+            Class<?> binding,
             Class<? extends ServiceInfo> serviceConfigurationClass,
             FreemarkerTemplateSupport templateSupport,
             GeoServer geoServer) {

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesDocument.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesDocument.java
@@ -20,7 +20,7 @@ import org.springframework.http.MediaType;
 public class QueryablesDocument extends AbstractDocument {
 
     private final String collectionId;
-    List<Queryable> queryables = new ArrayList();
+    List<Queryable> queryables = new ArrayList<>();
 
     public QueryablesDocument(FeatureTypeInfo fti) throws IOException {
         this.collectionId = fti.prefixedName();

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/SimpleHTTPMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/SimpleHTTPMessageConverter.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.HashMap;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.ServiceInfo;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 
@@ -35,7 +36,7 @@ public class SimpleHTTPMessageConverter<T> extends AbstractHTMLMessageConverter<
      */
     public SimpleHTTPMessageConverter(
             Class binding,
-            Class serviceConfigurationClass,
+            Class<? extends ServiceInfo> serviceConfigurationClass,
             Class serviceClass,
             FreemarkerTemplateSupport support,
             GeoServer geoServer,

--- a/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/OGCApiTestSupport.java
+++ b/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/OGCApiTestSupport.java
@@ -98,9 +98,9 @@ public class OGCApiTestSupport extends GeoServerSystemTestSupport {
         return json;
     }
 
-    /** Retuns a single element out of an array, checking that there is just one */
+    /** Returns a single element out of an array, checking that there is just one */
     protected <T> T readSingle(DocumentContext json, String path) {
-        List items = json.read(path);
+        List<Object> items = json.read(path);
         assertEquals(
                 "Found "
                         + items.size()

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/CollectionDocument.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/CollectionDocument.java
@@ -33,7 +33,7 @@ import org.springframework.http.MediaType;
 /** Description of a single collection, that will be serialized to JSON/XML/HTML */
 @JsonPropertyOrder({"id", "title", "description", "extent", "links"})
 @JacksonXmlRootElement(localName = "Collection", namespace = "http://www.opengis.net/wfs/3.0")
-public class CollectionDocument extends AbstractCollectionDocument {
+public class CollectionDocument extends AbstractCollectionDocument<FeatureTypeInfo> {
     static final Logger LOGGER = Logging.getLogger(CollectionDocument.class);
 
     FeatureTypeInfo featureType;

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 
 import com.jayway.jsonpath.DocumentContext;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import net.minidev.json.JSONArray;
@@ -489,8 +490,10 @@ public class FeatureTest extends FeaturesTestSupport {
         genericEntity.setName("EntitéGénérique");
         getCatalog().save(genericEntity);
         try {
-            String encodedLocalName = URLEncoder.encode(genericEntity.getName(), "UTF-8");
-            String typeName = URLEncoder.encode(genericEntity.prefixedName());
+            String encodedLocalName =
+                    URLEncoder.encode(genericEntity.getName(), StandardCharsets.UTF_8.name());
+            String typeName =
+                    URLEncoder.encode(genericEntity.prefixedName(), StandardCharsets.UTF_8.name());
             String encodedFeatureId = encodedLocalName + ".f004";
             DocumentContext json =
                     getAsJSONPath(

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImageListener.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImageListener.java
@@ -8,7 +8,7 @@ import org.geoserver.catalog.CoverageInfo;
 import org.opengis.feature.simple.SimpleFeature;
 
 /**
- * Allows implementor to listen to the addition/removal of granules in a {@link
+ * Allows implementer to listen to the addition/removal of granules in a {@link
  * org.geotools.coverage.grid.io.StructuredGridCoverage2DReader}.
  *
  * <p>This is a temporary setup, if the checkpoint service survives experimentation it should be
@@ -17,7 +17,7 @@ import org.opengis.feature.simple.SimpleFeature;
 public interface ImageListener {
 
     /**
-     * An image has been added to the to <code>ci</code>
+     * An image has been added to the <code>ci</code>.
      *
      * @param ci The coverage backed by a StructuredGridCoverage2DReader
      * @param feature The feature representing the image in the {@link
@@ -26,7 +26,7 @@ public interface ImageListener {
     void imageAdded(CoverageInfo ci, SimpleFeature feature);
 
     /**
-     * An image has been removed from the to <code>ci</code>
+     * An image has been removed from the <code>ci</code>.
      *
      * @param ci The coverage backed by a StructuredGridCoverage2DReader
      * @param feature The feature representing the image in the {@link

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImageListenerSupport.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImageListenerSupport.java
@@ -18,7 +18,7 @@ import org.opengis.feature.simple.SimpleFeature;
 /** Propagates image listener events to all listeners */
 class ImageListenerSupport {
 
-    private List<ImageListener> imageListeners;
+    private final List<ImageListener> imageListeners;
 
     public ImageListenerSupport(List<ImageListener> imageListeners) {
         this.imageListeners = imageListeners;

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImageResponseMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImageResponseMessageConverter.java
@@ -29,7 +29,6 @@ import org.springframework.stereotype.Component;
 public class ImageResponseMessageConverter extends MessageConverterResponseAdapter<ImagesResponse> {
 
     private static final Version V2 = new Version("2.0");
-    List<Response> responses;
 
     public ImageResponseMessageConverter() {
         super(ImagesResponse.class, FeatureCollectionResponse.class);

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesAPIBuilder.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Streams;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -21,7 +22,7 @@ import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
 import org.geotools.util.logging.Logging;
 import org.springframework.http.HttpStatus;
 
-/** Builds the OpenAPI definition for the iles service */
+/** Builds the OpenAPI definition for the Images service */
 public class ImagesAPIBuilder extends OpenAPIBuilder<ImagesServiceInfo> {
 
     static final Logger LOGGER = Logging.getLogger(ImagesAPIBuilder.class);
@@ -57,13 +58,13 @@ public class ImagesAPIBuilder extends OpenAPIBuilder<ImagesServiceInfo> {
                 geoServer.getGlobal().getResourceErrorHandling()
                         == ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS;
         List<String> validCollectionIds =
-                Streams.stream(geoServer.getCatalog().getCoverages())
+                Streams.stream(geoServer.getCatalog().getCoverages().iterator())
                         .filter(
                                 c -> {
                                     try {
                                         return c.getGridCoverageReader(null, null)
                                                 instanceof StructuredGridCoverage2DReader;
-                                    } catch (Exception e) {
+                                    } catch (IOException e) {
                                         if (skipInvalid) {
                                             LOGGER.log(Level.WARNING, "Skipping coverage  " + c);
                                             return false;

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesCollectionDocument.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesCollectionDocument.java
@@ -26,16 +26,16 @@ import org.springframework.http.MediaType;
 
 /** Description of a single collection, that will be serialized to JSON/XML/HTML */
 @JsonPropertyOrder({"id", "title", "description", "extent", "links"})
-public class ImagesCollectionDocument extends AbstractCollectionDocument {
+public class ImagesCollectionDocument extends AbstractCollectionDocument<CoverageInfo> {
     static final Logger LOGGER = Logging.getLogger(ImagesCollectionDocument.class);
     StructuredGridCoverage2DReader reader;
 
     /**
      * Builds a description of an image collection
      *
-     * @param reader The {@link StructuredGridCoverage2DReader}
+     * @param coverage The {@link CoverageInfo} that backs the images collection
      * @param summary If true, the info provided is minimal and assumed to be part of a {@link
-     *     IImageCollectionsDocument}, otherwise it's full and assumed to be the main response
+     *     ImagesCollectionsDocument}, otherwise it's full and assumed to be the main response
      */
     public ImagesCollectionDocument(CoverageInfo coverage, boolean summary)
             throws FactoryException, TransformException, IOException {

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
@@ -116,8 +116,8 @@ public class ImagesService implements ApplicationContextAware {
     // this could be done in an argument resolver returning a Filter, for example, however
     // each protocol would need a different thing, so kept the KVP parser as a way to have
     // private logic here
-    private ImagesBBoxKvpParser bboxParser = new ImagesBBoxKvpParser();
-    private TimeParser timeParser = new TimeParser();
+    private final ImagesBBoxKvpParser bboxParser = new ImagesBBoxKvpParser();
+    private final TimeParser timeParser = new TimeParser();
     private ImageListenerSupport imageListeners;
 
     public ImagesService(GeoServer geoServer, AssetHasher assetHasher) {

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/ImagesTestSupport.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/ImagesTestSupport.java
@@ -54,7 +54,7 @@ public class ImagesTestSupport extends OGCApiTestSupport {
      * StructuredGridCoverage2DReader}
      */
     protected Stream<CoverageInfo> getStructuredCoverages() {
-        return Streams.stream(getCatalog().getCoverages())
+        return Streams.stream(getCatalog().getCoverages().iterator())
                 .filter(
                         c -> {
                             try {

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
@@ -351,7 +351,7 @@ public class StylesService {
             // write out the style body
             catalog.getResourcePool().writeStyle(styleInfo, new ByteArrayInputStream(rawData));
 
-            MultiValueMap headers = new HttpHeaders();
+            MultiValueMap<String, String> headers = new HttpHeaders();
             String href =
                     ResponseUtils.buildURL(
                             APIRequestInfo.get().getBaseURL(),

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TiledCollectionsDocument.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TiledCollectionsDocument.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.gwc.GWC;
@@ -15,7 +16,10 @@ import org.geoserver.ogcapi.APIException;
 import org.geoserver.ogcapi.AbstractDocument;
 import org.geoserver.ogcapi.Link;
 import org.geoserver.wms.WMS;
+import org.geotools.util.logging.Logging;
 import org.geowebcache.layer.TileLayer;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.TransformException;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -24,6 +28,7 @@ import org.springframework.http.HttpStatus;
  */
 @JsonPropertyOrder({"links", "collections"})
 public class TiledCollectionsDocument extends AbstractDocument {
+    static final Logger LOGGER = Logging.getLogger(TiledCollectionsDocument.class);
 
     private final GWC gwc;
     private final GeoServer gs;
@@ -65,7 +70,7 @@ public class TiledCollectionsDocument extends AbstractDocument {
 
                         next = collection;
                         return true;
-                    } catch (Exception e) {
+                    } catch (FactoryException | TransformException e) {
                         if (skipInvalid) {
                             LOGGER.log(Level.WARNING, "Skipping tile layer " + tileLayers);
                         } else {

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesAPIBuilder.java
@@ -15,7 +15,7 @@ import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.ogcapi.OpenAPIBuilder;
 
-/** Builds the OpenAPI definition for the iles service */
+/** Builds the OpenAPI definition for the tiles service */
 public class TilesAPIBuilder extends OpenAPIBuilder<TilesServiceInfo> {
 
     private final GWC gwc;

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
@@ -482,7 +482,7 @@ public class TilesService {
         }
     }
 
-    /** Checks the specified griset is supported by the tile layer, and returns it */
+    /** Checks the specified gridset is supported by the tile layer, and returns it */
     public static GridSubset getGridSubset(TileLayer tileLayer, String tileMatrixSetId) {
         GridSubset gridSubset = tileLayer.getGridSubset(tileMatrixSetId);
         if (gridSubset == null) {

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/VectorLayerMetadata.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/VectorLayerMetadata.java
@@ -1,18 +1,6 @@
-/*
- *    GeoTools - The Open Source Java GIS Toolkit
- *    http://geotools.org
- *
- *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
- *
- *    This library is free software; you can redistribute it and/or
- *    modify it under the terms of the GNU Lesser General Public
- *    License as published by the Free Software Foundation;
- *    version 2.1 of the License.
- *
- *    This library is distributed in the hope that it will be useful,
- *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *    Lesser General Public License for more details.
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
  */
 package org.geoserver.ogcapi.tiles;
 
@@ -22,7 +10,7 @@ import java.util.Map;
 
 /** Maps to the JSON structure describing a layer of vector tiles */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-class VectorLayerMetadata {
+public class VectorLayerMetadata {
 
     /** Only reports the general type, not the specific one */
     enum GeometryType {

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/VolatileGeoServerTileLayer.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/VolatileGeoServerTileLayer.java
@@ -39,7 +39,6 @@ class VolatileGeoServerTileLayer extends GeoServerTileLayer {
     @Override
     protected void saveTiles(MetaTile metaTile, ConveyorTile tileProto, long requestTime)
             throws GeoWebCacheException {
-        final long[] gridLoc = tileProto.getTileIndex();
         final GridSubset gridSubset = getGridSubset(tileProto.getGridSetId());
         final long[] gridPos = metaTile.getTilesGridPositions()[0];
         if (!gridSubset.covers(gridPos)) {

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/CollectionTest.java
@@ -32,7 +32,7 @@ public class CollectionTest extends TilesTestSupport {
 
     @Test
     public void testOnlyMapLinks() throws Exception {
-        // this one only has rendered formats assocaited
+        // this one only has rendered formats associated
         String lakesId = getLayerId(MockData.LAKES);
         DocumentContext json = getAsJSONPath("ogc/tiles/collections/" + lakesId, 200);
 
@@ -43,7 +43,7 @@ public class CollectionTest extends TilesTestSupport {
 
     @Test
     public void testOnlyDataLinks() throws Exception {
-        // this one only has rendered formats assocaited
+        // this one only has rendered formats associated
         String forestsId = getLayerId(MockData.FORESTS);
 
         DocumentContext json = getAsJSONPath("ogc/tiles/collections/" + forestsId, 200);
@@ -82,13 +82,18 @@ public class CollectionTest extends TilesTestSupport {
         assertEquals("generic", json.read("$.styles[1].id"));
         assertEquals("Generic", json.read("$.styles[1].title"));
 
-        // queryable links
+        // queryables
         String queryablesLink =
                 readSingle(
                         json, "$.links[?(@.rel=='queryables' && @.type=='application/json')].href");
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/tiles/collections/cite:RoadSegments/queryables?f=application%2Fjson",
                 queryablesLink);
+        String queryablesTitle =
+                readSingle(
+                        json,
+                        "$.links[?(@.rel=='queryables' && @.type=='application/json')].title");
+        assertEquals("Collection queryables as application/json", queryablesTitle);
     }
 
     @Test


### PR DESCRIPTION
Minor code cleanups:
 - Fixes title issue in queryables for Tiles (also added unit test coverage for this)
 - Updates some deprecated uses of `Stream.stream(Collection ...)`, and one use of `URLEncoder.encode(String)` (updated existing case too)
 - Switches a few raw types to parameterised version.
 - Fixes some documentation typos.
 - Removes a couple of loggers on abstract base classes (which didn't need them directly) and adds one lower level logger
 - Adds some final markers for methods called from constructors, and for a few private member variables.
 - Renames a couple of variables that shadowed member variables.
 - Removes an unneeded unboxing.
 - Updates the license header on tiles VectorLayerMetadata to be GS GPL (was GeoTools LGPL)

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [N/A] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [N/A] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
