### PR TITLE
fixed bug GeometryCollection was not considered as geometry

### DIFF
--- a/src/community/schemaless-features/mongodb-schemaless/src/main/java/org/geoserver/schemalessfeatures/mongodb/MongoSchemalessUtils.java
+++ b/src/community/schemaless-features/mongodb-schemaless/src/main/java/org/geoserver/schemalessfeatures/mongodb/MongoSchemalessUtils.java
@@ -70,10 +70,16 @@ public class MongoSchemalessUtils {
 
     public static boolean isGeometry(DBObject object) {
         Set keys = object.keySet();
-        if (keys.size() != 2 || !keys.contains("coordinates") || !keys.contains("type")) {
-            // is mongo db object but not a geometry
+
+        if (!keys.contains("type")) {
             return false;
         }
-        return true;
+
+        final String type = (String) object.get("type");
+
+        // Geometry object must have 2 attributs: "type" and "coordinates" or "geometries" (for GeometryCollection)
+        return keys.size() == 2
+                && (("GeometryCollection".equals(type) && keys.contains("geometries"))
+                || (!"GeometryCollection".equals(type) && keys.contains("coordinates")));
     }
 }


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
In community plugin: gs-mongodb-schemaless.
Allow users to get features from mongodb collection who have a geometry of type GeometryCollection

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
