### PR TITLE
[GEOS-9937] Name of styles with colons are incorrect in REST API

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -1207,7 +1207,12 @@ public class XStreamPersister {
                 if (wsName == null && OwsUtils.has(source, "prefixedName")) {
                     prefixedName = (String) OwsUtils.get(source, "prefixedName");
                     if (prefixedName != null && prefixedName.indexOf(":") > 0) {
-                        wsName = prefixedName.substring(0, prefixedName.indexOf(":"));
+                        WorkspaceInfo ws =
+                                catalog.getWorkspaceByName(
+                                        prefixedName.substring(0, prefixedName.indexOf(":")));
+                        if (ws != null) {
+                            wsName = prefixedName.substring(0, prefixedName.indexOf(":"));
+                        }
                     }
                 }
 


### PR DESCRIPTION
[![GEOS-9937](https://badgen.net/badge/JIRA/GEOS-9937/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9937)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->
In the current implementation, it looks that anything present before the colon in style name is considered as a workspace name. It proceeds even if the workspace with the given name is not present. This fix assigns workspace name only if one with the given name exists

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->