### PR TITLE
[GEOS-10074] GeoFence "Admin rules" grant "ADMIN" access to unauthorized users

### DIFF
--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceIntegrationTestSupport.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceIntegrationTestSupport.java
@@ -1,0 +1,131 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+
+package org.geoserver.geofence.integration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import org.geoserver.geofence.cache.CachedRuleReader;
+import org.geoserver.geofence.core.model.AdminRule;
+import org.geoserver.geofence.core.model.GSInstance;
+import org.geoserver.geofence.core.model.IPAddressRange;
+import org.geoserver.geofence.core.model.Rule;
+import org.geoserver.geofence.core.model.RuleLimits;
+import org.geoserver.geofence.core.model.enums.AdminGrantType;
+import org.geoserver.geofence.core.model.enums.CatalogMode;
+import org.geoserver.geofence.core.model.enums.GrantType;
+import org.geoserver.geofence.core.model.enums.SpatialFilterType;
+import org.geoserver.geofence.services.AdminRuleAdminService;
+import org.geoserver.geofence.services.RuleAdminService;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.test.GeoServerTestApplicationContext;
+import org.junit.rules.ExternalResource;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+public class GeofenceIntegrationTestSupport extends ExternalResource {
+
+    private RuleAdminService ruleService;
+    private AdminRuleAdminService adminRuleService;
+    private Supplier<GeoServerTestApplicationContext> appContext;
+
+    private List<Long> ruleIds;
+    private List<Long> adminRuleIds;
+
+    public GeofenceIntegrationTestSupport(Supplier<GeoServerTestApplicationContext> appContext) {
+        this.appContext = appContext;
+    }
+
+    public @Override void before() {
+        ruleIds = new ArrayList<>();
+        adminRuleIds = new ArrayList<>();
+        @SuppressWarnings("PMD.CloseResource")
+        GeoServerTestApplicationContext context = appContext.get();
+        ruleService = context.getBean(RuleAdminService.class);
+        adminRuleService = context.getBean(AdminRuleAdminService.class);
+    }
+
+    public @Override void after() {
+        deleteRules();
+        // this is odd, RuleService.delete() should invalidate
+        CachedRuleReader cacheRuleReader = GeoServerExtensions.bean(CachedRuleReader.class);
+        cacheRuleReader.invalidateAll();
+    }
+
+    public long addAdminRule(
+            long priority,
+            String username,
+            String rolename,
+            String workspace,
+            AdminGrantType access) {
+        GSInstance gsInstance = null;
+        IPAddressRange addressRange = null;
+        AdminRule rule =
+                new AdminRule(
+                        priority, username, rolename, gsInstance, addressRange, workspace, access);
+        long id = adminRuleService.insert(rule);
+        this.adminRuleIds.add(id);
+        return id;
+    }
+
+    public long addRule(
+            GrantType access,
+            String username,
+            String roleName,
+            String service,
+            String request,
+            String workspace,
+            String layer,
+            long priority) {
+
+        Rule rule = new Rule();
+        rule.setAccess(access);
+        rule.setUsername(username);
+        rule.setRolename(roleName);
+        rule.setService(service);
+        rule.setRequest(request);
+        rule.setWorkspace(workspace);
+        rule.setLayer(layer);
+        rule.setPriority(priority);
+        long id = ruleService.insert(rule);
+        ruleIds.add(id);
+        return id;
+    }
+
+    public void addRuleLimits(long ruleId, CatalogMode mode, String allowedArea, Integer srid)
+            throws ParseException {
+        addRuleLimits(ruleId, mode, allowedArea, srid, null);
+    }
+
+    public void addRuleLimits(
+            long ruleId,
+            CatalogMode mode,
+            String allowedArea,
+            Integer srid,
+            SpatialFilterType spatialFilterType)
+            throws org.locationtech.jts.io.ParseException {
+        RuleLimits limits = new RuleLimits();
+        limits.setCatalogMode(mode);
+        MultiPolygon allowedAreaGeom = (MultiPolygon) new WKTReader().read(allowedArea);
+        if (srid != null) allowedAreaGeom.setSRID(srid);
+        limits.setAllowedArea(allowedAreaGeom);
+        if (spatialFilterType == null) spatialFilterType = SpatialFilterType.INTERSECT;
+        limits.setSpatialFilterType(spatialFilterType);
+        ruleService.setLimits(ruleId, limits);
+    }
+
+    public void deleteRules() {
+        ruleIds.forEach(ruleService::delete);
+        adminRuleIds.forEach(adminRuleService::delete);
+    }
+
+    public void deleteRules(Long... ids) {
+        for (Long id : ids) {
+            if (id != null) ruleService.delete(id);
+        }
+    }
+}

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -162,7 +162,7 @@ public class GeofenceAccessManager
             if (isAdmin(user)) {
                 LOGGER.log(
                         Level.FINE,
-                        "Admin level access, returning " + "full rights for workspace {0}",
+                        "Admin level access, returning full rights for workspace {0}",
                         workspace.getName());
 
                 return new WorkspaceAccessLimits(DEFAULT_CATALOG_MODE, true, true);
@@ -177,23 +177,27 @@ public class GeofenceAccessManager
             return new WorkspaceAccessLimits(DEFAULT_CATALOG_MODE, true, canWrite, canAdmin);
         }
 
