### PR TITLE
[GEOS-10320] Support GetFeatureInfo on raster layers with transformations turning the output into vector

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/LayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/LayerIdentifier.java
@@ -9,7 +9,10 @@ package org.geoserver.wms.featureinfo;
 import java.util.List;
 import org.geoserver.wms.FeatureInfoRequestParameters;
 import org.geoserver.wms.MapLayerInfo;
+import org.geoserver.wms.WMS;
 import org.geotools.feature.FeatureCollection;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.locationtech.jts.geom.Coordinate;
 
 /**
  * Extension point that helps run GetFeatureInfo on a specific layer
@@ -39,4 +42,26 @@ public interface LayerIdentifier<T> {
      * @param fs source to be clipped if GetFeatureInfo includes WMS Vendor parameter `clip`
      */
     T handleClipParam(FeatureInfoRequestParameters params, T fs);
+
+    /**
+     * Utility for implementors, allows to find a search area around the middle of the requested
+     * area
+     */
+    static ReferencedEnvelope getEnvelopeFilter(
+            FeatureInfoRequestParameters params, double radius) {
+        final int x = params.getX();
+        final int y = params.getY();
+        final ReferencedEnvelope bbox = params.getRequestedBounds();
+        final int width = params.getWidth();
+        final int height = params.getHeight();
+        Coordinate upperLeft = WMS.pixelToWorld(x - radius, y - radius, bbox, width, height);
+        Coordinate lowerRight = WMS.pixelToWorld(x + radius, y + radius, bbox, width, height);
+
+        return new ReferencedEnvelope(
+                upperLeft.x,
+                lowerRight.x,
+                lowerRight.y,
+                upperLeft.y,
+                bbox.getCoordinateReferenceSystem());
+    }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorBasicLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorBasicLayerIdentifier.java
@@ -31,7 +31,6 @@ import org.geotools.styling.Rule;
 import org.geotools.styling.Style;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Polygon;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -54,7 +53,7 @@ public class VectorBasicLayerIdentifier extends AbstractVectorLayerIdentifier {
 
     public static final String FEATUREINFO_DEFAULT_BUFFER =
             "org.geoserver.wms.featureinfo.minBuffer";
-    protected static final int MIN_BUFFER_SIZE = Integer.getInteger(FEATUREINFO_DEFAULT_BUFFER, 5);
+    public static final int MIN_BUFFER_SIZE = Integer.getInteger(FEATUREINFO_DEFAULT_BUFFER, 5);
 
     private WMS wms;
 
@@ -80,7 +79,7 @@ public class VectorBasicLayerIdentifier extends AbstractVectorLayerIdentifier {
         double radius = getSearchRadius(params, layer, rules);
 
         // compute the bbox for the request
-        ReferencedEnvelope queryEnvelope = getEnvelopeFilter(params, radius);
+        ReferencedEnvelope queryEnvelope = LayerIdentifier.getEnvelopeFilter(params, radius);
         CoordinateReferenceSystem requestedCRS = params.getRequestedCRS();
         CoordinateReferenceSystem dataCRS = layer.getCoordinateReferenceSystem();
         if ((requestedCRS != null) && !CRS.equalsIgnoreMetadata(dataCRS, requestedCRS)) {
@@ -223,23 +222,5 @@ public class VectorBasicLayerIdentifier extends AbstractVectorLayerIdentifier {
         Filter or = ff.or(filters);
         SimplifyingFilterVisitor simplifier = new SimplifyingFilterVisitor();
         return (Filter) or.accept(simplifier, null);
-    }
-
-    private ReferencedEnvelope getEnvelopeFilter(
-            FeatureInfoRequestParameters params, double radius) {
-        final int x = params.getX();
-        final int y = params.getY();
-        final ReferencedEnvelope bbox = params.getRequestedBounds();
-        final int width = params.getWidth();
-        final int height = params.getHeight();
-        Coordinate upperLeft = WMS.pixelToWorld(x - radius, y - radius, bbox, width, height);
-        Coordinate lowerRight = WMS.pixelToWorld(x + radius, y + radius, bbox, width, height);
-
-        return new ReferencedEnvelope(
-                upperLeft.x,
-                lowerRight.x,
-                lowerRight.y,
-                upperLeft.y,
-                bbox.getCoordinateReferenceSystem());
     }
 }

--- a/src/wms/src/test/resources/org/geoserver/wms/wms_1_1_1/footprints.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms_1_1_1/footprints.sld
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <Name>test_layer</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Transformation>
+                    <ogc:Function name="footprints"/>
+                </Transformation>
+                <Rule>
+                    <PolygonSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#000000</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                        <Fill>
+                            <CssParameter name="fill">#AAAAAA</CssParameter>
+                            <CssParameter name="fill-opacity">0.5</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/wms_1_1_1/rainContour.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/wms_1_1_1/rainContour.sld
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+  <StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+      <Name>contour_dem</Name>
+      <UserStyle>
+        <Title>Rain isolines</Title>
+        <Abstract>Extracts rain isolines</Abstract>
+        <FeatureTypeStyle>
+          <Transformation>
+            <ogc:Function name="ras:Contour">
+              <ogc:Function name="parameter">
+                <ogc:Literal>data</ogc:Literal>
+              </ogc:Function>
+              <ogc:Function name="parameter">
+                <ogc:Literal>interval</ogc:Literal>
+                <ogc:Literal>500</ogc:Literal>
+              </ogc:Function>
+            </ogc:Function>
+          </Transformation>
+          <Rule>
+            <Name>rule1</Name>
+            <Title>Contour Line</Title>
+            <LineSymbolizer>
+              <Stroke>
+                <CssParameter name="stroke">#000000</CssParameter>
+                <CssParameter name="stroke-width">1</CssParameter>
+              </Stroke>
+            </LineSymbolizer>
+            <TextSymbolizer>
+              <Label>
+                <ogc:PropertyName>value</ogc:PropertyName>
+              </Label>
+              <Font>
+                <CssParameter name="font-family">Arial</CssParameter>
+                <CssParameter name="font-style">Normal</CssParameter>
+                <CssParameter name="font-size">10</CssParameter>
+              </Font>
+              <LabelPlacement>
+                <LinePlacement/>
+              </LabelPlacement>
+              <Halo>
+                <Radius>
+                  <ogc:Literal>2</ogc:Literal>
+                </Radius>
+                <Fill>
+                  <CssParameter name="fill">#FFFFFF</CssParameter>
+                  <CssParameter name="fill-opacity">0.6</CssParameter>
+                </Fill>
+              </Halo>
+              <Fill>
+                <CssParameter name="fill">#000000</CssParameter>
+              </Fill>
+              <Priority>2000</Priority>
+              <VendorOption name="followLine">true</VendorOption>
+              <VendorOption name="repeat">100</VendorOption>
+              <VendorOption name="maxDisplacement">50</VendorOption>
+              <VendorOption name="maxAngleDelta">30</VendorOption>
+            </TextSymbolizer>
+          </Rule>
+        </FeatureTypeStyle>
+      </UserStyle>
+    </NamedLayer>
+   </StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-10320](https://badgen.net/badge/JIRA/GEOS-10320/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10320)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Will not compile until https://github.com/geotools/geotools/pull/3695 is merged.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->