### PR TITLE
[2.17.x backport][GEOS-9881] SldService throws IndexOutOfBoundException when percentages and continuous parameters are both set to true

### DIFF
--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/utils/classifier/RasterSymbolizerBuilder.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/utils/classifier/RasterSymbolizerBuilder.java
@@ -272,7 +272,9 @@ public class RasterSymbolizerBuilder {
                 Number b = breaks[i];
                 ColorMapEntry entry = SF.createColorMapEntry();
                 entry.setQuantity(FF.literal(b));
-                entry.setLabel(format.format(b) + getPercentagesLabelPortion(percentages, i));
+                String label = format.format(b);
+                if (i > 0) label += getPercentagesLabelPortion(percentages, i - 1);
+                entry.setLabel(label);
                 colorMap.addColorMapEntry(entry);
             }
         } else {

--- a/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/ClassifierTest.java
+++ b/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/ClassifierTest.java
@@ -2336,12 +2336,18 @@ public class ClassifierTest extends SLDServiceBaseTest {
         ColorMap cmQuantile = rsQuantile.getColorMap();
         ColorMapEntry[] entriesQuantile = cmQuantile.getColorMapEntries();
         assertEquals(entriesQuantile.length, 6);
+        double percentagesSum = 0.0;
         for (ColorMapEntry e : entriesQuantile) {
             if (e.getLabel() != null) {
+                String label = e.getLabel();
+                int i = label.lastIndexOf("(");
+                int i2 = label.indexOf("%)");
+                percentagesSum += Double.valueOf(label.substring(i + 1, i2));
                 Matcher matcher = rgx.matcher(e.getLabel());
-                matcher.find();
+                assertTrue(matcher.find());
             }
         }
+        assertEquals(100.0, percentagesSum, 0.0);
     }
 
     @Test
@@ -2370,7 +2376,7 @@ public class ClassifierTest extends SLDServiceBaseTest {
                 int i2 = label.indexOf("%)");
                 percentagesSum += Double.valueOf(label.substring(i + 1, i2));
                 Matcher matcher = rgx.matcher(e.getLabel());
-                matcher.find();
+                assertTrue(matcher.find());
             }
         }
         assertTrue(100.0 == percentagesSum);
@@ -2392,12 +2398,18 @@ public class ClassifierTest extends SLDServiceBaseTest {
         ColorMap cmJenks = rsJenks.getColorMap();
         ColorMapEntry[] entriesJenks = cmJenks.getColorMapEntries();
         assertEquals(entriesJenks.length, 6);
+        double percentagesSum = 0.0;
         for (ColorMapEntry e : entriesJenks) {
             if (e.getLabel() != null) {
+                String label = e.getLabel();
+                int i = label.lastIndexOf("(");
+                int i2 = label.indexOf("%)");
+                percentagesSum += Double.valueOf(label.substring(i + 1, i2));
                 Matcher matcher = rgx.matcher(e.getLabel());
-                matcher.find();
+                assertTrue(matcher.find());
             }
         }
+        assertEquals(100.0, percentagesSum, 0.0);
     }
 
     @Test
@@ -2416,12 +2428,18 @@ public class ClassifierTest extends SLDServiceBaseTest {
         ColorMap cmUnique = rsUnique.getColorMap();
         ColorMapEntry[] entriesUnique = cmUnique.getColorMapEntries();
         assertEquals(entriesUnique.length, 167);
+        double percentagesSum = 0.0;
         for (ColorMapEntry e : entriesUnique) {
             if (e.getLabel() != null) {
+                String label = e.getLabel();
+                int i = label.lastIndexOf("(");
+                int i2 = label.indexOf("%)");
+                percentagesSum += Double.valueOf(label.substring(i + 1, i2));
                 Matcher matcher = rgx.matcher(e.getLabel());
-                matcher.find();
+                assertTrue(matcher.find());
             }
         }
+        assertEquals(100.0, percentagesSum, 0.6d);
     }
 
     @Test
@@ -2471,12 +2489,18 @@ public class ClassifierTest extends SLDServiceBaseTest {
         ColorMap cmQuantile = rsQuantile.getColorMap();
         ColorMapEntry[] entriesQuantile = cmQuantile.getColorMapEntries();
         assertEquals(entriesQuantile.length, 6);
+        double percentagesSum = 0.0;
         for (ColorMapEntry e : entriesQuantile) {
             if (e.getLabel() != null) {
+                String label = e.getLabel();
+                int i = label.lastIndexOf("(");
+                int i2 = label.indexOf("%)");
+                percentagesSum += Double.valueOf(label.substring(i + 1, i2));
                 Matcher matcher = rgx.matcher(e.getLabel());
-                matcher.find();
+                assertTrue(matcher.find());
             }
         }
+        assertEquals(100.0, percentagesSum, 0.0);
     }
 
     @Test
@@ -2648,5 +2672,36 @@ public class ClassifierTest extends SLDServiceBaseTest {
             percentagesSum += Double.valueOf(label.substring(i + 1, i2));
         }
         assertEquals(100d, percentagesSum, 0d);
+    }
+
+    @Test
+    public void testPercentagesWithContinuousNotThrowsException() throws Exception {
+        String regex = "\\d+(\\.\\d)%";
+        Pattern rgx = Pattern.compile(regex);
+        final String restPathJenks =
+                RestBaseController.ROOT_PATH
+                        + "/sldservice/cite:dem/"
+                        + getServiceUrl()
+                        + ".xml?"
+                        + "method=jenks&intervals=6"
+                        + "&ramp=red&fullSLD=true&percentages=true&continuous=true";
+        Document domjenks = getAsDOM(restPathJenks, 200);
+        RasterSymbolizer rsJenks = getRasterSymbolizer(domjenks);
+        ColorMap cmJenks = rsJenks.getColorMap();
+        ColorMapEntry[] entriesJenks = cmJenks.getColorMapEntries();
+        assertEquals(entriesJenks.length, 6);
+        double percentagesSum = 0.0;
+        for (int i = 0; i < entriesJenks.length; i++) {
+            ColorMapEntry e = entriesJenks[i];
+            if (e.getLabel() != null && i > 0) {
+                String label = e.getLabel();
+                int i2 = label.lastIndexOf("(");
+                int i3 = label.indexOf("%)");
+                percentagesSum += Double.valueOf(label.substring(i2 + 1, i3));
+                Matcher matcher = rgx.matcher(e.getLabel());
+                assertTrue(matcher.find());
+            }
+        }
+        assertEquals(100.0, percentagesSum, 0.0);
     }
 }


### PR DESCRIPTION


<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
