### PR TITLE
[2.20.x][GEOS-10319] includeFlat a JSON database field to a features template

### DIFF
--- a/doc/en/user/source/community/features-templating/directives.rst
+++ b/doc/en/user/source/community/features-templating/directives.rst
@@ -1081,7 +1081,8 @@ The following JSON snippet shows the four possible syntax options for template i
        "anArray" : [
           "$include{arrayElement.json}", 
           "$includeFlat{subArray.json}" 
-       ]
+       ],
+      "$includeFlat": "${property}"
     }
 
 Notes:
@@ -1094,6 +1095,20 @@ Notes:
    element, or the creation of a nested array.
 4) The ``subArray.json`` template (line 6) must be an array itself, the container array will be stripped and
    its values directly integrated inside ``anArray``.
+
+In case of an includeFlat directive is specified and it's attribute value is a property interpolation directive, if the property name evaluates to a json it gets included flat in the final output.
+
+${property}:
+
+.. code-block:: json
+   :linenos: 
+
+    {
+       "aProperty": "10", 
+       "bProperty": "20"
+    }
+
+The ``${property}`` template (line 7) evaluates to a json, its properties will be passed to parent json without ``"$includeFlat"`` keyword.
 
 
 XML based templates (GML)

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicIncludeFlatBuilder.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicIncludeFlatBuilder.java
@@ -1,0 +1,50 @@
+package org.geoserver.featurestemplating.builders.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.Map;
+import org.geoserver.featurestemplating.builders.visitors.TemplateVisitor;
+import org.geoserver.featurestemplating.writers.TemplateOutputWriter;
+import org.xml.sax.helpers.NamespaceSupport;
+
+public class DynamicIncludeFlatBuilder extends DynamicValueBuilder {
+    public DynamicIncludeFlatBuilder(String key, String expression, NamespaceSupport namespaces) {
+        super(key, expression, namespaces);
+    }
+
+    @Override
+    public void evaluate(TemplateOutputWriter writer, TemplateBuilderContext context)
+            throws IOException {
+        Object evaluate = null;
+        if (xpath != null) {
+            evaluate = evaluateXPath(context);
+        } else if (cql != null) {
+            evaluate = evaluateExpressions(cql, context);
+        }
+
+        // updating the key and the value since we do not want to display includeFlat keyword in the
+        // result
+        if (evaluate instanceof ObjectNode) {
+            if (((ObjectNode) evaluate).fields().hasNext()) {
+                Map.Entry<String, JsonNode> includeFlatField =
+                        ((ObjectNode) evaluate).fields().next();
+                setKey(includeFlatField.getKey());
+                evaluate = includeFlatField.getValue();
+            }
+        }
+
+        if (evaluate instanceof JsonNode && hasDynamic((JsonNode) evaluate))
+            writeFromNestedTree(context, writer, (JsonNode) evaluate);
+        else writeValue(writer, evaluate, context);
+    }
+
+    private boolean hasDynamic(JsonNode node) {
+        return node.toString().contains("${");
+    }
+
+    @Override
+    public Object accept(TemplateVisitor visitor, Object value) {
+        return super.accept(visitor, value);
+    }
+}

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicMergeBuilder.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicMergeBuilder.java
@@ -3,14 +3,9 @@ package org.geoserver.featurestemplating.builders.impl;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.logging.Logger;
-import org.geoserver.featurestemplating.builders.TemplateBuilder;
-import org.geoserver.featurestemplating.builders.TemplateBuilderMaker;
 import org.geoserver.featurestemplating.builders.visitors.TemplateVisitor;
 import org.geoserver.featurestemplating.readers.JSONMerger;
-import org.geoserver.featurestemplating.readers.JSONTemplateReader;
-import org.geoserver.featurestemplating.readers.TemplateReaderConfiguration;
 import org.geoserver.featurestemplating.writers.TemplateOutputWriter;
 import org.geotools.util.logging.Logging;
 import org.xml.sax.helpers.NamespaceSupport;
@@ -60,21 +55,6 @@ public class DynamicMergeBuilder extends DynamicValueBuilder {
             else // contains static content
             writeValue(writer, mergedNodes, context);
         }
