### PR TITLE
docs: Referenced where WEB-INF is located

### DIFF
--- a/doc/en/user/source/styling/css/install.rst
+++ b/doc/en/user/source/styling/css/install.rst
@@ -11,7 +11,7 @@ The installation process is similar to other GeoServer extensions:
    
    Verify that the version number in the filename corresponds to the version of GeoServer you are running (for example |release| above).
 
-#. Extract the contents of the archive into the :file:`WEB-INF/lib` directory in GeoServer.
+#. Extract the contents of the archive into the :file:`WEB-INF/lib` directory in GeoServer, which can be found in :file:`/usr/local/tomcat/webapps/geoserver` in the docker container.
    Make sure you do not create any sub-directories during the extraction process.
 
 #. Restart GeoServer.


### PR DESCRIPTION
I looked over the styling guide and was very confused where `WEB-INF` was supposed to be at first. This might be common knowledge for anyone deeper in `geoserver`, but I haven't come across this information before. Feel free to change the wording if you don't want to reference docker like this.

# Checklist
- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
     - You have my permission to do what you want with these changes -- fkarg
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [N/A] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [N/A] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [N/A] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [N/A] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [N/A] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [N/A] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).