### PR TITLE
Fix broken links in docs for native netcdf4 docs

### DIFF
--- a/doc/en/user/source/extensions/netcdf-out/nc4.rst
+++ b/doc/en/user/source/extensions/netcdf-out/nc4.rst
@@ -6,12 +6,12 @@ Installing required NetCDF-4 Native libraries
 =============================================
 In order to write NetCDF-4 files, you must have the NetCDF-4 C library (version 4.3.1 or above) available on your system, along with all supporting libraries (HDF5, zlib, etc). 
 The following sections provide quick reference installation instructions.
-For more detailed info, please take a look at the `NetCDF-4 C Library Loading <http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/reference/netcdf4Clibrary.html>`_ page.
+For more detailed info, please take a look at the `NetCDF-4 C Library Loading <https://docs.unidata.ucar.edu/netcdf-java/current/userguide/netcdf4_c_library.html>`_ page.
 
 
 Windows install
 ---------------
-#. Download the latest NetCDF4 installer from the `NetCDF-C Windows Libraries <http://www.unidata.ucar.edu/software/netcdf/docs/winbin.html>`_ page.
+#. Download the latest NetCDF4 installer from the `NetCDF-C Windows Libraries <https://www.unidata.ucar.edu/software/netcdf/docs/winbin.html>`_ page.
 #. Install the executable
 #. Make sure to add the *bin* folder of the package you have extracted, to the ``PATH`` environment variable.
 


### PR DESCRIPTION
Fix a broken link in the docs for installing the native netcdf4 C libraries for the netcdf-out plugin.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
