### PR TITLE
[GEOS-9459] Layer preview in KML format broken in version 2.16

### DIFF
--- a/src/web/demo/src/main/java/org/geoserver/web/demo/KMLFormatLink.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/KMLFormatLink.java
@@ -14,7 +14,7 @@ public class KMLFormatLink extends CommonFormatLink {
         ExternalLink kmlLink =
                 new ExternalLink(
                         this.getComponentId(),
-                        layer.getWmsLink() + "/kml?layers=" + layer.getName(),
+                        layer.getKmlLink(),
                         (new StringResourceModel(this.getTitleKey(), null, null)).getString());
         kmlLink.setVisible(layer.hasServiceSupport("WMS"));
         return kmlLink;

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
@@ -228,8 +228,19 @@ public class PreviewLayer {
         params.put(
                 "styles",
                 request.getStyles().size() > 0 ? request.getStyles().get(0).getName() : "");
-
         return ResponseUtils.buildURL(getBaseURL(), getPath("wms", false), params, URLType.SERVICE);
+    }
+
+    /**
+     * Build the KML reflector request.
+     *
+     * @return the KML reflector link in refresh mode, suitable for Google Earth.
+     */
+    public String getKmlLink() {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("layers", getName());
+        return ResponseUtils.buildURL(
+                getBaseURL(), getPath("wms/kml", false), params, URLType.SERVICE);
     }
 
     /**

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
@@ -223,6 +223,10 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
                             (ExternalLink)
                                     c.get("itemProperties:3:component:commonFormat:1")
                                             .getDefaultModelObject();
+                    ExternalLink kmlLink =
+                            (ExternalLink)
+                                    c.get("itemProperties:3:component:commonFormat:2")
+                                            .getDefaultModelObject();
 
                     assertEquals(
                             "http://localhost/context/cite/wms?service=WMS&amp;version=1.1.0&amp;"
@@ -237,6 +241,9 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
                                     "http://localhost/context/cite/ows?service=WFS&amp;version=1"
                                             + ".0.0&amp;request=GetFeature&amp;"
                                             + "typeName=cite%3ALakes%20%2B%20a%20plus"));
+                    assertEquals(
+                            kmlLink.getDefaultModelObjectAsString(),
+                            "http://localhost/context/cite/wms/kml?layers=cite%3ALakes%20%2B%20a%20plus");
                 }
             }
             assertTrue("Could not find layer with expected name", exists);


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-9459

Fixes broken KML preview link.

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones. Current plan is not to backport.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ X PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
