### PR TITLE
Replace direct use of log4j loggers by j.u.l through GeoTools Logging utility class

### DIFF
--- a/src/extension/feature-pregeneralized/src/main/java/org/geoserver/data/gen/DSFinderRepository.java
+++ b/src/extension/feature-pregeneralized/src/main/java/org/geoserver/data/gen/DSFinderRepository.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
-import org.apache.log4j.Logger;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.platform.GeoServerExtensions;
@@ -19,6 +18,7 @@ import org.geoserver.platform.resource.Files;
 import org.geoserver.platform.resource.Resources;
 import org.geotools.data.DataStore;
 import org.geotools.data.Repository;
+import org.geotools.util.logging.Logging;
 import org.opengis.feature.type.Name;
 
 /**
@@ -64,7 +64,7 @@ public class DSFinderRepository extends org.geotools.data.gen.DSFinderRepository
                 throw new RuntimeException(ex);
             }
         }
-        Logger.getLogger(this.getClass().getName())
+        Logging.getLogger(this.getClass().getName())
                 .info("Not in Geoserver catalog: " + name.toString());
         return super.dataStore(name);
     }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
@@ -20,8 +20,9 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.opengis.wfs.FeatureCollectionType;
-import org.apache.log4j.Logger;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.platform.GeoServerExtensions;
@@ -35,6 +36,7 @@ import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.featureinfo.FreemarkerStaticsAccessRule.RuleItem;
 import org.geotools.feature.FeatureCollection;
+import org.geotools.util.logging.Logging;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 /**
@@ -66,24 +68,24 @@ public abstract class FreeMarkerTemplateManager {
     private static DirectTemplateFeatureCollectionFactory tfcFactory =
             new DirectTemplateFeatureCollectionFactory();
 
-    private static Logger logger = Logger.getLogger(FreeMarkerTemplateManager.class);
+    private static Logger logger = Logging.getLogger(FreeMarkerTemplateManager.class);
     private static FreemarkerStaticsAccessRule staticsAccessRule;
 
     /** Initializes the {@link #staticsAccessRule}. */
     static void initStaticsAccessRule() {
         String tmpAccessPattern = GeoServerExtensions.getProperty(KEY_STATIC_MEMBER_ACCESS);
         FreemarkerStaticsAccessRule tmpRule = fromPattern(tmpAccessPattern);
-        logger.debug("Initializing with " + tmpRule);
+        logger.fine("Initializing with " + tmpRule);
         for (RuleItem tmpItem : tmpRule.getAllowedItems()) {
             if (tmpItem.isNumberedAlias()) {
-                logger.warn(
+                logger.warning(
                         "Granting access to static members of "
                                 + tmpItem.getClassName()
                                 + " using the variable name "
                                 + tmpItem.getAlias()
                                 + " to keep names unique.");
-            } else if (logger.isDebugEnabled()) {
-                logger.debug(
+            } else if (logger.isLoggable(Level.FINER)) {
+                logger.finer(
                         "Granting access to static members of "
                                 + tmpItem.getClassName()
                                 + " using the variable name "

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreemarkerStaticsAccessRule.java
@@ -10,8 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.logging.Logger;
 import javax.lang.model.SourceVersion;
-import org.apache.log4j.Logger;
+import org.geotools.util.logging.Logging;
 
 /**
  * Represents the rules for accessing static members from within Freemarker templates.
@@ -75,13 +76,13 @@ class FreemarkerStaticsAccessRule {
                 try {
                     tmpClasses.add(Class.forName(tmpCandidate));
                 } catch (ClassNotFoundException e) {
-                    logger.warn(
+                    logger.warning(
                             "Denying access to static members of '"
                                     + tmpCandidate
                                     + "': Class not found.");
                 }
             } else {
-                logger.warn(
+                logger.warning(
                         "Denying access to static members of '"
                                 + tmpCandidate
                                 + "': Not a valid class name.");
@@ -110,7 +111,7 @@ class FreemarkerStaticsAccessRule {
         return new FreemarkerStaticsAccessRule(tmpItems);
     }
 
-    private static Logger logger = Logger.getLogger(FreemarkerStaticsAccessRule.class);
+    private static Logger logger = Logging.getLogger(FreemarkerStaticsAccessRule.class);
 
     /** "true" for rules representing unrestricted access */
     private boolean unrestricted;


### PR DESCRIPTION
Some classes used log4j loggers directly instead of following
GeoServer's convention of using jul logging and obtaining them
from GeoTools' Logging.getLogger() utility.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->