### PR TITLE
[2.19.x backport][GEOS-10028] Allow to customize ComplexGeoJsonWriter encoding of nested element and non mandatory attributes (#4987)

### DIFF
--- a/src/wfs/pom.xml
+++ b/src/wfs/pom.xml
@@ -98,6 +98,13 @@
       <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+      <version>${gt.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriter.java
@@ -13,12 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.StreamSupport;
-import org.geotools.data.DataStoreFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.NameImpl;
@@ -43,7 +38,6 @@ class ComplexGeoJsonWriter {
 
     static final Logger LOGGER = Logging.getLogger(ComplexGeoJsonWriter.class);
 
-    private static Class NON_FEATURE_TYPE_PROXY;
     private static final String DATATYPE = "@dataType";
     /**
      * A string constant for representing a not needed key name because object is being added inside
@@ -51,39 +45,21 @@ class ComplexGeoJsonWriter {
      */
     private static final String INSIDE_ARRAY_ATTRIBUTE = "${inside-array}";
 
-    static {
-        try {
-            NON_FEATURE_TYPE_PROXY =
-                    Class.forName("org.geotools.data.complex.config.NonFeatureTypeProxy");
-        } catch (ClassNotFoundException e) {
-            // might be ok if the app-schema datastore is not around
-            if (StreamSupport.stream(
-                            Spliterators.spliteratorUnknownSize(
-                                    DataStoreFinder.getAllDataStores(), Spliterator.ORDERED),
-                            false)
-                    .anyMatch(
-                            f ->
-                                    f != null
-                                            && f.getClass()
-                                                    .getSimpleName()
-                                                    .equals("AppSchemaDataAccessFactory"))) {
-                LOGGER.log(
-                        Level.FINE,
-                        "Could not find NonFeatureTypeProxy yet App-schema is around, probably the class changed name, package or does not exist anymore",
-                        e);
-            }
-            NON_FEATURE_TYPE_PROXY = null;
-        }
-    }
-
     private final GeoJSONBuilder jsonWriter;
 
     private boolean geometryFound = false;
     private CoordinateReferenceSystem crs;
     private long featuresCount = 0;
 
-    public ComplexGeoJsonWriter(GeoJSONBuilder jsonWriter) {
+    private final ComplexGeoJsonWriterOptions settings;
+
+    public ComplexGeoJsonWriter(GeoJSONBuilder jsonWriter, ComplexGeoJsonWriterOptions settings) {
         this.jsonWriter = jsonWriter;
+        this.settings = settings;
+    }
+
+    public ComplexGeoJsonWriter(GeoJSONBuilder jsonWriter) {
+        this(jsonWriter, new DefaultComplexGeoJsonWriterOptions());
     }
 
     public void write(List<FeatureCollection> collections) {
@@ -645,8 +621,10 @@ class ComplexGeoJsonWriter {
             key(name);
             jsonWriter.object();
             // encode the datatype
-            jsonWriter.key(DATATYPE);
-            jsonWriter.value(getSimplifiedTypeName(attribute.getType().getName()));
+            if (settings.encodeComplexAttributeType()) {
+                jsonWriter.key(DATATYPE);
+                jsonWriter.value(getSimplifiedTypeName(attribute.getType().getName()));
+            }
             // let's see if we have actually some properties to encode
             if (attribute.getProperties() != null && !attribute.getProperties().isEmpty()) {
                 // encode the object properties, since this is not a top feature or a
@@ -667,8 +645,7 @@ class ComplexGeoJsonWriter {
      */
     private boolean isFullFeature(ComplexAttribute attribute) {
         return attribute instanceof Feature
-                && (NON_FEATURE_TYPE_PROXY == null
-                        || !NON_FEATURE_TYPE_PROXY.isInstance(attribute.getType()));
+                && !settings.encodeNestedFeatureAsProperty(attribute.getType());
     }
 
     /**

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriterOptions.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/ComplexGeoJsonWriterOptions.java
@@ -1,0 +1,44 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import java.util.List;
+import org.geotools.feature.FeatureCollection;
+import org.opengis.feature.type.ComplexType;
+
+/**
+ * Extension point to define the behaviour regarding non standard mandatory encoding behaviours of
+ * the ComplexGeoJsonWriter.
+ */
+public interface ComplexGeoJsonWriterOptions {
+
+    /**
+     * Method to check if the List of FeatureCollection being passed are supported by this specific
+     * options.
+     *
+     * @param features the list of FeatureCollection being encoded by the ComplexGeoJsonWriter
+     * @return true if this option can handle the features being encoded false otherwise.
+     */
+    boolean canHandle(List<FeatureCollection> features);
+
+    /**
+     * Method to check if the ComplexGeoJsonWriter should encode the a ComplexAttributeType name
+     * using the @dataType key in the final GeoJson output.
+     *
+     * @return true if @dataType should be included in the output, false otherwise.
+     */
+    boolean encodeComplexAttributeType();
+
+    /**
+     * Method to check if a nested Feature should be encoded as full GeoJson feature, with a
+     * properties object, an id and a geometry attribute, or can be encoded as property hence a JSON
+     * object.
+     *
+     * @param complexType the type of the nested Feature.
+     * @return true if the ComplexGeoJsonWriter can encode the nested Feature as a property, false
+     *     otherwise.
+     */
+    boolean encodeNestedFeatureAsProperty(ComplexType complexType);
+}

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/DefaultComplexGeoJsonWriterOptions.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/DefaultComplexGeoJsonWriterOptions.java
@@ -1,0 +1,67 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.StreamSupport;
+import org.geotools.data.DataStoreFinder;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.util.logging.Logging;
+import org.opengis.feature.type.ComplexType;
+
+/**
+ * This class provides the options to encode ComplexFeatures when serving them trough an AppSchema
+ * store.
+ */
+public class DefaultComplexGeoJsonWriterOptions implements ComplexGeoJsonWriterOptions {
+
+    static final Logger LOGGER = Logging.getLogger(DefaultComplexGeoJsonWriterOptions.class);
+
+    private static Class NON_FEATURE_TYPE_PROXY;
+
+    static {
+        try {
+            NON_FEATURE_TYPE_PROXY =
+                    Class.forName("org.geotools.data.complex.config.NonFeatureTypeProxy");
+        } catch (ClassNotFoundException e) {
+            // might be ok if the app-schema datastore is not around
+            if (StreamSupport.stream(
+                            Spliterators.spliteratorUnknownSize(
+                                    DataStoreFinder.getAllDataStores(), Spliterator.ORDERED),
+                            false)
+                    .anyMatch(
+                            f ->
+                                    f != null
+                                            && f.getClass()
+                                                    .getSimpleName()
+                                                    .equals("AppSchemaDataAccessFactory"))) {
+                LOGGER.log(
+                        Level.FINE,
+                        "Could not find NonFeatureTypeProxy yet App-schema is around, probably the class changed name, package or does not exist anymore",
+                        e);
+            }
+            NON_FEATURE_TYPE_PROXY = null;
+        }
+    }
+
+    @Override
+    public boolean canHandle(List<FeatureCollection> features) {
+        return true;
+    }
+
+    @Override
+    public boolean encodeComplexAttributeType() {
+        return true;
+    }
+
+    @Override
+    public boolean encodeNestedFeatureAsProperty(ComplexType complexType) {
+        return NON_FEATURE_TYPE_PROXY != null && NON_FEATURE_TYPE_PROXY.isInstance(complexType);
+    }
+}

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -190,9 +190,12 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
             featuresInfo =
                     encodeSimpleFeatures(jsonWriter, resultsList, isFeatureBounding(), operation);
         } else {
+
+            ComplexGeoJsonWriterOptions complexWriterOptions =
+                    getComplexGeoJsonWriterOptions(resultsList);
             // encode collection with complex features
             ComplexGeoJsonWriter complexWriter =
-                    new ComplexGeoJsonWriter(jsonWriter) {
+                    new ComplexGeoJsonWriter(jsonWriter, complexWriterOptions) {
 
                         @Override
                         protected void writeExtraFeatureProperties(
@@ -574,5 +577,19 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
 
     protected String getExtension(FeatureCollectionResponse response) {
         return "json";
+    }
+
+    private ComplexGeoJsonWriterOptions getComplexGeoJsonWriterOptions(
+            List<FeatureCollection> resultsList) {
+        List<ComplexGeoJsonWriterOptions> settings =
+                GeoServerExtensions.extensions(ComplexGeoJsonWriterOptions.class);
+        ComplexGeoJsonWriterOptions chosen = null;
+        for (ComplexGeoJsonWriterOptions setting : settings) {
+            if (setting.canHandle(resultsList)) chosen = setting;
+        }
+        if (chosen == null) chosen = new DefaultComplexGeoJsonWriterOptions();
+        if (LOGGER.isLoggable(Level.FINE))
+            LOGGER.log(Level.FINE, "Chosen ComplexGeoJsonWriterOptions " + chosen.getClass());
+        return chosen;
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/ComplexGeoJsonWriterTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/ComplexGeoJsonWriterTest.java
@@ -5,12 +5,28 @@
 package org.geoserver.wfs.json;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.feature.AttributeBuilder;
+import org.geotools.feature.ComplexFeatureBuilder;
+import org.geotools.feature.FakeTypes;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.LenientFeatureFactoryImpl;
+import org.geotools.feature.type.AttributeDescriptorImpl;
+import org.geotools.feature.type.FeatureTypeImpl;
 import org.junit.Test;
+import org.opengis.feature.Attribute;
 import org.opengis.feature.ComplexAttribute;
+import org.opengis.feature.Feature;
 import org.opengis.feature.IllegalAttributeException;
 import org.opengis.feature.Property;
 import org.opengis.feature.type.AttributeDescriptor;
@@ -20,7 +36,26 @@ import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.feature.type.PropertyType;
 import org.opengis.filter.identity.Identifier;
 
-public class ComplexGeoJsonWriterTest {
+public class ComplexGeoJsonWriterTest extends GeoServerSystemTestSupport {
+
+    private static final ComplexType MINENAMETYPE_TYPE =
+            new FeatureTypeImpl(
+                    /* name: */ FakeTypes.Mine.NAME_MineNameType,
+                    /* properties: */ FakeTypes.Mine.MINENAMETYPE_SCHEMA,
+                    /* identified: */ null,
+                    /* isAbstract: */ false,
+                    /* restrictions: */ Collections.emptyList(),
+                    /* superType: */ FakeTypes.ANYTYPE_TYPE,
+                    /* description: */ null);
+
+    private static final AttributeDescriptor MINENAME_DESCRIPTOR =
+            new AttributeDescriptorImpl(
+                    /* type: */ MINENAMETYPE_TYPE,
+                    /* name: */ FakeTypes.Mine.NAME_MineName,
+                    /* min: */ 1,
+                    /* max: */ 1,
+                    /* isNillable: */ false,
+                    /* defaultValue: */ null);
 
     /*
      * Tests Null safety when attribute parameter is null in checkIfFeatureIsLinked util method.
@@ -143,5 +178,97 @@ public class ComplexGeoJsonWriterTest {
                 return null;
             }
         };
+    }
+
+    @Test
+    public void testGeoJsonWriterOptions() {
+        // test the default behaviour of the ComplexGeoJsonWriter
+        // with respect to nested features
+        Feature f = buildComplexFeature();
+        StringWriter w = new StringWriter();
+        GeoJSONBuilder jWriter = new GeoJSONBuilder(w);
+        TestComplexGeoJsonWriter testWriter = new TestComplexGeoJsonWriter(jWriter);
+
+        testWriter.encodeFeature(f);
+        JSONObject jsonF = (JSONObject) JSONSerializer.toJSON(w.toString());
+        JSONObject mineName = jsonF.getJSONObject("properties").getJSONObject("MineName");
+        assertTrue(mineName.has("id"));
+        assertTrue(mineName.has("geometry"));
+        assertTrue(mineName.has("properties"));
+        assertTrue(mineName.getJSONObject("properties").has("@featureType"));
+    }
+
+    @Test
+    public void testGeoJsonWriterOptionsCustom() {
+        // test behaviour of the ComplexGeoJsonWriter with a
+        // ComplexGeoJsonWriterOptions object asking for the econding
+        // of nested features as complex properties
+        ComplexGeoJsonWriterOptions options =
+                new ComplexGeoJsonWriterOptions() {
+                    @Override
+                    public boolean canHandle(List<FeatureCollection> features) {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean encodeComplexAttributeType() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean encodeNestedFeatureAsProperty(ComplexType complexType) {
+                        return true;
+                    }
+                };
+        Feature f = buildComplexFeature();
+        StringWriter w = new StringWriter();
+        GeoJSONBuilder jWriter = new GeoJSONBuilder(w);
+        TestComplexGeoJsonWriter testWriter = new TestComplexGeoJsonWriter(jWriter, options);
+
+        testWriter.encodeFeature(f);
+        JSONObject jsonF = (JSONObject) JSONSerializer.toJSON(w.toString());
+        JSONObject mineName = jsonF.getJSONObject("properties").getJSONObject("MineName");
+        assertFalse(mineName.has("id"));
+        assertFalse(mineName.has("geometry"));
+        assertFalse(mineName.has("properties"));
+        assertFalse(mineName.has("@dataType"));
+    }
+
+    /** used to expose a public encodeFeature method for testing purposes * */
+    class TestComplexGeoJsonWriter extends ComplexGeoJsonWriter {
+
+        public TestComplexGeoJsonWriter(
+                GeoJSONBuilder jsonWriter, ComplexGeoJsonWriterOptions settings) {
+            super(jsonWriter, settings);
+        }
+
+        public TestComplexGeoJsonWriter(GeoJSONBuilder jsonWriter) {
+            super(jsonWriter);
+        }
+
+        public void encodeFeature(Feature feature) {
+            super.encodeFeature(feature, true);
+        }
+    }
+
+    // build a complexFeature with a nested Feature
+    private Feature buildComplexFeature() {
+        ComplexFeatureBuilder fBuilder = new ComplexFeatureBuilder(FakeTypes.Mine.MINETYPE_TYPE);
+        ComplexAttribute attr = getNestedFeature("a name", true);
+        fBuilder.append(FakeTypes.Mine.NAME_mineName, attr);
+        return fBuilder.buildFeature("id");
+    }
+
+    private static ComplexAttribute getNestedFeature(String name, boolean isPreferred) {
+        ComplexFeatureBuilder complexFB = new ComplexFeatureBuilder(MINENAME_DESCRIPTOR);
+        AttributeBuilder builder = new AttributeBuilder(new LenientFeatureFactoryImpl());
+        builder.setDescriptor(FakeTypes.Mine.ISPREFERRED_DESCRIPTOR);
+        Attribute isPrefAttr = builder.buildSimple("isPreferred_testId", isPreferred);
+        builder.setDescriptor(FakeTypes.Mine.mineNAME_DESCRIPTOR);
+        Attribute nameAttr = builder.buildSimple("mineName_testId", name);
+        complexFB.append(FakeTypes.Mine.NAME_isPreferred, isPrefAttr);
+        complexFB.append(FakeTypes.Mine.NAME_mineName, nameAttr);
+
+        return complexFB.buildFeature(null);
     }
 }


### PR DESCRIPTION
[![GEOS-10028](https://badgen.net/badge/JIRA/GEOS-10028/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10028) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* [GEOS-10028] Allow to customize ComplexGeoJsonWriter encoding of nested element and non mandatory attributes

* review feedback

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.