### PR TITLE
[GEOS-10033] Update startup and shutdown scripts to handle spaces in paths

### DIFF
--- a/src/release/bin/shutdown.sh
+++ b/src/release/bin/shutdown.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+set -o errexit
+set -o nounset
+
+IFS=$(printf '\n\t')
 # -----------------------------------------------------------------------------
 # Start Script for GEOSERVER
 #
@@ -6,19 +10,19 @@
 # -----------------------------------------------------------------------------
 
 # Guard against misconfigured JAVA_HOME
-if [ ! -z "$JAVA_HOME" -a ! -x "$JAVA_HOME"/bin/java ]; then
+if [ -n "${JAVA_HOME:-}" ] && [ ! -x "${JAVA_HOME}/bin/java" ]; then
   echo "The JAVA_HOME environment variable is set but JAVA_HOME/bin/java"
   echo "is missing or not executable:"
-  echo "    JAVA_HOME=$JAVA_HOME"
+  echo "    JAVA_HOME=${JAVA_HOME}"
   echo "Please either set JAVA_HOME so that the Java runtime is JAVA_HOME/bin/java"
   echo "or unset JAVA_HOME to use the Java runtime on the PATH."
   exit 1
 fi
 
 # Find java from JAVA_HOME or PATH
-if [ ! -z "$JAVA_HOME" ]; then
-  _RUNJAVA="$JAVA_HOME"/bin/java
-elif [ ! -z "$(which java)" ]; then
+if [ -n "${JAVA_HOME:-}" ]; then
+  _RUNJAVA="${JAVA_HOME}/bin/java"
+elif [ -n "$(command -v java)" ]; then
   _RUNJAVA=java
 else
   echo "A Java runtime (java) was not found in JAVA_HOME/bin or on the PATH."
@@ -27,37 +31,38 @@ else
   exit 1
 fi
 
-if [ -z $GEOSERVER_HOME ]; then
+if [ -z "${GEOSERVER_HOME:-}" ]; then
   #If GEOSERVER_HOME not set then guess a few locations before giving
   # up and demanding user set it.
   if [ -r start.jar ]; then
      echo "GEOSERVER_HOME environment variable not found, using current "
      echo "directory.  If not set then running this script from other "
      echo "directories will not work in the future."
-     export GEOSERVER_HOME=.
+     GEOSERVER_HOME="$(pwd)"
   else 
     if [ -r ../start.jar ]; then
       echo "GEOSERVER_HOME environment variable not found, using current "
       echo "location.  If not set then running this script from other "
       echo "directories will not work in the future."
-      export GEOSERVER_HOME=..
+      GEOSERVER_HOME="$(pwd)/.."
     fi
   fi 
 
-  if [ -z "$GEOSERVER_HOME" ]; then
+  if [ -z "${GEOSERVER_HOME:-}" ]; then
     echo "The GEOSERVER_HOME environment variable is not defined"
     echo "This environment variable is needed to run this program"
     echo "Please set it to the directory where geoserver was installed"
     exit 1
   fi
 
+  export GEOSERVER_HOME
 fi
 
-if [ ! -r "$GEOSERVER_HOME"/start.jar ]; then
+if [ ! -r "${GEOSERVER_HOME}/start.jar" ]; then
   echo "The GEOSERVER_HOME environment variable is not defined correctly"
   echo "This environment variable is needed to run this program"
   exit 1
 fi
 
-cd "$GEOSERVER_HOME"
-exec "$_RUNJAVA" $JAVA_OPTS -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar start.jar --stop
+cd "${GEOSERVER_HOME}" || exit 1
+exec "${_RUNJAVA}" "${JAVA_OPTS:--DnoJavaOpts}" -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar start.jar --stop

--- a/src/release/bin/startup.sh
+++ b/src/release/bin/startup.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+set -o errexit
+set -o nounset
+
+IFS=$(printf '\n\t')
 # -----------------------------------------------------------------------------
 # Start Script for GEOSERVER
 #
@@ -6,19 +10,19 @@
 # -----------------------------------------------------------------------------
 
 # Guard against misconfigured JAVA_HOME
-if [ ! -z "$JAVA_HOME" -a ! -x "$JAVA_HOME"/bin/java ]; then
+if [ -n "${JAVA_HOME:-}" ] && [ ! -x "${JAVA_HOME}/bin/java" ]; then
   echo "The JAVA_HOME environment variable is set but JAVA_HOME/bin/java"
   echo "is missing or not executable:"
-  echo "    JAVA_HOME=$JAVA_HOME"
+  echo "    JAVA_HOME=${JAVA_HOME}"
   echo "Please either set JAVA_HOME so that the Java runtime is JAVA_HOME/bin/java"
   echo "or unset JAVA_HOME to use the Java runtime on the PATH."
   exit 1
 fi
 
 # Find java from JAVA_HOME or PATH
-if [ ! -z "$JAVA_HOME" ]; then
-  _RUNJAVA="$JAVA_HOME"/bin/java
-elif [ ! -z "$(which java)" ]; then
+if [ -n "${JAVA_HOME:-}" ]; then
+  _RUNJAVA="${JAVA_HOME}/bin/java"
+elif [ -n "$(command -v java)" ]; then
   _RUNJAVA=java
 else
   echo "A Java runtime (java) was not found in JAVA_HOME/bin or on the PATH."
