### PR TITLE
[GEOS-10037] WMTS Multidimensional extension make layers encoding fail on TileLayers not being GeoServerTileLayers

### DIFF
--- a/src/extension/wmts-multi-dimensional/pom.xml
+++ b/src/extension/wmts-multi-dimensional/pom.xml
@@ -59,6 +59,11 @@
       <artifactId>xmlunit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
+++ b/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
@@ -10,7 +10,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +37,9 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.impl.DimensionInfoImpl;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.gwc.wmts.dimensions.Dimension;
+import org.geowebcache.io.XMLBuilder;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.layer.TileLayerDispatcher;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -1263,5 +1268,18 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         // print(dom);
         assertXpathEvaluatesTo(CUSTOM_DIMENSION_NAME, "/md:DomainValues/ows:Identifier", dom);
         assertXpathEvaluatesTo("CustomDimValueA", "/md:DomainValues/md:Domain", dom);
+    }
+
+    @Test
+    public void testTileLayerNotInstanceOfGeoServerTileLayer() throws IOException {
+        TileLayer tileLayer = mock(TileLayer.class);
+        TileLayerDispatcher tld = mock(TileLayerDispatcher.class);
+        XMLBuilder xml = new XMLBuilder(new StringBuilder());
+        MultiDimensionalExtension extension =
+                new MultiDimensionalExtension(getGeoServer(), getWMS(), getCatalog(), tld);
+        // No exception is thrown when the layer isn't a GeoServerTileLayer whilst
+        // the call below  was used to throw an exception when dealing with different
+        // TileLayer implementations
+        extension.encodeLayer(xml, tileLayer);
     }
 }


### PR DESCRIPTION
[![GEOS-10037](https://badgen.net/badge/JIRA/GEOS-10037/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10037) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixing the WMS-Multi-dimensional extension throwing a ServiceException when encoding a TileLayer not being instance of GeoServerTileLayer

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.