### PR TITLE
[GEOS-10269] Dynamic merge when evaluated part is base

### DIFF
--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicMergeBuilder.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicMergeBuilder.java
@@ -36,6 +36,28 @@ public class DynamicMergeBuilder extends DynamicValueBuilder {
     }
 
     @Override
+    protected boolean canWriteValue(Object value) {
+        if (overlayExpression) {
+            return super.canWriteValue(value);
+        } else if (node != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean checkNotNullValue(TemplateBuilderContext context) {
+        if (overlayExpression) {
+            return super.checkNotNullValue(context);
+        } else if (node != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
     public void evaluate(TemplateOutputWriter writer, TemplateBuilderContext context)
             throws IOException {
         Object evaluate = null;
@@ -53,7 +75,12 @@ public class DynamicMergeBuilder extends DynamicValueBuilder {
             else writeValue(writer, node, context);
         } else {
             JSONMerger jsonMerger = new JSONMerger();
-            ObjectNode mergedNodes = jsonMerger.mergeTrees(node, (JsonNode) evaluate);
+            ObjectNode mergedNodes;
+            if (overlayExpression) {
+                mergedNodes = jsonMerger.mergeTrees(node, (JsonNode) evaluate);
+            } else {
+                mergedNodes = jsonMerger.mergeTrees((JsonNode) evaluate, node);
+            }
 
             // if the expression contains dynamic content
             if (hasDynamic(mergedNodes)) writeFromNestedTree(context, writer, mergedNodes);

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/builders/impl/DynamicMergeBuilderTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/builders/impl/DynamicMergeBuilderTest.java
@@ -115,9 +115,9 @@ public class DynamicMergeBuilderTest extends DataTestCase {
                 json.getJSONObject("dynamicMergeBuilder")
                         .getJSONObject("metadata")
                         .getJSONObject("metadata_iso_19139");
-        assertEquals("metadata_iso_19139", metadata19139.getString("title"));
-        assertEquals("http://metadata_iso_19139.org", metadata19139.getString("href"));
-        assertEquals("metadata", metadata19139.getString("type"));
+        assertEquals("basetext", metadata19139.getString("title"));
+        assertEquals("basehref", metadata19139.getString("href"));
+        assertEquals("basetype", metadata19139.getString("type"));
         assertEquals("dynamic value result", metadata19139.getString("dynamicValue"));
     }
 
@@ -128,9 +128,9 @@ public class DynamicMergeBuilderTest extends DataTestCase {
                 json.getJSONObject("dynamicMergeBuilder")
                         .getJSONObject("metadata")
                         .getJSONObject("metadata_iso_19139");
-        assertEquals("metadata_iso_19139", metadata19139.getString("title"));
-        assertEquals("http://metadata_iso_19139.org", metadata19139.getString("href"));
-        assertEquals("metadata", metadata19139.getString("type"));
+        assertEquals("basetext", metadata19139.getString("title"));
+        assertEquals("basehref", metadata19139.getString("href"));
+        assertEquals("basetype", metadata19139.getString("type"));
     }
 
     @Test

--- a/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/stac/items.json
+++ b/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/stac/items.json
@@ -27,15 +27,6 @@
         "instruments": "${eo:collection/eo:instrument}",
         "constellation": "$${strToLowerCase(eop:parentIdentifier)}",
         "eo:cloud_cover": "${opt:cloudCover}",
-        "mergeThumbnail": {
-            "href":"will be replaced",
-            "type":"will be replaced",
-            "title":"Thumbnail to be replaced",
-            "roles":[
-              "will be replaced"
-            ]
-        },
-        "mergeThumbnail2": "$${jsonPointer(assets, '/thumbnail')}",
         // "view:off_nadir": "${opt:instrumentElevationAngle}",
         // "view:incidence_angle": "${opt:incidenceAngle}",
         // "view:azimuth": "${opt:instrumentAzimuthAngle}",

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ItemsTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ItemsTest.java
@@ -350,29 +350,14 @@ public class ItemsTest extends STACTestSupport {
         DocumentContext result = getAsJSONPath("ogc/stac/collections/LANDSAT8/items", 200);
 
         // tests before the dynamic merge with expression on overlay
-        String href = result.read("features[0].properties.mergeThumbnail.href");
-        String title = result.read("features[0].properties.mergeThumbnail.title");
-        String type = result.read("features[0].properties.mergeThumbnail.type");
-        String roles = result.read("features[0].properties.mergeThumbnail.roles[0]");
-        assertEquals(
-                "https://landsat-pds.s3.us-west-2.amazonaws.com/c1/L8/218/077/LC08_L1TP_218077_20210511_20210511_01_T1/LC08_L1TP_218077_20210511_20210511_01_T1_thumb_large.jpg",
-                href);
-        assertEquals("image/jpeg", type);
-        assertEquals("thumbnail", roles);
-        assertEquals("Thumbnail", title);
+        String href = result.read("features[0].assets.thumbnail.href");
+        String title = result.read("features[0].assets.thumbnail.title");
+        String type = result.read("features[0].assets.thumbnail.type");
+        int additional = result.read("features[0].assets.thumbnail.additional");
 
-        // tests the dynamic merge with expression on base
-        href = result.read("features[0].properties.mergeThumbnail2.href");
-        title = result.read("features[0].properties.mergeThumbnail2.title");
-        type = result.read("features[0].properties.mergeThumbnail2.type");
-        roles = result.read("features[0].properties.mergeThumbnail2.roles[0]");
-        Integer additional = result.read("features[0].properties.mergeThumbnail2.additional");
-        assertEquals(
-                "https://landsat-pds.s3.us-west-2.amazonaws.com/c1/L8/218/077/LC08_L1TP_218077_20210511_20210511_01_T1/LC08_L1TP_218077_20210511_20210511_01_T1_thumb_large.jpg",
-                href);
-        assertEquals("image/jpeg", type);
-        assertEquals("thumbnail", roles);
+        assertEquals("will replace", href);
+        assertEquals("will replace", type);
         assertEquals("Thumbnail", title);
-        assertEquals(0, additional.intValue());
+        assertEquals(0, additional);
     }
 }

--- a/src/community/oseo/oseo-stac/src/test/resources/items-LANDSAT8.json
+++ b/src/community/oseo/oseo-stac/src/test/resources/items-LANDSAT8.json
@@ -10,19 +10,16 @@
       ],
       "properties": {
         "eo:cloud_cover": "$${opt:cloudCover / 2}",
-        "mergeThumbnail": "$${jsonPointer(assets, '/thumbnail')}",
-        "mergeThumbnail2": {
-          "additional": "$${opt:cloudCover}",
-          "href":"will be replaced",
-          "type":"will be replaced",
-          "title":"Thumbnail to be replaced",
-          "roles":[
-            "will be replaced"
-          ]
-        },
         "gsd": 30, 
         "landsat:tier": "pre-collection",
         "landsat:orbit": "${eop:orbitNumber}" // just to have a custom queriable
+      },
+      "assets": {
+        "thumbnail": {
+          "additional": "$${opt:cloudCover}",
+          "href":"will replace",
+          "type":"will replace"
+        }
       },
       "links": [ // custom link here
         "$includeFlat{mandatoryLinks.json}",


### PR DESCRIPTION
[![GEOS-10269](https://badgen.net/badge/JIRA/GEOS-10269/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10269)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Handled dynamic merge when evaluated part is base.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->