### PR TITLE
[GEOS-10051] Fix edge cases in the elevation parser

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/kvp/ElevationParser.java
+++ b/src/ows/src/main/java/org/geoserver/ows/kvp/ElevationParser.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Logger;
 import org.geoserver.platform.ServiceException;
-import org.geotools.util.DateRange;
 import org.geotools.util.NumberRange;
 import org.geotools.util.logging.Logging;
 
@@ -169,8 +168,9 @@ public class ElevationParser {
                 if (local.equals(step)) return false;
             } else {
                 // convert
-                final DateRange local = (DateRange) element;
-                if (local.contains(step)) return false;
+                @SuppressWarnings("unchecked")
+                final NumberRange<Double> local = (NumberRange<Double>) element;
+                if (local.contains((Number) step)) return false;
             }
         }
         return result.add(step);

--- a/src/ows/src/test/java/org/geoserver/ows/kvp/ElevationKvpParserTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/kvp/ElevationKvpParserTest.java
@@ -9,6 +9,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.geoserver.platform.ServiceException;
 import org.geotools.util.NumberRange;
 import org.junit.Assert;
 import org.junit.Test;
@@ -65,5 +66,44 @@ public class ElevationKvpParserTest {
         Assert.assertEquals(4.0, elements.get(3));
         Assert.assertEquals(5.0, elements.get(4));
         Assert.assertEquals(8.9, elements.get(5));
+    }
+
+    @Test
+    public void testInfiniteLoopZeroInterval() {
+        String value = "0/0/0";
+        ServiceException e =
+                Assert.assertThrows(
+                        ServiceException.class,
+                        () -> new ElevationKvpParser("ELEVATION").parse(value));
+        Assert.assertEquals(
+                "Exceeded 100 iterations parsing elevations, bailing out.", e.getMessage());
+        Assert.assertEquals(ServiceException.INVALID_PARAMETER_VALUE, e.getCode());
+        Assert.assertEquals("elevation", e.getLocator());
+    }
+
+    @Test
+    public void testInfiniteLoopPositiveInfinity() {
+        String value = "Infinity/Infinity/1";
+        ServiceException e =
+                Assert.assertThrows(
+                        ServiceException.class,
+                        () -> new ElevationKvpParser("ELEVATION").parse(value));
+        Assert.assertEquals(
+                "Exceeded 100 iterations parsing elevations, bailing out.", e.getMessage());
+        Assert.assertEquals(ServiceException.INVALID_PARAMETER_VALUE, e.getCode());
+        Assert.assertEquals("elevation", e.getLocator());
+    }
+
+    @Test
+    public void testInfiniteLoopNegativeInfinity() {
+        String value = "-Infinity/-Infinity/1";
+        ServiceException e =
+                Assert.assertThrows(
+                        ServiceException.class,
+                        () -> new ElevationKvpParser("ELEVATION").parse(value));
+        Assert.assertEquals(
+                "Exceeded 100 iterations parsing elevations, bailing out.", e.getMessage());
+        Assert.assertEquals(ServiceException.INVALID_PARAMETER_VALUE, e.getCode());
+        Assert.assertEquals("elevation", e.getLocator());
     }
 }


### PR DESCRIPTION
[![GEOS-10051](https://badgen.net/badge/JIRA/GEOS-10051/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10051) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added a check that will exit the loop when attempting to parse certain invalid inputs.
https://osgeo-org.atlassian.net/browse/GEOS-10051

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.