### PR TITLE
[GEOS-10259][GEOS-10260] Use class action-group to align actions horizontally across table

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -927,7 +927,8 @@ padding-top: 1em;
 }
 /* action group above tables */
 .action-group li {
-  display: inline;
+  display: inline-block;
+  margin-right: 10px;
 }
 
 /* internationalization */

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/LayerPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/LayerPage.html
@@ -11,7 +11,7 @@
     </wicket:fragment>
     
     <wicket:fragment wicket:id="header">
-      <ul>
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
       </ul>

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/NewFeatureTypePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/NewFeatureTypePage.html
@@ -29,7 +29,7 @@
 	</wicket:fragment>
     
     <wicket:fragment wicket:id="header">
-      <ul>
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
       </ul>

--- a/src/web/core/src/main/java/org/geoserver/web/data/layergroup/LayerGroupEntryPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layergroup/LayerGroupEntryPanel.html
@@ -6,7 +6,7 @@
               <span><wicket:message key="layers">Layers</wicket:message></span>
               <a href="#" wicket:id="layersHelp" class="help-link"></a>
         </legend>
-      <ul>
+      <ul class="action-group">
        <li><a class="add-link" wicket:id="addLayer"><wicket:message key="addLayer">Add Layer...</wicket:message></a></li>
        <li><a class="add-link" wicket:id="addLayerGroup"><wicket:message key="addLayerGroup">Add Layer Group...</wicket:message></a></li>
        <li>

--- a/src/web/core/src/main/java/org/geoserver/web/data/layergroup/LayerGroupPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layergroup/LayerGroupPage.html
@@ -10,7 +10,7 @@
         <div wicket:id="dialog"></div>
         
         <wicket:fragment wicket:id="header">
-          <ul>
+          <ul class="action-group">
             <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
             <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
           </ul>

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/StorePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/StorePage.html
@@ -7,7 +7,7 @@
 	<div wicket:id="table"></div>
     
     <wicket:fragment wicket:id="header">
-      <ul>
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
       </ul>

--- a/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspacePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspacePage.html
@@ -7,7 +7,7 @@
   <div wicket:id="table"></div>
   
   <wicket:fragment wicket:id="header">
-      <ul>
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
       </ul>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/blob/BlobStoresPage.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/blob/BlobStoresPage.html
@@ -1,21 +1,16 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">	
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">	
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org/" >
 <body>
-	<wicket:extend>
-	
-		<wicket:fragment wicket:id="header">
-		<ul>
-			<li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
-			<li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
-		</ul>
-		</wicket:fragment>
-
-		<div wicket:id="storesPanel"></div>	
-			
-			
-	    <div wicket:id="confirmDeleteDialog"></div>
-	</wicket:extend>
-  
+  <wicket:extend>
+    <wicket:fragment wicket:id="header">
+      <ul class="action-group">
+        <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
+        <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
+      </ul>
+    </wicket:fragment>
+    <div wicket:id="storesPanel"></div>	
+    <div wicket:id="confirmDeleteDialog"></div>
+  </wicket:extend>
 </body>
 </html>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/GridSetsPage.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/gridset/GridSetsPage.html
@@ -7,7 +7,7 @@
 	<div wicket:id="table"></div>
     
     <wicket:fragment wicket:id="header">
-      <ul>
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
       </ul>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayersPage.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/CachedLayersPage.html
@@ -12,7 +12,7 @@
 	</wicket:fragment>
     
     <wicket:fragment wicket:id="header">
-      <ul>
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>        
       </ul>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityNamedServicesPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityNamedServicesPanel.html
@@ -5,7 +5,7 @@
   </div>
   <ul>
     <li>
-     <ul>
+     <ul class="action-group">
         <li>
           <a class="add-link" wicket:id="add"><wicket:message key="addNew"></wicket:message></a>
         </li>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/auth/SecurityFilterChainsPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/auth/SecurityFilterChainsPanel.html
@@ -5,13 +5,9 @@
   </div>
   <ul>
     <li>
-     <ul>
-        <li>
-          <a class="add-link" wicket:id="addServiceChain"><wicket:message key="addServiceChain"></wicket:message></a>
-        </li>
-        <li>
-          <a class="add-link" wicket:id="addHtmlChain"><wicket:message key="addHtmlChain"></wicket:message></a>
-        </li>        
+     <ul class="action-group">
+        <li><a class="add-link" wicket:id="addServiceChain"><wicket:message key="addServiceChain"></wicket:message></a></li>
+        <li><a class="add-link" wicket:id="addHtmlChain"><wicket:message key="addHtmlChain"></wicket:message></a></li>        
      </ul>
     </li>
     <li>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/data/DataSecurityPage.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/data/DataSecurityPage.html
@@ -25,7 +25,7 @@
 <wicket:extend>
 
      <wicket:fragment wicket:id="header">
-      <ul>
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
       </ul>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/group/GroupPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/group/GroupPanel.html
@@ -8,12 +8,15 @@
   <ul>
     <li>
       <ul wicket:id="header">
