### PR TITLE
Revert "[GEOS-10350] Upgrade NetCDF to 4.6.19"

### DIFF
--- a/src/community/netcdf-ghrsst/pom.xml
+++ b/src/community/netcdf-ghrsst/pom.xml
@@ -17,7 +17,7 @@
   <name>NetCDF GHRSST encoder</name>
 
   <properties>
-    <netcdf.version>4.6.19</netcdf.version>
+    <netcdf.version>4.6.15</netcdf.version>
   </properties>
 
   <dependencies>
@@ -26,7 +26,38 @@
       <artifactId>gs-netcdf-out</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--  NetCDF logging dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
 
+    <!-- TODO: relax this dependency: just need to depends on NetCDF java library from Unidata -->
+    <dependency>
+      <groupId>edu.ucar</groupId>
+      <artifactId>udunits</artifactId>
+      <version>${netcdf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-netcdf</artifactId>
+      <version>${gt.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-api</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jcl-over-slf4j</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wcs2_0</artifactId>

--- a/src/extension/netcdf-out/pom.xml
+++ b/src/extension/netcdf-out/pom.xml
@@ -28,6 +28,10 @@
   <packaging>jar</packaging>
   <name>WCS NetCDF output Module</name>
 
+  <properties>
+    <netcdf.version>4.6.15</netcdf.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -107,6 +111,38 @@
       <scope>test</scope>
     </dependency>
 
+    <!--  NetCDF logging dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+
+    <!-- TODO: relax this dependency: just need to depends on NetCDF java library from Unidata -->
+    <dependency>
+      <groupId>edu.ucar</groupId>
+      <artifactId>udunits</artifactId>
+      <version>${netcdf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-netcdf</artifactId>
+      <version>${gt.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-api</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jcl-over-slf4j</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>


### PR DESCRIPTION
Reverts geoserver/geoserver#5562

The update of the NetCDF version makes the netcdf-out grib test fails on builds and jenkins PR.
Details incoming:
