### PR TITLE
[GEOS-10206] MapML extension support forcedDecimal, numDecimal, padWithZeros

### DIFF
--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGenerator.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGenerator.java
@@ -14,7 +14,7 @@ import org.geoserver.mapml.xml.Feature;
 import org.geoserver.mapml.xml.GeometryContent;
 import org.geoserver.mapml.xml.ObjectFactory;
 import org.geoserver.mapml.xml.PropertyContent;
-import org.geoserver.wfs.json.RoundingUtil;
+import org.geotools.gml.producer.CoordinateFormatter;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.opengis.feature.simple.SimpleFeature;
@@ -34,7 +34,8 @@ public class MapMLGenerator {
 
     static ObjectFactory factory = new ObjectFactory();
 
-    private int numDecimals = 6;
+    private int DEFAULT_NUM_DECIMALS = 8;
+    private CoordinateFormatter formatter = new CoordinateFormatter(DEFAULT_NUM_DECIMALS);
 
     /**
      * @param sf a feature
@@ -287,10 +288,7 @@ public class MapMLGenerator {
     private org.geoserver.mapml.xml.Point buildPoint(org.locationtech.jts.geom.Point p) {
         org.geoserver.mapml.xml.Point point = new org.geoserver.mapml.xml.Point();
         point.getCoordinates()
-                .add(
-                        RoundingUtil.round(p.getX(), this.numDecimals)
-                                + " "
-                                + RoundingUtil.round(p.getY(), this.numDecimals));
+                .add(this.formatter.format(p.getX()) + " " + this.formatter.format(p.getY()));
         return point;
     }
     /**
@@ -320,14 +318,27 @@ public class MapMLGenerator {
         }
         for (int i = 0; i < cs.size(); i++) {
             coordList.add(
-                    RoundingUtil.round(cs.getX(i), this.numDecimals)
-                            + " "
-                            + RoundingUtil.round(cs.getY(i), this.numDecimals));
+                    this.formatter.format(cs.getX(i)) + " " + this.formatter.format(cs.getY(i)));
         }
         return coordList;
     }
     /** @param numDecimals */
     public void setNumDecimals(int numDecimals) {
-        this.numDecimals = numDecimals;
+        // make a copy of relevant object state
+        boolean fd = this.formatter.isForcedDecimal();
+        boolean pad = this.formatter.isPadWithZeros();
+        // create new formatter
+        this.formatter = new CoordinateFormatter(numDecimals);
+        // apply state to new formatter
+        this.formatter.setForcedDecimal(fd);
+        this.formatter.setPadWithZeros(pad);
+    }
+    /** @param forcedDecimal */
+    public void setForcedDecimal(boolean forcedDecimal) {
+        this.formatter.setForcedDecimal(forcedDecimal);
+    }
+    /** @param padWithZeros */
+    public void setPadWithZeros(boolean padWithZeros) {
+        this.formatter.setPadWithZeros(padWithZeros);
     }
 }

--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGetFeatureInfoOutputFormat.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGetFeatureInfoOutputFormat.java
@@ -125,6 +125,12 @@ public class MapMLGetFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat 
         featureBuilder.setNumDecimals(
                 getNumDecimals(
                         featureCollections, wms.getGeoServer(), wms.getGeoServer().getCatalog()));
