### PR TITLE
[GEOS-9983] Sanitize transitive dependencies coming from root pom

### DIFF
--- a/src/ows/pom.xml
+++ b/src/ows/pom.xml
@@ -19,6 +19,10 @@
  <name>Open Web Service Module</name>
  
  <dependencies>
+  <dependency>
+   <groupId>org.springframework</groupId>
+   <artifactId>spring-webmvc</artifactId>
+  </dependency>
    <dependency>
     <groupId>org.springframework.security</groupId>
     <artifactId>spring-security-core</artifactId>

--- a/src/platform/pom.xml
+++ b/src/platform/pom.xml
@@ -20,6 +20,10 @@
 
  <dependencies>
   <dependency>
+    <groupId>org.geotools</groupId>
+    <artifactId>gt-metadata</artifactId>
+  </dependency>
+  <dependency>
    <groupId>org.springframework</groupId>
    <artifactId>spring-beans</artifactId>
   </dependency>
@@ -33,7 +37,7 @@
   </dependency>
   <dependency>
    <groupId>org.springframework</groupId>
-   <artifactId>spring-webmvc</artifactId>
+   <artifactId>spring-web</artifactId>
   </dependency>
   <dependency>
    <groupId>org.apache.commons</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1341,26 +1341,6 @@
 
  <dependencies>
   <dependency>
-   <groupId>org.springframework</groupId>
-   <artifactId>spring-beans</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>org.springframework</groupId>
-   <artifactId>spring-core</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>org.springframework</groupId>
-   <artifactId>spring-context</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>org.springframework</groupId>
-   <artifactId>spring-webmvc</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>org.geotools</groupId>
-   <artifactId>gt-main</artifactId>
-  </dependency>
-  <dependency>
    <groupId>junit</groupId>
    <artifactId>junit</artifactId>
    <scope>test</scope>


### PR DESCRIPTION
[GEOS-9983](https://osgeo-org.atlassian.net/browse/GEOS-9983)

The root pom forces a number of transitive dependencies an all modules,
which prevents having modules that don't depend on spring-webmvc, or
gt-main, etc.

This is the list of changes required to remove those direct dependencies
forced by the root pom down to all modules (- is a dependency removed,
+ a dependency added):

```
* root:
  - spring-beans
  - spring-core
  - spring-context
  - spring-webmvc
  - gt-main
* platform:
  - spring-webmvc
  + spring-web
  + gt-metadata
* ows:
  + spring-webmvc
```

---

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)

`N/A` PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.

`N/A` New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)

`N/A` Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
`N/A` Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.
