### PR TITLE
[GEOS-10032] Group Layer in Catalag Mode Hide not in capabilities when unauthenticated

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
@@ -550,7 +550,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
             String wsNameProperty;
             if (LayerGroupInfo.class.isAssignableFrom(clazz)) {
                 // resource.store.workspace.name is not applicable for layergroups
-                wsNameProperty = "workspace.name";           
+                wsNameProperty = "workspace.name";
             } else if (PublishedInfo.class.isAssignableFrom(clazz)) {
                 wsNameProperty = "resource.store.workspace.name";
             } else {

--- a/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
@@ -548,7 +548,10 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
 
             // get the right ws property name
             String wsNameProperty;
-            if (PublishedInfo.class.isAssignableFrom(clazz)) {
+            if (LayerGroupInfo.class.isAssignableFrom(clazz)) {
+                // resource.store.workspace.name is not applicable for layergroups
+                wsNameProperty = "workspace.name";           
+            } else if (PublishedInfo.class.isAssignableFrom(clazz)) {
                 wsNameProperty = "resource.store.workspace.name";
             } else {
                 wsNameProperty = "store.workspace.name";

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1823,5 +1824,13 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
         // the ws specific group is made available by the workspace rule
         assertNotNull(sc.getLayerGroupByName("nurc", "wsContainerD"));
         assertNotNull(sc.getLayerByName(arcGridLayer.prefixedName()));
+
+        // check access is working also when iterating over all groups
+        try (CloseableIterator<LayerGroupInfo> groupIterator =
+                sc.list(LayerGroupInfo.class, Filter.INCLUDE)) {
+            ImmutableList<LayerGroupInfo> groups = ImmutableList.copyOf(groupIterator);
+            assertEquals(1, groups.size());
+            assertEquals("wsContainerD", groups.get(0).getName());
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-10032](https://badgen.net/badge/JIRA/GEOS-10032/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10032)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This pull request solves the issue, that layergroups are not output to capabilities in catalog mode hide, when the user is not the admin user. The reason lies in a not applicable filter put on layergroups by DefaultResourceAccessManager.

<Include a few sentences describing the overall goals for this Pull Request. Please do not remove the checklist below, pull requests missing it will be ignored.>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [x] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.