### PR TITLE
GEOS-10044: allows GWC to cache layergroups when a cql_filter is specified and a requestParamFilter for FILTER is configured in the tile layer

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -575,6 +575,12 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                     }
                 }
                 getMap.setStyles(newStyles);
+                if (newFilters != null
+                        && !newFilters.isEmpty()
+                        && getMap.getCQLFilter() != null
+                        && !getMap.getCQLFilter().isEmpty()) {
+                    getMap.setCQLFilter(newFilters);
+                }
                 getMap.setFilter(newFilters);
                 getMap.setSortBy(newSortBy);
             }

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -112,6 +112,15 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         gi2.getStyles().add(getCatalog().getStyleByName("raster"));
         cb.calculateLayerGroupBounds(gi2);
         getCatalog().add(gi2);
+
+        LayerGroupInfo gi3 = cf.createLayerGroup();
+        gi3.setName("testGroup3");
+        gi3.getLayers().add(getCatalog().getLayerByName(MockData.BUILDINGS.getLocalPart()));
+        gi3.getStyles().add(getCatalog().getStyleByName("raster"));
+        gi3.getLayers().add(getCatalog().getLayerByName(MockData.BUILDINGS.getLocalPart()));
+        gi3.getStyles().add(getCatalog().getStyleByName("raster"));
+        cb.calculateLayerGroupBounds(gi3);
+        getCatalog().add(gi3);
     }
 
     @Override
@@ -307,6 +316,19 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         assertNull(request.getInterpolations().get(1));
         assertNotNull(request.getInterpolations().get(2));
         assertTrue(request.getInterpolations().get(2) instanceof InterpolationBilinear);
+    }
+
+    @Test
+    public void testFiltersForLayerGroups() throws Exception {
+        HashMap kvp = new HashMap();
+        kvp.put("layers", "testGroup3");
+        kvp.put("cql_filter", "ADDRESS='123 Main Street'");
+        GetMapRequest request = reader.createRequest();
+        request = reader.read(request, parseKvp(kvp), caseInsensitiveKvp(kvp));
+        assertNotNull(request.getFilter());
+        assertEquals(2, request.getFilter().size());
+        assertNotNull(request.getCQLFilter());
+        assertEquals(2, request.getCQLFilter().size());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10044](https://badgen.net/badge/JIRA/GEOS-10044/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10044) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Allows layergroups to be properly cacheable by GWC when a requestParamFilter for FILTER is configured for the TileLayer and a cql_filter is specified on the WMS GetMap request.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.