### PR TITLE
[2.19.x backport][GEOS-10040] Bump commons-io from 2.6 to 2.8.0

### DIFF
--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/topojson/TopoJSONEncoderTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/topojson/TopoJSONEncoderTest.java
@@ -39,7 +39,7 @@ public class TopoJSONEncoderTest {
         layers.put("topp:states", layer);
 
         Topology topology = new Topology(identity, arcs, layers);
-        try (Writer writer = new OutputStreamWriter(new NullOutputStream())) {
+        try (Writer writer = new OutputStreamWriter(NullOutputStream.NULL_OUTPUT_STREAM)) {
             encoder.encode(topology, writer);
         }
     }
@@ -69,7 +69,7 @@ public class TopoJSONEncoderTest {
         layers.put("topp:states", layer);
         Topology topology = new Topology(tx, arcs, layers);
 
-        try (Writer writer = new OutputStreamWriter(new NullOutputStream())) {
+        try (Writer writer = new OutputStreamWriter(NullOutputStream.NULL_OUTPUT_STREAM)) {
             encoder.encode(topology, writer);
         }
     }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -798,7 +798,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.6</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>


### PR DESCRIPTION
[![GEOS-10040](https://badgen.net/badge/JIRA/GEOS-10040/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10040) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Bump commons-io:commons-io from 2.7 to 2.8.0
Commons IO resolved CVE-2021-29425 in 2.7: https://issues.apache.org/jira/browse/IO-556

backports #5007 to 2.19.x





## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.