### PR TITLE
[GEOS-10245] jdbcconfig: prefixedName filter field not updated (fix t…

### DIFF
--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
@@ -57,6 +57,7 @@ import org.geoserver.catalog.impl.DataStoreInfoImpl;
 import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.NamespaceInfoImpl;
 import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.catalog.impl.WMSLayerInfoImpl;
 import org.geoserver.catalog.impl.WMSStoreInfoImpl;
@@ -184,6 +185,11 @@ public class ConfigDatabaseTest {
         ws.setName("ws1");
         database.add(ws);
 
+        NamespaceInfoImpl ns = new NamespaceInfoImpl();
+        ns.setId("nsid");
+        ns.setPrefix("ws1");
+        database.add(ns);
+
         Catalog catalog = database.getCatalog();
         DataStoreInfoImpl ds = new DataStoreInfoImpl(catalog);
         ds.setWorkspace(ws);
@@ -198,6 +204,7 @@ public class ConfigDatabaseTest {
 
         ResourceInfo ri = new FeatureTypeInfoImpl(catalog);
         ((FeatureTypeInfoImpl) ri).setId("resourceid");
+        ri.setNamespace(ns);
         ri.setName("ri1");
         ri.setStore(ds);
         ri = database.add(ri);


### PR DESCRIPTION
[![GEOS-10245](https://badgen.net/badge/JIRA/GEOS-10245/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10245)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…ests)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->