### PR TITLE
[GEOS-9942] Remove dependency on xpp3, use standard StAX API

### DIFF
--- a/src/ows/pom.xml
+++ b/src/ows/pom.xml
@@ -67,10 +67,6 @@
    <scope>provided</scope>
   </dependency>
   <dependency>
-   <groupId>xpp3</groupId>
-   <artifactId>xpp3</artifactId>
-  </dependency>
-  <dependency>
    <groupId>org.springframework</groupId>
    <artifactId>spring-test</artifactId>
    <scope>test</scope>

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -11,6 +11,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.CharArrayReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -36,7 +37,9 @@ import javax.servlet.http.HttpServletResponse;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -366,20 +369,22 @@ public class Dispatcher extends AbstractController {
                 request.setInput(reader(httpRequest));
             }
 
-            char[] req = new char[xmlPostRequestLogBufferSize];
-            int read = request.getInput().read(req, 0, xmlPostRequestLogBufferSize);
+            if (-1 == request.getInput().read()) {
+                request.setInput(null);
+            } else {
+                request.getInput().reset();
+            }
+            if (request.getInput() != null && logger.isLoggable(Level.FINE)) {
+                char[] req = new char[xmlPostRequestLogBufferSize];
+                final int read = request.getInput().read(req, 0, xmlPostRequestLogBufferSize);
+                request.getInput().reset();
 
-            if (logger.isLoggable(Level.FINE)) {
-                if (read == -1) {
-                    request.setInput(null);
-                } else if (read < xmlPostRequestLogBufferSize) {
+                if (read < xmlPostRequestLogBufferSize) {
                     logger.fine("Raw XML request: " + new String(req));
-                } else if (xmlPostRequestLogBufferSize != 0) {
+                } else {
                     logger.fine("Raw XML request starts with: " + new String(req) + "...");
                 }
             }
-            if (read == -1) request.setInput(null);
-            else request.getInput().reset();
         }
         // parse the request path into two components. (1) the 'path' which
         // is the string after the last '/', and the 'context' which is the
@@ -509,22 +514,7 @@ public class Dispatcher extends AbstractController {
         }
         // check the body
         if (req.getInput() != null && "POST".equalsIgnoreCase(req.getHttpRequest().getMethod())) {
-            Map xml = readOpPost(req.getInput());
-            if (xml.get("service") != null) {
-                req.setService(normalize((String) xml.get("service")));
-            }
-            if (xml.get("version") != null) {
-                req.setVersion(normalizeVersion(normalize((String) xml.get("version"))));
-            }
-            if (xml.get("request") != null) {
-                req.setRequest(normalize((String) xml.get("request")));
-            }
-            if (xml.get("outputFormat") != null) {
-                req.setOutputFormat(normalize((String) xml.get("outputFormat")));
-            }
-            if (xml.get("namespace") != null) {
-                req.setNamespace(normalize((String) xml.get("namespace")));
-            }
+            req = readOpPost(req);
         }
 
         // try to infer from context
@@ -1527,6 +1517,14 @@ public class Dispatcher extends AbstractController {
         return null;
     }
 
+    /**
+     * To be called once it was determined the request is a POST request with an XML request body;
+     * uses {@link XmlRequestReader} to parse the {@link Request#getInput() request input}.
+     *
+     * <p>This method expects {@code request.} {@link Request#getNamespace() namespace}, {@link
+     * Request#getPostRequestElementName() postRequestElementName}, {@link Request#getVersion()
+     * version}, and {@link Request#getService() service} to be set already.
+     */
     Object parseRequestXML(Object requestBean, BufferedReader input, Request request)
             throws Exception {
         // check for an empty input stream
@@ -1534,34 +1532,12 @@ public class Dispatcher extends AbstractController {
             return null;
         }
 
-        // create stream parser
-        XMLInputFactory factory = XMLInputFactory.newFactory();
-        // disable DTDs
-        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-        // disable external entities
-        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        XMLStreamReader parser = factory.createXMLStreamReader(input);
-        // position at root element
-        while (parser.hasNext()) {
-            if (START_ELEMENT == parser.next()) {
-                break;
-            }
-        }
-
-        String namespace = parser.getNamespaceURI() == null ? "" : parser.getNamespaceURI();
-        String element = parser.getLocalName();
-        String version = null;
-        String service = null;
-
-        for (int i = 0; i < parser.getAttributeCount(); i++) {
-            if ("version".equals(parser.getAttributeLocalName(i))) {
-                version = parser.getAttributeValue(i);
-            }
-            if ("service".equals(parser.getAttributeLocalName(i))) {
-                service = parser.getAttributeValue(i);
-            }
-        }
-        input.reset();
+        String namespace = request.getNamespace();
+        // resolve reader based on root XML element name, may differ from request name (e.g.
+        // request=GetMap, root element=StyledLayerDescriptor)
+        String element = request.getPostRequestElementName();
+        String version = request.getVersion();
+        String service = request.getService();
 
         XmlRequestReader xmlReader = findXmlReader(namespace, element, service, version);
         if (xmlReader == null) {
@@ -1589,50 +1565,98 @@ public class Dispatcher extends AbstractController {
     }
 
     /**
-     * Reads the following parameters from an OWS XML request body: * request * namespace * service
-     * * version * outputFormat Resets the input reader after reading
+     * To be called once determined the incoming request is an HTTP POST request
+     * with a request body, and the request's {@link Request#getInput() input
+     * reader} has been set; in order to pre-parse the XML request body root element
+     * and establish the following request properties:
+     * <p>
+     * <ul>
+     * <li>{@link Request#setNamespace namespace}: The xml root element's namespace,
+     * or {@code ""} (empty string) if {@code null}
+     * <li>{@link Request#setPostRequestElementName PostRequestElementName}: The xml
+     * root element name (e.g. {@code GetMap}, {@code GetFeature},
+     * {@code StyledLayerDescriptor}, etc.)
+     * <li>{@link Request#setRequest: The xml root element name, assuming it matches
+     * the request name, might be overriten later while parting the request's query
+     * string key-value pairs
+     * <li>{@link Request#setService service}: matching the xml root element's
+     * {@code service} attribute, or {@code null}
+     * <li>{@link Request#setVersion version}: matching the xml root element's
+     * {@code version} attribute, or {@code null}
+     * <li>{@link Request#setOutputFormat outputFormat}: matching the xml root
+     * element's {@code outputFormat} attribute, or {@code null}
+     * </ul>
      *
-     * @param input {@link BufferedReader} containing a valid OWS XML request body
+     * @param req The request to set properties to based on the xml request body's
+     *            root element
      * @return a {@link Map} containing the parsed parameters.
      * @throws Exception if there was an error reading the input.
      */
-    public static Map readOpPost(BufferedReader input) throws Exception {
+    public Request readOpPost(Request req) throws Exception {
+        String namespace;
+        String elementName;
+        String request;
+        String service;
+        String version;
+        String outputFormat;
+
+        XMLStreamReader parser = createParserForRootElement(req);
+        try {
+            // position at root element
+            while (parser.hasNext()) {
+                if (START_ELEMENT == parser.next()) {
+                    break;
+                }
+            }
+            namespace = parser.getNamespaceURI() == null ? "" : parser.getNamespaceURI();
+            elementName = parser.getLocalName();
+            request = elementName;
+            service = parser.getAttributeValue(null, "service");
+            version = parser.getAttributeValue(null, "version");
+            outputFormat = parser.getAttributeValue(null, "outputFormat");
+        } finally {
+            parser.close();
+        }
+
+        req.setNamespace(normalize(namespace));
+        req.setPostRequestElementName(normalize(elementName));
+        // These may already be given by the request query string KVP's, override only if non-null
+        if (request != null) {
+            req.setRequest(normalize(request));
+        }
+        if (service != null) {
+            req.setService(normalize(service));
+        }
+        if (version != null) {
+            req.setVersion(normalizeVersion(normalize(version)));
+        }
+        if (outputFormat != null) {
+            req.setOutputFormat(normalize(outputFormat));
+        }
+
+        return req;
+    }
+
+    private XMLStreamReader createParserForRootElement(Request req)
+            throws IOException, FactoryConfigurationError, XMLStreamException {
+        char[] buff = new char[XML_LOOKAHEAD];
+        {
+            // Read into buff and use that for the XML stream reader, using req.getInput() directly
+            // can mess up the BufferedReader's state depending on the implementation
+            @SuppressWarnings("PMD.CloseResource")
+            BufferedReader input = req.getInput();
+            input.mark(XML_LOOKAHEAD);
+            input.read(buff);
+            input.reset();
+        }
         // create stream parser
         XMLInputFactory factory = XMLInputFactory.newFactory();
         // disable DTDs
         factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         // disable external entities
         factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        XMLStreamReader parser = factory.createXMLStreamReader(input);
-        // position at root element
-        while (parser.hasNext()) {
-            if (START_ELEMENT == parser.next()) {
-                break;
-            }
-        }
-
-        Map<String, String> map = new HashMap<>();
-        map.put("request", parser.getLocalName());
-        map.put("namespace", parser.getNamespaceURI());
-
-        for (int i = 0; i < parser.getAttributeCount(); i++) {
-            String attName = parser.getAttributeLocalName(i);
-
-            if ("service".equals(attName)) {
-                map.put("service", parser.getAttributeValue(i));
-            }
-
-            if ("version".equals(attName)) {
-                map.put("version", parser.getAttributeValue(i));
-            }
-
-            if ("outputFormat".equals(attName)) {
-                map.put("outputFormat", parser.getAttributeValue(i));
-            }
-        }
-        input.reset();
-
-        return map;
+        XMLStreamReader parser = factory.createXMLStreamReader(new CharArrayReader(buff));
+        return parser;
     }
 
     void exception(Throwable t, Service service, Request request) {

--- a/src/ows/src/main/java/org/geoserver/ows/Request.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Request.java
@@ -48,6 +48,9 @@ public class Request {
     /** OWS request (ie operation) combined with service and version */
     protected String request;
 
+    /** XML root element name as parsed from a POST request with an xml request body */
+    protected String postRequestElementName;
+
     /** OWS protocol version (combined with service and request) */
     protected String version;
 
@@ -300,6 +303,24 @@ public class Request {
      */
     public void setRequest(String request) {
         this.request = request;
+    }
+
+    /**
+     * The xml root element name (e.g. {@code GetMap}, {@code GetFeature}, {@code
+     * StyledLayerDescriptor}. etc.), as pre-parsed during a Dispatcher POST request initialization,
+     * since it may differ from the final {@link #getRequest() request name}
+     */
+    String getPostRequestElementName() {
+        return postRequestElementName;
+    }
+
+    /**
+     * The xml root element name (e.g. {@code GetMap}, {@code GetFeature}, {@code
+     * StyledLayerDescriptor}. etc.), as pre-parsed during a Dispatcher POST request initialization,
+     * since it may differ from the final {@link #getRequest() request name}
+     */
+    void setPostRequestElementName(String rootXmlElementName) {
+        this.postRequestElementName = rootXmlElementName;
     }
 
     /**

--- a/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
@@ -5,7 +5,6 @@
  */
 package org.geoserver.ows.util;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -200,22 +199,8 @@ public class RequestUtils {
     public static BufferedReader getBufferedXMLReader(InputStream stream, int xmlLookahead)
             throws IOException {
 
-        // create a buffer so we can reset the input stream
-        BufferedInputStream input = new BufferedInputStream(stream);
-        input.mark(xmlLookahead);
-
-        // create object to hold encoding info
-        EncodingInfo encoding = new EncodingInfo();
-
-        // call this method to set the encoding info
-        XmlCharsetDetector.getCharsetAwareReader(input, encoding);
-
-        // call this method to create the reader
-        @SuppressWarnings("PMD.CloseResource") // just a wrapper
-        Reader reader = XmlCharsetDetector.createReader(input, encoding);
-
-        // rest the input
-        input.reset();
+        @SuppressWarnings("PMD.CloseResource")
+        Reader reader = XmlCharsetDetector.getCharsetAwareReader(stream);
 
         return getBufferedXMLReader(reader, xmlLookahead);
     }
@@ -234,7 +219,7 @@ public class RequestUtils {
         // ensure the reader is a buffered reader
 
         if (!(reader instanceof BufferedReader)) {
-            reader = new BufferedReader(reader);
+            reader = new BufferedReader(reader, xmlLookahead);
         }
 
         // mark the input stream

--- a/src/ows/src/test/java/org/geoserver/ows/DispatcherTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/DispatcherTest.java
@@ -8,6 +8,8 @@ package org.geoserver.ows;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -118,12 +120,13 @@ public class DispatcherTest {
 
         try (BufferedReader buffered = new BufferedReader(new InputStreamReader(input))) {
             buffered.mark(2048);
+            Request req = new Request();
+            req.setInput(buffered);
 
-            Map map = dispatcher.readOpPost(buffered);
-
-            Assert.assertNotNull(map);
-            Assert.assertEquals("Hello", map.get("request"));
-            Assert.assertEquals("hello", map.get("service"));
+            Request res = dispatcher.readOpPost(req);
+            assertSame(req, res);
+            assertEquals("Hello", res.getRequest());
+            assertEquals("hello", res.getService());
         }
     }
 
@@ -177,6 +180,11 @@ public class DispatcherTest {
 
                 Request req = new Request();
                 req.setInput(input);
+                // this is what Dispatcher.service() would have done before calling
+                // dispatch()->parseRequestXML(...)
+                req.setRequest("Hello");
+                req.setPostRequestElementName("Hello");
+                req.setService("hello");
 
                 Object object = dispatcher.parseRequestXML(null, input, req);
                 Assert.assertEquals(new Message("Hello world!"), object);

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -675,11 +675,6 @@
      <version>2.7.2</version>
    </dependency>
    <dependency>
-    <groupId>xpp3</groupId>
-    <artifactId>xpp3</artifactId>
-    <version>1.1.3.4.O</version>
-   </dependency>
-   <dependency>
     <groupId>org.codehaus.jettison</groupId>
     <artifactId>jettison</artifactId>
     <version>1.0.1</version>

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/TransactionTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/TransactionTest.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.wfs.v2_0;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -1311,7 +1313,8 @@ public class TransactionTest extends WFS20TestSupport {
             Node serviceException = serviceExceptionList.item(0);
             // the service exception should contain the JAXP00010001 error code, that means entity
             // expansion limit is working.
-            assertTrue(serviceException.getTextContent().contains("JAXP00010001"));
+            String textContent = serviceException.getTextContent();
+            assertThat(textContent, containsString("JAXP00010001"));
         } finally {
             System.getProperties().remove(WFSXmlUtils.ENTITY_EXPANSION_LIMIT);
         }


### PR DESCRIPTION
Remove dependency on xpp3 and use the standard StAX API instead.

[xpp3](https://mvnrepository.com/artifact/xpp3/xpp3) is an XML pull parser. Last released version is 14 years old. The
JRE comes with a standard StAX pull parser since Java 1.6.

Relates to https://github.com/geotools/geotools/pull/3382

---

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
