### PR TITLE
[GEOS-10255] i18n use classes, selfclear and leftwise for layout

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/InternationalStringPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/InternationalStringPanel.html
@@ -3,19 +3,18 @@
 <body>
 <wicket:panel>
     <div wicket:id="container">
-    <ul>
+    <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew"/></a></li>
     </ul>
-    <div wicket:id="tablePanel"/>
+    <div class="i18n-panel" wicket:id="tablePanel"/>
     </div>
-    <br/>
 </wicket:panel>
 <wicket:fragment wicket:id="txtFragment">
-		<span wicket:id="border"><input wicket:id="txt"
+        <span wicket:id="border"><input wicket:id="txt"
                                         type="text" class="text"/></span>
 </wicket:fragment>
 <wicket:fragment wicket:id="txtAreaFragment">
-		<span wicket:id="border"><textarea wicket:id="txt" class="field textarea" rows="10" cols="30"/></span>
+        <span wicket:id="border"><textarea wicket:id="txt" class="field textarea" rows="10" cols="30"/></span>
 </wicket:fragment>
 <wicket:fragment wicket:id="selectFragment">
     <span wicket:id="border"><select wicket:id="select"/></span>

--- a/src/web/core/src/main/java/org/geoserver/web/StringAndInternationalStringPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/StringAndInternationalStringPanel.html
@@ -3,14 +3,15 @@
 <head />
 <body>
 <wicket:panel>
-    <ul>
+    <ul class="i18n-text" >
         <li>
-            <br/>
-            <span wicket:id="labelContainer">
-                  <label style="float:left" wicket:id="stringLabel" />
-                  <input style="float:left" type="checkbox" wicket:id="labelContainer_i18nCheckbox" />
-                  <wicket:message key="i18nCheckBox">i18n</wicket:message>
-               </span>
+            <span wicket:id="labelContainer" class="selfclear">
+                  <label class="leftwise" wicket:id="stringLabel" />
+                  <span class="leftwise" >
+                    <input type="checkbox" wicket:id="labelContainer_i18nCheckbox" />
+                    <wicket:message key="i18nCheckBox">i18n</wicket:message>
+                  </span>
+            </span>
         </li>
         <li>
             <input class="text" type="text" wicket:id="stringField" />

--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -925,6 +925,19 @@ padding-top: 18px;
 .page-footer {
 padding-top: 1em;
 }
+/* action group above tables */
+.action-group li {
+  display: inline;
+}
+
+/* internationalization */
+.i18n-panel {
+  margin-bottom: 5px;
+}
+
+.i18n-panel td {
+  vertical-align: top;
+}
 
 /* button bar in forms */
 .toolbar-sticky {

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/TitleAndAbstractPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/TitleAndAbstractPanel.html
@@ -3,14 +3,13 @@
 <head />
 <body>
 <wicket:panel>
-    <ul>
+    <ul class="i18n-tile-and-abstract">
         <li>
-            <br/>
             <span wicket:id="titleLabel">
-                  <label style="float:left" for="title" wicket:id="titleLabel" />
-                  <input style="float:left" type="checkbox" wicket:id="titleLabel_i18nCheckbox" />
+                  <label class="leftwise" for="title" wicket:id="titleLabel" />
+                  <input class="leftwise" type="checkbox" wicket:id="titleLabel_i18nCheckbox" />
                   <wicket:message key="i18nCheckBox">i18n</wicket:message>
-               </span>
+            </span>
         </li>
         <li>
             <input class="text" type="text" wicket:id="title" />
@@ -19,11 +18,11 @@
             <div wicket:id="internationalTitle" />
         </li>
         <li>
-               <span wicket:id="abstractLabel">
-                  <label style="float:left" for="abstract" wicket:id="abstractLabel" />
-                  <input style="float:left" type="checkbox" wicket:id="abstractLabel_i18nCheckbox" />
-                  <wicket:message key="i18nCheckBox">i18n</wicket:message>
-               </span>
+            <span wicket:id="abstractLabel">
+               <label class="leftwise" for="abstract" wicket:id="abstractLabel" />
+               <input class="leftwise" type="checkbox" wicket:id="abstractLabel_i18nCheckbox" />
+               <wicket:message key="i18nCheckBox">i18n</wicket:message>
+            </span>
         </li>
         <li>
             <textarea wicket:id="abstract" class="field textarea" rows="10" cols="30" />


### PR DESCRIPTION
[![GEOS-10255](https://badgen.net/badge/JIRA/GEOS-10255/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10255)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This code provides some fixes to the new i18n fragments allowing layout using csss (rather than hard coded styles and br).

Signed-off-by: Jody Garnett <jody.garnett@gmail.com>

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the https://osgeo-org.atlassian.net/browse/GEOS-10255
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).