### PR TITLE
[2.18.x backport][GEOS-9898] Make Restore process respect original workspaces IDs

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
@@ -107,11 +107,33 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
         restoreCatalog.setResourceLoader(gsCatalog.getResourceLoader());
         restoreCatalog.setResourcePool(gsCatalog.getResourcePool());
 
+        keepExistingWorkspaces(restoreCatalog, gsCatalog);
+
         for (CatalogListener listener : gsCatalog.getListeners()) {
             restoreCatalog.addListener(listener);
         }
 
         return restoreCatalog;
+    }
+
+    /** Pass existing workspaces and namespaces to the resulting restore catalog. */
+    private void keepExistingWorkspaces(CatalogImpl restoreCatalog, Catalog gsCatalog) {
+        gsCatalog
+                .getNamespaces()
+                .forEach(
+                        nsInfo -> {
+                            restoreCatalog.add(nsInfo);
+                            restoreCatalog.save(
+                                    restoreCatalog.getNamespaceByPrefix(nsInfo.getPrefix()));
+                        });
+        gsCatalog
+                .getWorkspaces()
+                .forEach(
+                        wsInfo -> {
+                            restoreCatalog.add(wsInfo);
+                            restoreCatalog.save(
+                                    restoreCatalog.getWorkspaceByName(wsInfo.getName()));
+                        });
     }
 
     @Override

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
@@ -71,11 +71,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
             }
 
             LOGGER.info(
-                    "Processing resource: "
-                            + resource
-                            + " - Progress: ["
-                            + getCurrentJobExecution().getProgress()
-                            + "]");
+                    () ->
+                            "Processing resource: "
+                                    + resource
+                                    + " - Progress: ["
+                                    + getCurrentJobExecution().getProgress()
+                                    + "]");
 
             if (resource instanceof WorkspaceInfo) {
                 WorkspaceInfo ws = ((WorkspaceInfo) resource);

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
@@ -25,6 +25,8 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Files;
@@ -229,16 +231,37 @@ public class BackupTest extends BackupRestoreTestSupport {
             assertEquals(33, restoreCatalog.getLayers().size());
             assertEquals(3, restoreCatalog.getLayerGroups().size());
         }
+        // check Workspaces and Namespaces IDs are respected
+        checkWorkspacesAndNamespacesIds(restoreCatalog);
 
         checkExtraPropertiesExists();
         if (restoreExecution.getStatus() == BatchStatus.COMPLETED) {
             assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
             // check that generic listener was invoked for the backup job
-            assertThat(GenericListener.getBackupAfterInvocations(), is(2));
-            assertThat(GenericListener.getBackupBeforeInvocations(), is(2));
+            assertThat(GenericListener.getBackupAfterInvocations(), is(3));
+            assertThat(GenericListener.getBackupBeforeInvocations(), is(3));
             assertThat(GenericListener.getRestoreAfterInvocations(), is(3));
             assertThat(GenericListener.getRestoreBeforeInvocations(), is(3));
         }
+    }
+
+    private void checkWorkspacesAndNamespacesIds(final Catalog restoreCatalog) {
+        // Check workspaces former IDs are respected
+        catalog.getWorkspaces()
+                .forEach(
+                        wsInfo -> {
+                            WorkspaceInfo restoreInfo =
+                                    restoreCatalog.getWorkspaceByName(wsInfo.getName());
+                            assertEquals(wsInfo.getId(), restoreInfo.getId());
+                        });
+        // Check Namespaces former IDs are respected
+        catalog.getNamespaces()
+                .forEach(
+                        nsInfo -> {
+                            NamespaceInfo restpreNsInfo =
+                                    restoreCatalog.getNamespaceByPrefix(nsInfo.getPrefix());
+                            assertEquals(nsInfo.getId(), restpreNsInfo.getId());
+                        });
     }
 
     @Test
@@ -448,8 +471,8 @@ public class BackupTest extends BackupRestoreTestSupport {
     public void testBackupExcludedResources() throws Exception {
         GeoServerDataDirectory dd = backupFacade.getGeoServerDataDirectory();
 
-        BackupUtils.dir(dd.get(Paths.BASE), "/foo/folder");
-        assertTrue(Resources.exists(dd.get("/foo/folder")));
+        BackupUtils.dir(dd.get(Paths.BASE), "foo/folder");
+        assertTrue(Resources.exists(dd.get("foo/folder")));
 
         Hints hints = new Hints(new HashMap(2));
         hints.add(


### PR DESCRIPTION
Restore process rewrites always a new Workspace and Namespace ID even if the same Workspace name and Namespace prefix already exists in the GeoServer catalog. This broke some resources(stores and layers) linked by these IDs on partial restores.

This fix checks for existing Workspaces and Namespaces adding them with the same IDs to the resulting new catalog.

Jira issue:
https://osgeo-org.atlassian.net/browse/GEOS-9898

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
