### PR TITLE
[2.20.x backport][GEOS-10223] Support MBTiles in OGC Tiles API

### DIFF
--- a/src/community/ogcapi/ogcapi-tiles/pom.xml
+++ b/src/community/ogcapi/ogcapi-tiles/pom.xml
@@ -120,6 +120,24 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geowebcache</groupId>
+      <artifactId>gwc-mbtiles</artifactId>
+      <version>1.20-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <version>1.6.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TileJSONBuilder.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TileJSONBuilder.java
@@ -36,6 +36,7 @@ import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.Grid;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSubset;
+import org.geowebcache.layer.TileJSONProvider;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.meta.LayerMetaInformation;
 import org.geowebcache.layer.meta.TileJSON;
@@ -155,6 +156,13 @@ class TileJSONBuilder {
         tileJSON.setTiles(new String[] {tilesURL});
 
         if (!(tileLayer instanceof GeoServerTileLayer)) {
+            TileJSONProvider tileJSONProvider = (TileJSONProvider) tileLayer;
+            if (tileJSONProvider.supportsTileJSON()) {
+                tileJSON = tileJSONProvider.getTileJSON();
+                tileJSON.setTiles(new String[] {tilesURL});
+                tileJSON.setFormat(tileFormat);
+                return tileJSON;
+            }
             throw new InvalidParameterValueException(
                     "TileJSON metadata is not supported on this layer");
         }

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/Tileset.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/Tileset.java
@@ -78,7 +78,11 @@ public class Tileset extends AbstractDocument {
                         URLMangler.URLType.SERVICE);
         this.tileMatrixSetDefinition = this.tileMatrixSetURI;
 
-        if (!gridSubset.fullGridSetCoverage() && addDetails) {
+        boolean hasLimits =
+                !gridSubset.fullGridSetCoverage()
+                        || (gridSubset.getGridSet().getNumLevels()
+                                != gridSubset.getZoomStop() - gridSubset.getZoomStart() + 1);
+        if (hasLimits && addDetails) {
             String[] levelNames = gridSubset.getGridNames();
             long[][] wmtsLimits = gridSubset.getWMTSCoverages();
 
@@ -90,6 +94,7 @@ public class Tileset extends AbstractDocument {
                                 wmtsLimits[i][3],
                                 wmtsLimits[i][0],
                                 wmtsLimits[i][2]);
+                validateLimits(limit, gridSubset, i);
                 tileMatrixSetLimits.add(limit);
             }
         }
@@ -196,6 +201,16 @@ public class Tileset extends AbstractDocument {
                         "Tiles of this type are not yet supported: " + dataType);
             }
         }
