### PR TITLE
[GEOS-10268] null support is added with ! string

### DIFF
--- a/doc/en/user/source/community/features-templating/directives.rst
+++ b/doc/en/user/source/community/features-templating/directives.rst
@@ -46,6 +46,9 @@ The following are the directives available in JSON based templates.
    * - allows a template to extend another template
      - $merge
      - specify the :code:`$merge` directive as an attribute name containing the path to the extended template (:code: `"$merged":"base_template.json"`).
+   * - allows null values to be encoded. default is not encoded.
+     - ${property}! or $${expression}!
+     - ! at the end of a property interpolation or cql directive (:code:`"attribute":"${property}!"` or :code:`"attribute":"$${expression}!"`).
 
 
 XML based templates
@@ -80,6 +83,9 @@ The following are the directives available in XML based templates.
    * - allows including a template into another
      - $include, gft:includeFlat
      - specify the :code:`$include` option as an element value (:code:`<element>$include{included.xml}</element>`) and the :code:`gft:includeFlat` as an element having the included template as text content (:code:`<gft:includeFlat>included.xml</gft:includeFlat>`)
+   * - allows null values to be encoded. default is not encoded.
+     - ${property}!
+     - specify it either as an element value (:code:`<element>${property}!</element>`) or as an xml attribute value (:code:`<element attribute:"${property}!"/>`)
 
 A step by step introduction to features-templating syntax
 ---------------------------------------------------------

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicValueBuilder.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicValueBuilder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.featurestemplating.builders.AbstractTemplateBuilder;
+import org.geoserver.featurestemplating.builders.EncodingHints;
 import org.geoserver.featurestemplating.builders.JSONFieldSupport;
 import org.geoserver.featurestemplating.builders.visitors.TemplateVisitor;
 import org.geoserver.featurestemplating.expressions.TemplateCQLManager;
