### PR TITLE
fix a `code-block::` directive

### DIFF
--- a/doc/en/user/source/extensions/cas/index.rst
+++ b/doc/en/user/source/extensions/cas/index.rst
@@ -84,7 +84,7 @@ from a given attribute repository, and then allow their release in the GeoServer
 For example, the following ``cas.properties`` file sets up a JDBC user source, as well as as JDBC
 attribute repository (this configuration file might useful for testing purposes, but not setup for production):
 
-.. code-block::
+.. code-block:: none
 
     cas.server.name=https://localhost:8443
     cas.server.prefix=${cas.server.name}/cas


### PR DESCRIPTION
This fixes the error shown below. Perhaps my sphinx is more picky than others

```
└─ $ ▶ which sphinx-build
/usr/bin/sphinx-build
└─ $ ▶ /usr/bin/sphinx-build --version
sphinx-build 1.8.5
```

```
sphinx:
     [echo] Running sphinx-build -D release=2.19-SNAPSHOT -W -b html -d "/home/mark/dev/projects/geoserver/doc/en/target/user/doctrees" . "/home/mark/dev/projects/geoserver/doc/en/target/user/html"
     [exec] /home/mark/dev/projects/geoserver/doc/en/user/source/community/wps-jdbc/index.rst:27: WARNING: Error in "code-block" directive:
     [exec] 1 argument(s) required, 0 supplied.

...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.101 s
[INFO] Finished at: 2021-02-18T10:42:10+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.3:run (sphinx) on project gs-docs: An Ant BuildException has occured: The following error occurred while executing this line:
[ERROR] /home/mark/dev/projects/geoserver/doc/en/build.xml:48: The following error occurred while executing this line:
[ERROR] /home/mark/dev/projects/geoserver/doc/en/build.xml:101: exec returned: 1

```


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
