### PR TITLE
[2.18.x backport][GEOS-9913] Integration test for AppSchema inconsistent count recordswith maxFeatures param - [GEOS-9914] Allow the numberMatched to be displayed for GetFeatures request with ComplexFeatures

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GetFeaturesNumberMatchedTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GetFeaturesNumberMatchedTest.java
@@ -87,7 +87,6 @@ public class GetFeaturesNumberMatchedTest extends AbstractAppSchemaTestSupport {
                                 + "&cql_filter=gsml:MappedFeature.gsml:specification.gsml:GeologicUnit.gml:description = 'Olivine basalt'");
         LOGGER.info(prettyString(doc));
 
-        assertXpathEvaluatesTo("1", "/wfs:FeatureCollection/@numberMatched", doc);
         assertXpathEvaluatesTo("1", "/wfs:FeatureCollection/@numberReturned", doc);
     }
 
@@ -96,11 +95,10 @@ public class GetFeaturesNumberMatchedTest extends AbstractAppSchemaTestSupport {
 
         Document doc =
                 getAsDOM(
-                        "ows?service=WFS&version=2.0.0&outputFormat=gml32&request=GetFeature&typeNames=gsml:MappedFeature"
-                                + "&cql_filter=gsml:MappedFeature.gsml:specification.gsml:GeologicUnit.gml:description LIKE %27%25Olivine%20basalt%2C%20tuff%25%27");
+                        "ows?service=WFS&version=2.0.0&outputFormat=gml3&request=GetFeature&typeNames=gsml:MappedFeature&resulttype=hits"
+                                + "&cql_filter=gsml:MappedFeature.gsml:specification.gsml:GeologicUnit.gml:description LIKE %27%25Olivine%20basalt%2C%20tuff%25%27&count=1");
         LOGGER.info(prettyString(doc));
 
         assertXpathEvaluatesTo("3", "/wfs:FeatureCollection/@numberMatched", doc);
-        assertXpathEvaluatesTo("3", "/wfs:FeatureCollection/@numberReturned", doc);
     }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml30WfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml30WfsTest.java
@@ -78,7 +78,6 @@ public class Gsml30WfsTest extends AbstractAppSchemaTestSupport {
         Document doc = getAsDOM(path);
         LOGGER.info("Response for " + path + " :" + newline + prettyString(doc));
         assertXpathEvaluatesTo("2", "/wfs:FeatureCollection/@numberReturned", doc);
-        assertXpathEvaluatesTo("unknown", "/wfs:FeatureCollection/@numberMatched", doc);
         assertXpathCount(2, "//gsml:MappedFeature", doc);
         // test names
         assertXpathEvaluatesTo("First", "//gsml:MappedFeature[@gml:id='mf.1']/gml:name", doc);
@@ -103,7 +102,6 @@ public class Gsml30WfsTest extends AbstractAppSchemaTestSupport {
         Document doc = getAsDOM(path);
         LOGGER.info("Response for " + path + " :" + newline + prettyString(doc));
         assertXpathEvaluatesTo("2", "/wfs:FeatureCollection/@numberReturned", doc);
-        assertXpathEvaluatesTo("unknown", "/wfs:FeatureCollection/@numberMatched", doc);
         assertXpathCount(2, "/wfs:FeatureCollection/wfs:member", doc);
         // test that all namespaces are present on the root element
         for (String prefix : getRequiredNamespaces().keySet()) {

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml32BoreholeIntervalWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml32BoreholeIntervalWfsTest.java
@@ -31,7 +31,6 @@ public class Gsml32BoreholeIntervalWfsTest extends AbstractAppSchemaTestSupport 
         LOGGER.info("Response for " + path + " :" + newline + prettyString(doc));
 
         assertXpathEvaluatesTo("2", "/wfs:FeatureCollection/@numberReturned", doc);
-        assertXpathEvaluatesTo("unknown", "/wfs:FeatureCollection/@numberMatched", doc);
         assertXpathCount(2, "//gsmlbh:Borehole", doc);
 
         // #First linestring

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml32BoreholeWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/Gsml32BoreholeWfsTest.java
@@ -31,7 +31,6 @@ public class Gsml32BoreholeWfsTest extends AbstractAppSchemaTestSupport {
         LOGGER.info("Response for " + path + " :" + newline + prettyString(doc));
 
         assertXpathEvaluatesTo("2", "/wfs:FeatureCollection/@numberReturned", doc);
-        assertXpathEvaluatesTo("unknown", "/wfs:FeatureCollection/@numberMatched", doc);
         assertXpathCount(2, "//gsmlbh:Borehole", doc);
 
         // First borehole

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SpecimenWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SpecimenWfsTest.java
@@ -57,7 +57,6 @@ public class SpecimenWfsTest extends AbstractAppSchemaTestSupport {
         Document doc = getAsDOM(path);
         LOGGER.info("Response for " + path + " :" + newline + prettyString(doc));
         assertXpathEvaluatesTo("2", "/wfs:FeatureCollection/@numberReturned", doc);
-        assertXpathEvaluatesTo("unknown", "/wfs:FeatureCollection/@numberMatched", doc);
         assertXpathCount(2, "//spec:SF_Specimen", doc);
         assertXpathEvaluatesTo("First", "//spec:SF_Specimen[@gml:id='specimen.1']/gml:name", doc);
         assertXpathEvaluatesTo("2.7", "//spec:SF_Specimen[@gml:id='specimen.1']/spec:size", doc);

--- a/src/wfs/src/main/resources/ChangeNumberOfFeature32.xslt
+++ b/src/wfs/src/main/resources/ChangeNumberOfFeature32.xslt
@@ -13,9 +13,6 @@
     <xsl:template match="/wfs:FeatureCollection">
         <xsl:copy>
             <xsl:copy-of select="@*" />
-            <xsl:attribute name="numberMatched">
-                <xsl:text>unknown</xsl:text>
-            </xsl:attribute>
             <xsl:attribute name="numberReturned">
                 <xsl:value-of select="count(//wfs:FeatureCollection/wfs:member)" />
             </xsl:attribute>


### PR DESCRIPTION
* [GEOS-9913] Integration test for AppSchema inconsistent count records with maxFeatures param

* [GEOS-9914] Allow the numberMatched to be displayed for GetFeatures request with ComplexFeatures

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
