### PR TITLE
[GEOS-10137] SAML community module UI fixes

### DIFF
--- a/src/community/saml/pom.xml
+++ b/src/community/saml/pom.xml
@@ -60,6 +60,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.security</groupId>
+      <artifactId>gs-security-tests</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/src/community/saml/src/main/java/org/geoserver/security/saml/GeoServerPreAuthenticatedCompositeUserNameFilter.java
+++ b/src/community/saml/src/main/java/org/geoserver/security/saml/GeoServerPreAuthenticatedCompositeUserNameFilter.java
@@ -85,13 +85,13 @@ public abstract class GeoServerPreAuthenticatedCompositeUserNameFilter
         }
     }
 
-    protected List<Filter> nestedFilters = new ArrayList<Filter>();
+    protected List<Filter> nestedFilters = new ArrayList<>();
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 
-        if (nestedFilters == null || nestedFilters.size() == 0) {
+        if (nestedFilters == null || nestedFilters.isEmpty()) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/community/saml/src/main/java/org/geoserver/security/saml/LoggingHTTPMetadataProvider.java
+++ b/src/community/saml/src/main/java/org/geoserver/security/saml/LoggingHTTPMetadataProvider.java
@@ -18,11 +18,6 @@ public class LoggingHTTPMetadataProvider extends HTTPMetadataProvider {
 
     static final Logger LOGGER = Logging.getLogger(LoggingHTTPMetadataProvider.class);
 
-    public LoggingHTTPMetadataProvider(String metadataURL, int requestTimeout)
-            throws MetadataProviderException {
-        super(metadataURL, requestTimeout);
-    }
-
     public LoggingHTTPMetadataProvider(
             Timer backgroundTaskTimer, HttpClient client, String metadataURL)
             throws MetadataProviderException {

--- a/src/community/saml/src/main/java/org/geoserver/security/saml/SAMLAuthenticationFilter.java
+++ b/src/community/saml/src/main/java/org/geoserver/security/saml/SAMLAuthenticationFilter.java
@@ -106,6 +106,7 @@ public class SAMLAuthenticationFilter extends GeoServerPreAuthenticatedComposite
                 generator.setWantAssertionSigned(authConfig.getWantAssertionSigned() || signing);
                 ExtendedMetadata em = new ExtendedMetadata();
                 em.setRequireLogoutRequestSigned(signing);
+                if (signing) em.setSigningKey(authConfig.getKeyStoreId());
                 generator.setExtendedMetadata(em);
                 MetadataGeneratorFilter metadataGeneratorFilter =
                         new MetadataGeneratorFilter(generator);

--- a/src/community/saml/src/main/java/org/geoserver/security/saml/SAMLSecurityProvider.java
+++ b/src/community/saml/src/main/java/org/geoserver/security/saml/SAMLSecurityProvider.java
@@ -7,7 +7,6 @@ package org.geoserver.security.saml;
 import java.util.List;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.security.ConstantFilterChain;
-import org.geoserver.security.GeoServerAuthenticationProvider;
 import org.geoserver.security.GeoServerSecurityFilterChain;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.RequestFilterChain;
@@ -16,6 +15,7 @@ import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.filter.AbstractFilterProvider;
 import org.geoserver.security.filter.GeoServerSecurityFilter;
 import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.saml.SAMLAuthenticationProvider;
 import org.springframework.security.saml.SAMLLogoutFilter;
 import org.springframework.security.saml.SAMLLogoutProcessingFilter;
@@ -42,7 +42,7 @@ public class SAMLSecurityProvider extends AbstractFilterProvider
     /** Adds {@link #SAMLAuthenticationProvider} as {@link #AuthenticationProvider} */
     @Override
     public void handlePostChanged(GeoServerSecurityManager securityManager) {
-        List<GeoServerAuthenticationProvider> aps = securityManager.getAuthenticationProviders();
+        List<AuthenticationProvider> aps = securityManager.getProviders();
         if (aps != null && !aps.contains(this.samlAuthenticationProvider)) {
             securityManager.getProviders().add(this.samlAuthenticationProvider);
         }

--- a/src/community/saml/src/main/java/org/geoserver/security/saml/SAMLUserDetailsServiceImpl.java
+++ b/src/community/saml/src/main/java/org/geoserver/security/saml/SAMLUserDetailsServiceImpl.java
@@ -68,7 +68,7 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
     public Object loadUserBySAML(SAMLCredential credential) throws UsernameNotFoundException {
 
         String principal = credential.getNameID().getValue();
-        Set<GeoServerRole> roles = new HashSet<GeoServerRole>();
+        Set<GeoServerRole> roles = new HashSet<>();
         if (GeoServerUser.ROOT_USERNAME.equals(principal)) {
             roles = Collections.singleton(GeoServerRole.ADMIN_ROLE);
         } else {
@@ -96,7 +96,6 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
                             ((XSString) xmlValue).getValue() != null
                                     ? ((XSString) xmlValue).getValue()
                                     : "";
-                    ;
                 }
                 if (xmlValue instanceof XSInteger) {
                     attrValue =
@@ -110,7 +109,6 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
                             ((XSDateTime) xmlValue).getValue() != null
                                     ? formatter.print(((XSDateTime) xmlValue).getValue())
                                     : "";
-                    ;
                 }
             }
             user.getProperties().setProperty(attrName, attrValue);
@@ -156,7 +154,7 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
      */
     protected Collection<GeoServerRole> getRolesFromUserGroupService(String principal)
             throws IOException {
-        Collection<GeoServerRole> roles = new ArrayList<GeoServerRole>();
+        Collection<GeoServerRole> roles = new ArrayList<>();
 
         GeoServerUserGroupService service =
                 securityManager.loadUserGroupService(userGroupServiceName);
@@ -182,7 +180,7 @@ public class SAMLUserDetailsServiceImpl implements SAMLUserDetailsService {
      */
     protected Collection<GeoServerRole> getRolesFromHttpAttribute(String principal)
             throws IOException {
-        Collection<GeoServerRole> roles = new ArrayList<GeoServerRole>();
+        Collection<GeoServerRole> roles = new ArrayList<>();
 
         if (request != null) {
             String rolesString = request.getHeader(rolesHeaderAttribute);

--- a/src/community/saml/src/main/java/org/geoserver/security/web/saml/SAMLAuthFilterPanel.java
+++ b/src/community/saml/src/main/java/org/geoserver/security/web/saml/SAMLAuthFilterPanel.java
@@ -35,8 +35,12 @@ public class SAMLAuthFilterPanel
         add(new TextArea<String>("metadata"));
         add(new CheckBox("signing"));
         add(new TextField<String>("keyStorePath"));
-        add(new PasswordTextField("keyStorePassword"));
+        PasswordTextField ksPassword = new PasswordTextField("keyStorePassword");
+        ksPassword.setResetPassword(false);
+        add(ksPassword);
         add(new TextField<String>("keyStoreId"));
-        add(new PasswordTextField("keyStoreIdPassword"));
+        PasswordTextField keyStoreId = new PasswordTextField("keyStoreIdPassword");
+        keyStoreId.setResetPassword(false);
+        add(keyStoreId);
     }
 }

--- a/src/community/saml/src/test/java/org/geoserver/security/saml/test/SAMLAuthFilterPanelTest.java
+++ b/src/community/saml/src/test/java/org/geoserver/security/saml/test/SAMLAuthFilterPanelTest.java
@@ -1,0 +1,71 @@
+package org.geoserver.security.saml.test;
+
+import org.apache.wicket.Component;
+import org.geoserver.security.web.AbstractSecurityNamedServicePanelTest;
+import org.geoserver.security.web.AbstractSecurityPage;
+import org.geoserver.security.web.SecurityNamedServiceNewPage;
+import org.geoserver.security.web.auth.AuthenticationPage;
+import org.geoserver.security.web.saml.SAMLAuthFilterPanel;
+import org.geoserver.security.web.saml.SAMLAuthFilterPanelInfo;
+import org.junit.Test;
+
+public class SAMLAuthFilterPanelTest extends AbstractSecurityNamedServicePanelTest {
+
+    @Test
+    public void testPasswordFieldsNotEmptyWhenEdit() throws Exception {
+        navigateToSAMLPanel("defaultSAML");
+        formTester.setValue(
+                "panel:content:metadata", "<md:EntitiesDescriptor></md:EntitiesDescriptor>");
+        formTester.setValue("panel:content:signing", true);
+        formTester.setValue("panel:content:keyStorePath", "/path/to/keystore.jks");
+        formTester.setValue("panel:content:keyStoreId", "keystoreId");
+        formTester.setValue("panel:content:keyStorePassword", "keyStorePass");
+        formTester.setValue("panel:content:keyStoreIdPassword", "keyStoreIdPassword");
+        clickSave();
+        tester.assertNoErrorMessage();
+        clickNamedServiceConfig("defaultSAML");
+        tester.debugComponentTrees();
+        tester.assertModelValue("panel:panel:form:panel:keyStorePassword", "keyStorePass");
+        tester.assertModelValue("panel:panel:form:panel:keyStoreIdPassword", "keyStoreIdPassword");
+    }
+
+    @Override
+    protected AbstractSecurityPage getBasePage() {
+        return new AuthenticationPage();
+    }
+
+    @Override
+    protected String getBasePanelId() {
+        return "form:authFilters";
+    }
+
+    @Override
+    protected Integer getTabIndex() {
+        return 2;
+    }
+
+    @Override
+    protected Class<? extends Component> getNamedServicesClass() {
+        return SAMLAuthFilterPanel.class;
+    }
+
+    @Override
+    protected String getDetailsFormComponentId() {
+        return "authenticationFilterPanel:namedConfig";
+    }
+
+    protected void navigateToSAMLPanel(String name) throws Exception {
+        initializeForXML();
+
+        activatePanel();
+
+        // Test simple add
+        clickAddNew();
+
+        tester.assertRenderedPage(SecurityNamedServiceNewPage.class);
+        setSecurityConfigClassName(SAMLAuthFilterPanelInfo.class);
+
+        newFormTester();
+        setSecurityConfigName(name);
+    }
+}

--- a/src/community/saml/src/test/java/org/geoserver/security/saml/test/SAMLAuthenticationTest.java
+++ b/src/community/saml/src/test/java/org/geoserver/security/saml/test/SAMLAuthenticationTest.java
@@ -12,6 +12,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -20,7 +21,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.StringWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +133,7 @@ public class SAMLAuthenticationTest extends AbstractAuthenticationProviderTest {
         MockFilterChain chain = new MockFilterChain();
         getProxy().doFilter(request, response, chain);
 
-        assertTrue(response.getStatus() == MockHttpServletResponse.SC_MOVED_TEMPORARILY);
+        assertEquals(response.getStatus(), MockHttpServletResponse.SC_MOVED_TEMPORARILY);
         String redirectURL = response.getHeader("Location");
 
         assertThat(redirectURL, CoreMatchers.containsString(REDIRECT_URL));
@@ -193,7 +194,7 @@ public class SAMLAuthenticationTest extends AbstractAuthenticationProviderTest {
         String metadata =
                 IOUtils.toString(
                         getClass().getResourceAsStream("/__files/metadata_signed.xml"),
-                        Charset.forName("UTF-8"));
+                        StandardCharsets.UTF_8);
         configureFilter(PreAuthenticatedUserNameRoleSource.UserGroupService, metadata, true);
         MockHttpServletRequest request = createRequest("/foo/bar");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -201,7 +202,7 @@ public class SAMLAuthenticationTest extends AbstractAuthenticationProviderTest {
         getProxy().doFilter(request, response, chain);
 
         assertNotNull(response.getHeader("Location"));
-        assertTrue(response.getHeader("Location").indexOf("&Signature=") != -1);
+        assertNotEquals(-1, response.getHeader("Location").indexOf("&Signature="));
     }
 
     @Test
@@ -209,7 +210,7 @@ public class SAMLAuthenticationTest extends AbstractAuthenticationProviderTest {
         String metadata =
                 IOUtils.toString(
                         getClass().getResourceAsStream("/__files/metadata.xml"),
-                        Charset.forName("UTF-8"));
+                        StandardCharsets.UTF_8);
         configureFilter(PreAuthenticatedUserNameRoleSource.UserGroupService, metadata, false);
         MockHttpServletRequest request = createRequest("/foo/bar");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -217,7 +218,7 @@ public class SAMLAuthenticationTest extends AbstractAuthenticationProviderTest {
         getProxy().doFilter(request, response, chain);
 
         assertNotNull(response.getHeader("Location"));
-        assertTrue(response.getHeader("Location").indexOf("&Signature=") == -1);
+        assertEquals(-1, response.getHeader("Location").indexOf("&Signature="));
     }
 
     @Test
@@ -269,7 +270,7 @@ public class SAMLAuthenticationTest extends AbstractAuthenticationProviderTest {
         String metadata =
                 IOUtils.toString(
                         getClass().getResourceAsStream("/__files/metadata.xml"),
-                        Charset.forName("UTF-8"));
+                        StandardCharsets.UTF_8);
         configureFilter(PreAuthenticatedUserNameRoleSource.UserGroupService, metadata, false);
         MockHttpServletRequest request = createRequest("/foo/bar");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -400,7 +401,7 @@ public class SAMLAuthenticationTest extends AbstractAuthenticationProviderTest {
                                 .loadFilter(GeoServerSecurityFilterChain.FORM_LOGOUT_FILTER);
         logoutFilter.doFilter(request, response, chain);
 
-        assertTrue(response.getStatus() == MockHttpServletResponse.SC_MOVED_TEMPORARILY);
+        assertEquals(response.getStatus(), MockHttpServletResponse.SC_MOVED_TEMPORARILY);
         String redirectURL = response.getHeader("Location");
 
         /*

--- a/src/community/saml/src/test/java/org/geoserver/security/saml/test/SSLUtilities.java
+++ b/src/community/saml/src/test/java/org/geoserver/security/saml/test/SSLUtilities.java
@@ -16,9 +16,8 @@ import javax.net.ssl.TrustManagerFactory;
 public final class SSLUtilities {
 
     public static void registerKeyStore(String keyStoreName) {
-        try {
-            ClassLoader classLoader = SSLUtilities.class.getClassLoader();
-            InputStream keyStoreInputStream = classLoader.getResourceAsStream(keyStoreName);
+        ClassLoader classLoader = SSLUtilities.class.getClassLoader();
+        try (InputStream keyStoreInputStream = classLoader.getResourceAsStream(keyStoreName)) {
             if (keyStoreInputStream == null) {
                 throw new FileNotFoundException(
                         "Could not find file named '" + keyStoreName + "' in the CLASSPATH");

--- a/src/community/saml/src/test/java/org/geoserver/security/saml/test/StringSamlDecoder.java
+++ b/src/community/saml/src/test/java/org/geoserver/security/saml/test/StringSamlDecoder.java
@@ -11,8 +11,9 @@ import org.opensaml.saml2.binding.decoding.HTTPRedirectDeflateDecoder;
 public class StringSamlDecoder extends HTTPRedirectDeflateDecoder {
 
     public SAMLObject decode(String message) throws Exception {
-        InputStream samlMessageIns = decodeMessage(message);
-        SAMLObject samlMessage = (SAMLObject) unmarshallMessage(samlMessageIns);
-        return samlMessage;
+        try (InputStream samlMessageIns = decodeMessage(message)) {
+            SAMLObject samlMessage = (SAMLObject) unmarshallMessage(samlMessageIns);
+            return samlMessage;
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-10137](https://badgen.net/badge/JIRA/GEOS-10137/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10137)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This pr
- fix bug on the filter UI preventing the password fields to be reload when editing the filter.
- fix a small bug preventing global logout to be handled from idp that requires it to be signed

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.