### PR TITLE
[GEOS-10048] Schemaless-features mongoDB layer not present in WMS capabilities - [GEOS-10049] Schemaless-features layer with name different from the mongo collection throws exception

### DIFF
--- a/doc/en/user/source/community/schemaless-features/install.rst
+++ b/doc/en/user/source/community/schemaless-features/install.rst
@@ -1,7 +1,7 @@
-Installing the Schemaless Features module
+Installing the Schemaless Mongo module
 =========================================
 
-#. Download the nightly GeoServer community module :download_community:`schemaless-features`. 
+#. Download :download_community:`schemaless-mongo` nightly GeoServer community module.
    
    .. warning:: Verify that the version number in the filename corresponds to the version of GeoServer you are running (for example geoserver-|release|-schemaless-features-plugin.zip above).
 

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -98,7 +98,7 @@
             <descriptor>release/ext-imagemosaic-jdbc.xml</descriptor>
             <descriptor>release/ext-smart-data-loader.xml</descriptor>
             <descriptor>release/ext-cov-json.xml</descriptor>
-            <descriptor>release/ext-schemaless-features.xml</descriptor>
+            <descriptor>release/ext-schemaless-mongo.xml</descriptor>
             <descriptor>release/ext-web-service-auth.xml</descriptor>
             <descriptor>release/ext-gwc-mbtiles.xml</descriptor>
           </descriptors>

--- a/src/community/release/ext-schemaless-mongo.xml
+++ b/src/community/release/ext-schemaless-mongo.xml
@@ -1,5 +1,5 @@
 <assembly>
-    <id>schemaless-features-plugin</id>
+    <id>schemaless-mongo-plugin</id>
     <formats>
         <format>zip</format>
     </formats>

--- a/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/data/SchemalessFeatureSource.java
+++ b/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/data/SchemalessFeatureSource.java
@@ -6,11 +6,13 @@ package org.geoserver.schemalessfeatures.data;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.geoserver.schemalessfeatures.type.DynamicFeatureType;
 import org.geotools.gml3.v3_2.GMLSchema;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.feature.type.Name;
+import org.opengis.feature.type.PropertyDescriptor;
 
 /**
  * A FeatureSource relying on a DynamicFeatureType. The getSchema() method will provide by default
@@ -28,10 +30,12 @@ public abstract class SchemalessFeatureSource extends ComplexFeatureSource {
         FeatureType featureType = null;
         if (featureType == null) {
             GeometryDescriptor descriptor = getGeometryDescriptor();
+            List<PropertyDescriptor> descriptorList = new ArrayList<>();
+            descriptorList.add(descriptor);
             featureType =
                     new DynamicFeatureType(
                             name,
-                            new ArrayList<>(),
+                            descriptorList,
                             descriptor,
                             false,
                             Collections.emptyList(),

--- a/src/community/schemaless-features/schemaless-mongo/pom.xml
+++ b/src/community/schemaless-features/schemaless-mongo/pom.xml
@@ -58,6 +58,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/src/community/schemaless-features/schemaless-mongo/src/main/java/org/geoserver/schemalessfeatures/mongodb/data/MongoComplexContentDataAccess.java
+++ b/src/community/schemaless-features/schemaless-mongo/src/main/java/org/geoserver/schemalessfeatures/mongodb/data/MongoComplexContentDataAccess.java
@@ -44,14 +44,13 @@ public class MongoComplexContentDataAccess extends ComplexContentDataAccess {
 
     @Override
     protected List<Name> createTypeNames() {
-
-        Set<String> collectionNames = new LinkedHashSet<>();
-        database.listCollectionNames().forEach(n -> collectionNames.add(n));
-        return collectionNames.stream().map(s -> name(s)).collect(Collectors.toList());
+        return getCollectionNames().stream().map(s -> name(s)).collect(Collectors.toList());
     }
 
     @Override
     public FeatureSource<FeatureType, Feature> getFeatureSource(Name typeName) throws IOException {
+        if (!getCollectionNames().contains(typeName.getLocalPart()))
+            throw new IOException("Type with name " + typeName.getLocalPart() + " not found");
         MongoCollection<DBObject> collection =
                 database.getCollection(typeName.getLocalPart(), DBObject.class);
         return new MongoSchemalessFeatureSource(typeName, collection, this);
@@ -121,5 +120,11 @@ public class MongoComplexContentDataAccess extends ComplexContentDataAccess {
     @Override
     public void dispose() {
         client.close();
+    }
+
+    private Set<String> getCollectionNames() {
+        Set<String> collectionNames = new LinkedHashSet<>();
+        database.listCollectionNames().forEach(n -> collectionNames.add(n));
+        return collectionNames;
     }
 }

--- a/src/community/schemaless-features/schemaless-mongo/src/test/java/org/geoserver/schemalessfeatures/mongodb/WMSSchemalessMongoTest.java
+++ b/src/community/schemaless-features/schemaless-mongo/src/test/java/org/geoserver/schemalessfeatures/mongodb/WMSSchemalessMongoTest.java
@@ -9,6 +9,8 @@ import java.io.ByteArrayInputStream;
 import javax.imageio.ImageIO;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -22,6 +24,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
 
 @SuppressWarnings({
     "PMD.JUnit4TestShouldUseAfterAnnotation",
@@ -259,5 +262,17 @@ public class WMSSchemalessMongoTest extends AbstractMongoDBOnlineTestSupport {
         JSONArray measurements = properties.getJSONArray("measurements");
         assertNotNull(measurements);
         assertTrue(measurements.size() > 0);
+    }
+
+    @Test
+    public void testSchemalessLayerInCapabilities() throws Exception {
+        LayerInfo layerInfo =
+                getCatalog().getLayerByName(new NameImpl("gs", StationsTestSetup.COLLECTION_NAME));
+        // execute the WMS GetMap request
+        Document doc = getAsDOM("wms?request=GetCapabilities&service=WMS&version=1.1.1");
+        XpathEngine xpath = XMLUnit.newXpathEngine();
+        assertTrue(
+                xpath.getMatchingNodes("//Layer/Name[contains(.,geoJSONStations)]", doc).getLength()
+                        > 0);
     }
 }


### PR DESCRIPTION
[![GEOS-10048](https://badgen.net/badge/JIRA/GEOS-10048/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10048) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Jira tickets here
https://osgeo-org.atlassian.net/browse/GEOS-10048
https://osgeo-org.atlassian.net/browse/GEOS-10049

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.