### PR TITLE
make all KVP of a WFS GetFeature Request available as extendedProperties

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/kvp/GetFeatureKvpRequestReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/kvp/GetFeatureKvpRequestReader.java
@@ -168,6 +168,9 @@ public class GetFeatureKvpRequestReader extends BaseFeatureKvpRequestReader {
             req.setViewParams(viewParams);
         }
 
+        // support for extra parameters
+        req.setExtendedProperties(kvp);
+
         return request;
     }
 

--- a/src/wfs/src/main/java/org/geoserver/wfs/request/GetFeatureRequest.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/request/GetFeatureRequest.java
@@ -9,6 +9,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 import net.opengis.wfs.GetFeatureType;
 import net.opengis.wfs.GetFeatureWithLockType;
 import net.opengis.wfs.ResultTypeType;
@@ -24,6 +25,8 @@ import org.geotools.xsd.EMFUtils;
  * @author Justin Deoliveira, OpenGeo
  */
 public abstract class GetFeatureRequest extends RequestObject {
+
+    private final Logger LOGGER = org.geotools.util.logging.Logging.getLogger(this.getClass());
 
     public static GetFeatureRequest adapt(Object request) {
         if (request instanceof GetFeatureType) {
@@ -56,6 +59,11 @@ public abstract class GetFeatureRequest extends RequestObject {
         List<Map<String, String>> l = eGet(adaptee, "viewParams", List.class);
         l.clear();
         l.addAll(viewParams);
+    }
+
+    public void setExtendedProperties(Map<String, Object> vsp) {
+        LOGGER.info("setting extendedProperties" + vsp.toString());
+        eSet(adaptee, "extendedProperties", vsp);
     }
 
     public abstract List<Query> getQueries();


### PR DESCRIPTION
Plugin development may need to access vendor specific parameters submitted with a WFS GetFeature request.
For example, it might be required that a Bearer Access Token is submitted via the GET Query: "access_token=...".

The proposed code change is very simple, as it adds the not existing setter function setExtendedProperties() to populate all KVP into the existing slot for "extendedProperties". One can later use the existing getter function getExtendedProperties() from Request.java for fetching the "rawKVP":
  
There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS-10244) describing the contribution.