### PR TITLE
[2.18.x backport][GEOS-9884] Update Spring to v5.1.20.RELEASE and Spring security to 51.13.RELEASE

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1949,8 +1949,8 @@
   <gt.version>24-SNAPSHOT</gt.version>
   <gwc.version>1.18-SNAPSHOT</gwc.version>
   <jts.version>1.17.1</jts.version>
-  <spring.version>5.1.16.RELEASE</spring.version>
-  <spring.security.version>5.1.11.RELEASE</spring.security.version>
+  <spring.version>5.1.20.RELEASE</spring.version>
+  <spring.security.version>5.1.13.RELEASE</spring.security.version>
   <servlet-api.version>3.0.1</servlet-api.version>
   <jetty.version>9.4.18.v20190429</jetty.version>
   <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>


### PR DESCRIPTION
Spring has resolved CVE-2020-5421

backports #4687 to 2.18.x

related https://github.com/GeoWebCache/geowebcache/pull/922


