### PR TITLE
[GEOS-10116] authkey: Resolve REST role service config from environment

### DIFF
--- a/src/extension/authkey/src/main/java/org/geoserver/security/GeoServerRestRoleService.java
+++ b/src/extension/authkey/src/main/java/org/geoserver/security/GeoServerRestRoleService.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.minidev.json.JSONArray;
+import org.geoserver.platform.GeoServerEnvironment;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.event.RoleLoadedListener;
 import org.geoserver.security.impl.AbstractGeoServerSecurityService;
@@ -127,6 +129,18 @@ public class GeoServerRestRoleService extends AbstractGeoServerSecurityService
                         .build(); // look Ma, no CacheLoader
     }
 
+    /* Resolve GeoServer environment placeholders */
+    private String resolveEnvironmentValue(String value) {
+        final GeoServerEnvironment gsEnvironment =
+                GeoServerExtensions.bean(GeoServerEnvironment.class);
+
+        if (gsEnvironment != null && GeoServerEnvironment.allowEnvParametrization()) {
+            return (String) gsEnvironment.resolveValue(value);
+        }
+
+        return value;
+    }
+
     /** Read only store. */
     @Override
     public boolean canCreateStore() {
@@ -178,12 +192,12 @@ public class GeoServerRestRoleService extends AbstractGeoServerSecurityService
         try {
             return (SortedSet<GeoServerRole>)
                     connectToRESTEndpoint(
-                            restRoleServiceConfig.getBaseUrl(),
+                            resolveEnvironmentValue(restRoleServiceConfig.getBaseUrl()),
                             restRoleServiceConfig.getUsersRESTEndpoint() + "/" + username,
                             restRoleServiceConfig
                                     .getUsersJSONPath()
                                     .replace("${username}", username),
-                            restRoleServiceConfig.getAuthApiKey(),
+                            resolveEnvironmentValue(restRoleServiceConfig.getAuthApiKey()),
                             new RestEndpointConnectionCallback() {
 
                                 @Override
@@ -280,10 +294,10 @@ public class GeoServerRestRoleService extends AbstractGeoServerSecurityService
         try {
             return (SortedSet<GeoServerRole>)
                     connectToRESTEndpoint(
-                            restRoleServiceConfig.getBaseUrl(),
+                            resolveEnvironmentValue(restRoleServiceConfig.getBaseUrl()),
                             restRoleServiceConfig.getRolesRESTEndpoint(),
                             restRoleServiceConfig.getRolesJSONPath(),
-                            restRoleServiceConfig.getAuthApiKey(),
+                            resolveEnvironmentValue(restRoleServiceConfig.getAuthApiKey()),
                             new RestEndpointConnectionCallback() {
 
                                 @Override
@@ -343,10 +357,10 @@ public class GeoServerRestRoleService extends AbstractGeoServerSecurityService
         try {
             return (GeoServerRole)
                     connectToRESTEndpoint(
-                            restRoleServiceConfig.getBaseUrl(),
+                            resolveEnvironmentValue(restRoleServiceConfig.getBaseUrl()),
                             restRoleServiceConfig.getRolesRESTEndpoint(),
                             restRoleServiceConfig.getRolesJSONPath(),
-                            restRoleServiceConfig.getAuthApiKey(),
+                            resolveEnvironmentValue(restRoleServiceConfig.getAuthApiKey()),
                             new RestEndpointConnectionCallback() {
 
                                 @Override
@@ -401,10 +415,10 @@ public class GeoServerRestRoleService extends AbstractGeoServerSecurityService
             try {
                 return (GeoServerRole)
                         connectToRESTEndpoint(
-                                restRoleServiceConfig.getBaseUrl(),
+                                resolveEnvironmentValue(restRoleServiceConfig.getBaseUrl()),
                                 restRoleServiceConfig.getAdminRoleRESTEndpoint(),
                                 restRoleServiceConfig.getAdminRoleJSONPath(),
-                                restRoleServiceConfig.getAuthApiKey(),
+                                resolveEnvironmentValue(restRoleServiceConfig.getAuthApiKey()),
                                 new RestEndpointConnectionCallback() {
 
                                     @Override


### PR DESCRIPTION
[![GEOS-10116](https://badgen.net/badge/JIRA/GEOS-10116/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10116)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-9198](https://osgeo-org.atlassian.net/browse/GEOS-9198) / #3477 added  support for resolving env parameters in the authkey module configuration, but not for the REST role service. 

This extends support for resolving parameters in the following `GeoServerRESTRoleServiceConfig` properties:

* `baseUrl`
* `authApiKey`

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] ~Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)~
- [x] ~Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.~