### PR TITLE
GeoPackage community module improvemets, cumulative 2.20.x backport

### DIFF
--- a/doc/en/user/source/community/geopkg/output.rst
+++ b/doc/en/user/source/community/geopkg/output.rst
@@ -123,6 +123,9 @@ Outline of the tiles layer:
         <gridset>
             ...
         </gridset>
+        <parameters>
+          <parameter name="...">value</parameter>
+        <parameters>
     </tiles>
 
 Each tiles layer has the following properties: 
@@ -136,7 +139,8 @@ Each tiles layer has the following properties:
   * ``transparent`` (optional): transparency (true or false)
   * ``coverage`` (optional)
   * ``minzoom``, ``maxzoom``, ``minColumn``, ``maxColumn``, ``minRow``, ``maxRow`` (all optional): set the minimum and maximum zoom level, column, and rows
-  * ``gridset`` (optional): see following
+  * ``gridset`` (optional): see below
+  * ``parameters`` (optional): list of other parameters that can be used in a GetMap to produce tiles (open to all GeoServer vendor parameters)
 
 Gridset can take on two possible (mutually exclusive) forms:
 

--- a/src/community/geopkg/src/main/java/applicationContext.xml
+++ b/src/community/geopkg/src/main/java/applicationContext.xml
@@ -24,6 +24,7 @@
       <constructor-arg index="3" ref="filterFactory"/>
       <constructor-arg index="4" ref="dataDirectory"/>
       <constructor-arg index="5" ref="entityResolverProvider"/>
+      <constructor-arg index="6" ref="getMapKvpReader"/>
     </bean>
     
     <bean id="geopkgProcessRequestPPIO" class="org.geoserver.geopkg.wps.GeoPackageProcessRequestPPIO" >

--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormat.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormat.java
@@ -5,7 +5,9 @@
  */
 package org.geoserver.geopkg;
 
-import static org.geoserver.geopkg.GeoPkg.*;
+import static org.geoserver.geopkg.GeoPkg.EXTENSION;
+import static org.geoserver.geopkg.GeoPkg.MIME_TYPE;
+import static org.geoserver.geopkg.GeoPkg.NAMES;
 
 import com.google.common.collect.Sets;
 import java.io.File;
@@ -35,6 +37,7 @@ import org.geotools.geopkg.TileEntry;
 import org.geotools.geopkg.TileMatrix;
 import org.geotools.referencing.CRS;
 import org.geotools.util.logging.Logging;
+import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.Grid;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSubset;
@@ -112,6 +115,19 @@ public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputForma
                 // m.setYPixelSize(gridSet.getPixelSize());
 
                 e.getTileMatricies().add(m);
+            }
+            // tile index is calculated relative to the gridset, so we need to use
+            // the gridset bounds (otherwise the layer bounds will be used as the gridset ones)
+            BoundingBox subsetBounds = gridSubset.getGridSetBounds();
+            if (subsetBounds != null) {
+                ReferencedEnvelope re =
+                        new ReferencedEnvelope(
+                                subsetBounds.getMinX(),
+                                subsetBounds.getMaxX(),
+                                subsetBounds.getMinY(),
+                                subsetBounds.getMaxY(),
+                                box.getCoordinateReferenceSystem());
+                e.setTileMatrixSetBounds(re);
             }
 
             // figure out the actual bounds of the tiles to be renderered

--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormat.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormat.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.logging.Logger;
+import java.util.logging.Level;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.gwc.GWC;
 import org.geoserver.ows.util.OwsUtils;
@@ -30,19 +30,20 @@ import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WebMap;
 import org.geoserver.wms.WebMapService;
+import org.geotools.data.util.DefaultProgressListener;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.geopkg.GeoPackage;
 import org.geotools.geopkg.Tile;
 import org.geotools.geopkg.TileEntry;
 import org.geotools.geopkg.TileMatrix;
 import org.geotools.referencing.CRS;
