### PR TITLE
[GEOS-10160] Requested Language in GetCapabilities

### DIFF
--- a/doc/en/user/source/services/internationalization/index.rst
+++ b/doc/en/user/source/services/internationalization/index.rst
@@ -41,7 +41,7 @@ The response content language can be selected using the ``AcceptLanguages`` requ
 
 * If not all the configurable elements have i18n title and abstract available for the requested language, GeoServer will encode those attributes only for services, layers, layergroups and styles that have them defined. In case the missing value is the tile, in place of the missing internationalized content an error message like the following, will appear: ``DID NOT FIND i18n CONTENT FOR THIS ELEMENT``.
 
-
+* When using ``AcceptLanguages`` parameter GeoServer will encode URL present in the response adding language parameter with the first value retrieved from the ``AcceptLanguages`` parameter.
 
 .. figure:: img/ErrorMessages.png
 

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetCapabilitiesTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetCapabilitiesTest.java
@@ -105,9 +105,9 @@ public class GetCapabilitiesTest extends WPSTestSupport {
 
     @Test
     public void testBasicGetLanguage() throws Exception { // Standard Test A.4.2.3
-        Document d = getAsDOM("wps?service=wps&request=getcapabilities&language=en-US");
+        Document d = getAsDOM("wps?service=wps&request=getcapabilities&Language=en-US");
         // print(d);
-        basicCapabilitiesTest(d, null);
+        basicCapabilitiesTest(d, null, "Language=en-US");
     }
 
     @Test
@@ -138,6 +138,11 @@ public class GetCapabilitiesTest extends WPSTestSupport {
     }
 
     private void basicCapabilitiesTest(Document d, String workspace) throws Exception {
+        basicCapabilitiesTest(d, workspace, null);
+    }
+
+    private void basicCapabilitiesTest(Document d, String workspace, String language)
+            throws Exception {
         // print(d);
         checkValidationErrors(d);
 
@@ -156,6 +161,11 @@ public class GetCapabilitiesTest extends WPSTestSupport {
         if (workspace != null) {
             expectedOperationUrl = "http://localhost:8080/geoserver/" + workspace + "/wps";
         }
+
+        if (language != null) {
+            expectedOperationUrl = expectedOperationUrl + "?" + language;
+        }
+
         String[] operations = {"GetCapabilities", "DescribeProcess", "Execute"};
         for (String operation : operations) {
             String getPath =

--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -248,6 +248,10 @@
     <constructor-arg value="ows"/>
   </bean>
 
+    <!-- URL mangler for handling Languange and AcceptLanguages parameters -->
+    <bean id="languageURLMangler" class="org.geoserver.ows.LanguageURLMangler">
+    </bean>
+
   <!-- xstream persister factory -->
   <bean id="xstreamPersisterFactory" class="org.geoserver.config.util.XStreamPersisterFactory"/>
 

--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -248,9 +248,8 @@
     <constructor-arg value="ows"/>
   </bean>
 
-    <!-- URL mangler for handling Languange and AcceptLanguages parameters -->
-    <bean id="languageURLMangler" class="org.geoserver.ows.LanguageURLMangler">
-    </bean>
+  <!-- URL mangler for handling Languange and AcceptLanguages parameters -->
+  <bean id="languageURLMangler" class="org.geoserver.ows.LanguageURLMangler"/>
 
   <!-- xstream persister factory -->
   <bean id="xstreamPersisterFactory" class="org.geoserver.config.util.XStreamPersisterFactory"/>

--- a/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
@@ -4,48 +4,53 @@
  */
 package org.geoserver.ows;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
 
 /** Mangles service URL's based on the AcceptLanguages and Languages parameters */
 public class LanguageURLMangler implements URLMangler {
 
     public static final String ACCEPT_LANGUAGES = "AcceptLanguages";
     public static final String LANGUAGE = "Language";
-    private String languageParameter = "";
-    private String acceptLanguagesParameter = "";
 
     @Override
     public void mangleURL(
             StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
         if (Dispatcher.REQUEST.get() == null || !type.equals(URLType.SERVICE)) return;
 
-        String language = "";
+        String languageParameter = null;
+        String acceptLanguagesParameter = null;
+
         HttpServletRequest httpRequest = Dispatcher.REQUEST.get().getHttpRequest();
         Enumeration<String> parameterNames = httpRequest.getParameterNames();
-        Collections.list(parameterNames)
-                .forEach(
-                        parameter -> {
-                            if (parameter.equalsIgnoreCase(LANGUAGE)) {
-                                languageParameter = parameter;
-                            } else if (parameter.equalsIgnoreCase(ACCEPT_LANGUAGES)) {
-                                acceptLanguagesParameter = parameter;
-                            }
-                        });
 
-        String acceptLanguages = httpRequest.getParameter(acceptLanguagesParameter);
-        language = httpRequest.getParameter(languageParameter);
-
-        if (acceptLanguages != null) {
-            String comaSplit = acceptLanguages.split(",")[0];
-            String spaceSplit = comaSplit.split(" ")[0];
-            if (spaceSplit.length() >= 1) {
-                language = spaceSplit;
-            } else {
-                language = comaSplit;
+        for (String parameter : Collections.list(parameterNames)) {
+            if (parameter.equalsIgnoreCase(LANGUAGE)) {
+                languageParameter = parameter;
+            } else if (parameter.equalsIgnoreCase(ACCEPT_LANGUAGES)) {
+                acceptLanguagesParameter = parameter;
             }
+        }
+
+        String language = "";
+
+        if (acceptLanguagesParameter != null) {
+            String acceptLanguages = httpRequest.getParameter(acceptLanguagesParameter);
+            if (acceptLanguages != null) {
+                String commaSplit = acceptLanguages.split(",")[0];
+                String spaceSplit = commaSplit.split(" ")[0];
+                if (spaceSplit.length() >= 1) {
+                    language = spaceSplit;
+                } else {
+                    language = commaSplit;
+                }
+            }
+        }
+
+        if (languageParameter != null) {
+            language = httpRequest.getParameter(languageParameter);
         }
 
         if (language != null && language.length() > 0) {

--- a/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
@@ -4,10 +4,10 @@
  */
 package org.geoserver.ows;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 
 /** Mangles service URL's based on the AcceptLanguages and Languages parameters */
 public class LanguageURLMangler implements URLMangler {

--- a/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
@@ -1,0 +1,37 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows;
+
+import java.util.Map;
+
+/** Mangles service URL's based on the AcceptLanguages and Languages parameters */
+public class LanguageURLMangler implements URLMangler {
+
+    public static final String ACCEPT_LANGUAGES = "AcceptLanguages";
+    public static final String LANGUAGE = "Language";
+
+    @Override
+    public void mangleURL(
+            StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
+        if (Dispatcher.REQUEST.get() == null) return;
+
+        String language = "";
+        Map<String, String[]> parameterMap =
+                Dispatcher.REQUEST.get().getHttpRequest().getParameterMap();
+
+        for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(LANGUAGE)
+                    && entry.getValue() != null
+                    && entry.getValue()[0] != null) language = entry.getValue()[0];
+            if (entry.getKey().equalsIgnoreCase(ACCEPT_LANGUAGES)
+                    && entry.getValue() != null
+                    && entry.getValue()[0] != null) language = entry.getValue()[0];
+        }
+
+        if (language.length() > 0) {
+            kvp.put("language", language.trim());
+        }
+    }
+}

--- a/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.ows;
 
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Map;
 
 /** Mangles service URL's based on the AcceptLanguages and Languages parameters */
@@ -11,6 +13,8 @@ public class LanguageURLMangler implements URLMangler {
 
     public static final String ACCEPT_LANGUAGES = "AcceptLanguages";
     public static final String LANGUAGE = "Language";
+    private String languageParameter = "";
+    private String acceptLanguagesParameter = "";
 
     @Override
     public void mangleURL(
@@ -18,20 +22,34 @@ public class LanguageURLMangler implements URLMangler {
         if (Dispatcher.REQUEST.get() == null) return;
 
         String language = "";
-        Map<String, String[]> parameterMap =
-                Dispatcher.REQUEST.get().getHttpRequest().getParameterMap();
+        Enumeration<String> parameterNames =
+                Dispatcher.REQUEST.get().getHttpRequest().getParameterNames();
+        Collections.list(parameterNames)
+                .forEach(
+                        parameter -> {
+                            if (parameter.equalsIgnoreCase(LANGUAGE)) {
+                                languageParameter = parameter;
+                            } else if (parameter.equalsIgnoreCase(ACCEPT_LANGUAGES)) {
+                                acceptLanguagesParameter = parameter;
+                            }
+                        });
 
-        for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
-            if (entry.getKey().equalsIgnoreCase(LANGUAGE)
-                    && entry.getValue() != null
-                    && entry.getValue()[0] != null) language = entry.getValue()[0];
-            if (entry.getKey().equalsIgnoreCase(ACCEPT_LANGUAGES)
-                    && entry.getValue() != null
-                    && entry.getValue()[0] != null) language = entry.getValue()[0];
+        String acceptLanguages =
+                Dispatcher.REQUEST.get().getHttpRequest().getParameter(acceptLanguagesParameter);
+        language = Dispatcher.REQUEST.get().getHttpRequest().getParameter(languageParameter);
+
+        if (acceptLanguages != null) {
+            String comaSplit = acceptLanguages.split(",")[0];
+            String spaceSplit = comaSplit.split(" ")[0];
+            if (spaceSplit.length() >= 1) {
+                language = spaceSplit;
+            } else {
+                language = comaSplit;
+            }
         }
 
-        if (language.length() > 0) {
-            kvp.put("language", language.trim());
+        if (language != null && language.length() > 0) {
+            kvp.put("Language", language.trim());
         }
     }
 }

--- a/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
@@ -7,6 +7,7 @@ package org.geoserver.ows;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 
 /** Mangles service URL's based on the AcceptLanguages and Languages parameters */
 public class LanguageURLMangler implements URLMangler {
@@ -19,11 +20,11 @@ public class LanguageURLMangler implements URLMangler {
     @Override
     public void mangleURL(
             StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
-        if (Dispatcher.REQUEST.get() == null) return;
+        if (Dispatcher.REQUEST.get() == null || !type.equals(URLType.SERVICE)) return;
 
         String language = "";
-        Enumeration<String> parameterNames =
-                Dispatcher.REQUEST.get().getHttpRequest().getParameterNames();
+        HttpServletRequest httpRequest = Dispatcher.REQUEST.get().getHttpRequest();
+        Enumeration<String> parameterNames = httpRequest.getParameterNames();
         Collections.list(parameterNames)
                 .forEach(
                         parameter -> {
@@ -34,9 +35,8 @@ public class LanguageURLMangler implements URLMangler {
                             }
                         });
 
-        String acceptLanguages =
-                Dispatcher.REQUEST.get().getHttpRequest().getParameter(acceptLanguagesParameter);
-        language = Dispatcher.REQUEST.get().getHttpRequest().getParameter(languageParameter);
+        String acceptLanguages = httpRequest.getParameter(acceptLanguagesParameter);
+        language = httpRequest.getParameter(languageParameter);
 
         if (acceptLanguages != null) {
             String comaSplit = acceptLanguages.split(",")[0];

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/GetCapabilitiesTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/kvp/GetCapabilitiesTest.java
@@ -8,8 +8,8 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.geoserver.data.test.MockData.TASMANIA_DEM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import java.util.Locale;
 
+import java.util.Locale;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.Keyword;
@@ -21,7 +21,6 @@ import org.geoserver.wcs2_0.WCSTestSupport;
 import org.geotools.util.GrowableInternationalString;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.vfny.geoserver.wcs.WcsException.WcsExceptionCode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -185,14 +184,15 @@ public class GetCapabilitiesTest extends WCSTestSupport {
         abstractInfo.add(Locale.ENGLISH, "abstract");
         abstractInfo.add(Locale.ITALIAN, "italiano abstract");
         ci.setInternationalAbstract(abstractInfo);
-
         catalog.save(ci);
 
-        MockHttpServletResponse response =
-                getAsServletResponse(
+        Document dom =
+                getAsDOM(
                         "wcs?service=WCS&version=2.0.1&request=GetCapabilities&AcceptLanguages=it");
-        String responseMsg = response.getContentAsString();
 
-        assertTrue(responseMsg.contains("wcs?Language=it"));
+        assertXpathEvaluatesTo(
+                "http://localhost:8080/geoserver/wcs?Language=it&",
+                "//ows:DCP/ows:HTTP/ows:Get/@xlink:href",
+                dom);
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetCapabilitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetCapabilitiesTest.java
@@ -789,11 +789,13 @@ public class GetCapabilitiesTest extends WFS20TestSupport {
         fti.setInternationalTitle(title);
         catalog.save(fti);
 
-        MockHttpServletResponse response =
-                getAsServletResponse(
+        Document dom =
+                getAsDOM(
                         "wfs?service=WFS&request=getCapabilities&version=2.0.0&acceptLanguages=it");
-        String responseMsg = response.getContentAsString();
 
-        assertTrue(responseMsg.contains("Language=it"));
+        assertXpathEvaluatesTo(
+                "src/test/resources/geoserver/wfs?Language=it",
+                "//ows:DCP/ows:HTTP/ows:Get/@xlink:href",
+                dom);
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetCapabilitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetCapabilitiesTest.java
@@ -685,6 +685,16 @@ public class GetCapabilitiesTest extends WFS20TestSupport {
         assertXpathEvaluatesTo("titolo italiano", fifteenLayer + "/wfs:Title", doc);
         assertXpathEvaluatesTo("abstract italiano", fifteenLayer + "/wfs:Abstract", doc);
         assertXpathEvaluatesTo("parola chiave", fifteenLayer + "/ows:Keywords/ows:Keyword", doc);
+
+        doc = getAsDOM("wfs?service=WFS&request=getCapabilities&version=2.0.0&Language=eng");
+        service = "//ows:ServiceIdentification";
+        assertXpathEvaluatesTo("a i18n title for WFS service", service + "/ows:Title", doc);
+        assertXpathEvaluatesTo("a i18n abstract for WFS service", service + "/ows:Abstract", doc);
+        fifteenLayer =
+                "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[wfs:Name='cdf:Fifteen']";
+        assertXpathEvaluatesTo("Fifteen", fifteenLayer + "/wfs:Title", doc);
+        assertXpathEvaluatesTo("abstract about Fifteen", fifteenLayer + "/wfs:Abstract", doc);
+        assertXpathEvaluatesTo("Fifteen", fifteenLayer + "/ows:Keywords/ows:Keyword", doc);
     }
 
     @Test
@@ -718,6 +728,7 @@ public class GetCapabilitiesTest extends WFS20TestSupport {
         wfs.setInternationalTitle(title);
         wfs.setInternationalAbstract(_abstract);
         gs.save(wfs);
+
         MockHttpServletResponse response =
                 getAsServletResponse(
                         "wfs?service=WFS&request=getCapabilities&version=2.0.0&acceptLanguages=fre");

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetCapabilitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetCapabilitiesTest.java
@@ -685,16 +685,6 @@ public class GetCapabilitiesTest extends WFS20TestSupport {
         assertXpathEvaluatesTo("titolo italiano", fifteenLayer + "/wfs:Title", doc);
         assertXpathEvaluatesTo("abstract italiano", fifteenLayer + "/wfs:Abstract", doc);
         assertXpathEvaluatesTo("parola chiave", fifteenLayer + "/ows:Keywords/ows:Keyword", doc);
-
-        doc = getAsDOM("wfs?service=WFS&request=getCapabilities&version=2.0.0&Language=eng");
-        service = "//ows:ServiceIdentification";
-        assertXpathEvaluatesTo("a i18n title for WFS service", service + "/ows:Title", doc);
-        assertXpathEvaluatesTo("a i18n abstract for WFS service", service + "/ows:Abstract", doc);
-        fifteenLayer =
-                "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[wfs:Name='cdf:Fifteen']";
-        assertXpathEvaluatesTo("Fifteen", fifteenLayer + "/wfs:Title", doc);
-        assertXpathEvaluatesTo("abstract about Fifteen", fifteenLayer + "/wfs:Abstract", doc);
-        assertXpathEvaluatesTo("Fifteen", fifteenLayer + "/ows:Keywords/ows:Keyword", doc);
     }
 
     @Test
@@ -787,5 +777,23 @@ public class GetCapabilitiesTest extends WFS20TestSupport {
         // it was not specified french should have been selected
         assertXpathEvaluatesTo("resumé", fifteenLayer + "/wfs:Abstract", doc);
         assertXpathEvaluatesTo("parola chiave", fifteenLayer + "/ows:Keywords/ows:Keyword", doc);
+    }
+
+    @Test
+    public void testAcceptLanguagesParameter() throws Exception {
+        Catalog catalog = getCatalog();
+        FeatureTypeInfo fti = catalog.getFeatureTypeByName(getLayerId(MockData.FIFTEEN));
+        GrowableInternationalString title = new GrowableInternationalString();
+        title.add(Locale.ENGLISH, "a i18n title for fti fifteen");
+        title.add(Locale.ITALIAN, "titolo italiano");
+        fti.setInternationalTitle(title);
+        catalog.save(fti);
+
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wfs?service=WFS&request=getCapabilities&version=2.0.0&acceptLanguages=it");
+        String responseMsg = response.getContentAsString();
+
+        assertTrue(responseMsg.contains("Language=it"));
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesReponseTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesReponseTest.java
@@ -113,6 +113,24 @@ public class GetCapabilitiesReponseTest extends WMSTestSupport {
                 "a i18n abstract for group nature", natureGroup + "/Abstract", result);
 
         assertXpathEvaluatesTo("english keyword", natureGroup + "/KeywordList/Keyword", result);
+
+        request = "wms?version=1.1.1&request=GetCapabilities&service=WMS&" + "Language=eng";
+        result = getAsDOM(request);
+
+        service = "/WMT_MS_Capabilities/Service";
+        assertXpathEvaluatesTo("a i18n title for WMS service", service + "/Title", result);
+        assertXpathEvaluatesTo("a i18n abstract for WMS service", service + "/Abstract", result);
+
+        fifteenLayer = "/WMT_MS_Capabilities/Capability/Layer/Layer[Name = 'cdf:Fifteen']";
+        assertXpathEvaluatesTo("Fifteen", fifteenLayer + "/Title", result);
+        assertXpathEvaluatesTo("abstract about Fifteen", fifteenLayer + "/Abstract", result);
+
+        natureGroup = "/WMT_MS_Capabilities/Capability/Layer/Layer/Layer[Name = 'nature']";
+        assertXpathEvaluatesTo("a i18n title for group nature", natureGroup + "/Title", result);
+        assertXpathEvaluatesTo(
+                "a i18n abstract for group nature", natureGroup + "/Abstract", result);
+
+        assertXpathEvaluatesTo("parola chiave", natureGroup + "/KeywordList/Keyword", result);
     }
 
     @Test

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesReponseTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesReponseTest.java
@@ -6,15 +6,14 @@
 package org.geoserver.wms.capabilities;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Locale;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.Keyword;
 import org.geoserver.catalog.KeywordInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
-import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.data.test.MockData;
 import org.geoserver.wms.WMSInfo;
@@ -192,11 +191,20 @@ public class GetCapabilitiesReponseTest extends WMSTestSupport {
         fti.setInternationalTitle(title);
         catalog.save(fti);
 
-        MockHttpServletResponse response =
-                getAsServletResponse(
+        Document dom =
+                getAsDOM(
                         "wms?version=1.1.1&request=GetCapabilities&service=WMS&AcceptLanguages=it");
-        String responseMsg = response.getContentAsString();
 
-        assertTrue(responseMsg.contains("Language=it"));
+        assertXpathEvaluatesTo(
+                "http://localhost:8080/geoserver/?Language=it",
+                "WMT_MS_Capabilities/Service/OnlineResource/@xlink:href",
+                dom);
+        assertXpathEvaluatesTo(
+                "http://localhost:8080/geoserver/wms?SERVICE=WMS&Language=it&",
+                "WMT_MS_Capabilities/Capability/Request/GetCapabilities/DCPType/HTTP/Get/OnlineResource/@xlink:href",
+                dom);
+        assertXpathEvaluatesTo(
+                "http://localhost:8080/geoserver/wms?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=nature&Language=it",
+                "//Layer[Name='nature']/Style/LegendURL/OnlineResource/@xlink:href", dom);
     }
 }


### PR DESCRIPTION
[![GEOS-10160](https://badgen.net/badge/JIRA/GEOS-10160/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10160)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This pull request adds the possibility to have the language parameter in the URL in the GetCapabilities response.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.**


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for community modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOS-XYZW] Title of the Jira ticket" (export to XML in Jira generates the message in this exact form)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Commits changing the UI, existing user workflows, or adding new functionality, need to include documentation updates (screenshots, text)
- [ ] Commits changing the REST API, or any configuration object, should check if the REST API docs (Swagger YAML files and classic documentation) need to be updated.