### PR TITLE
[GEOS-9652] stores page without links when using hz-cluster

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/store/StoreProvider.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/StoreProvider.java
@@ -64,7 +64,7 @@ public class StoreProvider extends GeoServerDataProvider<StoreInfo> {
 
     static final Property<StoreInfo> NAME = new BeanProperty<>("name", "name");
 
-    final Property<StoreInfo> TYPE =
+    static final Property<StoreInfo> TYPE =
             new AbstractProperty<StoreInfo>("type") {
 
                 public Object getPropertyValue(StoreInfo item) {
@@ -73,7 +73,7 @@ public class StoreProvider extends GeoServerDataProvider<StoreInfo> {
                         return type;
                     }
                     try {
-                        ResourcePool resourcePool = getCatalog().getResourcePool();
+                        ResourcePool resourcePool = item.getCatalog().getResourcePool();
                         if (item instanceof DataStoreInfo) {
                             DataStoreInfo dsInfo = (DataStoreInfo) item;
                             DataAccessFactory factory = resourcePool.getDataStoreFactory(dsInfo);
@@ -102,7 +102,7 @@ public class StoreProvider extends GeoServerDataProvider<StoreInfo> {
     static final Property<StoreInfo> CREATED_TIMESTAMP =
             new BeanProperty<>("datecreated", "dateCreated");
 
-    final List<Property<StoreInfo>> PROPERTIES =
+    static final List<Property<StoreInfo>> PROPERTIES =
             Arrays.asList(DATA_TYPE, WORKSPACE, NAME, TYPE, ENABLED);
 
     WorkspaceInfo workspace;

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/StorePageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/StorePageTest.java
@@ -8,6 +8,10 @@ package org.geoserver.web.data.store;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.apache.wicket.markup.repeater.data.DataView;
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.geoserver.catalog.Catalog;
@@ -95,5 +99,26 @@ public class StorePageTest extends GeoServerWicketTestSupport {
         // should show both columns
         assertTrue(provider.getProperties().contains(StoreProvider.CREATED_TIMESTAMP));
         assertTrue(provider.getProperties().contains(StoreProvider.MODIFIED_TIMESTAMP));
+    }
+
+    @Test
+    public void testSerializedProvider() throws Exception {
+        StoreProvider provider = new StoreProvider();
+
+        byte[] serialized;
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            try (ObjectOutputStream oos = new ObjectOutputStream(os)) {
+                oos.writeObject(provider);
+            }
+            serialized = os.toByteArray();
+        }
+        StoreProvider provider2;
+        try (ByteArrayInputStream is = new ByteArrayInputStream(serialized)) {
+            try (ObjectInputStream ois = new ObjectInputStream(is)) {
+                provider2 = (StoreProvider) ois.readObject();
+            }
+        }
+
+        assertEquals(provider.getProperties(), provider2.getProperties());
     }
 }


### PR DESCRIPTION
[![GEOS-9652](https://badgen.net/badge/JIRA/GEOS-9652/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9652) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is another serialization bug that only comes to surface when using hz-cluster.

When you first load the page, you do get the links. But once you filter or sort, they are gone.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.