### PR TITLE
[backport-2.18.x][GEOS-10173]: Fixing securing CoverageViewReader's format class

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
@@ -43,10 +43,12 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.coverage.grid.io.AbstractGridCoverage2DReader;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.grid.io.OverviewPolicy;
 import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
+import org.geotools.coverage.grid.io.imageio.GeoToolsWriteParams;
 import org.geotools.coverage.processing.CoverageProcessor;
 import org.geotools.data.ResourceInfo;
 import org.geotools.data.ServiceInfo;
@@ -62,6 +64,7 @@ import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
 import org.opengis.coverage.grid.Format;
 import org.opengis.coverage.grid.GridCoverage;
+import org.opengis.coverage.grid.GridCoverageWriter;
 import org.opengis.coverage.grid.GridEnvelope;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.geometry.BoundingBox;
@@ -670,9 +673,10 @@ public class CoverageViewReader implements GridCoverage2DReader {
 
     @Override
     public Format getFormat() {
-        return new Format() {
+        return new AbstractGridFormat() {
 
-            private final Format delegateFormat = delegate.getFormat();
+            private final AbstractGridFormat delegateFormat =
+                    (AbstractGridFormat) delegate.getFormat();
 
             @Override
             public ParameterValueGroup getWriteParameters() {
@@ -680,8 +684,38 @@ public class CoverageViewReader implements GridCoverage2DReader {
             }
 
             @Override
+            public GeoToolsWriteParams getDefaultImageIOWriteParameters() {
+                return delegateFormat.getDefaultImageIOWriteParameters();
+            }
+
+            @Override
+            public GridCoverageWriter getWriter(Object o, Hints hints) {
+                return delegateFormat.getWriter(o, hints);
+            }
+
+            @Override
             public String getVersion() {
                 return delegateFormat.getVersion();
+            }
+
+            @Override
+            public AbstractGridCoverage2DReader getReader(Object o) {
+                return delegateFormat.getReader(o);
+            }
+
+            @Override
+            public AbstractGridCoverage2DReader getReader(Object o, Hints hints) {
+                return delegateFormat.getReader(o, hints);
+            }
+
+            @Override
+            public GridCoverageWriter getWriter(Object o) {
+                return delegateFormat.getWriter(o);
+            }
+
+            @Override
+            public boolean accepts(Object o, Hints hints) {
+                return delegateFormat.accepts(o, hints);
             }
 
             @Override

--- a/src/security/security-tests/src/test/java/org/geoserver/security/decorators/SecuredGridCoverage2DReaderTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/decorators/SecuredGridCoverage2DReaderTest.java
@@ -8,22 +8,34 @@ package org.geoserver.security.decorators;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import javax.media.jai.ImageLayout;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageView;
+import org.geoserver.catalog.CoverageViewReader;
 import org.geoserver.catalog.Predicates;
 import org.geoserver.security.CatalogMode;
 import org.geoserver.security.CoverageAccessLimits;
 import org.geoserver.security.WrapperPolicy;
 import org.geoserver.security.impl.SecureObjectsTest;
+import org.geotools.coverage.grid.GeneralGridEnvelope;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.gce.imagemosaic.ImageMosaicFormat;
+import org.geotools.geometry.GeneralEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Test;
 import org.opengis.coverage.grid.Format;
 import org.opengis.filter.Filter;
@@ -78,6 +90,58 @@ public class SecuredGridCoverage2DReaderTest extends SecureObjectsTest {
         final ParameterValue pv = ImageMosaicFormat.FILTER.createValue();
         pv.setValue(requestFilter);
         secured.read(new GeneralParameterValue[] {pv});
+    }
+
+    @Test
+    public void testCoverageViewSecured() throws Exception {
+        DefaultSecureDataFactory factory = new DefaultSecureDataFactory();
+
+        GridCoverage2DReader reader = createNiceMock(GridCoverage2DReader.class);
+        expect(reader.getOriginalEnvelope())
+                .andReturn(new GeneralEnvelope(new double[] {-90, -90}, new double[] {90, 90}))
+                .anyTimes();
+        expect(reader.getOriginalGridRange())
+                .andReturn(new GeneralGridEnvelope(new Rectangle(0, 0, 100, 100)))
+                .anyTimes();
+        expect(reader.getCoordinateReferenceSystem())
+                .andReturn(DefaultGeographicCRS.WGS84)
+                .anyTimes();
+        BufferedImage bi = new BufferedImage(100, 100, BufferedImage.TYPE_BYTE_GRAY);
+        expect(reader.getImageLayout("coverageView")).andReturn(new ImageLayout(bi)).anyTimes();
+        replay(reader);
+
+        CoverageView coverageView = createNiceMock(CoverageView.class);
+        CoverageInfo coverageInfo = createNiceMock(CoverageInfo.class);
+        expect(coverageView.getName()).andReturn("coverageView").anyTimes();
+        CoverageView.CoverageBand coverageBand =
+                new CoverageView.CoverageBand(
+                        Collections.singletonList(
+                                new CoverageView.InputCoverageBand("coverageView", "band1")),
+                        "band1",
+                        0,
+                        CoverageView.CompositionType.BAND_SELECT);
+        List<CoverageView.CoverageBand> bands = Collections.singletonList(coverageBand);
+        expect(coverageView.getCoverageBands()).andReturn(bands).anyTimes();
+        expect(coverageView.getBand(0)).andReturn(coverageBand).anyTimes();
+        expect(coverageView.getSelectedResolution())
+                .andReturn(CoverageView.SelectedResolution.BEST)
+                .anyTimes();
+        expect(coverageView.getEnvelopeCompositionType())
+                .andReturn(CoverageView.EnvelopeCompositionType.UNION)
+                .anyTimes();
+        replay(coverageView);
+
+        CoverageViewReader viewReader =
+                new CoverageViewReader(reader, coverageView, coverageInfo, null);
+        CoverageAccessLimits accessLimits =
+                new CoverageAccessLimits(CatalogMode.HIDE, null, null, null);
+
+        Object securedObject = factory.secure(viewReader, WrapperPolicy.readOnlyHide(accessLimits));
+        assertTrue(securedObject instanceof SecuredGridCoverage2DReader);
+
+        securedObject =
+                factory.secure(viewReader.getFormat(), WrapperPolicy.readOnlyHide(accessLimits));
+        assertTrue(securedObject instanceof SecuredGridFormat);
     }
 
     private static void setupReadAssertion(


### PR DESCRIPTION
[![GEOS-10173](https://badgen.net/badge/JIRA/GEOS-10173/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10173)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backporting GEOS-10173 to 2.18.x