+        featureBuilder.setForcedDecimal(
+                this.getForcedDecimal(
+                        featureCollections, wms.getGeoServer(), wms.getGeoServer().getCatalog()));
+        featureBuilder.setPadWithZeros(
+                this.getPadWithZeros(
+                        featureCollections, wms.getGeoServer(), wms.getGeoServer().getCatalog()));
         if (!featureCollections.isEmpty()) {
             Iterator<FeatureCollection> fci = featureCollections.iterator();
             while (fci.hasNext()) {
@@ -224,6 +230,50 @@ public class MapMLGetFeatureInfoOutputFormat extends GetFeatureInfoOutputFormat 
     /**
      * Copied from org.geoserver.wfs.WFSGetFeatureOutputFormat
      *
+     * @param featureCollections
+     * @param geoServer
+     * @param catalog
+     * @return
+     */
+    protected boolean getPadWithZeros(
+            List featureCollections, GeoServer geoServer, Catalog catalog) {
+        boolean padWithZeros = false;
+        for (Object featureCollection : featureCollections) {
+            Boolean pad =
+                    getFeatureTypeInfoProperty(
+                            catalog,
+                            (FeatureCollection) featureCollection,
+                            fti -> fti.getPadWithZeros());
+            if (Boolean.TRUE.equals(pad)) {
+                padWithZeros = true;
+            }
+        }
+        return padWithZeros;
+    }
+    /**
+     * Copied from org.geoserver.wfs.WFSGetFeatureOutputFormat
+     *
+     * @param featureCollections
+     * @param geoServer
+     * @param catalog
+     * @return
+     */
+    protected boolean getForcedDecimal(
+            List featureCollections, GeoServer geoServer, Catalog catalog) {
+        boolean forcedDecimal = false;
+        for (Object featureCollection : featureCollections) {
+            Boolean forced =
+                    getFeatureTypeInfoProperty(
+                            catalog,
+                            (FeatureCollection) featureCollection,
+                            fti -> fti.getForcedDecimal());
+            if (Boolean.TRUE.equals(forced)) {
+                forcedDecimal = true;
+            }
+        }
+        return forcedDecimal;
+    }
+    /**
      * @param <T>
      * @param catalog
      * @param features

--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGetFeatureOutputFormat.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGetFeatureOutputFormat.java
@@ -138,6 +138,10 @@ public class MapMLGetFeatureOutputFormat extends WFSGetFeatureOutputFormat {
         MapMLGenerator featureBuilder = new MapMLGenerator();
         int numDecimals = this.getNumDecimals(featureCollections, gs, gs.getCatalog());
         featureBuilder.setNumDecimals(numDecimals);
+        featureBuilder.setForcedDecimal(
+                this.getForcedDecimal(featureCollections, gs, gs.getCatalog()));
+        featureBuilder.setPadWithZeros(
+                this.getPadWithZeros(featureCollections, gs, gs.getCatalog()));
         try (SimpleFeatureIterator iterator = fc.features()) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLGeneratorTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLGeneratorTest.java
@@ -101,4 +101,106 @@ public class MapMLGeneratorTest extends GeoServerTestSupport {
                         .contains(
                                 "<multipoint xmlns=\"http://www.w3.org/1999/xhtml\"><coordinates>-75.70534 45.39779 -75.70208 45.39785</coordinates>"));
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPadWithZeros() throws Exception {
+
+        GeometryFactory jtsf = new GeometryFactory();
+        Coordinate[] ca1 = {new Coordinate(-75.705338D, 45.3977853D)};
+        Coordinate[] ca2 = {new Coordinate(-75.702082D, 45.3978472D)};
+        Point[] points = {
+            new Point(new CoordinateArraySequence(ca1), jtsf),
+            new Point(new CoordinateArraySequence(ca2), jtsf)
+        };
+        MapMLGenerator featureBuilder = new MapMLGenerator();
+        featureBuilder.setPadWithZeros(true);
+        featureBuilder.setNumDecimals(10);
+        org.locationtech.jts.geom.MultiPoint jtsMultiPoint =
+                new org.locationtech.jts.geom.MultiPoint(points, jtsf);
+        JAXBElement<org.geoserver.mapml.xml.MultiPoint> mp = null;
+        try {
+            GeometryContent g = featureBuilder.buildGeometry(jtsMultiPoint);
+
+            mp = (JAXBElement<org.geoserver.mapml.xml.MultiPoint>) g.getGeometryContent();
+        } catch (Exception e) {
+            fail("org.geoserver.mapml.xml.MultiPoint should be returned by JAXB");
+        }
+
+        StringWriter sw = new StringWriter();
+        try {
+            mapmlMarshaller.marshal(mp, new StreamResult(sw));
+        } catch (DataBindingException ex) {
+            fail("DataBindingException while reading MapML JAXB MultiPoint object");
+        }
+        assertTrue(
+                "Coordinates should be rounded to 5 decimal places (non-default numDecimals)",
+                sw.toString()
+                        .contains(
+                                "<multipoint xmlns=\"http://www.w3.org/1999/xhtml\"><coordinates>-75.7053380000 45.3977853000 -75.7020820000 45.3978472000</coordinates>"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testForcedDecimal() throws Exception {
+
+        GeometryFactory jtsf = new GeometryFactory();
+        Coordinate[] ca1 = {new Coordinate(-1000000000.1D, 1000000000.2D)};
+        Coordinate[] ca2 = {new Coordinate(-1000000001.3D, 1000000001.4D)};
+        Point[] points = {
+            new Point(new CoordinateArraySequence(ca1), jtsf),
+            new Point(new CoordinateArraySequence(ca2), jtsf)
+        };
+        MapMLGenerator featureBuilder = new MapMLGenerator();
+        // when encoded in scientific notation, these parameters are ignored
+        featureBuilder.setNumDecimals(3);
+        featureBuilder.setPadWithZeros(true);
+        org.locationtech.jts.geom.MultiPoint jtsMultiPoint =
+                new org.locationtech.jts.geom.MultiPoint(points, jtsf);
+        JAXBElement<org.geoserver.mapml.xml.MultiPoint> mp = null;
+        try {
+            GeometryContent g = featureBuilder.buildGeometry(jtsMultiPoint);
+
+            mp = (JAXBElement<org.geoserver.mapml.xml.MultiPoint>) g.getGeometryContent();
+        } catch (Exception e) {
+            fail("org.geoserver.mapml.xml.MultiPoint should be returned by JAXB");
+        }
+
+        StringWriter sw = new StringWriter();
+        try {
+            mapmlMarshaller.marshal(mp, new StreamResult(sw));
+        } catch (DataBindingException ex) {
+            fail("DataBindingException while reading MapML JAXB MultiPoint object");
+        }
+        assertTrue(
+                "Coordinates should encoded in scientific notation",
+                sw.toString()
+                        .contains(
+                                "<multipoint xmlns=\"http://www.w3.org/1999/xhtml\"><coordinates>-1.0000000001E9 1.0000000002E9 -1.0000000013E9 1.0000000014E9</coordinates>"));
+
+        // when NOT encoded in scientific notation, these parameters are used
+        featureBuilder.setForcedDecimal(true);
+        featureBuilder.setPadWithZeros(true);
+        jtsMultiPoint = new org.locationtech.jts.geom.MultiPoint(points, jtsf);
+        mp = null;
+        try {
+            GeometryContent g = featureBuilder.buildGeometry(jtsMultiPoint);
+
+            mp = (JAXBElement<org.geoserver.mapml.xml.MultiPoint>) g.getGeometryContent();
+        } catch (Exception e) {
+            fail("org.geoserver.mapml.xml.MultiPoint should be returned by JAXB");
+        }
+
+        sw = new StringWriter();
+        try {
+            mapmlMarshaller.marshal(mp, new StreamResult(sw));
+        } catch (DataBindingException ex) {
+            fail("DataBindingException while reading MapML JAXB MultiPoint object");
+        }
+        assertTrue(
+                "Coordinates should encoded in decimal notation",
+                sw.toString()
+                        .contains(
+                                "<multipoint xmlns=\"http://www.w3.org/1999/xhtml\"><coordinates>-1000000000.100 1000000000.200 -1000000001.300 1000000001.400</coordinates>"));
+    }
 }


### PR DESCRIPTION
[![GEOS-10206](https://badgen.net/badge/JIRA/GEOS-10206/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10206)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Allows the MapML extension to respect the WFS settings that the user can change: forcedDecimals, numDecimal, padWithZeros.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).