### PR TITLE
[Backport-2.17.x][GEOS-9991]: WCS 2.0 slicing lat/lon fix

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
@@ -359,7 +359,11 @@ public class WCSDimensionsSubsetHelper {
                                 reader.getOriginalGridToWorld(PixelInCell.CELL_CENTER));
                 final double scale =
                         axisIndex == 0 ? affineTransform.getScaleX() : -affineTransform.getScaleY();
-                subsettingEnvelope.setRange(axisIndex, slicePoint, slicePoint + scale);
+
+                // Center the tiny rectangle across the slicePoint
+                double min = slicePoint - (scale * 0.5);
+                double max = min + scale;
+                subsettingEnvelope.setRange(axisIndex, min, max);
 
                 // slice point outside coverage
                 if (sourceEnvelopeInSubsettingCRS.getMinimum(axisIndex) > slicePoint

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/xml/GetCoverageTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/xml/GetCoverageTest.java
@@ -473,8 +473,8 @@ public class GetCoverageTest extends WCSTestSupport {
             // 1 dimensional slice along latitude
             final GeneralEnvelope expectedEnvelope =
                     new GeneralEnvelope(
-                            new double[] {146.49999999999477, -43.5},
-                            new double[] {146.99999999999477, -43.49583333333119});
+                            new double[] {146.49999999999477, -43.504166666664524},
+                            new double[] {146.99999999999477, -43.49999999999786});
             expectedEnvelope.setCoordinateReferenceSystem(CRS.decode("EPSG:4326", true));
 
             final double scale = getScale(targetCoverage);
@@ -684,8 +684,8 @@ public class GetCoverageTest extends WCSTestSupport {
             // 1 dimensional slice along latitude
             final GeneralEnvelope expectedEnvelope =
                     new GeneralEnvelope(
-                            new double[] {146.49999999999477, -43.499999999997854},
-                            new double[] {147.99999999999474, -43.49583333333119});
+                            new double[] {146.49999999999477, -43.504166666664524},
+                            new double[] {147.99999999999474, -43.49999999999786});
             expectedEnvelope.setCoordinateReferenceSystem(CRS.decode("EPSG:4326", true));
 
             final double scale = getScale(targetCoverage);

--- a/src/wcs2_0/src/test/resources/trimming/requestGetCoverageTrimmingSlicingNativeCRSXML.xml
+++ b/src/wcs2_0/src/test/resources/trimming/requestGetCoverageTrimmingSlicingNativeCRSXML.xml
@@ -8,7 +8,7 @@
 	<wcs:CoverageId>wcs__BlueMarble</wcs:CoverageId>
     <wcs:DimensionSlice>
 		<wcs:Dimension>Lat</wcs:Dimension>
-        <wcs:SlicePoint>-43.5</wcs:SlicePoint>
+        <wcs:SlicePoint>-43.501</wcs:SlicePoint>
     </wcs:DimensionSlice>	
 	<wcs:DimensionTrim>
 		<wcs:Dimension>Long</wcs:Dimension>


### PR DESCRIPTION
[![GEOS-9991](https://badgen.net/badge/JIRA/GEOS-9991/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9991) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

