### PR TITLE
[GEOS-10213] WMS requests fail on LayerGroup default style names, when used (2.18.x)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -14,7 +14,6 @@ import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import static org.geoserver.ows.util.ResponseUtils.params;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_ABSTRACT_PREFIX;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_ABSTRACT_SUFFIX;
-import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_NAME;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_TITLE_PREFIX;
 import static org.geoserver.wms.capabilities.CapabilityUtil.LAYER_GROUP_STYLE_TITLE_SUFFIX;
 import static org.geoserver.wms.capabilities.CapabilityUtil.validateLegendInfo;
@@ -1210,7 +1209,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
          */
         private void handleLayerGroupStyles(String layerName) {
             start("Style");
-            element("Name", LAYER_GROUP_STYLE_NAME.concat("-").concat(layerName));
+            element("Name", CapabilityUtil.getGroupDefaultStyleName(layerName));
             element(
                     "Title",
                     LAYER_GROUP_STYLE_TITLE_PREFIX
@@ -1441,7 +1440,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             handleMetadataList(metadataLinks);
 
             // add the layer group style
-            if (encodeGroupDefaultStyle(layerGroup)) handleLayerGroupStyles(layerName);
+            if (CapabilityUtil.encodeGroupDefaultStyle(wmsConfig, layerGroup))
+                handleLayerGroupStyles(layerName);
 
             // the layer style is not provided since the group does just have
             // one possibility, the lack of styles that will make it use
@@ -1464,14 +1464,6 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
             }
 
             end("Layer");
-        }
-
-        private boolean encodeGroupDefaultStyle(LayerGroupInfo lgi) {
-            LayerGroupInfo.Mode mode = lgi.getMode();
-            boolean opaqueOrSingle =
-                    mode.equals(LayerGroupInfo.Mode.SINGLE)
-                            || mode.equals(LayerGroupInfo.Mode.OPAQUE_CONTAINER);
-            return opaqueOrSingle || wmsConfig.isDefaultGroupStyleEnabled();
         }
 
         protected void handleAttribution(PublishedInfo layer) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/CapabilityUtil.java
@@ -13,6 +13,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.wms.WMS;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.Rule;
 import org.geotools.styling.Style;
@@ -26,7 +27,7 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public final class CapabilityUtil {
 
-    protected static final String LAYER_GROUP_STYLE_NAME = "default-style";
+    public static final String LAYER_GROUP_STYLE_NAME = "default-style";
     protected static final String LAYER_GROUP_STYLE_TITLE_PREFIX = "";
     protected static final String LAYER_GROUP_STYLE_TITLE_SUFFIX = " style";
     protected static final String LAYER_GROUP_STYLE_ABSTRACT_PREFIX = "Default style for ";
@@ -206,5 +207,30 @@ public final class CapabilityUtil {
         attrs.addAttribute(XLINK_NS, "href", "xlink:href", "", legendURL);
 
         return attrs;
+    }
+
+    /** Checks if a default style name for layer groups should be used, or not */
+    public static boolean encodeGroupDefaultStyle(WMS wms, LayerGroupInfo lgi) {
+        LayerGroupInfo.Mode mode = lgi.getMode();
+        boolean opaqueOrSingle =
+                mode.equals(LayerGroupInfo.Mode.SINGLE)
+                        || mode.equals(LayerGroupInfo.Mode.OPAQUE_CONTAINER);
+        return opaqueOrSingle || wms.isDefaultGroupStyleEnabled();
+    }
+
+    /**
+     * Returns the layer group default style name (to be used when {@link
+     * #encodeGroupDefaultStyle(WMS, LayerGroupInfo)} returns true)
+     */
+    public static String getGroupDefaultStyleName(String groupName) {
+        return LAYER_GROUP_STYLE_NAME.concat("-").concat(groupName);
+    }
+
+    /**
+     * Returns the layer group default style name (to be used when {@link
+     * #encodeGroupDefaultStyle(WMS, LayerGroupInfo)} returns true)
+     */
+    public static String getGroupDefaultStyleName(LayerGroupInfo groupName) {
+        return getGroupDefaultStyleName(groupName.prefixedName());
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
@@ -43,6 +43,7 @@ import org.geoserver.wms.GetLegendGraphicRequest;
 import org.geoserver.wms.GetLegendGraphicRequest.LegendRequest;
 import org.geoserver.wms.MapLayerInfo;
 import org.geoserver.wms.WMS;
+import org.geoserver.wms.capabilities.CapabilityUtil;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.util.FeatureUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -489,18 +490,21 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
             if (LOGGER.isLoggable(Level.FINER)) {
                 LOGGER.finer("taking style from STYLE parameter");
             }
-            int pos = 0;
             for (String styleName : styleNames) {
                 // if we have a layer group and no style is specified
                 // use the default one for the layer in the current position
-                if (styleName.equals("") && infoObj instanceof LayerGroupInfo) {
+                if (infoObj instanceof LayerGroupInfo) {
                     LayerGroupInfo layerGroupInfo = (LayerGroupInfo) infoObj;
-                    List<LayerInfo> groupLayers = layerGroupInfo.layers();
-                    if (pos < groupLayers.size()) {
-                        sldStyles.add(getStyleFromLayer(groupLayers.get(pos)));
+                    if (isGroupDefaultStyle(styleName, layerGroupInfo)) {
+                        addLayerGroupStyles(req, layerGroupInfo, sldStyles);
+                    } else {
+                        throwNoSuchStyle(styleName);
                     }
                 } else {
-                    sldStyles.add(wms.getStyleByName(styleName));
+                    Style style = wms.getStyleByName(styleName);
+                    if (style == null) throwNoSuchStyle(styleName);
+
+                    sldStyles.add(style);
                     if (infoObj instanceof LayerInfo) {
                         StyleInfo styleInfo = wms.getCatalog().getStyleByName(styleName);
                         if (styleInfo != null) {
@@ -519,7 +523,6 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
                         }
                     }
                 }
-                pos++;
             }
 
         } else {
@@ -539,30 +542,7 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
                     }
                 }
             } else if (infoObj instanceof LayerGroupInfo) {
-                LayerGroupInfo layerGroupInfo = (LayerGroupInfo) infoObj;
-                List<LayerInfo> groupLayers = layerGroupInfo.layers();
-                List<StyleInfo> groupStyles = layerGroupInfo.styles();
-                for (int count = 0; count < groupLayers.size(); count++) {
-                    LayerInfo layerInfo = groupLayers.get(count);
-                    StyleInfo styleInfo = null;
-                    if (count < groupStyles.size() && groupStyles.get(count) != null) {
-                        styleInfo = groupStyles.get(count);
-                        sldStyles.add(styleInfo.getStyle());
-                    } else {
-                        sldStyles.add(getStyleFromLayer(layerInfo));
-                        styleInfo = layerInfo.getDefaultStyle();
-                    }
-                    LegendInfo legend = resolveLegendInfo(styleInfo.getLegend(), req, styleInfo);
-                    if (legend != null) {
-                        Name name = layerInfo.getResource().getQualifiedName();
-                        LegendRequest legendRequest = req.getLegend(name);
-                        if (legendRequest != null) {
-                            configureLegendInfo(req, legendRequest, legend);
-                        } else {
-                            LOGGER.log(Level.FINE, "Unable to set LegendInfo for " + name);
-                        }
-                    }
-                }
+                addLayerGroupStyles(req, (LayerGroupInfo) infoObj, sldStyles);
             }
         }
 
