### PR TITLE
[GEOS-10336]-INSPIRE failure: version not propagated in GetCapabilities LegendURL

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1696,6 +1696,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                     params(
                             "service",
                             "WMS",
+                            "version",
+                            request.getVersion(),
                             "request",
                             "GetLegendGraphic",
                             "format",

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -1596,6 +1596,8 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                     params(
                             "request",
                             "GetLegendGraphic",
+                            "version",
+                            request.getVersion(),
                             "format",
                             defaultFormat,
                             "width",

--- a/src/wms/src/test/java/org/geoserver/wms/LegendNonValidCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/LegendNonValidCapabilitiesTest.java
@@ -94,7 +94,7 @@ public class LegendNonValidCapabilitiesTest extends WMSTestSupport {
         assertXpathEvaluatesTo(LEGEND_FORMAT, legendUrlPath + "/wms:Format", dom);
         assertXpathEvaluatesTo(
                 BASE
-                        + "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fpng&width=20"
+                        + "/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&width=20"
                         + "&height=20&layer=gs%3Awatertemp",
                 legendUrlPath + "/wms:OnlineResource/@xlink:href",
                 dom);
@@ -111,7 +111,7 @@ public class LegendNonValidCapabilitiesTest extends WMSTestSupport {
         assertXpathEvaluatesTo(LEGEND_FORMAT, legendUrlPath + "/Format", dom);
         assertXpathEvaluatesTo(
                 BASE
-                        + "/wms?request=GetLegendGraphic&format=image%2Fpng&width=20"
+                        + "/wms?request=GetLegendGraphic&version=1.1.1&format=image%2Fpng&width=20"
                         + "&height=20&layer=gs%3Awatertemp",
                 legendUrlPath + "/OnlineResource/@xlink:href",
                 dom);

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
@@ -413,7 +413,7 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
         assertTrue(href.contains("height=20"));
     }
 
-    /** Tests that checks Legend Graphic URL contains version or not. */
+    /** Tests that Legend Graphic URL contains version. */
     @Test
     public void testOnlineResourceLegendURLVersion() throws Exception {
 

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesLegendURLTest.java
@@ -413,6 +413,25 @@ public abstract class GetCapabilitiesLegendURLTest extends WMSTestSupport {
         assertTrue(href.contains("height=20"));
     }
 
+    /** Tests that checks Legend Graphic URL contains version or not. */
+    @Test
+    public void testOnlineResourceLegendURLVersion() throws Exception {
+
+        TransformerBase tr = createTransformer();
+        tr.setIndentation(2);
+        Document dom = WMSTestSupport.transform(req, tr);
+
+        NodeList onlineResources =
+                XPATH.getMatchingNodes(getOnlineResourceXPath("cite:BasicPolygons"), dom);
+        assertEquals(1, onlineResources.getLength());
+        Element onlineResource = (Element) onlineResources.item(0);
+        String href = onlineResource.getAttribute("xlink:href");
+
+        assertNotNull(href);
+        assertTrue(href.contains("GetLegendGraphic"));
+        assertTrue(href.contains("version"));
+    }
+
     /**
      * Tests that width and height in legend online resources are consistent with the ones specified
      * in legendURL when dealing with static legends.

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesReponseTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesReponseTest.java
@@ -224,7 +224,7 @@ public class GetCapabilitiesReponseTest extends WMSTestSupport {
                 "WMT_MS_Capabilities/Capability/Request/GetCapabilities/DCPType/HTTP/Get/OnlineResource/@xlink:href",
                 dom);
         assertXpathEvaluatesTo(
-                "http://localhost:8080/geoserver/wms?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=nature&Language=it",
+                "http://localhost:8080/geoserver/wms?request=GetLegendGraphic&version=1.1.1&format=image%2Fpng&width=20&height=20&layer=nature&Language=it",
                 "//Layer[Name='nature']/Style/LegendURL/OnlineResource/@xlink:href", dom);
     }
 

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LegendCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/LegendCapabilitiesTest.java
@@ -128,14 +128,14 @@ public class LegendCapabilitiesTest extends WMSTestSupport {
         // two
         // cases
         String expectedGetLegendGraphicRequestURL =
-                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width="
+                "/wms?request=GetLegendGraphic&version=1.1.1&format=image%2Fjpeg&width="
                         + LEGEND_WIDTH
                         + "&height="
                         + LEGEND_HEIGHT
                         + "&layer=gs%3A"
                         + LAYER_NAME;
         String expectedGetLegendGraphicRequestURLHttp =
-                "/wms?request=GetLegendGraphic&format=image%2Fjpeg&width="
+                "/wms?request=GetLegendGraphic&version=1.1.1&format=image%2Fjpeg&width="
                         + LEGEND_WIDTH
                         + "&height="
                         + LEGEND_HEIGHT

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LegendCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/LegendCapabilitiesTest.java
@@ -147,21 +147,21 @@ public class LegendCapabilitiesTest extends WMSTestSupport {
         // three
         // cases
         String expectedGetLegendGraphicRequestURL =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width="
+                "/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fjpeg&width="
                         + LEGEND_WIDTH
                         + "&height="
                         + LEGEND_HEIGHT
                         + "&layer=gs%3A"
                         + LAYER_NAME;
         String expectedGetLegendGraphicRequestURLWS =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width="
+                "/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fjpeg&width="
                         + LEGEND_WIDTH
                         + "&height="
                         + LEGEND_HEIGHT
                         + "&layer=gs%3A"
                         + LAYER_NAME_WS;
         String expectedGetLegendGraphicRequestURLHttp =
-                "/ows?service=WMS&request=GetLegendGraphic&format=image%2Fjpeg&width="
+                "/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fjpeg&width="
                         + LEGEND_WIDTH
                         + "&height="
                         + LEGEND_HEIGHT


### PR DESCRIPTION
[![GEOS-10336](https://badgen.net/badge/JIRA/GEOS-10336/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10336)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

WMS Version propagation issue in the Legend URL has been fixed.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->



