### PR TITLE
[GEOS-10200] GetLegendGraphic can fail if SCALE removes all rules (2.18.x)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/ImageUtils.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/ImageUtils.java
@@ -93,7 +93,12 @@ public class ImageUtils {
      *     </code> parameter.
      */
     public static BufferedImage createImage(
-            final int width, int height, final IndexColorModel palette, final boolean transparent) {
+            int width, int height, final IndexColorModel palette, final boolean transparent) {
+        // tolerance against image generation with zero width/height (can happen in various places
+        // for the legend generation code, easier to handle it once here)
+        height = Math.max(1, height);
+        width = Math.max(1, width);
+
         // WARNING: whenever this method is changed, change getDrawingSurfaceMemoryUse
         // accordingly
         if (palette != null) {
@@ -110,12 +115,6 @@ public class ImageUtils {
 
         if (transparent) {
             return new BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR);
-        }
-
-        // in case there was no active rule, the height is going to be zero, push it up
-        // so that we build a transparent image
-        if (height == 0) {
-            height = 1;
         }
 
         // don't use alpha channel if the image is not transparent (load testing shows this

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -343,6 +343,20 @@ public class GetLegendGraphicTest extends WMSTestSupport {
     }
 
     @Test
+    public void testTransparentBelowMinScaleDenominator() throws Exception {
+        BufferedImage image =
+                getAsImage(
+                        "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                                + "&layer="
+                                + getLayerId(MockData.LAKES)
+                                + "&style=scaleDependent"
+                                + "&format=image/png&width=20&height=20&scale=5000"
+                                + "&transparent=true",
+                        "image/png");
+        assertEquals(1, image.getHeight());
+    }
+
+    @Test
     public void testNoLegendAboveMinScaleDenominator() throws Exception {
         BufferedImage image =
                 getAsImage(


### PR DESCRIPTION
[![GEOS-10200](https://badgen.net/badge/JIRA/GEOS-10200/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10200)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main to 2.18.x

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->