### PR TITLE
[2.17.x backport][GEOS-9894] Enable GeoServer environment parametrization in Base Proxy configuration

### DIFF
--- a/doc/en/user/source/configuration/globalsettings.rst
+++ b/doc/en/user/source/configuration/globalsettings.rst
@@ -67,6 +67,17 @@ Proxy Base URL
 
 GeoServer can have the capabilities documents report a proxy properly. "The Proxy Base URL" field is the base URL seen beyond a reverse proxy.
 
+Environment parametrization support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Proxy Base URL field support environment parametrization (see :ref:`Parameterize catalog settings <datadir_configtemplate>` ) by activating the JVM parameter::
+
+    -DALLOW_ENV_PARAMETRIZATION=true
+
+Once activated the environment parametrization Proxy Base URL can be parameters placeholders like::
+
+    ${proxy.base.url}
+
 Use headers for Proxy URL
 -------------------------
 
@@ -89,6 +100,10 @@ For instance, a Proxy Base URL of ``http://${X-Forwarded-Host}/geoserver http://
 
 Both header names and the appended path (e.g. ``/geoserver``) in templates are case-insensitive.
 
+When environment parametrization is activated with headers support for Proxy URL, the order of evaluation is:
+
+1. Environment parametrization placeholders replacement (if placeholder is not found on environment variables, it remains untouched).
+2. Headers placeholders replacements.
 
 Logging Profile
 ---------------

