### PR TITLE
[GEOS-9932]: Multidim-Dimensions subset split in nondeterministic order

### DIFF
--- a/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/NetCDFCoverageResponseDelegate.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/NetCDFCoverageResponseDelegate.java
@@ -20,6 +20,7 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wcs2_0.response.GranuleStack;
+import org.geoserver.wcs2_0.response.MultidimensionalCoverageResponse;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
 import org.geotools.util.logging.Logging;
@@ -34,7 +35,9 @@ import ucar.ma2.InvalidRangeException;
  * @author Daniele Romagnoli, GeoSolutions SAS
  */
 public class NetCDFCoverageResponseDelegate extends BaseCoverageResponseDelegate
-        implements CoverageResponseDelegate, ApplicationContextAware {
+        implements CoverageResponseDelegate,
+                ApplicationContextAware,
+                MultidimensionalCoverageResponse {
 
     public static final Logger LOGGER =
             Logging.getLogger("org.geoserver.wcs.responses.NetCDFCoverageResponseDelegate");
@@ -44,7 +47,7 @@ public class NetCDFCoverageResponseDelegate extends BaseCoverageResponseDelegate
     public NetCDFCoverageResponseDelegate(GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList(NetCDFUtilities.NETCDF), // output formats
+                Arrays.asList(NetCDFUtilities.NETCDF, NetCDFUtilities.NETCDF4),
                 new HashMap<String, String>() { // file extensions
                     {
                         put(NetCDFUtilities.NETCDF, "nc");

--- a/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSMultiDimSubsetTest.java
+++ b/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSMultiDimSubsetTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Field;
-import java.util.Set;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.DimensionPresentation;
@@ -45,17 +43,6 @@ public class WCSMultiDimSubsetTest extends WCSNetCDFBaseTest {
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         // workaround to add our custom multi dimensional format
-        try {
-            Field field = GetCoverage.class.getDeclaredField("mdFormats");
-            field.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Set<String> values = (Set<String>) field.get(null);
-            values.add(WCSResponseInterceptor.MIME_TYPE);
-        } catch (NoSuchFieldException
-                | IllegalAccessException
-                | IllegalArgumentException
-                | SecurityException e) {
-        }
 
         super.onSetUp(testData);
         testData.addRasterLayer(

--- a/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSNetCDFMosaicTest.java
+++ b/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSNetCDFMosaicTest.java
@@ -14,12 +14,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import javax.xml.namespace.QName;
 import org.apache.commons.io.FileUtils;
@@ -37,6 +36,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.data.test.CiteTestData;
+import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.test.TestSetup;
 import org.geoserver.test.TestSetupFrequency;
@@ -54,6 +54,7 @@ import org.geotools.coverage.io.netcdf.crs.NetCDFCRSAuthorityFactory;
 import org.geotools.feature.NameImpl;
 import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
+import org.geotools.util.DateRange;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,6 +100,8 @@ public class WCSNetCDFMosaicTest extends WCSNetCDFBaseTest {
 
     public static QName BANDWITHCRS =
             new QName(CiteTestData.WCS_URI, "Band1", CiteTestData.WCS_PREFIX);
+    private static final QName TIMESERIES =
+            new QName(MockData.SF_URI, "timeseries", MockData.SF_PREFIX);
 
     private static final String STANDARD_NAME = "visibility_in_air";
     private static final Section NETCDF_SECTION;
@@ -141,17 +144,9 @@ public class WCSNetCDFMosaicTest extends WCSNetCDFBaseTest {
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         // workaround to add our custom multi dimensional format
-        try {
-            Field field = GetCoverage.class.getDeclaredField("mdFormats");
-            field.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Set<String> values = (Set<String>) field.get(null);
-            values.add(WCSResponseInterceptor.MIME_TYPE);
-        } catch (NoSuchFieldException
-                | IllegalAccessException
-                | IllegalArgumentException
-                | SecurityException e) {
-        }
+        testData.addRasterLayer(TIMESERIES, "timeseries.zip", null, getCatalog());
+        setupRasterDimension(
+                TIMESERIES, ResourceInfo.TIME, DimensionPresentation.LIST, null, null, null);
 
         super.onSetUp(testData);
         testData.addRasterLayer(
@@ -852,6 +847,32 @@ public class WCSNetCDFMosaicTest extends WCSNetCDFBaseTest {
                     dataset.findGlobalAttribute("test-global-attribute-double").getNumericValue());
         } finally {
             FileUtils.deleteQuietly(file);
+        }
+    }
+
+    @Test
+    public void getTime() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                                + "&coverageId=timeseries"
+                                + "&subset=time(\"2014-01-01T00:00:00Z\",\"2019-01-01T00:00:00Z\")"
+                                + "&format=application/custom");
+        assertNotNull(response);
+        GridCoverage2D lastResult =
+                applicationContext.getBean(WCSResponseInterceptor.class).getLastResult();
+        assertTrue(lastResult instanceof GranuleStack);
+        GranuleStack stack = (GranuleStack) lastResult;
+
+        // we expect 6 granules with 6 years starting from 2014
+        List<GridCoverage2D> granulesList = stack.getGranules();
+        int startingYear = 2014;
+        assertEquals(6, granulesList.size());
+
+        Calendar calendar = Calendar.getInstance();
+        for (GridCoverage2D c : granulesList) {
+            calendar.setTime(((DateRange) c.getProperty("TIME")).getMinValue());
+            assertEquals(startingYear++, calendar.get(Calendar.YEAR));
         }
     }
 }

--- a/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSResponseInterceptor.java
+++ b/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSResponseInterceptor.java
@@ -14,10 +14,11 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wcs.responses.BaseCoverageResponseDelegate;
 import org.geoserver.wcs.responses.CoverageResponseDelegate;
+import org.geoserver.wcs2_0.response.MultidimensionalCoverageResponse;
 import org.geotools.coverage.grid.GridCoverage2D;
 
 public final class WCSResponseInterceptor extends BaseCoverageResponseDelegate
-        implements CoverageResponseDelegate {
+        implements CoverageResponseDelegate, MultidimensionalCoverageResponse {
 
     public static final String MIME_TYPE = "application/custom";
 

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/MultidimensionalCoverageResponse.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/MultidimensionalCoverageResponse.java
@@ -1,0 +1,12 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs2_0.response;
+
+/**
+ * Marker interface to be implemented by {@link
+ * org.geoserver.wcs.responses.CoverageResponseDelegate} implementations supporting Multidimensional
+ * format
+ */
+public interface MultidimensionalCoverageResponse {}

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +66,7 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
 import org.opengis.geometry.MismatchedDimensionException;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -922,7 +924,7 @@ public class WCSDimensionsSubsetHelper {
             throws MismatchedDimensionException, UnsupportedOperationException, IOException,
                     TransformException, FactoryException {
         List<GridCoverageRequest> list = splitRequest();
-        Set<GridCoverageRequest> set = new HashSet<>();
+        Set<GridCoverageRequest> set = new LinkedHashSet<>();
         for (GridCoverageRequest request : list) {
             set.add(request);
         }
@@ -1047,16 +1049,20 @@ public class WCSDimensionsSubsetHelper {
         // spatial subset
         Filter filter = filterSpatial(gcr, reader, source);
 
+        List<SortBy> sortByList = new ArrayList<>();
         // temporal subset
-        filter = filterTime(filter, gcr, coverageName, reader);
+        filter = filterTime(filter, gcr, coverageName, reader, sortByList);
 
         // elevation subset
-        filter = filterElevation(filter, gcr, coverageName, reader);
+        filter = filterElevation(filter, gcr, coverageName, reader, sortByList);
 
         // dimensionsSubset
-        filter = filterDimensions(filter, gcr, coverageName, reader);
+        filter = filterDimensions(filter, gcr, coverageName, reader, sortByList);
 
         Query query = new Query(null, filter);
+        if (!sortByList.isEmpty()) {
+            query.setSortBy(sortByList.stream().toArray(SortBy[]::new));
+        }
         return query;
     }
 
@@ -1089,7 +1095,8 @@ public class WCSDimensionsSubsetHelper {
             Filter filter,
             GridCoverageRequest gcr,
             String coverageName,
-            StructuredGridCoverage2DReader reader) {
+            StructuredGridCoverage2DReader reader,
+            List<SortBy> sortByList) {
         NumberRange elevationRange = gcr.getElevationSubset();
         String startElevation = null;
         String endElevation = null;
@@ -1106,7 +1113,8 @@ public class WCSDimensionsSubsetHelper {
                             endElevation,
                             elevationRange.getMinValue(),
                             elevationRange.getMaxValue(),
-                            filter);
+                            filter,
+                            sortByList);
         }
         return elevationFilter;
     }
@@ -1119,7 +1127,8 @@ public class WCSDimensionsSubsetHelper {
             Filter filter,
             GridCoverageRequest gcr,
             String coverageName,
-            StructuredGridCoverage2DReader reader) {
+            StructuredGridCoverage2DReader reader,
+            List<SortBy> sortByList) {
         DateRange timeRange = gcr.getTemporalSubset();
         DimensionDescriptor timeDescriptor = null;
         String startTime = null;
@@ -1136,7 +1145,8 @@ public class WCSDimensionsSubsetHelper {
                             endTime,
                             timeRange.getMinValue(),
                             timeRange.getMaxValue(),
-                            filter);
+                            filter,
+                            sortByList);
         }
         return timeFilter;
     }
@@ -1145,7 +1155,8 @@ public class WCSDimensionsSubsetHelper {
             Filter filter,
             GridCoverageRequest gcr,
             String coverageName,
-            StructuredGridCoverage2DReader reader) {
+            StructuredGridCoverage2DReader reader,
+            List<SortBy> sortByList) {
         Map<String, List<Object>> subset = gcr.getDimensionsSubset();
         Filter dimensionsFilter = filter;
         if (subset != null && !subset.isEmpty()) {
@@ -1166,7 +1177,11 @@ public class WCSDimensionsSubsetHelper {
                     final String endAttrib = dimensionDescriptor.getEndAttribute();
                     dimensionsFilter =
                             filterDimension(
-                                    startAttrib, endAttrib, dimensionValues, dimensionsFilter);
+                                    startAttrib,
+                                    endAttrib,
+                                    dimensionValues,
+                                    dimensionsFilter,
+                                    sortByList);
 
                 } else {
                     if (LOGGER.isLoggable(Level.WARNING)) {
@@ -1187,7 +1202,8 @@ public class WCSDimensionsSubsetHelper {
             String startAttribute,
             String endAttribute,
             List<Object> dimensionValues,
-            Filter filter) {
+            Filter filter,
+            List<SortBy> sortByList) {
         Filter localFilter = null;
 
         if (dimensionValues != null && !dimensionValues.isEmpty()) {
@@ -1222,6 +1238,7 @@ public class WCSDimensionsSubsetHelper {
                 Filter f2 = ff.greaterOrEqual(ff.property(endAttribute), ff.literal(min));
                 localFilter = ff.and(Arrays.asList(f1, f2));
             }
+            sortByList.add(ff.sort(startAttribute, SortBy.NATURAL_ORDER.getSortOrder()));
             if (filter == null) {
                 filter = localFilter;
             } else {
@@ -1237,7 +1254,8 @@ public class WCSDimensionsSubsetHelper {
             String endAttribute,
             Comparable minValue,
             Comparable maxValue,
-            Filter filter) {
+            Filter filter,
+            List<SortBy> sortByList) {
         Filter localFilter = null;
         if (endAttribute == null) {
             // single value time
@@ -1252,6 +1270,8 @@ public class WCSDimensionsSubsetHelper {
             Filter f2 = ff.greaterOrEqual(ff.property(endAttribute), ff.literal(minValue));
             localFilter = ff.and(Arrays.asList(f1, f2));
         }
+        sortByList.add(ff.sort(startAttribute, SortBy.NATURAL_ORDER.getSortOrder()));
+
         if (filter == null) {
             filter = localFilter;
         } else {


### PR DESCRIPTION
- Fixing WCSDimensionSubsetHelper splitting request in nondeterministic order.
- also slightly modified the multidim capability check for easier testing

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
