### PR TITLE
[GEOS-10322] JDBCConfig community module does not deal with stale connections to the database

### DIFF
--- a/doc/en/user/source/community/jdbcconfig/configuration.rst
+++ b/doc/en/user/source/community/jdbcconfig/configuration.rst
@@ -40,9 +40,14 @@ Provide the connection parameters directly in the configuration file. This inclu
 
 - ``pool.poolPreparedStatements``: whether to pool prepared statements
 
-- ``pool.maxOpenPreparedStatements``: size of prepared statement cache, only used if pool.poolPreparedStatements = true
+- ``pool.maxOpenPreparedStatements``: size of prepared statement cache, only used if ``pool.poolPreparedStatements`` is true
 
 - ``pool.testOnBorrow``: whether to validate connections when obtaining from the pool
 
-- ``pool.validationQuery``: validation query for connections from pool, must be set when pool.testOnBorrow = true
+- ``pool.validationQuery``: validation query for connections from pool, must be set when ``pool.testOnBorrow`` is true
+
+- ``pool.testWhileIdle``: whether to validate idle connections, used in conjunction with the idle timer below 
+
+- ``pool.setTimeBetweenEvictionRunsMillis``: period in millseconds for the idle object evictor, -1 to disable
+
 

--- a/doc/en/user/source/community/jdbcstore/configuration.rst
+++ b/doc/en/user/source/community/jdbcstore/configuration.rst
@@ -50,3 +50,7 @@ Provide the connection parameters directly in the configuration file. This inclu
 
 - ``pool.validationQuery``: validation query for connections from pool, must be set when ``pool.testOnBorrow`` is true
 
+- ``pool.testWhileIdle``: whether to validate idle connections, used in conjunction with the idle timer below 
+
+- ``pool.setTimeBetweenEvictionRunsMillis``: period in millseconds for the idle object evictor, -1 to disable
+

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/DataSourceFactoryBean.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/DataSourceFactoryBean.java
@@ -173,10 +173,10 @@ public class DataSourceFactoryBean implements FactoryBean<DataSource>, Disposabl
                 get(config, "pool.poolPreparedStatements", Boolean.class, false).or(true));
         dataSource.setMaxOpenPreparedStatements(
                 get(config, "pool.maxOpenPreparedStatements", Integer.class, false).or(50));
-        
+
         dataSource.setTestWhileIdle(
                 get(config, "pool.testWhileIdle", Boolean.class, false).or(false));
-        
+
         dataSource.setTimeBetweenEvictionRunsMillis(
                 get(config, "pool.timeBetweenEvictionRunsMillis", Long.class, false).or(-1L));
 

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/DataSourceFactoryBean.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/DataSourceFactoryBean.java
@@ -173,6 +173,12 @@ public class DataSourceFactoryBean implements FactoryBean<DataSource>, Disposabl
                 get(config, "pool.poolPreparedStatements", Boolean.class, false).or(true));
         dataSource.setMaxOpenPreparedStatements(
                 get(config, "pool.maxOpenPreparedStatements", Integer.class, false).or(50));
