### PR TITLE
[GEOS-10222] WFS CSV OutputFormat delimiter

### DIFF
--- a/doc/en/user/source/services/wfs/outputformats.rst
+++ b/doc/en/user/source/services/wfs/outputformats.rst
@@ -135,3 +135,15 @@ JSON output ``format_options``:
 JSON output ``system properties``:
 
 * ``json.maxDepth=<max_value>`` is used to determine the max number of allowed JSON nested objects on encoding phase.  By default the value is 100.
+
+
+CSV output
+----------------
+
+A Default CSV file uses a comma to separate values. Each line of the file is a data record. Each record consists of one or more fields, separated by commas. The separator can be changed using format_options as specified below.
+
+csv file output ``format_options``:
+
+* ``format_option=filename:<file>``: if a file name is provided, the name is used as the output file name. For example, ``format_options=filename:roads.csv``.
+* ``format_option=csvseparator:<csvseparator>`` (default is ```,``` ): if a separator is provided, it is used to separate values in output csv file. For example, ``format_options=csvseparator:-`` is used to get dash separated file.
+

--- a/doc/en/user/source/services/wfs/vendor.rst
+++ b/doc/en/user/source/services/wfs/vendor.rst
@@ -37,6 +37,7 @@ The supported format option is:
 * ``callback`` (default is ``parseResponse``)—Specifies the callback function name for the JSONP response format
 * ``id_policy`` (default is ``true``)- Specifies id generation for the JSON output format. To include feature id in output use an attribute name, or use ``format_options=id_policy:true`` for feature id generation. To avoid the use of feature id completely use ``format_options=id_policy:false``.
 * ``filename`` (default is :file:`features` or generated from feature type name)- provide a ``Content-Disposition`` header indicating the attachment filename (used as a suggestion by browsers saving content to disk using :command:`Save-As`). For example ``format_options=filename:content.txt``.
+* ``csvseparator`` (default is ```,``` )- Specifies a separator that can be used in output csv file
 
 Reprojection
 ------------


### PR DESCRIPTION
[![GEOS-10222](https://badgen.net/badge/JIRA/GEOS-10222/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10222)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->