### PR TITLE
[GEOS-9331] Upgrade Freemarker to 2.3.31

### DIFF
--- a/src/main/src/main/java/org/geoserver/template/FeatureWrapper.java
+++ b/src/main/src/main/java/org/geoserver/template/FeatureWrapper.java
@@ -5,9 +5,12 @@
  */
 package org.geoserver.template;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
+
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.CollectionModel;
 import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.SimpleHash;
 import freemarker.template.TemplateCollectionModel;
 import freemarker.template.TemplateModel;
@@ -106,11 +109,13 @@ public class FeatureWrapper extends BeansWrapper {
     protected TemplateFeatureCollectionFactory templateFeatureCollectionFactory;
 
     public FeatureWrapper() {
+        super(FM_VERSION);
         setSimpleMapWrapper(true);
         this.templateFeatureCollectionFactory = copyTemplateFeatureCollectionFactory;
     }
 
     public FeatureWrapper(TemplateFeatureCollectionFactory templateFeatureCollectionFactory) {
+        super(FM_VERSION);
         setSimpleMapWrapper(true);
         this.templateFeatureCollectionFactory = templateFeatureCollectionFactory;
     }
@@ -201,7 +206,7 @@ public class FeatureWrapper extends BeansWrapper {
         // check for feature collection
         if (object instanceof FeatureCollection) {
             // create a model with just one variable called 'features'
-            SimpleHash map = new SimpleHash();
+            SimpleHash map = new SimpleHash(new DefaultObjectWrapper(FM_VERSION));
             map.put(
                     "features",
                     templateFeatureCollectionFactory.createTemplateFeatureCollection(
@@ -241,7 +246,7 @@ public class FeatureWrapper extends BeansWrapper {
 
         // build up the result, feature type is represented by its name an
         // attributes
-        SimpleHash map = new SimpleHash();
+        SimpleHash map = new SimpleHash(new DefaultObjectWrapper(FM_VERSION));
         map.put("attributes", new SequenceMapModel(attributeMap, this));
         map.put("name", ft.getName().getLocalPart());
         map.put("namespace", getNamespace(ft.getName()));
@@ -252,7 +257,7 @@ public class FeatureWrapper extends BeansWrapper {
 
     private SimpleHash buildComplex(ComplexAttribute att) {
         // create the model
-        SimpleHash map = new SimpleHash();
+        SimpleHash map = new SimpleHash(new DefaultObjectWrapper(FM_VERSION));
 
         // next create the Map representing the per attribute useful
         // properties for a template

--- a/src/main/src/main/java/org/geoserver/template/TemplateUtils.java
+++ b/src/main/src/main/java/org/geoserver/template/TemplateUtils.java
@@ -5,9 +5,12 @@
 
 package org.geoserver.template;
 
+import static freemarker.template.Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS;
+
 import freemarker.core.TemplateClassResolver;
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
+import freemarker.template.Version;
 import freemarker.template.utility.ClassUtil;
 import java.util.Arrays;
 import java.util.Collection;
@@ -18,6 +21,9 @@ import java.util.Collection;
  * @author Kevin Smith, Boundless
  */
 public class TemplateUtils {
+    /** Reference feature version for Freemarker templates */
+    public static Version FM_VERSION = Configuration.VERSION_2_3_0;
+
     /** Classes that should not be resolved in Freemarker templates */
     private static final Collection<String> ILLEGAL_FREEMARKER_CLASSES =
             Arrays.asList(
@@ -32,7 +38,7 @@ public class TemplateUtils {
 
     /** Get a Freemarker configuration that is safe against malicious templates */
     public static Configuration getSafeConfiguration() {
-        Configuration config = new Configuration();
+        Configuration config = new Configuration(DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
         config.setNewBuiltinClassResolver(
                 (name, env, template) -> {
                     if (ILLEGAL_FREEMARKER_CLASSES.stream().anyMatch(name::equals)) {

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1070,7 +1070,7 @@
    <dependency>
     <groupId>org.freemarker</groupId>
     <artifactId>freemarker</artifactId>
-    <version>2.3.18</version>
+    <version>2.3.31</version>
    </dependency>
    <dependency> 
      <groupId>net.sf.json-lib</groupId> 

--- a/src/rest/src/main/java/org/geoserver/rest/IndexController.java
+++ b/src/rest/src/main/java/org/geoserver/rest/IndexController.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.rest;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
+
+import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.SimpleHash;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +46,7 @@ public class IndexController extends RestBaseController {
     )
     public RestWrapper get() {
 
-        SimpleHash model = new SimpleHash();
+        SimpleHash model = new SimpleHash(new DefaultObjectWrapper(FM_VERSION));
         model.put("links", getLinks());
         model.put("page", RequestInfo.get());
 

--- a/src/rest/src/main/java/org/geoserver/rest/ObjectToMapWrapper.java
+++ b/src/rest/src/main/java/org/geoserver/rest/ObjectToMapWrapper.java
@@ -4,9 +4,12 @@
  */
 package org.geoserver.rest;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
+
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.CollectionModel;
 import freemarker.ext.beans.MapModel;
+import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.SimpleHash;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
@@ -46,6 +49,7 @@ public class ObjectToMapWrapper<T> extends BeansWrapper {
      * classesToExpand will be unwrapped to a map
      */
     public ObjectToMapWrapper(Class<T> clazz, Collection<Class<?>> classesToExpand) {
+        super(FM_VERSION);
         this.clazz = clazz;
         this.classesToExpand = classesToExpand;
     }
@@ -82,7 +86,7 @@ public class ObjectToMapWrapper<T> extends BeansWrapper {
         if (object instanceof Collection) {
             Collection c = (Collection) object;
             if (c.isEmpty() || clazz.isAssignableFrom(c.iterator().next().getClass())) {
-                SimpleHash hash = new SimpleHash();
+                SimpleHash hash = new SimpleHash(new DefaultObjectWrapper(FM_VERSION));
                 hash.put("values", new CollectionModel(c, this));
                 setRequestInfo(hash);
                 wrapInternal(hash, (Collection<T>) object);
@@ -92,7 +96,7 @@ public class ObjectToMapWrapper<T> extends BeansWrapper {
         if (object != null && clazz.isAssignableFrom(object.getClass())) {
             Map<String, Object> map = objectToMap(object, clazz);
 
-            SimpleHash model = new SimpleHash();
+            SimpleHash model = new SimpleHash(new DefaultObjectWrapper(FM_VERSION));
             model.put("properties", new MapModel(map, this));
             model.put("className", clazz.getSimpleName());
             setRequestInfo(model);

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/AboutStatusController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/AboutStatusController.java
@@ -4,9 +4,12 @@
  */
 package org.geoserver.rest.catalog;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
+
 import com.thoughtworks.xstream.XStream;
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.CollectionModel;
+import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.ObjectWrapper;
 import freemarker.template.SimpleHash;
 import freemarker.template.TemplateModel;
@@ -99,22 +102,25 @@ public class AboutStatusController extends RestBaseController {
 
     @Override
     protected <T> ObjectWrapper createObjectWrapper(Class<T> clazz) {
-        return new BeansWrapper() {
+        return new BeansWrapper(FM_VERSION) {
             @Override
             public TemplateModel wrap(Object obj) throws TemplateModelException {
                 if (obj instanceof List) { // we expect List of ModuleStatus
                     List<?> list = (List<?>) obj;
-                    SimpleHash hash = new SimpleHash();
+                    SimpleHash hash = new SimpleHash(new DefaultObjectWrapper(FM_VERSION));
                     hash.put(
                             "values",
                             new CollectionModel(
                                     list,
-                                    new BeansWrapper() {
+                                    new BeansWrapper(FM_VERSION) {
                                         public TemplateModel wrap(Object object)
                                                 throws TemplateModelException {
                                             if (object instanceof ModuleStatus) {
                                                 ModuleStatus status = (ModuleStatus) object;
-                                                SimpleHash hash = new SimpleHash();
+                                                SimpleHash hash =
+                                                        new SimpleHash(
+                                                                new DefaultObjectWrapper(
+                                                                        FM_VERSION));
                                                 hash.put("module", status.getModule());
                                                 hash.put("name", status.getName());
                                                 hash.put(

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/OpenLayersPreviewPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/OpenLayersPreviewPanel.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.wms.web.data;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
+
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.Template;
@@ -67,7 +69,7 @@ public class OpenLayersPreviewPanel extends StyleEditTabPanel implements IHeader
     static {
         templates = TemplateUtils.getSafeConfiguration();
         templates.setClassForTemplateLoading(OpenLayersPreviewPanel.class, "");
-        templates.setObjectWrapper(new DefaultObjectWrapper());
+        templates.setObjectWrapper(new DefaultObjectWrapper(FM_VERSION));
     }
 
     final Random rand = new Random();

--- a/src/wms/src/main/java/org/geoserver/wms/decoration/TextDecoration.java
+++ b/src/wms/src/main/java/org/geoserver/wms/decoration/TextDecoration.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.wms.decoration;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
+
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.StringModel;
 import freemarker.template.Template;
@@ -148,7 +150,7 @@ public class TextDecoration implements MapDecoration {
                         "name",
                         new StringReader(messageTemplate),
                         TemplateUtils.getSafeConfiguration());
-        final BeansWrapper bw = new BeansWrapper();
+        final BeansWrapper bw = new BeansWrapper(FM_VERSION);
         return FreeMarkerTemplateUtils.processTemplateIntoString(
                 t,
                 new TemplateHashModel() {

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureTemplate.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureTemplate.java
@@ -74,6 +74,9 @@ public class FeatureTemplate {
         // TODO: this may be somethign we want to configure/change
         templateConfig.setLocale(Locale.US);
         templateConfig.setNumberFormat("0.###########");
+
+        // encoding
+        templateConfig.setDefaultEncoding("UTF-8");
     }
 
     /** The pattern used by DATETIME_FORMAT */
@@ -314,7 +317,6 @@ public class FeatureTemplate {
         synchronized (templateConfig) {
             templateConfig.setTemplateLoader(templateLoader);
             t = templateConfig.getTemplate(template);
-            t.setEncoding("UTF-8");
         }
         templateCache.put(key, t);
         return t;

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
@@ -6,6 +6,7 @@ package org.geoserver.wms.featureinfo;
 
 import static org.geoserver.wms.featureinfo.FreemarkerStaticsAccessRule.fromPattern;
 
+import freemarker.cache.NullCacheStorage;
 import freemarker.template.Configuration;
 import freemarker.template.SimpleHash;
 import freemarker.template.Template;
@@ -134,6 +135,14 @@ public abstract class FreeMarkerTemplateManager {
                         return (TemplateHashModel) getStaticModels().get(path);
                     }
                 });
+        // as we want to look up different templates for each resource, the templates cannot
+        // be cached by name. Freemarker used to clear the cache when setting the loader,
+        // but does not do that anymore since
+        // https://github.com/apache/freemarker/commit/fc9eba51492c3cd4da3547ba15b95c7db9b3d237
+        // because we use the same loader, we just re-configure it to point to a different resource
+        templateConfig.setCacheStorage(new NullCacheStorage());
+
+        templateConfig.setDefaultEncoding("UTF-8");
     }
 
     private GeoServerResourceLoader resourceLoader;
@@ -257,8 +266,6 @@ public abstract class FreeMarkerTemplateManager {
                 // throws exception just for text/html that completely rely on templates
                 if (format.equals(OutputFormat.HTML)) throw ex;
             }
-
-            if (t != null) t.setEncoding(charset.name());
 
             return t;
         }

--- a/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.wms.map;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
+
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -97,7 +99,7 @@ public abstract class AbstractOpenLayersMapOutputFormat implements GetMapOutputF
     static {
         cfg = TemplateUtils.getSafeConfiguration();
         cfg.setClassForTemplateLoading(AbstractOpenLayersMapOutputFormat.class, "");
-        BeansWrapper bw = new BeansWrapper();
+        BeansWrapper bw = new BeansWrapper(FM_VERSION);
         bw.setExposureLevel(BeansWrapper.EXPOSE_PROPERTIES_ONLY);
         cfg.setObjectWrapper(bw);
     }

--- a/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapOutputFormatTest.java
@@ -113,7 +113,7 @@ public class OpenLayersMapOutputFormatTest extends WMSTestSupport {
                 htmlDoc.replace("\\n", "")
                         .replace("\\r", "")
                         .indexOf(
-                                "\"</script\\><script\\>alert(\\'x-scripted\\');</script\\><script\\>\": 'foo'");
+                                "\"<\\/script><script>alert(\\'x-scripted\\');<\\/script><script>\": 'foo'");
         assertTrue(index > -1);
         index =
                 htmlDoc.replace("\\n", "")
@@ -300,7 +300,6 @@ public class OpenLayersMapOutputFormatTest extends WMSTestSupport {
         request.setFormat("application/openlayers");
 
         String htmlDoc = getAsHTML(map);
-        // System.out.println(htmlDoc);
         int index = htmlDoc.indexOf("yx : {'EPSG:4326' : true}");
 
         assertTrue(index > -1);
@@ -453,7 +452,7 @@ public class OpenLayersMapOutputFormatTest extends WMSTestSupport {
                 htmlDoc.replace("\\n", "")
                         .replace("\\r", "")
                         .indexOf(
-                                "\"</script\\><script\\>alert(\\'x-scripted\\');</script\\><script\\>\": 'foo'");
+                                "\"<\\/script><script>alert(\\'x-scripted\\');<\\/script><script>\": 'foo'");
         assertTrue(index > -1);
         index =
                 htmlDoc.replace("\\n", "")

--- a/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapTemplateTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/OpenLayersMapTemplateTest.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.wms.map;
 
+import static org.geoserver.template.TemplateUtils.FM_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -38,7 +39,7 @@ public class OpenLayersMapTemplateTest extends WMSTestSupport {
     public void test() throws Exception {
         Configuration cfg = TemplateUtils.getSafeConfiguration();
         cfg.setClassForTemplateLoading(OpenLayersMapOutputFormat.class, "");
-        cfg.setObjectWrapper(new BeansWrapper());
+        cfg.setObjectWrapper(new BeansWrapper(FM_VERSION));
 
         Template template = cfg.getTemplate("OpenLayers2MapTemplate.ftl");
         assertNotNull(template);


### PR DESCRIPTION
Upgrades the freemarker library to the latest version. The planted a "bomb" in the 2.3.21 version that was difficult to figure out, a change in behavior that was meant to be an improvement, but turned out to be very damaging in GeoServer. Thankfully, once figured out the nature of the issue, it was not difficult to work around it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] ~~New unit tests have been added covering the changes~~ As a version upgrade, only checked that existing tests do pass, and updated them according to changed behavior (small changes in json escaping)
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
