### PR TITLE
[GEOS-10017] Depend on gt-flatgeobuf instead of flatgeobuf

### DIFF
--- a/src/community/flatgeobuf/pom.xml
+++ b/src/community/flatgeobuf/pom.xml
@@ -28,9 +28,9 @@
       <artifactId>gs-web-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.wololo</groupId>
-      <artifactId>flatgeobuf</artifactId>
-      <version>3.10.1</version>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-flatgeobuf</artifactId>
+      <version>${gt.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/community/flatgeobuf/src/main/java/org/geoserver/wfs/flatgeobuf/FlatGeobufOutputFormat.java
+++ b/src/community/flatgeobuf/src/main/java/org/geoserver/wfs/flatgeobuf/FlatGeobufOutputFormat.java
@@ -15,10 +15,10 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.WFSInfo;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
+import org.geotools.data.flatgeobuf.FeatureCollectionConversions;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureCollection;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.wololo.flatgeobuf.geotools.FeatureCollectionConversions;
 
 /**
  * A GetFeatureInfo response handler specialized in producing FlatGeobuf data for a GetFeatureInfo


### PR DESCRIPTION
[![GEOS-10017](https://badgen.net/badge/JIRA/GEOS-10017/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10017) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Migrate to gt-flatgeobuf to make flatgeobuf a transitive dependency via geotools instead of the older flatgeobuf version which had a geotools dependency causing potential version clashes.