### PR TITLE
[Backport 2.19.x] Updating to imageio-ext 1.3.10 for ZSTD decompression support

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -99,7 +99,7 @@
     <poi.version>4.0.0</poi.version>
     <wicket.version>7.18.0</wicket.version>
     <ant.version>1.10.9</ant.version>
-    <imageio-ext.version>1.3.9</imageio-ext.version>
+    <imageio-ext.version>1.3.10</imageio-ext.version>
     <jaiext.version>1.1.20</jaiext.version>
     <java.awt.headless>true</java.awt.headless>
     <sun.java2d.d3d>true</sun.java2d.d3d>


### PR DESCRIPTION
[backport to 2.19.x]Updating to imageio-ext 1.3.10 for ZSTD support