### PR TITLE
[GEOS-10357]-WFS 2.0 expects namespace request parameter instead of namespaces

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/kvp/BaseFeatureKvpRequestReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/kvp/BaseFeatureKvpRequestReader.java
@@ -88,6 +88,15 @@ public abstract class BaseFeatureKvpRequestReader extends WFSKvpRequestReader {
                 new String[] {"featureId", "resourceId", "filter", "bbox", "cql_filter"},
                 eObject);
 
+        // check strict cite compliance
+        if (getWFS().isCiteCompliant()) {
+            if (kvp.containsKey("namespace")) {
+                throw new WFSException(
+                        eObject,
+                        "Strict Cite Compliance is enabled.Request contains [namespace].Only [namespaces] is supported for WFS 2.0");
+            }
+        }
+
         // did the user supply alternate namespace prefixes?
         NamespaceSupport namespaces = null;
         if (kvp.containsKey("namespace") || kvp.containsKey("namespaces")) {
@@ -333,11 +342,12 @@ public abstract class BaseFeatureKvpRequestReader extends WFSKvpRequestReader {
                     // namespace
                     namespaceURI = uri;
                 }
-            } else if (namespaces.getURI(prefix) != null) {
+            } else if ((namespaces.getURI(prefix) != null) && (qName.getNamespaceURI() != null)) {
                 // so request used a custom prefix and declared the prefix:uri mapping?
                 namespaceURI = namespaces.getURI(qName.getPrefix());
             }
             NamespaceInfo ns = catalog.getNamespaceByURI(namespaceURI);
+
             if (ns == null) {
                 throw new WFSException(
                         "Unknown namespace [" + qName.getPrefix() + "]",

--- a/src/wfs/src/test/java/org/geoserver/wfs/kvp/GetFeatureKvpRequestReaderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/kvp/GetFeatureKvpRequestReaderTest.java
@@ -88,7 +88,6 @@ public class GetFeatureKvpRequestReaderTest extends GeoServerSystemTestSupport {
         final String namespace = SystemTestData.MLINES.getNamespaceURI();
         final String alternamePrefix = "ex";
         final String alternameTypeName = alternamePrefix + ":" + localPart;
-
         Map<String, Object> raw = new HashMap<>();
         raw.put("service", "WFS");
         raw.put("version", "1.1.0");
@@ -121,6 +120,31 @@ public class GetFeatureKvpRequestReaderTest extends GeoServerSystemTestSupport {
         raw.put("request", "GetFeature");
         raw.put("typeName", typeName);
         raw.put("namespace", "xmlns(" + defaultNamespace + ")");
+
+        Map<String, Object> parsed = parseKvp(raw);
+
+        GetFeatureType req = WfsFactory.eINSTANCE.createGetFeatureType();
+        Object read = reader.read(req, parsed, raw);
+        GetFeatureType parsedReq = (GetFeatureType) read;
+        QueryType query = (QueryType) parsedReq.getQuery().get(0);
+        List<QName> typeNames = query.getTypeName();
+        assertEquals(1, typeNames.size());
+        assertEquals(qName, typeNames.get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUserProvidedDefaultNamespaces() throws Exception {
+        final QName qName = SystemTestData.STREAMS;
+        final String typeName = qName.getLocalPart();
+        final String defaultNamespace = qName.getNamespaceURI();
+
+        Map<String, Object> raw = new HashMap<>();
+        raw.put("service", "WFS");
+        raw.put("version", "1.1.0");
+        raw.put("request", "GetFeature");
+        raw.put("typeName", typeName);
+        raw.put("namespaces", "xmlns(" + defaultNamespace + ")");
 
         Map<String, Object> parsed = parseKvp(raw);
 


### PR DESCRIPTION
[![GEOS-10357](https://badgen.net/badge/JIRA/GEOS-10357/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10357)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

WFS 2.0 GetFeature Request allows namespace and namespaces.But it allows only namespaces for STRICT Compliance enabled.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