-import org.geotools.util.logging.Logging;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.Grid;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSubset;
 import org.locationtech.jts.geom.Envelope;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.util.ProgressListener;
 
 /**
  * WMS GetMap Output Format for GeoPackage
@@ -50,8 +51,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  * @author Justin Deoliveira, Boundless
  */
 public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputFormat {
-
-    static Logger LOGGER = Logging.getLogger("org.geoserver.geopkg");
 
     public GeoPackageGetMapOutputFormat(WebMapService webMapService, WMS wms, GWC gwc) {
         super(MIME_TYPE, "." + EXTENSION, Sets.newHashSet(NAMES), webMapService, wms, gwc);
@@ -178,9 +177,14 @@ public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputForma
     }
 
     /** Add tiles to an existing GeoPackage */
-    public void addTiles(GeoPackage geopkg, TileEntry e, GetMapRequest req, String name)
+    public void addTiles(
+            GeoPackage geopkg,
+            TileEntry e,
+            GetMapRequest req,
+            String name,
+            ProgressListener listener)
             throws IOException {
-        addTiles(new GeopackageWrapper(geopkg, e), req, name);
+        addTiles(new GeopackageWrapper(geopkg, e), req, name, listener);
     }
 
     /**
@@ -192,12 +196,15 @@ public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputForma
             TileEntry e,
             GetMapRequest request,
             List<TileMatrix> matrices,
-            String name)
+            String name,
+            ProgressListener listener)
             throws IOException, ServiceException {
+
+        if (listener == null) listener = new DefaultProgressListener();
 
         List<MapLayerInfo> mapLayers = request.getLayers();
 
-        SortedMap<Integer, TileMatrix> matrixSet = new TreeMap<Integer, TileMatrix>();
+        SortedMap<Integer, TileMatrix> matrixSet = new TreeMap<>();
         for (TileMatrix matrix : matrices) {
             matrixSet.put(matrix.getZoomLevel(), matrix);
         }
@@ -217,7 +224,7 @@ public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputForma
         e.setBounds(bbox);
         e.setSrid(srid(request));
         e.getTileMatricies().addAll(matrices);
-        LOGGER.fine("Creating tile entry" + e.getTableName());
+        LOGGER.fine("Creating tile entry " + e.getTableName());
         geopkg.create(e);
 
         GetMapRequest req = new GetMapRequest();
@@ -320,6 +327,11 @@ public class GeoPackageGetMapOutputFormat extends AbstractTilesGetMapOutputForma
                     // Cleanup
                     cleaner.finished(null);
                 }
+            }
+
+            if (listener.isCanceled()) {
+                LOGGER.log(Level.FINE, "Stopping tile generation, request has been canceled");
+                return;
             }
         }
     }

--- a/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormatTest.java
+++ b/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormatTest.java
@@ -7,9 +7,11 @@ package org.geoserver.geopkg;
 
 import static org.geoserver.data.test.MockData.LAKES;
 import static org.geoserver.data.test.MockData.WORLD;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -18,9 +20,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import javax.imageio.ImageIO;
 import javax.xml.namespace.QName;
+import org.geoserver.config.GeoServer;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.gwc.GWC;
+import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WMSTestSupport;
 import org.geoserver.wms.WebMap;
@@ -31,6 +36,7 @@ import org.geotools.geopkg.Tile;
 import org.geotools.geopkg.TileEntry;
 import org.geotools.image.test.ImageAssert;
 import org.geotools.util.URLs;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Envelope;
@@ -109,6 +115,32 @@ public class GeoPackageGetMapOutputFormatTest extends WMSTestSupport {
 
         ImageAssert.assertEquals(
                 URLs.urlToFile(getClass().getResource("toplefttile.png")), tileImg, 250);
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+        GeoServer gs = getGeoServer();
+        WMSInfo wms = gs.getService(WMSInfo.class);
+        wms.setMaxRenderingTime(1);
+        gs.save(wms);
+
+        // a set of zooms so large, it can only go in timeout
+        WMSMapContent mapContent = createMapContent(WORLD, LAKES);
+        mapContent
+                .getRequest()
+                .setBbox(new Envelope(-0.17578125, -0.087890625, 0.17578125, 0.087890625));
+        mapContent.getRequest().getFormatOptions().put("min_zoom", "10");
+        mapContent.getRequest().getFormatOptions().put("max_zoom", "30");
+
+        try {
+            format.produceMap(mapContent);
+            fail("Should not have got here, and if it does, would have taken hours?");
+        } catch (ServiceException e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("used more time than allowed"));
+        } finally {
+            wms.setMaxRenderingTime(-1);
+            gs.save(wms);
+        }
     }
 
     GeoPackage createGeoPackage(WebMap map) throws IOException {

--- a/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormatTest.java
+++ b/src/community/geopkg/src/test/java/org/geoserver/geopkg/GeoPackageGetMapOutputFormatTest.java
@@ -25,8 +25,10 @@ import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WMSTestSupport;
 import org.geoserver.wms.WebMap;
 import org.geoserver.wms.map.RawMap;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.geopkg.GeoPackage;
 import org.geotools.geopkg.Tile;
+import org.geotools.geopkg.TileEntry;
 import org.geotools.image.test.ImageAssert;
 import org.geotools.util.URLs;
 import org.junit.Before;
@@ -65,7 +67,14 @@ public class GeoPackageGetMapOutputFormatTest extends WMSTestSupport {
 
         assertTrue(geopkg.features().isEmpty());
         assertEquals(1, geopkg.tiles().size());
-        assertNotNull(geopkg.tile("World_Lakes"));
+        TileEntry tile = geopkg.tile("World_Lakes");
+        assertNotNull(tile);
+        // the bounds should be the ones of the tile matrix, not the ones of the layer
+        ReferencedEnvelope bounds = tile.getTileMatrixSetBounds();
+        assertEquals(-180, bounds.getMinimum(0), 0d);
+        assertEquals(180, bounds.getMaximum(0), 0d);
+        assertEquals(-90, bounds.getMinimum(1), 0d);
+        assertEquals(90, bounds.getMaximum(1), 0d);
     }
 
     @Test

--- a/src/community/geopkg/src/test/resources/GPKG_LOGGING.properties
+++ b/src/community/geopkg/src/test/resources/GPKG_LOGGING.properties
@@ -1,0 +1,35 @@
+## This log4j configuration file needs to stay here, and is used as the default logging setup
+## during data_dir upgrades and in case the chosen logging config isn't available.
+##
+## As GeoTools uses java.util.logging logging instead of log4j, GeoServer makes
+## the following mappings to adjust the log4j levels specified in this file to
+## the GeoTools logging system:
+##
+## Log4J Level          java.util.logging Level
+## --------------------------------------------
+## ALL                   FINEST
+## TRACE                 FINER
+## DEBUG                 FINE (includes CONFIG)
+## INFO                  INFO
+## WARN/ERROR            WARNING
+## FATAL                 SEVERE
+## OFF                   OFF
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM HH:mm:ss} %p [%c{2}] - %m%n
+
+log4j.category.log4j=FATAL
+
+log4j.category.org.geotools=ERROR
+log4j.category.org.geotools.factory=ERROR
+log4j.category.org.geoserver=ERROR
+log4j.category.org.vfny.geoserver=ERROR
+
+log4j.category.org.springframework=ERROR
+
+log4j.category.org.geowebcache=ERROR
+
+log4j.category.org.geoserver.tiles=INFO

--- a/src/community/geopkg/src/test/resources/org/geoserver/geopkg/wps/fillenv.sld
+++ b/src/community/geopkg/src/test/resources/org/geoserver/geopkg/wps/fillenv.sld
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <Name>Simple polygon</Name>
+        <UserStyle>
+            <Title>SLD Cook Book: Simple polygon</Title>
+            <FeatureTypeStyle>
+                <Rule>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">
+                                <ogc:Function name="env">
+                                    <ogc:Literal>fill</ogc:Literal>
+                                    <ogc:Literal>#AAAAAA</ogc:Literal>
+                                </ogc:Function>
+                            </CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/src/community/mbtiles/src/main/java/org/geoserver/mbtiles/MBTilesGetMapOutputFormat.java
+++ b/src/community/mbtiles/src/main/java/org/geoserver/mbtiles/MBTilesGetMapOutputFormat.java
@@ -26,6 +26,7 @@ import org.geotools.mbtiles.MBTilesTile;
 import org.geotools.referencing.CRS;
 import org.geowebcache.grid.GridSubset;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.util.ProgressListener;
 
 /**
  * WMS GetMap Output Format for mbtiles
@@ -165,7 +166,9 @@ public class MBTilesGetMapOutputFormat extends AbstractTilesGetMapOutputFormat {
     }
 
     /** Add tiles to an existing MBtile file */
-    public void addTiles(MBTilesFile mbtiles, GetMapRequest req, String name) throws IOException {
-        addTiles(new MbTilesFileWrapper(mbtiles), req, name);
+    public void addTiles(
+            MBTilesFile mbtiles, GetMapRequest req, String name, ProgressListener listener)
+            throws IOException {
+        addTiles(new MbTilesFileWrapper(mbtiles), req, name, listener);
     }
 }

--- a/src/community/mbtiles/src/main/java/org/geoserver/mbtiles/gs/wps/MBTilesProcess.java
+++ b/src/community/mbtiles/src/main/java/org/geoserver/mbtiles/gs/wps/MBTilesProcess.java
@@ -37,6 +37,7 @@ import org.geotools.styling.Style;
 import org.geotools.util.URLs;
 import org.geotools.util.logging.Logging;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.util.ProgressListener;
 
 @DescribeProcess(title = "MBTiles", description = "MBTiles Process")
 public class MBTilesProcess implements GeoServerProcess {
@@ -163,7 +164,8 @@ public class MBTilesProcess implements GeoServerProcess {
                         description = "Body of the style to use",
                         min = 0
                     )
-                    String styleBody)
+                    String styleBody,
+            ProgressListener listener)
             throws IOException {
 
         // Extract the filename if present
@@ -328,7 +330,7 @@ public class MBTilesProcess implements GeoServerProcess {
             request.setFormatOptions(formatOptions);
 
             // Execute the requests
-            mapOutput.addTiles(mbtile, request, name);
+            mapOutput.addTiles(mbtile, request, name, listener);
         } catch (Exception e) {
             if (LOGGER.isLoggable(Level.SEVERE)) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);


### PR DESCRIPTION
Backports 3 commits from main, all improving the GeoPackage community module:
- [GEOS-10311] GeoPackage process cannot use layer groups and vendor parameters like the WMS output format does
- [GEOS-8262] GeoPackage tile matrix set extents not set correctly
- [GEOS-10313] Support WMS rendering timeout in GeoPackage WMS output, support cancellation in WPS process

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->