### PR TITLE
[2.19.x-backport] Fixing cov-json community zip

### DIFF
--- a/src/community/release/ext-cov-json.xml
+++ b/src/community/release/ext-cov-json.xml
@@ -1,5 +1,5 @@
 <assembly>
-  <id>cov-json</id>
+  <id>cov-json-plugin</id>
   <formats>
     <format>zip</format>
   </formats>


### PR DESCRIPTION
[backport to 2.19.x] fixing assembly of cov-json plugin 