### PR TITLE
[GEOS-9928] Make GeoServer runs its startup loading process as root

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/DefaultGeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/DefaultGeoServerLoader.java
@@ -24,6 +24,8 @@ public class DefaultGeoServerLoader extends GeoServerLoader {
     ConfigurationListener listener;
     GeoServerConfigPersister configPersister;
 
+    private GeoServerLoaderListener loaderListener = null;
+
     public DefaultGeoServerLoader(GeoServerResourceLoader resourceLoader) {
         super(resourceLoader);
     }
@@ -38,6 +40,7 @@ public class DefaultGeoServerLoader extends GeoServerLoader {
             catalog.addListener(new GeoServerConfigPersister(resourceLoader, xp));
             catalog.addListener(new GeoServerResourcePersister(catalog));
         }
+        executeListener(catalog, xp);
     }
 
     protected void loadGeoServer(final GeoServer geoServer, XStreamPersister xp) throws Exception {
@@ -67,6 +70,7 @@ public class DefaultGeoServerLoader extends GeoServerLoader {
             // attach back the catalog persister and the service one
             geoserver.addListener(configPersister);
             geoserver.addListener(listener);
+            executeListener(geoServer, xp);
         }
     }
 
@@ -82,5 +86,27 @@ public class DefaultGeoServerLoader extends GeoServerLoader {
 
         catalog.removeListener(cp);
         catalog.removeListener(rp);
+    }
+
+    protected void executeListener(Catalog catalog, XStreamPersister xp) {
+        getLoaderListener().loadCatalog(catalog, xp);
+    }
+
+    protected void executeListener(GeoServer geoServer, XStreamPersister xp) {
+        getLoaderListener().loadGeoServer(geoServer, xp);
+    }
+
+    private GeoServerLoaderListener getLoaderListener() {
+        if (loaderListener == null) {
+            loadLoaderListener();
+        }
+        return loaderListener;
+    }
+
+    /** Loads the registered listener from Spring application context if exists. */
+    private synchronized void loadLoaderListener() {
+        if (loaderListener != null) return;
+        GeoServerLoaderListener bean = GeoServerExtensions.bean(GeoServerLoaderListener.class);
+        loaderListener = bean != null ? bean : GeoServerLoaderListener.EMPTY_LISTENER;
     }
 }

--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoaderListener.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoaderListener.java
@@ -1,0 +1,43 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.util.XStreamPersister;
+
+/**
+ * Listener interface for {@linkplain DefaultGeoServerLoader} load catalog and geoServer startup
+ * process.
+ */
+public interface GeoServerLoaderListener {
+
+    public static final GeoServerLoaderListener EMPTY_LISTENER = new EmptyGeoServerLoaderListener();
+
+    /**
+     * Listener method executed after GeoServer catalog loading procedure.
+     *
+     * @param catalog GeoServer catalog instance
+     * @param xp {@linkplain XStreamPersister} instance
+     */
+    void loadCatalog(Catalog catalog, XStreamPersister xp);
+
+    /**
+     * Listener method executed after GeoServer setup loading procedure.
+     *
+     * @param geoServer GeoServer instance
+     * @param xp {@linkplain XStreamPersister} instance
+     */
+    void loadGeoServer(GeoServer geoServer, XStreamPersister xp);
+
+    /** Empty implementation to mark there is no listener active. */
+    public static final class EmptyGeoServerLoaderListener implements GeoServerLoaderListener {
+
+        @Override
+        public void loadCatalog(Catalog catalog, XStreamPersister xp) {}
+
+        @Override
+        public void loadGeoServer(GeoServer geoServer, XStreamPersister xp) {}
+    }
+}

--- a/src/main/src/test/java/applicationContext.xml
+++ b/src/main/src/test/java/applicationContext.xml
@@ -12,4 +12,7 @@
   <bean id="memoryRISecurityProvider" class="org.geoserver.security.impl.MemoryReadOnlySecurityProvider"/>
 
   <bean id="propStyleHandler" class="org.geoserver.catalog.PropertyStyleHandler"/>
+  
+  <bean id="rootStartupListener" class="org.geoserver.config.RootStartupListener"/>
+  
 </beans>

--- a/src/main/src/test/java/org/geoserver/config/GeoServerRootStartupTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerRootStartupTest.java
@@ -1,0 +1,77 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.security.impl.GeoServerRole;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Testing class to check the roles involved on catalog and geoserver startup loading process should
+ * be ADMIN.
+ */
+public class GeoServerRootStartupTest extends GeoServerSystemTestSupport {
+
+    private volatile Collection<? extends GrantedAuthority> catalogRoles = null;
+    private volatile Collection<? extends GrantedAuthority> geoServerRoles = null;
+
+    @Override
+    protected void setUpTestData(SystemTestData testData) throws Exception {
+        super.setUpTestData(testData);
+        testData.setUpDefault();
+        RootStartupListener.setListener(
+                new GeoServerLoaderListener() {
+
+                    @Override
+                    public void loadGeoServer(GeoServer geoServer, XStreamPersister xp) {
+                        catalogRoles = getCurrentRoles();
+                    }
+
+                    @Override
+                    public void loadCatalog(Catalog catalog, XStreamPersister xp) {
+                        geoServerRoles = getCurrentRoles();
+                    }
+                });
+    }
+
+    @After
+    public void onEnd() {
+        RootStartupListener.setListener(GeoServerLoaderListener.EMPTY_LISTENER);
+    }
+
+    @Test
+    public void testRootStartupCatalogLoad() {
+        assertTrue(hasAdminRole(catalogRoles));
+        assertTrue(hasAdminRole(geoServerRoles));
+    }
+
+    private boolean hasAdminRole(Collection<? extends GrantedAuthority> roles) {
+        if (roles == null) return false;
+        for (GrantedAuthority grantedAuthority : roles) {
+            if (GeoServerRole.ADMIN_ROLE.equals(grantedAuthority)
+                    || GeoServerRole.GROUP_ADMIN_ROLE.equals(grantedAuthority)) return true;
+        }
+        return false;
+    }
+
+    private static Collection<? extends GrantedAuthority> getCurrentRoles() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        if (context == null || context.getAuthentication() == null) {
+            return Collections.emptyList();
+        }
+        return context.getAuthentication().getAuthorities();
+    }
+}

--- a/src/main/src/test/java/org/geoserver/config/RootStartupListener.java
+++ b/src/main/src/test/java/org/geoserver/config/RootStartupListener.java
@@ -1,0 +1,32 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.util.XStreamPersister;
+
+/**
+ * Testing utility listener to check the roles involved on catalog and geoserver startup loading
+ * process. Defined in testing applicationContext.xml file as id="rootStartupListener".
+ */
+public class RootStartupListener implements GeoServerLoaderListener {
+
+    private static volatile GeoServerLoaderListener delegate =
+            GeoServerLoaderListener.EMPTY_LISTENER;
+
+    @Override
+    public void loadCatalog(Catalog catalog, XStreamPersister xp) {
+        delegate.loadCatalog(catalog, xp);
+    }
+
+    @Override
+    public void loadGeoServer(GeoServer geoServer, XStreamPersister xp) {
+        delegate.loadGeoServer(geoServer, xp);
+    }
+
+    public static void setListener(GeoServerLoaderListener listener) {
+        delegate = listener;
+    }
+}


### PR DESCRIPTION
GeoServer is not Root/Admin during startup process, making it fails to load secured workspaces settings (WMS, WFS, ...).  Current workaround is to reload catalog from Admin user UI.  This PR introduces a fix to this issue, making GeoServer uses the root user and admin role during its startup loading process.

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-9928

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
