### PR TITLE
[GEOS-10289]: Improve Shapefiles Directory datastore performances with huge amount of files

### DIFF
--- a/doc/en/user/source/data/vector/directory.rst
+++ b/doc/en/user/source/data/vector/directory.rst
@@ -34,6 +34,8 @@ To begin, navigate to :menuselection:`Stores --> Add a new store --> Directory o
      - Location of the directory. Can be an absolute path (such as :file:`file:C:\\Data\\shapefile_directory`) or a path relative to the data directory (such as :file:`file:data/shapefile_directory`.
    * - :guilabel:`namespace`
      - Namespace to be associated with the store.  This field is altered by changing the workspace name.
+   * - :guilabel:`skip scan`
+     - Skip scan of alternative shapefile extensions (i.e. .SHP, .shp.XML, .CPG, ...) on Not-Windows systems. This can be useful when you have a directory containing several thousands of shapefiles. By Default, the shapefile plugin will look for all the shapefile extensions (.shp, .dbf, .shx, .prj, .qix, .fix, .shp.xml, .cpg). As soon as one of these is missing, it will do a search on the directory for the missing file, ignoring the case. This might be time consuming on directories with a huge number of files.
 
 When finished, click :guilabel:`Save`.
 

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/shape/ShapefileDirectoryEditPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/shape/ShapefileDirectoryEditPanel.html
@@ -1,0 +1,7 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+<body>
+<wicket:extend>
+	<div wicket:id="skipScan"></div>
+</wicket:extend>
+</body>
+</html>

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/shape/ShapefileDirectoryEditPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/shape/ShapefileDirectoryEditPanel.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.web.data.store.shape;
 
+import static org.geotools.data.shapefile.ShapefileDataStoreFactory.SKIP_SCAN;
 import static org.geotools.data.shapefile.ShapefileDataStoreFactory.URLP;
 
 import java.util.Map;
@@ -12,6 +13,7 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.geoserver.web.data.store.panel.CheckBoxParamPanel;
 import org.geoserver.web.data.store.panel.DirectoryParamPanel;
 import org.geoserver.web.util.MapModel;
 import org.geoserver.web.wicket.ParamResourceModel;
@@ -37,6 +39,11 @@ public class ShapefileDirectoryEditPanel extends ShapefileStoreEditPanel {
                         new MapModel<>(paramsModel, URLP.key),
                         new ParamResourceModel("shapefile", this),
                         true);
+        add(
+                new CheckBoxParamPanel(
+                        "skipScan",
+                        new MapModel<>(paramsModel, SKIP_SCAN.key),
+                        new ParamResourceModel("skipScan", this)));
         file.setFileFilter(new Model<>(new ExtensionFileFilter(".shp")));
         return file;
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/shape/ShapefileStoreEditPanel.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/shape/ShapefileStoreEditPanel.html
@@ -8,6 +8,7 @@
 	  <div wicket:id="spatialIndex"></div>
 	  <div wicket:id="memoryMapped"></div>
 	  <div wicket:id="cacheMemoryMaps"></div>
+		<wicket:child></wicket:child>
 	</fieldset>
 </wicket:panel>
 </body>

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -581,6 +581,7 @@ ShapefileStoreEditPanel.cacheMemoryMaps=Cache and reuse memory maps (Requires 'U
 
 ShapefileDirectoryEditPanel.shapefile=Directory of shapefiles
 ShapefileDirectoryEditPanel.charset=DBF files charset
+ShapefileDirectoryEditPanel.skipScan=Skip scan of optional alternative shapefile extensions (i.e. .shp.XML, .Cpg, ...) on Not-Windows systems
 
 SQLViewAbstractPage.name=View Name 
 SQLViewAbstractPage.sqlDefinition=SQL statement

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/ShapefileDirectoryStorePageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/ShapefileDirectoryStorePageTest.java
@@ -19,7 +19,7 @@ import org.geotools.data.shapefile.ShapefileDirectoryFactory;
 import org.junit.Test;
 
 /**
- * Test for the shapefile directory ppanel
+ * Test for the shapefile directory panel
  *
  * @author Andrea Aime
  */
@@ -45,7 +45,6 @@ public class ShapefileDirectoryStorePageTest extends GeoServerWicketTestSupport 
     @Test
     public void testChangeWorkspaceNamespace() throws Exception {
         startPage();
-
         WorkspaceInfo defaultWs = getCatalog().getDefaultWorkspace();
 
         tester.assertModelValue(
@@ -66,6 +65,11 @@ public class ShapefileDirectoryStorePageTest extends GeoServerWicketTestSupport 
                 "parametersPanel:url:fileInput:border:border_body:paramValue",
                 "file://" + new File("./target").getCanonicalPath());
         ft.select("workspacePanel:border:border_body:paramValue", 2);
+
+        // By default, skipScan is false. Let's set it to true
+        ft.setValue("parametersPanel:skipScan:paramValue", true);
+        tester.executeAjaxEvent("dataStoreForm:parametersPanel:skipScan:paramValue", "change");
+
         ft.submit();
         tester.executeAjaxEvent("dataStoreForm:save", "click");
 
@@ -79,5 +83,6 @@ public class ShapefileDirectoryStorePageTest extends GeoServerWicketTestSupport 
         assertEquals(
                 getCatalog().getNamespaceByPrefix(ws.getName()).getURI(),
                 store.getConnectionParameters().get("namespace"));
+        assertEquals(true, store.getConnectionParameters().get("skipScan"));
     }
 }


### PR DESCRIPTION
[![GEOS-10289](https://badgen.net/badge/JIRA/GEOS-10289/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10289)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->