### PR TITLE
[GEOS-10287] loadJSON function is added to OSEO-STAC

### DIFF
--- a/src/community/oseo/oseo-service/src/main/java/org/geoserver/opensearch/eo/response/TemplatesProcessor.java
+++ b/src/community/oseo/oseo-service/src/main/java/org/geoserver/opensearch/eo/response/TemplatesProcessor.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.opensearch.eo.response;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import freemarker.ext.beans.BeanModel;
 import freemarker.ext.beans.SimpleMapModel;
 import freemarker.template.Template;
@@ -12,7 +13,6 @@ import freemarker.template.TemplateMethodModelEx;
 import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateScalarModel;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
@@ -30,7 +30,6 @@ import org.geotools.gml3.v3_2.GMLConfiguration;
 import org.geotools.util.Converters;
 import org.geotools.util.logging.Logging;
 import org.geotools.xsd.Encoder;
-import org.json.simple.parser.JSONParser;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.Feature;
 
@@ -175,7 +174,6 @@ public class TemplatesProcessor {
     }
 
     private String loadJSON(String filePath) {
-        JSONParser parser = new JSONParser();
         try {
             GeoServerDataDirectory geoServerDataDirectory =
                     GeoServerExtensions.bean(GeoServerDataDirectory.class);
@@ -187,7 +185,8 @@ public class TemplatesProcessor {
                         "File " + filePath + " is outside of the data directory");
             }
 
-            return parser.parse(new FileReader(file.getPath())).toString();
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readTree(file).toString();
         } catch (Exception e) {
             LOGGER.warning("Failed to parse JSON file " + e.getLocalizedMessage());
         }

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/LoadJSONTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/LoadJSONTest.java
@@ -1,0 +1,76 @@
+package org.geoserver.ogcapi.stac;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.data.test.SystemTestData;
+import org.jsoup.nodes.Document;
+import org.junit.Test;
+
+/**
+ * This test class is created separately due to copying collection.ftl file to the data directory in
+ * the tests. If it is not done in another class, it fails the tests that uses collection.ftl
+ */
+public class LoadJSONTest extends STACTestSupport {
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        copyAbsolutePathToCollectionsFtl();
+
+        copyTemplate("/collections-SENTINEL2.json");
+        copyTemplate("/collection.ftl");
+        copyTemplate("/collections.ftl");
+
+        GeoServerDataDirectory dd =
+                (GeoServerDataDirectory) applicationContext.getBean("dataDirectory");
+
+        File file = dd.getResourceLoader().createFile("/readAndEval.json");
+        dd.getResourceLoader().copyFromClassPath("/readAndEval.json", file, getClass());
+    }
+
+    // it replaces the path with machine's local path
+    private void copyAbsolutePathToCollectionsFtl() throws IOException {
+        String collectionsPath =
+                LoadJSONTest.class.getClassLoader().getResource("collections.ftl").getPath();
+
+        String nestedJsonPath =
+                LoadJSONTest.class.getClassLoader().getResource("readAndEval.json").getPath();
+        File fileToBeModified = new File(collectionsPath);
+
+        FileWriter writer = null;
+
+        try {
+            String oldContent = new String(Files.readAllBytes(Paths.get(collectionsPath)));
+            String newContent = oldContent.replaceAll("willBeReplaced", nestedJsonPath);
+            writer = new FileWriter(fileToBeModified);
+            writer.write(newContent);
+        } catch (Exception e) {
+            System.out.println();
+        } finally {
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testReadAndEvalJSON() throws Exception {
+        Document dom = getAsJSoup("ogc/stac/collections/SENTINEL2?f=html");
+
+        assertEquals("attribute1 => 1 attribute2 => 2", dom.select("h2").text());
+    }
+
+    @Test
+    public void testReadFileOutsideOfDataDir() throws Exception {
+        Document dom = getAsJSoup("ogc/stac/collections?f=html");
+
+        // should return an empty element since collections.ftl loadJSON will not evaluate the file
+        // outside of data dir
+        assertEquals("", dom.select("h2").text());
+    }
+}

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACTestSupport.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACTestSupport.java
@@ -103,6 +103,14 @@ public class STACTestSupport extends OGCApiTestSupport {
         }
     }
 
+    protected void copyTemplate(String template, InputStream is) throws IOException {
+        GeoServerDataDirectory dd = getDataDirectory();
+        Resource target = dd.get("templates/ogc/stac/", template);
+        try (OutputStream os = target.out()) {
+            IOUtils.copy(is, os);
+        }
+    }
+
     protected void checkLandsat8_02(DocumentContext l8_02) {
         // ... instrument related
         assertEquals("LANDSAT_8", l8_02.read("properties.platform"));

--- a/src/community/oseo/oseo-stac/src/test/resources/collection.ftl
+++ b/src/community/oseo/oseo-stac/src/test/resources/collection.ftl
@@ -1,0 +1,7 @@
+<#assign loadedJSON = "${loadJSON('readAndEval.json')}">
+<#assign evalJSON = loadedJSON?eval_json>
+
+<h1>This is a LANDSAT product!</h1>
+<#list evalJSON as k, v>
+    <h2>${k} => ${v}</h2>
+</#list>

--- a/src/community/oseo/oseo-stac/src/test/resources/collections.ftl
+++ b/src/community/oseo/oseo-stac/src/test/resources/collections.ftl
@@ -1,0 +1,1 @@
+<#assign loadedJSON = "${loadJSON('willBeReplaced')}">

--- a/src/community/oseo/oseo-stac/src/test/resources/collections.ftl
+++ b/src/community/oseo/oseo-stac/src/test/resources/collections.ftl
@@ -1,1 +1,6 @@
 <#assign loadedJSON = "${loadJSON('willBeReplaced')}">
+
+<h1>Collections</h1>
+<#list loadedJSON as k, v>
+    <h2>${k} => ${v}</h2>
+</#list>

--- a/src/community/oseo/oseo-stac/src/test/resources/readAndEval.json
+++ b/src/community/oseo/oseo-stac/src/test/resources/readAndEval.json
@@ -1,0 +1,4 @@
+{
+  "attribute1":"1",
+  "attribute2":"2"
+}

--- a/src/community/oseo/oseo-stac/src/test/resources/readAndEvalNestedDir.json
+++ b/src/community/oseo/oseo-stac/src/test/resources/readAndEvalNestedDir.json
@@ -1,0 +1,4 @@
+{
+  "attribute3":"3",
+  "attribute4":"4"
+}


### PR DESCRIPTION
[![GEOS-10287](https://badgen.net/badge/JIRA/GEOS-10287/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10287)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

loadJSON functionality is added to OSEO-STAC module which enables to load a JSON file in geoserver data directory.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->