+        
+        dataSource.setTestWhileIdle(
+                get(config, "pool.testWhileIdle", Boolean.class, false).or(false));
+        
+        dataSource.setTimeBetweenEvictionRunsMillis(
+                get(config, "pool.timeBetweenEvictionRunsMillis", Long.class, false).or(-1l));
 
         boolean testOnBorrow = get(config, "pool.testOnBorrow", Boolean.class, false).or(false);
         if (testOnBorrow) {

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/DataSourceFactoryBean.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/DataSourceFactoryBean.java
@@ -178,7 +178,7 @@ public class DataSourceFactoryBean implements FactoryBean<DataSource>, Disposabl
                 get(config, "pool.testWhileIdle", Boolean.class, false).or(false));
         
         dataSource.setTimeBetweenEvictionRunsMillis(
-                get(config, "pool.timeBetweenEvictionRunsMillis", Long.class, false).or(-1l));
+                get(config, "pool.timeBetweenEvictionRunsMillis", Long.class, false).or(-1L));
 
         boolean testOnBorrow = get(config, "pool.testOnBorrow", Boolean.class, false).or(false);
         if (testOnBorrow) {

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
@@ -37,3 +37,9 @@ pool.testOnBorrow=true
 
 # validation query for connections from pool, must be set when pool.testOnBorrow = true
 pool.validationQuery=SELECT now()
+
+# The indication of whether objects will be validated by the idle object evictor (if any). If an object fails to validate, it will be dropped from the pool. 
+pool.testWhileIdle=false
+
+# The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run. 
+pool.timeBetweenEvictionRunsMillis=30000

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
@@ -42,4 +42,4 @@ pool.validationQuery=SELECT now()
 pool.testWhileIdle=false
 
 # The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run. 
-pool.timeBetweenEvictionRunsMillis=30000
+pool.timeBetweenEvictionRunsMillis=-1

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
@@ -42,4 +42,4 @@ pool.validationQuery=SELECT now()
 pool.testWhileIdle=false
 
 # The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run. 
-pool.timeBetweenEvictionRunsMillis=-1
+pool.timeBetweenEvictionRunsMillis=-1L

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.h2
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.h2
@@ -43,7 +43,7 @@ pool.validationQuery=SELECT now()
 
 
 # The indication of whether objects will be validated by the idle object evictor (if any). If an object fails to validate, it will be dropped from the pool. 
-# pool.testWhileIdle=false
+pool.testWhileIdle=false
 
 # The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run. 
-# pool.timeBetweenEvictionRunsMillis=-1L
+pool.timeBetweenEvictionRunsMillis=-1L

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.h2
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.h2
@@ -40,3 +40,10 @@ pool.testOnBorrow=true
 
 # validation query for connections from pool, must be set when pool.testOnBorrow = true
 pool.validationQuery=SELECT now()
+
+
+# The indication of whether objects will be validated by the idle object evictor (if any). If an object fails to validate, it will be dropped from the pool. 
+# pool.testWhileIdle=false
+
+# The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run. 
+# pool.timeBetweenEvictionRunsMillis=-1L

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.postgres
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.postgres
@@ -66,3 +66,9 @@ pool.testOnBorrow=true
 
 # validation query for connections from pool, must be set when pool.testOnBorrow = true
 pool.validationQuery=SELECT now()
+
+# The indication of whether objects will be validated by the idle object evictor (if any). If an object fails to validate, it will be dropped from the pool. 
+# pool.testWhileIdle=false
+
+# The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run. 
+# pool.timeBetweenEvictionRunsMillis=-1L

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.postgres
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.postgres
@@ -68,7 +68,7 @@ pool.testOnBorrow=true
 pool.validationQuery=SELECT now()
 
 # The indication of whether objects will be validated by the idle object evictor (if any). If an object fails to validate, it will be dropped from the pool. 
-# pool.testWhileIdle=false
+pool.testWhileIdle=false
 
 # The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run. 
-# pool.timeBetweenEvictionRunsMillis=-1L
+pool.timeBetweenEvictionRunsMillis=-1L

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/DataSourceFactoryBeanTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/DataSourceFactoryBeanTest.java
@@ -48,6 +48,8 @@ public class DataSourceFactoryBeanTest {
         expect(config.getProperty("password")).andStubReturn("swordfish");
         ds.setPassword("swordfish");
 
+        expect(config.getProperty("pool.testWhileIdle")).andStubReturn(null);
+        expect(config.getProperty("pool.timeBetweenEvictionRunsMillis")).andStubReturn(null);
         expect(config.getProperty("pool.minIdle")).andStubReturn(null);
         expect(config.getProperty("pool.maxActive")).andStubReturn(null);
         expect(config.getProperty("pool.poolPreparedStatements")).andStubReturn(null);
@@ -57,6 +59,10 @@ public class DataSourceFactoryBeanTest {
         config.setDatasourceId("jdbc:test");
         expectLastCall();
 
+        ds.setTestWhileIdle(false);
+        expectLastCall();
+        ds.setTimeBetweenEvictionRunsMillis(-1L);
+        expectLastCall();
         ds.setMinIdle(1);
         expectLastCall();
         ds.setMaxActive(10);
@@ -155,6 +161,8 @@ public class DataSourceFactoryBeanTest {
         expect(config.getProperty("password")).andStubReturn("swordfish");
         ds.setPassword("swordfish");
 
+        expect(config.getProperty("pool.testWhileIdle")).andStubReturn(null);
+        expect(config.getProperty("pool.timeBetweenEvictionRunsMillis")).andStubReturn(null);
         expect(config.getProperty("pool.minIdle")).andStubReturn(null);
         expect(config.getProperty("pool.maxActive")).andStubReturn(null);
         expect(config.getProperty("pool.poolPreparedStatements")).andStubReturn(null);
@@ -164,6 +172,10 @@ public class DataSourceFactoryBeanTest {
         config.setDatasourceId("jdbc:test");
         expectLastCall();
 
+        ds.setTestWhileIdle(false);
+        expectLastCall();
+        ds.setTimeBetweenEvictionRunsMillis(-1L);
+        expectLastCall();
         ds.setMinIdle(1);
         expectLastCall();
         ds.setMaxActive(10);


### PR DESCRIPTION
Expose Apache Common BasicDataSource additional properties to solve stale connection problems.
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
