### PR TITLE
[GEOS-9726] External Legend Graphic reported size incorrect in WMS

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1596,9 +1596,9 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                             "format",
                             defaultFormat,
                             "width",
-                            String.valueOf(GetLegendGraphicRequest.DEFAULT_WIDTH),
+                            String.valueOf(legendWidth),
                             "height",
-                            String.valueOf(GetLegendGraphicRequest.DEFAULT_HEIGHT),
+                            String.valueOf(legendHeight),
                             "layer",
                             layerName);
             if (style != null) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1576,7 +1576,6 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.fine("Adding GetLegendGraphic call as LegendURL");
             }
-
             AttributesImpl attrs = new AttributesImpl();
             attrs.addAttribute("", "width", "width", "", String.valueOf(legendWidth));
 
@@ -1587,6 +1586,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             element("Format", defaultFormat);
             attrs.clear();
 
+            // encode the Legend width and height in the URL too if we have a static legend
+            boolean hasExternalGraphic = legend != null && legend.getOnlineResource() != null;
             Map<String, String> params =
                     params(
                             "service",
@@ -1596,9 +1597,15 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                             "format",
                             defaultFormat,
                             "width",
-                            String.valueOf(legendWidth),
+                            String.valueOf(
+                                    hasExternalGraphic
+                                            ? legendWidth
+                                            : GetLegendGraphicRequest.DEFAULT_WIDTH),
                             "height",
-                            String.valueOf(legendHeight),
+                            String.valueOf(
+                                    hasExternalGraphic
+                                            ? legendHeight
+                                            : GetLegendGraphicRequest.DEFAULT_HEIGHT),
                             "layer",
                             layerName);
             if (style != null) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -1508,6 +1508,9 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             element("Format", defaultFormat);
             attrs.clear();
 
+            // encode the Legend width and height in the URL too if we have a static legend
+            boolean hasExternalGraphic = legend != null && legend.getOnlineResource() != null;
+
             Map<String, String> params =
                     params(
                             "request",
@@ -1515,9 +1518,15 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                             "format",
                             defaultFormat,
                             "width",
-                            String.valueOf(legendWidth),
+                            String.valueOf(
+                                    hasExternalGraphic
+                                            ? legendWidth
+                                            : GetLegendGraphicRequest.DEFAULT_WIDTH),
                             "height",
-                            String.valueOf(legendHeight),
+                            String.valueOf(
+                                    hasExternalGraphic
+                                            ? legendHeight
+                                            : GetLegendGraphicRequest.DEFAULT_HEIGHT),
                             "layer",
                             layerName);
             if (style != null) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -1515,9 +1515,9 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                             "format",
                             defaultFormat,
                             "width",
-                            String.valueOf(GetLegendGraphicRequest.DEFAULT_WIDTH),
+                            String.valueOf(legendWidth),
                             "height",
