### PR TITLE
[GEOS-8793] WFS GeoPackage output forced to required X,Y,Z,M order

### DIFF
--- a/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
+++ b/src/community/geopkg/src/main/java/org/geoserver/geopkg/GeoPackageGetFeatureOutputFormat.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
+import org.geoserver.feature.ReprojectingFeatureCollection;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
@@ -27,7 +28,10 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.geopkg.FeatureEntry;
 import org.geotools.geopkg.GeoPackage;
+import org.geotools.referencing.CRS;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.referencing.ReferenceIdentifier;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * WFS GetFeature OutputFormat for GeoPackage
@@ -67,6 +71,39 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
         return EXTENSION;
     }
 
+    /**
+     * According to GeoPKG spec, the coordinates MUST be in XY order. If this FC is in YX format, we
+     * reproject to the equivalent XY project.
+     *
+     * <p>If already XY, return the input FC.
+     *
+     * @param fc underlying feature collection
+     * @return feature collection which is has axis order in XY (NORTH_EAST)
+     */
+    public static SimpleFeatureCollection forceXY(SimpleFeatureCollection fc) {
+        CoordinateReferenceSystem sourceCRS = fc.getSchema().getCoordinateReferenceSystem();
+        if ((CRS.getAxisOrder(sourceCRS) == CRS.AxisOrder.EAST_NORTH)
+                || (CRS.getAxisOrder(sourceCRS) == CRS.AxisOrder.INAPPLICABLE)) {
+            return fc;
+        }
+
+        for (ReferenceIdentifier identifier : sourceCRS.getIdentifiers()) {
+            try {
+                String _identifier = identifier.toString();
+                CoordinateReferenceSystem flippedCRS = CRS.decode(_identifier, true);
+                if (CRS.getAxisOrder(flippedCRS) == CRS.AxisOrder.EAST_NORTH) {
+                    ReprojectingFeatureCollection result =
+                            new ReprojectingFeatureCollection(fc, flippedCRS);
+                    result.setDefaultSource(sourceCRS);
+                    return result;
+                }
+            } catch (Exception e) {
+                // couldn't flip - try again
+            }
+        }
+        return fc;
+    }
+
     @Override
     protected void write(
             FeatureCollectionResponse featureCollection, OutputStream output, Operation getFeature)
@@ -85,6 +122,9 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
             }
 
             SimpleFeatureCollection features = (SimpleFeatureCollection) collection;
+
+            features = forceXY(features); // geopkg requires data in XY orientation
+
             FeatureTypeInfo meta = lookupFeatureType(features);
             if (meta != null) {
                 // initialize entry metadata


### PR DESCRIPTION
[![GEOS-8793](https://badgen.net/badge/JIRA/GEOS-8793/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-8793)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The choice of WFS [axis order](https://docs.geoserver.org/latest/en/user/services/wfs/axis_order.html) results in a wide range of possibilities. In this case the output format can take responsibility for converting the data appropriately to conform to GeoPKG spec (Coordinate order must be X,Y.).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->