### PR TITLE
[2.20.x backport][GEOS-10235] Prevent double-quote to be specified as CSV separator

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
@@ -11,6 +11,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.security.InvalidParameterException;
 import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.Collection;
@@ -232,6 +233,8 @@ public class CSVOutputFormat extends WFSGetFeatureOutputFormat {
             separator = " ";
         } else if (separator.equalsIgnoreCase("tab")) {
             separator = "\t";
+        } else if (separator.equals("\"")) {
+            throw new InvalidParameterException("A double quote is not allowed as a CSV separator");
         }
 
         return separator;


### PR DESCRIPTION
[![GEOS-10235](https://badgen.net/badge/JIRA/GEOS-10235/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10235)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
This is backport of [5285](https://github.com/geoserver/geoserver/pull/5285) for 2.20.x

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->