### PR TITLE
[GEOS-10213] WMS requests fail on LayerGroup default style names, when used (2.19.x)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -14,7 +14,6 @@ import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import static org.geoserver.ows.util.ResponseUtils.params;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_ABSTRACT_PREFIX;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_ABSTRACT_SUFFIX;
-import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_NAME;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_TITLE_PREFIX;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_TITLE_SUFFIX;
 import static org.geoserver.wms.capabilities.CapabilityUtil.validateLegendInfo;
@@ -1209,7 +1208,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
          */
         private void handleLayerGroupStyles(String layerName) {
             start("Style");
-            element("Name", LAYER_GROUP_STYLE_NAME.concat("-").concat(layerName));
+            element("Name", CapabilityUtil.getGroupDefaultStyleName(layerName));
             element(
                     "Title",
                     LAYER_GROUP_STYLE_TITLE_PREFIX
@@ -1440,7 +1439,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             handleMetadataList(metadataLinks);
 
             // add the layer group style
-            if (encodeGroupDefaultStyle(layerGroup)) handleLayerGroupStyles(layerName);
+            if (CapabilityUtil.encodeGroupDefaultStyle(wmsConfig, layerGroup))
+                handleLayerGroupStyles(layerName);
 
             // the layer style is not provided since the group does just have
             // one possibility, the lack of styles that will make it use
@@ -1463,14 +1463,6 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             }
 
             end("Layer");
-        }
-
-        private boolean encodeGroupDefaultStyle(LayerGroupInfo lgi) {
-            LayerGroupInfo.Mode mode = lgi.getMode();
-            boolean opaqueOrSingle =
-                    mode.equals(LayerGroupInfo.Mode.SINGLE)
-                            || mode.equals(LayerGroupInfo.Mode.OPAQUE_CONTAINER);
-            return opaqueOrSingle || wmsConfig.isDefaultGroupStyleEnabled();
         }
 
         protected void handleAttribution(PublishedInfo layer) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
@@ -13,6 +13,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.wms.WMS;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.Rule;
 import org.geotools.styling.Style;