-    }
-
-    private void writeFromNestedTree(
-            TemplateBuilderContext context, TemplateOutputWriter writer, JsonNode node)
-            throws IOException {
-        TemplateReaderConfiguration configuration =
-                new TemplateReaderConfiguration(getNamespaces());
-        JSONTemplateReader jsonTemplateReader =
-                new JSONTemplateReader(node, configuration, new ArrayList<>());
-        TemplateBuilderMaker maker = configuration.getBuilderMaker();
-        maker.namespaces(configuration.getNamespaces());
-        writer.startObject(getKey(context), getEncodingHints());
-        jsonTemplateReader.getBuilderFromJson(getKey(context), node, this, maker);
-        for (TemplateBuilder child : getChildren()) child.evaluate(writer, context);
-        writer.endObject(getKey(context), encodingHints);
     }
 
     private boolean hasDynamic(JsonNode node) {

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/readers/JSONTemplateReader.java
@@ -10,6 +10,7 @@ import static org.geoserver.featurestemplating.builders.VendorOptions.JSONLD_TYP
 import static org.geoserver.featurestemplating.builders.VendorOptions.JSON_LD_STRING_ENCODE;
 import static org.geoserver.featurestemplating.builders.VendorOptions.SEPARATOR;
 import static org.geoserver.featurestemplating.readers.JSONMerger.*;
+import static org.geoserver.featurestemplating.readers.RecursiveJSONParser.INCLUDE_FLAT_KEY;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Iterator;
@@ -134,6 +135,12 @@ public class JSONTemplateReader implements TemplateReader {
                     currentBuilder = createCompositeIfNeeded(currentBuilder, maker);
                     maker.name(entryName).jsonNode(valueNode);
                     currentBuilder.addChild(maker.build());
+                } else if (entryName.startsWith(INCLUDE_FLAT_KEY)) {
+                    currentBuilder.addChild(
+                            maker.jsonNode(valueNode)
+                                    .name(entryName)
+                                    .dynamicIncludeFlatBuilder(true)
+                                    .build());
                 } else {
                     if (valueNode.isObject()) {
                         if (entryName.startsWith(DYNAMIC_MERGE_KEY)) {

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/builders/impl/DynamicIncludeFlatBuilderTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/builders/impl/DynamicIncludeFlatBuilderTest.java
@@ -1,0 +1,103 @@
+package org.geoserver.featurestemplating.builders.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
+import org.geoserver.featurestemplating.writers.GeoJSONWriter;
+import org.geotools.data.DataTestCase;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.jdbc.JDBCDataStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.xml.sax.helpers.NamespaceSupport;
+
+public class DynamicIncludeFlatBuilderTest extends DataTestCase {
+    private static final String DYNAMIC_METADATA =
+            "{\"metadata\":{\"metadata_iso_19139\":{\"title\":\"metadata_iso_19139\",\"dynamicValue\":\"${dynamicValue}\",\"href\":\"http://metadata_iso_19139.org\",\"type\":\"metadata\"}}}";
+    private static final String STATIC_METADATA =
+            "{\"metadata\":{\"metadata_iso_19139\":{\"title\":\"metadata_iso_19139\",\"href\":\"http://metadata_iso_19139.org\",\"type\":\"metadata\"}}}";
+
+    private SimpleFeature jsonFieldSimpleFeature;
+
+    @Before
+    public void setup() throws Exception {
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.userData(JDBCDataStore.JDBC_NATIVE_TYPENAME, "json");
+        tb.add("dynamicMetadata", String.class);
+        tb.add("staticMetadata", String.class);
+        tb.add("dynamicValue", String.class);
+        tb.add("arrayMetadata", String.class);
+        tb.setName("jsonFieldSimpleType");
+        SimpleFeatureType schema = tb.buildFeatureType();
+        schema.getDescriptor("dynamicMetadata")
+                .getUserData()
+                .put(JDBCDataStore.JDBC_NATIVE_TYPENAME, "json");
+        schema.getDescriptor("staticMetadata")
+                .getUserData()
+                .put(JDBCDataStore.JDBC_NATIVE_TYPENAME, "json");
+
+        SimpleFeatureBuilder fb = new SimpleFeatureBuilder(schema);
+        fb.add(DYNAMIC_METADATA);
+        fb.add(STATIC_METADATA);
+        fb.add("dynamic value result");
+        jsonFieldSimpleFeature = fb.buildFeature("jsonFieldSimpleType.1");
+    }
+
+    @Test
+    public void testDynamicIncludeFlatDynamicResult() throws Exception {
+        JSONObject json = encodeDynamicIncludeFlat("${dynamicMetadata}", jsonFieldSimpleFeature);
+        JSONObject metadata19139 =
+                json.getJSONObject("metadata").getJSONObject("metadata_iso_19139");
+        assertEquals("metadata_iso_19139", metadata19139.getString("title"));
+        assertEquals("http://metadata_iso_19139.org", metadata19139.getString("href"));
+        assertEquals("metadata", metadata19139.getString("type"));
+        assertEquals("dynamic value result", metadata19139.getString("dynamicValue"));
+    }
+
+    @Test
+    public void testDynamicIncludeFlatStaticResult() throws Exception {
+        JSONObject json = encodeDynamicIncludeFlat("${staticMetadata}", jsonFieldSimpleFeature);
+        JSONObject metadata19139 =
+                json.getJSONObject("metadata").getJSONObject("metadata_iso_19139");
+        assertEquals("metadata_iso_19139", metadata19139.getString("title"));
+        assertEquals("http://metadata_iso_19139.org", metadata19139.getString("href"));
+        assertEquals("metadata", metadata19139.getString("type"));
+    }
+
+    @Test
+    public void testNoDynamicIncludeFlatResult() throws Exception {
+        JSONObject json = encodeDynamicIncludeFlat("${dynamicValue}", jsonFieldSimpleFeature);
+        assertEquals("dynamic value result", json.get("dynamicIncludeFlatBuilder"));
+    }
+
+    private JSONObject encodeDynamicIncludeFlat(String expression, Feature feature)
+            throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GeoJSONWriter writer =
+                new GeoJSONWriter(
+                        new JsonFactory().createGenerator(baos, JsonEncoding.UTF8),
+                        TemplateIdentifier.JSON);
+
+        DynamicIncludeFlatBuilder builder =
+                new DynamicIncludeFlatBuilder(
+                        "dynamicIncludeFlatBuilder", expression, new NamespaceSupport());
+        writer.writeStartObject();
+        builder.evaluate(writer, new TemplateBuilderContext(feature));
+        writer.writeEndObject();
+        writer.close();
+
+        // nothing has been encoded
+        String jsonString = new String(baos.toByteArray());
+        return (JSONObject) JSONSerializer.toJSON(jsonString);
+    }
+}

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/JSONIncludesTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/JSONIncludesTest.java
@@ -198,6 +198,13 @@ public class JSONIncludesTest {
         assertTrue(rootBuilder.needsReload());
     }
 
+    @Test
+    public void testObtainDynamicIncludeFlatKeyword() throws IOException {
+        RecursiveJSONParser parser = new RecursiveJSONParser(store.get("dynamicIncludeFlat.json"));
+        JsonNode parse = parser.parse();
+        assertTrue(parse.toString().contains("$includeFlat"));
+    }
+
     private RuntimeException checkThrowingTemplate(String s) {
         return assertThrows(
                 RuntimeException.class, () -> new RecursiveJSONParser(store.get(s)).parse());

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/writers/JsonWriterTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/writers/JsonWriterTest.java
@@ -206,7 +206,7 @@ public class JsonWriterTest {
         JSONObject object = json.getJSONObject("geometry");
         JSONArray coordinates = object.getJSONArray("coordinates");
         for (int i = 0; i < coordinates.size(); i++) {
-            assertTrue(coordinates.get(i) instanceof Double);
+            assertTrue(coordinates.get(i) instanceof Number);
         }
     }
 }

--- a/src/community/features-templating/features-templating-core/src/test/resources/jsonIncludes/dynamicIncludeFlat.json
+++ b/src/community/features-templating/features-templating-core/src/test/resources/jsonIncludes/dynamicIncludeFlat.json
@@ -1,0 +1,5 @@
+{
+  "name": "test for dynamicIncludeFlat",
+  "$includeFlat": "${assets}",
+  "end": "endMarker"
+}

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ItemsTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ItemsTest.java
@@ -375,4 +375,22 @@ public class ItemsTest extends STACTestSupport {
         assertEquals("Thumbnail", title);
         assertEquals(0, additional.intValue());
     }
+
+    @Test
+    public void dynamicIncludeFlatTest() throws Exception {
+        DocumentContext result = getAsJSONPath("ogc/stac/collections/LANDSAT8/items", 200);
+
+        // tests before the dynamic merge with expression on overlay
+        String randomNumber = result.read("features[0].assets.dynamicIncludeFlatTest.randomNumber");
+        String href = result.read("features[0].assets.dynamicIncludeFlatTest.thumbnail.href");
+        String title = result.read("features[0].assets.dynamicIncludeFlatTest.thumbnail.title");
+        String type = result.read("features[0].assets.dynamicIncludeFlatTest.thumbnail.type");
+
+        assertEquals("23", randomNumber);
+        assertEquals(
+                "https://landsat-pds.s3.us-west-2.amazonaws.com/c1/L8/218/077/LC08_L1TP_218077_20210511_20210511_01_T1/LC08_L1TP_218077_20210511_20210511_01_T1_thumb_large.jpg",
+                href);
+        assertEquals("image/jpeg", type);
+        assertEquals("Thumbnail", title);
+    }
 }

--- a/src/community/oseo/oseo-stac/src/test/resources/items-LANDSAT8.json
+++ b/src/community/oseo/oseo-stac/src/test/resources/items-LANDSAT8.json
@@ -20,7 +20,7 @@
             "will be replaced"
           ]
         },
-        "gsd": 30, 
+        "gsd": 30,
         "landsat:tier": "pre-collection",
         "landsat:orbit": "${eop:orbitNumber}" // just to have a custom queriable
       },


### PR DESCRIPTION
[![GEOS-10319](https://badgen.net/badge/JIRA/GEOS-10319/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10319)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport of [GEOS-10319](https://github.com/geoserver/geoserver/pull/5418/commits) includeFlat a JSON database field to a features template
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->