### PR TITLE
[GEOS-9921] Include layer name(s) in WMS ServiceException

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/RenderedImageMapOutputFormat.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import javax.media.jai.ImageLayout;
 import javax.media.jai.Interpolation;
 import javax.media.jai.InterpolationBicubic2;
@@ -49,6 +50,7 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.DefaultWebMapService;
 import org.geoserver.wms.GetMapOutputFormat;
 import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.MapLayerInfo;
 import org.geoserver.wms.MapProducerCapabilities;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSInfo;
@@ -632,7 +634,8 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                         new ServiceException(
                                 "More than "
                                         + maxErrors
-                                        + " rendering errors occurred, bailing out.",
+                                        + " rendering errors occurred, bailing out. Layers: "
+                                        + buildMapLayerNameList(mapContent),
                                 errorChecker.getLastException(),
                                 "internalError");
             }
@@ -643,14 +646,18 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
                                 "This request used more time than allowed and has been forcefully stopped. "
                                         + "Max rendering time is "
                                         + (maxRenderingTime / 1000.0)
-                                        + "s");
+                                        + "s. Layers: "
+                                        + buildMapLayerNameList(mapContent));
             }
             // check if a non ignorable error occurred
             if (nonIgnorableExceptionListener.exceptionOccurred()) {
                 Exception renderError = nonIgnorableExceptionListener.getException();
                 serviceException =
                         new ServiceException(
-                                "Rendering process failed", renderError, "internalError");
+                                "Rendering process failed. Layers: "
+                                        + buildMapLayerNameList(mapContent),
+                                renderError,
+                                "internalError");
             }
 
             // If there were no exceptions, return the map
@@ -676,6 +683,14 @@ public class RenderedImageMapOutputFormat extends AbstractMapOutputFormat {
             }
         }
         throw serviceException;
+    }
+
+    /** Helper method to build a comma separated list of layer names in the map. * */
+    private String buildMapLayerNameList(WMSMapContent mapContent) {
+        List<MapLayerInfo> layers = mapContent.getRequest().getLayers();
+        return layers == null
+                ? ""
+                : layers.stream().map(MapLayerInfo::getName).collect(Collectors.joining(", "));
     }
 
     /**

--- a/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatTest.java
@@ -6,6 +6,9 @@
 package org.geoserver.wms.map;
 
 import static org.geoserver.data.test.CiteTestData.STREAMS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -695,6 +698,8 @@ public class RenderedImageMapOutputFormatTest extends WMSTestSupport {
                                         MockData.BASIC_POLYGONS.getPrefix(),
                                         MockData.BASIC_POLYGONS.getLocalPart())
                                 .getFeatureSource(null, null);
+        MapLayerInfo mapLayerInfo = new MapLayerInfo(fs);
+        request.setLayers(Collections.singletonList(mapLayerInfo));
         Envelope env = fs.getBounds();
         SimpleFeatureCollection features = fs.getFeatures();
         SimpleFeatureCollection delayedCollection = new DelayedFeatureCollection(features, 50);
@@ -720,7 +725,10 @@ public class RenderedImageMapOutputFormatTest extends WMSTestSupport {
             RenderedImageMap imageMap = this.rasterMapProducer.produceMap(map);
             fail("Timeout was not reached");
         } catch (ServiceException e) {
-            assertTrue(e.getMessage().startsWith("This request used more time than allowed"));
+            assertThat(e.getMessage(), startsWith("This request used more time than allowed"));
+            String expectedLayerNameMsg =
+                    "Layers: " + mapLayerInfo.getRemoteFeatureSource().getSchema().getTypeName();
+            assertThat(e.getMessage(), containsString(expectedLayerNameMsg));
         }
 
         // Test partial image exception format


### PR DESCRIPTION
When GetMap fails due to timeout, max error count reached, or other
non-ignorable exception, include the requested layer names in the error
message.

This exceptions get logged and otherwise it's difficult for an admin to
figure out which layers are causing trouble.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
