### PR TITLE
[GEOS-10301] Upgrade ogcapi and wfs3 to woodstox-core 6.2.6

### DIFF
--- a/src/community/ogcapi/ogcapi-core/pom.xml
+++ b/src/community/ogcapi/ogcapi-core/pom.xml
@@ -46,14 +46,12 @@
     </dependency>
     <dependency>
       <!-- this is added to avoid https://github.com/FasterXML/jackson-dataformat-xml/issues/32 -->
-      <groupId>org.codehaus.woodstox</groupId>
-      <artifactId>woodstox-core-asl</artifactId>
-      <version>4.1.2</version>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-core</artifactId>
-      <version>2.0.2</version>
       <exclusions>
         <!-- Just need the module to read/write swagger definitions, keep deps to a minimum -->
         <exclusion>

--- a/src/community/wfs3/pom.xml
+++ b/src/community/wfs3/pom.xml
@@ -64,14 +64,12 @@
     </dependency>
     <dependency>
       <!-- this is added to avoid https://github.com/FasterXML/jackson-dataformat-xml/issues/32 -->
-      <groupId>org.codehaus.woodstox</groupId>
-      <artifactId>woodstox-core-asl</artifactId>
-      <version>4.1.2</version>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-core</artifactId>
-      <version>2.0.2</version>
       <exclusions>
         <!-- Just need the module to read/write swagger definitions, keep deps to a minimum -->
         <exclusion>

--- a/src/community/wfs3/src/test/java/org/geoserver/wfs3/StyleTest.java
+++ b/src/community/wfs3/src/test/java/org/geoserver/wfs3/StyleTest.java
@@ -140,7 +140,7 @@ public class StyleTest extends WFS3TestSupport {
         assertEquals(SLDHandler.MIMETYPE_10, response.getContentType());
         final Document dom = dom(response, true);
         // print(dom);
-        assertXpathEvaluatesTo("A boring default style", "//sld:UserStyle/sld:Title", dom);
+        assertXpathEvaluatesTo("Blue Line", "//sld:UserStyle/sld:Title", dom);
         assertXpathEvaluatesTo("1", "count(//sld:Rule)", dom);
         assertXpathEvaluatesTo("1", "count(//sld:LineSymbolizer)", dom);
         assertXpathEvaluatesTo(

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1138,6 +1138,12 @@
         <artifactId>jackson-databind</artifactId>
         <version>${jackson2.databind.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId>
+        <artifactId>woodstox-core</artifactId>
+        <version>6.2.6</version>
+        <!-- match with jackson2.databind.version above -->
+      </dependency>
 
       <dependency>
         <groupId>javax.mail</groupId>
@@ -1194,6 +1200,12 @@
         <groupId>com.noelios.restlet</groupId>
         <artifactId>com.noelios.restlet.ext.servlet</artifactId>
         <version>1.0.8</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-core</artifactId>
+        <version>2.0.2</version>
+        <!-- exclude: javax.xml.bind, org.slf4j, swagger-annotations -->
       </dependency>
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>


### PR DESCRIPTION
[![GEOS-10301](https://badgen.net/badge/JIRA/GEOS-10301/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10301)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This replaces woodstox-core-asl 4.1.2 initialy brought in to assist with xmlns="" for community modules wfs3.

See https://github.com/FasterXML/jackson-dataformat-xml/issues/32

Signed-off-by: Jody Garnett <jody.garnett@gmail.com>

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue https://osgeo-org.atlassian.net/browse/GEOS-10301
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->