### PR TITLE
[GEOS-9949] System dependency affecting tests in core platform module (Paths.java)

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Paths.java
@@ -423,7 +423,12 @@ public class Paths {
      */
     public static File toFile(File base, String path) {
         for (String item : Paths.names(path)) {
-            base = new File(base, item);
+            base =
+                    new File(
+                            base,
+                            base == null && File.separator.equalsIgnoreCase("\\")
+                                    ? item + "\\"
+                                    : item);
         }
         return base;
     }

--- a/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/PathsTest.java
@@ -12,6 +12,7 @@ import static org.geoserver.platform.resource.Paths.path;
 import static org.geoserver.platform.resource.Paths.sidecar;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -32,6 +33,8 @@ public class PathsTest {
     final String SUBFOLDER = "directory/folder";
 
     final String FILE3 = "directory/folder/file3.txt";
+
+    final boolean WIN = System.getProperty("os.name").startsWith("Windows");
 
     @Test
     public void pathTest() {
@@ -134,6 +137,30 @@ public class PathsTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void toFileTest() {
+      File base;
+        if (WIN) {
+            File expected = new File("C:\\file.txt");
+            assertTrue(expected.isAbsolute());
+            assertTrue(Paths.toFile(null, "C:/file.txt").isAbsolute());
+            assertTrue(!Paths.toFile(null, "foo/bar/file.txt").isAbsolute());
+            assertTrue(!Paths.toFile(null, "C:file.txt").isAbsolute());
+            assertTrue(!Paths.toFile(null, "/foo/bar/file.txt").isAbsolute());
+            base = new File("c:\\foo");
+            assertTrue(Paths.toFile(base, "bar/file.txt").isAbsolute());
+        } else {
+            File expected = new File("/file.txt");
+            assertTrue(expected.isAbsolute());
+            assertTrue(!Paths.toFile(null, "/file.txt").isAbsolute());
+            assertTrue(!Paths.toFile(null, "foo/bar/file.txt").isAbsolute());
+            assertTrue(Paths.toFile(null, "/foo/bar/file.txt").isAbsolute());
+            base = new File("/foo");
+            assertTrue(Paths.toFile(base, "bar/file.txt").isAbsolute());
+        }
+        assertTrue(!Paths.toFile(null, "file.txt").isAbsolute());
     }
 
     @Test


### PR DESCRIPTION
The first component of an absolute path on windows is a drive letter, which if it doesn't get a "\" appended to it gets treated oddly in some circumstances only, apparently.  Affects tests FileWrapperResourceTheoryTest, ResourcesTest in core platform module.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
