### PR TITLE
[GEOS-9844] Add standardDeviation classification for raster in SLDService module

### DIFF
--- a/doc/en/user/source/extensions/sldservice/index.rst
+++ b/doc/en/user/source/extensions/sldservice/index.rst
@@ -139,7 +139,7 @@ The parameters usable to customize the SLD are:
      - No default for vectors, "1" for rasters
    * - method
      - Classification method
-     - equalInterval, uniqueInterval, quantile, jenks, equalArea, standardDeviation (intervals above and below the mean of one standard deviation, available for vectors only)
+     - equalInterval, uniqueInterval, quantile, jenks, equalArea, standardDeviation (intervals above and below the mean of one standard deviation)
      - equalInterval
    * - open
      - open or closed ranges

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ClassifierController.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/ClassifierController.java
@@ -422,6 +422,10 @@ public class ClassifierController extends BaseSLDServiceController {
                     colorMap = builder.quantileClassification(image, intervals, open, continuous);
                 } else if ("jenks".equals(method)) {
                     colorMap = builder.jenksClassification(image, intervals, open, continuous);
+                } else if ("standardDeviation".equals(method)) {
+                    colorMap =
+                            builder.standardDeviationClassification(
+                                    image, intervals, open, continuous);
                 } else {
                     throw new RestException(
                             "Unknown classification method " + method, HttpStatus.BAD_REQUEST);

--- a/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/SldServiceCapabilities.java
+++ b/src/extension/sldService/src/main/java/org/geoserver/sldservice/rest/SldServiceCapabilities.java
@@ -24,7 +24,13 @@ class SldServiceCapabilities {
                     "standardDeviation");
 
     private final List<String> rasterClassifications =
-            Arrays.asList("quantile", "jenks", "equalArea", "equalInterval", "uniqueInterval");
+            Arrays.asList(
+                    "quantile",
+                    "jenks",
+                    "equalArea",
+                    "equalInterval",
+                    "uniqueInterval",
+                    "standardDeviation");
 
     List<String> getVectorClassifications() {
         return vectorClassifications;


### PR DESCRIPTION
[![GEOS-9844](https://badgen.net/badge/JIRA/GEOS-9844/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9844)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This pr:

- adds standardDeviationClassification for raster data in the SLD Service

- consequently updates the capabilities endpoint

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.