+    }
+
+    private void validateLimits(TileMatrixSetLimit limit, GridSubset gridSubset, int zoomLevel) {
+
+        long numTilesHeight = gridSubset.getGridSet().getGrid(zoomLevel).getNumTilesHigh();
+        long numTilesWide = gridSubset.getGridSet().getGrid(zoomLevel).getNumTilesWide();
+        if (limit.getMinTileRow() < 0) limit.setMinTileRow(0);
+        if (limit.getMinTileCol() < 0) limit.setMinTileCol(0);
+        if (limit.getMaxTileRow() > numTilesHeight - 1) limit.setMaxTileRow(numTilesHeight - 1);
+        if (limit.getMaxTileCol() > numTilesWide - 1) limit.setMaxTileCol(numTilesWide - 1);
     }
 
     public String getTileMatrixSetURI() {

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/tiles/tileMatrixSet.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/tiles/tileMatrixSet.ftl
@@ -1,8 +1,8 @@
-<#global pagetitle=model.identifier>
+<#global pagetitle=model.id>
 <#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='"+serviceLink("tileMatrixSets")+"'>Tile Matrix Sets</a></li><li class='breadcrumb-item active'>"+pagetitle+"</li>">
 <#include "common-header.ftl">
 
-  <h2>${model.identifier}</h2>
+  <h2>${model.id}</h2>
   <p class="my-4">
     Tile matrix set definition for ${model.id}, expressed in ${model.supportedCRS}
     <#if model.title??>${model.title}</#if>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/tiles/tileset-include.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/tiles/tileset-include.ftl
@@ -55,7 +55,7 @@
               <td>${limit.tileMatrix}</td>
               <td>${limit.minTileRow}</td>
               <td>${limit.maxTileRow}</td>
-              <td>${limit.maxTileCol}</td>
+              <td>${limit.minTileCol}</td>
               <td>${limit.maxTileCol}</td>
             </tr>
           </#list>

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/GetTileTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/GetTileTest.java
@@ -69,7 +69,7 @@ public class GetTileTest extends TilesTestSupport {
         assertEquals("-180.0,-90.0,0.0,90.0", sr.getHeader("geowebcache-tile-bounds"));
         assertEquals(layerName, sr.getHeader("geowebcache-layer"));
         assertEquals("MISS", sr.getHeader("geowebcache-cache-result"));
-        assertEquals("no-cache", sr.getHeader("Cache-Control"));
+        assertEquals("no-cache, no-store, must-revalidate", sr.getHeader("Cache-Control"));
         assertNotNull(sr.getHeader("ETag"));
         assertNotNull(sr.getHeader("Last-Modified"));
         assertValidPNGResponse(sr);
@@ -336,7 +336,7 @@ public class GetTileTest extends TilesTestSupport {
                 "0.0,0.0,39135.7584765628,39135.7584765628",
                 sr.getHeader("geowebcache-tile-bounds"));
         assertEquals(layerId, sr.getHeader("geowebcache-layer"));
-        assertEquals("no-cache", sr.getHeader("Cache-Control"));
+        assertEquals("no-cache, no-store, must-revalidate", sr.getHeader("Cache-Control"));
         assertNotNull(sr.getHeader("ETag"));
         assertNotNull(sr.getHeader("Last-Modified"));
     }

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/TileJSONBuilderTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/TileJSONBuilderTest.java
@@ -1,0 +1,75 @@
+package org.geoserver.ogcapi.tiles;
+
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
+import org.geoserver.ogcapi.APIRequestInfo;
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.layer.meta.LayerMetaInformation;
+import org.geowebcache.layer.meta.TileJSON;
+import org.geowebcache.mbtiles.layer.MBTilesLayer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(APIRequestInfo.class)
+@PowerMockIgnore({"jdk.internal.reflect.*"})
+public class TileJSONBuilderTest {
+
+    @Test
+    public void testMBTiles() throws Exception {
+
+        PowerMock.mockStatic(APIRequestInfo.class);
+        APIRequestInfo requestInfo = createNiceMock(APIRequestInfo.class);
+        expect(APIRequestInfo.get()).andReturn(requestInfo).anyTimes();
+        PowerMock.replay(APIRequestInfo.class);
+
+        expect(requestInfo.getBaseURL()).andReturn("http://localhost:8081/geoserver");
+        replay(requestInfo);
+
+        MBTilesLayer mbTilesLayer = mock(MBTilesLayer.class);
+        LayerMetaInformation metaInformation = mock(LayerMetaInformation.class);
+        GridSubset subset = mock(GridSubset.class);
+
+        expect(mbTilesLayer.getName()).andReturn("countries").anyTimes();
+        expect(mbTilesLayer.getGridSubset(anyString())).andReturn(subset).anyTimes();
+        expect(mbTilesLayer.getMetaInformation()).andReturn(metaInformation).anyTimes();
+        expect(mbTilesLayer.supportsTileJSON()).andReturn(true).anyTimes();
+        TileJSON tileJSON = new TileJSON();
+        tileJSON.setName("countries");
+        tileJSON.setDescription("Natural Earth Data with .shp data from  TileMill");
+        tileJSON.setAttribution("Natural Earth Data");
+        tileJSON.setMinZoom(0);
+        tileJSON.setMaxZoom(6);
+        tileJSON.setScheme("xyz");
+        expect(mbTilesLayer.getTileJSON()).andReturn(tileJSON);
+        replay(mbTilesLayer);
+
+        TileJSONBuilder tileJSONBuilder =
+                new TileJSONBuilder(
+                        "countries",
+                        "application/vnd.mapbox-vector-tile",
+                        "EPSG:900913",
+                        mbTilesLayer);
+        TileJSON actualJson = tileJSONBuilder.build();
+
+        assertEquals("countries", actualJson.getName());
+        assertEquals(
+                "http://localhost:8081/geoserver/ogc/tiles/collections/countries/tiles/EPSG:900913/{z}/{y}/{x}?f=application%2Fvnd.mapbox-vector-tile",
+                actualJson.getTiles()[0]);
+        assertEquals(
+                "Natural Earth Data with .shp data from  TileMill", actualJson.getDescription());
+        assertEquals("Natural Earth Data", tileJSON.getAttribution());
+        assertEquals(0, tileJSON.getMinZoom().longValue());
+        assertEquals(6, tileJSON.getMaxZoom().longValue());
+        assertEquals("xyz", tileJSON.getScheme());
+    }
+}


### PR DESCRIPTION
[![GEOS-10223](https://badgen.net/badge/JIRA/GEOS-10223/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10223)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->
This is backport of [5288](https://github.com/geoserver/geoserver/pull/5288) for 2.20.x
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->