### PR TITLE
[GEOS-10335] Update GeoServer to a log4j version that does not support RCEs

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1018,7 +1018,7 @@
       <dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+        <version>1.2.17.norce</version>
       </dependency>
       <dependency>
         <groupId>com.lowagie</groupId>


### PR DESCRIPTION
[![GEOS-10335](https://badgen.net/badge/JIRA/GEOS-10335/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10335)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket, and also http://geoserver.org/announcements/2021/12/13/logj4-rce-statement.html
Re-packaged log4j-1.2.17 comes from here: https://github.com/aaime/log4j/tree/1.2.17.x

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->