### PR TITLE
[2.19.x][GEOS-10057] Escape style editor page user input

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/AbstractStylePage.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -115,7 +116,7 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
             String enableSpectrum =
                     "$(\"#chooser\").spectrum({\n"
                             + "    color: \""
-                            + initialColor
+                            + StringEscapeUtils.escapeEcmaScript(initialColor)
                             + "\",\n"
                             + "    showInput: true,\n"
                             + "    flat: true,\n"
@@ -476,11 +477,9 @@ public abstract class AbstractStylePage extends GeoServerSecuredPage {
                                             return false;
                                         }
                                     }
-                                    target.appendJavaScript(
-                                            "replaceSelection('"
-                                                    + styleHandler()
-                                                            .insertImageCode(imageFileName, input)
-                                                    + "');");
+                                    String code = StringEscapeUtils.escapeEcmaScript(imageFileName);
+                                    code = styleHandler().insertImageCode(code, input);
+                                    target.appendJavaScript("replaceSelection('" + code + "');");
                                     return true;
                                 }
 


### PR DESCRIPTION
[![GEOS-10057](https://badgen.net/badge/JIRA/GEOS-10057/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10057) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

2.19.x backport for https://github.com/geoserver/geoserver/pull/5042

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.