### PR TITLE
[GEOS-100031] GWC loses GridSets bounds when importing data through the Importer plugin (2.18.x)

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogLayerEventListener.java
@@ -270,6 +270,13 @@ public class CatalogLayerEventListener implements CatalogListener {
                     || changedProperties.contains("workspace")) {
                 handleRename(tileLayerInfo, source, changedProperties, oldValues, newValues);
             }
+
+            GeoServerTileLayer tileLayer = mediator.getTileLayer(source);
+            if (tileLayer != null
+                    && (changedProperties.contains("nativeBoundingBox")
+                            || changedProperties.contains("bounds"))) {
+                tileLayer.boundsChanged();
+            }
         } else if (source instanceof WorkspaceInfo) {
             if (changedProperties.contains("name")) {
                 handleWorkspaceRename(source, changedProperties, oldValues, newValues);

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -8,7 +8,6 @@ package org.geoserver.gwc.layer;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static org.geoserver.gwc.GWC.tileLayerName;
 import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import static org.geoserver.ows.util.ResponseUtils.params;
 
@@ -31,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import org.geoserver.catalog.Catalog;
@@ -328,48 +328,6 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
     public boolean isQueryable() {
         boolean queryable = GWC.get().isQueryable(this);
         return queryable;
-    }
-
-    private ReferencedEnvelope getLatLonBbox() throws IllegalStateException {
-        final CoordinateReferenceSystem wgs84LonFirst;
-        try {
-            final boolean longitudeFirst = true;
-            wgs84LonFirst = CRS.decode("EPSG:4326", longitudeFirst);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        ReferencedEnvelope latLongBbox;
-        final PublishedInfo publishedInfo = getPublishedInfo();
-        if (publishedInfo instanceof LayerGroupInfo) {
-            LayerGroupInfo groupInfo = (LayerGroupInfo) publishedInfo;
-            try {
-                ReferencedEnvelope bounds = groupInfo.getBounds();
-                boolean lenient = true;
-                latLongBbox = bounds.transform(wgs84LonFirst, lenient);
-            } catch (Exception e) {
-                String msg =
-                        "Can't get lat long bounds for layer group " + tileLayerName(groupInfo);
-                LOGGER.log(Level.WARNING, msg, e);
-                throw new IllegalStateException(msg, e);
-            }
-        } else {
-            ResourceInfo resourceInfo = getResourceInfo();
-            latLongBbox = resourceInfo.getLatLonBoundingBox();
-            if (null == latLongBbox) {
-                latLongBbox = new ReferencedEnvelope(wgs84LonFirst);
-            }
-            if (null == latLongBbox.getCoordinateReferenceSystem()) {
-                ReferencedEnvelope tmp = new ReferencedEnvelope(wgs84LonFirst);
-                tmp.init(
-                        latLongBbox.getMinX(),
-                        latLongBbox.getMaxX(),
-                        latLongBbox.getMinY(),
-                        latLongBbox.getMaxY());
-                latLongBbox = tmp;
-            }
-        }
-        return latLongBbox;
     }
 
     /**
@@ -855,7 +813,9 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
     /** @see org.geowebcache.layer.TileLayer#getGridSubsets() */
     @Override
     public Set<String> getGridSubsets() {
-        return new HashSet<String>(gridSubsets().keySet());
+        Set<XMLGridSubset> gridSubsets = info.getGridSubsets();
+        if (gridSubsets == null) return Collections.emptySet();
+        return gridSubsets.stream().map(ss -> ss.getGridSetName()).collect(Collectors.toSet());
     }
 
     @Override
@@ -919,14 +879,18 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         this._subSets.set(null);
     }
 
+    /** Can be called to notify the layer bounds changed. Resets the grid subsets cache. */
+    public void boundsChanged() {
+        this._subSets.set(null);
+    }
+
     /**
      * Actually computes the layer's {@link GridSubset}s. This method is intended as a helper for
      * {@link #gridSubsets()} to compute the mappings atomically in a lock-free way
      */
     private Map<String, GridSubset> computeGridSubsets() {
-        ReferencedEnvelope latLongBbox = getLatLonBbox();
         try {
-            return getGrids(latLongBbox, gridSetBroker);
+            return getGrids(gridSetBroker);
         } catch (ConfigurationException e) {
             String msg = "Can't create grids for '" + getName() + "': " + e.getMessage();
             LOGGER.log(Level.WARNING, msg, e);
@@ -935,10 +899,8 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer {
         }
     }
 
-    private Map<String, GridSubset> getGrids(
-            final ReferencedEnvelope latLonBbox, final GridSetBroker gridSetBroker)
+    private Map<String, GridSubset> getGrids(final GridSetBroker gridSetBroker)
             throws ConfigurationException {
-
         Set<XMLGridSubset> cachedGridSets = info.getGridSubsets();
         if (cachedGridSets.size() == 0) {
             return Collections.emptyMap();

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -1607,6 +1607,8 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
         // layer)
         GridSetBroker gridSetBroker = GWC.get().getGridSetBroker();
         GridSet testGridSet = namedGridsetCopy("TEST", gridSetBroker.getDefaults().worldEpsg4326());
+        // gridset bounds are computed only for gridsets known to the broker
+        gridSetBroker.addGridSet(testGridSet);
         GridSubset testGridSubset =
                 GridSubsetFactory.createGridSubSet(
                         testGridSet,


### PR DESCRIPTION
[![GEOS-100031](https://badgen.net/badge/JIRA/GEOS-100031/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-100031) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.