### PR TITLE
[2.19.x backport][GEOS-9972] Update Jetty to 9.4.38.v20210224

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1963,7 +1963,7 @@
   <spring.version>5.1.20.RELEASE</spring.version>
   <spring.security.version>5.1.13.RELEASE</spring.security.version>
   <servlet-api.version>3.0.1</servlet-api.version>
-  <jetty.version>9.4.36.v20210114</jetty.version>
+  <jetty.version>9.4.38.v20210224</jetty.version>
   <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>
   <poi.version>4.0.0</poi.version>
   <wicket.version>7.6.0</wicket.version>


### PR DESCRIPTION
The Jetty project has resolved CVE-2020-27223

backports #4859 to 2.19.x

