### PR TITLE
[2.19.x backport][GEOS-10027] CoverageReaderFileConverter fails to convert valid input file path or url (#4986)

### DIFF
--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -46,6 +46,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
@@ -95,6 +96,7 @@ import org.geotools.util.URLs;
 import org.geotools.util.Version;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.locationtech.jts.geom.Point;
@@ -884,6 +886,54 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
 
         GridCoverageReader reader = pool.getGridCoverageReader(info, null);
 
+        // the CoverageReaderFileConverter should have successfully converted the URL string to a
+        // File object
+        assertTrue(reader.getSource() instanceof File);
+    }
+
+    /**
+     * Tests that even if the input string cannot be parsed as a valid URI reference, but the it is
+     * nontheless a valid file URL, the CoverageReaderFileConverter is able to do the conversion.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testCoverageReaderInputConverterInvalidURI() throws IOException {
+        Assume.assumeTrue(SystemUtils.IS_OS_WINDOWS);
+        String fileURL = MockData.class.getResource("tazdem.tiff").getFile().replace("/", "\\");
+        fileURL = "file://" + fileURL;
+        // the file URL is not now a valid URI but the converter should be able to convert it
+        Catalog catalog = getCatalog();
+        ResourcePool pool = new ResourcePool(catalog);
+
+        CoverageStoreInfo info = catalog.getFactory().createCoverageStore();
+        info.setType("GeoTIFF");
+        info.setURL(fileURL);
+
+        GridCoverageReader reader = pool.getGridCoverageReader(info, null);
+        // the CoverageReaderFileConverter should have successfully converted the URL string to a
+        // File object
+        assertTrue(reader.getSource() instanceof File);
+    }
+
+    /**
+     * Tests that even if the input string is a valid file path, the CoverageReaderFileConverter is
+     * able to do the conversion.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testCoverageReaderInputConverterFilePath() throws IOException {
+        String fileURL = MockData.class.getResource("tazdem.tiff").getFile();
+        // the file URL is not now a valid URI but the converter should be able to convert it
+        Catalog catalog = getCatalog();
+        ResourcePool pool = new ResourcePool(catalog);
+
+        CoverageStoreInfo info = catalog.getFactory().createCoverageStore();
+        info.setType("GeoTIFF");
+        info.setURL(fileURL);
+
+        GridCoverageReader reader = pool.getGridCoverageReader(info, null);
         // the CoverageReaderFileConverter should have successfully converted the URL string to a
         // File object
         assertTrue(reader.getSource() instanceof File);


### PR DESCRIPTION
[![GEOS-10027](https://badgen.net/badge/JIRA/GEOS-10027/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10027) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* [GEOS-10027] CoverageReaderFileConverter fails to convert valid input file path or url

* review feedback

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.