-                            String.valueOf(GetLegendGraphicRequest.DEFAULT_HEIGHT),
+                            String.valueOf(legendHeight),
                             "layer",
                             layerName);
             if (style != null) {

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
@@ -404,8 +404,37 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
         Element onlineResource = (Element) onlineResources.item(0);
         String href = onlineResource.getAttribute("xlink:href");
         assertNotNull(href);
-        assertTrue(href.contains("width=20"));
-        assertTrue(href.contains("height=20"));
+        assertTrue(href.contains("width=50"));
+        assertTrue(href.contains("height=10"));
+    }
+
+    /**
+     * Tests that width and height in legend online resources are consistent with the ones specified
+     * in legendURL and not always with default value of 20.
+     */
+    @Test
+    public void testWidthHeightInHrefConsistentWithLegendURL() throws Exception {
+        TransformerBase tr = createTransformer();
+        tr.setIndentation(2);
+        Document dom = WMSTestSupport.transform(req, tr);
+
+        NodeList legendURLS = XPATH.getMatchingNodes(getLegendURLXPath("cite:Bridges"), dom);
+        assertEquals(1, legendURLS.getLength());
+        Element legendURL = (Element) legendURLS.item(0);
+        assertTrue(legendURL.hasAttribute("width"));
+        assertTrue(legendURL.hasAttribute("height"));
+        String legendURLWidth = legendURL.getAttribute("width");
+        String legendURLHeight = legendURL.getAttribute("height");
+        assertNotEquals("20", legendURLWidth);
+        assertNotEquals("20", legendURLHeight);
+        NodeList onlineResources =
+                XPATH.getMatchingNodes(getOnlineResourceXPath("cite:Bridges"), dom);
+        assertEquals(1, onlineResources.getLength());
+        Element onlineResource = (Element) onlineResources.item(0);
+        String href = onlineResource.getAttribute("xlink:href");
+        assertNotNull(href);
+        assertTrue(href.contains("width=" + legendURLWidth));
+        assertTrue(href.contains("height=" + legendURLHeight));
     }
 
     private String getLegendURLXPath(String layerName) {

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
@@ -22,7 +22,11 @@ import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.LegendInfo;
+import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.LegendInfoImpl;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.impl.ContactInfoImpl;
@@ -404,37 +408,54 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
         Element onlineResource = (Element) onlineResources.item(0);
         String href = onlineResource.getAttribute("xlink:href");
         assertNotNull(href);
-        assertTrue(href.contains("width=50"));
-        assertTrue(href.contains("height=10"));
+
+        assertTrue(href.contains("width=20"));
+        assertTrue(href.contains("height=20"));
     }
 
     /**
      * Tests that width and height in legend online resources are consistent with the ones specified
-     * in legendURL and not always with default value of 20.
+     * in legendURL when dealing with static legends.
      */
     @Test
