### PR TITLE
[GEOS-10249] GWC produce NPE when it comes to race condition (2.20.x)

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -354,31 +354,23 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
      */
     public PublishedInfo getPublishedInfo() {
         PublishedInfo publishedInfo = this._publishedInfo.get();
-        if (publishedInfo == null) {
-            publishedInfo =
-                    this._publishedInfo.accumulateAndGet(
-                            null,
-                            (currVal, nullUpdateVal) -> {
-                                if (currVal == null) {
-                                    // see if it's a layer or a layer group
-                                    PublishedInfo catalogLayer = catalog.getLayer(publishedInfoId);
-                                    if (catalogLayer == null) {
-                                        catalogLayer = catalog.getLayerGroup(publishedInfoId);
-                                    }
-                                    if (catalogLayer == null) {
-                                        throw new IllegalStateException(
-                                                "Could not locate a layer or layer group with id "
-                                                        + publishedInfoId
-                                                        + " within GeoServer configuration, the GWC configuration seems to be out of synch");
-                                    } else {
-                                        TileLayerInfoUtil.checkAutomaticStyles(catalogLayer, info);
-                                    }
-                                    return catalogLayer;
-                                }
-                                // returning null when the current value is not null, prevents
-                                // accumulateAndGet from replacing the current reference
-                                return null;
-                            });
+        while (publishedInfo == null) {
+            // see if it's a layer or a layer group
+            PublishedInfo catalogLayer = catalog.getLayer(publishedInfoId);
+            if (catalogLayer == null) {
+                catalogLayer = catalog.getLayerGroup(publishedInfoId);
+            }
+            if (catalogLayer == null) {
+                throw new IllegalStateException(
+                        "Could not locate a layer or layer group with id "
+                                + publishedInfoId
+                                + " within GeoServer configuration, the GWC configuration seems to be out of "
+                                + "synch");
+            } else {
+                TileLayerInfoUtil.checkAutomaticStyles(catalogLayer, info);
+            }
+            this._publishedInfo.compareAndSet(null, catalogLayer);
+            publishedInfo = this._publishedInfo.get();
         }
         return publishedInfo;
     }

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -50,8 +50,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 import javax.media.jai.RenderedOp;
@@ -65,6 +70,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.LegendInfo;
 import org.geoserver.catalog.MetadataMap;
 import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.PublishedType;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.ResourcePool;
@@ -1395,5 +1401,27 @@ public class GeoServerTileLayerTest {
         resource.setLatLonBoundingBox(new ReferencedEnvelope(-180, 0, -90, 0, WGS84));
         GridSubset subset = layer.getGridSubset("EPSG:4326");
         assertArrayEquals(new long[] {0, 1, 0, 0, 1}, subset.getCoverage(1));
+    }
+
+    /** GEOS-10249 */
+    @Test
+    public void testGetPublishedInfoOnRaceCondition() throws Exception {
+        GeoServerTileLayer tileLayer =
+                new GeoServerTileLayer(
+                        catalog,
+                        layerInfo.getId(),
+                        gridSetBroker,
+                        TileLayerInfoUtil.loadOrCreate(layerInfo, defaults));
+        // here, parallelism equals to cpu cores
+        int parallelism = Runtime.getRuntime().availableProcessors();
+        ExecutorService pool = Executors.newFixedThreadPool(parallelism);
+        List<Future<PublishedInfo>> results =
+                IntStream.range(0, parallelism)
+                        .mapToObj(i -> pool.submit(tileLayer::getPublishedInfo))
+                        .collect(Collectors.toList());
+        for (Future<PublishedInfo> result : results) {
+            assertNotNull(result.get());
+        }
+        pool.shutdown();
     }
 }


### PR DESCRIPTION
[![GEOS-10249](https://badgen.net/badge/JIRA/GEOS-10249/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10249)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

2.20.x backport of https://github.com/geoserver/geoserver/pull/5301

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->