### PR TITLE
[2.20.x backport][GEOS-10228] Wrap the category text values of a legend

### DIFF
--- a/doc/en/user/source/services/wms/get_legend_graphic/index.rst
+++ b/doc/en/user/source/services/wms/get_legend_graphic/index.rst
@@ -97,6 +97,7 @@ Here is a description of the various parameters that can be used in ``LEGEND_OPT
     - **countMatched** When set to true, adds at the end of each label the number of features matching that rule in the current map. Requires extra parameters, see details in the :ref:`dedicated section <content-dependent>`.
     - **hideEmptyRules** When set to true hides rules that are not matching any feature.
     - **wrap** When set to true word wraps long legend labels, leading to taller legends but less wide ones.
+    - **wrap_limit** when set, it wraps the legend label with the specified number of pixels.
 
 Here is a sample request sporting most the options::
 

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendUtils.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendUtils.java
@@ -412,6 +412,20 @@ public class LegendUtils {
     }
 
     /**
+     * Get the wrap limit
+     *
+     * @param req the {@link GetLegendGraphicRequest} from which to extract wrap limit.
+     * @return the wrap limit or -1 if no wrap limit provided
+     */
+    public static int getWrapLimit(final GetLegendGraphicRequest req) {
+        if (req.getLegendOptions().get("wrap_limit") instanceof String) {
+            String wrapVal = (String) req.getLegendOptions().get("wrap_limit");
+            return Integer.parseInt(wrapVal);
+        }
+        return -1;
+    }
+
+    /**
      * Returns the image background color for the given {@link GetLegendGraphicRequest}.
      *
      * @param req a {@link GetLegendGraphicRequest} from which we should extract the background
@@ -626,7 +640,7 @@ public class LegendUtils {
      * @return a {@link BufferedImage} of the properly rendered label.
      */
     public static BufferedImage renderLabel(
-            final String label, final Graphics2D g, final GetLegendGraphicRequest req) {
+            String label, final Graphics2D g, final GetLegendGraphicRequest req) {
 
         ensureNotNull(label);
         ensureNotNull(g);
@@ -636,13 +650,13 @@ public class LegendUtils {
         BufferedImage renderedLabel;
         Color labelColor = getLabelFontColor(req);
         if (LegendUtils.isWrap(req)) {
-            // if label is longer than width, word wrap it.
-            Rectangle2D labelBounds = g.getFontMetrics().getStringBounds(label, g);
-            if (labelBounds.getWidth() > req.getWidth()) {
-                FontMetrics fm = g.getFontMetrics();
-                int widthChars = req.getWidth() / fm.stringWidth("m");
-                WordUtils.wrap(label, widthChars, "\n", true);
+            int width = getWrapLimit(req);
+            if (width == -1) {
+                width = req.getWidth();
             }
+            FontMetrics fm = g.getFontMetrics();
+            int widthChars = width / fm.stringWidth("m");
+            label = WordUtils.wrap(label, widthChars, "\n", true);
         }
         if ((label.indexOf("\n") != -1) || (label.indexOf("\\n") != -1)) {
             // this is a label WITH line-breaks...we need to figure out it's height *and*

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicOutputFormatTest.java
@@ -1283,6 +1283,13 @@ public class BufferedImageLegendGraphicOutputFormatTest
             image = this.legendProducer.buildLegendGraphic(req);
 
             assertTrue("Title didn't wrap", image.getWidth() > absoluteWidth);
+
+            legendOptions.put("wrap", "true");
+            legendOptions.put("wrap_limit", "10");
+            req.setLegendOptions(legendOptions);
+            BufferedImage wrappedLabelImage = this.legendProducer.buildLegendGraphic(req);
+            assertTrue("label wrapped", wrappedLabelImage.getWidth() < image.getWidth());
+
         } finally {
             RenderedImage ri = coverage.getRenderedImage();
             if (coverage instanceof GridCoverage2D) {


### PR DESCRIPTION
[![GEOS-10228](https://badgen.net/badge/JIRA/GEOS-10228/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10228)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

This is backport of [5278](https://github.com/geoserver/geoserver/pull/5278) for 2.20.x

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->