### PR TITLE
[GEOS-9950] LayerPreview use format string if translation not available

### DIFF
--- a/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
@@ -275,11 +275,18 @@ public class MapPreviewPage extends GeoServerBasePage {
         return f;
     }
 
+    /**
+     * Translate format (if translation available).
+     *
+     * @param prefix protocol
+     * @param format output format
+     * @return format translation (defaults to format if unavailable)
+     */
     private String translateFormat(String prefix, String format) {
         try {
             return getLocalizer().getString(prefix + format, this);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e.getMessage());
+            LOGGER.log(Level.FINE, e.getMessage());
             return format;
         }
     }

--- a/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
+++ b/src/web/demo/src/test/java/org/geoserver/web/demo/MapPreviewPageTest.java
@@ -18,8 +18,10 @@ import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.markup.repeater.data.DataView;
 import org.apache.wicket.util.tester.TagTester;
+import org.apache.wicket.util.visit.IVisitor;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -240,6 +242,20 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
                     assertEquals(
                             kmlLink.getDefaultModelObjectAsString(),
                             "http://localhost/context/cite/wms/kml?layers=cite%3ALakes%20%2B%20a%20plus");
+
+                    // check formats
+                    RepeatingView wmsFormats =
+                            (RepeatingView) c.get("itemProperties:4:component:menu:wms:wmsFormats");
+                    if (wmsFormats != null) {
+                        assertFormat(wmsFormats, "JPEG-PNG", true);
+                    }
+
+                    RepeatingView wfsFormats =
+                            (RepeatingView) c.get("itemProperties:4:component:menu:wfs:wfsFormats");
+                    if (wfsFormats != null) {
+                        assertFormat(wfsFormats, "CSV", true);
+                        assertFormat(wfsFormats, "text/csv", true);
+                    }
                 }
             }
             assertTrue("Could not find layer with expected name", exists);
@@ -263,6 +279,19 @@ public class MapPreviewPageTest extends GeoServerWicketTestSupport {
             ft.setName("Lines");
             catalog.save(ft);
         }
+    }
+
+    private void assertFormat(RepeatingView view, String format, boolean expected) {
+        Boolean found =
+                view.visitChildren(
+                        Label.class,
+                        (IVisitor<Label, Boolean>)
+                                (label, visit) -> {
+                                    if (label.getDefaultModelObjectAsString().contains(format)) {
+                                        visit.stop(true);
+                                    }
+                                });
+        assertEquals(format, expected, found == null ? false : found);
     }
 
     /** Test for layer group service support check */


### PR DESCRIPTION
[![GEOS-9950](https://badgen.net/badge/JIRA/GEOS-9950/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9950)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This avoids filling up the logs if a localization is not available for a given output format.

Experimented with skipping output formats that did not have a localization, but that was not fair to third-party output formats being developed. 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue https://osgeo-org.atlassian.net/browse/GEOS-9950
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).