### PR TITLE
[GEOS-9920] Log resource name when failing to load a style or layer group

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -101,17 +101,23 @@ public abstract class GeoServerLoader {
         }
     }
 
-    /** Data store IO resources */
-    static final class StoreContents {
-        Resource resource;
-        byte[] contents;
+    /**
+     * Holder for both the contents and the resource of a single file to aid in identifying the
+     * offending file when loading fails *
+     */
+    static final class SingleResourceContents {
+        final Resource resource;
+        final byte[] contents;
 
-        public StoreContents(Resource resource, byte[] contents) {
-            super();
+        public SingleResourceContents(Resource resource, byte[] contents) {
             this.resource = resource;
             this.contents = contents;
         }
     }
+
+    /** Basic {@link ResourceMapper} for a single {@link Resource} * */
+    static final ResourceMapper<SingleResourceContents> RESOURCE_MAPPER =
+            r -> new SingleResourceContents(r, r.getContents());
 
     /** Layer IO resources */
     static final class LayerContents {
@@ -554,24 +560,24 @@ public abstract class GeoServerLoader {
                 }
             }
 
-            // maps each store into a StoreContents
-            ResourceMapper<StoreContents> storeMapper =
+            // maps each store into a SingleResourceContents
+            ResourceMapper<SingleResourceContents> storeMapper =
                     sd -> {
                         Resource f = sd.get("datastore.xml");
                         if (Resources.exists(f)) {
-                            return new StoreContents(f, f.getContents());
+                            return new SingleResourceContents(f, f.getContents());
                         }
                         f = sd.get("coveragestore.xml");
                         if (Resources.exists(f)) {
-                            return new StoreContents(f, f.getContents());
+                            return new SingleResourceContents(f, f.getContents());
                         }
                         f = sd.get("wmsstore.xml");
                         if (Resources.exists(f)) {
-                            return new StoreContents(f, f.getContents());
+                            return new SingleResourceContents(f, f.getContents());
                         }
                         f = sd.get("wmtsstore.xml");
                         if (Resources.exists(f)) {
-                            return new StoreContents(f, f.getContents());
+                            return new SingleResourceContents(f, f.getContents());
                         }
                         if (!isConfigDirectory(sd)) {
                             LOGGER.warning("Ignoring store directory '" + sd.name() + "'");
@@ -582,24 +588,24 @@ public abstract class GeoServerLoader {
 
             for (Resource wsd : workspaceList) {
                 // load the stores for this workspace
-                try (AsynchResourceIterator<StoreContents> it =
+                try (AsynchResourceIterator<SingleResourceContents> it =
                         new AsynchResourceIterator<>(
                                 wsd, Resources.DirectoryFilter.INSTANCE, storeMapper)) {
                     while (it.hasNext()) {
-                        StoreContents storeContents = it.next();
-                        final String resourceName = storeContents.resource.name();
+                        SingleResourceContents SingleResourceContents = it.next();
+                        final String resourceName = SingleResourceContents.resource.name();
                         if ("datastore.xml".equals(resourceName)) {
-                            loadDataStore(storeContents, catalog, xp, checkStores);
+                            loadDataStore(SingleResourceContents, catalog, xp, checkStores);
                         } else if ("coveragestore.xml".equals(resourceName)) {
-                            loadCoverageStore(storeContents, catalog, xp);
+                            loadCoverageStore(SingleResourceContents, catalog, xp);
                         } else if ("wmsstore.xml".equals(resourceName)) {
-                            loadWmsStore(storeContents, catalog, xp);
+                            loadWmsStore(SingleResourceContents, catalog, xp);
                         } else if ("wmtsstore.xml".equals(resourceName)) {
-                            loadWmtsStore(storeContents, catalog, xp);
-                        } else if (!isConfigDirectory(storeContents.resource)) {
+                            loadWmtsStore(SingleResourceContents, catalog, xp);
+                        } else if (!isConfigDirectory(SingleResourceContents.resource)) {
                             LOGGER.warning(
                                     "Ignoring store directory '"
-                                            + storeContents.resource.name()
+                                            + SingleResourceContents.resource.name()
                                             + "'");
                             continue;
                         }
@@ -631,11 +637,13 @@ public abstract class GeoServerLoader {
     }
 
     private void loadWmsStore(
-            StoreContents storeContents, CatalogImpl catalog, XStreamPersister xp) {
-        final Resource storeResource = storeContents.resource;
+            SingleResourceContents SingleResourceContents,
+            CatalogImpl catalog,
+            XStreamPersister xp) {
+        final Resource storeResource = SingleResourceContents.resource;
         WMSStoreInfo wms = null;
         try {
-            wms = depersist(xp, storeContents.contents, WMSStoreInfo.class);
+            wms = depersist(xp, SingleResourceContents.contents, WMSStoreInfo.class);
             catalog.add(wms);
 
             LOGGER.info(
@@ -664,11 +672,13 @@ public abstract class GeoServerLoader {
     }
 
     private void loadWmtsStore(
-            StoreContents storeContents, CatalogImpl catalog, XStreamPersister xp) {
-        final Resource storeResource = storeContents.resource;
+            SingleResourceContents SingleResourceContents,
+            CatalogImpl catalog,
+            XStreamPersister xp) {
+        final Resource storeResource = SingleResourceContents.resource;
         WMTSStoreInfo wmts = null;
         try {
-            wmts = depersist(xp, storeContents.contents, WMTSStoreInfo.class);
+            wmts = depersist(xp, SingleResourceContents.contents, WMTSStoreInfo.class);
             catalog.add(wmts);
 
             LOGGER.info("Loaded wmtsstore '" + wmts.getName() + "'");
@@ -694,11 +704,13 @@ public abstract class GeoServerLoader {
     }
 
     private void loadCoverageStore(
-            StoreContents storeContents, CatalogImpl catalog, XStreamPersister xp) {
+            SingleResourceContents SingleResourceContents,
+            CatalogImpl catalog,
+            XStreamPersister xp) {
         CoverageStoreInfo cs = null;
-        final Resource storeResource = storeContents.resource;
+        final Resource storeResource = SingleResourceContents.resource;
         try {
-            cs = depersist(xp, storeContents.contents, CoverageStoreInfo.class);
+            cs = depersist(xp, SingleResourceContents.contents, CoverageStoreInfo.class);
             catalog.add(cs);
 
             if (LOGGER.isLoggable(Level.INFO)) {
@@ -732,14 +744,14 @@ public abstract class GeoServerLoader {
     }
 
     private void loadDataStore(
-            StoreContents storeContents,
+            SingleResourceContents SingleResourceContents,
             CatalogImpl catalog,
             XStreamPersister xp,
             boolean checkStores) {
-        final Resource storeResource = storeContents.resource;
+        final Resource storeResource = SingleResourceContents.resource;
         DataStoreInfo ds;
         try {
-            ds = depersist(xp, storeContents.contents, DataStoreInfo.class);
+            ds = depersist(xp, SingleResourceContents.contents, DataStoreInfo.class);
             catalog.add(ds);
 
             if (LOGGER.isLoggable(Level.INFO)) {
@@ -961,29 +973,31 @@ public abstract class GeoServerLoader {
     void loadStyles(Resource styles, Catalog catalog, XStreamPersister xp) throws IOException {
         Filter<Resource> styleFilter =
                 r -> XML_FILTER.accept(r) && !Resources.exists(styles.get(r.name() + ".xml"));
-        try (AsynchResourceIterator<byte[]> it =
-                new AsynchResourceIterator<>(styles, styleFilter, r -> r.getContents())) {
+        try (AsynchResourceIterator<SingleResourceContents> it =
+                new AsynchResourceIterator<>(styles, styleFilter, RESOURCE_MAPPER)) {
             while (it.hasNext()) {
+                SingleResourceContents r = it.next();
                 try {
-                    StyleInfo s = depersist(xp, it.next(), StyleInfo.class);
+                    StyleInfo s = depersist(xp, r.contents, StyleInfo.class);
                     catalog.add(s);
 
                     if (LOGGER.isLoggable(Level.INFO)) {
                         LOGGER.info("Loaded style '" + s.getName() + "'");
                     }
                 } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Failed to load style", e);
+                    LOGGER.log(Level.WARNING, "Failed to load style" + r.resource.name(), e);
                 }
             }
         }
     }
 
     void loadLayerGroups(Resource layerGroups, Catalog catalog, XStreamPersister xp) {
-        try (AsynchResourceIterator<byte[]> it =
-                new AsynchResourceIterator<>(layerGroups, XML_FILTER, r -> r.getContents())) {
+        try (AsynchResourceIterator<SingleResourceContents> it =
+                new AsynchResourceIterator<>(layerGroups, XML_FILTER, RESOURCE_MAPPER)) {
             while (it.hasNext()) {
+                SingleResourceContents r = it.next();
                 try {
-                    LayerGroupInfo lg = depersist(xp, it.next(), LayerGroupInfo.class);
+                    LayerGroupInfo lg = depersist(xp, r.contents, LayerGroupInfo.class);
                     if (lg.getLayers() == null || lg.getLayers().size() == 0) {
                         LOGGER.warning(
                                 "Skipping empty layer group '" + lg.getName() + "', it is invalid");
@@ -993,7 +1007,7 @@ public abstract class GeoServerLoader {
 
                     LOGGER.info("Loaded layer group '" + lg.getName() + "'");
                 } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Failed to load layer group", e);
+                    LOGGER.log(Level.WARNING, "Failed to load layer group " + r.resource.name(), e);
                 }
             }
         }


### PR DESCRIPTION
Rename inner class `StoreContents` as `SingleResourceContents`, and use it
also for the async loading of styles and layer groups, so the log
message can include the resource name when an error occurrs loading them.

> Note no test case added, doesn't seem easily feasible to unit test a log message?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [N/A] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
