### PR TITLE
A couple of improvements to handle AUTO codes in GeoServer reprojection console and map preview  (2.19.x)

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/wicket/CRSPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/CRSPanel.java
@@ -178,7 +178,9 @@ public class CRSPanel extends FormComponentPanel<CoordinateReferenceSystem> {
                         }
                         target.add(wktLink);
 
-                        onSRSUpdated(toSRS(crs), target);
+                        String srs = toSRS(crs);
+                        if (srs == null && crs != null) srs = srsTextField.getInput();
+                        onSRSUpdated(srs, target);
                     }
                 });
 

--- a/src/web/core/src/test/java/org/geoserver/web/wicket/CRSPanelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/wicket/CRSPanelTest.java
@@ -183,6 +183,20 @@ public class CRSPanelTest extends GeoServerWicketTestSupport {
         assertEquals(CRS.decode("EPSG:3005"), foo.crs);
     }
 
+    @Test
+    public void testAutoCode() throws Exception {
+        // create a test page that will check the updated SRS is the AUTO one
+        final String AUTO = "AUTO:42003,9001,-20,-45";
+        tester.startPage(new CRSPanelTestPage(AUTO));
+        // write try out an AUTO code case
+        FormTester ft = tester.newFormTester("form");
+        ft.setValue("crs:srs", AUTO);
+        ft.submit();
+        tester.assertNoErrorMessage();
+        CRSPanel crsPanel = (CRSPanel) tester.getComponentFromLastRenderedPage("form:crs");
+        assertTrue(CRS.equalsIgnoreMetadata(CRS.decode(AUTO), crsPanel.getCRS()));
+    }
+
     static class Foo implements Serializable {
         public CoordinateReferenceSystem crs;
 

--- a/src/web/core/src/test/java/org/geoserver/web/wicket/CRSPanelTestPage.java
+++ b/src/web/core/src/test/java/org/geoserver/web/wicket/CRSPanelTestPage.java
@@ -5,6 +5,9 @@
  */
 package org.geoserver.web.wicket;
 
+import static org.junit.Assert.assertEquals;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.CompoundPropertyModel;
@@ -18,6 +21,19 @@ public class CRSPanelTestPage extends WebPage {
         add(form);
 
         form.add(new CRSPanel("crs", new CRSModel(null)));
+    }
+
+    public CRSPanelTestPage(String expectedSRS) {
+        Form form = new Form("form");
+        add(form);
+
+        form.add(
+                new CRSPanel("crs", new CRSModel(null)) {
+                    @Override
+                    protected void onSRSUpdated(String srs, AjaxRequestTarget target) {
+                        assertEquals(expectedSRS, srs);
+                    }
+                });
     }
 
     public CRSPanelTestPage(Object o) {

--- a/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/AbstractOpenLayersMapOutputFormat.java
@@ -207,6 +207,7 @@ public abstract class AbstractOpenLayersMapOutputFormat implements GetMapOutputF
     private boolean isWms13FlippedCRS(CoordinateReferenceSystem crs) {
         try {
             String code = CRS.lookupIdentifier(crs, false);
+            if (code == null) return false;
             if (!code.contains("EPSG:")) {
                 code = "EPGS:" + code;
             }

--- a/src/wms/src/test/resources/OL_LOGGING.properties
+++ b/src/wms/src/test/resources/OL_LOGGING.properties
@@ -1,0 +1,33 @@
+## This log4j configuration file needs to stay here, and is used as the default logging setup
+## during data_dir upgrades and in case the chosen logging config isn't available.
+##
+## As GeoTools uses java.util.logging logging instead of log4j, GeoServer makes
+## the following mappings to adjust the log4j levels specified in this file to
+## the GeoTools logging system:
+##
+## Log4J Level          java.util.logging Level
+## --------------------------------------------
+## ALL                   FINEST
+## TRACE                 FINER
+## DEBUG                 FINE (includes CONFIG)
+## INFO                  INFO
+## WARN/ERROR            WARNING
+## FATAL                 SEVERE
+## OFF                   OFF
+
+log4j.rootLogger=WARN, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM HH:mm:ss} %p [%c{2}] - %m%n
+
+log4j.category.log4j=FATAL
+
+log4j.category.org.geotools=ERROR
+log4j.category.org.geotools.factory=ERROR
+log4j.category.org.geoserver=WARN
+log4j.category.org.vfny.geoserver=ERROR
+
+log4j.category.org.springframework=WARN
+
+log4j.category.org.geowebcache=ERROR


### PR DESCRIPTION
Backport of https://github.com/geoserver/geoserver/pull/5391

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->