### PR TITLE
[2.19.x backport][GEOS-10257] Features templating UI preview fails on secured layers - [GEOS-10258] Features templating cache might retain orphan templates

### DIFF
--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/FeatureTypeTemplateDAOListener.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/FeatureTypeTemplateDAOListener.java
@@ -58,6 +58,7 @@ public class FeatureTypeTemplateDAOListener implements TemplateDAOListener {
                     TemplateRule r = rule.get();
                     if (!r.getTemplateName().equals(info.getFullName()))
                         r.setTemplateName(info.getFullName());
+                    updateCache(info);
                     rules.removeIf(tr -> tr.getTemplateIdentifier().equals(info.getIdentifier()));
                     rules.add(r);
                     layerConfig.setTemplateRules(rules);
@@ -74,7 +75,7 @@ public class FeatureTypeTemplateDAOListener implements TemplateDAOListener {
     }
 
     private void updateCache(TemplateInfo info) {
-        TemplateLoader loader = GeoServerExtensions.bean(TemplateLoader.class);
+        TemplateLoader loader = TemplateLoader.get();
         loader.cleanCache(fti, info.getIdentifier());
     }
 }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateLoader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateLoader.java
@@ -25,6 +25,7 @@ import org.geoserver.featurestemplating.readers.TemplateReaderConfiguration;
 import org.geoserver.featurestemplating.validation.TemplateValidator;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geotools.data.complex.AppSchemaDataAccessRegistry;
 import org.geotools.data.complex.DataAccessRegistry;
