### PR TITLE
Docs: fix empty placeholder in search field

### DIFF
--- a/doc/en/themes/geoserver/layout.html
+++ b/doc/en/themes/geoserver/layout.html
@@ -111,7 +111,7 @@
             <fieldset>
                 <input type="hidden" name="check_keywords" value="yes" />
                 <input type="hidden" name="area" value="default" />
-                <input id="quick-search-query" type="text" name="q" accessKey="q" name="searchQuery.queryString" size="25" value="Search {{ manual|e }}&hellip;" size="20" tabindex="3" onblur="if(this.value=='') this.value='Search {{ manual|e }}&hellip;';" onfocus="if(this.value=='Search Documentation&hellip;') this.value='';" />
+                <input id="quick-search-query" type="text" name="q" accessKey="q" name="searchQuery.queryString" size="25" size="20" tabindex="3" placeholder="Search {{ manual|e }}&hellip;" />
                 <input id="quick-search-submit" type="image" value="Search" src="{{ pathto('_static/chrome/search_icon_green.png', 1)}}" />
             </fieldset>
         </form>


### PR DESCRIPTION
Currently the placeholder behaviour in the doc search is broken because of a bug in the javascript:

https://user-images.githubusercontent.com/59874/138251104-5aadb004-85ab-47ea-bfa2-bd26298f66b8.mp4

Fix this by:

1. not preseeding the `value` attribute at all
2. replace the javascript for placeholder text with the HTML `placeholder` attribute which does the same thing natively

https://user-images.githubusercontent.com/59874/138251958-173b72d6-4fc6-4ce3-9617-151670384ea6.mp4


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

(n/a)