### PR TITLE
[2.19.x backport][GEOS-10254] Features templating JSON-LD output should not encode all attributes as string (#5304)

### DIFF
--- a/doc/en/user/source/community/features-templating/directives.rst
+++ b/doc/en/user/source/community/features-templating/directives.rst
@@ -39,8 +39,8 @@ The following are the directives available in JSON based templates.
      - specify it inside the first nested object in arrays (:code:`{"$filter":"condition"}`) or as an attribute in objects (:code:`"$filter":"condition"`) or in an attribute next to the attribute value separated by a :code:`,` (:code:`"attribute":"$filter{condition}, ${property}"`)
    * - defines options to customize the output outside of a feature scope
      - $options
-     - specify it at the top of the JSON template as a JSON object (GeoJSON options: :code:`"$options":{"flat_output":true, "separator":"."}`; JSON-LD options: :code:`"$options":{"@context": "the context json"}`).
-   * - allows to include a template into another
+     - specify it at the top of the JSON template as a JSON object (GeoJSON options: :code:`"$options":{"flat_output":true, "separator":"."}`; JSON-LD options: :code:`"$options":{"@context": "the context json", "encode_as_string": true}`).
+   * - allows including a template into another
      - $include, $includeFlat
      - specify the :code:`$include` option as an attribute value (:code:`"attribute":"$include{subProperty.json}"`) and the :code:`$includeFlat` as an attribute name with the included template path as a value (:code:`"$includeFlat":"included.json"`)
    * - allows a template to extend another template
@@ -711,6 +711,7 @@ To accomplish this requirement it is possible to specify the :code:`@context` as
 
   {
    "$options":{
+      "encode_as_string": true,
       "@context":[
          "https://opengeospatial.github.io/ELFIE/contexts/elfie-2/elf-index.jsonld",
          "https://opengeospatial.github.io/ELFIE/contexts/elfie-2/gwml2.jsonld",
@@ -827,6 +828,7 @@ The :code:`@context` will show up at the beginning of the JSON-LD output:
    ]
  }
 
+The above template defines, along with the :code:`@context`, also the :code:`option` :code:`encode_as_string`. The option is used to request a JSON-LD output where all the attributes are encoded as text. By default attributes are instead encoded as in :code:`GeoJSON` output format.
 
 When dealing with a GetFeatureInfo request over a LayerGroup asking for a JSON-LD output the plug-in will perform a union of the JSON-LD :code:`@context` (when different) defined in the template of each containted layer. This means that in case of conflicting attributes name the attributes name will override each other according to the processing order of the layers.
 The user can prevent this behaviour by taking advantage of the  :code:`include` directive, explained below, defining a single :code:`@context` included in the template of each contained layer. In this way all the layer will share the same context definition.

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/EncodingHints.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/EncodingHints.java
@@ -70,6 +70,19 @@ public class EncodingHints extends HashMap<String, Object> {
     }
 
     /**
+     * Get the hint value with the requested type.
+     *
+     * @param key the hint name.
+     * @param cast the type requested.
+     * @return the value of the hint if found, otherwise null.
+     */
+    public <T> T get(String key, Class<T> cast, T defaultValue) {
+        T value = cast.cast(get(key));
+        if (value == null) value = defaultValue;
+        return value;
+    }
+
+    /**
      * Check if the current request is an OGCAPI request by feature id.
      *
      * @return true if is a single feature request, false otherwise.

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/VendorOptions.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/VendorOptions.java
@@ -31,6 +31,9 @@ public class VendorOptions extends HashMap<String, Object> {
 
     public static final String LINK = "link";
 
+    // encoding hint to encode all json-ld attributes as string
+    public static final String JSON_LD_STRING_ENCODE = "encode_as_string";
+
     public <T> T get(String key, Class<T> cast) {
         Object value = get(key);
         T result = null;

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
@@ -5,6 +5,7 @@
 package org.geoserver.featurestemplating.readers;
 
 import static org.geoserver.featurestemplating.builders.VendorOptions.FLAT_OUTPUT;
+import static org.geoserver.featurestemplating.builders.VendorOptions.JSON_LD_STRING_ENCODE;
 import static org.geoserver.featurestemplating.builders.VendorOptions.SEPARATOR;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -243,6 +244,13 @@ public class JSONTemplateReader implements TemplateReader {
 
         if (node.has(CONTEXTKEY)) {
             builder.addVendorOption(CONTEXTKEY, node.get(CONTEXTKEY));
+        }
+        if (node.has(JSON_LD_STRING_ENCODE)) {
+            JsonNode stringEncodeJSONLD = node.get(JSON_LD_STRING_ENCODE);
+            if (!stringEncodeJSONLD.isBoolean())
+                throw new RuntimeException(
+                        "The option " + JSON_LD_STRING_ENCODE + " can only be a boolean value");
+            builder.addVendorOption(JSON_LD_STRING_ENCODE, stringEncodeJSONLD.booleanValue());
         }
         Expression flatOutput =
                 builder.getVendorOptions()

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/GeoJSONWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/GeoJSONWriter.java
@@ -6,23 +6,17 @@
 package org.geoserver.featurestemplating.writers;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import org.geoserver.featurestemplating.builders.EncodingHints;
 import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
 import org.geoserver.util.ISO8601Formatter;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
-import org.geotools.util.Converters;
-import org.locationtech.jts.geom.Geometry;
 
 /** Implements its superclass methods to write a valid GeoJSON output */
 public class GeoJSONWriter extends CommonJSONWriter {
@@ -33,50 +27,6 @@ public class GeoJSONWriter extends CommonJSONWriter {
 
     public GeoJSONWriter(JsonGenerator generator) {
         super(generator, TemplateIdentifier.JSON);
-    }
-
-    @Override
-    public void writeValue(Object value) throws IOException {
-        if (value instanceof String) {
-            generator.writeString((String) value);
-        } else if (value instanceof Integer) {
-            generator.writeNumber((Integer) value);
-        } else if (value instanceof Double) {
-            generator.writeNumber((Double) value);
-        } else if (value instanceof Float) {
-            generator.writeNumber((Float) value);
-        } else if (value instanceof Long) {
-            generator.writeNumber((Long) value);
-        } else if (value instanceof BigInteger) {
-            generator.writeNumber((BigInteger) value);
-        } else if (value instanceof BigDecimal) {
-            generator.writeNumber((BigDecimal) value);
-        } else if (value instanceof Boolean) {
-            generator.writeBoolean((Boolean) value);
-        } else if (value instanceof Date) {
-            generator.writeString(new ISO8601Formatter().format(value));
-        } else if (value.getClass().isArray()) {
-            List list = Converters.convert(value, List.class);
-            generator.writeStartArray();
-            for (Object o : list) {
-                writeValue(o);
-            }
-            generator.writeEndArray();
-        } else {
-            generator.writeString(value.toString());
-        }
-    }
-
-    @Override
-    public void writeGeometry(Object value) throws IOException {
-        JsonNode node = toJsonNode((Geometry) value);
-        writeObjectNode(null, node);
-    }
-
-    private JsonNode toJsonNode(Geometry geometry) throws JsonProcessingException {
-        String jsonGeom = org.geotools.data.geojson.GeoJSONWriter.toGeoJSON(geometry);
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readTree(jsonGeom);
     }
 
     @Override

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/JSONLDWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/JSONLDWriter.java
@@ -20,20 +20,27 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 /** Implements its superclass methods to write a valid json-ld output */
 public class JSONLDWriter extends CommonJSONWriter {
 
+    private boolean encodeAsString;
+
     public JSONLDWriter(JsonGenerator generator) {
         super(generator, TemplateIdentifier.JSONLD);
     }
 
     @Override
     public void writeValue(Object value) throws IOException {
-        generator.writeString(String.valueOf(value));
+        if (!encodeAsString) super.writeValue(value);
+        else generator.writeString(String.valueOf(value));
     }
 
     @Override
     public void writeGeometry(Object value) throws IOException {
-        FilterFunction_toWKT toWKT = new FilterFunction_toWKT();
-        String wkt = (String) toWKT.evaluate(value);
-        generator.writeString(wkt);
+        if (!encodeAsString) {
+            super.writeGeometry(value);
+        } else {
+            FilterFunction_toWKT toWKT = new FilterFunction_toWKT();
+            String wkt = (String) toWKT.evaluate(value);
+            generator.writeString(wkt);
+        }
     }
 
     @Override
@@ -87,5 +94,9 @@ public class JSONLDWriter extends CommonJSONWriter {
     @Override
     public void endObject(String name, EncodingHints encodingHints) throws IOException {
         if (!skipObjectWriting(encodingHints)) super.endObject(name, encodingHints);
+    }
+
+    public void setEncodeAsString(boolean encodeAsString) {
+        this.encodeAsString = encodeAsString;
     }
 }

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/FirstParentFeature_invalid.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/FirstParentFeature_invalid.json
@@ -1,4 +1,7 @@
 {
+  "$options": {
+    "encode_as_string": true
+  },
   "@context": {
     "gsp": "http://www.opengis.net/ont/geosparql#",
     "sf": "http://www.opengis.net/ont/sf#",

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/GeologicUnitDynamicStaticFilter.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/GeologicUnitDynamicStaticFilter.json
@@ -1,4 +1,7 @@
 {
+  "$options": {
+    "encode_as_string": true
+  },
   "@context":[
     "http://www.opengis.net/url1",
     "http://www.opengis.net/url2",

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/GeologicUnit_invalid.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/GeologicUnit_invalid.json
@@ -1,4 +1,7 @@
 {
+  "$options": {
+    "encode_as_string": true
+  },
   "@context": {
     "gsp": "http://www.opengis.net/ont/geosparql#",
     "sf": "http://www.opengis.net/ont/sf#",

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureJSONLD.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureJSONLD.json
@@ -1,5 +1,6 @@
 {
   "$options": {
+    "encode_as_string": true,
     "@context": {
       "gsp": "http://www.opengis.net/ont/geosparql#",
       "sf": "http://www.opengis.net/ont/sf#",

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/MappedFeatureIteratingAndCompositeFilter.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/MappedFeatureIteratingAndCompositeFilter.json
@@ -1,4 +1,7 @@
 {
+  "$options": {
+    "encode_as_string": true
+  },
   "@context":[
     "http://www.opengis.net/url1",
     "http://www.opengis.net/url2",

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/MfJsonLdDefEncoding.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/MfJsonLdDefEncoding.json
@@ -1,7 +1,4 @@
 {
-  "$options": {
-    "encode_as_string": true
-  },
   "@context": {
     "gsp": "http://www.opengis.net/ont/geosparql#",
     "sf": "http://www.opengis.net/ont/sf#",
@@ -89,10 +86,7 @@
           }
         ]
       },
-      "geometry": {
-        "@type": "Polygon",
-        "wkt": "$${toWKT(xpath('gsml:shape'))}"
-      }
+      "geometry": "${gsml:shape}"
     }
   ]
 }

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/NamedPlaces.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/NamedPlaces.json
@@ -1,4 +1,7 @@
 {
+  "$options": {
+    "encode_as_string": true
+  },
   "@context": {
     "gsp": "http://www.opengis.net/ont/geosparql#",
     "sf": "http://www.opengis.net/ont/sf#",

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/SimplifiedPropertyNames.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/SimplifiedPropertyNames.json
@@ -1,4 +1,7 @@
 {
+  "$options": {
+    "encode_as_string": true
+  },
   "@context": {
     "gsp": "http://www.opengis.net/ont/geosparql#",
     "sf": "http://www.opengis.net/ont/sf#",

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/JSONLDGetFeatureResponse.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/JSONLDGetFeatureResponse.java
@@ -20,6 +20,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.featurestemplating.builders.EncodingHints;
 import org.geoserver.featurestemplating.builders.TemplateBuilder;
+import org.geoserver.featurestemplating.builders.VendorOptions;
 import org.geoserver.featurestemplating.builders.impl.RootBuilder;
 import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
 import org.geoserver.featurestemplating.configuration.TemplateLoader;
@@ -168,7 +169,13 @@ public class JSONLDGetFeatureResponse extends BaseTemplateGetFeatureResponse {
 
     @Override
     protected void beforeFeatureIteration(
-            TemplateOutputWriter writer, RootBuilder root, FeatureTypeInfo typeInfo) {}
+            TemplateOutputWriter writer, RootBuilder root, FeatureTypeInfo typeInfo) {
+        Boolean encodeAsString =
+                root.getVendorOptions()
+                        .get(VendorOptions.JSON_LD_STRING_ENCODE, Boolean.class, false);
+        JSONLDWriter jsonldWriter = (JSONLDWriter) writer;
+        jsonldWriter.setEncodeAsString(encodeAsString);
+    }
 
     @Override
     protected void beforeEvaluation(


### PR DESCRIPTION
[![GEOS-10254](https://badgen.net/badge/JIRA/GEOS-10254/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10254)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->