### PR TITLE
[2.18.x backport][GEOS-9911] Params-extractor plugin, wrong url in getCapabilities when having context with addition /

### DIFF
--- a/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
+++ b/src/community/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
@@ -6,8 +6,6 @@ package org.geoserver.params.extractor;
 
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -20,8 +18,6 @@ import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.platform.resource.Resource;
 
 public class UrlMangler implements URLMangler {
-
-    private static final Pattern URI_PATTERN = Pattern.compile("^((?:/)[^/]+/)(.*)$");
 
     private List<EchoParameter> echoParameters;
 
@@ -70,12 +66,10 @@ public class UrlMangler implements URLMangler {
         if (httpRequest instanceof RequestWrapper) {
             requestUri = ((RequestWrapper) httpRequest).getOriginalRequestURI();
         }
-        Matcher matcher = URI_PATTERN.matcher(requestUri);
-        if (!matcher.matches()) {
-            return;
-        }
+        int i = httpRequest.getContextPath().length() + 1;
+        String pathInfo = requestUri.substring(i);
         path.delete(0, path.length());
-        path.append(matcher.group(2));
+        path.append(pathInfo);
     }
 
     private void forwardParameters(Map requestRawKvp, Map<String, String> kvp) {

--- a/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/UrlManglerTest.java
+++ b/src/community/params-extractor/src/test/java/org/geoserver/params/extractor/UrlManglerTest.java
@@ -36,6 +36,7 @@ public final class UrlManglerTest extends TestSupport {
         MockHttpServletRequest httpRequest =
                 new MockHttpServletRequest(
                         "GET", "http://127.0.0.1/geoserver/it.geosolutions/param/wms");
+        httpRequest.setContextPath("/geoserver");
         UrlTransform transform = new UrlTransform("/geoserver/workspace/param/wms", params);
         transform.removeMatch("/param");
         RequestWrapper wrapper = new RequestWrapper(transform, httpRequest);
@@ -59,6 +60,7 @@ public final class UrlManglerTest extends TestSupport {
         MockHttpServletRequest httpRequest =
                 new MockHttpServletRequest(
                         "GET", "http://127.0.0.1/geoserver/it.geosolutions/param/wms");
+        httpRequest.setContextPath("/geoserver");
         UrlTransform transform = new UrlTransform("/geoserver/workspace/param/wms", params);
         transform.removeMatch("/param");
         RequestWrapper wrapper = new RequestWrapper(transform, httpRequest);
@@ -70,6 +72,30 @@ public final class UrlManglerTest extends TestSupport {
         Dispatcher.REQUEST.set(request);
         UrlMangler mangler = new UrlMangler(getDataDirectory());
         StringBuilder path = new StringBuilder("/geoserver/workspace/param/wms");
+        Map<String, String> kvp = new HashMap<String, String>();
+        mangler.mangleURL(new StringBuilder(), path, kvp, null);
+        assertEquals("workspace/param/wms", path.toString());
+    }
+
+    @Test
+    public void testMultiSlashContextPath() {
+
+        Map<String, String[]> params = new HashMap<String, String[]>();
+
+        MockHttpServletRequest httpRequest =
+                new MockHttpServletRequest(
+                        "GET", "http://127.0.0.1/my/ohmy/geoserver/it.geosolutions/param/wms");
+        httpRequest.setContextPath("/my/ohmy/geoserver");
+        UrlTransform transform = new UrlTransform("/my/ohmy/geoserver/workspace/param/wms", params);
+        transform.removeMatch("/param");
+        RequestWrapper wrapper = new RequestWrapper(transform, httpRequest);
+        Request request = new Request();
+        request.setHttpRequest(wrapper);
+        request.setRequest("GetCapabilities");
+
+        Dispatcher.REQUEST.set(request);
+        UrlMangler mangler = new UrlMangler(getDataDirectory());
+        StringBuilder path = new StringBuilder("/my/ohmy/geoserver/workspace/param/wms");
         Map<String, String> kvp = new HashMap<String, String>();
         mangler.mangleURL(new StringBuilder(), path, kvp, null);
         assertEquals("workspace/param/wms", path.toString());


### PR DESCRIPTION
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