--- a/src/community/backup-restore/extension/src/main/java/org/geoserver/backuprestore/imagemosaic/reader/ImageMosaicAdditionalResourceReader.java
+++ b/src/community/backup-restore/extension/src/main/java/org/geoserver/backuprestore/imagemosaic/reader/ImageMosaicAdditionalResourceReader.java
@@ -118,7 +118,7 @@ public class ImageMosaicAdditionalResourceReader extends ImageMosaicAdditionalRe
         for (Entry<Object, Object> propEntry : templateProperties.entrySet()) {
             String value = (String) propEntry.getValue();
 
-            if (GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (GeoServerEnvironment.allowEnvParametrization()) {
                 value = (String) gsEnvironment.resolveValue(value);
             }
 

--- a/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/GeoServerKeycloakFilterConfig.java
+++ b/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/GeoServerKeycloakFilterConfig.java
@@ -139,7 +139,7 @@ public class GeoServerKeycloakFilterConfig extends SecurityFilterConfig
         if (target != null
                 && allowEnvParametrization
                 && gsEnvironment != null
-                && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                && GeoServerEnvironment.allowEnvParametrization()) {
             target.setName((String) gsEnvironment.resolveValue(name));
         }
 

--- a/src/extension/authkey/src/main/java/org/geoserver/security/AuthenticationKeyFilterConfig.java
+++ b/src/extension/authkey/src/main/java/org/geoserver/security/AuthenticationKeyFilterConfig.java
@@ -96,7 +96,7 @@ public class AuthenticationKeyFilterConfig extends SecurityFilterConfig
                         Object value = param.getValue();
 
                         if (gsEnvironment != null
-                                && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                                && GeoServerEnvironment.allowEnvParametrization()) {
                             value = gsEnvironment.resolveValue(value);
                         }
 

--- a/src/extension/authkey/src/test/java/org/geoserver/security/AuthKeyAuthenticationTest.java
+++ b/src/extension/authkey/src/test/java/org/geoserver/security/AuthKeyAuthenticationTest.java
@@ -16,8 +16,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,35 +104,15 @@ public class AuthKeyAuthenticationTest extends AbstractAuthenticationProviderTes
     }
 
     @BeforeClass
-    public static void setupClass()
-            throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException,
-                    SecurityException {
-        // Playing with System.Properties and Static boolean fields can raises issues
-        // when running Junit tests via Maven, due to initialization orders.
-        // So let's change the fields via reflections for these tests
-        Field field = GeoServerEnvironment.class.getDeclaredField("ALLOW_ENV_PARAMETRIZATION");
-        field.setAccessible(true);
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(null, true);
+    public static void setupClass() {
         System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
+        GeoServerEnvironment.reloadAllowEnvParametrization();
     }
 
     @AfterClass
-    public static void tearDownClass()
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException,
-                    IllegalAccessException {
-        // Playing with System.Properties and Static boolean fields can raises issues
-        // when running Junit tests via Maven, due to initialization orders.
-        // So let's change the fields via reflections for these tests
-        Field field = GeoServerEnvironment.class.getDeclaredField("ALLOW_ENV_PARAMETRIZATION");
-        field.setAccessible(true);
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(null, false);
+    public static void tearDownClass() {
         System.clearProperty("ALLOW_ENV_PARAMETRIZATION");
+        GeoServerEnvironment.reloadAllowEnvParametrization();
     }
 
     @Override

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -2406,7 +2406,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
      */
     public void syncEnv() throws IllegalArgumentException {
         if (gsEnvironment != null && gsEnvironment.isStale() && gwcEnvironment != null) {
-            if (GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION
+            if (GeoServerEnvironment.allowEnvParametrization()
                     && gsEnvironment.getProps() != null) {
                 Properties gwcProps = gwcEnvironment.getProps();
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
@@ -1527,8 +1527,8 @@ public class GWCTest {
 
     @Test
     public void testGeoServerEnvParametrization() throws Exception {
-        if (GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
-            assertTrue("H2".equals(jdbcStorage.getJDBCDiskQuotaConfig().clone(true).getDialect()));
+        if (GeoServerEnvironment.allowEnvParametrization()) {
+            assertEquals("H2", jdbcStorage.getJDBCDiskQuotaConfig().clone(true).getDialect());
         }
     }
 

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -698,7 +698,7 @@ public class ResourcePool {
             String key = (String) entry.getKey();
             Object value = entry.getValue();
 
-            if (gsEnvironment != null && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (gsEnvironment != null && GeoServerEnvironment.allowEnvParametrization()) {
                 value = gsEnvironment.resolveValue(value);
             }
 
@@ -2714,7 +2714,7 @@ public class ResourcePool {
                         Object value = param.getValue();
 
                         if (gsEnvironment != null
-                                && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                                && GeoServerEnvironment.allowEnvParametrization()) {
                             value = gsEnvironment.resolveValue(value);
                         }
 
@@ -2748,7 +2748,7 @@ public class ResourcePool {
         final GeoServerEnvironment gsEnvironment =
                 GeoServerExtensions.bean(GeoServerEnvironment.class);
 
-        if (gsEnvironment != null && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+        if (gsEnvironment != null && GeoServerEnvironment.allowEnvParametrization()) {
             target.setURL((String) gsEnvironment.resolveValue(source.getURL()));
         } else {
             target.setURL(source.getURL());
@@ -2766,7 +2766,7 @@ public class ResourcePool {
                     String key = param.getKey();
                     Object value = param.getValue();
 
-                    if (gsEnvironment != null && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                    if (gsEnvironment != null && GeoServerEnvironment.allowEnvParametrization()) {
                         value = gsEnvironment.resolveValue(value);
                     }
 
@@ -2801,7 +2801,7 @@ public class ResourcePool {
             final GeoServerEnvironment gsEnvironment =
                     GeoServerExtensions.bean(GeoServerEnvironment.class);
 
-            if (gsEnvironment != null && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (gsEnvironment != null && GeoServerEnvironment.allowEnvParametrization()) {
                 target.setCapabilitiesURL(
                         (String) gsEnvironment.resolveValue(source.getCapabilitiesURL()));
                 target.setUsername((String) gsEnvironment.resolveValue(source.getUsername()));
@@ -2835,7 +2835,7 @@ public class ResourcePool {
             final GeoServerEnvironment gsEnvironment =
                     GeoServerExtensions.bean(GeoServerEnvironment.class);
 
-            if (gsEnvironment != null && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (gsEnvironment != null && GeoServerEnvironment.allowEnvParametrization()) {
                 target.setCapabilitiesURL(
                         (String) gsEnvironment.resolveValue(source.getCapabilitiesURL()));
                 target.setUsername((String) gsEnvironment.resolveValue(source.getUsername()));

--- a/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
@@ -10,7 +10,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.geoserver.config.GeoServer;
+import org.geoserver.platform.GeoServerEnvironment;
 import org.geoserver.platform.GeoServerExtensions;
 import org.vfny.geoserver.util.Requests;
 
@@ -87,6 +89,9 @@ public class ProxifyingURLMangler implements URLMangler {
                         ? GeoServerExtensions.getProperty(Requests.PROXY_PARAM)
                         : this.geoServer.getSettings().getProxyBaseUrl();
 
+        // resolve parameters values if parametrization is activated
+        proxyBase = resolveParametrization(proxyBase);
+
         // Mangles the URL base in different ways based on a flag
         // (for two reasons: a) speed; b) to make the admin aware of
         // possible security liabilities)
@@ -95,6 +100,18 @@ public class ProxifyingURLMangler implements URLMangler {
         } else {
             this.mangleURLFixedURL(baseURL, proxyBase);
         }
+    }
+
+    /**
+     * Resolve parameters values in the provided String if GeoServer parametrization is activated.
+     */
+    private String resolveParametrization(String proxyBase) {
+        if (GeoServerEnvironment.allowEnvParametrization() && StringUtils.isNotBlank(proxyBase)) {
+            GeoServerEnvironment gsEnvironment =
+                    GeoServerExtensions.bean(GeoServerEnvironment.class);
+            proxyBase = (String) gsEnvironment.resolveValue(proxyBase);
+        }
+        return proxyBase;
     }
 
     /**

--- a/src/main/src/main/java/org/geoserver/security/config/BaseSecurityNamedServiceConfig.java
+++ b/src/main/src/main/java/org/geoserver/security/config/BaseSecurityNamedServiceConfig.java
@@ -87,7 +87,7 @@ public class BaseSecurityNamedServiceConfig implements SecurityNamedServiceConfi
         if (target != null) {
             if (allowEnvParametrization
                     && gsEnvironment != null
-                    && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                    && GeoServerEnvironment.allowEnvParametrization()) {
                 target.setName((String) gsEnvironment.resolveValue(name));
             }
         }

--- a/src/main/src/main/java/org/geoserver/security/config/BruteForcePreventionConfig.java
+++ b/src/main/src/main/java/org/geoserver/security/config/BruteForcePreventionConfig.java
@@ -131,7 +131,7 @@ public class BruteForcePreventionConfig implements SecurityConfig {
         if (clone != null) {
             if (allowEnvParametrization
                     && gsEnvironment != null
-                    && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                    && GeoServerEnvironment.allowEnvParametrization()) {
                 List<String> resolvedMasks = new ArrayList<>();
                 for (String mask : whitelistedMasks) {
                     String resolved = (String) gsEnvironment.resolveValue(mask);

--- a/src/main/src/main/java/org/geoserver/security/config/SecurityManagerConfig.java
+++ b/src/main/src/main/java/org/geoserver/security/config/SecurityManagerConfig.java
@@ -138,7 +138,7 @@ public class SecurityManagerConfig implements SecurityConfig {
         if (target != null) {
             if (allowEnvParametrization
                     && gsEnvironment != null
-                    && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                    && GeoServerEnvironment.allowEnvParametrization()) {
                 target.setConfigPasswordEncrypterName(
                         (String) gsEnvironment.resolveValue(configPasswordEncrypterName));
                 target.setRoleServiceName((String) gsEnvironment.resolveValue(roleServiceName));

--- a/src/main/src/main/java/org/geoserver/security/password/MasterPasswordConfig.java
+++ b/src/main/src/main/java/org/geoserver/security/password/MasterPasswordConfig.java
@@ -49,7 +49,7 @@ public class MasterPasswordConfig implements SecurityConfig {
         if (target != null) {
             if (allowEnvParametrization
                     && gsEnvironment != null
-                    && GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                    && GeoServerEnvironment.allowEnvParametrization()) {
                 target.setProviderName((String) gsEnvironment.resolveValue(providerName));
             }
         }

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -511,17 +511,13 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
             assertTrue(ds.getConnectionParameters().get("host").equals("${jdbc.host}"));
             assertTrue(ds.getConnectionParameters().get("port").equals("${jdbc.port}"));
 
-            if (GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
-                assertTrue(
-                        expandedDs
-                                .getConnectionParameters()
-                                .get("host")
-                                .equals(gsEnvironment.resolveValue("${jdbc.host}")));
-                assertTrue(
-                        expandedDs
-                                .getConnectionParameters()
-                                .get("port")
-                                .equals(gsEnvironment.resolveValue("${jdbc.port}")));
+            if (GeoServerEnvironment.allowEnvParametrization()) {
+                assertEquals(
+                        expandedDs.getConnectionParameters().get("host"),
+                        gsEnvironment.resolveValue("${jdbc.host}"));
+                assertEquals(
+                        expandedDs.getConnectionParameters().get("port"),
+                        gsEnvironment.resolveValue("${jdbc.port}"));
             } else {
                 assertTrue(expandedDs.getConnectionParameters().get("host").equals("${jdbc.host}"));
                 assertTrue(expandedDs.getConnectionParameters().get("port").equals("${jdbc.port}"));

--- a/src/main/src/test/java/org/geoserver/ows/URLManglersTest.java
+++ b/src/main/src/test/java/org/geoserver/ows/URLManglersTest.java
@@ -8,12 +8,18 @@ package org.geoserver.ows;
 import static org.geoserver.ows.util.ResponseUtils.*;
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.util.Collections;
+import org.apache.commons.io.FileUtils;
 import org.geoserver.config.GeoServerInfo;
+import org.geoserver.data.test.SystemTestData;
 import org.geoserver.ows.URLMangler.URLType;
+import org.geoserver.platform.GeoServerEnvironment;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.test.SystemTest;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -21,6 +27,26 @@ import org.junit.experimental.categories.Category;
 public class URLManglersTest extends GeoServerSystemTestSupport {
 
     private static final String BASEURL = "http://localhost:8080/geoserver";
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
+        GeoServerEnvironment.reloadAllowEnvParametrization();
+    }
+
+    @AfterClass
+    public static void finalizing() {
+        System.setProperty("ALLOW_ENV_PARAMETRIZATION", "false");
+        GeoServerEnvironment.reloadAllowEnvParametrization();
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        FileUtils.copyFileToDirectory(
+                new File("./src/test/resources/geoserver-environment.properties"),
+                testData.getDataDirectoryRoot());
+    }
 
     @Before
     public void setup() {
@@ -54,5 +80,21 @@ public class URLManglersTest extends GeoServerSystemTestSupport {
 
         String url = buildURL(BASEURL, "test", null, URLType.SERVICE);
         assertEquals("http://geoserver.org/test", url);
+    }
+
+    @Test
+    public void testProxyBaseParametrized() {
+        GeoServerInfo gi = getGeoServer().getGlobal();
+        gi.getSettings().setProxyBaseUrl("${proxy.custom}");
+        getGeoServer().save(gi);
+        String url = buildURL(BASEURL, "test", null, URLType.SERVICE);
+        assertEquals("http://custom.host/test", url);
+
+        // check not-matched placeholders remain intact, like the headers placeholders
+        gi.getSettings()
+                .setProxyBaseUrl("${X-Forwarded-Proto}://${X-Forwarded-Host}/${proxy.custom}");
+        getGeoServer().save(gi);
+        url = buildURL(BASEURL, "test", null, URLType.SERVICE);
+        assertEquals("${X-Forwarded-Proto}://${X-Forwarded-Host}/http://custom.host/test", url);
     }
 }

--- a/src/main/src/test/resources/geoserver-environment.properties
+++ b/src/main/src/test/resources/geoserver-environment.properties
@@ -2,3 +2,4 @@ demo.wms.url = http://demo.geo-solutions.it/geoserver
 test.env = AF-TEST
 jdbc.host = localhost
 jdbc.port = 5432
+proxy.custom = http://custom.host/

--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerEnvironment.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerEnvironment.java
@@ -43,13 +43,31 @@ public class GeoServerEnvironment {
     private static final Constants constants = new Constants(PlaceholderConfigurerSupport.class);
 
     /**
-     * Constant set via System Environment in order to instruct GeoServer to make use or not of the
+     * Variable set via System Environment in order to instruct GeoServer to make use or not of the
      * config placeholders translation.
      *
      * <p>Default to FALSE
      */
-    public static final boolean ALLOW_ENV_PARAMETRIZATION =
+    private static volatile boolean allowEnvParametrization =
             Boolean.valueOf(System.getProperty("ALLOW_ENV_PARAMETRIZATION", "false"));
+
+    /**
+     * Returns the variable set via System Environment in order to instruct GeoServer to make use or
+     * not of the config placeholders translation.
+     */
+    public static boolean allowEnvParametrization() {
+        return allowEnvParametrization;
+    }
+
+    /**
+     * Reloads the variable set via System Environment in order to instruct GeoServer to make use or
+     * not of the config placeholders translation. Use this synchronized method only for testing
+     * purposes.
+     */
+    public static synchronized void reloadAllowEnvParametrization() {
+        allowEnvParametrization =
+                Boolean.valueOf(System.getProperty("ALLOW_ENV_PARAMETRIZATION", "false"));
+    }
 
     private static final String PROPERTYFILENAME = "geoserver-environment.properties";
 

--- a/src/platform/src/test/java/org/geoserver/platform/GeoServerEnvironmentTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/GeoServerEnvironmentTest.java
@@ -89,7 +89,7 @@ public class GeoServerEnvironmentTest {
     public void testSystemProperty() {
         // check for a property we did set up in the setUp
         GeoServerEnvironment genv = new GeoServerEnvironment();
-        LOGGER.info("GeoServerEnvironment = " + GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION);
+        LOGGER.info("GeoServerEnvironment = " + GeoServerEnvironment.allowEnvParametrization());
 
         assertEquals("ABC", genv.resolveValue("${TEST_SYS_PROPERTY}"));
         assertEquals("${TEST_PROPERTY}", genv.resolveValue("${TEST_PROPERTY}"));

--- a/src/platform/src/test/java/org/geoserver/platform/SystemEnvironmentTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/SystemEnvironmentTest.java
@@ -5,6 +5,7 @@
 
 package org.geoserver.platform;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -69,7 +70,7 @@ public class SystemEnvironmentTest {
             GeoServerEnvironment genv = new GeoServerEnvironment();
             // LOGGER.info("GeoServerEnvironment = " +
             // GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION);
-            assertTrue(!GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION);
+            assertFalse(GeoServerEnvironment.allowEnvParametrization());
         }
     }
 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/GeoServerSecurityManagerTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/GeoServerSecurityManagerTest.java
@@ -231,7 +231,7 @@ public class GeoServerSecurityManagerTest extends GeoServerSecurityTestSupport {
         String oldRoleServiceName = config.getRoleServiceName();
 
         try {
-            if (GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (GeoServerEnvironment.allowEnvParametrization()) {
                 System.setProperty("TEST_SYS_PROPERTY", oldRoleServiceName);
 
                 config.setRoleServiceName("${TEST_SYS_PROPERTY}");

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DefaultDataStoreEditPanel.java
@@ -227,7 +227,7 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
 
             // AF: Disable Validator if GeoServer Env Parametrization is enabled!
             if (paramName.equalsIgnoreCase("url")) {
-                if (gsEnvironment == null || !GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+                if (gsEnvironment == null || !GeoServerEnvironment.allowEnvParametrization()) {
                     fc.add(new FileExistsValidator());
                 }
             }
@@ -238,7 +238,7 @@ public class DefaultDataStoreEditPanel extends StoreEditPanel {
             // absolute and bye bye data dir portability
 
             // AF: Disable Binding if GeoServer Env Parametrization is enabled!
-            if (gsEnvironment == null || !GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (gsEnvironment == null || !GeoServerEnvironment.allowEnvParametrization()) {
                 if (binding != null
                         && !String.class.equals(binding)
                         && !File.class.equals(binding)

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreNewPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/WMSStoreNewPage.java
@@ -45,7 +45,7 @@ public class WMSStoreNewPage extends AbstractWMSStorePage {
                     GeoServerExtensions.bean(GeoServerEnvironment.class);
 
             // AF: Disable Binding if GeoServer Env Parametrization is enabled!
-            if (gsEnvironment == null || !GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (gsEnvironment == null || !GeoServerEnvironment.allowEnvParametrization()) {
                 capabilitiesURL.getFormComponent().add(new WMSCapabilitiesURLValidator());
             }
         } catch (IOException e) {

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/WMTSStoreNewPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/WMTSStoreNewPage.java
@@ -45,7 +45,7 @@ public class WMTSStoreNewPage extends AbstractWMTSStorePage {
                     GeoServerExtensions.bean(GeoServerEnvironment.class);
 
             // AF: Disable Binding if GeoServer Env Parametrization is enabled!
-            if (gsEnvironment == null || !GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+            if (gsEnvironment == null || !GeoServerEnvironment.allowEnvParametrization()) {
                 capabilitiesURL.getFormComponent().add(new WMTSCapabilitiesURLValidator());
             }
         } catch (IOException e) {

--- a/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceEditPage.java
@@ -44,7 +44,6 @@ import org.apache.wicket.model.util.ListModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.validation.validator.RangeValidator;
-import org.apache.wicket.validation.validator.UrlValidator;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -459,8 +458,9 @@ public class WorkspaceEditPage extends GeoServerSecuredPage {
             otherSettingsPanel.add(
                     new TextField<Integer>("numDecimals").add(RangeValidator.minimum(0)));
             otherSettingsPanel.add(
-                    new DropDownChoice<String>("charset", GlobalSettingsPage.AVAILABLE_CHARSETS));
-            otherSettingsPanel.add(new TextField<String>("proxyBaseUrl").add(new UrlValidator()));
+                    new DropDownChoice<>("charset", GlobalSettingsPage.AVAILABLE_CHARSETS));
+            // Formerly provided a new UrlValidator(), but removed with placeholder compatibility
+            otherSettingsPanel.add(new TextField<String>("proxyBaseUrl"));
 
             // Addition of pluggable extension points
             ListView<SettingsPluginPanelInfo> extensions =

--- a/src/web/core/src/main/java/org/geoserver/web/services/BaseServiceAdminPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/services/BaseServiceAdminPage.java
@@ -117,7 +117,7 @@ public abstract class BaseServiceAdminPage<T extends ServiceInfo> extends GeoSer
                 GeoServerExtensions.bean(GeoServerEnvironment.class);
 
         // AF: Disable Binding if GeoServer Env Parametrization is enabled!
-        if (gsEnvironment == null || !GeoServerEnvironment.ALLOW_ENV_PARAMETRIZATION) {
+        if (gsEnvironment == null || !GeoServerEnvironment.allowEnvParametrization()) {
             onlineResource.add(new UrlValidator());
         }
 


### PR DESCRIPTION
Currently GeoServer Proxy Base setting doesn't handle environment parameters from geoserver-environment.properties configuration. The target for this enhancement is to add support for ENV parameters in Proxy Base when ALLOW_ENV_PARAMETRIZATION system property is set to "true".

JIRA ticket:
https://osgeo-org.atlassian.net/browse/GEOS-9894

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
