### PR TITLE
[GEOS-10183] Geofence-server extension seems to not work as expected with Chrome

### DIFF
--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -230,7 +230,9 @@ public class GeofenceAccessManager
 
                 return InetAddress.getByName(ips[0]).getHostAddress();
             } else {
-                return http.getRemoteAddr();
+                // Returns an IP address, removes surrounding brackets present in case of IPV6
+                // addresses
+                return http.getRemoteAddr().replaceAll("[\\[\\]]", "");
             }
         } catch (Exception e) {
             LOGGER.log(Level.INFO, "Failed to get remote address", e);

--- a/src/extension/geofence/src/test/java/org/geoserver/geofence/AccessManagerTest.java
+++ b/src/extension/geofence/src/test/java/org/geoserver/geofence/AccessManagerTest.java
@@ -33,6 +33,7 @@ import org.locationtech.jts.io.WKTReader;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.spatial.Intersects;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.Authentication;
 
 public class AccessManagerTest extends GeofenceBaseTest {
@@ -314,6 +315,15 @@ public class AccessManagerTest extends GeofenceBaseTest {
                                 "MULTIPOLYGON (((5343335.558077131 8859142.800565697, 5343335.558077131 9100250.907059547, 5454655.048870404 9100250.907059547, 5454655.048870404 8859142.800565697, 5343335.558077131 8859142.800565697)))");
 
         assertTrue(expectedLimit.equalsExact(accessLimits.getRasterFilter(), .000000001));
+    }
+
+    @Test
+    public void testIPv6Address() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("[0:0:0:0:0:0:0:1]");
+        String sourceAddress = accessManager.getSourceAddress(request);
+        // assert that address does not contain any brackets
+        assertFalse(sourceAddress.matches("\\[(.*)\\]"));
     }
 
     static class IntersectExtractor extends DefaultFilterVisitor {


### PR DESCRIPTION
[![GEOS-10183](https://badgen.net/badge/JIRA/GEOS-10183/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10183)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

JIRA TICKET: [GEOS-10183](https://osgeo-org.atlassian.net/browse/GEOS-10183)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->