-    public void testWidthHeightInHrefConsistentWithLegendURL() throws Exception {
-        TransformerBase tr = createTransformer();
-        tr.setIndentation(2);
-        Document dom = WMSTestSupport.transform(req, tr);
-
-        NodeList legendURLS = XPATH.getMatchingNodes(getLegendURLXPath("cite:Bridges"), dom);
-        assertEquals(1, legendURLS.getLength());
-        Element legendURL = (Element) legendURLS.item(0);
-        assertTrue(legendURL.hasAttribute("width"));
-        assertTrue(legendURL.hasAttribute("height"));
-        String legendURLWidth = legendURL.getAttribute("width");
-        String legendURLHeight = legendURL.getAttribute("height");
-        assertNotEquals("20", legendURLWidth);
-        assertNotEquals("20", legendURLHeight);
-        NodeList onlineResources =
-                XPATH.getMatchingNodes(getOnlineResourceXPath("cite:Bridges"), dom);
-        assertEquals(1, onlineResources.getLength());
-        Element onlineResource = (Element) onlineResources.item(0);
-        String href = onlineResource.getAttribute("xlink:href");
-        assertNotNull(href);
-        assertTrue(href.contains("width=" + legendURLWidth));
-        assertTrue(href.contains("height=" + legendURLHeight));
+    public void testWidthHeightInHrefConsistentWithLegendURLForStaticLegends() throws Exception {
+        LayerInfo li = getCatalog().getLayerByName("cite:Bridges");
+        StyleInfo styleInfo = li.getDefaultStyle();
+        LegendInfo legend = new LegendInfoImpl();
+        legend.setOnlineResource(
+                getClass().getResource("/legendURL/Bridges.png").toURI().toString());
+        legend.setHeight(10);
+        legend.setFormat("image/png;charset=utf-8");
+        legend.setWidth(50);
+        styleInfo.setLegend(legend);
+        catalog.save(styleInfo);
+        try {
+            TransformerBase tr = createTransformer();
+            tr.setIndentation(2);
+            Document dom = WMSTestSupport.transform(req, tr);
+            NodeList legendURLS = XPATH.getMatchingNodes(getLegendURLXPath("cite:Bridges"), dom);
+            assertEquals(1, legendURLS.getLength());
+            Element legendURL = (Element) legendURLS.item(0);
+            assertTrue(legendURL.hasAttribute("width"));
+            assertTrue(legendURL.hasAttribute("height"));
+            String legendURLWidth = legendURL.getAttribute("width");
+            String legendURLHeight = legendURL.getAttribute("height");
+            assertNotEquals("20", legendURLWidth);
+            assertNotEquals("20", legendURLHeight);
+            NodeList onlineResources =
+                    XPATH.getMatchingNodes(getOnlineResourceXPath("cite:Bridges"), dom);
+            assertEquals(1, onlineResources.getLength());
+            Element onlineResource = (Element) onlineResources.item(0);
+            String href = onlineResource.getAttribute("xlink:href");
+            assertNotNull(href);
+            assertTrue(href.contains("width=" + legendURLWidth));
+            assertTrue(href.contains("height=" + legendURLHeight));
+        } finally {
+            if (styleInfo != null) {
+                styleInfo.setLegend(null);
+                catalog.save(styleInfo);
+            }
+        }
     }
 
     private String getLegendURLXPath(String layerName) {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LegendCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LegendCapabilitiesTest.java
@@ -128,10 +128,10 @@ public class LegendCapabilitiesTest extends WMSTestSupport {
         // two
         // cases
         String expectedGetLegendGraphicRequestURL =
-                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width=20&height=20&layer=gs%3A"
+                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
                         + LAYER_NAME;
         String expectedGetLegendGraphicRequestURLHttp =
-                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width=20&height=20&layer=gs%3A"
+                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
                         + HTTP_LEGEND_LAYER;
 
         final String legendUrlPath = "//Layer[Name='gs:" + LAYER_NAME + "']/Style/LegendURL";

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LegendCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LegendCapabilitiesTest.java
@@ -128,10 +128,18 @@ public class LegendCapabilitiesTest extends WMSTestSupport {
         // two
         // cases
         String expectedGetLegendGraphicRequestURL =
-                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
+                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width="
+                        + LEGEND_WIDTH
+                        + "&height="
+                        + LEGEND_HEIGHT
+                        + "&layer=gs%3A"
                         + LAYER_NAME;
         String expectedGetLegendGraphicRequestURLHttp =
-                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
+                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width="
+                        + LEGEND_WIDTH
+                        + "&height="
+                        + LEGEND_HEIGHT
+                        + "&layer=gs%3A"
                         + HTTP_LEGEND_LAYER;
 
         final String legendUrlPath = "//Layer[Name='gs:" + LAYER_NAME + "']/Style/LegendURL";

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LegendCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LegendCapabilitiesTest.java
@@ -147,13 +147,25 @@ public class LegendCapabilitiesTest extends WMSTestSupport {
         // three
         // cases
         String expectedGetLegendGraphicRequestURL =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
+                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width="
+                        + LEGEND_WIDTH
+                        + "&height="
+                        + LEGEND_HEIGHT
+                        + "&layer=gs%3A"
                         + LAYER_NAME;
         String expectedGetLegendGraphicRequestURLWS =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
+                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width="
+                        + LEGEND_WIDTH
+                        + "&height="
+                        + LEGEND_HEIGHT
+                        + "&layer=gs%3A"
                         + LAYER_NAME_WS;
         String expectedGetLegendGraphicRequestURLHttp =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
+                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width="
+                        + LEGEND_WIDTH
+                        + "&height="
+                        + LEGEND_HEIGHT
+                        + "&layer=gs%3A"
                         + HTTP_LEGEND_LAYER;
 
         final String legendUrlPath =

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LegendCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LegendCapabilitiesTest.java
@@ -147,13 +147,13 @@ public class LegendCapabilitiesTest extends WMSTestSupport {
         // three
         // cases
         String expectedGetLegendGraphicRequestURL =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=20&height=20&layer=gs%3A"
+                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
                         + LAYER_NAME;
         String expectedGetLegendGraphicRequestURLWS =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=20&height=20&layer=gs%3A"
+                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
                         + LAYER_NAME_WS;
         String expectedGetLegendGraphicRequestURLHttp =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=20&height=20&layer=gs%3A"
+                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width=22&height=22&layer=gs%3A"
                         + HTTP_LEGEND_LAYER;
 
         final String legendUrlPath =


### PR DESCRIPTION
Jira ticket https://osgeo-org.atlassian.net/browse/GEOS-9726

Fixes a bug causing the legend width and height be always the default 20 in onlineResource element of getCapabilities, when dealing with static images.
Tests that were wrongly checking for the default value have been modified accordingly.
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
