### PR TITLE
GeoServer Extensions warnings cleanup

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
@@ -2608,15 +2608,15 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      */
     public List<GeoServerSecurityProvider> lookupSecurityProviders() {
         List<GeoServerSecurityProvider> list = new ArrayList<>();
-
-        for (GeoServerSecurityProvider provider :
-                GeoServerExtensions.extensions(GeoServerSecurityProvider.class, appContext)) {
-            if (!provider.isAvailable()) {
-                continue;
+        if (appContext != null) {
+            for (GeoServerSecurityProvider provider :
+                    GeoServerExtensions.extensions(GeoServerSecurityProvider.class, appContext)) {
+                if (!provider.isAvailable()) {
+                    continue;
+                }
+                list.add(provider);
             }
-            list.add(provider);
         }
-
         return list;
     }
 

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -73,6 +73,7 @@ import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.security.AccessMode;
 import org.geoserver.security.SecuredResourceNameChangeListener;
@@ -119,6 +120,7 @@ public class CatalogImplTest extends GeoServerSystemTestSupport {
 
     @Before
     public void setUp() throws Exception {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
         catalog = createCatalog();
         catalog.setResourceLoader(new GeoServerResourceLoader());
 

--- a/src/main/src/test/java/org/geoserver/catalog/impl/FeatureTypeInfoImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/FeatureTypeInfoImplTest.java
@@ -13,6 +13,7 @@ import java.util.function.Consumer;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geotools.util.GrowableInternationalString;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +24,7 @@ public class FeatureTypeInfoImplTest {
 
     @Before
     public void setUp() throws Exception {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
         catalog = new CatalogImpl();
     }
 

--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
@@ -16,13 +16,16 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogFactoryImpl;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.StyleInfoImpl;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geotools.styling.ExternalGraphic;
 import org.geotools.styling.PointSymbolizer;
 import org.geotools.styling.Style;
 import org.geotools.styling.Symbolizer;
 import org.geotools.util.Version;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.style.GraphicalSymbol;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -32,11 +35,21 @@ public class GeoServerDataDirectoryTest {
     ClassPathXmlApplicationContext ctx;
 
     GeoServerDataDirectory dataDir;
-    CatalogFactory factory = new CatalogFactoryImpl(new CatalogImpl());
+    static CatalogFactory factory;
+
+    @BeforeClass
+    public static void beforeClass() {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
+        factory = new CatalogFactoryImpl(new CatalogImpl());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        factory = null;
+    }
 
     @Before
     public void setUp() throws Exception {
-
         ctx =
                 new ClassPathXmlApplicationContext(
                         "GeoServerDataDirectoryTest-applicationContext.xml", getClass());

--- a/src/main/src/test/java/org/geoserver/config/GeoServerImplTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerImplTest.java
@@ -30,6 +30,7 @@ import org.geoserver.config.impl.GeoServerImpl;
 import org.geoserver.config.impl.GeoServerInfoImpl;
 import org.geoserver.config.impl.ServiceInfoImpl;
 import org.geoserver.ows.LocalWorkspace;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,6 +40,7 @@ public class GeoServerImplTest {
 
     @Before
     public void setUp() throws Exception {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
         geoServer = createGeoServer();
     }
 

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterIntegrationTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterIntegrationTest.java
@@ -15,6 +15,7 @@ import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,6 +90,7 @@ public class XStreamPersisterIntegrationTest extends GeoServerSystemTestSupport 
     }
 
     private WMSStoreInfo buildWmsStore() {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
         Catalog catalog = new CatalogImpl();
         CatalogFactory cFactory = catalog.getFactory();
 

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -76,6 +76,7 @@ import org.geoserver.config.impl.GeoServerImpl;
 import org.geoserver.config.impl.ServiceInfoImpl;
 import org.geoserver.config.util.XStreamPersister.CRSConverter;
 import org.geoserver.config.util.XStreamPersister.SRSConverter;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geotools.jdbc.RegexpValidator;
 import org.geotools.jdbc.VirtualTable;
 import org.geotools.jdbc.VirtualTableParameter;
@@ -1164,6 +1165,7 @@ public class XStreamPersisterTest {
 
     @Test
     public void testPersisterCustomization() throws Exception {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
         Catalog catalog = new CatalogImpl();
         CatalogFactory cFactory = catalog.getFactory();
 

--- a/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
@@ -47,6 +47,7 @@ import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.config.util.XStreamServiceLoader;
 import org.geoserver.ows.util.OwsUtils;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.util.IOUtils;
@@ -136,6 +137,7 @@ public class SystemTestData extends CiteTestData {
 
     @Override
     public void setUp() throws Exception {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
         createCatalog();
         createConfig();
     }

--- a/src/main/src/test/java/org/geoserver/security/impl/LayerGroupContainmentCacheTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/LayerGroupContainmentCacheTest.java
@@ -35,6 +35,7 @@ import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.NamespaceInfoImpl;
 import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.data.test.MockData;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.security.impl.LayerGroupContainmentCache.LayerGroupSummary;
 import org.geotools.data.property.PropertyDataStore;
@@ -66,6 +67,7 @@ public class LayerGroupContainmentCacheTest {
 
     @BeforeClass
     public static void setupBaseCatalog() throws Exception {
+        GeoServerExtensionsHelper.setIsSpringContext(false);
         catalog = new CatalogImpl();
         catalog.setResourceLoader(new GeoServerResourceLoader());
 


### PR DESCRIPTION
This is not intended as a functional change, although some private methods have been introduced.

I tried reducing the `warning` to `fine` detail, but on careful review this warning was correctly reporting two issues on application startup:

XStreamPersisterFactory is being used prior to extensions being made available:
```
getInitializers:72, XStreamPersisterFactory (org.geoserver.config.util)
buildPersister:65, XStreamPersisterFactory (org.geoserver.config.util)
createXMLPersister:53, XStreamPersisterFactory (org.geoserver.config.util)
getLogging:118, LoggingStartupContextListener (org.geoserver.logging)
contextInitialized:71, LoggingStartupContextListener (org.geoserver.logging)
```

* XStreamPersisterFactory is being constructed directly here

Security manager is trying to obtain security provider extensions before geoserver extension bean is available
```
lookupSecurityProviders:2609, GeoServerSecurityManager (org.geoserver.security)
buildPersister:2672, GeoServerSecurityManager (org.geoserver.security)
buildGlobalPersister:2645, GeoServerSecurityManager (org.geoserver.security)
globalPersister:2639, GeoServerSecurityManager (org.geoserver.security)
loadMasterPasswordConfig:2696, GeoServerSecurityManager (org.geoserver.security)
<init>:299, GeoServerSecurityManager (org.geoserver.security)
...
extensionNames:235, GeoServerExtensions (org.geoserver.platform)
extensions:138, GeoServerExtensions (org.geoserver.platform)
extensions:123, GeoServerExtensions (org.geoserver.platform)
bean:357, GeoServerExtensions (org.geoserver.platform)
lookupGeoServerLoader:79, GeoServerLoaderProxy (org.geoserver.config)
setApplicationContext:43, GeoServerLoaderProxy (org.geoserver.config)
```

* How can we get `GeoServerLoaderProxy` to load after `GeoServerExtensions` ?

I ended up taking a review of the flag `GeoServerExtensions.isSpringContext` as used by `GeoServerExtensionsHelper`:
- Introduced a flag to `checkContext( context, extensionPoint, isGeoServerExtensionsContext )` as the logic to check `if ( context == GeoServerExtension.context` is not very helpful when both are null.
- Added calls to GeoServerExtensionsHelper each time a CatalogImpl was created in tests, vastly reducing the warnings

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] https://osgeo-org.atlassian.net/browse/GEOS-10238
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-10238] Test logging WARNING: Extension lookup, but ApplicationContext is unset" (this will need to be done using squash and merge)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.