### PR TITLE
[2.19.x backport][GEOS-10014] Layers with dimensions are missing on WMS GetCapabilites output when catalog security is set to Challenge

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureTypeInfo.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.StoreInfo;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.Request;
 import org.geoserver.security.AccessLevel;
 import org.geoserver.security.SecureCatalogImpl;
 import org.geoserver.security.VectorAccessLimits;
@@ -39,6 +41,8 @@ import org.opengis.util.ProgressListener;
  * @author Andrea Aime - TOPP
  */
 public class SecuredFeatureTypeInfo extends DecoratingFeatureTypeInfo {
+
+    protected static final String GET_CAPABILITIES = "GetCapabilities";
 
     WrapperPolicy policy;
 
@@ -103,12 +107,39 @@ public class SecuredFeatureTypeInfo extends DecoratingFeatureTypeInfo {
             ProgressListener listener, Hints hints) throws IOException {
         final FeatureSource<? extends FeatureType, ? extends Feature> fs =
                 delegate.getFeatureSource(listener, hints);
-
-        if (policy.level == AccessLevel.METADATA) {
+        Request request = Dispatcher.REQUEST.get();
+        if (policy.level == AccessLevel.METADATA && !isGetCapabilities(request)) {
             throw SecureCatalogImpl.unauthorizedAccess(this.getName());
         } else {
-            return SecuredObjects.secure(fs, policy);
+            return SecuredObjects.secure(fs, computeWrapperPolicy(request));
         }
+    }
+
+    /**
+     * Checks if current request is GetCapabilities and returns a new WrapperPolicy with attributes
+     * read allowed to compute the dimensions values. If current request is not a GetCapabilities
+     * one, returns the same policy without changes.
+     */
+    private WrapperPolicy computeWrapperPolicy(Request request) {
+        if (isGetCapabilities(request) && policy.getLimits() instanceof VectorAccessLimits) {
+            VectorAccessLimits accessLimits = (VectorAccessLimits) policy.getLimits();
+            VectorAccessLimits newLimits =
+                    new VectorAccessLimits(
+                            accessLimits.getMode(),
+                            null,
+                            Filter.INCLUDE,
+                            accessLimits.getWriteAttributes(),
+                            accessLimits.getWriteFilter());
+            WrapperPolicy newPolicy = WrapperPolicy.readOnlyChallenge(newLimits);
+            return newPolicy;
+        }
+        return policy;
+    }
+
+    /** Returns true only if current request is a GetCapabilities, otherwise returns false. */
+    private boolean isGetCapabilities(Request request) {
+        if (request == null) return false;
+        return GET_CAPABILITIES.equalsIgnoreCase(request.getRequest());
     }
 
     @Override

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorCapabilitiesTest.java
@@ -8,6 +8,12 @@ package org.geoserver.wms.wms_1_1_1;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionDefaultValueSetting.Strategy;
@@ -18,12 +24,60 @@ import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.impl.LayerGroupInfoImpl;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.GeoServerUserGroupStore;
+import org.geoserver.security.TestResourceAccessManager;
+import org.geoserver.security.VectorAccessLimits;
+import org.geoserver.security.impl.AbstractUserGroupService;
 import org.geoserver.wms.WMSDimensionsTestSupport;
 import org.junit.Test;
+import org.opengis.filter.Filter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 public class DimensionsVectorCapabilitiesTest extends WMSDimensionsTestSupport {
+
+    /** Add the test resource access manager in the spring context */
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:/org/geoserver/wms/ResourceAccessManagerContext.xml");
+    }
+
+    /** Enable the Spring Security auth filters */
+    @Override
+    protected List<javax.servlet.Filter> getFilters() {
+        return Collections.singletonList(
+                (javax.servlet.Filter) GeoServerExtensions.bean("filterChainProxy"));
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        GeoServerUserGroupStore ugStore =
+                getSecurityManager()
+                        .loadUserGroupService(AbstractUserGroupService.DEFAULT_NAME)
+                        .createStore();
+        ugStore.addUser(ugStore.createUserObject("admin2", "geoserver", true));
+        ugStore.store();
+    }
+
+    @Override
+    protected void setUpTestData(SystemTestData testData) throws Exception {
+        super.setUpTestData(testData);
+
+        File security = new File(testData.getDataDirectoryRoot(), "security");
+        security.mkdir();
+
+        File users = new File(security, "users.properties");
+        Properties props = new Properties();
+        props.put("admin", "geoserver,ROLE_ADMINISTRATOR");
+        props.put("admin2", "ROLE_DUMMY");
+        props.store(new FileOutputStream(users), "");
+    }
 
     @Test
     public void testNoDimension() throws Exception {
@@ -418,5 +472,44 @@ public class DimensionsVectorCapabilitiesTest extends WMSDimensionsTestSupport {
         Document dom = dom(get("wms?request=getCapabilities&version=1.1.0"), false);
         assertXpathEvaluatesTo(
                 "2011-05-01T00:00:00Z", "//Layer[Name='sf:TimeElevation']/Extent/@default", dom);
+    }
+
+    @Test
+    public void testElevationContinuousChallenge() throws Exception {
+        Catalog catalog = getCatalog();
+        TestResourceAccessManager tam = getResourceAccessManager();
+
+        FeatureTypeInfo featureTypeInfo = catalog.getFeatureTypeByName("sf:TimeElevation");
+        tam.putLimits(
+                "admin2",
+                featureTypeInfo,
+                new VectorAccessLimits(
+                        CatalogMode.CHALLENGE, null, Filter.EXCLUDE, null, Filter.EXCLUDE));
+
+        setupVectorDimension(
+                ResourceInfo.ELEVATION,
+                "elevation",
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                UNITS,
+                UNIT_SYMBOL);
+
+        setRequestAuth("admin2", "geoserver");
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        // check dimension has been declared
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(UNITS, "//Layer/Dimension/@units", dom);
+        assertXpathEvaluatesTo(UNIT_SYMBOL, "//Layer/Dimension/@unitSymbol", dom);
+        // check we have the extent
+        assertXpathEvaluatesTo("1", "count(//Layer/Extent)", dom);
+        assertXpathEvaluatesTo("elevation", "//Layer/Extent/@name", dom);
+        assertXpathEvaluatesTo("0.0", "//Layer/Extent/@default", dom);
+        assertXpathEvaluatesTo("0.0/3.0/0", "//Layer/Extent", dom);
+    }
+
+    protected TestResourceAccessManager getResourceAccessManager() {
+        return (TestResourceAccessManager) applicationContext.getBean("testResourceAccessManager");
     }
 }


### PR DESCRIPTION
[![GEOS-10014](https://badgen.net/badge/JIRA/GEOS-10014/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10014) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR introduces a fix and some JUnit WMS GetCapabilities integration tests for issue: Layers with dimensions are missing on WMS GetCapabilites output when catalog security is set to Challenge.

Jira ticket:
https://osgeo-org.atlassian.net/browse/GEOS-10014

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.