### PR TITLE
[GEOS-10126] Mediatype x-gpkg is deprecated

### DIFF
--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
@@ -39,7 +39,7 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
     public static final String PROPERTY_INDEXED = "geopackage.wfs.indexed";
 
     public GeoPackageGetFeatureOutputFormat(GeoServer gs) {
-        super(gs, Sets.union(Sets.newHashSet(MIME_TYPE), Sets.newHashSet(NAMES)));
+        super(gs, Sets.union(Sets.newHashSet(MIME_TYPES), Sets.newHashSet(NAMES)));
     }
 
     @Override

--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPkg.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPkg.java
@@ -26,7 +26,11 @@ public class GeoPkg {
     public static final String EXTENSION = "gpkg";
 
     /** format mime type */
-    public static final String MIME_TYPE = "application/x-gpkg";
+    public static final String LEGACY_MIME_TYPE = "application/x-gpkg";
+
+    public static final String MIME_TYPE = "application/geopackage+sqlite3";
+    public static final Collection<String> MIME_TYPES =
+            Lists.newArrayList(MIME_TYPE, LEGACY_MIME_TYPE);
 
     /** names/aliases for the format */
     public static final Collection<String> NAMES =

--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/wps/GeoPackageProcess.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/wps/GeoPackageProcess.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.geopkg.wps;
 
+import static org.geoserver.geopkg.GeoPkg.MIME_TYPE;
+
 import com.google.common.base.Strings;
 import java.io.File;
 import java.io.IOException;
@@ -199,7 +201,7 @@ public class GeoPackageProcess implements GeoServerProcess {
         if (path != null && !remove) {
             return path;
         } else {
-            return new URL(resources.getOutputResourceUrl(outputName, "application/x-gpkg"));
+            return new URL(resources.getOutputResourceUrl(outputName, MIME_TYPE));
         }
     }
 

--- a/src/community/geopkg/src/main/resources/GeoServerApplication.properties
+++ b/src/community/geopkg/src/main/resources/GeoServerApplication.properties
@@ -1,9 +1,11 @@
 # Well known WMS formats
 format.wms.application/x-gpkg=GeoPackage
+format.wms.application/geopackage+sqlite3=GeoPackage
 format.wms.gpkg=GeoPackage
 
 # Well known WFS formats
 format.wfs.application/x-gpkg=GeoPackage
+format.wfs.application/geopackage+sqlite3=GeoPackage
 format.wfs.gpkg=GeoPackage
 format.wfs.geopkg=GeoPackage
 format.wfs.geopackage=GeoPackage

--- a/src/community/geopkg/src/main/resources/GeoServerApplication_es.properties
+++ b/src/community/geopkg/src/main/resources/GeoServerApplication_es.properties
@@ -1,8 +1,10 @@
 # Well known WMS formats
 format.wms.application/x-gpkg=Geopaquete
+format.wms.application/geopackage+sqlite3=Geopaquete
 
 # Well known WFS formats
 format.wfs.application/x-gpkg=Geopaquete
+format.wfs.application/geopackage+sqlite3=Geopaquete
 format.wfs.gpkg=Geopaquete
 format.wfs.geopkg=Geopaquete
 format.wfs.geopackage=Geopaquete

--- a/src/community/geopkg/src/main/resources/GeoServerApplication_ko.properties
+++ b/src/community/geopkg/src/main/resources/GeoServerApplication_ko.properties
@@ -1,8 +1,10 @@
 # Well known WMS formats
 format.wms.application/x-gpkg=GeoPackage
+format.wms.application/geopackage+sqlite3=GeoPackage
 
 # Well known WFS formats
 format.wfs.application/x-gpkg=GeoPackage
+format.wfs.application/geopackage+sqlite3=GeoPackage
 format.wfs.gpkg=GeoPackage
 format.wfs.geopkg=GeoPackage
 format.wfs.geopackage=GeoPackage

--- a/src/community/geopkg/src/main/resources/GeoServerApplication_pl.properties
+++ b/src/community/geopkg/src/main/resources/GeoServerApplication_pl.properties
@@ -1,8 +1,10 @@
 # Well known WMS formats
 format.wms.application/x-gpkg=GeoPakiet
+format.wms.application/geopackage+sqlite3=GeoPakiet
 
 # Well known WFS formats
 format.wfs.application/x-gpkg=GeoPakiet
+format.wfs.application/geopackage+sqlite3=GeoPakiet
 format.wfs.gpkg=GeoPakiet
 format.wfs.geopkg=GeoPakiet
 format.wfs.geopackage=GeoPakiet

--- a/src/community/geopkg/src/main/resources/GeoServerApplication_ru.properties
+++ b/src/community/geopkg/src/main/resources/GeoServerApplication_ru.properties
@@ -1,8 +1,10 @@
 # Well known WMS formats
 format.wms.application/x-gpkg=\u0413\u0435\u043e\u043f\u0430\u043a\u0435\u0442
+format.wms.application/geopackage+sqlite3=\u0413\u0435\u043e\u043f\u0430\u043a\u0435\u0442
 
 # Well known WFS formats
 format.wfs.application/x-gpkg=\u0413\u0435\u043e\u043f\u0430\u043a\u0435\u0442
+format.wfs.application/geopackage+sqlite3=\u0413\u0435\u043e\u043f\u0430\u043a\u0435\u0442
 format.wfs.gpkg=\u0413\u0435\u043e\u043f\u0430\u043a\u0435\u0442
 format.wfs.geopkg=\u0413\u0435\u043e\u043f\u0430\u043a\u0435\u0442
 format.wfs.geopackage=\u0413\u0435\u043e\u043f\u0430\u043a\u0435\u0442

--- a/src/community/geopkg/src/main/resources/GeoServerApplication_tr.properties
+++ b/src/community/geopkg/src/main/resources/GeoServerApplication_tr.properties
@@ -1,8 +1,10 @@
 # Well known WMS formats
 format.wms.application/x-gpkg=GeoPaket
+format.wms.application/geopackage+sqlite3=GeoPaket
 
 # Well known WFS formats
 format.wfs.application/x-gpkg=GeoPaket
+format.wfs.application/geopackage+sqlite3=GeoPaket
 format.wfs.gpkg=GeoPaket
 format.wfs.geopkg=GeoPaket
 format.wfs.geopackage=GeoPaket

--- a/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageMimeTypeTest.java
+++ b/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageMimeTypeTest.java
@@ -37,8 +37,9 @@ public class GeoPackageMimeTypeTest extends GeoServerWicketTestSupport {
         Iterator<? extends Component> iterator = view.iterator();
         // Check that GeoPackage has been found
         boolean gpkgFound = false;
-        // Get the string for the application/x-gpkg mimetype
-        ParamResourceModel rm = new ParamResourceModel("format.wms.application/x-gpkg", null, "");
+        // Get the string for the application/geopackage+sqlite3 mimetype
+        ParamResourceModel rm =
+                new ParamResourceModel("format.wms.application/geopackage+sqlite3", null, "");
         String mbtiles = rm.getString();
         while (iterator.hasNext()) {
             Component comp = iterator.next();


### PR DESCRIPTION
[![GEOS-10126](https://badgen.net/badge/JIRA/GEOS-10126/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10126)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Within GeoServer the mediatype for GeoPackage is  application/x-gpkg
However application/x-gpkg is a deprecated media-type, GeoPackage is now officially listed at https://www.iana.org/assignments/media-types/media-types.xhtml as application/geopackage+sqlite3

Resolves https://osgeo-org.atlassian.net/browse/GEOS-10126

## Checklist

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones. (No backports planned - community module).

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [N/A] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [N/A] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.

I checked the documentation for this community module - no changes required, since it uses the `geopackage` name rather than the MIME type in the examples.