### PR TITLE
add HTML conformance page for ogcapi implementations

### DIFF
--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/DGGSService.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/DGGSService.java
@@ -94,6 +94,8 @@ public class DGGSService {
 
     private final GeoServer gs;
 
+    private static final String DISPLAY_NAME = "DGGS";
+
     /**
      * This is used for time support, default time and time filtering.
      *
@@ -126,9 +128,10 @@ public class DGGSService {
 
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
+    @HTMLResponseBody(templateName = "conformance.ftl", fileName = "conformance.html")
     public ConformanceDocument conformance() {
         List<String> classes = Arrays.asList(CORE);
-        return new ConformanceDocument(classes);
+        return new ConformanceDocument(DISPLAY_NAME, classes);
     }
 
     @GetMapping(

--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/dggs/landingPage.ftl
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/dggs/landingPage.ftl
@@ -21,7 +21,9 @@
        This collection page is also available as
        <#list model.getLinksExcept("collections", "text/html") as link><a href="${link.href}">${link.type}</a><#if link_has_next>, </#if></#list>.
        </p>
-       
+
+       <#include "landingpage-conformance.ftl">
+
        <h2>Contact information</h2>
        <ul>
        <li>Server managed by ${contact.contactPerson!"-unspecified-"}</li>

--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/test/java/org/geoserver/ogcapi/dggs/ConformanceTest.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/test/java/org/geoserver/ogcapi/dggs/ConformanceTest.java
@@ -1,0 +1,44 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.dggs;
+
+import static org.junit.Assert.assertEquals;
+
+import com.jayway.jsonpath.DocumentContext;
+import org.junit.Test;
+
+public class ConformanceTest extends DGGSTestSupport {
+
+    @Test
+    public void testConformance() throws Exception {
+        DocumentContext json = getAsJSONPath("ogc/dggs/conformance", 200);
+        checkConformance(json);
+    }
+
+    private void checkConformance(DocumentContext json) {
+        assertEquals(1, (int) json.read("$.length()", Integer.class));
+        assertEquals(1, (int) json.read("$.conformsTo.length()", Integer.class));
+        assertEquals(DGGSService.CORE, json.read("$.conformsTo[0]", String.class));
+    }
+
+    @Test
+    public void testConformanceJson() throws Exception {
+        DocumentContext json = getAsJSONPath("ogc/dggs/conformance?f=json", 200);
+        checkConformance(json);
+    }
+
+    @Test
+    public void testCollectionsYaml() throws Exception {
+        String yaml = getAsString("ogc/dggs/conformance?f=application/x-yaml");
+        checkConformance(convertYamlToJsonPath(yaml));
+    }
+
+    @Test
+    public void testConformanceHTML() throws Exception {
+        org.jsoup.nodes.Document document = getAsJSoup("ogc/dggs/conformance?f=text/html");
+        assertEquals("GeoServer DGGS Conformance", document.select("#title").text());
+        assertEquals(DGGSService.CORE, document.select("#content li:eq(0)").text());
+    }
+}

--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/test/java/org/geoserver/ogcapi/dggs/LandingPageTest.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/test/java/org/geoserver/ogcapi/dggs/LandingPageTest.java
@@ -113,6 +113,9 @@ public class LandingPageTest extends OGCApiTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/dggs/api?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/dggs/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
     }
 
     @Test
@@ -125,6 +128,9 @@ public class LandingPageTest extends OGCApiTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/sf/ogc/dggs/api?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/sf/ogc/dggs/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
     }
 
     void checkJSONLandingPage(DocumentContext json) {

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceDocument.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceDocument.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.ogcapi;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,10 +13,24 @@ import java.util.List;
 public class ConformanceDocument extends AbstractDocument {
 
     List<String> conformsTo;
+    String apiName;
 
-    public ConformanceDocument(List<String> conformsTo) {
+    public ConformanceDocument(String apiName, List<String> conformsTo) {
+        this.apiName = apiName;
         // keep it editable, regardless of how the source has been provided
         this.conformsTo = new ArrayList<>(conformsTo);
+    }
+
+    /**
+     * Get the API that this conformance document applies to.
+     *
+     * <p>For example, for the Features spec, this is "OGC API Features".
+     *
+     * @return a printable (human readable) display name for the API.
+     */
+    @JsonIgnore
+    public String getApiName() {
+        return this.apiName;
     }
 
     /** Returns the lists of conformance classes */

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/conformance.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/conformance.ftl
@@ -1,0 +1,11 @@
+<#include "common-header.ftl">
+       <h2 id="title">GeoServer ${model.apiName} Conformance</h2>
+       <p>This document lists the OGC API conformance classes that are implemented by this service.<br/>
+
+       <p>Conformance classes:</p>
+       <ul>
+       <#list model.conformsTo as conformsTo>
+       <li>${conformsTo}</li>
+       </#list>
+       </ul>
+<#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/landingpage-conformance.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/landingpage-conformance.ftl
@@ -1,0 +1,6 @@
+       <h2>Conformance</h2>
+       <p>The <a id="htmlConformanceLink" href="${model.getLinkUrl('conformance', 'text/html')!}"> conformance page</a> provides a list of the conformance classes implemented by this service. 
+       <br/> 
+       This conformance page is also available as
+       <#list model.getLinksExcept("conformance", "text/html") as link><a href="${link.href}">${link.type}</a><#if link_has_next>, </#if></#list>.
+       </p>

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -74,9 +74,9 @@ public class FeatureService {
     public static final String GEOJSON =
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson";
     public static final String GMLSF0 =
-            "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/gmlsf0";
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/gmlsf0";
     public static final String GMLSF2 =
-            "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/gmlsf2";
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/gmlsf2";
     public static final String OAS30 =
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30";
     public static final String CQL_TEXT =
@@ -90,6 +90,8 @@ public class FeatureService {
     public static final String DEFAULT_CRS = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
 
     public static String ITEM_ID = "OGCFeatures:ItemId";
+
+    private static final String DISPLAY_NAME = "OGC API Features";
 
     private static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
 
@@ -222,9 +224,10 @@ public class FeatureService {
 
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
+    @HTMLResponseBody(templateName = "conformance.ftl", fileName = "conformance.html")
     public ConformanceDocument conformance() {
         List<String> classes = Arrays.asList(CORE, OAS30, HTML, GEOJSON, GMLSF0, CQL_TEXT);
-        return new ConformanceDocument(classes);
+        return new ConformanceDocument(DISPLAY_NAME, classes);
     }
 
     @GetMapping(path = "collections/{collectionId}/items/{itemId:.+}", name = "getFeature")

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/landingPage.ftl
@@ -25,6 +25,8 @@
        <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping --> 
        ${htmlExtensions('landing')}
        
+       <#include "landingpage-conformance.ftl">
+
        <h2>Contact information</h2>
        <ul>
        <li>Server managed by ${contact.contactPerson!"-unspecified-"}</li>

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ConformanceTest.java
@@ -20,6 +20,8 @@ public class ConformanceTest extends FeaturesTestSupport {
     }
 
     private void checkConformance(DocumentContext json) {
+        assertEquals(1, (int) json.read("$.length()", Integer.class));
+        assertEquals(6, (int) json.read("$.conformsTo.length()", Integer.class));
         assertEquals(FeatureService.CORE, json.read("$.conformsTo[0]", String.class));
         assertEquals(FeatureService.OAS30, json.read("$.conformsTo[1]", String.class));
         assertEquals(FeatureService.HTML, json.read("$.conformsTo[2]", String.class));
@@ -39,5 +41,17 @@ public class ConformanceTest extends FeaturesTestSupport {
     public void testCollectionsYaml() throws Exception {
         String yaml = getAsString("ogc/features/conformance/?f=application/x-yaml");
         checkConformance(convertYamlToJsonPath(yaml));
+    }
+
+    @Test
+    public void testConformanceHTML() throws Exception {
+        org.jsoup.nodes.Document document = getAsJSoup("ogc/features/conformance?f=text/html");
+        assertEquals("GeoServer OGC API Features Conformance", document.select("#title").text());
+        assertEquals(FeatureService.CORE, document.select("#content li:eq(0)").text());
+        assertEquals(FeatureService.OAS30, document.select("#content li:eq(1)").text());
+        assertEquals(FeatureService.HTML, document.select("#content li:eq(2)").text());
+        assertEquals(FeatureService.GEOJSON, document.select("#content li:eq(3)").text());
+        assertEquals(FeatureService.GMLSF0, document.select("#content li:eq(4)").text());
+        assertEquals(FeatureService.CQL_TEXT, document.select("#content li:eq(5)").text());
     }
 }

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/LandingPageTest.java
@@ -101,6 +101,9 @@ public class LandingPageTest extends FeaturesTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/features/api?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/features/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
@@ -110,6 +110,8 @@ public class ImagesService implements ApplicationContextAware {
     public static String IMAGE_ID = "OGCImages:ImageId";
     public static String COLLECTION_ID = "OGCImages:CollectionId";
 
+    private static final String DISPLAY_NAME = "OGC API Images";
+
     private final GeoServer geoServer;
     private final AssetHasher assetHasher;
 
@@ -141,6 +143,7 @@ public class ImagesService implements ApplicationContextAware {
 
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
+    @HTMLResponseBody(templateName = "conformance.ftl", fileName = "conformance.html")
     public ConformanceDocument conformance() {
         List<String> classes =
                 Arrays.asList(
@@ -148,7 +151,7 @@ public class ImagesService implements ApplicationContextAware {
                         ConformanceClass.COLLECTIONS,
                         IMAGES_CORE,
                         IMAGES_TRANSACTIONAL);
-        return new ConformanceDocument(classes);
+        return new ConformanceDocument(DISPLAY_NAME, classes);
     }
 
     @GetMapping(

--- a/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/images/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/images/landingPage.ftl
@@ -21,6 +21,8 @@
        This image collections page is also available as
        <#list model.getLinksExcept("collections", "text/html") as link><a href="${link.href}">${link.type}</a><#if link_has_next>, </#if></#list>.
        </p>
+
+       <#include "landingpage-conformance.ftl">
        
        <h2>Contact information</h2>
        <ul>

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/ConformanceTest.java
@@ -19,6 +19,8 @@ public class ConformanceTest extends ImagesTestSupport {
     }
 
     private void checkConformance(DocumentContext json) {
+        assertEquals(1, (int) json.read("$.length()", Integer.class));
+        assertEquals(4, (int) json.read("$.conformsTo.length()", Integer.class));
         assertEquals(ConformanceClass.CORE, json.read("$.conformsTo[0]", String.class));
         assertEquals(ConformanceClass.COLLECTIONS, json.read("$.conformsTo[1]", String.class));
         assertEquals(ImagesService.IMAGES_CORE, json.read("$.conformsTo[2]", String.class));
@@ -30,5 +32,16 @@ public class ConformanceTest extends ImagesTestSupport {
     public void testCollectionsYaml() throws Exception {
         String yaml = getAsString("ogc/images/conformance/?f=application/x-yaml");
         checkConformance(convertYamlToJsonPath(yaml));
+    }
+
+    @Test
+    public void testConformanceHTML() throws Exception {
+        org.jsoup.nodes.Document document = getAsJSoup("ogc/images/conformance?f=text/html");
+        assertEquals("GeoServer OGC API Images Conformance", document.select("#title").text());
+        assertEquals(ConformanceClass.CORE, document.select("#content li:eq(0)").text());
+        assertEquals(ConformanceClass.COLLECTIONS, document.select("#content li:eq(1)").text());
+        assertEquals(ImagesService.IMAGES_CORE, document.select("#content li:eq(2)").text());
+        assertEquals(
+                ImagesService.IMAGES_TRANSACTIONAL, document.select("#content li:eq(3)").text());
     }
 }

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/LandingPageTest.java
@@ -93,6 +93,9 @@ public class LandingPageTest extends ImagesTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/images/api?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/images/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
@@ -102,6 +102,8 @@ public class StylesService {
     public static final String SLD11 = "http://www.opengis.net/t15/opf-styles-1/1.0/conf/sld-11";
     public static final String CSS = "http://www.geoserver.org/opf-styles-1/1.0/conf/geocss";
 
+    private static final String DISPLAY_NAME = "OGC API Styles";
+
     private final GeoServer geoServer;
     private final GeoServerDataDirectory dataDirectory;
     private final SampleDataSupport sampleDataSupport;
@@ -148,9 +150,10 @@ public class StylesService {
 
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
+    @HTMLResponseBody(templateName = "conformance.ftl", fileName = "conformance.html")
     public ConformanceDocument conformance() {
         List<String> classes = Arrays.asList(CORE, HTML, JSON, MAPBOX, SLD10, SLD11);
-        return new ConformanceDocument(classes);
+        return new ConformanceDocument(DISPLAY_NAME, classes);
     }
 
     @GetMapping(

--- a/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/styles/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/styles/landingPage.ftl
@@ -22,6 +22,8 @@
        <#list model.getLinksExcept("styles", "text/html") as link><a href="${link.href}">${link.type}</a><#if link_has_next>, </#if></#list>.
        </p>
        
+       <#include "landingpage-conformance.ftl">
+
        <h2>Contact information</h2>
        <ul>
        <li>Server managed by ${contact.contactPerson!"-unspecified-"}</li>

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/ConformanceTest.java
@@ -18,9 +18,14 @@ public class ConformanceTest extends StylesTestSupport {
     }
 
     private void checkConformance(DocumentContext json) {
+        assertEquals(1, (int) json.read("$.length()", Integer.class));
+        assertEquals(6, (int) json.read("$.conformsTo.length()", Integer.class));
         assertEquals(StylesService.CORE, json.read("$.conformsTo[0]", String.class));
         assertEquals(StylesService.HTML, json.read("$.conformsTo[1]", String.class));
         assertEquals(StylesService.JSON, json.read("$.conformsTo[2]", String.class));
+        assertEquals(StylesService.MAPBOX, json.read("$.conformsTo[3]", String.class));
+        assertEquals(StylesService.SLD10, json.read("$.conformsTo[4]", String.class));
+        assertEquals(StylesService.SLD11, json.read("$.conformsTo[5]", String.class));
         // check the others as they get implemented
     }
 
@@ -28,5 +33,17 @@ public class ConformanceTest extends StylesTestSupport {
     public void testCollectionsYaml() throws Exception {
         String yaml = getAsString("ogc/styles/conformance/?f=application/x-yaml");
         checkConformance(convertYamlToJsonPath(yaml));
+    }
+
+    @Test
+    public void testConformanceHTML() throws Exception {
+        org.jsoup.nodes.Document document = getAsJSoup("ogc/styles/conformance?f=text/html");
+        assertEquals("GeoServer OGC API Styles Conformance", document.select("#title").text());
+        assertEquals(StylesService.CORE, document.select("#content li:eq(0)").text());
+        assertEquals(StylesService.HTML, document.select("#content li:eq(1)").text());
+        assertEquals(StylesService.JSON, document.select("#content li:eq(2)").text());
+        assertEquals(StylesService.MAPBOX, document.select("#content li:eq(3)").text());
+        assertEquals(StylesService.SLD10, document.select("#content li:eq(4)").text());
+        assertEquals(StylesService.SLD11, document.select("#content li:eq(5)").text());
     }
 }

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/LandingPageTest.java
@@ -103,6 +103,9 @@ public class LandingPageTest extends StylesTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/styles/api?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/styles/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
     }
 
     void checkJSONLandingPage(DocumentContext json) {

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
@@ -84,6 +84,8 @@ public class TilesService {
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/multitiles";
     public static final String CC_INFO = "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/info";
 
+    private static final String DISPLAY_NAME = "OGC API Tiles";
+
     private final GeoServer geoServer;
     private final GWC gwc;
     private final WMS wms;
@@ -134,6 +136,7 @@ public class TilesService {
 
     @GetMapping(path = "conformance", name = "getConformanceDeclaration")
     @ResponseBody
+    @HTMLResponseBody(templateName = "conformance.ftl", fileName = "conformance.html")
     public ConformanceDocument conformance() {
         List<String> classes =
                 Arrays.asList(
@@ -142,7 +145,7 @@ public class TilesService {
                         CC_TILESET,
                         CC_MULTITILES,
                         CC_INFO);
-        return new ConformanceDocument(classes);
+        return new ConformanceDocument(DISPLAY_NAME, classes);
     }
 
     @GetMapping(path = "tileMatrixSets", name = "getTileMatrixSets")

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/tiles/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/tiles/landingPage.ftl
@@ -29,6 +29,8 @@
        <#list model.getLinksExcept("collections", "text/html") as link><a href="${link.href}">${link.type}</a><#if link_has_next>, </#if></#list>.
        </p>
        
+       <#include "landingpage-conformance.ftl">
+
        <h2>Contact information</h2>
        <ul>
        <li>Server managed by ${contact.contactPerson!"-unspecified-"}</li>

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/ConformanceTest.java
@@ -19,6 +19,8 @@ public class ConformanceTest extends TilesTestSupport {
     }
 
     private void checkConformance(DocumentContext json) {
+        assertEquals(1, (int) json.read("$.length()", Integer.class));
+        assertEquals(5, (int) json.read("$.conformsTo.length()", Integer.class));
         assertEquals(ConformanceClass.CORE, json.read("$.conformsTo[0]", String.class));
         assertEquals(ConformanceClass.COLLECTIONS, json.read("$.conformsTo[1]", String.class));
         assertEquals(TilesService.CC_TILESET, json.read("$.conformsTo[2]", String.class));
@@ -31,5 +33,16 @@ public class ConformanceTest extends TilesTestSupport {
     public void testCollectionsYaml() throws Exception {
         String yaml = getAsString("ogc/tiles/conformance/?f=application/x-yaml");
         checkConformance(convertYamlToJsonPath(yaml));
+    }
+
+    @Test
+    public void testConformanceHTML() throws Exception {
+        org.jsoup.nodes.Document document = getAsJSoup("ogc/tiles/conformance?f=text/html");
+        assertEquals("GeoServer OGC API Tiles Conformance", document.select("#title").text());
+        assertEquals(ConformanceClass.CORE, document.select("#content li:eq(0)").text());
+        assertEquals(ConformanceClass.COLLECTIONS, document.select("#content li:eq(1)").text());
+        assertEquals(TilesService.CC_TILESET, document.select("#content li:eq(2)").text());
+        assertEquals(TilesService.CC_MULTITILES, document.select("#content li:eq(3)").text());
+        assertEquals(TilesService.CC_INFO, document.select("#content li:eq(4)").text());
     }
 }

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/LandingPageTest.java
@@ -104,6 +104,9 @@ public class LandingPageTest extends TilesTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/tiles/api?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/tiles/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
     }
 
     @Test
@@ -116,6 +119,9 @@ public class LandingPageTest extends TilesTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/sf/ogc/tiles/api?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/sf/ogc/tiles/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
     }
 
     void checkJSONLandingPage(DocumentContext json) {


### PR DESCRIPTION
Adds a HTML version of the conformance statement for various OGC API services, and links for the conformance page off the main landing page. Only affects community modules.

Includes tests.

## Checklist
For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
