### PR TITLE
[2.19.x backport][GEOS-10158] POST request -> j_spring_security_check is in http plain even if proxy base url is in https

### DIFF
--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import javax.servlet.Filter;
 import javax.xml.namespace.QName;
 import net.opengis.ows11.BoundingBoxType;
 import org.apache.commons.codec.binary.Base64;
@@ -45,6 +46,7 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ows.HTTPHeadersCollector;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ServiceException;
@@ -2243,5 +2245,10 @@ public class ExecuteTest extends WPSTestSupport {
                         "//wps:ExecuteResponse/wps:ProcessOutputs/wps:Output/wps:Reference/@href",
                         dom);
         assertThat(reference, CoreMatchers.startsWith("https://mycompany.com/geoserver"));
+    }
+
+    @Override
+    protected List<Filter> getFilters() {
+        return Arrays.asList(new HTTPHeadersCollector());
     }
 }

--- a/src/main/src/main/java/org/geoserver/ows/HTTPHeadersCollector.java
+++ b/src/main/src/main/java/org/geoserver/ows/HTTPHeadersCollector.java
@@ -4,10 +4,17 @@
  */
 package org.geoserver.ows;
 
+import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import org.geoserver.filters.GeoServerFilter;
 import org.geoserver.ows.util.CaseInsensitiveMap;
 
 /**
@@ -15,29 +22,9 @@ import org.geoserver.ows.util.CaseInsensitiveMap;
  * asynchronoous executions happening outside of request threads. Given the specific usage, only the
  * first value of headers is collected.
  */
-public class HTTPHeadersCollector extends AbstractDispatcherCallback {
+public class HTTPHeadersCollector implements GeoServerFilter {
 
     public static final ThreadLocal<Map<String, String>> HEADERS = new ThreadLocal<>();
-
-    @Override
-    public Request init(Request request) {
-        HttpServletRequest hr = request.getHttpRequest();
-        Enumeration<String> names = hr.getHeaderNames();
-        Map<String, String> headers = new CaseInsensitiveMap<>(new HashMap<>());
-        while (names.hasMoreElements()) {
-            String header = names.nextElement();
-            String value = hr.getHeader(header);
-            headers.put(header, value);
-        }
-        HEADERS.set(headers);
-
-        return request;
-    }
-
-    @Override
-    public void finished(Request request) {
-        HEADERS.remove();
-    }
 
     /**
      * Returns the value for the specified header, if the {@link #HEADERS} thread local is loaded,
@@ -48,4 +35,34 @@ public class HTTPHeadersCollector extends AbstractDispatcherCallback {
         if (headers == null) return null;
         return headers.get(header);
     }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        try {
+            collectHeaders((HttpServletRequest) request);
+
+            chain.doFilter(request, response);
+        } finally {
+            HEADERS.remove();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void collectHeaders(HttpServletRequest request) {
+        Enumeration<String> names = request.getHeaderNames();
+        Map<String, String> headers = new CaseInsensitiveMap(new HashMap<>());
+        while (names.hasMoreElements()) {
+            String header = names.nextElement();
+            String value = request.getHeader(header);
+            headers.put(header, value);
+        }
+        HEADERS.set(headers);
+    }
+
+    @Override
+    public void destroy() {}
 }

--- a/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
@@ -144,11 +144,6 @@ public class ProxifyingURLMangler implements URLMangler {
      */
     private StringBuilder mangleURLHeaders(StringBuilder baseURL, String proxyBase) {
 
-        // If the request is not an OWS request, does not proxy the URL
-        if (Dispatcher.REQUEST.get() == null) {
-            return baseURL;
-        }
-
         // If the proxy base URL does not contain templates, fall back to
         // the fixed URL cse
         if (!proxyBase.contains(TEMPLATE_PREFIX)) {

--- a/src/main/src/test/java/org/vfny/geoserver/util/URLProxifyingTest.java
+++ b/src/main/src/test/java/org/vfny/geoserver/util/URLProxifyingTest.java
@@ -11,23 +11,19 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletRequest;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.impl.GeoServerInfoImpl;
-import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.HTTPHeadersCollector;
 import org.geoserver.ows.ProxifyingURLMangler;
-import org.geoserver.ows.Request;
 import org.geoserver.ows.URLMangler;
 import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
-import org.springframework.mock.web.MockHttpServletRequest;
 
 public class URLProxifyingTest {
 
@@ -58,23 +54,60 @@ public class URLProxifyingTest {
                 forwardedPath);
         headers.put(ProxifyingURLMangler.Headers.FORWARDED.asString().toLowerCase(), forwarded);
 
-        Request request = createNiceMock(Request.class);
-        expect(request.getHttpRequest())
-                .andReturn(
-                        new HttpServletRequestWrapper(new MockHttpServletRequest()) {
-                            public String getHeader(String name) {
-                                return headers.get(name);
-                            }
+        HttpServletRequest servletRequest = createNiceMock(HttpServletRequest.class);
 
-                            @Override
-                            public Enumeration<String> getHeaderNames() {
-                                return Collections.enumeration(headers.keySet());
-                            }
-                        })
+        expect(
+                        servletRequest.getHeader(
+                                ProxifyingURLMangler.Headers.FORWARDED.asString().toLowerCase()))
+                .andReturn(
+                        headers.get(
+                                ProxifyingURLMangler.Headers.FORWARDED.asString().toLowerCase()))
                 .anyTimes();
-        replay(request);
-        Dispatcher.REQUEST.set(request);
-        new HTTPHeadersCollector().init(request);
+        expect(
+                        servletRequest.getHeader(
+                                ProxifyingURLMangler.Headers.FORWARDED_PROTO
+                                        .asString()
+                                        .toLowerCase()))
+                .andReturn(
+                        headers.get(
+                                ProxifyingURLMangler.Headers.FORWARDED_PROTO
+                                        .asString()
+                                        .toLowerCase()))
+                .anyTimes();
+        expect(servletRequest.getHeader(ProxifyingURLMangler.Headers.HOST.asString().toLowerCase()))
+                .andReturn(headers.get(ProxifyingURLMangler.Headers.HOST.asString().toLowerCase()))
+                .anyTimes();
+        expect(
+                        servletRequest.getHeader(
+                                ProxifyingURLMangler.Headers.FORWARDED_HOST
+                                        .asString()
+                                        .toLowerCase()))
+                .andReturn(
+                        headers.get(
+                                ProxifyingURLMangler.Headers.FORWARDED_HOST
+                                        .asString()
+                                        .toLowerCase()))
+                .anyTimes();
+        expect(
+                        servletRequest.getHeader(
+                                ProxifyingURLMangler.Headers.FORWARDED_PATH
+                                        .asString()
+                                        .toLowerCase()))
+                .andReturn(
+                        headers.get(
+                                ProxifyingURLMangler.Headers.FORWARDED_PATH
+                                        .asString()
+                                        .toLowerCase()))
+                .anyTimes();
+
+        expect(servletRequest.getHeaderNames())
+                .andReturn(Collections.enumeration(headers.keySet()))
+                .anyTimes();
+
+        replay(servletRequest);
+
+        HTTPHeadersCollector filter = new HTTPHeadersCollector();
+        filter.collectHeaders(servletRequest);
 
         GeoServer geoServer = createNiceMock(GeoServer.class);
         expect(geoServer.getGlobal())


### PR DESCRIPTION
[![GEOS-10158](https://badgen.net/badge/JIRA/GEOS-10158/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10158)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is backport of [5263](https://github.com/geoserver/geoserver/pull/5263) for branch 2.19.x

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->