### PR TITLE
use Charset definition in URL encoding

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/PostgresConfigBean.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/PostgresConfigBean.java
@@ -6,7 +6,6 @@ package org.geogig.geoserver.config;
 
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -164,24 +163,11 @@ public class PostgresConfigBean implements Serializable {
         MultiValueMap<String, String> queryParams = uri.getQueryParams();
         String username = queryParams.getFirst(USER);
         String password = queryParams.getFirst(PASSWORD);
-        try {
-            // username should be URLEncoded, decode it here
-            username = URLDecoder.decode(username, UTF8);
-        } catch (UnsupportedEncodingException uee) {
-            LOGGER.warn(
-                    String.format(
-                            "Error decoding PostgreSQL username value, attempting to use undecoded value: %s",
-                            username),
-                    uee);
-        }
-        try {
-            // password should be URLEncoded, decode it here
-            password = URLDecoder.decode(password, UTF8);
-        } catch (UnsupportedEncodingException uee) {
-            LOGGER.warn(
-                    "Error decoding PostgreSQL password value, attempting to use undecoded value",
-                    uee);
-        }
+        // username should be URLEncoded, decode it here
+        username = URLDecoder.decode(username, StandardCharsets.UTF_8);
+
+        // password should be URLEncoded, decode it here
+        password = URLDecoder.decode(password, StandardCharsets.UTF_8);
         PostgresConfigBean bean = new PostgresConfigBean();
         bean.setHost(host);
         bean.setPort(port);

--- a/src/community/geogig/src/test/java/org/geogig/geoserver/config/PostgresConfigBeanTest.java
+++ b/src/community/geogig/src/test/java/org/geogig/geoserver/config/PostgresConfigBeanTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
@@ -28,8 +27,7 @@ public class PostgresConfigBeanTest {
             String expectedRepoId,
             String expectedUser,
             String expectedPassword,
-            final URI uri)
-            throws UnsupportedEncodingException {
+            final URI uri) {
         // assert the URI is built correctly
         assertEquals("Unexpected HOST value", expectedHost, uri.getHost());
         if (expectedPort != null) {
@@ -76,10 +74,10 @@ public class PostgresConfigBeanTest {
         assertEquals("Malformed USER query parameter", 2, userParts.length);
         String[] passwordParts = passwordPair.split("=");
         assertEquals("Malformed PASSWORD query parameter", 2, passwordParts.length);
-        String decodedUser = URLDecoder.decode(userParts[1], UTF8);
+        String decodedUser = URLDecoder.decode(userParts[1], StandardCharsets.UTF_8);
         assertEquals(
                 "Unexpected URL decoded value for USER query parameter", expectedUser, decodedUser);
-        String decodedPassword = URLDecoder.decode(passwordParts[1], UTF8);
+        String decodedPassword = URLDecoder.decode(passwordParts[1], StandardCharsets.UTF_8);
         assertEquals(
                 "Unexpected URL decoded value for PASSWORD query parameter",
                 expectedPassword,
@@ -94,7 +92,7 @@ public class PostgresConfigBeanTest {
             String expectedRepoId,
             String expectedUser,
             String expectedPassword)
-            throws UnsupportedEncodingException, URISyntaxException {
+            throws URISyntaxException {
         // build the bean
         PostgresConfigBean bean = PostgresConfigBean.newInstance();
         bean.setHost(expectedHost);
@@ -116,7 +114,7 @@ public class PostgresConfigBeanTest {
             String expectedRepoId,
             String expectedUser,
             String expectedPassword)
-            throws UnsupportedEncodingException, URISyntaxException {
+            throws URISyntaxException {
         // build the bean and get the URI
         URI uri =
                 buildURIFromBean(
@@ -164,7 +162,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBuildUriForRepo() throws UnsupportedEncodingException, URISyntaxException {
+    public void testBuildUriForRepo() throws URISyntaxException {
         // set some typical values
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
@@ -185,8 +183,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBuildUriForRepo_specialCharacters_hash()
-            throws UnsupportedEncodingException, URISyntaxException {
+    public void testBuildUriForRepo_specialCharacters_hash() throws URISyntaxException {
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
         final String expectedDb = "testDb";
@@ -206,8 +203,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBuildUriForRepo_specialCharacters_ampersand()
-            throws UnsupportedEncodingException, URISyntaxException {
+    public void testBuildUriForRepo_specialCharacters_ampersand() throws URISyntaxException {
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
         final String expectedDb = "testDb";
@@ -227,8 +223,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBuildUriForRepo_specialCharacters_multi()
-            throws UnsupportedEncodingException, URISyntaxException {
+    public void testBuildUriForRepo_specialCharacters_multi() throws URISyntaxException {
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
         final String expectedDb = "testDb";
@@ -248,7 +243,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBeanFromURI() throws UnsupportedEncodingException, URISyntaxException {
+    public void testBeanFromURI() throws URISyntaxException {
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
         final String expectedDb = "testDb";
@@ -279,8 +274,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBeanFromURI_specialCharacters_hash()
-            throws UnsupportedEncodingException, URISyntaxException {
+    public void testBeanFromURI_specialCharacters_hash() throws URISyntaxException {
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
         final String expectedDb = "testDb";
@@ -311,8 +305,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBeanFromURI_specialCharacters_ampersand()
-            throws UnsupportedEncodingException, URISyntaxException {
+    public void testBeanFromURI_specialCharacters_ampersand() throws URISyntaxException {
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
         final String expectedDb = "testDb";
@@ -343,8 +336,7 @@ public class PostgresConfigBeanTest {
     }
 
     @Test
-    public void testBeanFromURI_specialCharacters_multi()
-            throws UnsupportedEncodingException, URISyntaxException {
+    public void testBeanFromURI_specialCharacters_multi() throws URISyntaxException {
         final String expectedHost = "testHost";
         final Integer expectedPort = Integer.valueOf(5432);
         final String expectedDb = "testDb";

--- a/src/community/importer-fgdb/src/test/java/org/geoserver/fgdb/OGRDataStoreFactoryTest.java
+++ b/src/community/importer-fgdb/src/test/java/org/geoserver/fgdb/OGRDataStoreFactoryTest.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -113,7 +112,7 @@ public class OGRDataStoreFactoryTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testCreateDataStoreURL() throws MalformedURLException, IOException {
+    public void testCreateDataStoreURL() throws MalformedURLException {
         if (skip) return;
 
         Map<String, Serializable> params = (Map) new KVP(OGRDataStoreFactory.OGR_NAME.key, gdbURL);
@@ -124,12 +123,12 @@ public class OGRDataStoreFactoryTest {
         assertEquals(1, names.size());
     }
 
-    private static File data(String path) throws IOException {
+    private static File data(String path) {
         URL url = OGRDataStoreFactory.class.getResource("test-data/" + path);
         if (url == null) {
             throw new FileNotFoundException("Could not find locations.zip");
         }
-        File file = new File(URLDecoder.decode(url.getPath(), "UTF-8"));
+        File file = new File(URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8));
         if (!file.exists()) {
             throw new FileNotFoundException("Can not locate test-data for \"" + path + '"');
         }
@@ -139,7 +138,7 @@ public class OGRDataStoreFactoryTest {
     //
     // Utility Methods
     //
-    private static void unpackFile(ZipInputStream in, File outdir, String name) throws IOException {
+    private static void unpackFile(ZipInputStream in, File outdir, String name) {
         File file = new File(outdir, name);
         FileOutputStream out = new FileOutputStream(file);
         try {
@@ -164,7 +163,7 @@ public class OGRDataStoreFactoryTest {
     }
 
     /** * Unpack archive to directory (maintaining directory structure). */
-    public static void unpack(File archive, File directory) throws IOException {
+    public static void unpack(File archive, File directory) {
         // see http://stackoverflow.com/questions/10633595/java-zip-how-to-unzip-folder
         ZipInputStream zip = new ZipInputStream(new FileInputStream(archive));
         try {

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
@@ -491,9 +491,9 @@ public class FeatureTest extends FeaturesTestSupport {
         getCatalog().save(genericEntity);
         try {
             String encodedLocalName =
-                    URLEncoder.encode(genericEntity.getName(), StandardCharsets.UTF_8.name());
+                    URLEncoder.encode(genericEntity.getName(), StandardCharsets.UTF_8);
             String typeName =
-                    URLEncoder.encode(genericEntity.prefixedName(), StandardCharsets.UTF_8.name());
+                    URLEncoder.encode(genericEntity.prefixedName(), StandardCharsets.UTF_8);
             String encodedFeatureId = encodedLocalName + ".f004";
             DocumentContext json =
                     getAsJSONPath(

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Rule.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Rule.java
@@ -5,6 +5,7 @@
 package org.geoserver.params.extractor;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -75,7 +76,10 @@ public final class Rule {
         }
         urlTransform.removeMatch(matcher.group(remove != null ? remove : 1));
         urlTransform.addParameter(
-                parameter, URLDecoder.decode(matcher.replaceAll(transform)), combine, repeat);
+                parameter,
+                URLDecoder.decode(matcher.replaceAll(transform), StandardCharsets.UTF_8),
+                combine,
+                repeat);
         return urlTransform;
     }
 

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/UrlTransform.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/UrlTransform.java
@@ -5,6 +5,7 @@
 package org.geoserver.params.extractor;
 
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class UrlTransform {
@@ -42,7 +43,7 @@ public class UrlTransform {
             queryStringBuilder
                     .append(parameter.getKey())
                     .append("=")
-                    .append(URLEncoder.encode(parameter.getValue()[0]))
+                    .append(URLEncoder.encode(parameter.getValue()[0], StandardCharsets.UTF_8))
                     .append("&");
         }
         if (queryStringBuilder.length() == 0) {

--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Utils.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/Utils.java
@@ -5,8 +5,8 @@
 package org.geoserver.params.extractor;
 
 import java.io.Closeable;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,8 +70,7 @@ public final class Utils {
         }
     }
 
-    public static Map<String, String[]> parseParameters(Optional<String> queryString)
-            throws UnsupportedEncodingException {
+    public static Map<String, String[]> parseParameters(Optional<String> queryString) {
         Map<String, String[]> parameters = new HashMap<>();
         if (!queryString.isPresent()) {
             return parameters;
@@ -82,8 +81,8 @@ public final class Utils {
             if (parameterParts.length < 2) {
                 continue;
             }
-            String name = URLDecoder.decode(parameterParts[0], "UTF-8");
-            String value = URLDecoder.decode(parameterParts[1], "UTF-8");
+            String name = URLDecoder.decode(parameterParts[0], StandardCharsets.UTF_8);
+            String value = URLDecoder.decode(parameterParts[1], StandardCharsets.UTF_8);
             String[] values = parameters.get(name);
             if (values == null) {
                 parameters.put(name, new String[] {value});

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/FileServiceImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/FileServiceImpl.java
@@ -7,10 +7,10 @@ package org.geoserver.taskmanager.external.impl;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -220,8 +220,10 @@ public class FileServiceImpl extends SecuredImpl implements FileService, Servlet
     private static URI toURI(Path path) {
         try {
             return new URI(
-                    "file:" + URLEncoder.encode(path.toString(), "UTF-8").replaceAll("%2F", "/"));
-        } catch (UnsupportedEncodingException | URISyntaxException e) {
+                    "file:"
+                            + URLEncoder.encode(path.toString(), StandardCharsets.UTF_8)
+                                    .replaceAll("%2F", "/"));
+        } catch (URISyntaxException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/ResourceFileServiceImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/ResourceFileServiceImpl.java
@@ -7,10 +7,10 @@ package org.geoserver.taskmanager.external.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
@@ -166,9 +166,9 @@ public class ResourceFileServiceImpl extends SecuredImpl implements FileService 
         try {
             return new URI(
                     "resource:"
-                            + URLEncoder.encode(rootFolder.get(path).path(), "UTF-8")
+                            + URLEncoder.encode(rootFolder.get(path).path(), StandardCharsets.UTF_8)
                                     .replaceAll("%2F", "/"));
-        } catch (UnsupportedEncodingException | URISyntaxException e) {
+        } catch (URISyntaxException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/src/community/taskmanager/s3/src/main/java/org/geoserver/taskmanager/external/impl/S3FileServiceImpl.java
+++ b/src/community/taskmanager/s3/src/main/java/org/geoserver/taskmanager/external/impl/S3FileServiceImpl.java
@@ -18,10 +18,10 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -311,9 +311,9 @@ public class S3FileServiceImpl implements FileService {
                             + "://"
                             + rootFolder
                             + "/"
-                            + URLEncoder.encode(filePath.toString(), "UTF-8")
+                            + URLEncoder.encode(filePath, StandardCharsets.UTF_8)
                                     .replaceAll("%2F", "/"));
-        } catch (URISyntaxException | UnsupportedEncodingException e) {
+        } catch (URISyntaxException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/src/community/wfs3/src/main/java/org/geoserver/wfs3/WFS3Filter.java
+++ b/src/community/wfs3/src/main/java/org/geoserver/wfs3/WFS3Filter.java
@@ -5,8 +5,8 @@
 package org.geoserver.wfs3;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -149,10 +149,12 @@ public class WFS3Filter implements GeoServerFilter {
                                 request = "getFeature";
                                 String layerName = matcher.group(1);
                                 if (layerName != null) {
-                                    layerName = urlDecode(layerName);
+                                    layerName =
+                                            URLDecoder.decode(layerName, StandardCharsets.UTF_8);
                                 }
                                 setLayerName(layerName);
-                                this.featureId = urlDecode(matcher.group(2));
+                                this.featureId =
+                                        URLDecoder.decode(matcher.group(2), StandardCharsets.UTF_8);
                             }
                             return matches;
                         });
@@ -165,7 +167,8 @@ public class WFS3Filter implements GeoServerFilter {
                                 request = "getFeature";
                                 String layerName = matcher.group(1);
                                 if (layerName != null) {
-                                    layerName = urlDecode(layerName);
+                                    layerName =
+                                            URLDecoder.decode(layerName, StandardCharsets.UTF_8);
                                 }
                                 setLayerName(layerName);
                             }
@@ -180,7 +183,8 @@ public class WFS3Filter implements GeoServerFilter {
                                 request = "tilingSchemes";
                                 String layerName = matcher.group(1);
                                 if (layerName != null) {
-                                    layerName = urlDecode(layerName);
+                                    layerName =
+                                            URLDecoder.decode(layerName, StandardCharsets.UTF_8);
                                 }
                                 setLayerName(layerName);
                             }
@@ -195,7 +199,8 @@ public class WFS3Filter implements GeoServerFilter {
                                 request = "collection";
                                 String layerName = matcher.group(1);
                                 if (layerName != null) {
-                                    layerName = urlDecode(layerName);
+                                    layerName =
+                                            URLDecoder.decode(layerName, StandardCharsets.UTF_8);
                                 }
                                 setLayerName(layerName);
                             }
@@ -222,13 +227,18 @@ public class WFS3Filter implements GeoServerFilter {
                                 request = "getTile";
                                 String layerName = matcher.group(1);
                                 if (layerName != null) {
-                                    layerName = urlDecode(layerName);
+                                    layerName =
+                                            URLDecoder.decode(layerName, StandardCharsets.UTF_8);
                                 }
                                 setLayerName(layerName);
-                                this.tilingScheme = urlDecode(matcher.group(2));
-                                this.level = urlDecode(matcher.group(3));
-                                this.row = urlDecode(matcher.group(4));
-                                this.col = urlDecode(matcher.group(5));
+                                this.tilingScheme =
+                                        URLDecoder.decode(matcher.group(2), StandardCharsets.UTF_8);
+                                this.level =
+                                        URLDecoder.decode(matcher.group(3), StandardCharsets.UTF_8);
+                                this.row =
+                                        URLDecoder.decode(matcher.group(4), StandardCharsets.UTF_8);
+                                this.col =
+                                        URLDecoder.decode(matcher.group(5), StandardCharsets.UTF_8);
                             }
                             return matches;
                         });
@@ -387,15 +397,5 @@ public class WFS3Filter implements GeoServerFilter {
                 return values[0];
             }
         }
-    }
-
-    /** URL decodes the given string */
-    private String urlDecode(String name) {
-        try {
-            name = URLDecoder.decode(name, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-        return name;
     }
 }

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/FeatureTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/FeatureTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertNull;
 
 import com.jayway.jsonpath.DocumentContext;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import net.minidev.json.JSONArray;
@@ -345,7 +346,8 @@ public class FeatureTest extends WFS3TestSupport {
         genericEntity.setName("EntitéGénérique");
         getCatalog().save(genericEntity);
         try {
-            String encodedLocalName = URLEncoder.encode(genericEntity.getName(), "UTF-8");
+            String encodedLocalName =
+                    URLEncoder.encode(genericEntity.getName(), StandardCharsets.UTF_8);
             String typeName = MockData.GENERICENTITY.getPrefix() + "__" + encodedLocalName;
             String encodedFeatureId = encodedLocalName + ".f004";
             DocumentContext json =

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetTileTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/GetTileTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.jayway.jsonpath.DocumentContext;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import no.ecc.vectortile.VectorTileDecoder;
 import no.ecc.vectortile.VectorTileDecoder.Feature;
@@ -69,7 +70,8 @@ public class GetTileTest extends WFS3TestSupport {
                         + roadSegments
                         + "/tiles/GlobalCRS84Geometric/12/2047/4095"
                         + "?f="
-                        + URLEncoder.encode(RFCGeoJSONFeaturesResponse.MIME, "UTF-8");
+                        + URLEncoder.encode(
+                                RFCGeoJSONFeaturesResponse.MIME, StandardCharsets.UTF_8);
         DocumentContext jsdoc = getAsJSONPath(path, 200);
         // features[0].geometry.type = "MultiLineString"
         assertEquals(jsdoc.read("features[0].geometry.type", String.class), "MultiLineString");
@@ -101,7 +103,8 @@ public class GetTileTest extends WFS3TestSupport {
                         + roadSegments
                         + "/tiles/GoogleMapsCompatible/16/32768/32767"
                         + "?f="
-                        + URLEncoder.encode(RFCGeoJSONFeaturesResponse.MIME, "UTF-8");
+                        + URLEncoder.encode(
+                                RFCGeoJSONFeaturesResponse.MIME, StandardCharsets.UTF_8);
         ;
         DocumentContext jsdoc = getAsJSONPath(path, 200);
         assertEquals(jsdoc.read("features[0].geometry.type", String.class), "MultiLineString");

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPErrorMessage.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPErrorMessage.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.wps.remote.plugin;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -38,12 +38,8 @@ public class XMPPErrorMessage implements XMPPMessage {
         Map<String, Object> metadata = new HashMap<String, Object>();
         metadata.put("serviceJID", packet.getFrom());
 
-        Exception cause = null;
-        try {
-            cause = new Exception(URLDecoder.decode(signalArgs.get("message"), "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            cause = e;
-        }
+        Exception cause =
+                new Exception(URLDecoder.decode(signalArgs.get("message"), StandardCharsets.UTF_8));
         final String pID = (signalArgs != null ? signalArgs.get("id") : null);
 
         // NOTIFY LISTENERS

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPLogMessage.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPLogMessage.java
@@ -5,6 +5,7 @@
 package org.geoserver.wps.remote.plugin;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -49,7 +50,10 @@ public class XMPPLogMessage implements XMPPMessage {
                         "Could not correctly parse the Log level; using the default one 'INFO'.");
             }
             String logMessage =
-                    "[" + pID + "]" + URLDecoder.decode(signalArgs.get("message"), "UTF-8");
+                    "["
+                            + pID
+                            + "]"
+                            + URLDecoder.decode(signalArgs.get("message"), StandardCharsets.UTF_8);
             LOGGER.log(logLevel, logMessage);
 
             // NOTIFY LISTENERS

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPOutputMessage.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPOutputMessage.java
@@ -5,8 +5,8 @@
 package org.geoserver.wps.remote.plugin;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -42,8 +42,9 @@ public abstract class XMPPOutputMessage implements XMPPMessage {
 
     /** */
     protected Object getOutPuts(XMPPClient xmppClient, Entry<String, String> result)
-            throws UnsupportedEncodingException, PickleException, IOException {
-        final String serviceResultString = URLDecoder.decode(result.getValue(), "UTF-8");
+            throws PickleException, IOException {
+        final String serviceResultString =
+                URLDecoder.decode(result.getValue(), StandardCharsets.UTF_8);
         final JSONObject serviceResultJSON =
                 (JSONObject) JSONSerializer.toJSON(serviceResultString);
 

--- a/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPRegisterMessage.java
+++ b/src/community/wps-remote/src/main/java/org/geoserver/wps/remote/plugin/XMPPRegisterMessage.java
@@ -5,6 +5,7 @@
 package org.geoserver.wps.remote.plugin;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -54,7 +55,8 @@ public class XMPPRegisterMessage implements XMPPMessage {
         final Name name = new NameImpl(serviceName[0], serviceName[1]);
 
         try {
-            String serviceDescriptorString = URLDecoder.decode(signalArgs.get("message"), "UTF-8");
+            String serviceDescriptorString =
+                    URLDecoder.decode(signalArgs.get("message"), StandardCharsets.UTF_8);
             JSONObject serviceDescriptorJSON =
                     (JSONObject) JSONSerializer.toJSON(serviceDescriptorString);
 

--- a/src/extension/feature-pregeneralized/src/main/java/org/geoserver/data/gen/DSFinderRepository.java
+++ b/src/extension/feature-pregeneralized/src/main/java/org/geoserver/data/gen/DSFinderRepository.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import org.apache.log4j.Logger;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
@@ -47,7 +48,7 @@ public class DSFinderRepository extends org.geotools.data.gen.DSFinderRepository
         } else {
             url = new URL(location);
         }
-        url = new URL(URLDecoder.decode(url.toExternalForm(), "UTF8"));
+        url = new URL(URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
         return url;
     }
 

--- a/src/extension/feature-pregeneralized/src/main/java/org/geoserver/data/gen/info/GeneralizationInfosProviderImpl.java
+++ b/src/extension/feature-pregeneralized/src/main/java/org/geoserver/data/gen/info/GeneralizationInfosProviderImpl.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Files;
@@ -44,7 +45,7 @@ public class GeneralizationInfosProviderImpl
             } else {
                 url = new URL(path);
             }
-            url = new URL(URLDecoder.decode(url.toExternalForm(), "UTF8"));
+            url = new URL(URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
             return url;
         }
         throw new IOException("Cannot read from " + source);

--- a/src/extension/importer/web/src/main/java/org/geoserver/importer/web/ImportDataPage.java
+++ b/src/extension/importer/web/src/main/java/org/geoserver/importer/web/ImportDataPage.java
@@ -6,9 +6,9 @@
 package org.geoserver.importer.web;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
@@ -406,11 +406,9 @@ public class ImportDataPage extends GeoServerSecuredPage {
 
                 NamespaceInfo ns = cat.getFactory().createNamespace();
                 ns.setPrefix(wsName);
-                try {
-                    ns.setURI("http://opengeo.org/#" + URLEncoder.encode(wsName, "ASCII"));
-                } catch (UnsupportedEncodingException e) {
-                    error(e);
-                }
+                ns.setURI(
+                        "http://opengeo.org/#"
+                                + URLEncoder.encode(wsName, StandardCharsets.US_ASCII));
 
                 cat.add(targetWorkspace);
                 cat.add(ns);

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
@@ -7,6 +7,7 @@ package org.geoserver.monitor;
 
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -97,7 +98,7 @@ public class MonitorFilter implements GeoServerFilter {
         data.setPath(req.getServletPath() + req.getPathInfo());
 
         if (req.getQueryString() != null) {
-            data.setQueryString(URLDecoder.decode(req.getQueryString(), "UTF-8"));
+            data.setQueryString(URLDecoder.decode(req.getQueryString(), StandardCharsets.UTF_8));
         }
 
         data.setHttpMethod(req.getMethod());

--- a/src/extension/security/cas/src/main/java/org/geoserver/security/cas/CasAuthenticationHelper.java
+++ b/src/extension/security/cas/src/main/java/org/geoserver/security/cas/CasAuthenticationHelper.java
@@ -15,6 +15,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +113,7 @@ public abstract class CasAuthenticationHelper {
                 if (buff.length() > 0) buff.append("&");
                 buff.append(entry.getKey())
                         .append("=")
-                        .append(URLEncoder.encode(entry.getValue(), "utf-8"));
+                        .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
             }
 
             out.writeBytes(buff.toString());

--- a/src/extension/security/cas/src/main/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilter.java
+++ b/src/extension/security/cas/src/main/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilter.java
@@ -10,6 +10,7 @@ import static org.geoserver.security.cas.CasAuthenticationFilterConfig.CasSpecif
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -107,7 +108,8 @@ public class GeoServerCasAuthenticationFilter extends GeoServerPreAuthenticatedU
                     "?"
                             + GeoServerCasConstants.LOGOUT_URL_PARAM
                             + "="
-                            + URLEncoder.encode(authConfig.getUrlInCasLogoutPage(), "utf-8");
+                            + URLEncoder.encode(
+                                    authConfig.getUrlInCasLogoutPage(), StandardCharsets.UTF_8);
 
         singleSignOut = authConfig.isSingleSignOut();
         aep = new GeoServerCasAuthenticationEntryPoint(authConfig);

--- a/src/extension/security/cas/src/test/java/org/geoserver/security/cas/CasAuthenticationTest.java
+++ b/src/extension/security/cas/src/test/java/org/geoserver/security/cas/CasAuthenticationTest.java
@@ -23,6 +23,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
@@ -174,7 +175,7 @@ public class CasAuthenticationTest extends AbstractAuthenticationProviderTest {
             request.setMethod("POST");
             MockHttpServletResponse response = new MockHttpServletResponse();
             MockFilterChain chain = new MockFilterChain();
-            String paramValue = URLDecoder.decode(buff.toString(), "utf-8");
+            String paramValue = URLDecoder.decode(buff.toString(), StandardCharsets.UTF_8);
             request.addParameter(
                     "logoutRequest", paramValue.substring(paramValue.indexOf("=") + 1));
             try {

--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/ProcessStatusPageTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/ProcessStatusPageTest.java
@@ -9,6 +9,7 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public class ProcessStatusPageTest extends WPSPagesTestSupport {
         // submit a monkey process
         String request =
                 "wps?service=WPS&version=1.0.0&request=Execute&Identifier=gs:Monkey&storeExecuteResponse=true&DataInputs="
-                        + URLEncoder.encode("id=x2", "ASCII");
+                        + URLEncoder.encode("id=x2", StandardCharsets.US_ASCII);
         Document dom = getAsDOM(request);
         // print(dom);
         assertXpathExists("//wps:ProcessAccepted", dom);

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -2126,7 +2127,7 @@ public class ExecuteTest extends WPSTestSupport {
     }
 
     String urlEncode(String string) throws Exception {
-        return URLEncoder.encode(string, "ASCII");
+        return URLEncoder.encode(string, StandardCharsets.US_ASCII);
     }
 
     private void checkShapefileIntegrity(String[] typeNames, final InputStream in)

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/InputLimitsTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/InputLimitsTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
@@ -741,7 +742,7 @@ public class InputLimitsTest extends WPSTestSupport {
     }
 
     String urlEncode(String string) throws Exception {
-        return URLEncoder.encode(string, "ASCII");
+        return URLEncoder.encode(string, StandardCharsets.US_ASCII);
     }
 
     private String submitAsynchronousRequest(String request) throws Exception {

--- a/src/kml/src/main/java/org/geoserver/kml/builder/SimpleNetworkLinkBuilder.java
+++ b/src/kml/src/main/java/org/geoserver/kml/builder/SimpleNetworkLinkBuilder.java
@@ -10,8 +10,8 @@ import de.micromata.opengis.kml.v_2_2_0.LookAt;
 import de.micromata.opengis.kml.v_2_2_0.NetworkLink;
 import de.micromata.opengis.kml.v_2_2_0.RefreshMode;
 import de.micromata.opengis.kml.v_2_2_0.ViewRefreshMode;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -99,13 +99,9 @@ public class SimpleNetworkLinkBuilder extends AbstractNetworkLinkBuilder {
             String href =
                     WMSRequests.getGetMapUrl(
                             requestCopy, layers.get(i).getName(), i, style, null, null);
-            try {
-                // WMSRequests.getGetMapUrl returns a URL encoded query string, but GoogleEarth
-                // 6 doesn't like URL encoded parameters. See GEOS-4483
-                href = URLDecoder.decode(href, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            // WMSRequests.getGetMapUrl returns a URL encoded query string, but GoogleEarth
+            // 6 doesn't like URL encoded parameters. See GEOS-4483
+            href = URLDecoder.decode(href, StandardCharsets.UTF_8);
 
             Link url = nl.createAndSetUrl();
             url.setHref(href);

--- a/src/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
@@ -22,9 +22,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -465,7 +465,7 @@ public class KMLReflectorTest extends WMSTestSupport {
     @Test
     public void testRasterTransformerSLD() throws Exception {
         URL url = getClass().getResource("allsymbolizers.sld");
-        String urlExternal = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String urlExternal = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         final String requestUrl =
                 "wms/reflect?layers="
                         + getLayerId(MockData.BASIC_POLYGONS)
@@ -481,7 +481,7 @@ public class KMLReflectorTest extends WMSTestSupport {
         String href =
                 XMLUnit.newXpathEngine()
                         .evaluate("//kml:Folder/kml:GroundOverlay/kml:Icon/kml:href", dom);
-        href = URLDecoder.decode(href, "UTF-8");
+        href = URLDecoder.decode(href, StandardCharsets.UTF_8);
         assertTrue(href.startsWith("http://localhost:8080/geoserver/wms"));
         assertTrue(href.contains("request=GetMap"));
         assertTrue(href.contains("format=image/png"));
@@ -1118,11 +1118,7 @@ public class KMLReflectorTest extends WMSTestSupport {
             String key = kvp[0].toUpperCase();
             String value = kvp.length > 1 ? kvp[1] : null;
             if (value != null) {
-                try {
-                    value = URLDecoder.decode(value, "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
+                value = URLDecoder.decode(value, StandardCharsets.UTF_8);
             }
             kvpMap.put(key, value);
         }

--- a/src/main/src/main/java/org/geoserver/filters/BufferedRequestWrapper.java
+++ b/src/main/src/main/java/org/geoserver/filters/BufferedRequestWrapper.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -158,20 +159,15 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
 
     protected void parsePair(String pair) {
         String[] split = pair.split("=", 2);
-        try {
-            String key = URLDecoder.decode(split[0], "UTF-8");
-            String value = (split.length > 1 ? URLDecoder.decode(split[1], "UTF-8") : "");
+        String key = URLDecoder.decode(split[0], StandardCharsets.UTF_8);
+        String value =
+                (split.length > 1 ? URLDecoder.decode(split[1], StandardCharsets.UTF_8) : "");
 
-            if (!myParameterMap.containsKey(key)) {
-                myParameterMap.put(key, new ArrayList<>());
-            }
-
-            myParameterMap.get(key).add(value);
-
-        } catch (UnsupportedEncodingException e) {
-            logger.severe("Failed to decode form values in LoggingFilter");
-            // we have the encoding hard-coded for now so no exceptions should be thrown...
+        if (!myParameterMap.containsKey(key)) {
+            myParameterMap.put(key, new ArrayList<>());
         }
+
+        myParameterMap.get(key).add(value);
     }
 
     private static class IteratorAsEnumeration<T> implements Enumeration<T> {

--- a/src/main/src/main/java/org/geoserver/ows/StylePublisher.java
+++ b/src/main/src/main/java/org/geoserver/ows/StylePublisher.java
@@ -8,6 +8,7 @@ package org.geoserver.ows;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletRequest;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -42,7 +43,7 @@ public class StylePublisher extends AbstractURLPublisher {
     protected URL getUrl(HttpServletRequest request) throws IOException {
         String ctxPath = request.getContextPath();
         String reqPath = request.getRequestURI();
-        reqPath = URLDecoder.decode(reqPath, "UTF-8");
+        reqPath = URLDecoder.decode(reqPath, StandardCharsets.UTF_8);
         reqPath = reqPath.substring(ctxPath.length());
 
         if ((reqPath.length() > 1) && reqPath.startsWith("/")) {

--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerCredentialsFromRequestHeaderFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerCredentialsFromRequestHeaderFilter.java
@@ -6,6 +6,8 @@ package org.geoserver.security.filter;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -120,8 +122,7 @@ public class GeoServerCredentialsFromRequestHeaderFilter extends GeoServerSecuri
      * Try to authenticate. If credentials are found in the configured header(s), then
      * authentication is delegated to the AuthenticationProvider chain.
      */
-    protected void doAuthenticate(HttpServletRequest request, HttpServletResponse response)
-            throws IOException {
+    protected void doAuthenticate(HttpServletRequest request, HttpServletResponse response) {
 
         String usHeader = request.getHeader(userNameHeaderName);
         String pwHeader = request.getHeader(passwordHeaderName);
@@ -136,8 +137,8 @@ public class GeoServerCredentialsFromRequestHeaderFilter extends GeoServerSecuri
             return;
         }
         if (decodeURI) {
-            us = java.net.URLDecoder.decode(us, "UTF-8");
-            pw = java.net.URLDecoder.decode(pw, "UTF-8");
+            us = URLDecoder.decode(us, StandardCharsets.UTF_8);
+            pw = URLDecoder.decode(pw, StandardCharsets.UTF_8);
         }
 
         UsernamePasswordAuthenticationToken result =
@@ -193,11 +194,7 @@ public class GeoServerCredentialsFromRequestHeaderFilter extends GeoServerSecuri
             return null;
         }
         if (decodeURI) {
-            try {
-                username = java.net.URLDecoder.decode(username, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                LOGGER.log(Level.WARNING, "unsupported decode user name");
-            }
+            username = URLDecoder.decode(username, StandardCharsets.UTF_8);
         }
         if (username == null || password == null) {
             return null;

--- a/src/main/src/test/java/org/geoserver/ows/StylePublisherTest.java
+++ b/src/main/src/test/java/org/geoserver/ows/StylePublisherTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -84,7 +85,7 @@ public class StylePublisherTest extends GeoServerSystemTestSupport {
         for (String s : path) {
             b.append('/').append(s);
         }
-        String uri = URLEncoder.encode(b.toString(), "UTF-8");
+        String uri = URLEncoder.encode(b.toString(), StandardCharsets.UTF_8);
         request.setRequestURI(uri);
         if (modifiedSince != null) {
             request.addHeader("If-Modified-Since", modifiedSince);

--- a/src/ows/src/main/java/org/geoserver/ows/FilePublisher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/FilePublisher.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import org.geoserver.platform.GeoServerResourceLoader;
@@ -64,7 +65,7 @@ public class FilePublisher extends AbstractURLPublisher {
     protected URL getUrl(HttpServletRequest request) throws IOException {
         String ctxPath = request.getContextPath();
         String reqPath = request.getRequestURI();
-        reqPath = URLDecoder.decode(reqPath, "UTF-8");
+        reqPath = URLDecoder.decode(reqPath, StandardCharsets.UTF_8);
         reqPath = reqPath.substring(ctxPath.length());
 
         if ((reqPath.length() > 1) && reqPath.startsWith("/")) {

--- a/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/KvpUtils.java
@@ -5,8 +5,8 @@
  */
 package org.geoserver.ows.util;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -279,11 +279,7 @@ public class KvpUtils {
         String clean = null;
 
         if (raw != null) {
-            try {
-                clean = java.net.URLDecoder.decode(raw, "UTF-8");
-            } catch (java.io.UnsupportedEncodingException e) {
-                LOGGER.finer("Bad encoding for decoder " + e);
-            }
+            clean = URLDecoder.decode(raw, StandardCharsets.UTF_8);
         } else {
             return "";
         }
@@ -293,7 +289,7 @@ public class KvpUtils {
         return clean;
     }
 
-    /** @param kvp unparsed/unormalized kvp set */
+    /** @param kvp unparsed/unnormalized kvp set */
     public static KvpMap<String, Object> normalize(Map<String, ?> kvp) {
         if (kvp == null) {
             return null;
@@ -627,14 +623,10 @@ public class KvpUtils {
             // check for any special characters
             if (keyValuePair.length > 1) {
                 // replace any equals or & characters
-                try {
-                    // if this one does not work first check if the url encoded content is really
-                    // properly encoded. I had good success with this:
-                    // http://meyerweb.com/eric/tools/dencoder/
-                    keyValuePair[1] = URLDecoder.decode(keyValuePair[1], "ISO-8859-1");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException("Totally unexpected... is your JVM busted?", e);
-                }
+                // if this one does not work first check if the url encoded content is really
+                // properly encoded. I had good success with this:
+                // http://meyerweb.com/eric/tools/dencoder/
+                keyValuePair[1] = URLDecoder.decode(keyValuePair[1], StandardCharsets.ISO_8859_1);
             }
 
             String key = keyValuePair[0];

--- a/src/ows/src/main/java/org/geoserver/ows/util/ResponseUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/ResponseUtils.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -473,12 +474,15 @@ public class ResponseUtils {
         return resultStr.toString();
     }
 
-    /** URL decods the value using ISO-8859-1 as the reference charset */
+    /**
+     * URL decodes the value using UTF-8 as the reference charset.
+     *
+     * @param value the string value to decode.
+     * @return decoded version of the string.
+     * @deprecated Use URLDecoder.decode(value, StandardCharsets.UTF_8) instead.
+     */
+    @Deprecated
     public static String urlDecode(String value) {
-        try {
-            return URLDecoder.decode(value, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("This is unexpected", e);
-        }
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
 }

--- a/src/ows/src/test/java/org/geoserver/ows/FilePublisherTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/FilePublisherTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -70,7 +71,7 @@ public class FilePublisherTest {
         for (String s : path) {
             b.append('/').append(s);
         }
-        String uri = URLEncoder.encode(b.toString(), "UTF-8");
+        String uri = URLEncoder.encode(b.toString(), StandardCharsets.UTF_8);
         request.setRequestURI(uri);
         if (modifiedSince != null) {
             request.addHeader("If-Modified-Since", modifiedSince);

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Resources.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Resources.java
@@ -12,12 +12,12 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -596,10 +596,7 @@ public class Resources {
             url = url.substring(5); // remove 'file:' prefix
 
             // revert encoded special characters and spaces
-            try {
-                url = URLDecoder.decode(url, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-            }
+            url = URLDecoder.decode(url, StandardCharsets.UTF_8);
 
             File f = new File(url);
 

--- a/src/rest/src/main/java/org/geoserver/rest/RestConfiguration.java
+++ b/src/rest/src/main/java/org/geoserver/rest/RestConfiguration.java
@@ -4,8 +4,8 @@
  */
 package org.geoserver.rest;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
@@ -198,11 +198,7 @@ public class RestConfiguration extends WebMvcConfigurationSupport {
         @Override
         public String decodeRequestString(HttpServletRequest request, String source) {
             // compatibility with old Restlet based config, it also decodes "+" into space
-            try {
-                return URLDecoder.decode(source, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            return URLDecoder.decode(source, StandardCharsets.UTF_8);
         }
     }
 }

--- a/src/rest/src/main/java/org/geoserver/rest/converters/XStreamMessageConverter.java
+++ b/src/rest/src/main/java/org/geoserver/rest/converters/XStreamMessageConverter.java
@@ -6,8 +6,8 @@ package org.geoserver.rest.converters;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import org.geoserver.rest.RequestInfo;
 import org.geotools.util.logging.Logging;
@@ -58,12 +58,7 @@ public abstract class XStreamMessageConverter<T> extends BaseMessageConverter<T>
     }
 
     public String encode(String component) {
-        try {
-            return URLEncoder.encode(component, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.warning("Unable to URL-encode component: " + component);
-            return component;
-        }
+        return URLEncoder.encode(component, StandardCharsets.UTF_8);
     }
 
     /** The extension used for resources of the type being encoded */

--- a/src/rest/src/main/java/org/geoserver/rest/util/RESTUtils.java
+++ b/src/rest/src/main/java/org/geoserver/rest/util/RESTUtils.java
@@ -9,9 +9,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -297,12 +297,7 @@ public class RESTUtils {
         if (value == null) {
             return null;
         }
-
-        try {
-            return URLDecoder.decode(value.toString(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            return null;
-        }
+        return URLDecoder.decode(value.toString(), StandardCharsets.UTF_8);
     }
 
     /** Method for searching an item inside the MetadataMap. */

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceController.java
@@ -12,9 +12,9 @@ import freemarker.template.ObjectWrapper;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLConnection;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -158,13 +158,7 @@ public class ResourceController extends RestBaseController {
         // Strip off "/resource"
         path = path.substring(9);
         // handle special characters
-        try {
-            path = URLDecoder.decode(path, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RestException(
-                    "Could not decode the resource URL to UTF-8 format",
-                    HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        path = URLDecoder.decode(path, StandardCharsets.UTF_8);
         return resources.get(path);
     }
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/AbstractAclController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/AbstractAclController.java
@@ -5,8 +5,8 @@
 package org.geoserver.rest.security;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -104,12 +104,12 @@ public abstract class AbstractAclController<
     }
 
     @DeleteMapping(path = "/**")
-    public void rulesDelete(HttpServletRequest request) throws UnsupportedEncodingException {
+    public void rulesDelete(HttpServletRequest request) {
         checkUserIsAdmin();
 
         String thePath = request.getPathInfo();
         String ruleString = thePath.substring(getBasePath().length() + 1);
-        ruleString = URLDecoder.decode(ruleString, "utf-8");
+        ruleString = URLDecoder.decode(ruleString, StandardCharsets.UTF_8);
 
         String msg = validateRuleKey(ruleString);
         if (msg != null) throw new RestException(msg, HttpStatus.UNPROCESSABLE_ENTITY);

--- a/src/security/security-tests/src/test/java/org/geoserver/security/auth/AuthenticationFilterTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/auth/AuthenticationFilterTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
@@ -433,7 +434,7 @@ public class AuthenticationFilterTest extends AbstractAuthenticationProviderTest
         request.setMethod("GET");
         response = new MockHttpServletResponse();
         chain = new MockFilterChain();
-        String masterPassword = URLEncoder.encode(getMasterPassword(), "UTF-8");
+        String masterPassword = URLEncoder.encode(getMasterPassword(), StandardCharsets.UTF_8);
         request.addHeader(
                 "X-Credentials",
                 "private-user=" + GeoServerUser.ROOT_USERNAME + "&private-pw=" + masterPassword);

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerSecuredPageTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import org.apache.wicket.protocol.http.WebSession;
@@ -40,7 +41,7 @@ public class GeoServerSecuredPageTest extends GeoServerWicketTestSupport {
                 (SavedRequest)
                         tester.getHttpSession().getAttribute(GeoServerSecuredPage.SAVED_REQUEST);
         assertNotNull(sr);
-        String redirectUrl = new URLDecoder().decode(sr.getRedirectUrl(), "UTF8");
+        String redirectUrl = URLDecoder.decode(sr.getRedirectUrl(), StandardCharsets.UTF_8);
         assertTrue(
                 redirectUrl.contains("wicket/bookmarkable/org.geoserver.web.data.layer.LayerPage"));
     }

--- a/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
+++ b/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletConfig;
@@ -220,7 +221,8 @@ public class TestWfsPost extends HttpServlet {
                     responseContent.append("\n");
                     if (acon.getResponseMessage() != null) {
                         responseContent.append(
-                                URLDecoder.decode(acon.getResponseMessage(), "UTF-8"));
+                                URLDecoder.decode(
+                                        acon.getResponseMessage(), StandardCharsets.UTF_8));
                     }
                     responseContent.append("</servlet-exception>\n");
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/kvp/Filter_1_0_0_KvpParserTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/kvp/Filter_1_0_0_KvpParserTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.Test;
 import org.opengis.filter.Filter;
@@ -27,7 +28,7 @@ public class Filter_1_0_0_KvpParserTest {
                         + "%2Fogc%3APropertyName%3E%3Cogc%3AAdd%3E%3Cogc%3ALiteral%3E4%3C%2Fogc%3A"
                         + "Literal%3E%3Cogc%3ALiteral%3E3%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3AAdd%3E%3C"
                         + "%2Fogc%3APropertyIsEqualTo%3E%3C%2Fogc%3AFilter%3E";
-        filter = URLDecoder.decode(filter, "UTF-8");
+        filter = URLDecoder.decode(filter, StandardCharsets.UTF_8);
 
         List filters = (List) new Filter_1_0_0_KvpParser(null).parse(filter);
         assertNotNull(filters);
@@ -44,7 +45,7 @@ public class Filter_1_0_0_KvpParserTest {
                         + "%3CFeatureId%20fid=%22states.3%22/%3E%3C/Filter%3E)"
                         + "(%3CFilter%20xmlns=%22http://www.opengis.net/ogc%22%3E%3CFeatureId"
                         + "%20fid=%22tiger_roads.3%22/%3E%3C/Filter%3E)";
-        filter = URLDecoder.decode(filter, "UTF-8");
+        filter = URLDecoder.decode(filter, StandardCharsets.UTF_8);
 
         List filters = (List) new Filter_1_0_0_KvpParser(null).parse(filter);
         assertNotNull(filters);
@@ -66,7 +67,7 @@ public class Filter_1_0_0_KvpParserTest {
         String param =
                 "()(%3CFilter%20xmlns=%22http://www.opengis.net/ogc"
                         + "%22%3E%3CFeatureId%20fid=%22roads.3%22/%3E%3C/Filter%3E)";
-        param = URLDecoder.decode(param, "UTF-8");
+        param = URLDecoder.decode(param, StandardCharsets.UTF_8);
 
         List filters = (List) new Filter_1_0_0_KvpParser(null).parse(param);
         assertNotNull(filters);

--- a/src/wfs/src/test/java/org/geoserver/wfs/kvp/Filter_2_0_0_KvpParserTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/kvp/Filter_2_0_0_KvpParserTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.wfs.kvp;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,7 +48,7 @@ public class Filter_2_0_0_KvpParserTest {
                         + "%3C/fes:Literal%3E%" //
                         + "3C/fes:PropertyIsLike%3E" //
                         + "%3C/fes:Filter%3E";
-        String xml = URLDecoder.decode(encodedXml, "UTF-8");
+        String xml = URLDecoder.decode(encodedXml, StandardCharsets.UTF_8);
         @SuppressWarnings("unchecked")
         List<Filter> filters = (List<Filter>) new Filter_2_0_0_KvpParser(null).parse(xml);
         Assert.assertEquals(1, filters.size());

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/DescribeFeatureTypeTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/DescribeFeatureTypeTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.xml.namespace.QName;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.geoserver.catalog.Catalog;
@@ -155,7 +156,7 @@ public class DescribeFeatureTypeTest extends WFSTestSupport {
                 "ows?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName=myPrefix:"
                         + typeName.getLocalPart()
                         + "&namespace=xmlns(myPrefix%3D"
-                        + URLEncoder.encode(typeName.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(typeName.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")";
         Document doc = getAsDOM(path);
         // print(doc);
@@ -170,7 +171,7 @@ public class DescribeFeatureTypeTest extends WFSTestSupport {
                 "ows?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName="
                         + typeName.getLocalPart()
                         + "&namespace=xmlns("
-                        + URLEncoder.encode(typeName.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(typeName.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")";
         Document doc = getAsDOM(path);
         // print(doc);

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -213,7 +214,8 @@ public class GetFeatureTest extends WFSTestSupport {
         String request =
                 "wfs?service=WFS&version=1.1.0&request=GetFeature&typename=sf:PrimitiveGeoFeature"
                         + "&namespace=xmlns("
-                        + URLEncoder.encode("sf=http://cite.opengeospatial.org/gmlsf", "UTF-8")
+                        + URLEncoder.encode(
+                                "sf=http://cite.opengeospatial.org/gmlsf", StandardCharsets.UTF_8)
                         + ")";
 
         Document doc = postAsDOM(request);
@@ -551,7 +553,8 @@ public class GetFeatureTest extends WFSTestSupport {
                 "wfs?request=GetFeature&typename=myPrefix:Fifteen&version=1.1.0&service=wfs&"
                         + "namespace=xmlns(myPrefix%3D" // the '=' sign shall be encoded, hence
                         // '%3D'
-                        + URLEncoder.encode(SystemTestData.FIFTEEN.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(
+                                SystemTestData.FIFTEEN.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")");
     }
 
@@ -560,7 +563,8 @@ public class GetFeatureTest extends WFSTestSupport {
         testGetFifteenAll(
                 "wfs?request=GetFeature&typename=Fifteen&version=1.1.0&service=wfs&"
                         + "namespace=xmlns("
-                        + URLEncoder.encode(SystemTestData.FIFTEEN.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(
+                                SystemTestData.FIFTEEN.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")");
     }
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/DescribeFeatureTypeTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/DescribeFeatureTypeTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Executors;
@@ -289,7 +290,7 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
                         + "typeName=myPrefix:"
                         + typeName.getLocalPart()
                         + "&namespaces=xmlns(myPrefix,"
-                        + URLEncoder.encode(typeName.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(typeName.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")";
 
         Document doc = getAsDOM(path);
@@ -305,7 +306,7 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
                         + "typeName="
                         + typeName.getLocalPart()
                         + "&namespace=xmlns("
-                        + URLEncoder.encode(typeName.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(typeName.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")";
 
         Document doc = getAsDOM(path);

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -606,10 +607,11 @@ public class GetFeaturePagingTest extends WFS20TestSupport {
         assertEquals(String.valueOf(startIndex), kvp.get("STARTINDEX"));
         assertEquals(String.valueOf(count), kvp.get("COUNT"));
         assertEquals(
-                "(" + typeName + ")", URLDecoder.decode((String) kvp.get("TYPENAMES"), "UTF-8"));
+                "(" + typeName + ")",
+                URLDecoder.decode((String) kvp.get("TYPENAMES"), StandardCharsets.UTF_8));
         assertNotNull(kvp.get("FILTER"));
 
-        assertFilter(filter, URLDecoder.decode((String) kvp.get("FILTER"), "UTF-8"));
+        assertFilter(filter, URLDecoder.decode((String) kvp.get("FILTER"), StandardCharsets.UTF_8));
     }
 
     void assertFilter(Filter expected, String filter) throws Exception {

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutorCompletionService;
@@ -421,7 +422,8 @@ public class GetFeatureTest extends WFS20TestSupport {
         String request =
                 "wfs?service=WFS&version=2.0.0&request=GetFeature&typename=sf:PrimitiveGeoFeature"
                         + "&namespace=xmlns("
-                        + URLEncoder.encode("sf=http://cite.opengeospatial.org/gmlsf", "UTF-8")
+                        + URLEncoder.encode(
+                                "sf=http://cite.opengeospatial.org/gmlsf", StandardCharsets.UTF_8)
                         + ")";
 
         Document doc = postAsDOM(request);
@@ -1056,7 +1058,8 @@ public class GetFeatureTest extends WFS20TestSupport {
         testGetFifteenAll(
                 "wfs?request=GetFeature&typename=myPrefix:Fifteen&version=2.0.0&service=wfs&"
                         + "namespaces=xmlns(myPrefix,"
-                        + URLEncoder.encode(MockData.FIFTEEN.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(
+                                MockData.FIFTEEN.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")");
     }
 
@@ -1065,7 +1068,8 @@ public class GetFeatureTest extends WFS20TestSupport {
         testGetFifteenAll(
                 "wfs?request=GetFeature&typename=Fifteen&version=2.0.0&service=wfs&"
                         + "namespace=xmlns("
-                        + URLEncoder.encode(MockData.FIFTEEN.getNamespaceURI(), "UTF-8")
+                        + URLEncoder.encode(
+                                MockData.FIFTEEN.getNamespaceURI(), StandardCharsets.UTF_8)
                         + ")");
     }
 

--- a/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
@@ -8,6 +8,8 @@ package org.geoserver.wms;
 import java.lang.reflect.Array;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -413,7 +415,8 @@ public class WMSRequests {
             params.put("remote_ows_type", req.getRemoteOwsType());
         }
         if (req.getRemoteOwsURL() != null) {
-            String url = ResponseUtils.urlDecode(req.getRemoteOwsURL().toString());
+            String url =
+                    URLDecoder.decode(req.getRemoteOwsURL().toString(), StandardCharsets.UTF_8);
             params.put("remote_ows_url", url);
         }
         if (req.getScaleMethod() != null) {
@@ -435,7 +438,7 @@ public class WMSRequests {
         if (req.getSld() != null) {
             // the request encoder will url-encode the url, if it has already url encoded
             // chars, the will be encoded twice
-            params.put("sld", ResponseUtils.urlDecode(req.getSld().toString()));
+            params.put("sld", URLDecoder.decode(req.getSld().toString(), StandardCharsets.UTF_8));
         }
 
         if (req.getSldBody() != null) {

--- a/src/wms/src/test/java/org/geoserver/wms/WMSRequestsTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSRequestsTest.java
@@ -10,6 +10,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +19,6 @@ import javax.xml.namespace.QName;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.ows.util.KvpMap;
-import org.geoserver.ows.util.ResponseUtils;
 import org.junit.Test;
 
 public class WMSRequestsTest extends WMSTestSupport {
@@ -167,7 +168,7 @@ public class WMSRequestsTest extends WMSTestSupport {
     /** Gets the GetMap URL for the full list of requested layers. */
     private static String getGetMapUrl(GetMapRequest request) {
         String url = WMSRequests.getGetMapUrl(request, null, 0, null, null);
-        return ResponseUtils.urlDecode(url);
+        return URLDecoder.decode(url, StandardCharsets.UTF_8);
     }
 
     /** Gets the GetMap URL for each layer in the requested layers list. */
@@ -176,7 +177,7 @@ public class WMSRequestsTest extends WMSTestSupport {
         for (int i = 0; i < request.getLayers().size(); i++) {
             String name = request.getLayers().get(i).getName();
             String url = WMSRequests.getGetMapUrl(request, name, i, null, null, null);
-            urls.add(ResponseUtils.urlDecode(url));
+            urls.add(URLDecoder.decode(url, StandardCharsets.UTF_8));
         }
         return urls;
     }

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/GetFeatureInfoKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/GetFeatureInfoKvpRequestReaderTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.geoserver.catalog.CatalogBuilder;
@@ -82,7 +83,7 @@ public class GetFeatureInfoKvpRequestReaderTest extends KvpRequestReaderTestSupp
     public void testSldDisabled() throws Exception {
         Map<String, Object> kvp = new HashMap<>();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsLibraryDefault.sld");
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         kvp.put("sld", decoded);
         kvp.put(
                 "layers",

--- a/src/wms/src/test/java/org/geoserver/wms/icons/IconPropertiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/icons/IconPropertiesTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.styling.Fill;
@@ -143,7 +144,7 @@ public class IconPropertiesTest extends IconTestSupport {
         final PointSymbolizer symbolizer =
                 externalGraphic("http://127.0.0.1/foo${field}.png", "image/png");
         final Style style = styleFromRules(catchAllRule(symbolizer, symbolizer));
-        final String url = URLEncoder.encode("http://127.0.0.1/", "UTF-8");
+        final String url = URLEncoder.encode("http://127.0.0.1/", StandardCharsets.UTF_8);
         assertEquals(
                 "0.0.0=&0.0.0.url=" + url + "foo1.png&0.0.1=&0.0.1.url=" + url + "foo1.png",
                 encode(style, fieldIs1));

--- a/src/wms/src/test/java/org/geoserver/wms/icons/IconTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/icons/IconTestSupport.java
@@ -6,8 +6,8 @@
 package org.geoserver.wms.icons;
 
 import java.awt.Color;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -67,23 +67,19 @@ public class IconTestSupport {
     }
 
     protected String queryString(Map<String, String> params) {
-        try {
-            StringBuilder buff = new StringBuilder();
-            boolean first = true;
-            for (Map.Entry<String, String> entry : params.entrySet()) {
-                if (first) {
-                    first = false;
-                } else {
-                    buff.append("&");
-                }
-                buff.append(entry.getKey())
-                        .append("=")
-                        .append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+        StringBuilder buff = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                buff.append("&");
             }
-            return buff.toString();
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            buff.append(entry.getKey())
+                    .append("=")
+                    .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
         }
+        return buff.toString();
     }
 
     protected final Fill fill(Color color, Double opacity) {

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -463,7 +464,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         HashMap kvp = new HashMap();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsLibraryNoDefault.sld");
         // the kvp should be already in decoded form
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         kvp.put("sld", decoded);
         kvp.put(
                 "layers",
@@ -485,7 +486,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         // no style name, but the sld has a default for that layer
         HashMap kvp = new HashMap();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsLibraryDefault.sld");
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         kvp.put("sld", decoded);
         kvp.put(
                 "layers",
@@ -583,7 +584,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
     public void testSldDisabled() throws Exception {
         HashMap kvp = new HashMap();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsLibraryDefault.sld");
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         kvp.put("sld", decoded);
         kvp.put(
                 "layers",
@@ -640,7 +641,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         // style name matching one in the sld
         HashMap kvp = new HashMap();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsLibraryNoDefault.sld");
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         kvp.put("sld", decoded);
         kvp.put(
                 "layers",
@@ -662,7 +663,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         // nothing matches the required style name
         HashMap kvp = new HashMap();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsLibraryNoDefault.sld");
-        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
         kvp.put(
                 "layers",
                 MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
@@ -685,7 +686,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
 
         URL url = new URL("http://hostthatdoesnotexist/");
 
-        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
         kvp.put(
                 "layers",
                 MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
@@ -708,7 +709,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
 
         URL url = new URL(GetMapKvpRequestReaderTest.class.getResource(""), "does-not-exist");
 
-        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
         kvp.put(
                 "layers",
                 MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
@@ -731,7 +732,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
 
         URL url = GetMapKvpRequestReaderTest.class.getResource("paletted.tif");
 
-        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
         kvp.put(
                 "layers",
                 MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
@@ -756,7 +757,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
                 GetMapKvpRequestReaderTest.class.getResource(
                         "WMSPostLayerGroupNonDefaultStyle.xml");
 
-        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+        kvp.put("sld", URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
         kvp.put(
                 "layers",
                 MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
@@ -777,7 +778,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         // no styles, no layer, the full definition is in the sld
         HashMap kvp = new HashMap();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsFeatureTypeConstaint.sld");
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         kvp.put("sld", decoded);
 
         GetMapRequest request = reader.createRequest();
@@ -806,7 +807,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         // no styles, no layer, the full definition is in the sld
         HashMap kvp = new HashMap();
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsFeatureTypeConstaint.sld");
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
         kvp.put("sld", decoded);
         kvp.put(
                 "layers",
@@ -932,7 +933,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         kvp.put("format", "image/png");
         final URL url = GetMapKvpRequestReader.class.getResource("BaseMapGroup.sld");
         // URLDecoder.decode fixes GEOS-3709
-        kvp.put("sld", URLDecoder.decode(url.toString(), "UTF-8"));
+        kvp.put("sld", URLDecoder.decode(url.toString(), StandardCharsets.UTF_8));
         kvp.put("version", "1.1.1");
 
         GetMapRequest request = reader.createRequest();
@@ -1032,7 +1033,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
     @Test
     public void testMissingLayersAndStylesParametersWithSld() throws Exception {
         URL url = GetMapKvpRequestReader.class.getResource("BasicPolygonsLibraryNoDefault.sld");
-        String decoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+        String decoded = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8);
 
         // Fix [GEOS-9646]: INSPIRE validation get errors of GetMapRequest parameters.
         HashMap raw = new HashMap();
@@ -1183,7 +1184,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
             // nothing matches the required style name
             HashMap kvp = new HashMap();
             URL url = new URL("http://localhost:" + port + "/sld/style.sld");
-            kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+            kvp.put("sld", URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
             kvp.put(
                     "layers",
                     MockData.BASIC_POLYGONS.getPrefix()
@@ -1227,7 +1228,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
             // nothing matches the required style name
             HashMap kvp = new HashMap();
             URL url = new URL("http://localhost:" + port + "/sld/style.sld");
-            kvp.put("sld", URLDecoder.decode(url.toExternalForm(), "UTF-8"));
+            kvp.put("sld", URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8));
             kvp.put(
                     "layers",
                     MockData.BASIC_POLYGONS.getPrefix()

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -14,6 +14,7 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import javax.imageio.ImageIO;
 import javax.xml.namespace.QName;
@@ -325,7 +326,7 @@ public class GetLegendGraphicTest extends WMSTestSupport {
                         + "&SLD_BODY=";
         String sld = IOUtils.toString(TestData.class.getResource("externalEntities.sld"), "UTF-8");
         MockHttpServletResponse response =
-                getAsServletResponse(base + URLEncoder.encode(sld, "UTF-8"));
+                getAsServletResponse(base + URLEncoder.encode(sld, StandardCharsets.UTF_8));
         // should fail with an error message poiting at entity resolution
         assertEquals("application/vnd.ogc.se_xml", response.getContentType());
         final String content = response.getContentAsString();


### PR DESCRIPTION
This PR changes uses of URLDecode and URLEncode that previously used String values to identify the encoding. That results in needing to handle an UnsupportedEncodingException that can never happen (because UTF-8 and ASCII are always supported). The cleaner way is to use a StandardCharsets value, which is more obvious and avoids the exception.

## Checklist


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones. [No backports on this]

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [N/A] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [N/A] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [N/A] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