@@ -586,6 +566,47 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
                 legend.setRule(s.next());
             }
         }
+    }
+
+    private void addLayerGroupStyles(
+            GetLegendGraphicRequest req, LayerGroupInfo infoObj, List<Style> sldStyles)
+            throws IOException {
+        LayerGroupInfo layerGroupInfo = infoObj;
+        List<LayerInfo> groupLayers = layerGroupInfo.layers();
+        List<StyleInfo> groupStyles = layerGroupInfo.styles();
+        for (int count = 0; count < groupLayers.size(); count++) {
+            LayerInfo layerInfo = groupLayers.get(count);
+            StyleInfo styleInfo = null;
+            if (count < groupStyles.size() && groupStyles.get(count) != null) {
+                styleInfo = groupStyles.get(count);
+                sldStyles.add(styleInfo.getStyle());
+            } else {
+                sldStyles.add(getStyleFromLayer(layerInfo));
+                styleInfo = layerInfo.getDefaultStyle();
+            }
+            LegendInfo legend = resolveLegendInfo(styleInfo.getLegend(), req, styleInfo);
+            if (legend != null) {
+                Name name = layerInfo.getResource().getQualifiedName();
+                LegendRequest legendRequest = req.getLegend(name);
+                if (legendRequest != null) {
+                    configureLegendInfo(req, legendRequest, legend);
+                } else {
+                    LOGGER.log(Level.FINE, "Unable to set LegendInfo for " + name);
+                }
+            }
+        }
+    }
+
+    private void throwNoSuchStyle(String styleName) {
+        String msg = "No such style: " + styleName;
+        throw new ServiceException(msg, "StyleNotDefined");
+    }
+
+    private boolean isGroupDefaultStyle(String styleName, LayerGroupInfo layerGroupInfo) {
+        return styleName.equals("")
+                || (CapabilityUtil.encodeGroupDefaultStyle(wms, layerGroupInfo)
+                        && styleName.equals(
+                                CapabilityUtil.getGroupDefaultStyleName(layerGroupInfo)));
     }
 
     /**

--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -64,6 +64,7 @@ import org.geoserver.wms.MapLayerInfo;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSErrorCode;
 import org.geoserver.wms.WMSInfo;
+import org.geoserver.wms.capabilities.CapabilityUtil;
 import org.geoserver.wms.clip.ClipWMSGetMapCallBack;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.data.DataStore;
@@ -1471,24 +1472,37 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                 // return null, this should flag request reader to use default for
                 // the associated layer
                 styles.add(null);
-            } else if (isRemoteWMSLayer(requestedLayerInfos.get(i))) {
-                // GEOS-9312
-                // if the style belongs to a remote layer check inside the remote layer capabilities
-                // instead of local WMS
-                WMSLayerInfo remoteWMSLayer =
-                        (WMSLayerInfo) ((LayerInfo) requestedLayerInfos.get(i)).getResource();
-                Optional<Style> remoteStyle = remoteWMSLayer.findRemoteStyleByName(styleName);
-                if (remoteStyle.isPresent()) styles.add(remoteStyle.get());
-                else
-                    throw new ServiceException(
-                            "No such remote style: " + styleName, "StyleNotDefined");
             } else {
-                final Style style = wms.getStyleByName(styleName);
-                if (style == null) {
-                    String msg = "No such style: " + styleName;
-                    throw new ServiceException(msg, "StyleNotDefined");
+                Object layer = requestedLayerInfos.get(i);
+                if (isRemoteWMSLayer(layer)) {
+                    // GEOS-9312
+                    // if the style belongs to a remote layer check inside the remote layer
+                    // capabilities
+                    // instead of local WMS
+                    WMSLayerInfo remoteWMSLayer = (WMSLayerInfo) ((LayerInfo) layer).getResource();
+                    Optional<Style> remoteStyle = remoteWMSLayer.findRemoteStyleByName(styleName);
+                    if (remoteStyle.isPresent()) styles.add(remoteStyle.get());
+                    else
+                        throw new ServiceException(
+                                "No such remote style: " + styleName, "StyleNotDefined");
+                } else {
+                    final Style style = wms.getStyleByName(styleName);
+                    if (style == null) {
+                        // default style for layer groups?
+                        if (layer instanceof LayerGroupInfo
+                                && CapabilityUtil.encodeGroupDefaultStyle(
+                                        wms, (LayerGroupInfo) layer)
+                                && styleName.equals(
+                                        CapabilityUtil.getGroupDefaultStyleName(
+                                                ((LayerGroupInfo) layer)))) {
+                            styles.add(null);
+                        } else {
+                            String msg = "No such style: " + styleName;
+                            throw new ServiceException(msg, "StyleNotDefined");
+                        }
+                    }
+                    styles.add(style);
                 }
-                styles.add(style);
             }
         }
         return styles;

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
@@ -195,11 +195,9 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
 
     @org.junit.Test
     public void testStylesForLayerGroup() throws Exception {
-        GetLegendGraphicRequest request;
-
         requiredParameters.put("LAYER", NATURE_GROUP);
-        requiredParameters.put("STYLE", "style1,style2");
-        request =
+        requiredParameters.put("STYLE", "");
+        GetLegendGraphicRequest request =
                 requestReader.read(
                         new GetLegendGraphicRequest(), requiredParameters, requiredParameters);
         assertTrue(request.getLegends().size() == 2);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -906,6 +906,19 @@ public class GetFeatureInfoTest extends WMSTestSupport {
         assertEquals("ServiceExceptionReport", dom.getDocumentElement().getNodeName());
     }
 
+    /** Check the group default style name works */
+    @Test
+    public void testGroupDefaultStyle() throws Exception {
+        String url =
+                "wms?service=wms&version=1.1.1"
+                        + "&layers=nature&style=default-style-nature&width=100&height=100&format=image/png"
+                        + "&srs=epsg:4326&bbox=-0.002,-0.003,0.005,0.002&info_format=text/plain"
+                        + "&request=GetFeatureInfo&query_layers=nature&x=50&y=50&feature_count=2";
+        String result = getAsString(url);
+        assertTrue(result.indexOf("Blue Lake") > 0);
+        assertTrue(result.indexOf("Green Forest") > 0);
+    }
+
     @Test
     public void testNonExactVersion() throws Exception {
         String layer = getLayerId(MockData.FORESTS);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
@@ -453,6 +453,31 @@ public class GetMapIntegrationTest extends WMSTestSupport {
     }
 
     @Test
+    public void testLayerGroupSingleDefaultStyle() throws Exception {
+        Catalog catalog = getCatalog();
+        LayerGroupInfo group =
+                createLakesPlacesLayerGroup(catalog, LayerGroupInfo.Mode.SINGLE, null);
+        try {
+            String name = group.getName();
+            String url =
+                    "wms?LAYERS="
+                            + name
+                            + "&STYLES=default-style-"
+                            + name
+                            + "&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A4326&WIDTH=256&HEIGHT=256&BBOX=0.0000,-0.0020,0.0035,0.0010";
+            BufferedImage image = getAsImage(url, "image/png");
+
+            assertPixel(image, 150, 160, Color.WHITE);
+            // places
+            assertPixel(image, 180, 16, COLOR_PLACES_GRAY);
+            // lakes
+            assertPixel(image, 90, 200, COLOR_LAKES_BLUE);
+        } finally {
+            catalog.remove(group);
+        }
+    }
+
+    @Test
     public void testLayerGroupNamed() throws Exception {
         Catalog catalog = getCatalog();
         LayerGroupInfo group =


### PR DESCRIPTION
[![GEOS-10213](https://badgen.net/badge/JIRA/GEOS-10213/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10213)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->