### PR TITLE
[GEOS-9991]: WCS 2.0 slicing lat/lon fix

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
@@ -361,7 +361,11 @@ public class WCSDimensionsSubsetHelper {
                                 reader.getOriginalGridToWorld(PixelInCell.CELL_CENTER));
                 final double scale =
                         axisIndex == 0 ? affineTransform.getScaleX() : -affineTransform.getScaleY();
-                subsettingEnvelope.setRange(axisIndex, slicePoint, slicePoint + scale);
+
+                // Center the tiny rectangle across the slicePoint
+                double min = slicePoint - (scale * 0.5);
+                double max = min + scale;
+                subsettingEnvelope.setRange(axisIndex, min, max);
 
                 // slice point outside coverage
                 if (sourceEnvelopeInSubsettingCRS.getMinimum(axisIndex) > slicePoint

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/xml/GetCoverageTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/xml/GetCoverageTest.java
@@ -474,8 +474,8 @@ public class GetCoverageTest extends WCSTestSupport {
             // 1 dimensional slice along latitude
             final GeneralEnvelope expectedEnvelope =
                     new GeneralEnvelope(
-                            new double[] {146.49999999999477, -43.5},
-                            new double[] {146.99999999999477, -43.49583333333119});
+                            new double[] {146.49999999999477, -43.504166666664524},
+                            new double[] {146.99999999999477, -43.49999999999786});
             expectedEnvelope.setCoordinateReferenceSystem(CRS.decode("EPSG:4326", true));
 
             final double scale = getScale(targetCoverage);
@@ -688,8 +688,8 @@ public class GetCoverageTest extends WCSTestSupport {
             // 1 dimensional slice along latitude
             final GeneralEnvelope expectedEnvelope =
                     new GeneralEnvelope(
-                            new double[] {146.49999999999477, -43.499999999997854},
-                            new double[] {147.99999999999474, -43.49583333333119});
+                            new double[] {146.49999999999477, -43.504166666664524},
+                            new double[] {147.99999999999474, -43.49999999999786});
             expectedEnvelope.setCoordinateReferenceSystem(CRS.decode("EPSG:4326", true));
 
             final double scale = getScale(targetCoverage);

--- a/src/wcs2_0/src/test/resources/trimming/requestGetCoverageTrimmingSlicingNativeCRSXML.xml
+++ b/src/wcs2_0/src/test/resources/trimming/requestGetCoverageTrimmingSlicingNativeCRSXML.xml
@@ -8,7 +8,7 @@
 	<wcs:CoverageId>wcs__BlueMarble</wcs:CoverageId>
     <wcs:DimensionSlice>
 		<wcs:Dimension>Lat</wcs:Dimension>
-        <wcs:SlicePoint>-43.5</wcs:SlicePoint>
+        <wcs:SlicePoint>-43.501</wcs:SlicePoint>
     </wcs:DimensionSlice>	
 	<wcs:DimensionTrim>
 		<wcs:Dimension>Long</wcs:Dimension>


### PR DESCRIPTION
[![GEOS-9991](https://badgen.net/badge/JIRA/GEOS-9991/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9991) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixing WCS 2.0 slicing on lat/lon sometime returning bad pixels

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.