### PR TITLE
[GEOS-10007] Update http status code when adding an already exist workspace

### DIFF
--- a/doc/en/api/1.0.0/workspaces.yaml
+++ b/doc/en/api/1.0.0/workspaces.yaml
@@ -94,7 +94,7 @@ paths:
             Location:
               description: URL where the newly created workspace can be found
               type: string
-        401:
+        409:
           description: Unable to add workspace as it already exists
      
     put:

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
@@ -112,8 +112,7 @@ public class WorkspaceController extends AbstractCatalogController {
 
         if (catalog.getWorkspaceByName(workspace.getName()) != null) {
             throw new RestException(
-                    "Workspace '" + workspace.getName() + "' already exists",
-                    HttpStatus.UNAUTHORIZED);
+                    "Workspace '" + workspace.getName() + "' already exists", HttpStatus.CONFLICT);
         }
         catalog.add(workspace);
         String name = workspace.getName();

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceTest.java
@@ -171,6 +171,11 @@ public class WorkspaceTest extends CatalogRESTTestSupport {
         NamespaceInfo ns = getCatalog().getNamespaceByPrefix("foo");
         assertNotNull(ns);
 
+        MockHttpServletResponse conflictResponse =
+                postAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/workspaces", xml, "text/xml");
+        assertEquals(409, conflictResponse.getStatus());
+
         removeWorkspace("foo");
     }
 
@@ -198,6 +203,11 @@ public class WorkspaceTest extends CatalogRESTTestSupport {
         WorkspaceInfo ws = getCatalog().getWorkspaceByName("foo");
         assertNotNull(ws);
         assertNotNull(ws.getDateCreated());
+
+        MockHttpServletResponse conflictResponse =
+                postAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/workspaces", json, "text/json");
+        assertEquals(409, conflictResponse.getStatus());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10007](https://badgen.net/badge/JIRA/GEOS-10007/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10007) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

# What changed
* Change the http status code from 401(UNAUTHORIZED) to 409(CONFLICT) when adding an already exist workspace
* Update the http status code description in doc/en/api/1.0.0/workspaces.yaml

Maybe 409 is more suiteable than 401 when adding an already exist workspace?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.