### PR TITLE
[GEOS-10282] Follow up, add enforcer check

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -2419,6 +2419,53 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>enforcer</id>
+      <activation>
+        <property>
+          <name>qa</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>localization-encodings</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireEncoding>
+                      <encoding>UTF-8</encoding>
+                      <includes>src/main/resources/GeoServerApplication*.utf8.properties</includes>
+                    </requireEncoding>
+                    <requireEncoding>
+                      <encoding>ISO-8859-1</encoding>
+                      <acceptAsciiSubset>true</acceptAsciiSubset>
+                      <includes>src/main/resources/GeoServerApplication*.properties</includes>
+                      <excludes>src/main/resources/GeoServerApplication*.utf8.properties</excludes>
+                    </requireEncoding>
+                  </rules>
+                  <fastFail>false</fastFail>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>extra-enforcer-rules</artifactId>
+                <version>1.3</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
[![GEOS-10282](https://badgen.net/badge/JIRA/GEOS-10282/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10282)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Follows up with GEOS-10282, adding a QA rule that should prevent improperly encoded files from landing in GeoServer (was not the issue, but we had a few).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->