### PR TITLE
[GEOS-9944] Revise generated filenames, extension, and format_option

### DIFF
--- a/doc/en/user/source/services/wfs/outputformats.rst
+++ b/doc/en/user/source/services/wfs/outputformats.rst
@@ -130,6 +130,8 @@ JSON output ``format_options``:
 
 * ``format_options=callback:<parseResponse>`` applies only to the JSONP output format. See :ref:`wms_vendor_parameters` to change the callback name. Note that this format is disabled by default (See :ref:`wms_global_variables`).
 
+* ``format_option=filename:<file>``: if a file name is provided, the name is used as the output file name. The extension :file:`json` is optional, for example ``format_options=filename:export`` or ``format_options=features.json``
+
 JSON output ``system properties``:
 
 * ``json.maxDepth=<max_value>`` is used to determine the max number of allowed JSON nested objects on encoding phase.  By default the value is 100.

--- a/doc/en/user/source/services/wfs/vendor.rst
+++ b/doc/en/user/source/services/wfs/vendor.rst
@@ -35,7 +35,8 @@ The ``format_options`` parameter is a container for other parameters that are fo
 The supported format option is:
 
 * ``callback`` (default is ``parseResponse``)—Specifies the callback function name for the JSONP response format
-* ``id_policy`` (default is ``true``)- Specifies id generation for the JSON output format. To include feature id in output use an attribute name, or use ``true`` for feature id generation. To avoid the use of feature id completely use ``false``.
+* ``id_policy`` (default is ``true``)- Specifies id generation for the JSON output format. To include feature id in output use an attribute name, or use ``format_options=id_policy:true`` for feature id generation. To avoid the use of feature id completely use ``format_options=id_policy:false``.
+* ``filename`` (default is :file:`features` or generated from feature type name)- provide a ``Content-Disposition`` header indicating the attachment filename (used as a suggestion by browsers saving content to disk using :command:`Save-As`). For example ``format_options=filename:content.txt``.
 
 Reprojection
 ------------

--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
@@ -69,6 +69,10 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
 
     @Override
     public String getAttachmentFileName(Object value, Operation operation) {
+        String fileName = super.getAttachmentFileName(value, operation);
+        if (fileName != null) {
+            return fileName;
+        }
         GetFeatureRequest req = GetFeatureRequest.adapt(operation.getParameters()[0]);
 
         return Joiner.on("_")
@@ -83,6 +87,11 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
                                         }))
                 + "."
                 + EXTENSION;
+    }
+
+    @Override
+    protected String getExtension(FeatureCollectionResponse response) {
+        return EXTENSION;
     }
 
     @Override

--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
@@ -7,9 +7,6 @@ package org.geoserver.geopkg;
 
 import static org.geoserver.geopkg.GeoPkg.*;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.File;
@@ -26,8 +23,6 @@ import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
-import org.geoserver.wfs.request.GetFeatureRequest;
-import org.geoserver.wfs.request.Query;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.geopkg.FeatureEntry;
@@ -65,28 +60,6 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
     @Override
     public String getPreferredDisposition(Object value, Operation operation) {
         return DISPOSITION_ATTACH;
-    }
-
-    @Override
-    public String getAttachmentFileName(Object value, Operation operation) {
-        String fileName = super.getAttachmentFileName(value, operation);
-        if (fileName != null) {
-            return fileName;
-        }
-        GetFeatureRequest req = GetFeatureRequest.adapt(operation.getParameters()[0]);
-
-        return Joiner.on("_")
-                        .join(
-                                Iterables.transform(
-                                        req.getQueries(),
-                                        new Function<Query, String>() {
-                                            @Override
-                                            public String apply(Query input) {
-                                                return input.getTypeNames().get(0).getLocalPart();
-                                            }
-                                        }))
-                + "."
-                + EXTENSION;
     }
 
     @Override

