### PR TITLE
[GEOS-10287] JSON read support for freemarker templates

### DIFF
--- a/doc/en/user/source/community/opensearch-eo/STAC.rst
+++ b/doc/en/user/source/community/opensearch-eo/STAC.rst
@@ -63,14 +63,3 @@ For example, if the collection is named ``SENTINEL2``:
 
 * The collections specific template for it is named ``collections-SENTINEL2.json``
 * The items template specific for it is named ``items-SENTINEL2.json``
-
-FTL Functions
-
-* parseJSON
-
-It takes json file location and parse that json file in the free marker templates. Usage of the function like as below
-
-:code:`<#assign loadedJSON = "${parseJSON('readAndEval.json')}">`
-:code:`<#assign evalJSON = loadedJSON?eval_json>`
-
-More information about writing templates can be found in the :ref:`templates guide <oseotemplates>`.

--- a/doc/en/user/source/community/opensearch-eo/STAC.rst
+++ b/doc/en/user/source/community/opensearch-eo/STAC.rst
@@ -64,4 +64,13 @@ For example, if the collection is named ``SENTINEL2``:
 * The collections specific template for it is named ``collections-SENTINEL2.json``
 * The items template specific for it is named ``items-SENTINEL2.json``
 
+FTL Functions
+
+* parseJSON
+
+It takes json file location and parse that json file in the free marker templates. Usage of the function like as below
+
+:code:`<#assign loadedJSON = "${parseJSON('readAndEval.json')}">`
+:code:`<#assign evalJSON = loadedJSON?eval_json>`
+
 More information about writing templates can be found in the :ref:`templates guide <oseotemplates>`.

--- a/doc/en/user/source/community/opensearch-eo/configuration.rst
+++ b/doc/en/user/source/community/opensearch-eo/configuration.rst
@@ -130,6 +130,16 @@ geometry (mind, the output must be forced not to be escaped, using ``?no_esc``, 
 as ``minx``, ``miny``, ``maxx``, ``maxy`` that can be used to extract the bounding box
 corner values. All these function expect a geometry as input.
 
+
+Finally templates can use a ``loadJSON`` function to read a JSON from a file inside the GeoServer data directory. 
+The path to the JSON file can be absolute eg. :code:`"${loadJSON('/path/to/read.json')}"`, or a plain file name, in case the JSON file is present in the GeoServer root directory eg. :code:`"${loadJSON('read.json')}"`.
+
+The function returns a string JSON that can be parsed using the  :code:`?eval_json` free marker built-in function:
+:code:`<#assign loadedJSON = "${parseJSON('readAndEval.json')}">`
+:code:`<#assign evalJSON = loadedJSON?eval_json>`
+
+More information about writing templates can be found in the :ref:`templates guide <oseotemplates>`.
+
 GeoJSON output templates
 ------------------------
 

--- a/src/community/oseo/oseo-service/src/main/java/org/geoserver/opensearch/eo/response/TemplatesProcessor.java
+++ b/src/community/oseo/oseo-service/src/main/java/org/geoserver/opensearch/eo/response/TemplatesProcessor.java
@@ -167,33 +167,32 @@ public class TemplatesProcessor {
                                 throw new RuntimeException("Failed to encode geometry", e);
                             }
                         });
