### PR TITLE
[GEOS-10332] GrowableInternationalStringConverter can cause random XStream conversion failures

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -172,6 +172,7 @@ import org.opengis.coverage.grid.GridGeometry;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
+import org.opengis.util.InternationalString;
 
 /**
  * Utility class which loads and saves catalog and configuration objects to and from an xstream.
@@ -2675,7 +2676,8 @@ public class XStreamPersister {
         @Override
         @SuppressWarnings("unchecked")
         public boolean canConvert(Class aClass) {
-            return aClass.isAssignableFrom(GrowableInternationalString.class);
+            // REST config actually tries to de-serialize based on InternationalString only
+            return InternationalString.class.isAssignableFrom(aClass);
         }
 
         @Override

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -8,6 +8,7 @@ package org.geoserver.config.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -16,6 +17,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.thoughtworks.xstream.converters.Converter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -27,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -85,6 +88,7 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.referencing.wkt.Formattable;
 import org.geotools.referencing.wkt.UnformattableObjectException;
+import org.geotools.util.GrowableInternationalString;
 import org.geotools.util.NumberRange;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1554,6 +1558,31 @@ public class XStreamPersisterTest {
 
         assertTrue(wmsLayerInfo.getPreferredFormat().equalsIgnoreCase("image/png"));
         assertTrue(wmsLayerInfo.getForcedRemoteStyle().isEmpty());
+    }
+
+    @Test
+    public void testGrowableInternationalStringConverter() {
+        Converter candidate =
+                persister
+                        .getXStream()
+                        .getConverterLookup()
+                        .lookupConverterForType(GrowableInternationalString.class);
+        XStreamPersister.GrowableInternationalStringConverter converter =
+                (XStreamPersister.GrowableInternationalStringConverter) candidate;
+
+        // the class
+        assertTrue(converter.canConvert(GrowableInternationalString.class));
+        // a subclass
+        GrowableInternationalString anonymous =
+                new GrowableInternationalString() {
+                    @Override
+                    public synchronized String toString(Locale locale) {
+                        return "foobar";
+                    }
+                };
+        assertTrue(converter.canConvert(anonymous.getClass()));
+        // wont' try to convert object though
+        assertFalse(converter.canConvert(Object.class));
     }
 
     ByteArrayOutputStream out() {


### PR DESCRIPTION
[![GEOS-10332](https://badgen.net/badge/JIRA/GEOS-10332/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10332)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->