### PR TITLE
[2.17.x backport][GEOS-9948]Fix existing layers ID overwrite on Backup & Restore plugin

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
@@ -107,7 +107,7 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
         restoreCatalog.setResourceLoader(gsCatalog.getResourceLoader());
         restoreCatalog.setResourcePool(gsCatalog.getResourcePool());
 
-        keepExistingWorkspaces(restoreCatalog, gsCatalog);
+        syncCatalogs(restoreCatalog, gsCatalog);
 
         for (CatalogListener listener : gsCatalog.getListeners()) {
             restoreCatalog.addListener(listener);
@@ -116,24 +116,11 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
         return restoreCatalog;
     }
 
-    /** Pass existing workspaces and namespaces to the resulting restore catalog. */
-    private void keepExistingWorkspaces(CatalogImpl restoreCatalog, Catalog gsCatalog) {
-        gsCatalog
-                .getNamespaces()
-                .forEach(
-                        nsInfo -> {
-                            restoreCatalog.add(nsInfo);
-                            restoreCatalog.save(
-                                    restoreCatalog.getNamespaceByPrefix(nsInfo.getPrefix()));
-                        });
-        gsCatalog
-                .getWorkspaces()
-                .forEach(
-                        wsInfo -> {
-                            restoreCatalog.add(wsInfo);
-                            restoreCatalog.save(
-                                    restoreCatalog.getWorkspaceByName(wsInfo.getName()));
-                        });
+    /** Synchronizes catalogs content. */
+    private void syncCatalogs(CatalogImpl restoreCatalog, Catalog gsCatalog) {
+        if (gsCatalog instanceof CatalogImpl) {
+            restoreCatalog.sync((CatalogImpl) gsCatalog);
+        }
     }
 
     @Override

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
 import org.geoserver.backuprestore.utils.BackupUtils;
@@ -25,7 +26,10 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
@@ -100,8 +104,8 @@ public class BackupTest extends BackupRestoreTestSupport {
         // check that generic listener was invoked for the backup job
         assertThat(GenericListener.getBackupAfterInvocations(), is(4));
         assertThat(GenericListener.getBackupBeforeInvocations(), is(4));
-        assertThat(GenericListener.getRestoreAfterInvocations(), is(3));
-        assertThat(GenericListener.getRestoreBeforeInvocations(), is(3));
+        assertThat(GenericListener.getRestoreAfterInvocations(), is(1));
+        assertThat(GenericListener.getRestoreBeforeInvocations(), is(1));
     }
 
     @Test
@@ -173,79 +177,7 @@ public class BackupTest extends BackupRestoreTestSupport {
         assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
     }
 
-    @Test
-    public void testRunSpringBatchRestoreJob() throws Exception {
-        Hints hints = new Hints(new HashMap(2));
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                        Backup.PARAM_BEST_EFFORT_MODE));
-
-        RestoreExecutionAdapter restoreExecution =
-                backupFacade.runRestoreAsync(
-                        file("geoserver-full-backup.zip"), null, null, null, hints);
-
-        // Wait a bit
-        Thread.sleep(100);
-
-        assertNotNull(backupFacade.getRestoreExecutions());
-        assertTrue(!backupFacade.getRestoreExecutions().isEmpty());
-
-        assertNotNull(restoreExecution);
-
-        Thread.sleep(100);
-
-        final Catalog restoreCatalog = restoreExecution.getRestoreCatalog();
-        assertNotNull(restoreCatalog);
-
-        int cnt = 0;
-        while (cnt < 100
-                && (restoreExecution.getStatus() != BatchStatus.COMPLETED
-                        || !restoreExecution.isRunning())) {
-            Thread.sleep(100);
-            cnt++;
-
-            if (restoreExecution.getStatus() == BatchStatus.ABANDONED
-                    || restoreExecution.getStatus() == BatchStatus.FAILED
-                    || restoreExecution.getStatus() == BatchStatus.UNKNOWN) {
-
-                for (Throwable exception : restoreExecution.getAllFailureExceptions()) {
-                    LOGGER.log(Level.INFO, "ERROR: " + exception.getLocalizedMessage(), exception);
-                    exception.printStackTrace();
-                }
-                break;
-            }
-        }
-
-        if (restoreExecution.getStatus() != BatchStatus.COMPLETED && restoreExecution.isRunning()) {
-            backupFacade.stopExecution(restoreExecution.getId());
-        }
-
-        if (restoreCatalog.getWorkspaces().size() > 0) {
-            assertEquals(
-                    restoreCatalog.getWorkspaces().size(), restoreCatalog.getNamespaces().size());
-            assertEquals(9, restoreCatalog.getDataStores().size(), 9);
-            assertEquals(43, restoreCatalog.getResources(FeatureTypeInfo.class).size());
-            assertEquals(4, restoreCatalog.getResources(CoverageInfo.class).size());
-            assertEquals(35, restoreCatalog.getStyles().size());
-            assertEquals(33, restoreCatalog.getLayers().size());
-            assertEquals(3, restoreCatalog.getLayerGroups().size());
-        }
-        // check Workspaces and Namespaces IDs are respected
-        checkWorkspacesAndNamespacesIds(restoreCatalog);
-
-        checkExtraPropertiesExists();
-        if (restoreExecution.getStatus() == BatchStatus.COMPLETED) {
-            assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
-            // check that generic listener was invoked for the backup job
-            assertThat(GenericListener.getBackupAfterInvocations(), is(3));
-            assertThat(GenericListener.getBackupBeforeInvocations(), is(3));
-            assertThat(GenericListener.getRestoreAfterInvocations(), is(3));
-            assertThat(GenericListener.getRestoreBeforeInvocations(), is(3));
-        }
-    }
-
-    private void checkWorkspacesAndNamespacesIds(final Catalog restoreCatalog) {
+    private static void checkWorkspacesAndNamespacesIds(final Catalog restoreCatalog) {
         // Check workspaces former IDs are respected
         catalog.getWorkspaces()
                 .forEach(
@@ -262,90 +194,6 @@ public class BackupTest extends BackupRestoreTestSupport {
                                     restoreCatalog.getNamespaceByPrefix(nsInfo.getPrefix());
                             assertEquals(nsInfo.getId(), restpreNsInfo.getId());
                         });
-    }
-
-    @Test
-    public void testParameterizedRestore() throws Exception {
-        Hints hints = new Hints(new HashMap(2));
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                        Backup.PARAM_BEST_EFFORT_MODE));
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_PARAMETERIZE_PASSWDS),
-                        Backup.PARAM_PARAMETERIZE_PASSWDS));
-
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_PASSWORD_TOKENS, "*"),
-                        "${sf:sf.passwd.encryptedValue}=foo"));
-
-        RestoreExecutionAdapter restoreExecution =
-                backupFacade.runRestoreAsync(
-                        file("parameterized-restore.zip"), null, null, null, hints);
-
-        // Wait a bit
-        Thread.sleep(100);
-
-        assertNotNull(backupFacade.getRestoreExecutions());
-        assertTrue(!backupFacade.getRestoreExecutions().isEmpty());
-
-        assertNotNull(restoreExecution);
-
-        Thread.sleep(100);
-
-        final Catalog restoreCatalog = restoreExecution.getRestoreCatalog();
-        assertNotNull(restoreCatalog);
-
-        int cnt = 0;
-        while (cnt < 100
-                && (restoreExecution.getStatus() != BatchStatus.COMPLETED
-                        || !restoreExecution.isRunning())) {
-            Thread.sleep(100);
-            cnt++;
-
-            if (restoreExecution.getStatus() == BatchStatus.ABANDONED
-                    || restoreExecution.getStatus() == BatchStatus.FAILED
-                    || restoreExecution.getStatus() == BatchStatus.UNKNOWN) {
-
-                for (Throwable exception : restoreExecution.getAllFailureExceptions()) {
-                    LOGGER.log(Level.INFO, "ERROR: " + exception.getLocalizedMessage(), exception);
-                    exception.printStackTrace();
-                }
-                break;
-            }
-        }
-
-        if (restoreExecution.getStatus() != BatchStatus.COMPLETED && restoreExecution.isRunning()) {
-            backupFacade.stopExecution(restoreExecution.getId());
-        }
-
-        if (restoreCatalog.getWorkspaces().size() > 0) {
-            assertEquals(
-                    restoreCatalog.getWorkspaces().size(), restoreCatalog.getNamespaces().size());
-            assertEquals(9, restoreCatalog.getDataStores().size());
-            assertEquals(47, restoreCatalog.getResources(FeatureTypeInfo.class).size());
-            assertEquals(4, restoreCatalog.getResources(CoverageInfo.class).size());
-            assertEquals(35, restoreCatalog.getStyles().size());
-            assertEquals(33, restoreCatalog.getLayers().size());
-            assertEquals(3, restoreCatalog.getLayerGroups().size());
-        }
-
-        checkExtraPropertiesExists();
-        if (restoreExecution.getStatus() == BatchStatus.COMPLETED) {
-            assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
-            // check that generic listener was invoked for the backup job
-            assertThat(GenericListener.getBackupAfterInvocations(), is(0));
-            assertThat(GenericListener.getBackupBeforeInvocations(), is(0));
-            assertThat(GenericListener.getRestoreAfterInvocations(), is(1));
-            assertThat(GenericListener.getRestoreBeforeInvocations(), is(1));
-
-            DataStoreInfo restoredDataStore =
-                    restoreCatalog.getStoreByName("sf", "sf", DataStoreInfo.class);
-            Serializable passwd = restoredDataStore.getConnectionParameters().get("passwd");
-            assertEquals("foo", passwd);
-        }
     }
 
     @Test