-        model.put(
-                "parseJSON",
-                (TemplateMethodModelEx)
-                        arguments -> {
-                            String filePath = arguments.get(0).toString();
-                            JSONParser parser = new JSONParser();
-                            try {
-                                GeoServerDataDirectory geoServerDataDirectory =
-                                        GeoServerExtensions.bean(GeoServerDataDirectory.class);
+        model.put("loadJSON", parseJSON());
+    }
 
-                                File file = geoServerDataDirectory.findFile(filePath);
-                                if (file == null) {
-                                    LOGGER.warning("File is outside of data directory");
-                                    throw new RuntimeException(
-                                            "File "
-                                                    + filePath
-                                                    + " is outside of the data directory");
-                                }
+    private TemplateMethodModelEx parseJSON() {
+        return arguments -> loadJSON(arguments.get(0).toString());
+    }
 
-                                return parser.parse(new FileReader(file.getPath())).toString();
-                            } catch (Exception e) {
-                                LOGGER.warning(
-                                        "Failed to parse JSON file " + e.getLocalizedMessage());
-                            }
-                            LOGGER.warning("Failed to create a JSON object");
-                            return "Failed to create a JSON object";
-                        });
+    private String loadJSON(String filePath) {
+        JSONParser parser = new JSONParser();
+        try {
+            GeoServerDataDirectory geoServerDataDirectory =
+                    GeoServerExtensions.bean(GeoServerDataDirectory.class);
+
+            File file = geoServerDataDirectory.findFile(filePath);
+            if (file == null) {
+                LOGGER.warning("File is outside of data directory");
+                throw new RuntimeException(
+                        "File " + filePath + " is outside of the data directory");
+            }
+
+            return parser.parse(new FileReader(file.getPath())).toString();
+        } catch (Exception e) {
+            LOGGER.warning("Failed to parse JSON file " + e.getLocalizedMessage());
+        }
+        LOGGER.warning("Failed to create a JSON object");
+        return "Failed to create a JSON object";
     }
 
     private String encodeToGML(Geometry g) throws IOException {

--- a/src/community/oseo/oseo-service/src/test/java/org/geoserver/opensearch/eo/SearchTest.java
+++ b/src/community/oseo/oseo-service/src/test/java/org/geoserver/opensearch/eo/SearchTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.awt.image.RenderedImage;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -49,6 +50,11 @@ public class SearchTest extends OSEOTestSupport {
         // this one is actually used instead
         copyTemplate("product-LANDSAT8.ftl");
         copyTemplate("collection-LANDSAT8.ftl");
+
+        GeoServerDataDirectory dd =
+                (GeoServerDataDirectory) applicationContext.getBean("dataDirectory");
+        File file = dd.getResourceLoader().createFile("readAndEval.json");
+        dd.getResourceLoader().copyFromClassPath("readAndEval.json", file, getClass());
     }
 
     @Test
@@ -1064,6 +1070,23 @@ public class SearchTest extends OSEOTestSupport {
                 hasXPath(
                         "/at:feed/at:entry[1]/at:summary",
                         containsString("<h1>This is a LANDSAT product!</h1>")));
+    }
+
+    @Test
+    public void testReadAndEvalJSON() throws Exception {
+        String uid = "LS8_TEST.02";
+        Document dom = getAsDOM("oseo/search?parentId=LANDSAT8&uid=" + uid);
+
+        assertThat(
+                dom,
+                hasXPath(
+                        "/at:feed/at:entry[1]/at:summary",
+                        containsString("<h2>attribute1 => 1</h2>")));
+        assertThat(
+                dom,
+                hasXPath(
+                        "/at:feed/at:entry[1]/at:summary",
+                        containsString("<h2>attribute2 => 2</h2>")));
     }
 
     private void summaryHasLink(Document dom, String link) {

--- a/src/community/oseo/oseo-service/src/test/java/org/geoserver/opensearch/eo/SearchTest.java
+++ b/src/community/oseo/oseo-service/src/test/java/org/geoserver/opensearch/eo/SearchTest.java
@@ -53,8 +53,12 @@ public class SearchTest extends OSEOTestSupport {
 
         GeoServerDataDirectory dd =
                 (GeoServerDataDirectory) applicationContext.getBean("dataDirectory");
-        File file = dd.getResourceLoader().createFile("readAndEval.json");
+        File file = dd.getResourceLoader().createFile("/readAndEval.json");
+        File nestedFile =
+                dd.getResourceLoader().createFile("/workspaces/readAndEvalNestedDir.json");
         dd.getResourceLoader().copyFromClassPath("readAndEval.json", file, getClass());
+        dd.getResourceLoader()
+                .copyFromClassPath("readAndEvalNestedDir.json", nestedFile, getClass());
     }
 
     @Test
@@ -1087,6 +1091,16 @@ public class SearchTest extends OSEOTestSupport {
                 hasXPath(
                         "/at:feed/at:entry[1]/at:summary",
                         containsString("<h2>attribute2 => 2</h2>")));
+        assertThat(
+                dom,
+                hasXPath(
+                        "/at:feed/at:entry[1]/at:summary",
+                        containsString("<h3>attribute4 => 4</h3>")));
+        assertThat(
+                dom,
+                hasXPath(
+                        "/at:feed/at:entry[1]/at:summary",
+                        containsString("<h3>attribute3 => 3</h3>")));
     }
 
     private void summaryHasLink(Document dom, String link) {

--- a/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/product-LANDSAT8.ftl
+++ b/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/product-LANDSAT8.ftl
@@ -1,10 +1,15 @@
 <#assign a = model.attributes />
-<#assign loadedJSON = "${parseJSON('readAndEval.json')}">
+<#assign loadedJSON = "${loadJSON('readAndEval.json')}">
+<#assign nestedLoadedJSON = "${loadJSON('workspaces/readAndEvalNestedDir.json')}">
 <#assign evalJSON = loadedJSON?eval_json>
+<#assign nestedEvalJSON = nestedLoadedJSON?eval_json>
 
 <h1>This is a LANDSAT product!</h1>
 <#list evalJSON as k, v>
     <h2>${k} => ${v}</h2>
+</#list>
+<#list nestedEvalJSON as k, v>
+    <h3>${k} => ${v}</h3>
 </#list>
 <table>
 <tr>

--- a/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/product-LANDSAT8.ftl
+++ b/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/product-LANDSAT8.ftl
@@ -1,5 +1,11 @@
 <#assign a = model.attributes />
+<#assign loadedJSON = "${parseJSON('readAndEval.json')}">
+<#assign evalJSON = loadedJSON?eval_json>
+
 <h1>This is a LANDSAT product!</h1>
+<#list evalJSON as k, v>
+    <h2>${k} => ${v}</h2>
+</#list>
 <table>
 <tr>
     <td valign="top" width="10%">

--- a/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/readAndEval.json
+++ b/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/readAndEval.json
@@ -1,0 +1,4 @@
+{
+  "attribute1":"1",
+  "attribute2":"2"
+}

--- a/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/readAndEvalNestedDir.json
+++ b/src/community/oseo/oseo-service/src/test/resources/org/geoserver/opensearch/eo/readAndEvalNestedDir.json
@@ -1,0 +1,4 @@
+{
+  "attribute3":"3",
+  "attribute4":"4"
+}


### PR DESCRIPTION
[![GEOS-10287](https://badgen.net/badge/JIRA/GEOS-10287/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10287)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Freemarker templates now have the ability to read properties from JSON files.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->