### PR TITLE
[GEOS-10246] Jdbc performance improvement from unnecessary transactions

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -185,6 +185,10 @@ public class ConfigDatabase implements ApplicationContextAware {
 
     private ConcurrentMap<String, Semaphore> locks;
 
+    // transaction management works only if the method
+    // is called from a Spring proxy that processed the annotations,
+    // so we cannot call getId directly, it needs to be done from
+    // "outside"
     /* the bean itself, but with the transactional proxy wrappers around */
     private ConfigDatabase transactionalConfigDatabase;
 
@@ -425,11 +429,7 @@ public class ConfigDatabase implements ApplicationContextAware {
                             @Nullable
                             @Override
                             public T apply(String id) {
-                                // tricky bit... transaction management works only if the method
-                                // is called from a Spring proxy that processed the annotations,
-                                // so we cannot call getId directly, it needs to be done from
-                                // "outside"
-                                return transactionalConfigDatabase.getById(id, of);
+                                return getById(id, of);
                             }
                         });
 
@@ -1106,12 +1106,6 @@ public class ConfigDatabase implements ApplicationContextAware {
         return propertyTypeIds.iterator().next();
     }
 
-    @Nullable
-    @Transactional(
-        transactionManager = "jdbcConfigTransactionManager",
-        propagation = Propagation.REQUIRED,
-        readOnly = true
-    )
     public <T extends Info> T getById(final String id, final Class<T> type) {
         Assert.notNull(id, "id");
 
@@ -1174,12 +1168,6 @@ public class ConfigDatabase implements ApplicationContextAware {
         return null;
     }
 
-    @Nullable
-    @Transactional(
-        transactionManager = "jdbcConfigTransactionManager",
-        propagation = Propagation.REQUIRED,
-        readOnly = true
-    )
     public <T extends Info> String getIdByIdentity(
             final Class<T> type, final String... identityMappings) {
         Assert.notNull(identityMappings, "id");
@@ -1250,11 +1238,6 @@ public class ConfigDatabase implements ApplicationContextAware {
     }
 
     @Nullable
-    @Transactional(
-        transactionManager = "jdbcConfigTransactionManager",
-        propagation = Propagation.REQUIRED,
-        readOnly = true
-    )
     public <T extends Info> T getByIdentity(final Class<T> type, final String... identityMappings) {
         String id = getIdByIdentity(type, identityMappings);
 
@@ -1323,6 +1306,12 @@ public class ConfigDatabase implements ApplicationContextAware {
     }
 
     /** @return immutable list of results */
+    @Nullable
+    @Transactional(
+        transactionManager = "jdbcConfigTransactionManager",
+        propagation = Propagation.REQUIRED,
+        readOnly = true
+    )
     public <T extends Info> List<T> getAll(final Class<T> clazz) {
 
         Map<String, ?> params = params("types", typesParam(clazz));
@@ -1412,17 +1401,28 @@ public class ConfigDatabase implements ApplicationContextAware {
 
         @Override
         public CatalogInfo call() throws Exception {
-            CatalogInfo info;
-            try {
-                String sql = "select blob from object where id = :id";
-                Map<String, String> params = ImmutableMap.of("id", id);
-                logStatement(sql, params);
-                info = template.queryForObject(sql, params, catalogRowMapper);
-            } catch (EmptyResultDataAccessException noSuchObject) {
-                return null;
-            }
-            return info;
+            return transactionalConfigDatabase.loadCatalog(id);
         }
+    }
+
+    @Nullable
+    @Transactional(
+        transactionManager = "jdbcConfigTransactionManager",
+        propagation = Propagation.REQUIRED,
+        readOnly = true
+    )
+    public CatalogInfo loadCatalog(String id) {
+
+        CatalogInfo info;
+        try {
+            String sql = "select blob from object where id = :id";
+            Map<String, String> params = ImmutableMap.of("id", id);
+            logStatement(sql, params);
+            info = template.queryForObject(sql, params, catalogRowMapper);
+        } catch (EmptyResultDataAccessException noSuchObject) {
+            return null;
+        }
+        return info;
     }
 
     private final class IdentityLoader implements Callable<String> {
@@ -1435,23 +1435,31 @@ public class ConfigDatabase implements ApplicationContextAware {
 
         @Override
         public String call() throws Exception {
-            Filter filter = Filter.INCLUDE;
-            for (int i = 0; i < identity.getDescriptor().length; i++) {
-                filter =
-                        and(
-                                filter,
-                                identity.getValues()[i] == null
-                                        ? isNull(identity.getDescriptor()[i])
-                                        : equal(
-                                                identity.getDescriptor()[i],
-                                                identity.getValues()[i]));
-            }
+            return transactionalConfigDatabase.loadIdentity(identity);
+        }
+    }
 
-            try {
-                return getId(identity.getClazz(), filter);
-            } catch (IllegalArgumentException multipleResults) {
-                return null;
-            }
+    @Nullable
+    @Transactional(
+        transactionManager = "jdbcConfigTransactionManager",
+        propagation = Propagation.REQUIRED,
+        readOnly = true
+    )
+    public String loadIdentity(InfoIdentity identity) {
+        Filter filter = Filter.INCLUDE;
+        for (int i = 0; i < identity.getDescriptor().length; i++) {
+            filter =
+                    and(
+                            filter,
+                            identity.getValues()[i] == null
+                                    ? isNull(identity.getDescriptor()[i])
+                                    : equal(identity.getDescriptor()[i], identity.getValues()[i]));
+        }
+
+        try {
+            return getId(identity.getClazz(), filter);
+        } catch (IllegalArgumentException multipleResults) {
+            return null;
         }
     }
 
@@ -1578,38 +1586,48 @@ public class ConfigDatabase implements ApplicationContextAware {
 
         @Override
         public Info call() throws Exception {
-            Info info;
-            try {
-                String sql = "select blob from object where id = :id";
-                Map<String, String> params = ImmutableMap.of("id", id);
-                logStatement(sql, params);
-                info = template.queryForObject(sql, params, configRowMapper);
-            } catch (EmptyResultDataAccessException noSuchObject) {
-                return null;
-            }
-            OwsUtils.resolveCollections(info);
-            if (info instanceof GeoServerInfo) {
-
-                GeoServerInfoImpl global = (GeoServerInfoImpl) info;
-                if (global.getMetadata() == null) {
-                    global.setMetadata(new MetadataMap());
-                }
-                if (global.getClientProperties() == null) {
-                    global.setClientProperties(new HashMap<Object, Object>());
-                }
-                if (global.getCoverageAccess() == null) {
-                    global.setCoverageAccess(new CoverageAccessInfoImpl());
-                }
-                if (global.getJAI() == null) {
-                    global.setJAI(new JAIInfoImpl());
-                }
-            }
-            if (info instanceof ServiceInfo) {
-                ((ServiceInfo) info).setGeoServer(geoServer);
-            }
-
-            return info;
+            return transactionalConfigDatabase.loadConfig(id);
         }
+    }
+
+    @Nullable
+    @Transactional(
+        transactionManager = "jdbcConfigTransactionManager",
+        propagation = Propagation.REQUIRED,
+        readOnly = true
+    )
+    public Info loadConfig(String id) {
+        Info info;
+        try {
+            String sql = "select blob from object where id = :id";
+            Map<String, String> params = ImmutableMap.of("id", id);
+            logStatement(sql, params);
+            info = template.queryForObject(sql, params, configRowMapper);
+        } catch (EmptyResultDataAccessException noSuchObject) {
+            return null;
+        }
+        OwsUtils.resolveCollections(info);
+        if (info instanceof GeoServerInfo) {
+
+            GeoServerInfoImpl global = (GeoServerInfoImpl) info;
+            if (global.getMetadata() == null) {
+                global.setMetadata(new MetadataMap());
+            }
+            if (global.getClientProperties() == null) {
+                global.setClientProperties(new HashMap<Object, Object>());
+            }
+            if (global.getCoverageAccess() == null) {
+                global.setCoverageAccess(new CoverageAccessInfoImpl());
+            }
+            if (global.getJAI() == null) {
+                global.setJAI(new JAIInfoImpl());
+            }
+        }
+        if (info instanceof ServiceInfo) {
+            ((ServiceInfo) info).setGeoServer(geoServer);
+        }
+
+        return info;
     }
 
     /**


### PR DESCRIPTION
[![GEOS-10246](https://badgen.net/badge/JIRA/GEOS-10246/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10246)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  https://osgeo-org.atlassian.net/browse/GEOS-10246

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->