@@ -26,7 +27,7 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public final class CapabilityUtil {
 
-    protected static final String LAYER_GROUP_STYLE_NAME = "default-style";
+    public static final String LAYER_GROUP_STYLE_NAME = "default-style";
     protected static final String LAYER_GROUP_STYLE_TITLE_PREFIX = "";
     protected static final String LAYER_GROUP_STYLE_TITLE_SUFFIX = " style";
     protected static final String LAYER_GROUP_STYLE_ABSTRACT_PREFIX = "Default style for ";
@@ -206,5 +207,30 @@ public final class CapabilityUtil {
         attrs.addAttribute(XLINK_NS, "href", "xlink:href", "", legendURL);
 
         return attrs;
+    }
+
+    /** Checks if a default style name for layer groups should be used, or not */
+    public static boolean encodeGroupDefaultStyle(WMS wms, LayerGroupInfo lgi) {
+        LayerGroupInfo.Mode mode = lgi.getMode();
+        boolean opaqueOrSingle =
+                mode.equals(LayerGroupInfo.Mode.SINGLE)
+                        || mode.equals(LayerGroupInfo.Mode.OPAQUE_CONTAINER);
+        return opaqueOrSingle || wms.isDefaultGroupStyleEnabled();
+    }
+
+    /**
+     * Returns the layer group default style name (to be used when {@link
+     * #encodeGroupDefaultStyle(WMS, LayerGroupInfo)} returns true)
+     */
+    public static String getGroupDefaultStyleName(String groupName) {
+        return LAYER_GROUP_STYLE_NAME.concat("-").concat(groupName);
+    }
+
+    /**
+     * Returns the layer group default style name (to be used when {@link
+     * #encodeGroupDefaultStyle(WMS, LayerGroupInfo)} returns true)
+     */
+    public static String getGroupDefaultStyleName(LayerGroupInfo groupName) {
+        return getGroupDefaultStyleName(groupName.prefixedName());
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
@@ -195,11 +195,9 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
 
     @org.junit.Test
     public void testStylesForLayerGroup() throws Exception {
-        GetLegendGraphicRequest request;
-
         requiredParameters.put("LAYER", NATURE_GROUP);
-        requiredParameters.put("STYLE", "style1,style2");
-        request =
+        requiredParameters.put("STYLE", "");
+        GetLegendGraphicRequest request =
                 requestReader.read(
                         new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
         assertEquals(2, request.getLegends().size());

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.wms.legendgraphic;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -22,6 +23,10 @@ import java.util.Map;
 import javax.xml.transform.TransformerException;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.custommonkey.xmlunit.NamespaceContext;
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -60,6 +65,7 @@ import org.opengis.feature.type.AttributeType;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryType;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.w3c.dom.Document;
 
 /**
  * Test the functioning of the abstract legend producer for JSON format,
@@ -80,6 +86,11 @@ public class JSONLegendGraphicOutputFormatTest extends BaseLegendTest<JSONLegend
         testData.addStyle("arealandmarks", this.getClass(), catalog);
         testData.addStyle("fixedArrows", this.getClass(), catalog);
         testData.addStyle("dynamicArrows", this.getClass(), catalog);
+
+        Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("ogc", "http://www.opengis.net/ogc");
+        NamespaceContext ctx = new SimpleNamespaceContext(namespaces);
+        XMLUnit.setXpathNamespaceContext(ctx);
     }
 
     @Before
@@ -1720,6 +1731,32 @@ public class JSONLegendGraphicOutputFormatTest extends BaseLegendTest<JSONLegend
         // only one symbolizer of the two defined should be present in the final output
         // the other one has the renderingLabel option set to false
         assertEquals(1, symbolizers.size());
+    }
+
+    @Test
+    public void testGroupDefaultStyle() throws Exception {
+        JSONObject json =
+                (JSONObject)
+                        getAsJSON(
+                                "wms?request=GetLegendGraphic&layer=nature&style=default-style-nature&format"
+                                        + "=application/json");
+        JSONArray legend = json.getJSONArray("Legend");
+        assertEquals(2, legend.size());
+        assertEquals("Lakes", legend.getJSONObject(0).getString("layerName"));
+        assertEquals("Forests", legend.getJSONObject(1).getString("layerName"));
+    }
+
+    @Test
+    public void testGroupInvalidStyleName() throws Exception {
+        Document dom =
+                getAsDOM(
+                        "wms?request=GetLegendGraphic&layer=nature&style=notAStyleName&format"
+                                + "=application/json");
+        assertXpathEvaluatesTo(
+                "StyleNotDefined", "/ogc:ServiceExceptionReport/ogc:ServiceException/@code", dom);
+        XpathEngine xpath = XMLUnit.newXpathEngine();
+        String exception = xpath.evaluate("/ogc:ServiceExceptionReport/ogc:ServiceException", dom);
+        assertEquals("No such style: notAStyleName", exception.trim());
     }
 
     /** @param result */

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -906,6 +906,19 @@ public class GetFeatureInfoTest extends WMSTestSupport {
         assertEquals("ServiceExceptionReport", dom.getDocumentElement().getNodeName());
     }
 
+    /** Check the group default style name works */
+    @Test
+    public void testGroupDefaultStyle() throws Exception {
+        String url =
+                "wms?service=wms&version=1.1.1"
+                        + "&layers=nature&style=default-style-nature&width=100&height=100&format=image/png"
+                        + "&srs=epsg:4326&bbox=-0.002,-0.003,0.005,0.002&info_format=text/plain"
+                        + "&request=GetFeatureInfo&query_layers=nature&x=50&y=50&feature_count=2";
+        String result = getAsString(url);
+        assertTrue(result.indexOf("Blue Lake") > 0);
+        assertTrue(result.indexOf("Green Forest") > 0);
+    }
+
     @Test
     public void testNonExactVersion() throws Exception {
         String layer = getLayerId(MockData.FORESTS);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
@@ -453,6 +453,31 @@ public class GetMapIntegrationTest extends WMSTestSupport {
     }
 
     @Test
+    public void testLayerGroupSingleDefaultStyle() throws Exception {
+        Catalog catalog = getCatalog();
+        LayerGroupInfo group =
+                createLakesPlacesLayerGroup(catalog, LayerGroupInfo.Mode.SINGLE, null);
+        try {
+            String name = group.getName();
+            String url =
+                    "wms?LAYERS="
+                            + name
+                            + "&STYLES=default-style-"
+                            + name
+                            + "&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A4326&WIDTH=256&HEIGHT=256&BBOX=0.0000,-0.0020,0.0035,0.0010";
+            BufferedImage image = getAsImage(url, "image/png");
+
+            assertPixel(image, 150, 160, Color.WHITE);
+            // places
+            assertPixel(image, 180, 16, COLOR_PLACES_GRAY);
+            // lakes
+            assertPixel(image, 90, 200, COLOR_LAKES_BLUE);
+        } finally {
+            catalog.remove(group);
+        }
+    }
+
+    @Test
     public void testLayerGroupNamed() throws Exception {
         Catalog catalog = getCatalog();
         LayerGroupInfo group =


### PR DESCRIPTION
[![GEOS-10213](https://badgen.net/badge/JIRA/GEOS-10213/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10213)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->