### PR TITLE
[GEOS-10215] Layers nested inside a group maintain their prefix even in workspace specific services (2.18.x)

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
@@ -6,8 +6,13 @@
 package org.geoserver.catalog.impl;
 
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
@@ -473,7 +478,52 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
                 return val.split(":")[1];
             }
 
-            return method.invoke(object, args);
+            Object result = method.invoke(object, args);
+            return wrapNested(result);
+        }
+
+        /** Delegate objects might also need to be wrapped */
+        @SuppressWarnings("unchecked") // for collection wrapping, we don't know the type
+        private Object wrapNested(Object result) {
+            // need to test type by type to build the right type of proxy
+            // (would have otherwise tested for CatalogInfo instead)
+            if (result instanceof FeatureTypeInfo) {
+                return create((FeatureTypeInfo) result, FeatureTypeInfo.class);
+            } else if (result instanceof LayerInfo) {
+                return create((LayerInfo) result, LayerInfo.class);
+            } else if (result instanceof StyleInfo) {
+                return create((StyleInfo) result, StyleInfo.class);
+            } else if (result instanceof LayerGroupInfo) {
+                return create((LayerGroupInfo) result, LayerGroupInfo.class);
+            }
+
+            // when grabbing styles from layers, or layers and styles inside a group
+            if (result instanceof Collection) {
+                Collection<?> collection = (Collection<?>) result;
+                if (collection.stream().anyMatch(i -> i instanceof CatalogInfo)) {
+                    return collection
+                            .stream()
+                            .map(i -> wrapNested(i))
+                            .collect(Collectors.toCollection(() -> newCollection(collection)));
+                }
+            }
+            return result;
+        }
+
+        private Collection newCollection(Collection source) {
+            try {
+                return source.getClass().getDeclaredConstructor().newInstance();
+            } catch (InstantiationException
+                    | NoSuchMethodException
+                    | InvocationTargetException
+                    | IllegalAccessException e) {
+                // we'll just pick something
+                if (source instanceof Set) {
+                    return new HashSet<>();
+                } else {
+                    return new ArrayList<>();
+                }
+            }
         }
 
         public static <T> T create(T object, Class<T> clazz) {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LayerGroupWorkspaceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LayerGroupWorkspaceTest.java
@@ -326,14 +326,14 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
     public void testWorkspaceGetMap() throws Exception {
         Document dom = getAsDOM("sf/wms?request=reflect&layers=base&format=rss");
         assertXpathExists(
-                "rss/channel/title[text() = 'sf:PrimitiveGeoFeature,sf:AggregateGeoFeature']", dom);
+                "rss/channel/title[text() = 'PrimitiveGeoFeature,AggregateGeoFeature']", dom);
 
         dom = getAsDOM("cite/wms?request=reflect&layers=base&format=rss");
-        assertXpathExists("rss/channel/title[text() = 'cite:Bridges,cite:Buildings']", dom);
+        assertXpathExists("rss/channel/title[text() = 'Bridges,Buildings']", dom);
 
         dom = getAsDOM("sf/wms?request=reflect&layers=cite:base&format=rss");
         assertXpathExists(
-                "rss/channel/title[text() = 'sf:PrimitiveGeoFeature,sf:AggregateGeoFeature']", dom);
+                "rss/channel/title[text() = 'PrimitiveGeoFeature,AggregateGeoFeature']", dom);
     }
 
     @Test

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
@@ -163,6 +163,7 @@ public class CapabilitiesIntegrationTest extends WMSTestSupport {
     @org.junit.Test
     public void testWorkspaceQualified() throws Exception {
         Document dom = dom(get("cite/wms?request=getCapabilities&version=1.3.0"), true);
+        print(dom);
         Element e = dom.getDocumentElement();
         assertEquals("WMS_Capabilities", e.getLocalName());
         XpathEngine xpath = XMLUnit.newXpathEngine();

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LayerGroupWorkspaceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LayerGroupWorkspaceTest.java
@@ -340,14 +340,14 @@ public class LayerGroupWorkspaceTest extends WMSTestSupport {
     public void testWorkspaceGetMap() throws Exception {
         Document dom = getAsDOM("sf/wms?request=reflect&layers=base&format=rss");
         assertXpathExists(
-                "rss/channel/title[text() = 'sf:PrimitiveGeoFeature,sf:AggregateGeoFeature']", dom);
+                "rss/channel/title[text() = 'PrimitiveGeoFeature,AggregateGeoFeature']", dom);
 
         dom = getAsDOM("cite/wms?request=reflect&layers=base&format=rss");
-        assertXpathExists("rss/channel/title[text() = 'cite:Bridges,cite:Buildings']", dom);
+        assertXpathExists("rss/channel/title[text() = 'Bridges,Buildings']", dom);
 
         dom = getAsDOM("sf/wms?request=reflect&layers=cite:base&format=rss");
         assertXpathExists(
-                "rss/channel/title[text() = 'sf:PrimitiveGeoFeature,sf:AggregateGeoFeature']", dom);
+                "rss/channel/title[text() = 'PrimitiveGeoFeature,AggregateGeoFeature']", dom);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10215](https://badgen.net/badge/JIRA/GEOS-10215/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10215)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->