### PR TITLE
OGC API - Styles metadata representation throws exception

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeaturesSampleDataProvider.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeaturesSampleDataProvider.java
@@ -35,7 +35,14 @@ public class FeaturesSampleDataProvider implements SampleDataProvider {
                             FeaturesResponse.class,
                             resourceId + " items as ",
                             "data",
-                            null,
+                            (media, link) -> {
+                                String href =
+                                        link.getHref()
+                                                + "&limit="
+                                                + service.getService()
+                                                        .getMaxNumberOfFeaturesForPreview();
+                                link.setHref(href);
+                            },
                             "data",
                             false);
         }

--- a/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/styles/styleMetadata.ftl
+++ b/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/styles/styleMetadata.ftl
@@ -8,9 +8,9 @@
       <h2>${model.id}</h2>
     </div>
     <div class="card-body">
-      <uL>
-        <li><b>Title</b>: ${model.title!"N/A"}</li>
-        <li><b>Description</b>: ${model.description!"N/A"}</li>
+      <ul>
+        <li id="title"><b>Title</b>: ${model.title!"N/A"}</li>
+        <li id="description"><b>Description</b>: ${model.description!"N/A"}</li>
         <li><b>Keywords</b>:
           <#if model.keywords?? && model.keywords?size gt 0>
             <ul>
@@ -21,7 +21,7 @@
           <#else>N/A
           </#if>
         </li>
-        <li><b>Point of contact</b>: ${model.pointOfContact!"N/A"}</li>
+        <li id="poc"><b>Point of contact</b>: ${model.pointOfContact!"N/A"}</li>
         <li><b>Access constraints</b>: ${model.accessConstraints!"N/A"}</li>
         <li><b>Dates</b>:
         <#if model.dates??>
@@ -35,19 +35,27 @@
         <#else>N/A
         </#if>
         </li>
-        <li><b>Stylesheets</b>:
+        <li id="stylesheets"><b>Stylesheets</b>:
             <ul>
               <#list model.stylesheets as ss>
             <li><a href="${ss.link.href}">${ss.title}</a> (${ss.native?string('native','converted')})</li>
           </#list>
             </ul>
         </li>
-        <li><b>Layers</b>:
+        <li id="layers"><b>Layers</b>:
           <ul>
             <#list model.layers as layer>
               <li>
                 ${layer.id}: ${layer.type}. 
-                <#if layer.sampleData??><a href="${layer.sampleData.href}">Sample data available</a>.</#if><br/>
+                <#if layer.sampleData??><br/>Sample data available:
+                      <select onchange="window.open(this.options[this.selectedIndex].value);this.selectedIndex=0" >
+                        <option value="none" selected>-- Please choose a format --</option>
+                        <#list layer.sampleData as link>
+                        <option value="${link.href}">${link.type}</option>
+                        </#list>
+                      </select>
+                </#if>
+                <br/>
                 <#if layer.attributes?? && layer.attributes?size gt 0>
                     <b>Attributes used by the style:</b>
                     <ul>

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/StyleMetadataTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/StyleMetadataTest.java
@@ -144,6 +144,21 @@ public class StyleMetadataTest extends StylesTestSupport {
     }
 
     @Test
+    public void testGetMetadataHTML() throws Exception {
+        org.jsoup.nodes.Document doc = getAsJSoup("ogc/styles/styles/polygon/metadata?f=html");
+
+        assertEquals("Title: " + POLYGON_TITLE, doc.select("#title").text());
+        assertEquals("Description: " + POLYGON_ABSTRACT, doc.select("#description").text());
+        assertEquals("Point of contact: " + POLYGON_POC, doc.select("#poc").text());
+
+        assertEquals(
+                "Stylesheet as SLD 1.0.0 (native)", doc.select("#stylesheets>ul>:eq(0)").text());
+        assertEquals(
+                "Default Polygon: polygon.",
+                doc.select("#layers>ul>li").first().textNodes().get(0).text().trim());
+    }
+
+    @Test
     public void testGetMetadataAttributesFromStyle() throws Exception {
         DocumentContext json =
                 getAsJSONPath("ogc/styles/styles/" + BUILDINGS_LABEL_STYLE + "/metadata", 200);


### PR DESCRIPTION
Fixing a HTML representation in community module ogcapi-styles

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->