### PR TITLE
[2.19.x backport] Fix for issue with GSR FeatureEncoder converting number based attribu…

### DIFF
--- a/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
+++ b/src/community/gsr/src/main/java/org/geoserver/gsr/translate/feature/FeatureEncoder.java
@@ -59,6 +59,10 @@ public class FeatureEncoder {
                     value = ((java.util.Date) prop.getValue()).getTime();
                 } else if (prop.getValue() instanceof java.lang.Boolean) {
                     value = ((Boolean) prop.getValue()) ? Integer.valueOf(1) : Integer.valueOf(0);
+                } else if (prop.getValue() instanceof java.lang.Integer) {
+                    value = ((Integer) prop.getValue());
+                } else if (prop.getValue() instanceof java.lang.Double) {
+                    value = ((Double) prop.getValue());
                 } else {
                     value = prop.getValue().toString();
                 }

--- a/src/community/gsr/src/test/java/org/geoserver/gsr/translate/feature/FeatureEncoderTest.java
+++ b/src/community/gsr/src/test/java/org/geoserver/gsr/translate/feature/FeatureEncoderTest.java
@@ -1,0 +1,64 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.gsr.translate.feature;
+
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.geoserver.gsr.api.GeoServicesJacksonJsonConverter;
+import org.geoserver.gsr.api.ServiceException;
+import org.geoserver.gsr.model.feature.Feature;
+import org.geoserver.gsr.model.geometry.SpatialReferenceWKID;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.SchemaException;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+public class FeatureEncoderTest extends GeoServerSystemTestSupport {
+
+    protected static final ObjectMapper mapper = new GeoServicesJacksonJsonConverter().getMapper();
+
+    @Test
+    public void testCreateFeature() throws IOException, ServiceException, SchemaException {
+        final SimpleFeatureType TYPE =
+                DataUtilities.createType(
+                        "Location",
+                        "the_geom:Point:srid=4326,"
+                                + // <- the geometry attribute: Point type
+                                "id:String,"
+                                + // <- a String attribute
+                                "intfield:Integer,"
+                                + // <- a Integer attribute
+                                "doublefield:Double");
+        // <- a Double attribute
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(TYPE);
+
+        Point point = geometryFactory.createPoint(new Coordinate(-112.6653, 34.54645645));
+        featureBuilder.add(point);
+        featureBuilder.add("t0002");
+        featureBuilder.add(2);
+        featureBuilder.add(2.54);
+        SimpleFeature feature = featureBuilder.buildFeature(null);
+
+        Feature encodedFeature =
+                FeatureEncoder.feature(feature, true, new SpatialReferenceWKID(32615), "id");
+        String featureJson = mapper.writeValueAsString(encodedFeature);
+
+        // Check the JSON to ensure the number attributes for the feature
+        // aren't encoded as strings
+        assertTrue(featureJson.contains("\"intfield\":2"));
+        assertTrue(featureJson.contains("\"doublefield\":2.54"));
+    }
+}


### PR DESCRIPTION
BACKPORT (#4897)

* Fix for issue with GSR FeatureEncoder converting number based attribute values to strings.  This was preventing Attribute based SLD styles using tags like <ogc:PropertyIsLessThan> from working in some clients.

* Fixed code formatting to follow AOSP style

Co-authored-by: Jeffrey Smith <jsmith@geospago.com>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.