### PR TITLE
[GEOS-10296] Upgrade to ErrorProne 2.10.0

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/XStreamPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/XStreamPPIO.java
@@ -98,6 +98,7 @@ public class XStreamPPIO extends XMLPPIO {
         }
 
         @Override
+        @SuppressWarnings("ReturnValueIgnored")
         public String realMember(@SuppressWarnings("rawtypes") Class type, String serialized) {
             String fieldName = super.realMember(type, serialized);
             try {

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -150,7 +150,7 @@
     <pom.fmt.action>sort</pom.fmt.action>
     <pom.fmt.skip>${fmt.skip}</pom.fmt.skip>
     <errorProneFlags></errorProneFlags>
-    <errorProne.version>2.9.0</errorProne.version>
+    <errorProne.version>2.10.0</errorProne.version>
     <javac.version>9+181-r4173-1</javac.version>
     <pmd.version>6.35.0</pmd.version>
     <checkstyle.skip>false</checkstyle.skip>


### PR DESCRIPTION
[![GEOS-10296](https://badgen.net/badge/JIRA/GEOS-10296/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10296)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->