### PR TITLE
[GEOS-10338] Upgrade jdom dependency

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -539,7 +539,7 @@
       <dependency>
         <groupId>org.jdom</groupId>
         <artifactId>jdom2</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.6.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
[![GEOS-10338](https://badgen.net/badge/JIRA/GEOS-10338/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10338)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Dependency upgrade from 2.6.0 to 2.6.0.1.

See http://www.jdom.org/news/index.html for the list of changes.

The key users of this dependency are app-schema and netcdf/grib.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [N/A] New unit tests have been added covering the changes.
- [N/A] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [N/A] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).