### PR TITLE
[GEOS-10144] Integration test AppSchema JdbcMultipleValue will fill wrong values if targeColumn is a PK

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NormalizedMultiValuesTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/NormalizedMultiValuesTest.java
@@ -113,7 +113,8 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
                     "/test-data/stations/multiValues/measurements.xsd",
                     "/test-data/stations/multiValues/measurements.properties",
                     "/test-data/stations/multiValues/tags.properties",
-                    "/test-data/stations/multiValues/info.properties");
+                    "/test-data/stations/multiValues/info.properties",
+                    "/test-data/stations/multiValues/use.properties");
             // add GML 3.2 feature types
             Map<String, String> gml32Parameters = new HashMap<>();
             gml32Parameters.put("GML_PREFIX", "gml32");
@@ -132,7 +133,8 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
                     "/test-data/stations/multiValues/measurements.xsd",
                     "/test-data/stations/multiValues/measurements.properties",
                     "/test-data/stations/multiValues/tags.properties",
-                    "/test-data/stations/multiValues/info.properties");
+                    "/test-data/stations/multiValues/info.properties",
+                    "/test-data/stations/multiValues/use.properties");
         }
     }
 
@@ -728,5 +730,44 @@ public final class NormalizedMultiValuesTest extends AbstractAppSchemaTestSuppor
                 1,
                 "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32/st_gml32:info"
                         + "[@xlink:title='ST2']");
+    }
+
+    @Test
+    public void testJDBCMultipleValueWithPKInTargetColumn() throws Exception {
+        // tests that when having a void targetValue for JDBCMultipleValue
+        // and multiple ClientProperties, on of which with xlink:href,
+        // in the same AttributeMapping, the client properties are properly encoded
+        // check if this is an online test with a JDBC based data store
+        if (notJdbcBased()) {
+            // not a JDBC online test
+            return;
+        }
+        String request = "wfs?request=GetFeature&version=2.0&typename=st_gml32:Station_gml32";
+        Document document = getAsDOM(request);
+        // check that we have two complex features
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                3,
+                "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32");
+        // check that the expected stations and measurements are present
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                1,
+                "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32/st_gml32:use"
+                        + "[@xlink:href='http://link/use1' and @xlink:title='use1']");
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                1,
+                "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32/st_gml32:info"
+                        + "[@xlink:href='http://link/use2' and @xlink:title='use2']");
+
+        checkCount(
+                WFS20_XPATH_ENGINE,
+                document,
+                1,
+                "/wfs:FeatureCollection/wfs:member/st_gml32:Station_gml32/st_gml32:info[@xlink:href='http://link/use3' and @xlink:title='use3']");
     }
 }

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.properties
@@ -1,4 +1,4 @@
-_=ID:String,NAME:String,PHONE:String,MAIL:String,LOCATION:Geometry:srid=4326
-st.1=st.1|station1|32154898|station1@stations.org|POINT(-1 1)
-st.2=st.2|station2|23754243|station2@stations.org|POINT(-2 -3)
-st.3=st.3|station3|66677788|station3@stations.org|POINT(0 0)
+_=ID:String,NAME:String,PHONE:String,MAIL:String,LOCATION:Geometry:srid=4326,info_id
+st.1=st.1|station1|32154898|station1@stations.org|POINT(-1 1)|tg.01
+st.2=st.2|station2|23754243|station2@stations.org|POINT(-2 -3)|tg.02
+st.3=st.3|station3|66677788|station3@stations.org|POINT(0 0)|tg.03

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.properties
@@ -1,4 +1,4 @@
-_=ID:String,NAME:String,PHONE:String,MAIL:String,LOCATION:Geometry:srid=4326,info_id
+_=ID:String,NAME:String,PHONE:String,MAIL:String,LOCATION:Geometry:srid=4326,use_id
 st.1=st.1|station1|32154898|station1@stations.org|POINT(-1 1)|tg.01
 st.2=st.2|station2|23754243|station2@stations.org|POINT(-2 -3)|tg.02
 st.3=st.3|station3|66677788|station3@stations.org|POINT(0 0)|tg.03

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.xml
@@ -84,9 +84,9 @@
         <AttributeMapping>
           <targetAttribute>st_${GML_PREFIX}:info</targetAttribute>
           <jdbcMultipleValue>
-            <sourceColumn>ID</sourceColumn>
+            <sourceColumn>info_id</sourceColumn>
             <targetTable>INFO_${GML_PREFIX_UPPER}</targetTable>
-            <targetColumn>OWNER</targetColumn>
+            <targetColumn>info_${GML_PREFIX}_PKEY</targetColumn>
             <targetValue></targetValue>
           </jdbcMultipleValue>
           <ClientProperty>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.xml
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.xml
@@ -84,9 +84,9 @@
         <AttributeMapping>
           <targetAttribute>st_${GML_PREFIX}:info</targetAttribute>
           <jdbcMultipleValue>
-            <sourceColumn>info_id</sourceColumn>
+            <sourceColumn>ID</sourceColumn>
             <targetTable>INFO_${GML_PREFIX_UPPER}</targetTable>
-            <targetColumn>info_${GML_PREFIX}_PKEY</targetColumn>
+            <targetColumn>OWNER</targetColumn>
             <targetValue></targetValue>
           </jdbcMultipleValue>
           <ClientProperty>
@@ -96,6 +96,23 @@
           <ClientProperty>
             <name>xlink:title</name>
             <value>CODE</value>
+          </ClientProperty>
+        </AttributeMapping>
+        <AttributeMapping>
+          <targetAttribute>st_${GML_PREFIX}:use</targetAttribute>
+          <jdbcMultipleValue>
+            <sourceColumn>use_id</sourceColumn>
+            <targetTable>USE_${GML_PREFIX_UPPER}</targetTable>
+            <targetColumn>USE_${GML_PREFIX}_PKEY</targetColumn>
+            <targetValue></targetValue>
+          </jdbcMultipleValue>
+          <ClientProperty>
+            <name>xlink:href</name>
+            <value>LINK</value>
+          </ClientProperty>
+          <ClientProperty>
+            <name>xlink:title</name>
+            <value>TITLE</value>
           </ClientProperty>
         </AttributeMapping>
       </attributeMappings>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.xsd
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/stations.xsd
@@ -31,6 +31,7 @@
           <xs:element maxOccurs="unbounded" minOccurs="0" name="tag" type="st:TagType"/>
           <xs:element name="measurements" type="ms:MeasurementPropertyType" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="info" type="gml:ReferenceType" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="use" type="gml:ReferenceType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>

--- a/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/use.properties
+++ b/src/extension/app-schema/app-schema-test/src/test/resources/test-data/stations/multiValues/use.properties
@@ -1,0 +1,4 @@
+_=OWNER:String,LINK:String,TITLE:String
+us.01=st.1|http://link/use1|use1
+us.02=st.2|http://link/use2|use2
+us.03=st.3|http://link/use3|use3


### PR DESCRIPTION
[![GEOS-10144](https://badgen.net/badge/JIRA/GEOS-10144/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10144)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Provides test coverage for [GEOT-6937]( https://github.com/geotools/geotools/pull/3579) by modifying existing app-schema mappings in multivalues/stations.xml in order to have one of the two jdbcMultipleValue relations defained using the primary key of the target column.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.