### PR TITLE
[GEOS-10337] Harden importer against failed imports, make failures more evident (2.20.x)

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/ImportContext.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/ImportContext.java
@@ -54,8 +54,8 @@ public class ImportContext implements Serializable {
         PENDING,
         /** Import is running */
         RUNNING,
-        /** Import is complete */
-        COMPLETE;
+        /** Import completed succesfully */
+        COMPLETE
     }
 
     /** identifier */
@@ -231,18 +231,24 @@ public class ImportContext implements Serializable {
         } else {
             newState = State.COMPLETE;
         }
-        O:
+        boolean error = false;
         for (ImportTask task : tasks) {
             switch (task.getState()) {
                 case COMPLETE:
                     continue;
                 case RUNNING:
                     newState = State.RUNNING;
-                    break O;
+                    break;
+                case ERROR:
+                    error = true;
+                    break;
                 default:
                     newState = State.PENDING;
-                    break O;
+                    break;
             }
+        }
+        if (error && newState == State.COMPLETE) {
+            setMessage("At least one task failed, look for error details in the tasks");
         }
         state = newState;
 


### PR DESCRIPTION
[![GEOS-10337](https://badgen.net/badge/JIRA/GEOS-10337/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10337)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main (does not contain the new COMPLETE_ERROR state to avoid introducing behavioral changes in a stable series).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->