### PR TITLE
[Backport-2.19.x][GEOT-6902]: Follow up on NetCDF performances improvement - caching

### DIFF
--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/mosaic/ImporterMosaicTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/mosaic/ImporterMosaicTest.java
@@ -39,6 +39,7 @@ import org.geotools.coverage.grid.io.GranuleSource;
 import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
 import org.geotools.data.Query;
 import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
 import org.geotools.util.URLs;
 import org.junit.Test;
 import org.opengis.filter.Filter;
@@ -307,6 +308,9 @@ public class ImporterMosaicTest extends ImporterTestSupport {
     public void testHarvestNetCDFWithAuxiliaryNetCDFStore() throws Exception {
         Catalog catalog = getCatalog();
         // same as test above, but using a auxiliary datastore for netcdf internal indexes
+        // Adding the same layer with different config. cleaning the cache
+        NetCDFUtilities.clearCaches();
+
         getTestData()
                 .addRasterLayer(
                         POLYPHEMUS,

--- a/src/extension/netcdf/src/main/java/org/geoserver/netcdf/NetCDFUnitsConfigurator.java
+++ b/src/extension/netcdf/src/main/java/org/geoserver/netcdf/NetCDFUnitsConfigurator.java
@@ -122,6 +122,7 @@ public class NetCDFUnitsConfigurator implements GeoServerLifecycleHandler {
 
     @Override
     public void onReset() {
+        NetCDFUtilities.clearCaches();
         configure();
     }
 
@@ -132,6 +133,7 @@ public class NetCDFUnitsConfigurator implements GeoServerLifecycleHandler {
 
     @Override
     public void beforeReload() {
+        NetCDFUtilities.clearCaches();
         // better reload the unit config before reloading the catalog
         configure();
     }


### PR DESCRIPTION
[![GEOT-6902](https://badgen.net/badge/JIRA/GEOT-6902/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6902)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

backporting doc updates and cache cleanup for [GEOT-6902] (NetCDF caching) to 2.19.x

Depends on 
https://github.com/geotools/geotools/pull/3556