### PR TITLE
[GEOS-10337] Harden importer against failed imports, make failures more evident (2.19.x)

### DIFF
--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/ImportContext.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/ImportContext.java
@@ -55,8 +55,8 @@ public class ImportContext implements Serializable {
         PENDING,
         /** Import is running */
         RUNNING,
-        /** Import is complete */
-        COMPLETE;
+        /** Import completed succesfully */
+        COMPLETE
     }
 
     /** identifier */
@@ -232,18 +232,24 @@ public class ImportContext implements Serializable {
         } else {
             newState = State.COMPLETE;
         }
-        O:
+        boolean error = false;
         for (ImportTask task : tasks) {
             switch (task.getState()) {
                 case COMPLETE:
                     continue;
                 case RUNNING:
                     newState = State.RUNNING;
-                    break O;
+                    break;
+                case ERROR:
+                    error = true;
+                    break;
                 default:
                     newState = State.PENDING;
-                    break O;
+                    break;
             }
+        }
+        if (error && newState == State.COMPLETE) {
+            setMessage("At least one task failed, look for error details in the tasks");
         }
         state = newState;
 

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Importer.java
@@ -942,6 +942,7 @@ public class Importer implements DisposableBean, ApplicationListener {
 
         context.setProgress(monitor);
         context.setState(ImportContext.State.RUNNING);
+        contextStore.save(context);
 
         LOGGER.log(Level.FINE, "Running import {0}", context.getId());
 
@@ -991,13 +992,20 @@ public class Importer implements DisposableBean, ApplicationListener {
         }
         LOGGER.log(Level.FINE, "Running task {0}", task);
         task.setState(ImportTask.State.RUNNING);
+        contextStore.save(task.getContext());
 
-        if (task.isDirect()) {
-            // direct import, simply add configured store and layers to catalog
-            doDirectImport(task);
-        } else {
-            // indirect import, read data from the source and into the target store
-            doIndirectImport(task);
+        try {
+            if (task.isDirect()) {
+                // direct import, simply add configured store and layers to catalog
+                doDirectImport(task);
+            } else {
+                // indirect import, read data from the source and into the target store
+                doIndirectImport(task);
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Task failed during import: " + task, e);
+            task.setState(ImportTask.State.ERROR);
+            task.setError(e);
         }
     }
 
@@ -1031,7 +1039,13 @@ public class Importer implements DisposableBean, ApplicationListener {
                         if (init) {
                             init(context, true);
                         }
-                        runInternal(context, filter, monitor);
+                        try {
+                            runInternal(context, filter, monitor);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.WARNING, "Import " + context.getId() + " failed", e);
+                            context.setState(ImportContext.State.COMPLETE);
+                            context.setMessage(e.getMessage());
+                        }
                         return context;
                     }
 
@@ -1124,37 +1138,31 @@ public class Importer implements DisposableBean, ApplicationListener {
 
         task.setState(ImportTask.State.RUNNING);
 
-        try {
-            // set up transform chain
-            TransformChain tx = task.getTransform();
+        // set up transform chain
+        TransformChain tx = task.getTransform();
 
-            // apply pre transform
-            if (!doPreTransform(task, task.getData(), tx)) {
-                return;
-            }
-
-            addToCatalog(task);
-
-            if (task.getLayer().getResource() instanceof FeatureTypeInfo) {
-                FeatureTypeInfo featureType = (FeatureTypeInfo) task.getLayer().getResource();
-                FeatureTypeInfo resource =
-                        getCatalog()
-                                .getResourceByName(
-                                        featureType.getQualifiedName(), FeatureTypeInfo.class);
-                calculateBounds(resource);
-            }
-
-            // apply post transform
-            if (!doPostTransform(task, task.getData(), tx)) {
-                return;
-            }
-
-            task.setState(ImportTask.State.COMPLETE);
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Task failed during import: " + task, e);
-            task.setState(ImportTask.State.ERROR);
-            task.setError(e);
+        // apply pre transform
+        if (!doPreTransform(task, task.getData(), tx)) {
+            return;
         }
+
+        addToCatalog(task);
+
+        if (task.getLayer().getResource() instanceof FeatureTypeInfo) {
+            FeatureTypeInfo featureType = (FeatureTypeInfo) task.getLayer().getResource();
+            FeatureTypeInfo resource =
+                    getCatalog()
+                            .getResourceByName(
+                                    featureType.getQualifiedName(), FeatureTypeInfo.class);
+            calculateBounds(resource);
+        }
+
+        // apply post transform
+        if (!doPostTransform(task, task.getData(), tx)) {
+            return;
+        }
+
+        task.setState(ImportTask.State.COMPLETE);
     }
 
     /*

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDataTest.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterDataTest.java
@@ -26,6 +26,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URL;
+import java.sql.Connection;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,6 +62,7 @@ import org.geotools.data.DataStore;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
+import org.geotools.data.Transaction;
 import org.geotools.data.h2.H2DataStoreFactory;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureSource;
@@ -560,6 +563,42 @@ public class ImporterDataTest extends ImporterTestSupport {
             assertEquals(archsitesCount * 2, archsitesCount2);
             assertEquals(bugsitesCount, bugsitesCount2);
         }
+    }
+
+    @Test
+    public void testImportIntoDatabaseDuplicateKey() throws Exception {
+        Catalog cat = getCatalog();
+
+        DataStoreInfo ds = createH2DataStore(cat.getDefaultWorkspace().getName(), "spearfish");
+
+        File dir = tmpDir();
+        unpack("shape/archsites_epsg_prj.zip", dir);
+
+        // run import once
+        ImportContext ctx1 = importer.createContext(new Directory(dir), ds);
+        assertEquals(1, ctx1.getTasks().size());
+        importer.run(ctx1);
+        assertEquals(ImportContext.State.COMPLETE, ctx1.getState());
+        assertNotNull(cat.getLayerByName("archsites"));
+
+        JDBCDataStore jdbc = (JDBCDataStore) ds.getDataStore(null);
+        try (Connection cx = jdbc.getConnection(Transaction.AUTO_COMMIT);
+                Statement st = cx.createStatement()) {
+            st.execute("CREATE UNIQUE INDEX \"archsites_cat_ids\" ON \"archsites\"(\"CAT_ID\")");
+        }
+
+        // run again, should fail and report issues happened
+        ImportContext ctx2 = importer.createContext(new Directory(dir), ds);
+        assertEquals(1, ctx2.getTasks().size());
+        ImportTask task = ctx2.getTasks().get(0);
+        task.setUpdateMode(UpdateMode.APPEND);
+        importer.run(ctx2);
+        assertEquals(ImportContext.State.COMPLETE, ctx2.getState());
+        assertEquals(State.ERROR, task.getState());
+        assertThat(
+                task.getError().getCause().getMessage(),
+                CoreMatchers.containsString(
+                        "Unique index or primary key violation: archsites_cat_ids"));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10337](https://badgen.net/badge/JIRA/GEOS-10337/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10337)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main (does not contain the new COMPLETE_ERROR state to avoid introducing behavioral changes in a stable series).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->