### PR TITLE
[GEOS-10277] Add a special keyword for semi-colon as a CSV Separator …

### DIFF
--- a/doc/en/user/source/services/wfs/outputformats.rst
+++ b/doc/en/user/source/services/wfs/outputformats.rst
@@ -147,3 +147,8 @@ csv file output ``format_options``:
 * ``format_option=filename:<file>``: if a file name is provided, the name is used as the output file name. For example, ``format_options=filename:roads.csv``.
 * ``format_option=csvseparator:<csvseparator>`` (default is ```,``` ): if a separator is provided, it is used to separate values in output csv file. For example, ``format_options=csvseparator:-`` is used to get dash separated file.
 
+Some special characters need to be handled using keywords as below:
+
+* space separated: ``format_options=csvseparator:space``
+* tab separated: ``format_options=csvseparator:tab``
+* semicolon separated: ``format_options=csvseparator:semicolon``

--- a/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/CSVOutputFormat.java
@@ -233,6 +233,8 @@ public class CSVOutputFormat extends WFSGetFeatureOutputFormat {
             separator = " ";
         } else if (separator.equalsIgnoreCase("tab")) {
             separator = "\t";
+        } else if (separator.equalsIgnoreCase("semicolon")) {
+            separator = ";";
         } else if (separator.equals("\"")) {
             throw new InvalidParameterException("A double quote is not allowed as a CSV separator");
         }

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
@@ -257,4 +257,40 @@ public class CSVOutputFormatTest extends WFSTestSupport {
                 "A double quote is not allowed as a CSV separator",
                 invalidParameterException.getMessage());
     }
+
+    @Test
+    public void testSemicolonAsCsvSeparator() throws Exception {
+
+        String separator = "semicolon";
+
+        // Get semicolon separated csv response
+        MockHttpServletResponse resp =
+                getAsServletResponse(
+                        "wfs?version=1.1.0&request=GetFeature&typeName=sf:PrimitiveGeoFeature&outputFormat=csv&format_options=csvSeparator:"
+                                + separator,
+                        "");
+
+        FeatureSource fs = getFeatureSource(MockData.PRIMITIVEGEOFEATURE);
+
+        // check the mime type
+        assertEquals("text/csv", resp.getContentType());
+
+        // check the charset encoding
+        assertEquals("UTF-8", resp.getCharacterEncoding());
+
+        // check the content disposition
+        assertEquals(
+                "attachment; filename=PrimitiveGeoFeature.csv",
+                resp.getHeader("Content-Disposition"));
+
+        List<String[]> lines = readLines(resp.getContentAsString(), ';');
+
+        // we should have one header line and then all the features in that feature type
+        assertEquals(fs.getCount(Query.ALL) + 1, lines.size());
+
+        for (String[] line : lines) {
+            // check each line has the expected number of elements (num of att + 1 for the id)
+            assertEquals(fs.getSchema().getDescriptors().size() + 1, line.length);
+        }
+    }
 }


### PR DESCRIPTION
[![GEOS-10277](https://badgen.net/badge/JIRA/GEOS-10277/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10277)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->