@@ -32,11 +33,19 @@ public class DynamicValueBuilder extends AbstractTemplateBuilder {
 
     protected NamespaceSupport namespaces;
 
+    private boolean encodeNull = false;
+
     private static final Logger LOGGER = Logging.getLogger(DynamicValueBuilder.class);
 
     public DynamicValueBuilder(String key, String expression, NamespaceSupport namespaces) {
         super(key, namespaces);
         this.namespaces = namespaces;
+
+        if (expression.endsWith("!")) {
+            this.encodeNull = true;
+            expression = expression.substring(0, expression.length() - 1);
+        }
+
         TemplateCQLManager cqlManager = new TemplateCQLManager(expression, namespaces);
         if (expression.startsWith("$${")) {
             this.cql = cqlManager.getExpressionFromString();
@@ -76,8 +85,9 @@ public class DynamicValueBuilder extends AbstractTemplateBuilder {
     protected void writeValue(
             TemplateOutputWriter writer, Object value, TemplateBuilderContext context)
             throws IOException {
-        if (canWriteValue(value)) {
-            writer.writeElementNameAndValue(getKey(context), value, getEncodingHints());
+        if (encodeNull || canWriteValue(value)) {
+            EncodingHints encodingHints = getEncodingHints();
+            writer.writeElementNameAndValue(getKey(context), value, encodingHints);
         }
     }
 
@@ -154,7 +164,7 @@ public class DynamicValueBuilder extends AbstractTemplateBuilder {
         } else if (value instanceof List && ((List) value).size() == 0) {
             if (((List) value).size() == 0) return false;
             else return true;
-        } else if (value == null) {
+        } else if (value == null || value.equals("null") || "".equals(value)) {
             return false;
         } else {
             return true;
@@ -171,11 +181,10 @@ public class DynamicValueBuilder extends AbstractTemplateBuilder {
     }
 
     public boolean checkNotNullValue(TemplateBuilderContext context) {
+        if (encodeNull) return true;
         Object o = null;
         if (xpath != null) {
-
             o = evaluateXPath(context);
-
         } else if (cql != null) {
             o = evaluateExpressions(cql, context);
         }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/IteratingBuilder.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/IteratingBuilder.java
@@ -60,7 +60,7 @@ public class IteratingBuilder extends SourceBuilder {
             boolean isArray = o != null && o.getClass().isArray();
             // if this is not a context as list and we don't have
             // iterate key hint we start the array and encode the key once here
-            if (!iterateKey && hasOwnOutput()) writer.startArray(key, encodingHints);
+            if (!iterateKey && hasOwnOutput()) writer.startArray(key, this.encodingHints);
 
             if (isList) {
                 evaluateCollection(
@@ -72,7 +72,7 @@ public class IteratingBuilder extends SourceBuilder {
                 evaluateInternal(writer, context, iterateKey);
             }
 
-            if (!iterateKey && hasOwnOutput()) writer.endArray(key, encodingHints);
+            if (!iterateKey && hasOwnOutput()) writer.endArray(key, this.encodingHints);
         }
     }
 

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/GMLTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/GMLTemplateReader.java
@@ -58,7 +58,8 @@ public class GMLTemplateReader extends XMLRecursiveTemplateReader {
 
     @Override
     protected void addVendorOption(StartElement element, RootBuilder builder) {
-        if (element.getName().toString().equals(NAME_SPACES_EL)) {
+        String elementName = element.getName().toString();
+        if (elementName.equals(NAME_SPACES_EL)) {
             Iterator<Attribute> attributeIterator = element.getAttributes();
             Map<String, String> namespaces = new HashMap<>();
             while (attributeIterator.hasNext()) {
@@ -67,15 +68,14 @@ public class GMLTemplateReader extends XMLRecursiveTemplateReader {
                 if (isNamespace(name)) namespaces.put(localPart(name), attr.getValue());
             }
             if (!namespaces.isEmpty())
-                ((RootBuilder) builder).addVendorOption(VendorOptions.NAMESPACES, namespaces);
-        } else if (element.getName().toString().equals(SCHEMA_LOCATION_EL)) {
+                builder.addVendorOption(VendorOptions.NAMESPACES, namespaces);
+        } else if (elementName.equals(SCHEMA_LOCATION_EL)) {
             Iterator<Attribute> attributeIterator = element.getAttributes();
             if (attributeIterator.hasNext()) {
                 Attribute attribute = attributeIterator.next();
                 QName name = attribute.getName();
                 if (isSchemaLocation(name)) {
-                    ((RootBuilder) builder)
-                            .addVendorOption(VendorOptions.SCHEMA_LOCATION, attribute.getValue());
+                    builder.addVendorOption(VendorOptions.SCHEMA_LOCATION, attribute.getValue());
                 }
             }
         }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
@@ -258,7 +258,6 @@ public class JSONTemplateReader implements TemplateReader {
                     new TemplateCQLManager(node.get(SEPARATOR).asText(), null);
             builder.addVendorOption(VendorOptions.SEPARATOR, cqlManager.getExpressionFromString());
         }
-
         if (node.has(CONTEXTKEY)) {
             builder.addVendorOption(CONTEXTKEY, node.get(CONTEXTKEY));
         }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/XMLRecursiveTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/XMLRecursiveTemplateReader.java
@@ -114,7 +114,7 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
                     // a self closing element, that did not start a new iteration.
                     // Builders are then created here and this iteration will not stop
                     while (!elementsStack.isEmpty()) {
-                        templateBuilderFromElement(elementsStack.pop(), builder);
+                        templateBuilderFromElement(elementsStack.pop(), builder, true);
                     }
                     if (!endElement.getName().toString().equals(INCLUDE_FLAT) && stopIteration)
                         break;
@@ -133,7 +133,8 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
             builderFromIncludedTemplate(resource, data, currentParent);
         } else if (data.startsWith(INCLUDE + "{") && data.endsWith("}")) {
             String path = data.substring(INCLUDE.length() + 1, data.length() - 1);
-            TemplateBuilder parentForIncluded = templateBuilderFromElement(element, currentParent);
+            TemplateBuilder parentForIncluded =
+                    templateBuilderFromElement(element, currentParent, false);
             builderFromIncludedTemplate(resource, path, parentForIncluded);
         } else {
             TemplateBuilder leafBuilder;
@@ -168,13 +169,13 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
     private TemplateBuilder getBuilderFromLastElInStack(TemplateBuilder currentParent) {
         StartElement previous = !elementsStack.isEmpty() ? elementsStack.pop() : null;
         if (previous != null) {
-            currentParent = templateBuilderFromElement(previous, currentParent);
+            currentParent = templateBuilderFromElement(previous, currentParent, false);
         }
         return currentParent;
     }
 
     private TemplateBuilder templateBuilderFromElement(
-            StartElement startElement, TemplateBuilder currentParent) {
+            StartElement startElement, TemplateBuilder currentParent, boolean emptyNode) {
         if (startElement != null) {
             String isCollection = getAttributeValueIfPresent(startElement, COLLECTION_ATTR);
             String stringName = startElement.getName().toString();
@@ -188,6 +189,9 @@ public abstract class XMLRecursiveTemplateReader extends RecursiveTemplateResour
                     .source(getAttributeValueIfPresent(startElement, SOURCE_ATTR))
                     .hasOwnOutput(hasOwnOutput)
                     .topLevelFeature(isRootOrManaged(currentParent));
+            if (emptyNode) {
+                maker.textContent("");
+            }
             if (collection) {
                 maker.encodingOption(ITERATE_KEY, "true");
             }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/CommonJSONWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/CommonJSONWriter.java
@@ -121,11 +121,15 @@ public abstract class CommonJSONWriter extends TemplateOutputWriter {
             generator.writeNumber(valueNode.asInt());
         } else if (valueNode.isBoolean()) {
             generator.writeBoolean(valueNode.asBoolean());
+        } else if (valueNode.isNull()) {
+            generator.writeNull();
         }
     }
 
     public void writeValue(Object value) throws IOException {
-        if (value instanceof String) {
+        if (isNull(value)) {
+            generator.writeNull();
+        } else if (value instanceof String) {
             generator.writeString((String) value);
         } else if (value instanceof Integer) {
             generator.writeNumber((Integer) value);

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/TemplateOutputWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/TemplateOutputWriter.java
@@ -7,10 +7,12 @@ package org.geoserver.featurestemplating.writers;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.List;
 import org.geoserver.featurestemplating.builders.EncodingHints;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.gml2.SrsSyntax;
 import org.geotools.referencing.CRS;
+import org.geotools.util.Converters;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
@@ -212,6 +214,18 @@ public abstract class TemplateOutputWriter implements AutoCloseable {
         } catch (FactoryException e) {
             throw new IOException(e);
         }
+    }
+
+    protected boolean isNull(Object value) {
+        boolean isNull = false;
+        if (value == null || value.equals("null") || "".equals(value)) isNull = true;
+        else if (value instanceof List) {
+            isNull = ((List) value).isEmpty();
+        } else if (value.getClass().isArray()) {
+            List list = Converters.convert(value, List.class);
+            isNull = list.isEmpty();
+        }
+        return isNull;
     }
 
     protected <T> T getEncodingHintIfPresent(

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
@@ -123,7 +123,14 @@ public abstract class XMLTemplateWriter extends TemplateOutputWriter {
             evaluateChildren(encodingHints);
         }
         try {
-            if (elementValue instanceof String
+            if (isNull(elementValue)) {
+                String value = "";
+                if (encodeAsAttribute) writeAsAttribute(key, value, encodingHints);
+                else {
+                    streamWriter.writeCharacters(value);
+                    canClose = true;
+                }
+            } else if (elementValue instanceof String
                     || elementValue instanceof Number
                     || elementValue instanceof Boolean
                     || elementValue instanceof URI

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGML32.xml
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGML32.xml
@@ -16,6 +16,7 @@
             <gsml:GeologicUnit gft:source="gsml:GeologicUnit" gft:isCollection="true">
                 <gml:description xlink:href="http://static_content.org">${gml:description}</gml:description>
                 <gml:name>${gml:name}</gml:name>
+                <gml:emptyText></gml:emptyText>
                 <gsml:staticContent xlink:title="${gml:name[0]}">static content</gsml:staticContent>
                 <gsml:purpose>${gsml:purpose}</gsml:purpose>
                 <gsml:composition gft:source="gsml:composition/gsml:CompositionPart" gft:isCollection="true">

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGeoJSON.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureGeoJSON.json
@@ -65,5 +65,7 @@
   "geometry": {
     "@type": "Polygon",
     "wkt": "$${toWKT(xpath('gsml:shape'))}"
-  }
+  },
+  "nullObject": null,
+  "nullText": null
 }

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureJSONLD.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/ManagedMappedFeatureJSONLD.json
@@ -86,5 +86,7 @@
   "geometry": {
     "@type": "Polygon",
     "wkt": "$${toWKT(xpath('gsml:shape'))}"
-  }
+  },
+  "nullObject": null,
+  "nullText": null
 }

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/ComplexGetFeatureInfoTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/ComplexGetFeatureInfoTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -135,6 +136,10 @@ public class ComplexGetFeatureInfoTest extends TemplateComplexTestSupport {
         assertEquals(1, features.size());
         JSONObject feature = (JSONObject) features.get(0);
         checkMappedFeatureJSON(feature);
+        assertEquals(feature.get("nullObject").toString(), "null");
+        assertEquals(feature.get("nullText").toString(), "null");
+        assertEquals(JSONNull.class, feature.get("nullObject").getClass());
+        assertEquals(JSONNull.class, feature.get("nullText").getClass());
     }
 
     @Test
@@ -147,6 +152,8 @@ public class ComplexGetFeatureInfoTest extends TemplateComplexTestSupport {
         assertEquals(1, features.size());
         JSONObject feature = (JSONObject) features.get(0);
         checkMappedFeatureJSON(feature);
+        assertEquals(feature.get("nullObject").toString(), "null");
+        assertEquals(feature.get("nullText").toString(), "null");
     }
 
     @Test
@@ -175,6 +182,8 @@ public class ComplexGetFeatureInfoTest extends TemplateComplexTestSupport {
 
         // filter on array element lithology
         assertXpathCount(1, "//gsml:lithology", doc);
+        assertXpathCount(1, "//gml:emptyText", doc);
+        assertXpathEvaluatesTo("", "//gml:emptyText", doc);
     }
 
     protected AbstractAppSchemaMockData createTestData() {


### PR DESCRIPTION
[![GEOS-10268](https://badgen.net/badge/JIRA/GEOS-10268/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10268)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Null support for the feature template is added with ! key. If that key is present at the end of the expression, null values will be in the end result
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->