### PR TITLE
Updated expected location of dimension attributes

### DIFF
--- a/doc/en/user/source/data/raster/imagemosaic/configuration.rst
+++ b/doc/en/user/source/data/raster/imagemosaic/configuration.rst
@@ -70,6 +70,12 @@ The table below describes the various elements in this configuration file.
    * - LocationAttribute
      - Y
      - The name of the attribute path in the shapefile index. Default is ``location``.
+   * - TimeAttribute
+     - N
+     - Specifies the name of the time-variant attribute.
+   * - ElevationAttribute
+     - N
+     - Specifies the name of the elevation attribute.
    * - SuggestedSPI
      - Y
      - Suggested plugin for reading the image files.
@@ -98,6 +104,8 @@ A sample configuration file follows::
   Caching=false
   ExpandToRGB=false
   LocationAttribute=location
+  TimeAttribute=ingestion
+  ElevationAttribute=elevation
   SuggestedSPI=it.geosolutions.imageioimpl.plugins.tiff.TIFFImageReaderSpi
   SuggestedFormat=org.geotools.gce.geotiff.GeoTiffFormat
   CheckAuxiliaryMetadata=false
@@ -201,7 +209,7 @@ Here is a sample :file:`datastore.properties` file for a PostGIS index via JNDI:
 :file:`indexer.properties`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to the required envelope and location attributes, the schema for the index store may expose other custom attributes which can be used later for filtering the ImageMosaic granules on the fly during a WMS or WCS request or to diver WMS and WCS dimensions like TIME, ELEVATION and so on. This is configured by the :file:`indexer.properties` file:
+In addition to the required envelope and location attributes, the schema for the index store may expose other custom attributes which can later be used for filtering the ImageMosaic granules on the fly during a WMS or WCS request.  These include the attributes to support the WMS and WCS dimensions (i.e. TIME and ELEVATION), as optionally specified in the Primary configuration file above.  This is configured by the :file:`indexer.properties` file:
 
 .. list-table::
    :widths: 15 5 80
@@ -217,12 +225,6 @@ In addition to the required envelope and location attributes, the schema for the
    * - PropertyCollectors
      - Y
      - A comma-separated list of PropertyCollectors. Each entry in the list includes the extractor class, the file name (within square brackets ``[ ]`` and not including the ``.properties`` suffix) containing the regular expression needed to extract the attribute value from the granule file name, and the attribute name (within parentheses ``( )``). The instance of the extractor class also indicates the type of object computed by the specific collector, so a ``TimestampFileNameExtractorSPI`` will return ``Timestamps`` while a ``DoubleFileNameExtractorSPI`` will return ``Double`` numbers.
-   * - TimeAttribute
-     - N
-     - Specifies the name of the time-variant attribute.
-   * - ElevationAttribute
-     - N
-     - Specifies the name of the elevation attribute.
    * - AuxiliaryFile
      - N
      - Path to an auxiliary file to be used for internal purposes (For example: when dealing with NetCDF granules, it refers to the NetCDF XML ancillary file.)
@@ -277,8 +279,6 @@ Here is a sample :file:`indexer.properties` file::
 
     Schema=*the_geom:Polygon,location:String,ingestion:java.util.Date,elevation:Double
     PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](ingestion),DoubleFileNameExtractorSPI[elevationregex](elevation)
-    TimeAttribute=ingestion
-    ElevationAttribute=elevation
     Caching=false
     AbsolutePath=false
 


### PR DESCRIPTION
Moved the TimeAttribute and ElevationAttribute properties from indexer.properties to the primary configuration file.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->