### PR TITLE
[2.18.x backport] Add custom ComplexGeoJsonWriterOptions to encode nested features as properties (#4988)

### DIFF
--- a/src/community/schemaless-features/schemaless-mongo/src/main/java/org/geoserver/schemalessfeatures/mongodb/response/MongoComplexGeoJsonWriterOptions.java
+++ b/src/community/schemaless-features/schemaless-mongo/src/main/java/org/geoserver/schemalessfeatures/mongodb/response/MongoComplexGeoJsonWriterOptions.java
@@ -1,0 +1,38 @@
+package org.geoserver.schemalessfeatures.mongodb.response;
+
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+import java.util.List;
+import org.geoserver.schemalessfeatures.type.DynamicFeatureType;
+import org.geoserver.wfs.json.ComplexGeoJsonWriterOptions;
+import org.geotools.feature.FeatureCollection;
+import org.opengis.feature.type.ComplexType;
+
+public class MongoComplexGeoJsonWriterOptions implements ComplexGeoJsonWriterOptions {
+
+    @Override
+    public boolean canHandle(List<FeatureCollection> features) {
+        boolean result = false;
+        if (features != null && !features.isEmpty())
+            result =
+                    features.stream()
+                            .allMatch(
+                                    f ->
+                                            f.getSchema() != null
+                                                    && f.getSchema() instanceof DynamicFeatureType);
+        return result;
+    }
+
+    @Override
+    public boolean encodeComplexAttributeType() {
+        return false;
+    }
+
+    @Override
+    public boolean encodeNestedFeatureAsProperty(ComplexType complexType) {
+        return true;
+    }
+}

--- a/src/community/schemaless-features/schemaless-mongo/src/main/resources/applicationContext.xml
+++ b/src/community/schemaless-features/schemaless-mongo/src/main/resources/applicationContext.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+        xmlns:mvc="http://www.springframework.org/schema/mvc"
+        xmlns:context="http://www.springframework.org/schema/context"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd">
+
+<context:component-scan base-package="org.geoserver.schemalessfeatures.mongodb"/>
+
+    <bean id="mongoComplexGeoJsonWriterSettings"
+          class="org.geoserver.schemalessfeatures.mongodb.response.MongoComplexGeoJsonWriterOptions">
+    </bean>
+
+</beans>

--- a/src/community/schemaless-features/schemaless-mongo/src/test/java/org/geoserver/schemalessfeatures/mongodb/WFSSchemalessMongoTest.java
+++ b/src/community/schemaless-features/schemaless-mongo/src/test/java/org/geoserver/schemalessfeatures/mongodb/WFSSchemalessMongoTest.java
@@ -1,6 +1,7 @@
 package org.geoserver.schemalessfeatures.mongodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -122,10 +123,22 @@ public class WFSSchemalessMongoTest extends AbstractMongoDBOnlineTestSupport {
         assertNotNull(properties.get("numericValue"));
         JSONObject contact = properties.getJSONObject("contact");
         assertNotNull(contact);
-        assertEquals(4, contact.size());
+        assertSkippedGeoJSONProperties(contact);
+        assertEquals(1, contact.size());
         JSONArray measurements = properties.getJSONArray("measurements");
         assertNotNull(measurements);
         assertTrue(measurements.size() > 0);
+        for (int i = 0; i < measurements.size(); i++) {
+            JSONObject measurement = measurements.getJSONObject(i);
+            assertSkippedGeoJSONProperties(measurement);
+        }
+    }
+
+    private static void assertSkippedGeoJSONProperties(JSONObject object) {
+        assertFalse(object.has("properties"));
+        assertFalse(object.has("geometry"));
+        assertFalse(object.has("id"));
+        assertFalse(object.has("type"));
     }
 
     private String readResourceContent(String resourcePath) {


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.