### PR TITLE
[GEOS-10266] Features Templating makes getfeatureinfo fail for raster data

### DIFF
--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/TemplateCallback.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/TemplateCallback.java
@@ -193,7 +193,7 @@ public class TemplateCallback extends AbstractDispatcherCallback {
                 TemplateIdentifier.fromOutputFormat(request.getInfoFormat());
         int nTemplates = 0;
         for (MapLayerInfo li : layerInfos) {
-            if (li != null) {
+            if (li != null && li.getResource() instanceof FeatureTypeInfo) {
                 if (ensureTemplatesExist(li.getFeature(), identifier.getOutputFormat()) != null)
                     nTemplates++;
             }

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/GetFeatureInfoGroupTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/GetFeatureInfoGroupTest.java
@@ -418,4 +418,16 @@ public class GetFeatureInfoGroupTest extends WMSTestSupport {
         assertEquals("I'm a lake", lakeAttr);
         assertEquals("I'm a forest", forestAttr);
     }
+
+    @Test
+    public void testGetFeatureInfoCoverageNotFails() throws Exception {
+        String url =
+                "wms?service=wms&version=1.1.1"
+                        + "&layers=wcs:World&width=100&height=100&format=image/png"
+                        + "&srs=epsg:4326&bbox=-180,-90,180,90&info_format=application/json"
+                        + "&request=GetFeatureInfo&query_layers=wcs:World&x=50&y=50";
+        JSONObject result = (JSONObject) getAsJSON(url);
+        assertNotNull(result);
+        assertEquals(6, result.size());
+    }
 }


### PR DESCRIPTION
[![GEOS-10266](https://badgen.net/badge/JIRA/GEOS-10266/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10266)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->