### PR TITLE
Tomcat hardening added

### DIFF
--- a/doc/en/developer/source/programming-guide/wps-services/design-guide.rst
+++ b/doc/en/developer/source/programming-guide/wps-services/design-guide.rst
@@ -99,7 +99,7 @@ Once the ProcessFilter is coded it can be activated by declaring it in the Sprin
 for example the ``ProcessSelector`` subclass that controls which processes can be exposed based on
 the WPS admin panel configuration is registered in ``applicationContext.xml`` as follows:
 
-.. code-block:: java
+.. code-block:: xml
 
     <!-- The default process filters -->
     <bean id="unsupportedParameterTypeProcessFilter" class="org.geoserver.wps.UnsupportedParameterTypeProcessFilter"/>

--- a/doc/en/user/source/installation/war.rst
+++ b/doc/en/user/source/installation/war.rst
@@ -25,12 +25,84 @@ Installation
 
    .. note:: A restart of your application server may be necessary.
 
+Tomcat Hardening
+----------------
+Hide the Tomcat version in error responses and its error details.
+
+To remove the Tomcat version, create following file with emtpy parameters
+::
+ cd $CATALINA_HOME (where Tomcat binaries are installed)
+ mkdir -p ./lib/org/apache/catalina/util/
+ cat > ./lib/org/apache/catalina/util/ServerInfo.properties <<EOF
+ server.info=
+ server.number=
+ server.built=
+ EOF
+
+
+Additionally add to server.xml the ErrorReportValve to disable showReport and showServerInfo. This is used to hide errors handled globally by tomcat in host section.
+
+``vi ./conf/server.xml``
+
+Add to ``<Host name=...`` section this new ErrorReportValve entry:
+::
+ ...
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+		
+        ...
+
+        <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
+
+      </Host>
+    </Engine>
+  </Service>
+ </Server>
+
+
+Why, if security by obscurity does not work?
+
+Even though this is not the final solution, it at least mitigates the visible eye-catcher of outdated software packages.
+
+Let's take the attackers point of view.
+
+Response with just HTTP status:
+::
+ HTTP Status 400 – Bad Request
+
+Ok, it looks like a Tomcat is installed.
+
+Default full response:
+::
+ HTTP Status 400 – Bad Request
+ Type Status Report
+ Message Invalid URI
+ Description The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+ Apache Tomcat/7.0.67
+
+Ahh, great, the software ist not really maintained. Tomcat is far outdated from Dec. 2015 (6 years old as of today Jan. 2022) with a lot of unfixed vulnerabilities.
+
+Notice: For support reason, the local output of version.sh still outputs the current version
+::
+ $CATALINA_HOME/bin/version.sh
+  ...
+  Server number:  7.0.67
+  ...
+
+
 Running
 -------
 
 Use your container application's method of starting and stopping webapps to run GeoServer. 
 
 To access the :ref:`web_admin`, open a browser and navigate to ``http://SERVER/geoserver`` . For example, with Tomcat running on port 8080 on localhost, the URL would be ``http://localhost:8080/geoserver``.
+
+Update
+------
+
+Update regularly at least the container application! And repeat the hardening.
+
+There are a lot of geoserver installations visible with outdated Tomcat versions.
 
 Uninstallation
 --------------

--- a/doc/en/user/source/installation/war.rst
+++ b/doc/en/user/source/installation/war.rst
@@ -31,6 +31,7 @@ Hide the Tomcat version in error responses and its error details.
 
 To remove the Tomcat version, create following file with emtpy parameters
 ::
+
  cd $CATALINA_HOME (where Tomcat binaries are installed)
  mkdir -p ./lib/org/apache/catalina/util/
  cat > ./lib/org/apache/catalina/util/ServerInfo.properties <<EOF
@@ -46,6 +47,7 @@ Additionally add to server.xml the ErrorReportValve to disable showReport and sh
 
 Add to ``<Host name=...`` section this new ErrorReportValve entry:
 ::
+
  ...
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
@@ -68,12 +70,14 @@ Let's take the attackers point of view.
 
 Response with just HTTP status:
 ::
+
  HTTP Status 400 – Bad Request
 
 Ok, it looks like a Tomcat is installed.
 
 Default full response:
 ::
+
  HTTP Status 400 – Bad Request
  Type Status Report
  Message Invalid URI
@@ -84,6 +88,7 @@ Ahh, great, the software ist not really maintained. Tomcat is far outdated from 
 
 Notice: For support reason, the local output of version.sh still outputs the current version
 ::
+
  $CATALINA_HOME/bin/version.sh
   ...
   Server number:  7.0.67


### PR DESCRIPTION
Do not make it too easy for the script-kiddy attacker and hide the tomcat version.

There is no related GEOS-xxxxxx ticket, because the PR is due to the mail to your security list.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->