### PR TITLE
backup-restore/CatalogItemProcessor: Improve code readability

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
@@ -321,44 +321,36 @@ public abstract class BackupRestoreItem<T> {
     protected boolean filteredResource(
             T resource, WorkspaceInfo ws, boolean strict, Class<?> clazz) {
         // Filtering Resources
-        if (filterIsValid()) {
-            if (resource == null || (clazz != null && clazz == WorkspaceInfo.class)) {
-                if ((strict && ws == null)
-                        || (ws != null
-                                && getFilters()[0] != null
-                                && !getFilters()[0].evaluate(ws))) {
-                    LOGGER.info("Skipped filtered workspace: " + ws);
-                    return true;
-                }
-            }
-
-            if (resource != null && clazz != null && clazz == StoreInfo.class) {
-                if (getFilters()[1] != null && !getFilters()[1].evaluate(resource)) {
-                    LOGGER.info("Skipped filtered resource: " + resource);
-                    return true;
-                }
-            }
-
-            if (resource != null && clazz != null && clazz == LayerInfo.class) {
-                if (getFilters()[2] != null && !getFilters()[2].evaluate(resource)) {
-                    LOGGER.info("Skipped filtered resource: " + resource);
-                    return true;
-                }
-            }
-
-            if (resource != null && clazz != null && clazz == ResourceInfo.class) {
-                if (((ResourceInfo) resource).getStore() == null
-                        ||
-                        // (getFilters()[1] != null && !getFilters()[1].evaluate(((ResourceInfo)
-                        // resource).getStore())) ||
-                        (getFilters()[2] != null && !getFilters()[2].evaluate(resource))) {
-                    LOGGER.info("Skipped filtered resource: " + resource);
-                    return true;
-                }
+        if (!filterIsValid()) {
+            return false;
+        }
+        if (resource == null || clazz == WorkspaceInfo.class) {
+            if ((strict && ws == null)
+                    || (ws != null && getFilters()[0] != null && !getFilters()[0].evaluate(ws))) {
+                LOGGER.info("Skipped filtered workspace: " + ws);
+                return true;
             }
         }
-
-        return false;
+        boolean skip = false;
+        if (resource != null) {
+            if (clazz == StoreInfo.class) {
+                skip = getFilters()[1] != null && !getFilters()[1].evaluate(resource);
+            } else if (clazz == LayerInfo.class) {
+                skip = getFilters()[2] != null && !getFilters()[2].evaluate(resource);
+            } else if (clazz == ResourceInfo.class) {
+                skip =
+                        ((ResourceInfo) resource).getStore() == null
+                                ||
+                                // (getFilters()[1] != null &&
+                                // !getFilters()[1].evaluate(((ResourceInfo)
+                                // resource).getStore())) ||
+                                (getFilters()[2] != null && !getFilters()[2].evaluate(resource));
+            }
+        }
+        if (skip) {
+            LOGGER.info("Skipped filtered resource: " + resource);
+        }
+        return skip;
     }
 
     /** */


### PR DESCRIPTION
Break up the 272 lines long CatalogItemProcessor.process() method into
smaller chunks for each CatalogInfo type needing specialized processing.
    
Fix a bug in processing ResourceInfo, where a ResourceInfo class was
used as argument to get a StoreInfo from the Catalog.

--- 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.