### PR TITLE
[GEOS-10133] Connecting to WMS Service via Http Proxy

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -96,7 +96,6 @@ import org.geotools.gml2.GML;
 import org.geotools.http.HTTPClient;
 import org.geotools.http.HTTPClientFinder;
 import org.geotools.http.HTTPConnectionPooling;
-import org.geotools.http.SimpleHttpClient;
 import org.geotools.measure.Measure;
 import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wms.WMSCapabilities;
@@ -1941,9 +1940,7 @@ public class ResourcePool {
                 mtClient.setMaxConnections(maxConnections);
             }
         } else {
-            client =
-                    HTTPClientFinder.createClient(
-                            new Hints(Hints.HTTP_CLIENT, SimpleHttpClient.class));
+            client = HTTPClientFinder.createClient();
         }
         String username = info.getUsername();
         String password = info.getPassword();

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -88,6 +89,7 @@ import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.VirtualTable;
 import org.geotools.jdbc.VirtualTableParameter;
 import org.geotools.ows.ServiceException;
+import org.geotools.ows.wms.WebMapServer;
 import org.geotools.styling.AbstractStyleVisitor;
 import org.geotools.styling.Mark;
 import org.geotools.styling.PolygonSymbolizer;
@@ -633,6 +635,35 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
             assertFalse(
                     "Expect external entity cause",
                     cause != null && cause instanceof FileNotFoundException);
+        }
+    }
+
+    @Test
+    public void testWebMapServerWithProxy() throws Exception {
+        System.setProperty("http.proxySet", "true");
+        System.setProperty("http.proxyHost", "our.proxy.de");
+        System.setProperty("http.proxyPort", "8080");
+        System.setProperty("https.proxyHost", "our.proxy.de");
+        System.setProperty("https.proxyPort", "8080");
+
+        try {
+            final ResourcePool rp = getCatalog().getResourcePool();
+            WMSStoreInfo info = getCatalog().getFactory().createWebMapServer();
+            info.setCapabilitiesURL("http://dummy.net/wms");
+            info.setUseConnectionPooling(false);
+
+            WebMapServer wms = null;
+            try {
+                wms = rp.getWebMapServer(info);
+            } catch (UnknownHostException e) {
+                // Proxy our.proxy.de should be unknown.
+            }
+        } finally {
+            System.clearProperty("http.proxySet");
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+            System.clearProperty("https.proxyHost");
+            System.clearProperty("https.proxyPort");
         }
     }
 

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -84,6 +84,7 @@ import org.geotools.feature.collection.DecoratingFeatureCollection;
 import org.geotools.feature.collection.SortedSimpleFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.gce.geotiff.GeoTiffFormat;
+import org.geotools.http.HTTPProxy;
 import org.geotools.image.util.ImageUtilities;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.VirtualTable;
@@ -99,6 +100,7 @@ import org.geotools.util.URLs;
 import org.geotools.util.Version;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -655,6 +657,9 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
             WebMapServer wms = null;
             try {
                 wms = rp.getWebMapServer(info);
+                // If we have a running proxy server and wms server
+                Assert.assertNotNull(wms);
+                Assert.assertTrue(wms.getHTTPClient() instanceof HTTPProxy);
             } catch (UnknownHostException e) {
                 // Proxy our.proxy.de should be unknown.
             }


### PR DESCRIPTION
[![GEOS-10133](https://badgen.net/badge/JIRA/GEOS-10133/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10133)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes the bug referenced in the JIRA. Didn't see immediately how to write a unit test for this specific problem though. It would involve a running proxy server and wms server, or some mocking to fully test the functionality. The introduced test makes the assumption that we will get an UnknownHostException for the missing proxy server.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.