### PR TITLE
[GEOS-9880] Monitor plugin throws NPE when maxSize is set to unbound

### DIFF
--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorServletRequest.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorServletRequest.java
@@ -76,7 +76,7 @@ public class MonitorServletRequest extends HttpServletRequestWrapper {
         public MonitorInputStream(ServletInputStream delegate, long maxSize) {
             this.delegate = delegate;
             this.maxSize = maxSize;
-            if (maxSize > 0) {
+            if (maxSize > 0 || maxSize == BODY_SIZE_UNBOUNDED) {
                 buffer = new ByteArrayOutputStream();
             }
         }
@@ -156,7 +156,8 @@ public class MonitorServletRequest extends HttpServletRequestWrapper {
         }
 
         boolean bufferIsFull() {
-            return maxSize == 0 || (buffer.size() >= maxSize && maxSize > 0);
+            return maxSize == 0
+                    || (buffer.size() >= maxSize && maxSize > 0 && maxSize != BODY_SIZE_UNBOUNDED);
         }
 
         public byte[] getData() {

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/MonitorServletRequestTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/MonitorServletRequestTest.java
@@ -137,4 +137,24 @@ public class MonitorServletRequestTest {
         ;
         assertArrayEquals(THE_REQUEST.getBytes(), request.getBodyContent());
     }
+
+    @Test
+    public void testNPEIsNotThrownWithBufferSizeUnbounded() throws Exception {
+        byte[] data = data();
+        DelegatingServletInputStream mock =
+                new DelegatingServletInputStream(new ByteArrayInputStream(data));
+
+        MonitorInputStream in = new MonitorInputStream(mock, -1);
+        byte[] read = read(in);
+
+        assertEquals(data.length, read.length);
+
+        byte[] buffer = in.getData();
+
+        for (int i = 0; i < buffer.length; i++) {
+            assertEquals(data[i], buffer[i]);
+        }
+
+        assertEquals(data.length - 1, in.getBytesRead());
+    }
 }


### PR DESCRIPTION
This pr fixes a bug in monitor plugin involving NPE when MaxBodiSize is set to unbounded

jira ticket https://osgeo-org.atlassian.net/browse/GEOS-9880

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
