### PR TITLE
[GEOS-9927] Add StyleComponentInfo in AbstractStylePage

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -613,6 +613,23 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
                     }
                 };
         add(cancelLink);
+
+        // add additional style components that may be used e.g. by extensions
+        List<StyleComponentInfo> compInfo =
+                getGeoServerApplication().getBeansOfType(StyleComponentInfo.class);
+        for (StyleComponentInfo comp : compInfo) {
+            try {
+                Class<?> component = comp.getComponentClass();
+                Component c =
+                        (Component)
+                                component
+                                        .getConstructor(String.class, AbstractStylePage.class)
+                                        .newInstance(comp.getId(), this);
+                styleForm.add(c);
+            } catch (Exception e) {
+                throw new WicketRuntimeException(e);
+            }
+        }
     }
 
     StyleHandler styleHandler() {

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleComponentInfo.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleComponentInfo.java
@@ -1,0 +1,20 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.web.data;
+
+import org.geoserver.web.ComponentInfo;
+
+/**
+ * Extend this class in your extensions applicationContext to get instantiated in the
+ * `AbstractStylePage` and get access to the style edit pages.
+ */
+public class StyleComponentInfo extends ComponentInfo {
+    public StyleComponentInfo(String id, AbstractStylePage parent) {}
+
+    public StyleComponentInfo(String id) {}
+
+    public StyleComponentInfo() {}
+}

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleComponentBean.xml
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleComponentBean.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+    <bean id="style-component-mock" class="org.geoserver.wms.web.data.StyleEditPageTest$MockStyleComponentInfo">
+        <property name="id" value="MyStyleComponent"/>
+        <property name="componentClass" value="org.geoserver.wms.web.data.StyleEditPageTest$MockStyleComponent"/>
+    </bean>
+</beans>

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -35,6 +35,7 @@ import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.util.tester.FormTester;
 import org.apache.wicket.util.tester.WicketTester;
 import org.apache.wicket.util.tester.WicketTesterHelper;
@@ -78,6 +79,12 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
 
     StyleInfo buildingsStyle;
     StyleEditPage edit;
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath*:/org/geoserver/wms/web/data/StyleComponentBean.xml");
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -956,5 +963,38 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
 
         tester.executeAjaxEvent("validate", "click");
         tester.assertNoErrorMessage();
+    }
+
+    @Test
+    public void testStyleComponents() {
+        // Reload the page
+        tester.startPage(
+                new StyleEditPage(getCatalog().getStyleByName(MockData.BUILDINGS.getLocalPart())));
+
+        // check for correct bean initialization
+        getGeoServerApplication().getApplicationContext().getBean("style-component-mock");
+
+        // check for correct registration by Extension
+        List<StyleComponentInfo> compInfo =
+                getGeoServerApplication().getBeansOfType(StyleComponentInfo.class);
+        assertEquals(1, compInfo.size());
+
+        // check for correct embedding in page
+        tester.assertComponent(
+                "styleForm:style-component-mock", StyleEditPageTest.MockStyleComponent.class);
+    }
+
+    public static class MockStyleComponentInfo extends StyleComponentInfo {
+        public MockStyleComponentInfo(String id, AbstractStylePage clazz) {
+            super("test", clazz);
+        }
+
+        public MockStyleComponentInfo() {}
+    }
+
+    public static class MockStyleComponent extends Panel {
+        public MockStyleComponent(String id, AbstractStylePage clazz) {
+            super("style-component-mock");
+        }
     }
 }


### PR DESCRIPTION
This adds a new entry point for extensions to be instantiated in the AbstractStylePage and thus get access to the style edit pages. For more information, see https://osgeo-org.atlassian.net/browse/GEOS-9927

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