-        // further logic disabled because of https://github.com/geosolutions-it/geofence/issues/6
-        return new WorkspaceAccessLimits(DEFAULT_CATALOG_MODE, true, false);
+        // further logic disabled because of
+        // https://github.com/geosolutions-it/geofence/issues/6 (gone)
+        final boolean readable = true;
+        final boolean writable = false;
+        return new WorkspaceAccessLimits(DEFAULT_CATALOG_MODE, readable, writable);
     }
 
     /** We expect the user not to be null and not to be admin */
     private boolean isWorkspaceAdmin(Authentication user, String workspaceName) {
         LOGGER.log(Level.FINE, "Getting admin auth for Workspace {0}", workspaceName);
 
-        // get the request infos
-        RuleFilter ruleFilter = new RuleFilter(RuleFilter.SpecialFilterType.ANY);
-
+        RuleFilter ruleFilter;
+        String username = getUserNameFromAuth(user);
+        if (null != username) {
+            ruleFilter = new RuleFilter(RuleFilter.SpecialFilterType.ANY);
+            ruleFilter.setUser(username);
+        } else {
+            ruleFilter = new RuleFilter(RuleFilter.SpecialFilterType.DEFAULT);
+        }
         ruleFilter.setInstance(configurationManager.getConfiguration().getInstanceName());
         ruleFilter.setWorkspace(workspaceName);
-        String username = user.getName();
-        if (username == null || username.isEmpty()) {
-            ruleFilter.setUser(RuleFilter.SpecialFilterType.DEFAULT);
-        }
 
         String sourceAddress = retrieveCallerIpAddress();
         if (sourceAddress != null) {

--- a/src/extension/geofence/src/test/java/org/geoserver/geofence/GeoFenceConfigurationManagerTest.java
+++ b/src/extension/geofence/src/test/java/org/geoserver/geofence/GeoFenceConfigurationManagerTest.java
@@ -26,7 +26,7 @@ import org.geoserver.test.GeoServerTestSupport;
 import org.junit.Test;
 import org.springframework.core.io.UrlResource;
 
-public class AccessManagerConfigTest extends GeoServerTestSupport {
+public class GeoFenceConfigurationManagerTest extends GeoServerTestSupport {
 
     // protected GeofenceAccessManager manager;
     // protected RuleReaderService geofenceService;

--- a/src/extension/geofence/src/test/java/org/geoserver/geofence/GeofenceAccessManagerTest.java
+++ b/src/extension/geofence/src/test/java/org/geoserver/geofence/GeofenceAccessManagerTest.java
@@ -36,7 +36,7 @@ import org.opengis.filter.spatial.Intersects;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.Authentication;
 
-public class AccessManagerTest extends GeofenceBaseTest {
+public class GeofenceAccessManagerTest extends GeofenceBaseTest {
 
     @Test
     public void testAdmin() {

--- a/src/extension/geofence/src/test/java/org/geoserver/geofence/GeofenceAccessManager_WMTSLayerTest.java
+++ b/src/extension/geofence/src/test/java/org/geoserver/geofence/GeofenceAccessManager_WMTSLayerTest.java
@@ -36,7 +36,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.w3c.dom.Document;
 
-public class AccessManagerWMTSLayerTest extends GeofenceBaseTest {
+public class GeofenceAccessManager_WMTSLayerTest extends GeofenceBaseTest {
 
     private static final String LAYER_NAME = "AMSR2_Snow_Water_Equivalent";
 


### PR DESCRIPTION
[![GEOS-10074](https://badgen.net/badge/JIRA/GEOS-10074/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10074)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Admin rules grant ADMIN access to unauthorized user

Rules didn't filter properly on user/roles and there were no tests for them.

[ticket](https://osgeo-org.atlassian.net/browse/GEOS-10074)
[reported as geofence issue](https://github.com/geoserver/geofence/issues/140)

- Fix `GeoFenceAccessManager.isWorkspaceAdmin()`: When a user name is
not provided, using a `RuleFilter` with `SpecialFilterType.ANY`
instead of `SpecialFilterType.DEFAULT` results in admin access to all
workspaces that have an AdminRule set, regardless of the user/role.
    
- Add `AdminRule` tests, introduce `GeofenceIntegrationTestSupport`
class to group utility methods and setup/cleanup.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.