### PR TITLE
[GEOS-10245] jdbcconfig: prefixedName filter field not updated

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -905,6 +905,8 @@ public class ConfigDatabase implements ApplicationContextAware {
             if (updateResouceLayersName) {
                 updateResourceLayerProperty(
                         (ResourceInfo) info, "name", ((ResourceInfo) info).getName());
+                updateResourceLayerProperty(
+                        (ResourceInfo) info, "prefixedName", ((ResourceInfo) info).prefixedName());
             }
             if (updateResouceLayersAdvertised) {
                 updateResourceLayerProperty(

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
@@ -161,6 +161,46 @@ public class CatalogImplWithJDBCFacadeTest extends org.geoserver.catalog.impl.Ca
     }
 
     @Test
+    public void testPrefixedName() {
+        final FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+
+        addDataStore();
+        addNamespace();
+
+        FeatureTypeInfo ft1 = newFeatureType("ft1", ds);
+        ft1.setEnabled(false);
+        catalog.add(ft1);
+        StyleInfo s1;
+        catalog.add(s1 = newStyle("s1", "s1Filename"));
+        LayerInfo l1 = newLayer(ft1, s1);
+        catalog.add(l1);
+        CloseableIterator<LayerInfo> it =
+                catalog.list(
+                        LayerInfo.class,
+                        ff.equals(ff.property("prefixedName"), ff.literal("wsName:ft1")));
+        assertTrue(it.hasNext());
+        assertEquals(l1.getName(), it.next().getName());
+
+        ft1 = catalog.getFeatureTypeByName("ft1");
+        ft1.setName("renamed_ft1");
+        catalog.save(ft1);
+
+        l1 = catalog.getLayerByName("renamed_ft1");
+
+        it =
+                catalog.list(
+                        LayerInfo.class,
+                        ff.equals(ff.property("prefixedName"), ff.literal("wsName:renamed_ft1")));
+        assertTrue(it.hasNext());
+        assertEquals(l1.getName(), it.next().getName());
+        it =
+                catalog.list(
+                        LayerInfo.class,
+                        ff.equals(ff.property("prefixedName"), ff.literal("wsName:ft1")));
+        assertFalse(it.hasNext());
+    }
+
+    @Test
     public void testOrderByMultiple() {
         addDataStore();
         addNamespace();


### PR DESCRIPTION
[![GEOS-10245](https://badgen.net/badge/JIRA/GEOS-10245/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10245)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->