--- a/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormatTest.java
+++ b/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormatTest.java
@@ -132,6 +132,24 @@ public class GeoPackageGetFeatureOutputFormatTest extends WFSTestSupport {
         assertEquals(
                 "attachment; filename=" + layerName + ".gpkg",
                 resp.getHeader("Content-Disposition"));
+
+        resp =
+                getAsServletResponse(
+                        "wfs?request=getfeature&typename="
+                                + layerName
+                                + "&outputformat=geopackage"
+                                + "&format_options=filename:test");
+        assertEquals(GeoPkg.MIME_TYPE, resp.getContentType());
+        assertEquals("attachment; filename=test.gpkg", resp.getHeader("Content-Disposition"));
+
+        resp =
+                getAsServletResponse(
+                        "wfs?request=getfeature&typename="
+                                + layerName
+                                + "&outputformat=geopackage"
+                                + "&format_options=filename:TEST.GPKG");
+        assertEquals(GeoPkg.MIME_TYPE, resp.getContentType());
+        assertEquals("attachment; filename=TEST.GPKG", resp.getHeader("Content-Disposition"));
     }
 
     public void testGetFeature(FeatureCollectionResponse fct, boolean indexed) throws IOException {

--- a/src/extension/dxf/core/src/main/java/org/geoserver/wfs/response/DXFOutputFormat.java
+++ b/src/extension/dxf/core/src/main/java/org/geoserver/wfs/response/DXFOutputFormat.java
@@ -75,6 +75,15 @@ public class DXFOutputFormat extends WFSGetFeatureOutputFormat {
         super(gs, formats);
     }
 
+    /** Sets the right extension for the response */
+    protected String getExtension(FeatureCollectionResponse response) {
+        String outputFormat = response.getOutputFormat().toUpperCase();
+        // DXF
+        if (outputFormat.equals("DXF")) return "dxf";
+        // DXF-ZIP
+        return "zip";
+    }
+
     /** Gets current request extension (dxf or zip). */
     public String getDxfExtension(Operation operation) {
         GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
@@ -138,6 +147,16 @@ public class DXFOutputFormat extends WFSGetFeatureOutputFormat {
 
     @Override
     public String getAttachmentFileName(Object value, Operation operation) {
+        GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
+        if (request.getFormatOptions() != null
+                && request.getFormatOptions().containsKey("FILENAME")) {
+            String fileName = (String) request.getFormatOptions().get("FILENAME");
+            if (fileName.contains(".")) {
+                return fileName; // includes extension
+            } else {
+                return fileName + "." + getDxfExtension(operation);
+            }
+        }
         return getFileName(operation) + '.' + getDxfExtension(operation);
     }
 

--- a/src/extension/excel/src/main/java/org/geoserver/wfs/response/ExcelOutputFormat.java
+++ b/src/extension/excel/src/main/java/org/geoserver/wfs/response/ExcelOutputFormat.java
@@ -20,7 +20,6 @@ import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
-import org.geoserver.wfs.request.GetFeatureRequest;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.opengis.feature.simple.SimpleFeature;
@@ -57,18 +56,6 @@ public abstract class ExcelOutputFormat extends WFSGetFeatureOutputFormat {
     @Override
     public String getMimeType(Object value, Operation operation) throws ServiceException {
         return mimeType;
-    }
-
-    @Override
-    public String getAttachmentFileName(Object value, Operation operation) {
-        String fileName = super.getAttachmentFileName(value, operation);
-        if (fileName != null) {
-            return fileName;
-        }
-        GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
-        String outputFileName = request.getQueries().get(0).getTypeNames().get(0).getLocalPart();
-
-        return outputFileName + "." + fileExtension;
     }
 
     @Override

--- a/src/extension/excel/src/main/java/org/geoserver/wfs/response/ExcelOutputFormat.java
+++ b/src/extension/excel/src/main/java/org/geoserver/wfs/response/ExcelOutputFormat.java
@@ -61,10 +61,19 @@ public abstract class ExcelOutputFormat extends WFSGetFeatureOutputFormat {
 
     @Override
     public String getAttachmentFileName(Object value, Operation operation) {
+        String fileName = super.getAttachmentFileName(value, operation);
+        if (fileName != null) {
+            return fileName;
+        }
         GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
         String outputFileName = request.getQueries().get(0).getTypeNames().get(0).getLocalPart();
 
         return outputFileName + "." + fileExtension;
+    }
+
+    @Override
+    protected String getExtension(FeatureCollectionResponse response) {
+        return fileExtension;
     }
 
     @Override

--- a/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrOutputFormat.java
+++ b/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrOutputFormat.java
@@ -191,12 +191,36 @@ public class Ogr2OgrOutputFormat extends WFSGetFeatureOutputFormat
         if (format == null) {
             throw new WFSException("Unknown output format " + outputFormat);
         } else {
-            String outputFileName = queries.get(0).getTypeNames().get(0).getLocalPart();
+            String outputFileName;
+
+            if (request.getFormatOptions() != null
+                    && request.getFormatOptions().containsKey("FILENAME")) {
+                outputFileName = (String) request.getFormatOptions().get("FILENAME");
+                if (outputFileName.contains(".")) {
+                    return outputFileName; // includes extension
+                }
+            } else {
+                outputFileName = queries.get(0).getTypeNames().get(0).getLocalPart();
+            }
+
             if (!format.isSingleFile() || queries.size() > 1) {
                 return outputFileName + ".zip";
             } else {
                 return outputFileName + format.getFileExtension();
             }
+        }
+    }
+
+    @Override
+    protected String getExtension(FeatureCollectionResponse response) {
+        String outputFormat = response.getOutputFormat();
+        Format format = formats.get(outputFormat);
+        if (format == null) {
+            throw new WFSException("Unknown output format " + outputFormat);
+        } else if (!format.isSingleFile() || response.getTypeNames().size() > 1) {
+            return "zip";
+        } else {
+            return format.getFileExtension();
         }
     }
 

--- a/src/kml/src/main/java/org/geoserver/kml/WFSKMLOutputFormat.java
+++ b/src/kml/src/main/java/org/geoserver/kml/WFSKMLOutputFormat.java
@@ -24,7 +24,6 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
-import org.geoserver.wfs.request.GetFeatureRequest;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.store.ReprojectingFeatureCollection;
 import org.geotools.feature.FeatureCollection;
@@ -138,10 +137,8 @@ public class WFSKMLOutputFormat extends WFSGetFeatureOutputFormat {
     }
 
     @Override
-    public String getAttachmentFileName(Object value, Operation operation) {
-        GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
-        String outputFileName = request.getQueries().get(0).getTypeNames().get(0).getLocalPart();
-        return outputFileName + ".kml";
+    protected String getExtension(FeatureCollectionResponse response) {
+        return "kml";
     }
 
     @Override

--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSGetFeatureOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSGetFeatureOutputFormat.java
@@ -7,7 +7,11 @@ package org.geoserver.wfs;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -572,8 +572,7 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
         return gs.getGlobal().getSettings().getCharset();
     }
 
-    @Override
-    public String getAttachmentFileName(Object value, Operation operation) {
-        return super.getAttachmentFileName(value, operation);
+    protected String getExtension(FeatureCollectionResponse response) {
+        return "json";
     }
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
@@ -69,14 +69,24 @@ public class CSVOutputFormat extends WFSGetFeatureOutputFormat {
     }
 
     @Override
+    protected String getExtension(FeatureCollectionResponse response) {
+        return "csv";
+    }
+
+    @Override
     public String getPreferredDisposition(Object value, Operation operation) {
         return DISPOSITION_ATTACH;
     }
 
     @Override
     public String getAttachmentFileName(Object value, Operation operation) {
+        String fileName = super.getAttachmentFileName(value, operation);
+        if (fileName != null) {
+            return fileName;
+        }
         GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
-        String outputFileName = request.getQueries().get(0).getTypeNames().get(0).getLocalPart();
+        String outputFileName =
+                request.getQueries().get(0).getTypeNames().get(0).getLocalPart();
         return outputFileName + ".csv";
     }
 

--- a/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
@@ -27,7 +27,6 @@ import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
-import org.geoserver.wfs.request.GetFeatureRequest;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
@@ -76,18 +75,6 @@ public class CSVOutputFormat extends WFSGetFeatureOutputFormat {
     @Override
     public String getPreferredDisposition(Object value, Operation operation) {
         return DISPOSITION_ATTACH;
-    }
-
-    @Override
-    public String getAttachmentFileName(Object value, Operation operation) {
-        String fileName = super.getAttachmentFileName(value, operation);
-        if (fileName != null) {
-            return fileName;
-        }
-        GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
-        String outputFileName =
-                request.getQueries().get(0).getTypeNames().get(0).getLocalPart();
-        return outputFileName + ".csv";
     }
 
     /** @see WFSGetFeatureOutputFormat#write(Object, OutputStream, Operation) */

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
@@ -63,8 +63,8 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat
     public static final String MIME_TYPE = "text/xml; subtype=gml/2.1.2";
 
     /**
-     * This is a "magic" class provided by Geotools that writes out GML for an array of
-     * FeatureResults.
+     * This is a "magic" class provided by GeoTools that writes out GML for an array of
+     * FeatureCollections.
      *
      * <p>This class seems to do all the work, if you have a problem with GML you will need to hunt
      * it down. We supply all of the header information in the execute method, and work through the

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
@@ -81,7 +81,6 @@ public class CSVOutputFormatTest extends WFSTestSupport {
                                 + "outputFormat=csv&format_options=filename:test",
                         "");
 
-        FeatureSource fs = getFeatureSource(MockData.PRIMITIVEGEOFEATURE);
         assertEquals("text/csv", resp.getContentType());
         assertEquals("UTF-8", resp.getCharacterEncoding());
         assertEquals("attachment; filename=test.csv", resp.getHeader("Content-Disposition"));

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
@@ -73,6 +73,21 @@ public class CSVOutputFormatTest extends WFSTestSupport {
     }
 
     @Test
+    public void testHTMLStuff() throws Exception {
+        MockHttpServletResponse resp =
+                getAsServletResponse(
+                        "wfs?version=1.1.0&request=GetFeature&"
+                                + "typeName=sf:PrimitiveGeoFeature&"
+                                + "outputFormat=csv&format_options=filename:test",
+                        "");
+
+        FeatureSource fs = getFeatureSource(MockData.PRIMITIVEGEOFEATURE);
+        assertEquals("text/csv", resp.getContentType());
+        assertEquals("UTF-8", resp.getCharacterEncoding());
+        assertEquals("attachment; filename=test.csv", resp.getHeader("Content-Disposition"));
+    }
+
+    @Test
     public void testEscapes() throws Exception {
         // build some fake data in memory, the property data store cannot handle newlines in its
         // data

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureJoinTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureJoinTest.java
@@ -995,7 +995,8 @@ public class GetFeatureJoinTest extends WFS20TestSupport {
         assertEquals("UTF-8", resp.getCharacterEncoding());
 
         // check the content disposition
-        assertEquals("attachment; filename=Forests.csv", resp.getHeader("Content-Disposition"));
+        assertEquals(
+                "attachment; filename=Forests_Lakes.csv", resp.getHeader("Content-Disposition"));
 
         // read the response back with a parser that can handle escaping, newlines
         // and what not
@@ -1047,7 +1048,8 @@ public class GetFeatureJoinTest extends WFS20TestSupport {
         assertEquals("UTF-8", resp.getCharacterEncoding());
 
         // check the content disposition
-        assertEquals("attachment; filename=Forests.csv", resp.getHeader("Content-Disposition"));
+        assertEquals(
+                "attachment; filename=Forests_Lakes.csv", resp.getHeader("Content-Disposition"));
 
         // read the response back with a parser that can handle escaping, newlines
         // and what not
@@ -1099,7 +1101,8 @@ public class GetFeatureJoinTest extends WFS20TestSupport {
         assertEquals("UTF-8", resp.getCharacterEncoding());
 
         // check the content disposition
-        assertEquals("attachment; filename=Forests.csv", resp.getHeader("Content-Disposition"));
+        assertEquals(
+                "attachment; filename=Forests_Lakes.csv", resp.getHeader("Content-Disposition"));
 
         // read the response back with a parser that can handle escaping, newlines
         // and what not
@@ -1149,7 +1152,8 @@ public class GetFeatureJoinTest extends WFS20TestSupport {
         assertEquals("UTF-8", resp.getCharacterEncoding());
 
         // check the content disposition
-        assertEquals("attachment; filename=Forests.csv", resp.getHeader("Content-Disposition"));
+        assertEquals(
+                "attachment; filename=Forests_Forests.csv", resp.getHeader("Content-Disposition"));
 
         // read the response back with a parser that can handle escaping, newlines
         // and what not
@@ -1193,7 +1197,8 @@ public class GetFeatureJoinTest extends WFS20TestSupport {
         assertEquals("UTF-8", resp.getCharacterEncoding());
 
         // check the content disposition
-        assertEquals("attachment; filename=Forests.csv", resp.getHeader("Content-Disposition"));
+        assertEquals(
+                "attachment; filename=Forests_Lakes.csv", resp.getHeader("Content-Disposition"));
 
         // read the response back with a parser that can handle escaping, newlines
         // and what not
@@ -1260,7 +1265,7 @@ public class GetFeatureJoinTest extends WFS20TestSupport {
         assertEquals("UTF-8", resp.getCharacterEncoding());
 
         // check the content disposition
-        assertEquals("attachment; filename=t1.csv", resp.getHeader("Content-Disposition"));
+        assertEquals("attachment; filename=t1_t2_t3.csv", resp.getHeader("Content-Disposition"));
 
         // read the response back with a parser that can handle escaping, newlines
         // and what not


### PR DESCRIPTION
Changing this to a bug report where depending on the version of geoserver and output format used GML3 content showing up as ``geoserver-GetFeature.application`` or ``features.xml`` where I expect something based on the typename requested ``kust_1915.xml`` or ``kust_1915.gml``.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira https://osgeo-org.atlassian.net/browse/GEOS-9944
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
