### PR TITLE
Update imagepyramid.rst: remove JPEG compression

### DIFF
--- a/doc/en/user/source/tutorials/imagepyramid/imagepyramid.rst
+++ b/doc/en/user/source/tutorials/imagepyramid/imagepyramid.rst
@@ -21,7 +21,7 @@ In order to build the pyramid we'll use the `gdal_retile.py <http://www.gdal.org
 The following commands will build a pyramid on disk::
 
    mkdir bmpyramid
-   gdal_retile.py -v -r bilinear -levels 4 -ps 2048 2048 -co "TILED=YES" -co "COMPRESS=JPEG" -targetDir bmpyramid bmreduced.tiff
+   gdal_retile.py -v -r bilinear -levels 4 -ps 2048 2048 -co "TILED=YES" -targetDir bmpyramid bmreduced.tiff
    
 The `gdal_retile.py  <http://www.gdal.org/gdal_retile.html>`_ user guide provides a detailed explanation for all the possible parameters, here is a description of the ones used in the command line above:
    
@@ -30,7 +30,6 @@ The `gdal_retile.py  <http://www.gdal.org/gdal_retile.html>`_ user guide provide
   * `-levels 4`: the number of levels in the pyramid
   * `-ps 2048 2048`: each tile in the pyramid will be a 2048x2048 GeoTIFF
   * `-co "TILED=YES"`: each GeoTIFF tile in the pyramid will be inner tiled
-  * `-co "COMPRESS=JPEG"`: each GeoTIFF tile in the pyramid will be JPEG compressed (trades small size for higher performance, try out it without this parameter too)
   * `-targetDir bmpyramid`: build the pyramid in the bmpyramid directory. The target directory must exist and be empty
   * `bmreduced.tiff`: the source file
   


### PR DESCRIPTION
Following this tutorial leads to an error as imagepyramid does not seem to handle JPEG compression, per here: https://gis.stackexchange.com/questions/213257/problem-with-rendering-jpeg-compressed-image-caused-by-java-lang-classnotfoun/213384#213384

```
03 Jul 03:13:44 WARN [io.imageio] - Unable to compute source area for URL file:/home/syldor/bmpyramid/0/kornelimuenster_Ortho_projection_2_01_01.tif
javax.imageio.IIOException: Unsupported Image Type
	at java.desktop/com.sun.imageio.plugins.jpeg.JPEGImageReader.readInternal(JPEGImageReader.java:1139)
	at java.desktop/com.sun.imageio.plugins.jpeg.JPEGImageReader.read(JPEGImageReader.java:1110)
	at it.geosolutions.imageioimpl.plugins.tiff.TIFFJPEGDecompressor.decodeRaw(TIFFJPEGDecompressor.java:282)
	at it.geosolutions.imageio.plugins.tiff.TIFFDecompressor.decode(TIFFDecompressor.java:2637)
	at it.geosolutions.imageioimpl.plugins.tiff.TIFFImageReader.decodeTile(TIFFImageReader.java:1764)
```