### PR TITLE
[2.18.x backport][GEOS-9922] include Db2 JDBC driver dependency

### DIFF
--- a/src/release/ext-db2.xml
+++ b/src/release/ext-db2.xml
@@ -18,6 +18,7 @@
 			<includes>
 				<include>gt-jdbc-core-*.jar</include>
 				<include>gt-jdbc-db2-*.jar</include>
+				<include>jcc-*.jar</include>
 			</includes>
 		</fileSet>
 		<fileSet>
@@ -25,6 +26,7 @@
 			<outputDirectory></outputDirectory>
 			<includes>
 				<include>LICENSE.txt</include>
+				<include>IBM-IPLA.txt</include>
 			</includes>
 		</fileSet>
         <fileSet>

--- a/src/release/extensions/IBM-IPLA.txt
+++ b/src/release/extensions/IBM-IPLA.txt
@@ -1,0 +1,50 @@
+LICENSE INFORMATION
+
+The Programs listed below are licensed under the following License Information terms and conditions
+in addition to the Program license terms previously agreed to by Client and IBM. If Client does not
+have previously agreed to license terms in effect for the Program, the International Program License
+Agreement (Z125-3301-14) applies.
+
+Program Name (Program Number):
+IBM Data Server Driver for JDBC and SQLJ v4.28 (11.5.5.0) (Tool)
+
+The following standard terms apply to Licensee's use of the Program.
+
+Limited use right
+
+Licensee is not authorized to use the Program to provide commercial IT services to any third party,
+to provide commercial hosting or timesharing, or to sublicense, rent, or lease the Program unless
+expressly provided for in the applicable agreements under which Licensee obtains authorizations to
+use the Program.
+
+Prohibited Uses
+
+Licensee may not use or authorize others to use the Program if failure of the Program could lead to
+death, bodily injury, or property or environmental damage.
+
+Redistributables
+
+The Program includes components that are Redistributable and they are listed below.
+Redistributables may be distributed, in object-code form, only as part of Licensee's value-added
+application that was developed using the Program ("Licensee's Application") and only to support use
+of Licensee's Application. If the Redistributables include a Java Runtime Environment, Licensee must
+also include other non-Java Redistributables with Licensee's Application. Licensee may not remove
+any copyright or notice files contained in the Redistributables or use IBM's, it's suppliers' or
+distributors' names or trademarks in connection with the marketing of Licensee's Application without
+IBM's or that supplier's or distributor's prior written consent. Licensee's license agreement with
+the end user must be at least as protective of IBM as the terms of this Agreement.
+
+IBM, its suppliers and distributors provide the Redistributables and related documentation without
+obligation of support and "AS IS", WITH NO WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+THE WARRANTY OF TITLE, NON-INFRINGEMENT OR NON-INTERFERENCE AND THE IMPLIED WARRANTIES AND CONDITIONS
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+The following are Redistributables:
+db2jcc4.jar
+sqlj4.zip
+
+L/N: L-CONN-BRAKR7
+D/N: L-CONN-BRAKR7
+P/N: L-CONN-BRAKR7
+
+https://www-03.ibm.com/software/sla/sladb.nsf/lilookup/179A6D1769B0A44D8525862400329FB8?OpenDocument

--- a/src/release/extensions/db2/db2-readme.txt
+++ b/src/release/extensions/db2/db2-readme.txt
@@ -10,15 +10,12 @@ Any other issues can be discussed on the mailing list (http://lists.sourceforge.
 
 INSTALLATION
 
-1. Copy the included gt2-db2 jar to your
+1. Copy the included jar files to your
 GeoServer library directory. In a binary install this is at
 [GEOSERVER_HOME]/server/geoserver/WEB-INF/lib/
 In a war install this is [container]/webapps/geoserver/WEB-INF/lib/
 
-2. Copy db2jcc_license_cu.jar and db2jcc.jar from the DB2 instance installation directory
-$DB2PATH/java to your GeoServer library directory.
-
-3. Restart GeoServer.
+2. Restart GeoServer.
 
 DB2 should now show up as an option in the web admin tool at
 Config -> Data -> DataStores -> New. Fill out the appropriate params.
@@ -26,5 +23,5 @@ For more information http://docs.geoserver.org/latest/en/user/data/database/db2.
 
 COMPATIBILITY
 
-This jar should work with any version of GeoServer based on GeoTools 15.x
-Currently this is anything in 2.9.x
+This jar should work with any version of GeoServer based on GeoTools 15.x and above
+This is GeoServer versions 2.9.x and above.


### PR DESCRIPTION
backports #4763 to 2.18.x
depends on https://github.com/geotools/geotools/pull/3362