### PR TITLE
[GEOS-10226] ResourcePool leaves empty files on failure

### DIFF
--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -671,11 +671,11 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
             assertThat(message, containsString("/this/file/does/not/exist"));
         }
     }
-    
+
     /**
-     * Triggers an exception to check that the file in data catalog is deleted.
-     * The exception occurs because the format is set to null.
-     * 
+     * Triggers an exception to check that the file in data catalog is deleted. The exception occurs
+     * because the format is set to null.
+     *
      * @throws Exception
      */
     @Test
@@ -684,7 +684,7 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
         style.setName("foo");
         style.setFilename("foo.sld");
         style.setFormat(null);
-        
+
         File sldFile =
                 new File(getTestData().getDataDirectoryRoot().getAbsolutePath(), "styles/foo.sld");
 
@@ -692,12 +692,11 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
         StyledLayerDescriptor sld = styleFactory.createStyledLayerDescriptor();
 
         try {
-        	ResourcePool pool = new ResourcePool(getCatalog());
-        	pool.writeSLD(style, sld);
-        	Assert.fail("Should fail with IOException");
-        }
-        catch (IOException e) {
-        	// writeStyleFile throws an IOException
+            ResourcePool pool = new ResourcePool(getCatalog());
+            pool.writeSLD(style, sld);
+            Assert.fail("Should fail with IOException");
+        } catch (IOException e) {
+            // writeStyleFile throws an IOException
         }
         Assert.assertFalse("foo.sld should not exist on disk after a failure.", sldFile.exists());
     }


### PR DESCRIPTION
[![GEOS-10226](https://badgen.net/badge/JIRA/GEOS-10226/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10226)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added some code that cleans up the file created during a failing writeStyle call.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->