### PR TITLE
[GEOS-10193] Indirect imports will drop the target table if there is any failure during the import process (2.19.x)

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
@@ -1509,11 +1509,13 @@ public class Importer implements DisposableBean, ApplicationListener {
                         e1);
             }
 
-            // attempt to drop the type that was created as well
-            try {
-                dropSchema(dataStoreDestination, featureTypeName);
-            } catch (Exception e1) {
-                LOGGER.log(Level.WARNING, "Error dropping schema in rollback", e1);
+            // drop the type that was created as well, only if it was created to start with
+            if (task.getUpdateMode() == UpdateMode.CREATE) {
+                try {
+                    dropSchema(dataStoreDestination, featureTypeName);
+                } catch (Exception e1) {
+                    LOGGER.log(Level.WARNING, "Error dropping schema in rollback", e1);
+                }
             }
         }
 
@@ -1597,11 +1599,13 @@ public class Importer implements DisposableBean, ApplicationListener {
                 LOGGER.log(Level.WARNING, "Error rolling back transaction", e1);
             }
 
-            // attempt to drop the type that was created as well
-            try {
-                dropSchema(dataStoreDestination, featureTypeName);
-            } catch (Exception e1) {
-                LOGGER.log(Level.WARNING, "Error dropping schema in rollback", e1);
+            // drop the type that was created as well, only if it was created to start with
+            if (task.getUpdateMode() == UpdateMode.CREATE) {
+                try {
+                    dropSchema(dataStoreDestination, featureTypeName);
+                } catch (Exception e1) {
+                    LOGGER.log(Level.WARNING, "Error dropping schema in rollback", e1);
+                }
             }
         }
         return error;


### PR DESCRIPTION
[![GEOS-10193](https://badgen.net/badge/JIRA/GEOS-10193/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10193)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->