### PR TITLE
Fix list of dependencies for ext-flatgeobuf

### DIFF
--- a/src/community/release/ext-flatgeobuf.xml
+++ b/src/community/release/ext-flatgeobuf.xml
@@ -10,6 +10,7 @@
             <outputDirectory></outputDirectory>
             <includes>
                 <include>gs-flatgeobuf*.jar</include>
+                <include>gt-flatgeobuf*.jar</include>
                 <include>flatgeobuf*.jar</include>
                 <include>flatbuffers-java*.jar</include>
             </includes>


### PR DESCRIPTION
Follow up to https://github.com/geoserver/geoserver/pull/4952, needs `gs-flatgeobuf` in the release builder project to properly include in the built zip artifact.