### PR TITLE
[GEOS-10341]: Interpolation not being propagated to the reader when a renderingTransformation is involved

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatExtendedTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatExtendedTest.java
@@ -11,11 +11,15 @@ import static org.junit.Assert.assertNotNull;
 import java.awt.image.ColorModel;
 import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
+import java.awt.image.renderable.ParameterBlock;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Vector;
+import javax.media.jai.Interpolation;
+import javax.media.jai.RenderedOp;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
@@ -198,6 +202,93 @@ public class RenderedImageMapOutputFormatExtendedTest extends WMSTestSupport {
         dstImageMap.dispose();
 
         map.dispose();
+    }
+
+    /**
+     * Test to check that the interpolation is being propagated down to the reader when a rendering
+     * transformation is in the mix.
+     */
+    @Test
+    public void testInterpolationAppliedWithRenderingTransformation() throws Exception {
+
+        final Catalog catalog = getCatalog();
+
+        // Get the RGB-IR View which is combining an RGB GeoTIFF and an IR GeoTIFF
+        final CoverageInfo ci = catalog.getCoverageByName(RGB_IR_VIEW);
+
+        final GridCoverage2DReader reader =
+                (GridCoverage2DReader) ci.getGridCoverageReader(null, null);
+        final ReferencedEnvelope bbox = new ReferencedEnvelope(reader.getOriginalEnvelope());
+
+        final GetMapRequest request = new GetMapRequest();
+        request.setBbox(bbox);
+        request.setSRS("urn:x-ogc:def:crs:EPSG:32632");
+        request.setFormat("image/png");
+        request.setInterpolations(
+                Collections.singletonList(
+                        Interpolation.getInstance(Interpolation.INTERP_BILINEAR)));
+
+        final WMSMapContent map = new WMSMapContent(request);
+        map.setMapWidth(20);
+        map.setMapHeight(20);
+        map.setTransparent(false);
+        map.getViewport().setBounds(bbox);
+
+        // Setup a style
+        final SLDParser parser = new SLDParser(CommonFactoryFinder.getStyleFactory());
+        parser.setInput(
+                RasterSymbolizerVisitorTest.class.getResource("CropTransformAndChannelSelect.sld"));
+        final StyledLayerDescriptor sld = parser.parseSLD();
+        final NamedLayer ul = (NamedLayer) sld.getStyledLayers()[0];
+        final Style style = ul.getStyles()[0];
+
+        final Layer dl = new CachedGridReaderLayer(reader, style);
+        map.addLayer(dl);
+
+        RenderedImageMap dstImageMap = this.rasterMapProducer.produceMap(map);
+        RenderedImage destImage = dstImageMap.getImage();
+
+        assertNotNull(destImage);
+
+        Interpolation interpolation = getScalingInterpolation(destImage);
+        assertNotNull(interpolation);
+        assertEquals(interpolation, Interpolation.getInstance(Interpolation.INTERP_BILINEAR));
+        dstImageMap.dispose();
+
+        map.dispose();
+    }
+
+    private Interpolation getScalingInterpolation(RenderedImage destImage) {
+        RenderedOp scalingOp = getScalingOpImage(destImage);
+        ParameterBlock parameterBlock = scalingOp.getParameterBlock();
+        Interpolation interpolation = null;
+        for (int i = 0; i < parameterBlock.getNumParameters(); i++) {
+            Object param = parameterBlock.getObjectParameter(i);
+            if (param instanceof Interpolation) {
+                interpolation = (Interpolation) param;
+                continue;
+            }
+        }
+        return interpolation;
+    }
+
+    @SuppressWarnings("PMD.ReplaceVectorWithList")
+    private RenderedOp getScalingOpImage(RenderedImage destImage) {
+        if (destImage != null) {
+            Vector<RenderedImage> sources = destImage.getSources();
+            for (RenderedImage source : sources) {
+                if (source instanceof RenderedOp) {
+                    RenderedOp op = (RenderedOp) source;
+                    String opName = op.getOperationName();
+                    if ("Scale".equalsIgnoreCase(opName)) {
+                        return op;
+                    }
+                    RenderedOp opImage = getScalingOpImage(source);
+                    if (opImage != null) return opImage;
+                }
+            }
+        }
+        return null;
     }
 
     /** Test to check that disabling ADVANCED PROJECTION HANDLING will not return a blank image */


### PR DESCRIPTION
[![GEOS-10341](https://badgen.net/badge/JIRA/GEOS-10341/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10341)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10341]

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->