@@ -27,56 +31,59 @@ else
   exit 1
 fi
 
-if [ -z $GEOSERVER_HOME ]; then
+if [ -z "${GEOSERVER_HOME:-}" ]; then
   #If GEOSERVER_HOME not set then guess a few locations before giving
   # up and demanding user set it.
   if [ -r start.jar ]; then
      echo "GEOSERVER_HOME environment variable not found, using current "
      echo "directory.  If not set then running this script from other "
      echo "directories will not work in the future."
-     export GEOSERVER_HOME=`pwd`
+     GEOSERVER_HOME="$(pwd)"
   else 
     if [ -r ../start.jar ]; then
       echo "GEOSERVER_HOME environment variable not found, using current "
       echo "location.  If not set then running this script from other "
       echo "directories will not work in the future."
-      export GEOSERVER_HOME=`pwd`/..
+      GEOSERVER_HOME="$(pwd)/.."
     fi
   fi 
 
-  if [ -z "$GEOSERVER_HOME" ]; then
+  if [ -z "${GEOSERVER_HOME:-}" ]; then
     echo "The GEOSERVER_HOME environment variable is not defined"
     echo "This environment variable is needed to run this program"
     echo "Please set it to the directory where geoserver was installed"
     exit 1
   fi
 
+  export GEOSERVER_HOME
 fi
 
-if [ ! -r "$GEOSERVER_HOME"/bin/startup.sh ]; then
+if [ ! -r "${GEOSERVER_HOME}/bin/startup.sh" ]; then
   echo "The GEOSERVER_HOME environment variable is not defined correctly"
   echo "This environment variable is needed to run this program"
   exit 1
 fi
 
 #Find the configuration directory: GEOSERVER_DATA_DIR
-if [ -z $GEOSERVER_DATA_DIR ]; then
-    if [ -r "$GEOSERVER_HOME"/data_dir ]; then
-        export GEOSERVER_DATA_DIR="$GEOSERVER_HOME"/data_dir
+if [ -z "${GEOSERVER_DATA_DIR:-}" ]; then
+    if [ -r "${GEOSERVER_HOME}/data_dir" ]; then
+        export GEOSERVER_DATA_DIR="${GEOSERVER_HOME}/data_dir"
     else
         echo "No GEOSERVER_DATA_DIR found, using application defaults"
 	      GEOSERVER_DATA_DIR=""
     fi
 fi
 
-cd "$GEOSERVER_HOME"
+cd "${GEOSERVER_HOME}" || exit 1
 
-if [ -z $MARLIN_JAR]; then
-    export MARLIN_JAR=`find \`pwd\`/webapps -name "marlin*.jar" | head -1`
-    export MARLIN_ENABLER="-Xbootclasspath/a:$MARLIN_JAR -Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine"
+if [ -z "${MARLIN_JAR:-}" ]; then
+    MARLIN_JAR=$(find "$(pwd)/webapps" -name "marlin*.jar" | head -1)
+    MARLIN_ENABLER="-Xbootclasspath/a:${MARLIN_JAR}"
+    RENDERER="-Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine"
+    export MARLIN_JAR MARLIN_ENABLER RENDERER
 fi
 
-echo "GEOSERVER DATA DIR is $GEOSERVER_DATA_DIR"
+echo "GEOSERVER DATA DIR is ${GEOSERVER_DATA_DIR}"
 #added headless to true by default, if this messes anyone up let the list
 #know and we can change it back, but it seems like it won't hurt -ch
-exec "$_RUNJAVA" $JAVA_OPTS $MARLIN_ENABLER -DGEOSERVER_DATA_DIR="$GEOSERVER_DATA_DIR" -Djava.awt.headless=true -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar start.jar 
+exec "${_RUNJAVA}" "${JAVA_OPTS:--DNoJavaOpts}" "${MARLIN_ENABLER:--DMarlinDisabled}" "${RENDERER:--DDefaultrenderer}" "-Djetty.base=${GEOSERVER_HOME}" "-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}" -Djava.awt.headless=true -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar "${GEOSERVER_HOME}/start.jar"


### PR DESCRIPTION
[![GEOS-10033](https://badgen.net/badge/JIRA/GEOS-10033/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10033) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

On linux, I tried to launch a fresh copy of Geoserver from a path containing spaces. It failed.
I looked at the startup.sh and shutdown.sh scripts and fixed quoting issues then linted those files [shellcheck](https://www.shellcheck.net/) and fixed warning.
I hope it will ease the onboarding process for new users :)

[JIRA ticket 10033](https://osgeo-org.atlassian.net/browse/GEOS-10033#)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] ~~Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)~~
- [ ] ~~Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.~~

## Details

To handle spaces in paths, `exec` command needs to be called with each argument as a single string (quoted if necessary). If an argument is empty, `java` will throw an error. I handle this by replacing empty arguments (`JAVA_OPTS` for example) by useless variables definitions (`-DNoJavaOpts`)