### PR TITLE
[GEOS-10263] WPSRequestBuilderTest assumes that JTS:area is the first process in the list

### DIFF
--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSRequestBuilderTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSRequestBuilderTest.java
@@ -11,12 +11,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.wps.ProcessInfo;
+import org.geoserver.wps.WPSInfo;
 import org.junit.Test;
 
 /** @author Martin Davis OpenGeo */
@@ -31,14 +34,19 @@ public class WPSRequestBuilderTest extends GeoServerWicketTestSupport {
 
         tester.assertComponent("form:requestBuilder:process", DropDownChoice.class);
 
+        // Find out what the first process is called
+        
+        WPSInfo wps = getGeoServer().getService(WPSInfo.class);
+        ProcessInfo proc = wps.getProcessGroups().get(0).getFilteredProcesses().get(0);
         // look for JTS area
         DropDownChoice choice =
                 (DropDownChoice)
                         tester.getComponentFromLastRenderedPage("form:requestBuilder:process");
         int index = -1;
         final List choices = choice.getChoices();
+        String name = proc.getName().toString();// "JTS:area";
         for (Object o : choices) {
-            if (o.equals("JTS:area")) {
+          if (o.equals(name)) {
                 index = 0;
                 break;
             }
@@ -52,7 +60,7 @@ public class WPSRequestBuilderTest extends GeoServerWicketTestSupport {
         // print(tester.getComponentFromLastRenderedPage("form"), true, true);
 
         // check process description
-        tester.assertModelValue("form:requestBuilder:process", "JTS:area");
+        tester.assertModelValue("form:requestBuilder:process", name);
         Label label =
                 (Label)
                         tester.getComponentFromLastRenderedPage(

--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSRequestBuilderTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSRequestBuilderTest.java
@@ -33,7 +33,7 @@ import org.opengis.feature.type.Name;
 public class WPSRequestBuilderTest extends GeoServerWicketTestSupport {
 
     @Test
-    public void testJTSAreaWorkflow() throws Exception {
+    public void testFirstProcessWorkflow() throws Exception {
         login();
 
         // start the page
@@ -51,15 +51,15 @@ public class WPSRequestBuilderTest extends GeoServerWicketTestSupport {
             ProcessFactory pf = GeoServerProcessors.getProcessFactory(factoryClass, false);
             for (Name n : pf.getNames()) {
                 names.add(n.toString());
-                // the locale is hard coded in to the panel builder
+                // the locale is hard coded into the panel builder
                 desc.put(n.toString(), pf.getDescription(n).toString(Locale.ENGLISH));
             }
         }
         Collections.sort(names);
-        String name = names.get(0); // "JTS:area";
+        String name = names.get(0); // e.g. "JTS:area";
 
-        String description = desc.get(name); // "area";
-        // look for JTS area
+        String description = desc.get(name); // e.g. "area";
+        // look for first process
         DropDownChoice choice =
                 (DropDownChoice)
                         tester.getComponentFromLastRenderedPage("form:requestBuilder:process");


### PR DESCRIPTION
[![GEOS-10263](https://badgen.net/badge/JIRA/GEOS-10263/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10263)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->