### PR TITLE
Improve description of FlatGeobuf extension

### DIFF
--- a/src/community/flatgeobuf/README.md
+++ b/src/community/flatgeobuf/README.md
@@ -1,5 +1,5 @@
-# FlatGeobuf WFS output format prototype
+# FlatGeobuf DataStore and WFS output format extension
 
-This module contains a prototype FlatGeobuf WFS output format.
+This module adds FlatGeobuf as DataStore and WFS output format.
 
-* https://github.com/bjornharrtell/flatgeobuf
+* https://flatgeobuf.org

--- a/src/community/flatgeobuf/pom.xml
+++ b/src/community/flatgeobuf/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>org.geoserver.community</groupId>
   <artifactId>gs-flatgeobuf</artifactId>
-  <name>FlatGeobuf WFS custom output format</name>
+  <name>FlatGeobuf DataStore and WFS output format</name>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
As of https://github.com/geoserver/geoserver/pull/4952 the FlatGeobuf extension is no longer only providing WFS output format but also adds itself as a GeoServer compatible DataStore. This PR fixes the description of the extension accordingly and removes "prototype" I now see it as complete.