### PR TITLE
[GEOS-10101] Recalculating a featuretype via geoserver rest, fails if the SRS handling is set to Keep Native

### DIFF
--- a/doc/en/user/source/rest/api/featuretypes.rst
+++ b/doc/en/user/source/rest/api/featuretypes.rst
@@ -155,6 +155,23 @@ The ``recalculate`` parameter specifies whether to recalculate any bounding boxe
 * ``recalculate=nativebbox``: Recalculate the native bounding box, but do not recalculate the lat/long bounding box.
 * ``recalculate=nativebbox,latlonbbox``: Recalculate both the native bounding box and the lat/long bounding box.
 
+``Projection Policy``
+^^^^^^^^^^^^^^^^^^^^^
+
+When specifying the Projection Policy in a FeatureType defined in the request body, the internal name should be used instead of the one available on the UI. The following table shows the correspondence between display and internal names:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Display Name
+     - Internal Name
+   * - Force declared
+     - FORCE_DECLARED
+   * - Keep native
+     - NONE
+   * - Reproject native to declared
+     - REPROJECT_TO_DECLARED
+
 .. _rest_api_featuretypes_quietOnNotFound:
 
 ``quietOnNotFound``


### PR DESCRIPTION
[![GEOS-10101](https://badgen.net/badge/JIRA/GEOS-10101/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10101)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->