### PR TITLE
[GEOS-10027] CoverageReaderFileConverter fails to convert valid input file path or url

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
@@ -82,7 +82,7 @@ public class CoverageReaderFileConverter implements CoverageReaderInputObjectCon
             URI uri = new URL(input).toURI();
             canConvert = uri.getScheme() == null || "file".equalsIgnoreCase(uri.getScheme());
         } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
-            if (input.startsWith("file")) {
+            if (input.startsWith("file:")) {
                 canConvert = true;
             } else {
                 // lets see if we have a normal file path

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageReaderFileConverter.java
@@ -5,8 +5,10 @@
 package org.geoserver.catalog;
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.geoserver.platform.resource.Files;
@@ -74,14 +76,21 @@ public class CoverageReaderFileConverter implements CoverageReaderInputObjectCon
      *     input to File.
      */
     protected boolean canConvert(String input) {
-        // Check to see if our "url" points to a file or not, otherwise we use the string itself for
-        // reading
+        boolean canConvert = false;
+        // Check to see if our "url" points to a file or not.
         try {
-            URI uri = new URI(input);
-            return uri.getScheme() == null || "file".equalsIgnoreCase(uri.getScheme());
-        } catch (URISyntaxException e) {
-            return false;
+            URI uri = new URL(input).toURI();
+            canConvert = uri.getScheme() == null || "file".equalsIgnoreCase(uri.getScheme());
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
+            if (input.startsWith("file")) {
+                canConvert = true;
+            } else {
+                // lets see if we have a normal file path
+                File file = new File(input);
+                canConvert = file.exists() || !file.isAbsolute();
+            }
         }
+        return canConvert;
     }
 
     /**

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -47,6 +47,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
@@ -96,6 +97,7 @@ import org.geotools.util.URLs;
 import org.geotools.util.Version;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.locationtech.jts.geom.Point;
@@ -886,6 +888,55 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
 
         GridCoverageReader reader = pool.getGridCoverageReader(info, null);
 
+        // the CoverageReaderFileConverter should have successfully converted the URL string to a
+        // File object
+        assertTrue(reader.getSource() instanceof File);
+    }
+
+    /**
+     * Tests that even if the input string cannot be parsed as a valid URI reference, but the it is
+     * nontheless a valid file URL, the CoverageReaderFileConverter is able to do the conversion.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testCoverageReaderInputConverterInvalidURI() throws IOException {
+        Assume.assumeTrue(SystemUtils.IS_OS_WINDOWS);
+        String fileURL =
+                MockData.class.getResource("tazdem.tiff").getFile().replaceAll("/", "\\\\");
+        fileURL = "file://" + fileURL;
+        // the file URL is not now a valid URI but the converter should be able to convert it
+        Catalog catalog = getCatalog();
+        ResourcePool pool = new ResourcePool(catalog);
+
+        CoverageStoreInfo info = catalog.getFactory().createCoverageStore();
+        info.setType("GeoTIFF");
+        info.setURL(fileURL);
+
+        GridCoverageReader reader = pool.getGridCoverageReader(info, null);
+        // the CoverageReaderFileConverter should have successfully converted the URL string to a
+        // File object
+        assertTrue(reader.getSource() instanceof File);
+    }
+
+    /**
+     * Tests that even if the input string is a valid file path, the CoverageReaderFileConverter is
+     * able to do the conversion.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testCoverageReaderInputConverterFilePath() throws IOException {
+        String fileURL = MockData.class.getResource("tazdem.tiff").getFile();
+        // the file URL is not now a valid URI but the converter should be able to convert it
+        Catalog catalog = getCatalog();
+        ResourcePool pool = new ResourcePool(catalog);
+
+        CoverageStoreInfo info = catalog.getFactory().createCoverageStore();
+        info.setType("GeoTIFF");
+        info.setURL(fileURL);
+
+        GridCoverageReader reader = pool.getGridCoverageReader(info, null);
         // the CoverageReaderFileConverter should have successfully converted the URL string to a
         // File object
         assertTrue(reader.getSource() instanceof File);

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -902,8 +902,7 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
     @Test
     public void testCoverageReaderInputConverterInvalidURI() throws IOException {
         Assume.assumeTrue(SystemUtils.IS_OS_WINDOWS);
-        String fileURL =
-                MockData.class.getResource("tazdem.tiff").getFile().replaceAll("/", "\\\\");
+        String fileURL = MockData.class.getResource("tazdem.tiff").getFile().replace("/", "\\");
         fileURL = "file://" + fileURL;
         // the file URL is not now a valid URI but the converter should be able to convert it
         Catalog catalog = getCatalog();


### PR DESCRIPTION
[![GEOS-10027](https://badgen.net/badge/JIRA/GEOS-10027/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10027) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Jira ticket https://osgeo-org.atlassian.net/browse/GEOS-10027

fix a regression caused  by the CoverageReaderFileConverter preventing a coverage file name to be retrieved when saving the store and automatically set as the layer name.

Before the introduction of the CoverageReaderFileConverter [the check on the input string](https://github.com/geoserver/geoserver/blob/2.17.x/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java#L1645), 
 was returning false only if the URI was not a file uri, but was true even if the URI constructor failed.
This pr switch to the URL constructor that seems more tolerant  of the URI on the string passed, and performs few more checks.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.