-         <li>
-          <span wicket:id="message"></span>
+        <li wicket:id="message"></li>
+        <li><span><wicket:message key="GroupPanel.title"/></span></li>
+        <li>
+          <ul class="action-group">
+            <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
+            <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
+            <li><a class="remove-link" href="#" wicket:id="removeSelectedWithRoles"><wicket:message key="removeSelectedWithRoles" /></a></li>
+          </ul>
         </li>
-        <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
-        <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
-        <li><a class="remove-link" href="#" wicket:id="removeSelectedWithRoles"><wicket:message key="removeSelectedWithRoles" /></a></li>
       </ul>
     </li>
     <li>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/RolePanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/RolePanel.html
@@ -9,8 +9,13 @@
     <li>
       <ul wicket:id="header">
         <li wicket:id="message"></li>
-        <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
-        <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
+        <li><span><wicket:message key="RolePanel.title"/></span></li>
+        <li>
+          <ul class="action-group">
+            <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
+            <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
+          </ul>
+        </li>
       </ul>
     </li>
     <li>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/service/ServiceAccessRulePage.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/service/ServiceAccessRulePage.html
@@ -8,14 +8,14 @@
 <body>
 <wicket:extend>
 
-	<wicket:fragment wicket:id="header">
-      <ul>
+    <wicket:fragment wicket:id="header">
+      <ul class="action-group">
         <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
         <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
       </ul>
     </wicket:fragment>
     
-	<div wicket:id="table"></div>
+    <div wicket:id="table"></div>
 
 </wicket:extend>
 </body>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/user/UserPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/user/UserPanel.html
@@ -9,9 +9,14 @@
     <li>
       <ul wicket:id="header">
         <li wicket:id="message"></li>
-        <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
-        <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
-        <li><a class="remove-link" href="#" wicket:id="removeSelectedWithRoles"><wicket:message key="removeSelectedWithRoles" /></a></li>
+        <li><span><wicket:message key="UserPanel.title"></wicket:message></span></li>
+        <li>
+          <ul class="action-group">
+            <li><a class="add-link" href="#" wicket:id="addNew"><wicket:message key="addNew" /></a></li>
+            <li><a class="remove-link" href="#" wicket:id="removeSelected"><wicket:message key="removeSelected" /></a></li>
+            <li><a class="remove-link" href="#" wicket:id="removeSelectedWithRoles"><wicket:message key="removeSelectedWithRoles" /></a></li>
+          </ul>
+        </li>
       </ul>
     </li>
     <li>

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StylePage.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StylePage.html
@@ -7,7 +7,7 @@
     <div wicket:id="table"></div>
     
     <wicket:fragment wicket:id="header">
-        <ul>
+        <ul class="action-group">
             <li><a class="add-link" href="#" wicket:id="addNew">
                 <wicket:message key="addNew" />
             </a></li>


### PR DESCRIPTION
[![GEOS-10259](https://badgen.net/badge/JIRA/GEOS-10259/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10259)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[![GEOS-10260](https://badgen.net/badge/JIRA/GEOS-10259/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10260)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A small user interface change that makes me happy.

Documentation not updated as part of this change as the screen snaps are close enough not to confuse anyone.

1) workspaces

![image](https://user-images.githubusercontent.com/629681/135207670-92455c5d-19b7-42b2-9a58-cc946054a8fe.png)

2) stores

![image](https://user-images.githubusercontent.com/629681/135207696-034d0c67-df8a-4b70-aed3-72a0e638f3b5.png)

3) layers, layer groups, styles etc...

![image](https://user-images.githubusercontent.com/629681/135207798-01e3aa02-2139-4989-baac-ed3cd306477d.png)
![image](https://user-images.githubusercontent.com/629681/135207811-e28e2792-6eef-4665-86f3-1060d6f18c8a.png)
![image](https://user-images.githubusercontent.com/629681/135207828-d667a6c9-2e12-4a58-9bd9-5393ebd7bd61.png)

4) security 

![image](https://user-images.githubusercontent.com/629681/135207941-fc3bf41d-20cb-4c55-b5a3-9406d8a507d2.png)
![image](https://user-images.githubusercontent.com/629681/135207935-b84ad7e6-9166-4304-bb84-6e88cd10c7bd.png)
![image](https://user-images.githubusercontent.com/629681/135207973-2ae34842-5406-4972-b10b-89a559916ecc.png)
![image](https://user-images.githubusercontent.com/629681/135207995-d89a7112-496c-4033-9e72-77435ca471fd.png)
![image](https://user-images.githubusercontent.com/629681/135208007-65218316-57f7-4561-a6de-eaf2800fce98.png)

5) security panels (separate commit as title is introduced to provide visual separator)

These ones had heading breaks already:

![image](https://user-images.githubusercontent.com/629681/135208082-b069a14a-da4b-49ba-b025-f2ef25fce152.png)

User/Group page has expanding sections for each service, made use of panel title to provide a visual separation (now that action group does not provide a block of empty space.

![image](https://user-images.githubusercontent.com/629681/135208216-a59004bd-a6ab-48a4-9525-53596aaebaaa.png)

Similar for role service (shown with two expanded roles services):

![image](https://user-images.githubusercontent.com/629681/135208269-58a144e8-eb06-43fc-b540-0b84ddc92bd0.png)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue https://osgeo-org.atlassian.net/browse/GEOS-10259
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->