@@ -113,26 +114,26 @@ public class TemplateLoader {
 
     private class CacheKey {
         private FeatureTypeInfo resource;
-        private String path;
+        private String templateIdentifier;
 
-        public CacheKey(FeatureTypeInfo resource, String path) {
+        public CacheKey(FeatureTypeInfo resource, String templateIdentifier) {
             this.resource = resource;
-            this.path = path;
+            this.templateIdentifier = templateIdentifier;
         }
 
         public FeatureTypeInfo getResource() {
             return resource;
         }
 
-        public String getPath() {
-            return path;
+        public String getTemplateIdentifier() {
+            return templateIdentifier;
         }
 
         @Override
         public boolean equals(Object o) {
             if (!(o instanceof CacheKey)) return false;
             CacheKey other = (CacheKey) o;
-            if (!other.getPath().equals(path)) return false;
+            if (!other.getTemplateIdentifier().equals(templateIdentifier)) return false;
             else if (!(other.getResource().getName().equals(resource.getName()))) return false;
             else if (!(other.getResource().getNamespace().equals(resource.getNamespace())))
                 return false;
@@ -141,7 +142,7 @@ public class TemplateLoader {
 
         @Override
         public int hashCode() {
-            return Objects.hash(resource, path);
+            return Objects.hash(resource, templateIdentifier);
         }
     }
 
@@ -193,9 +194,30 @@ public class TemplateLoader {
         return null;
     }
 
+    /**
+     * Remove from the cache the entry with the specified identifier and Feature Type
+     *
+     * @param fti the FeatureType to which is associated the entry.
+     * @param templateIdentifier the templateIdentifier of the cached template.
+     */
     public void cleanCache(FeatureTypeInfo fti, String templateIdentifier) {
         CacheKey key = new CacheKey(fti, templateIdentifier);
         if (templateCache.getIfPresent(key) != null) this.templateCache.invalidate(key);
+    }
+
+    /**
+     * Remove all the cached entries with the specified templateIdentifier.
+     *
+     * @param templateIdentifier the templateIdentifier used to identify the cache entries to
+     *     remove.
+     */
+    public void removeAllWithIdentifier(String templateIdentifier) {
+        Set<CacheKey> keys = templateCache.asMap().keySet();
+        for (CacheKey key : keys) {
+            if (key.getTemplateIdentifier().equals(templateIdentifier)) {
+                templateCache.invalidate(key);
+            }
+        }
     }
 
     private TemplateFileManager getTemplateFileManager() {
@@ -216,11 +238,11 @@ public class TemplateLoader {
                                 + "Exception is: "
                                 + e.getMessage());
             }
-            TemplateInfo templateInfo = TemplateInfoDAO.get().findById(key.getPath());
+            TemplateInfo templateInfo = TemplateInfoDAO.get().findById(key.getTemplateIdentifier());
             Resource resource;
             if (templateInfo != null)
                 resource = getTemplateFileManager().getTemplateResource(templateInfo);
-            else resource = getDataDirectory().get(key.getResource(), key.getPath());
+            else resource = getDataDirectory().get(key.getResource(), key.getTemplateIdentifier());
             Template template = new Template(resource, new TemplateReaderConfiguration(namespaces));
             RootBuilder builder = template.getRootBuilder();
             if (builder != null) {
@@ -230,7 +252,12 @@ public class TemplateLoader {
         }
     }
 
+    /** Invalidate all the cache entries. */
     public void reset() {
         templateCache.invalidateAll();
+    }
+
+    public static TemplateLoader get() {
+        return GeoServerExtensions.bean(TemplateLoader.class);
     }
 }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateService.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateService.java
@@ -1,0 +1,49 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.featurestemplating.configuration;
+
+/**
+ * This class provides the business logic to handle save, update and delete operation on a template.
+ */
+public class TemplateService {
+
+    private TemplateLoader loader;
+    private TemplateFileManager templateFileManager;
+    private TemplateInfoDAO templateInfoDAO;
+
+    public TemplateService() {
+        this.loader = TemplateLoader.get();
+        this.templateFileManager = TemplateFileManager.get();
+        this.templateInfoDAO = TemplateInfoDAO.get();
+    }
+
+    /**
+     * Save or update a Template. Clean the cache from the previous template if necessary.
+     *
+     * @param templateInfo the Template Info to save or update.
+     * @param rawTemplate the raw Template to save or update.
+     */
+    public void saveOrUpdate(TemplateInfo templateInfo, String rawTemplate) {
+        templateFileManager.saveTemplateFile(templateInfo, rawTemplate);
+        TemplateInfo current = templateInfoDAO.findById(templateInfo.getIdentifier());
+        if (current != null && !current.getFullName().equals(templateInfo.getFullName())) {
+            if (templateFileManager.delete(current)) {
+                loader.removeAllWithIdentifier(templateInfo.getIdentifier());
+            }
+        }
+        templateInfoDAO.saveOrUpdate(templateInfo);
+    }
+
+    /**
+     * Delete a Template and removes it from the cache.
+     *
+     * @param templateInfo the Template Info object to delete.
+     */
+    public void delete(TemplateInfo templateInfo) {
+        templateFileManager.delete(templateInfo);
+        loader.removeAllWithIdentifier(templateInfo.getIdentifier());
+        templateInfoDAO.delete(templateInfo);
+    }
+}

--- a/src/community/features-templating/features-templating-rest/src/main/java/org/geoserver/featurestemplating/rest/TemplateRestController.java
+++ b/src/community/features-templating/features-templating-rest/src/main/java/org/geoserver/featurestemplating/rest/TemplateRestController.java
@@ -31,6 +31,7 @@ import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.featurestemplating.configuration.TemplateFileManager;
 import org.geoserver.featurestemplating.configuration.TemplateInfo;
 import org.geoserver.featurestemplating.configuration.TemplateInfoDAO;
+import org.geoserver.featurestemplating.configuration.TemplateService;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.rest.ResourceNotFoundException;
 import org.geoserver.rest.RestBaseController;
@@ -347,8 +348,7 @@ public class TemplateRestController extends AbstractCatalogController {
         try {
             byte[] rawData = IOUtils.toByteArray(inputStream);
             String content = new String(rawData, Charset.defaultCharset());
-            TemplateFileManager.get().saveTemplateFile(info, content);
-            TemplateInfoDAO.get().saveOrUpdate(info);
+            new TemplateService().saveOrUpdate(info, content);
         } catch (IOException e) {
             throw new RestException(
                     "Error while writing the template", HttpStatus.INTERNAL_SERVER_ERROR);
@@ -382,8 +382,7 @@ public class TemplateRestController extends AbstractCatalogController {
         String fullName = buildFullName(ws, featureType, templateName);
         TemplateInfoDAO dao = TemplateInfoDAO.get();
         TemplateInfo info = dao.findByFullName(fullName);
-        TemplateFileManager.get().delete(info);
-        dao.delete(info);
+        new TemplateService().delete(info);
         LOGGER.info("Deleted template with name " + info.getFullName());
     }
 

--- a/src/community/features-templating/features-templating-web/src/main/java/org/geoserver/featurestemplating/web/TemplateConfigurationPage.java
+++ b/src/community/features-templating/features-templating-web/src/main/java/org/geoserver/featurestemplating/web/TemplateConfigurationPage.java
@@ -27,7 +27,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.geoserver.featurestemplating.configuration.TemplateFileManager;
 import org.geoserver.featurestemplating.configuration.TemplateInfo;
-import org.geoserver.featurestemplating.configuration.TemplateInfoDAO;
+import org.geoserver.featurestemplating.configuration.TemplateService;
 import org.geoserver.platform.exception.GeoServerException;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.web.GeoServerSecuredPage;
@@ -207,8 +207,7 @@ public class TemplateConfigurationPage extends GeoServerSecuredPage {
     }
 
     void saveTemplateInfo(TemplateInfo templateInfo, String rawTemplate) {
-        TemplateFileManager.get().saveTemplateFile(templateInfo, rawTemplate);
-        TemplateInfoDAO.get().saveOrUpdate(templateInfo);
+        new TemplateService().saveOrUpdate(templateInfo, rawTemplate);
     }
 
     public CodeMirrorEditor getEditor() {

--- a/src/community/features-templating/features-templating-web/src/main/java/org/geoserver/featurestemplating/web/TemplateInfoPage.java
+++ b/src/community/features-templating/features-templating-web/src/main/java/org/geoserver/featurestemplating/web/TemplateInfoPage.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.featurestemplating.web;
 
+import java.util.List;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxCallListener;
@@ -14,9 +15,9 @@ import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.geoserver.featurestemplating.configuration.FileTemplateDAOListener;
-import org.geoserver.featurestemplating.configuration.TemplateFileManager;
 import org.geoserver.featurestemplating.configuration.TemplateInfo;
 import org.geoserver.featurestemplating.configuration.TemplateInfoDAO;
+import org.geoserver.featurestemplating.configuration.TemplateService;
 import org.geoserver.web.GeoServerSecuredPage;
 import org.geoserver.web.wicket.GeoServerDataProvider;
 import org.geoserver.web.wicket.GeoServerTablePanel;
@@ -96,10 +97,9 @@ public class TemplateInfoPage extends GeoServerSecuredPage {
 
             @Override
             public void onClick(AjaxRequestTarget target) {
-                TemplateInfoDAO dao = TemplateInfoDAO.get();
-                TemplateFileManager fileManager = TemplateFileManager.get();
-                tablePanel.getSelection().forEach(ti -> fileManager.delete(ti));
-                dao.delete(tablePanel.getSelection());
+                TemplateService service = new TemplateService();
+                List<TemplateInfo> templates = tablePanel.getSelection();
+                templates.forEach(ti -> service.delete(ti));
                 tablePanel.modelChanged();
                 target.add(tablePanel);
                 target.add(TemplateInfoPage.this);

--- a/src/community/features-templating/features-templating-web/src/test/java/org/geoserver/featurestemplating/web/TemplateConfigurationPageTest.java
+++ b/src/community/features-templating/features-templating-web/src/test/java/org/geoserver/featurestemplating/web/TemplateConfigurationPageTest.java
@@ -2,19 +2,36 @@ package org.geoserver.featurestemplating.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.http.client.CookieStore;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.protocol.http.mock.MockHttpServletRequest;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.featurestemplating.configuration.SupportedFormat;
+import org.geoserver.featurestemplating.configuration.Template;
 import org.geoserver.featurestemplating.configuration.TemplateFileManager;
 import org.geoserver.featurestemplating.configuration.TemplateInfo;
 import org.geoserver.featurestemplating.configuration.TemplateInfoDAO;
+import org.geoserver.ows.Request;
+import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.GeoServerWicketTestSupport;
 import org.geoserver.web.wicket.CodeMirrorEditor;
 import org.junit.Test;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+
+import java.util.List;
 
 public class TemplateConfigurationPageTest extends GeoServerWicketTestSupport {
 
@@ -218,6 +235,18 @@ public class TemplateConfigurationPageTest extends GeoServerWicketTestSupport {
                     + "      </ul>\n"
                     + "    </li>\n"
                     + "  </ul>\n"
+                    + "</gft:Template>";
+
+
+    private static final String GML_STATIC_TEMPLATE =
+            "<gft:Template>\n"
+                    + "<gft:Options>\n"
+                    + "  <gft:Namespaces xmlns:topp=\"http://www.openplans.org/topp\"/>\n"
+                    + "  <gft:SchemaLocation xsi:schemaLocation=\"http://www.opengis.net/wfs/2.0 http://brgm-dev.geo-solutions.it/geoserver/schemas/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd\"/>\n"
+                    + "</gft:Options>\n"
+                    + "  <theFeature gml:id=\"idVal\">\n"
+                    + "  \t<name>name</name>\n"
+                    + "  </theFeature>\n"
                     + "</gft:Template>";
 
     @Test
@@ -464,5 +493,77 @@ public class TemplateConfigurationPageTest extends GeoServerWicketTestSupport {
         } finally {
             TemplateInfoDAO.get().deleteAll();
         }
+    }
+
+    @Test
+    public void testPreviewRequestCanSendJsessionId() {
+        // tests that the http client requesting a wfs preview
+        // is able to send the JSESSIONID cookie to authenticate the wfs request according to the user
+        // preview the template fromUI.
+        TemplateInfo info = new TemplateInfo();
+        info.setWorkspace("cite");
+        info.setTemplateName("testGMLTemplate");
+        info.setExtension("xml");
+        info = TemplateInfoDAO.get().saveOrUpdate(info);
+        TemplateFileManager.get().saveTemplateFile(info, GML_STATIC_TEMPLATE);
+        try {
+            login();
+            MockHttpServletRequest request=(MockHttpServletRequest) GeoServerApplication.get().servletRequest();
+            RequestAttributes requestAttributes=new ServletRequestAttributes(request);
+            RequestContextHolder.setRequestAttributes(requestAttributes);
+            tester.startPage(new TemplateConfigurationPage(new Model<>(info), false));
+            tester.assertModelValue("theForm:tabbedPanel:panel:templateName", "testGMLTemplate");
+
+            tester.assertModelValue("theForm:tabbedPanel:panel:extension", "xml");
+            tester.assertModelValue("theForm:tabbedPanel:panel:workspace", "cite");
+            tester.assertModelValue("theForm:tabbedPanel:panel:featureTypeInfo", null);
+            tester.clickLink("theForm:tabbedPanel:tabs-container:tabs:1:link");
+            FormTester form2 = tester.newFormTester("theForm:tabbedPanel:panel:previewForm");
+            form2.select("outputFormats", 0);
+            tester.assertComponent(
+                    "theForm:tabbedPanel:panel:previewForm:workspaces", DropDownChoice.class);
+            tester.assertComponent(
+                    "theForm:tabbedPanel:panel:previewForm:featureTypes", DropDownChoice.class);
+            tester.assertComponent(
+                    "theForm:tabbedPanel:panel:previewForm:previewArea", CodeMirrorEditor.class);
+            tester.assertComponent(
+                    "theForm:tabbedPanel:panel:previewForm:preview", AjaxSubmitLink.class);
+            tester.assertComponent(
+                    "theForm:tabbedPanel:panel:previewForm:validate", AjaxSubmitLink.class);
+            DropDownChoice ws =
+                    (DropDownChoice)
+                            tester.getComponentFromLastRenderedPage(
+                                    "theForm:tabbedPanel:panel:previewForm:workspaces");
+            // template is Local to feature type no need to select ws
+            assertFalse(ws.isEnabled());
+
+            DropDownChoice ft =
+                    (DropDownChoice)
+                            tester.getComponentFromLastRenderedPage(
+                                    "theForm:tabbedPanel:panel:previewForm:featureTypes");
+            // template is not Local to feature type is needed select ft
+            assertTrue(ft.isEnabled());
+            form2.select("featureTypes", 0);
+
+            // checks that the JSESSIONID has been picked up by the HttpClient.
+            TemplatePreviewPanel previewPanel=(TemplatePreviewPanel)tester.getComponentFromLastRenderedPage("theForm:tabbedPanel:panel");
+            List<Cookie> httpCookies=getCookiesFromPreviewRequest(previewPanel);
+            Cookie cookie=httpCookies.stream().filter(c->c.getName().equals("JSESSIONID")).findFirst().get();
+            assertNotNull(cookie);
+            assertEquals(requestAttributes.getSessionId(),cookie.getValue());
+
+
+            tester.newFormTester("theForm").submit("save");
+            tester.assertNoErrorMessage();
+            tester.assertRenderedPage(TemplateInfoPage.class);
+        } finally {
+            TemplateInfoDAO.get().deleteAll();
+        }
+    }
+
+    private List<Cookie> getCookiesFromPreviewRequest(TemplatePreviewPanel previewPanel){
+            CookieStore cookieStore=new PropertyModel<CookieStore>(previewPanel.buildHttpClient(),"cookieStore").getObject();
+            return cookieStore.getCookies();
+
     }
 }


### PR DESCRIPTION
[![GEOS-10257](https://badgen.net/badge/JIRA/GEOS-10257/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10257)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->