### PR TITLE
[GEOS-10268] null support for feature templating

### DIFF
--- a/doc/en/user/source/community/features-templating/directives.rst
+++ b/doc/en/user/source/community/features-templating/directives.rst
@@ -46,6 +46,9 @@ The following are the directives available in JSON based templates.
    * - allows a template to extend another template
      - $merge
      - specify the :code:`$merge` directive as an attribute name containing the path to the extended template (:code: `"$merged":"base_template.json"`)
+   * - allows null values to be encoded. default is not encoded.
+     - ${property}!
+     - specify it with ! at the end of dynamic property (:code:`"json_attribute":"${property}!"`)
 
 
 XML based templates
@@ -80,6 +83,9 @@ The following are the directives available in XML based templates.
    * - allows including a template into another
      - $include, gft:includeFlat
      - specify the :code:`$include` option as an element value (:code:`<element>$include{included.xml}</element>`) and the :code:`gft:includeFlat` as an element having the included template as text content (:code:`<gft:includeFlat>included.xml</gft:includeFlat>`)
+   * - allows null values to be encoded. default is not encoded.
+     - ${property}!
+     - specify it either as an element value (:code:`<element>${property}!</element>`) or as an xml attribute value (:code:`<element attribute:"${property}!"/>`)
 
 A step by step introduction to features-templating syntax
 ---------------------------------------------------------

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/IteratingBuilder.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/IteratingBuilder.java
@@ -60,7 +60,7 @@ public class IteratingBuilder extends SourceBuilder {
             boolean isArray = o != null && o.getClass().isArray();
             // if this is not a context as list and we don't have
             // iterate key hint we start the array and encode the key once here
-            if (!iterateKey && hasOwnOutput()) writer.startArray(key, encodingHints);
+            if (!iterateKey && hasOwnOutput()) writer.startArray(key, this.encodingHints);
 
             if (isList) {
                 evaluateCollection(
@@ -72,7 +72,7 @@ public class IteratingBuilder extends SourceBuilder {
                 evaluateInternal(writer, context, iterateKey);
             }
 
-            if (!iterateKey && hasOwnOutput()) writer.endArray(key, encodingHints);
+            if (!iterateKey && hasOwnOutput()) writer.endArray(key, this.encodingHints);
         }
     }
 

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/GMLTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/GMLTemplateReader.java
@@ -58,7 +58,8 @@ public class GMLTemplateReader extends XMLRecursiveTemplateReader {
 
     @Override
     protected void addVendorOption(StartElement element, RootBuilder builder) {
-        if (element.getName().toString().equals(NAME_SPACES_EL)) {
+        String elementName = element.getName().toString();
+        if (elementName.equals(NAME_SPACES_EL)) {
             Iterator<Attribute> attributeIterator = element.getAttributes();
             Map<String, String> namespaces = new HashMap<>();
             while (attributeIterator.hasNext()) {
@@ -67,15 +68,14 @@ public class GMLTemplateReader extends XMLRecursiveTemplateReader {
                 if (isNamespace(name)) namespaces.put(localPart(name), attr.getValue());
             }
             if (!namespaces.isEmpty())
-                ((RootBuilder) builder).addVendorOption(VendorOptions.NAMESPACES, namespaces);
-        } else if (element.getName().toString().equals(SCHEMA_LOCATION_EL)) {
+                builder.addVendorOption(VendorOptions.NAMESPACES, namespaces);
+        } else if (elementName.equals(SCHEMA_LOCATION_EL)) {
             Iterator<Attribute> attributeIterator = element.getAttributes();
             if (attributeIterator.hasNext()) {
                 Attribute attribute = attributeIterator.next();
                 QName name = attribute.getName();
                 if (isSchemaLocation(name)) {
-                    ((RootBuilder) builder)
-                            .addVendorOption(VendorOptions.SCHEMA_LOCATION, attribute.getValue());
+                    builder.addVendorOption(VendorOptions.SCHEMA_LOCATION, attribute.getValue());
                 }
             }
         }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
@@ -241,7 +241,6 @@ public class JSONTemplateReader implements TemplateReader {
                     new TemplateCQLManager(node.get(SEPARATOR).asText(), null);
             builder.addVendorOption(VendorOptions.SEPARATOR, cqlManager.getExpressionFromString());
         }
-
         if (node.has(CONTEXTKEY)) {
             builder.addVendorOption(CONTEXTKEY, node.get(CONTEXTKEY));
         }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/XMLRecursiveTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/XMLRecursiveTemplateReader.java
@@ -114,7 +114,7 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
                     // a self closing element, that did not start a new iteration.
                     // Builders are then created here and this iteration will not stop
                     while (!elementsStack.isEmpty()) {
-                        templateBuilderFromElement(elementsStack.pop(), builder);
+                        templateBuilderFromElement(elementsStack.pop(), builder, true);
                     }
                     if (!endElement.getName().toString().equals(INCLUDE_FLAT) && stopIteration)
                         break;
@@ -133,7 +133,8 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
             builderFromIncludedTemplate(resource, data, currentParent);
         } else if (data.startsWith(INCLUDE + "{") && data.endsWith("}")) {
             String path = data.substring(INCLUDE.length() + 1, data.length() - 1);
-            TemplateBuilder parentForIncluded = templateBuilderFromElement(element, currentParent);
+            TemplateBuilder parentForIncluded =
+                    templateBuilderFromElement(element, currentParent, false);
             builderFromIncludedTemplate(resource, path, parentForIncluded);
         } else {
             TemplateBuilder leafBuilder;
@@ -168,13 +169,13 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
     private TemplateBuilder getBuilderFromLastElInStack(TemplateBuilder currentParent) {
         StartElement previous = !elementsStack.isEmpty() ? elementsStack.pop() : null;
         if (previous != null) {
-            currentParent = templateBuilderFromElement(previous, currentParent);
+            currentParent = templateBuilderFromElement(previous, currentParent, false);
         }
         return currentParent;
     }
 
     private TemplateBuilder templateBuilderFromElement(
-            StartElement startElement, TemplateBuilder currentParent) {
+            StartElement startElement, TemplateBuilder currentParent, boolean emptyNode) {
         if (startElement != null) {
             String isCollection = getAttributeValueIfPresent(startElement, COLLECTION_ATTR);
             String stringName = startElement.getName().toString();
@@ -188,6 +189,9 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
                     .source(getAttributeValueIfPresent(startElement, SOURCE_ATTR))
                     .hasOwnOutput(hasOwnOutput)
                     .topLevelFeature(isRootOrManaged(currentParent));
+            if (emptyNode) {
+                maker.textContent("");
+            }
             if (collection) {
                 maker.encodingOption(ITERATE_KEY, "true");
             }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/CommonJSONWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/CommonJSONWriter.java
@@ -121,11 +121,15 @@ public abstract class CommonJSONWriter extends TemplateOutputWriter {
             generator.writeNumber(valueNode.asInt());
         } else if (valueNode.isBoolean()) {
             generator.writeBoolean(valueNode.asBoolean());
+        } else if (valueNode.isNull()) {
+            generator.writeNull();
         }
     }
 
     public void writeValue(Object value) throws IOException {
-        if (value instanceof String) {
+        if (value == null || value.equals("null")) {
+            generator.writeNull();
+        } else if (value instanceof String) {
             generator.writeString((String) value);
         } else if (value instanceof Integer) {
             generator.writeNumber((Integer) value);

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
@@ -161,6 +161,9 @@ public abstract class XMLTemplateWriter extends TemplateOutputWriter {
                         writeElementNameAndValue(key, list.get(i), encodingHints);
                     }
                 }
+            } else if (elementValue == null) {
+                streamWriter.writeCharacters("");
+                canClose = true;
             }
         } catch (XMLStreamException e) {
             throw new IOException(e);

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/builders/impl/DynamicValueBuilderTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/builders/impl/DynamicValueBuilderTest.java
@@ -23,11 +23,18 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.HashMap;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
+import org.geoserver.featurestemplating.writers.GMLTemplateWriter;
 import org.geoserver.featurestemplating.writers.GeoJSONWriter;
 import org.geotools.data.DataTestCase;
 import org.geotools.factory.CommonFactoryFinder;
@@ -50,7 +57,7 @@ import org.xml.sax.helpers.NamespaceSupport;
 
 public class DynamicValueBuilderTest extends DataTestCase {
 
-    private static final String JSON_PAYLOAD = "{ \"a\": 1, \"b\": [1, 2, 3]}";
+    private static final String JSON_PAYLOAD = "{ \"a\": 1, \"c\": null, \"b\": [1, 2, 3]}";
     private SimpleFeature jsonFieldSimpleFeature;
     private Feature jsonFieldComplexFeature;
 
@@ -65,6 +72,18 @@ public class DynamicValueBuilderTest extends DataTestCase {
         SimpleFeatureBuilder fb = new SimpleFeatureBuilder(schema);
         fb.add(JSON_PAYLOAD);
         jsonFieldSimpleFeature = fb.buildFeature("jsonFieldSimpleType.1");
+    }
+
+    public SimpleFeature setupNullSimpleFeature() {
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.userData(JDBCDataStore.JDBC_NATIVE_TYPENAME, "json");
+        tb.add("nullAttribute", String.class);
+        tb.setName("nullFeatureType");
+        SimpleFeatureType schema = tb.buildFeatureType();
+
+        SimpleFeatureBuilder fb = new SimpleFeatureBuilder(schema);
+        fb.add(null);
+        return fb.buildFeature("nullType.1");
     }
 
     @Before
@@ -91,34 +110,49 @@ public class DynamicValueBuilderTest extends DataTestCase {
 
     @Test
     public void testEncodePath() throws IOException {
-        JSONObject json = encodeDynamic("${id}", roadFeatures[0]);
+        JSONObject json = encodeDynamic("${id}", roadFeatures[0], false);
         assertEquals(1, json.size());
         assertEquals("1", json.getString("key"));
     }
 
     @Test
     public void testEncodeNullPath() throws IOException {
-        JSONObject json = encodeDynamic("${missingAttribute}", roadFeatures[0]);
+        JSONObject json = encodeDynamic("${missingAttribute}", roadFeatures[0], false);
         assertTrue(json.isEmpty());
     }
 
     @Test
     public void testEncodeNullCQL() throws IOException {
-        JSONObject json = encodeDynamic("${a + b}", roadFeatures[0]);
+        JSONObject json = encodeDynamic("${a + b}", roadFeatures[0], false);
         assertTrue(json.isEmpty());
     }
 
     @Test
     public void testJSONXPathSimpleFeature() throws Exception {
-        JSONObject json = encodeDynamic("${jf}", jsonFieldSimpleFeature);
+        JSONObject json = encodeDynamic("${jf}", jsonFieldSimpleFeature, false);
         JSONObject obj = json.getJSONObject("key");
         assertEquals(1, obj.getInt("a"));
         assertEquals(Arrays.asList(1, 2, 3), obj.getJSONArray("b"));
     }
 
     @Test
+    public void testJSONXPathEncodeNull() throws Exception {
+        JSONObject json = encodeDynamic("${jf}", jsonFieldSimpleFeature, true);
+        JSONObject obj = json.getJSONObject("key");
+        assertEquals("null", obj.get("c").toString());
+        assertEquals(JSONNull.class, obj.get("c").getClass());
+    }
+
+    @Test
+    public void testXMLXPathEncodeNull() throws Exception {
+        SimpleFeature nullFeature = setupNullSimpleFeature();
+        String xml = encodeXML("${nullAttribute}!", nullFeature);
+        assertEquals(xml, "<key></key>");
+    }
+
+    @Test
     public void testJSONXPathComplexFeature() throws Exception {
-        JSONObject json = encodeDynamic("${jf}", jsonFieldComplexFeature);
+        JSONObject json = encodeDynamic("${jf}", jsonFieldComplexFeature, false);
         JSONObject obj = json.getJSONObject("key");
         assertEquals(1, obj.getInt("a"));
         assertEquals(Arrays.asList(1, 2, 3), obj.getJSONArray("b"));
@@ -126,7 +160,7 @@ public class DynamicValueBuilderTest extends DataTestCase {
 
     @Test
     public void testJSONCQLSimpleFeature() throws Exception {
-        JSONObject json = encodeDynamic("$${jf}", jsonFieldSimpleFeature);
+        JSONObject json = encodeDynamic("$${jf}", jsonFieldSimpleFeature, false);
         JSONObject obj = json.getJSONObject("key");
         assertEquals(1, obj.getInt("a"));
         assertEquals(Arrays.asList(1, 2, 3), obj.getJSONArray("b"));
@@ -134,7 +168,7 @@ public class DynamicValueBuilderTest extends DataTestCase {
 
     @Test
     public void testJSONCQLComplexFeature() throws Exception {
-        JSONObject json = encodeDynamic("$${jf}", jsonFieldComplexFeature);
+        JSONObject json = encodeDynamic("$${jf}", jsonFieldComplexFeature, false);
         JSONObject obj = json.getJSONObject("key");
         assertEquals(1, obj.getInt("a"));
         assertEquals(Arrays.asList(1, 2, 3), obj.getJSONArray("b"));
@@ -142,12 +176,14 @@ public class DynamicValueBuilderTest extends DataTestCase {
 
     @Test
     public void testJSONPointer() throws Exception {
-        JSONObject json = encodeDynamic("$${jsonPointer(jf, '/b')}", jsonFieldComplexFeature);
+        JSONObject json =
+                encodeDynamic("$${jsonPointer(jf, '/b')}", jsonFieldComplexFeature, false);
         JSONArray obj = json.getJSONArray("key");
         assertEquals(Arrays.asList(1, 2, 3), obj);
     }
 
-    private JSONObject encodeDynamic(String expression, Feature feature) throws IOException {
+    private JSONObject encodeDynamic(String expression, Feature feature, boolean encodeNull)
+            throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         GeoJSONWriter writer =
                 new GeoJSONWriter(
@@ -156,6 +192,10 @@ public class DynamicValueBuilderTest extends DataTestCase {
 
         DynamicValueBuilder builder =
                 new DynamicValueBuilder("key", expression, new NamespaceSupport());
+        if (encodeNull) {
+            builder.addEncodingHint("ENCODE_NULL", true);
+        }
+
         writer.writeStartObject();
         builder.evaluate(writer, new TemplateBuilderContext(feature));
         writer.writeEndObject();
@@ -164,5 +204,29 @@ public class DynamicValueBuilderTest extends DataTestCase {
         // nothing has been encoded
         String jsonString = new String(baos.toByteArray());
         return (JSONObject) JSONSerializer.toJSON(jsonString);
+    }
+
+    private String encodeXML(String expression, Feature feature) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GMLTemplateWriter outputWriter = getGmlWriter(TemplateIdentifier.GML31, baos);
+
+        DynamicValueBuilder builder =
+                new DynamicValueBuilder("key", expression, new NamespaceSupport());
+        builder.addEncodingHint("ENCODE_NULL", true);
+        builder.evaluate(outputWriter, new TemplateBuilderContext(feature));
+        outputWriter.close();
+
+        // nothing has been encoded
+        return new String(baos.toByteArray());
+    }
+
+    private GMLTemplateWriter getGmlWriter(TemplateIdentifier identifier, OutputStream out)
+            throws XMLStreamException {
+        XMLOutputFactory xMLOutputFactory = XMLOutputFactory.newInstance();
+        XMLStreamWriter xMLStreamWriter = xMLOutputFactory.createXMLStreamWriter(out);
+        GMLTemplateWriter outputWriter =
+                new GMLTemplateWriter(xMLStreamWriter, identifier.getOutputFormat());
+        outputWriter.addNamespaces(new HashMap<>());
+        return outputWriter;
     }
 }

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGML32.xml
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGML32.xml
@@ -16,6 +16,7 @@
             <gsml:GeologicUnit gft:source="gsml:GeologicUnit" gft:isCollection="true">
                 <gml:description xlink:href="http://static_content.org">${gml:description}</gml:description>
                 <gml:name>${gml:name}</gml:name>
+                <gml:emptyText></gml:emptyText>
                 <gsml:staticContent xlink:title="${gml:name[0]}">static content</gsml:staticContent>
                 <gsml:purpose>${gsml:purpose}</gsml:purpose>
                 <gsml:composition gft:source="gsml:composition/gsml:CompositionPart" gft:isCollection="true">

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGeoJSON.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGeoJSON.json
@@ -65,5 +65,7 @@
   "geometry": {
     "@type": "Polygon",
     "wkt": "$${toWKT(xpath('gsml:shape'))}"
-  }
+  },
+  "nullObject": null,
+  "nullText": null
 }

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureJSONLD.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureJSONLD.json
@@ -86,5 +86,7 @@
   "geometry": {
     "@type": "Polygon",
     "wkt": "$${toWKT(xpath('gsml:shape'))}"
-  }
+  },
+  "nullObject": null,
+  "nullText": null
 }

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/TemplateCallback.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/TemplateCallback.java
@@ -193,7 +193,7 @@ public class TemplateCallback extends AbstractDispatcherCallback {
                 TemplateIdentifier.fromOutputFormat(request.getInfoFormat());
         int nTemplates = 0;
         for (MapLayerInfo li : layerInfos) {
-            if (li != null) {
+            if (li != null && li.getResource() instanceof FeatureTypeInfo) {
                 if (ensureTemplatesExist(li.getFeature(), identifier.getOutputFormat()) != null)
                     nTemplates++;
             }

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/ComplexGetFeatureInfoTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/ComplexGetFeatureInfoTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -135,6 +136,10 @@ public class ComplexGetFeatureInfoTest extends TemplateComplexTestSupport {
         assertEquals(1, features.size());
         JSONObject feature = (JSONObject) features.get(0);
         checkMappedFeatureJSON(feature);
+        assertEquals(feature.get("nullObject").toString(), "null");
+        assertEquals(feature.get("nullText").toString(), "null");
+        assertEquals(JSONNull.class, feature.get("nullObject").getClass());
+        assertEquals(JSONNull.class, feature.get("nullText").getClass());
     }
 
     @Test
@@ -147,6 +152,8 @@ public class ComplexGetFeatureInfoTest extends TemplateComplexTestSupport {
         assertEquals(1, features.size());
         JSONObject feature = (JSONObject) features.get(0);
         checkMappedFeatureJSON(feature);
+        assertEquals(feature.get("nullObject").toString(), "null");
+        assertEquals(feature.get("nullText").toString(), "null");
     }
 
     @Test
@@ -175,6 +182,8 @@ public class ComplexGetFeatureInfoTest extends TemplateComplexTestSupport {
 
         // filter on array element lithology
         assertXpathCount(1, "//gsml:lithology", doc);
+        assertXpathCount(1, "//gml:emptyText", doc);
+        assertXpathEvaluatesTo("", "//gml:emptyText", doc);
     }
 
     protected AbstractAppSchemaMockData createTestData() {

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/GetFeatureInfoGroupTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/GetFeatureInfoGroupTest.java
@@ -418,4 +418,16 @@ public class GetFeatureInfoGroupTest extends WMSTestSupport {
         assertEquals("I'm a lake", lakeAttr);
         assertEquals("I'm a forest", forestAttr);
     }
+
+    @Test
+    public void testGetFeatureInfoCoverageNotFails() throws Exception {
+        String url =
+                "wms?service=wms&version=1.1.1"
+                        + "&layers=wcs:World&width=100&height=100&format=image/png"
+                        + "&srs=epsg:4326&bbox=-180,-90,180,90&info_format=application/json"
+                        + "&request=GetFeatureInfo&query_layers=wcs:World&x=50&y=50";
+        JSONObject result = (JSONObject) getAsJSON(url);
+        assertNotNull(result);
+        assertEquals(6, result.size());
+    }
 }


### PR DESCRIPTION
[![GEOS-10268](https://badgen.net/badge/JIRA/GEOS-10268/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10268)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Null support for the feature template is added.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->