### PR TITLE
[2.19.x backport][GEOS-10273] GeofenceAccesManager throws index out of bound when requesting nested layerGroups

### DIFF
--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceWMSTestSupport.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceWMSTestSupport.java
@@ -1,0 +1,103 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.integration;
+
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.geofence.core.model.Rule;
+import org.geoserver.geofence.core.model.RuleLimits;
+import org.geoserver.geofence.core.model.enums.CatalogMode;
+import org.geoserver.geofence.core.model.enums.GrantType;
+import org.geoserver.geofence.core.model.enums.SpatialFilterType;
+import org.geoserver.geofence.services.RuleAdminService;
+import org.geoserver.wms.WMSTestSupport;
+import org.junit.Before;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+public class GeofenceWMSTestSupport extends WMSTestSupport {
+
+    protected RuleAdminService ruleService;
+
+    @Before
+    public void before() {
+        ruleService = (RuleAdminService) applicationContext.getBean("ruleAdminService");
+    }
+
+    static long addRule(
+            GrantType access,
+            String username,
+            String roleName,
+            String service,
+            String request,
+            String workspace,
+            String layer,
+            long priority,
+            RuleAdminService ruleService) {
+
+        Rule rule = new Rule();
+        rule.setAccess(access);
+        rule.setUsername(username);
+        rule.setRolename(roleName);
+        rule.setService(service);
+        rule.setRequest(request);
+        rule.setWorkspace(workspace);
+        rule.setLayer(layer);
+        rule.setPriority(priority);
+        return ruleService.insert(rule);
+    }
+
+    static void addRuleLimits(
+            long ruleId,
+            CatalogMode mode,
+            String allowedArea,
+            Integer srid,
+            RuleAdminService ruleService)
+            throws ParseException {
+        addRuleLimits(ruleId, mode, allowedArea, srid, null, ruleService);
+    }
+
+    static void addRuleLimits(
+            long ruleId,
+            CatalogMode mode,
+            String allowedArea,
+            Integer srid,
+            SpatialFilterType spatialFilterType,
+            RuleAdminService ruleService)
+            throws org.locationtech.jts.io.ParseException {
+        RuleLimits limits = new RuleLimits();
+        limits.setCatalogMode(mode);
+        MultiPolygon allowedAreaGeom = (MultiPolygon) new WKTReader().read(allowedArea);
+        if (srid != null) allowedAreaGeom.setSRID(srid);
+        limits.setAllowedArea(allowedAreaGeom);
+        if (spatialFilterType == null) spatialFilterType = SpatialFilterType.INTERSECT;
+        limits.setSpatialFilterType(spatialFilterType);
+        ruleService.setLimits(ruleId, limits);
+    }
+
+    static void deleteRules(RuleAdminService ruleService, Long... ids) {
+        for (Long id : ids) {
+            if (id != null) ruleService.delete(id);
+        }
+    }
+
+    protected LayerGroupInfo addLakesPlacesLayerGroup(LayerGroupInfo.Mode mode, String name)
+            throws Exception {
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        LayerGroupInfo group = createLakesPlacesLayerGroup(getCatalog(), name, mode, null);
+        logout();
+        return group;
+    }
+
+    protected void removeLayerGroup(LayerGroupInfo... groups) {
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        for (LayerGroupInfo group : groups) {
+            if (group != null) {
+                getCatalog().remove(group);
+            }
+        }
+        logout();
+    }
+}

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GetLegendGraphicGeofenceTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GetLegendGraphicGeofenceTest.java
@@ -1,0 +1,55 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.geofence.integration;
+
+import static org.geoserver.geofence.integration.GeofenceGetMapIntegrationTest.deleteRules;
+import static org.junit.Assert.assertEquals;
+
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.geofence.core.model.enums.GrantType;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class GetLegendGraphicGeofenceTest extends GeofenceWMSTestSupport {
+
+    @Test
+    public void testLegendGraphicNestedGroups() throws Exception {
+        Long ruleId1 = null;
+        LayerGroupInfo group = null;
+        LayerGroupInfo nested = null;
+        try {
+            ruleId1 = addRule(GrantType.ALLOW, null, null, null, null, null, null, 1, ruleService);
+
+            addLakesPlacesLayerGroup(LayerGroupInfo.Mode.SINGLE, "nested");
+
+            addLakesPlacesLayerGroup(LayerGroupInfo.Mode.OPAQUE_CONTAINER, "container");
+
+            login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+            group = getCatalog().getLayerGroupByName("container");
+            nested = getCatalog().getLayerGroupByName("nested");
+            group.getLayers().add(nested);
+            group.getStyles().add(null);
+            getCatalog().save(group);
+            logout();
+
+            login("anonymousUser", "", "ROLE_ANONYMOUS");
+            String url =
+                    "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                            + "&layer="
+                            + group.getName()
+                            + "&style="
+                            + "&format=image/png&width=20&height=20";
+            MockHttpServletResponse response = getAsServletResponse(url);
+            assertEquals(response.getContentType(), "image/png");
+
+        } finally {
+            deleteRules(ruleService, ruleId1);
+            logout();
+            removeLayerGroup(group);
+            removeLayerGroup(nested);
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-10273](https://badgen.net/badge/JIRA/GEOS-10273/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10273)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->