### PR TITLE
[GEOS-10292] Changing worker pool size in raster access is not actually applied (silent error) (2.20.x)

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -414,14 +414,16 @@ public class ResourcePool {
     }
 
     /**
-     * Sets the size of the feature type cache.
-     *
-     * <p>A warning that calling this method will blow away the existing cache.
+     * Sets the coverage executor used for concurrent processing of files (e.g. in image mosaic,
+     * when multi-threaded loading is enabled)
      */
-    public void setCoverageExecutor(ThreadPoolExecutor coverageExecutor) {
-        synchronized (this) {
-            this.coverageExecutor = coverageExecutor;
-        }
+    public synchronized void setCoverageExecutor(ThreadPoolExecutor coverageExecutor) {
+        this.coverageExecutor = coverageExecutor;
+    }
+
+    /** Returns the coverage executor. See also {@link #setCoverageExecutor(ThreadPoolExecutor)}. */
+    public synchronized ThreadPoolExecutor getCoverageExecutor() {
+        return this.coverageExecutor;
     }
 
     /** Adds a pool listener. */

--- a/src/main/src/main/java/org/geoserver/coverage/CoverageAccessInitializer.java
+++ b/src/main/src/main/java/org/geoserver/coverage/CoverageAccessInitializer.java
@@ -104,8 +104,13 @@ public class CoverageAccessInitializer implements GeoServerInitializer, Extensio
                 // If the queue type is the same, I can simply override the parameter settings.
                 if ((queue instanceof LinkedBlockingQueue && queueType == QueueType.UNBOUNDED)
                         || (queue instanceof SynchronousQueue && queueType == QueueType.DIRECT)) {
-                    executor.setCorePoolSize(coverageAccess.getCorePoolSize());
+                    // avoid IllegalArgumentException happening because the max pool size
+                    // is temporarily lower than core, or vice-versa. Unfortunately it's not
+                    // possible to set the both at the same time
+                    executor.setCorePoolSize(1);
+                    // now reconfigure
                     executor.setMaximumPoolSize(coverageAccess.getMaxPoolSize());
+                    executor.setCorePoolSize(coverageAccess.getCorePoolSize());
                     executor.setKeepAliveTime(
                             coverageAccess.getKeepAliveTime(), TimeUnit.MILLISECONDS);
                     coverageAccess.setThreadPoolExecutor(executor);

--- a/src/main/src/test/java/org/geoserver/coverage/CoverageAccessInitializerTest.java
+++ b/src/main/src/test/java/org/geoserver/coverage/CoverageAccessInitializerTest.java
@@ -1,0 +1,58 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.coverage;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
+import org.easymock.EasyMock;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.ResourcePool;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.impl.CoverageAccessInfoImpl;
+import org.geoserver.config.impl.GeoServerInfoImpl;
+import org.junit.Test;
+
+public class CoverageAccessInitializerTest {
+
+    @Test
+    public void testChangePoolSize() throws Exception {
+        // start point
+        CoverageAccessInfoImpl caInfo = new CoverageAccessInfoImpl();
+        caInfo.setCorePoolSize(5);
+        caInfo.setMaxPoolSize(5);
+        GeoServerInfoImpl gsInfo = new GeoServerInfoImpl();
+        gsInfo.setCoverageAccess(caInfo);
+
+        GeoServer gs = EasyMock.createNiceMock(GeoServer.class);
+        Catalog catalog = EasyMock.createNiceMock(Catalog.class);
+        ResourcePool rp = ResourcePool.create(catalog);
+        expect(gs.getCatalog()).andReturn(catalog).anyTimes();
+        expect(gs.getGlobal()).andReturn(gsInfo).anyTimes();
+        expect(catalog.getResourcePool()).andReturn(rp).anyTimes();
+        replay(gs);
+        replay(catalog);
+
+        CoverageAccessInitializer initializer = new CoverageAccessInitializer();
+        initializer.initialize(gs);
+        assertEquals(5, rp.getCoverageExecutor().getCorePoolSize());
+        assertEquals(5, rp.getCoverageExecutor().getMaximumPoolSize());
+
+        // going up
+        caInfo.setCorePoolSize(32);
+        caInfo.setMaxPoolSize(32);
+        initializer.initialize(gs);
+        assertEquals(32, rp.getCoverageExecutor().getCorePoolSize());
+        assertEquals(32, rp.getCoverageExecutor().getMaximumPoolSize());
+
+        // and back down
+        caInfo.setCorePoolSize(5);
+        caInfo.setMaxPoolSize(5);
+        initializer.initialize(gs);
+        assertEquals(5, rp.getCoverageExecutor().getCorePoolSize());
+        assertEquals(5, rp.getCoverageExecutor().getMaximumPoolSize());
+    }
+}


### PR DESCRIPTION
[![GEOS-10292](https://badgen.net/badge/JIRA/GEOS-10292/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10292)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport to 2.20.x

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->