### PR TITLE
Remove setFinalStaticField and use new setter

### DIFF
--- a/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSNetCDFTest.java
+++ b/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSNetCDFTest.java
@@ -67,20 +67,6 @@ public class WCSNetCDFTest extends WCSNetCDFBaseTest {
         super.setUpTestData(testData);
     }
 
-    private void setFinalStaticField(String fieldName, boolean value)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException,
-                    IllegalAccessException {
-        // Playing with System.Properties and Static boolean fields can raises issues
-        // when running Junit tests via Maven, due to initialization orders.
-        // So let's change the fields via reflections for these tests
-        Field field = NetCDFCRSUtilities.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(null, value);
-    }
-
     @Override
     @SuppressWarnings("unchecked")
     protected GetCoverageType parse(String url) throws Exception {
@@ -533,7 +519,7 @@ public class WCSNetCDFTest extends WCSNetCDFBaseTest {
 
     @Test
     public void testKmAxisUnitSupport() throws Exception {
-        setFinalStaticField("CONVERT_AXIS_KM", false);
+        NetCDFCRSUtilities.setConvertAxisKm(false);
         MockHttpServletResponse response =
                 getAsServletResponse(
                         "ows?request=GetCoverage&service=WCS&version=2.0.1"


### PR DESCRIPTION
This removes the use of reflection to override a static final in geotools, which is forbidden since Java 12, and instead uses new public API introduced in geotools PR https://github.com/geotools/geotools/pull/3612.