@@ -550,7 +398,7 @@ public class BackupTest extends BackupRestoreTestSupport {
     /**
      * Helper method that just check if the extra properties file was correctly backup / restore.
      */
-    private void checkExtraPropertiesExists() {
+    static void checkExtraPropertiesExists() {
         // find the properties file on the current data dir
         GeoServerDataDirectory dataDirectory =
                 GeoServerExtensions.bean(GeoServerDataDirectory.class);
@@ -568,5 +416,211 @@ public class BackupTest extends BackupRestoreTestSupport {
         assertThat(extraProperties.size(), is(2));
         assertThat(extraProperties.getProperty("property.a"), is("1"));
         assertThat(extraProperties.getProperty("property.b"), is("2"));
+    }
+
+    public static class ParameterizedRestoreTest extends BackupRestoreTestSupport {
+
+        @Before
+        public void beforeTest() throws InterruptedException {
+            ensureCleanedQueues();
+
+            // Authenticate as Administrator
+            login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        }
+
+        @Test
+        public void testParameterizedRestore() throws Exception {
+            Hints hints = new Hints(new HashMap(2));
+            hints.add(
+                    new Hints(
+                            new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
+                            Backup.PARAM_BEST_EFFORT_MODE));
+            hints.add(
+                    new Hints(
+                            new Hints.OptionKey(Backup.PARAM_PARAMETERIZE_PASSWDS),
+                            Backup.PARAM_PARAMETERIZE_PASSWDS));
+
+            hints.add(
+                    new Hints(
+                            new Hints.OptionKey(Backup.PARAM_PASSWORD_TOKENS, "*"),
+                            "${sf:sf.passwd.encryptedValue}=foo"));
+
+            removeSfDatastore();
+
+            RestoreExecutionAdapter restoreExecution =
+                    backupFacade.runRestoreAsync(
+                            file("parameterized-restore.zip"), null, null, null, hints);
+
+            // Wait a bit
+            Thread.sleep(100);
+
+            assertNotNull(backupFacade.getRestoreExecutions());
+            assertTrue(!backupFacade.getRestoreExecutions().isEmpty());
+
+            assertNotNull(restoreExecution);
+
+            Thread.sleep(100);
+
+            final Catalog restoreCatalog = restoreExecution.getRestoreCatalog();
+            assertNotNull(restoreCatalog);
+
+            int cnt = 0;
+            while (cnt < 100
+                    && (restoreExecution.getStatus() != BatchStatus.COMPLETED
+                            || !restoreExecution.isRunning())) {
+                Thread.sleep(100);
+                cnt++;
+
+                if (restoreExecution.getStatus() == BatchStatus.ABANDONED
+                        || restoreExecution.getStatus() == BatchStatus.FAILED
+                        || restoreExecution.getStatus() == BatchStatus.UNKNOWN) {
+
+                    for (Throwable exception : restoreExecution.getAllFailureExceptions()) {
+                        LOGGER.log(
+                                Level.INFO, "ERROR: " + exception.getLocalizedMessage(), exception);
+                        exception.printStackTrace();
+                    }
+                    break;
+                }
+            }
+
+            if (restoreExecution.getStatus() != BatchStatus.COMPLETED
+                    && restoreExecution.isRunning()) {
+                backupFacade.stopExecution(restoreExecution.getId());
+            }
+
+            if (restoreCatalog.getWorkspaces().size() > 0) {
+                assertEquals(
+                        restoreCatalog.getWorkspaces().size(),
+                        restoreCatalog.getNamespaces().size());
+                assertEquals(9, restoreCatalog.getDataStores().size());
+                assertEquals(47, restoreCatalog.getResources(FeatureTypeInfo.class).size());
+                assertEquals(4, restoreCatalog.getResources(CoverageInfo.class).size());
+                assertEquals(35, restoreCatalog.getStyles().size());
+                assertEquals(30, restoreCatalog.getLayers().size());
+                assertEquals(1, restoreCatalog.getLayerGroups().size());
+            }
+
+            checkExtraPropertiesExists();
+            if (restoreExecution.getStatus() == BatchStatus.COMPLETED) {
+                assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
+                // check that generic listener was invoked for the backup job
+                assertThat(GenericListener.getBackupAfterInvocations(), is(4));
+                assertThat(GenericListener.getBackupBeforeInvocations(), is(4));
+                assertThat(GenericListener.getRestoreAfterInvocations(), is(2));
+                assertThat(GenericListener.getRestoreBeforeInvocations(), is(2));
+
+                DataStoreInfo restoredDataStore =
+                        restoreCatalog.getStoreByName("sf", "sf", DataStoreInfo.class);
+                Serializable passwd = restoredDataStore.getConnectionParameters().get("passwd");
+                assertEquals("foo", passwd);
+            }
+        }
+
+        private void removeSfDatastore() {
+            DataStoreInfo sfDataStore = catalog.getStoreByName("sf", "sf", DataStoreInfo.class);
+            List<ResourceInfo> resourcesByStore =
+                    catalog.getResourcesByStore(sfDataStore, ResourceInfo.class);
+            for (ResourceInfo ri : resourcesByStore) {
+                List<LayerInfo> layers = catalog.getLayers(ri);
+                for (LayerInfo li : layers) {
+                    List<LayerGroupInfo> layerGroups = catalog.getLayerGroups();
+                    for (LayerGroupInfo gi : layerGroups) {
+                        if (gi.getLayers().contains(li)) {
+                            catalog.remove(gi);
+                        }
+                    }
+                    catalog.remove(li);
+                }
+                catalog.remove(ri);
+            }
+            catalog.remove(sfDataStore);
+        }
+    }
+
+    public static class RunSpringBatchRestoreJobTest extends BackupRestoreTestSupport {
+
+        @Before
+        public void beforeTest() throws InterruptedException {
+            ensureCleanedQueues();
+
+            // Authenticate as Administrator
+            login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        }
+
+        @Test
+        public void testRunSpringBatchRestoreJob() throws Exception {
+            Hints hints = new Hints(new HashMap(2));
+            hints.add(
+                    new Hints(
+                            new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
+                            Backup.PARAM_BEST_EFFORT_MODE));
+
+            RestoreExecutionAdapter restoreExecution =
+                    backupFacade.runRestoreAsync(
+                            file("geoserver-full-backup.zip"), null, null, null, hints);
+
+            // Wait a bit
+            Thread.sleep(100);
+
+            assertNotNull(backupFacade.getRestoreExecutions());
+            assertTrue(!backupFacade.getRestoreExecutions().isEmpty());
+
+            assertNotNull(restoreExecution);
+
+            Thread.sleep(100);
+
+            final Catalog restoreCatalog = restoreExecution.getRestoreCatalog();
+            assertNotNull(restoreCatalog);
+
+            int cnt = 0;
+            while (cnt < 100
+                    && (restoreExecution.getStatus() != BatchStatus.COMPLETED
+                            || !restoreExecution.isRunning())) {
+                Thread.sleep(100);
+                cnt++;
+
+                if (restoreExecution.getStatus() == BatchStatus.ABANDONED
+                        || restoreExecution.getStatus() == BatchStatus.FAILED
+                        || restoreExecution.getStatus() == BatchStatus.UNKNOWN) {
+
+                    for (Throwable exception : restoreExecution.getAllFailureExceptions()) {
+                        LOGGER.log(
+                                Level.INFO, "ERROR: " + exception.getLocalizedMessage(), exception);
+                        exception.printStackTrace();
+                    }
+                    break;
+                }
+            }
+
+            if (restoreExecution.getStatus() != BatchStatus.COMPLETED
+                    && restoreExecution.isRunning()) {
+                backupFacade.stopExecution(restoreExecution.getId());
+            }
+
+            if (restoreCatalog.getWorkspaces().size() > 0) {
+                assertEquals(
+                        restoreCatalog.getWorkspaces().size(),
+                        restoreCatalog.getNamespaces().size());
+                assertEquals(9, restoreCatalog.getDataStores().size(), 9);
+                assertEquals(50, restoreCatalog.getResources(FeatureTypeInfo.class).size());
+                assertEquals(4, restoreCatalog.getResources(CoverageInfo.class).size());
+                assertEquals(35, restoreCatalog.getStyles().size());
+                assertEquals(33, restoreCatalog.getLayers().size());
+                assertEquals(3, restoreCatalog.getLayerGroups().size());
+            }
+            // check Workspaces and Namespaces IDs are respected
+            checkWorkspacesAndNamespacesIds(restoreCatalog);
+
+            checkExtraPropertiesExists();
+            if (restoreExecution.getStatus() == BatchStatus.COMPLETED) {
+                assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
+                // check that generic listener was invoked for the backup job
+                assertThat(GenericListener.getBackupAfterInvocations(), is(4));
+                assertThat(GenericListener.getBackupBeforeInvocations(), is(4));
+                assertThat(GenericListener.getRestoreAfterInvocations(), is(3));
+                assertThat(GenericListener.getRestoreBeforeInvocations(), is(3));
+            }
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-9948](https://badgen.net/badge/JIRA/GEOS-9948/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9948) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backup and Restore replaces not involved layers during restore process, generating new IDs and hence breaking GWC layers definitions since they are layer-ID linked. This PR introduces a fix for this issue.

JIRA ticket:
https://osgeo-org.atlassian.net/browse/GEOS-9948

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.