### PR TITLE
[backport 2.19.x]Updating GeoFence documentation with example on CQL read filter limits on time range

### DIFF
--- a/doc/en/user/source/extensions/geofence-server/gui.rst
+++ b/doc/en/user/source/extensions/geofence-server/gui.rst
@@ -25,19 +25,35 @@ This page is displayed both when creating a new rule and modifying an existing r
 
 Priority can be changed manually by specifying a priority number. If this priority number is already occupied by another rule, this will cause that rule and all rules after it to shift one place to a lower priority.
 
-If using the IP Address range to limit access then on Linux (and other systems with IPv6 enabled) to add the ``-Djava.net.preferIPv4Stack=true`` flag to the GeoServer startup options to make sure that the IP range matching works with IPv4 style 
-addresses. Currently, IPv6 style address ranges are not supported by GeoFence.
+If using the IP Address range to limit access then on Linux (and other systems with IPv6 enabled) add the ``-Djava.net.preferIPv4Stack=true`` flag to the GeoServer startup options to make sure that the IP range matching works with IPv4 style addresses.
+Currently, IPv6 style address ranges are not supported by GeoFence.
 
 When Access type LIMIT is selected, additional options are displayed that allows the user to select the Catalog Mode and the Allowed Area (WKT) associated with this rule. The Spatial Filter Type parameter allows to define whether apply the Allowed Area filter to vector data as an Intersects or a Clip filter. 
 
 .. figure:: images/limit.png
    :align: center
   
-When Access type ACCESS is selected as well as a specific layer, it becomes possible to specify the "layer details" in a separate tab. These make it possible to add additional filters to the layer for the rule in question. For example, the rule can alter the default style of the layer, specify which styles are available at all, which attributes are accessible for reading and/or writing, specify CQL filters for both reading and writing, specify a catalog mode, and an allowed area (WKT) filter.
+When Access type ACCESS is selected as well as a specific layer, it becomes possible to specify the "layer details" in a separate tab.
+These make it possible to add additional filters to the layer for the rule in question. For example, the rule can alter the default style of the layer, specify which styles are available at all, which attributes are accessible for reading and/or writing, specify CQL filters for both reading and writing, specify a catalog mode, and an allowed area (WKT) filter.
 
 .. figure:: images/layerdetails.png
    :align: center
 
+
+A CQL Read Filter can be setup to allow users to only access a subset of the available data.
+
+For example, having a daily time series layer (a Layer with time attribute/dimension), 
+it's possible to restrict access to a given time range.
+
+A CQL filter to limit access to the whole 2020 year (static time range) would look as follows::
+
+   time between 2020-01-01 and 2020-12-31
+
+A CQL filter limiting access to data older than a week (dynamic time range) would look like this instead::
+
+   dateDifference(now(), time, 'd') > 7
+
+(see :ref:`temporal-functions <temporal-functions>` for more details on the date difference function)
 
 Allowed area can be defined in whatever SRID. Geoserver will automatically reproject it to the resource CRS when needed.
 

--- a/doc/en/user/source/filter/function_reference.rst
+++ b/doc/en/user/source/filter/function_reference.rst
@@ -541,9 +541,11 @@ Parsing and formatting functions
    * - parseLong
      - ``number``:String
      - Parses a string into a long integer
-     
+
+.. _temporal-functions:
+
 Temporal functions
---------------------------------
+------------------
 
 .. list-table::
    :widths: 20 25 55


### PR DESCRIPTION
backporting to 2.19.x