### PR TITLE
[GEOS-10371] Removing LayerGroup does not remove associated data access rules

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecuredResourceNameChangeListener.java
+++ b/src/main/src/main/java/org/geoserver/security/SecuredResourceNameChangeListener.java
@@ -5,10 +5,14 @@
 package org.geoserver.security;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.CatalogInfo;
@@ -51,37 +55,29 @@ public class SecuredResourceNameChangeListener implements CatalogListener {
 
     @Override
     public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
-        String resourceWorkSpaceName = null;
-        CatalogInfo resourceInfo = event.getSource();
-        String resourceName = null;
-        if (resourceInfo instanceof LayerInfo) {
-            resourceWorkSpaceName =
-                    ((LayerInfo) resourceInfo).getResource().getStore().getWorkspace().getName();
-            resourceName = ((LayerInfo) resourceInfo).getName();
-        } else if (event.getSource() instanceof LayerGroupInfo) {
-            resourceWorkSpaceName = ((LayerGroupInfo) resourceInfo).getWorkspace().getName();
-            resourceName = ((LayerGroupInfo) resourceInfo).getName();
+        final String removedObjectName; // for logging
+        final Predicate<DataAccessRule> filter;
+        final CatalogInfo eventSource = event.getSource();
+        if (eventSource instanceof WorkspaceInfo) {
+            WorkspaceInfo ws = (WorkspaceInfo) eventSource;
+            filter = workspaceFilter(ws.getName());
+            removedObjectName = "Workspace " + ws.getName();
+        } else if (eventSource instanceof LayerInfo) {
+            LayerInfo l = (LayerInfo) eventSource;
+            WorkspaceInfo ws = l.getResource().getStore().getWorkspace();
+            filter = layerFilter(ws.getName(), l.getName());
+            removedObjectName = "Layer " + l.getName();
+        } else if (eventSource instanceof LayerGroupInfo) {
+            LayerGroupInfo lg = (LayerGroupInfo) eventSource;
+            filter = layerGroupFilter(lg.getWorkspace(), lg.getName());
+            removedObjectName = "Layer Group " + lg.getName();
+        } else {
+            return;
         }
 
-        if (resourceWorkSpaceName != null && resourceInfo != null) {
-            // if a security rule exists for the layer whose name has been changed
-            if (layerHasSecurityRule(resourceWorkSpaceName, resourceName)) {
-                LOGGER.info(
-                        String.format(
-                                "Removing Security Rules for removed layer: %s", resourceName));
-
-                List<DataAccessRule> rulesToRemove = getDataAccessRule(resourceInfo, resourceName);
-                for (DataAccessRule r : rulesToRemove) {
-                    dao.removeRule(r);
-                }
-                try {
-                    dao.storeRules();
-                } catch (IOException e) {
-                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
-                    throw new CatalogException(e);
-                }
-            }
-        }
+        Supplier<String> message =
+                () -> String.format("Removing Security Rules for deleted %s", removedObjectName);
+        apply(filter, dao::removeRule, message);
     }
 
     @Override
@@ -91,61 +87,113 @@ public class SecuredResourceNameChangeListener implements CatalogListener {
 
     @Override
     public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {
-        // no names where change
-        if (event.getPropertyNames().indexOf("name") == -1) return;
-        String oldName =
-                String.valueOf(event.getOldValues().get(event.getPropertyNames().indexOf("name")));
-        String newName =
-                String.valueOf(event.getNewValues().get(event.getPropertyNames().indexOf("name")));
-        // dont go anything if name has not changed
-        if (oldName.equalsIgnoreCase(newName)) return;
-        // will be used if name of
-        String resourceWorkSpaceName = null;
-        CatalogInfo resourceInfo = null;
-        // if workspace has been renamed
-        if (event.getSource() instanceof WorkspaceInfo) {
-            // if a security rule exists for the workspaec whose name has been changed
-            if (workspaceHasSecurityRule(oldName)) {
-                LOGGER.info(
-                        String.format(
-                                "Updating Security Rules for Renamed Workspace: %s", oldName));
+        final String oldName;
+        final String newName;
+        {
+            final int indexOfName = event.getPropertyNames().indexOf("name");
+            // no names where changed
+            if (indexOfName == -1) return;
+            oldName = String.valueOf(event.getOldValues().get(indexOfName));
+            newName = String.valueOf(event.getNewValues().get(indexOfName));
+            // dont go anything if name has not changed
+            if (oldName.equalsIgnoreCase(newName)) return;
+        }
 
-                // get rules in which workspace name should be updated
-                List<DataAccessRule> rulesToModifyList =
-                        getDataAccessRule(event.getSource(), oldName);
-                for (DataAccessRule rule : rulesToModifyList) rule.setRoot(newName);
-            }
-        } else if (event.getSource() instanceof ResourceInfo) {
+        final String renamedObject; // for logging
+        final CatalogInfo eventSource = event.getSource();
+        final Predicate<DataAccessRule> filter;
+        final Consumer<DataAccessRule> updater;
+        if (eventSource instanceof WorkspaceInfo) {
+            // if workspace has been renamed
+            filter = workspaceFilter(oldName);
+            updater = r -> r.setRoot(newName);
+            renamedObject = "Workspace";
+        } else if (eventSource instanceof ResourceInfo) {
             // if a layer has been renamed
             // similar layer names can exist in different workspaces
-            resourceInfo = event.getSource();
-            resourceWorkSpaceName =
-                    ((ResourceInfo) resourceInfo).getStore().getWorkspace().getName();
-
-        } else if (event.getSource() instanceof LayerGroupInfo) {
-            // if a layergroup has been renamed
-            // similar layergroup names can exist in different workspaces
-            resourceInfo = event.getSource();
-            resourceWorkSpaceName = ((LayerGroupInfo) resourceInfo).getWorkspace().getName();
+            String wsName = ((ResourceInfo) eventSource).getStore().getWorkspace().getName();
+            filter = layerFilter(wsName, oldName);
+            updater = r -> r.setLayer(newName);
+            renamedObject = "Resource";
+        } else if (eventSource instanceof LayerGroupInfo) {
+            LayerGroupInfo lg = (LayerGroupInfo) eventSource;
+            filter = layerGroupFilter(lg.getWorkspace(), oldName);
+            updater = layerGroupRuleUpdater(lg.getWorkspace(), newName);
+            renamedObject = "LayerGroup";
+        } else {
+            return;
         }
 
-        if (resourceWorkSpaceName != null && resourceInfo != null) {
-            // if a security rule exists for the layer whose name has been changed
-            if (layerHasSecurityRule(resourceWorkSpaceName, oldName)) {
-                LOGGER.info(
+        Supplier<String> message =
+                () ->
                         String.format(
-                                "Updating Security Rules for Renamed Feature Type: %s", oldName));
+                                "Updating Security Rules for renamed %s: %s -> %s",
+                                renamedObject, oldName, newName);
+        apply(filter, updater, message);
+    }
 
-                // get rules in which workspace name should be updated
-                List<DataAccessRule> rulesToModifyList = getDataAccessRule(resourceInfo, oldName);
-                for (DataAccessRule rule : rulesToModifyList) rule.setLayer(newName);
-            }
+    /**
+     * Updates the {@link DataAccessRule#setRoot root} if it's a global layer group (i.e. {@code ws
+     * == null}), or the {@link DataAccessRule#setLayer layer} otherwsie.
+     */
+    private Consumer<DataAccessRule> layerGroupRuleUpdater(WorkspaceInfo ws, String newName) {
+        if (ws == null) {
+            return r -> r.setRoot(newName);
         }
+        return r -> r.setLayer(newName);
+    }
 
+    /**
+     * @return rule predicate that checks the rule relates to a workspace, matching {@link
+     *     DataAccessRule#getRoot() root} with the workspace name, and checking the {@link
+     *     DataAccessRule#getLayer() layer} <b>is not</b> {@code null}.
+     */
+    private Predicate<DataAccessRule> workspaceFilter(String workspaceName) {
+        return r -> r.getRoot().equalsIgnoreCase(workspaceName) && r.getLayer() != null;
+    }
+
+    /**
+     * @return rule predicate that matches both the {@link DataAccessRule#getRoot() root} and {@link
+     *     DataAccessRule#getLayer() layer} against the non-null {@code worksapce} and {@code
+     *     layerName}, respectively.
+     */
+    private Predicate<DataAccessRule> layerFilter(String workspace, String layerName) {
+        return filter(workspace::equalsIgnoreCase, layerName::equalsIgnoreCase);
+    }
+
+    /**
+     * Predicate that matches if a rule applies to the given layer group.
+     *
+     * <p>For global layer groups, checks the layer group name matches the rule's {@link
+     * DataAccessRule#getRoot() root}, and the rule's layer is {@code null}. For non global layer
+     * groups, behaves like {@link #layerFilter(String, String)}
+     */
+    private Predicate<DataAccessRule> layerGroupFilter(WorkspaceInfo ws, String lgName) {
+        final boolean isGlobalLayerGroup = null == ws;
+        // for root layer groups, its name is set as the rule's root, and the rule's layer is null
+        if (isGlobalLayerGroup) return filter(lgName::equalsIgnoreCase, Objects::isNull);
+        // otherwise the rule's root is the workspace name as with LayerInfo's
+        return layerFilter(ws.getName(), lgName);
+    }
+
+    void apply(
+            Predicate<DataAccessRule> filter,
+            Consumer<DataAccessRule> action,
+            Supplier<String> logMessage) {
+        List<DataAccessRule> matches = getDataAccessRules(filter);
+        if (!matches.isEmpty()) {
+            LOGGER.info(logMessage);
+            matches.forEach(action);
+            save();
+        }
+    }
+
+    private void save() {
         try {
             dao.storeRules();
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            throw new CatalogException(e);
         }
     }
 
@@ -154,52 +202,16 @@ public class SecuredResourceNameChangeListener implements CatalogListener {
         // ignore
     }
 
-    private boolean workspaceHasSecurityRule(String workspaceName) {
-        List<DataAccessRule> rules = this.dao.getRules();
-
-        for (DataAccessRule rule : rules) {
-            if (rule.getRoot().equalsIgnoreCase(workspaceName)) return true;
-        }
-
-        return false;
+    /**
+     * Returns a {@code Predicate<DataAccessRule>} that satisfies both {@link
+     * DataAccessRule#getRoot() root} {@link DataAccessRule#getLayer() layer} predicates
+     */
+    private Predicate<DataAccessRule> filter(
+            Predicate<String> rootFilter, Predicate<String> layerFilter) {
+        return r -> rootFilter.test(r.getRoot()) && layerFilter.test(r.getLayer());
     }
 
-    private boolean layerHasSecurityRule(String workspaceName, String layerName) {
-        List<DataAccessRule> rules = this.dao.getRules();
-
-        for (DataAccessRule rule : rules) {
-            if (rule.getRoot().equalsIgnoreCase(workspaceName)
-                    && rule.getLayer().equalsIgnoreCase(layerName)) return true;
-        }
-
-        return false;
-    }
-
-    private List<DataAccessRule> getDataAccessRule(CatalogInfo catalogInfo, String oldName) {
-        List<DataAccessRule> rules = this.dao.getRules();
-        List<DataAccessRule> rulesToUpdate = new ArrayList<>();
-
-        for (DataAccessRule rule : rules) {
-            if (catalogInfo instanceof WorkspaceInfo) {
-                if (rule.getRoot().equalsIgnoreCase(oldName)) rulesToUpdate.add(rule);
-            } else if (catalogInfo instanceof ResourceInfo) {
-                ResourceInfo resourceInfo = (ResourceInfo) catalogInfo;
-                String workspaceName = resourceInfo.getStore().getWorkspace().getName();
-                if (rule.getRoot().equalsIgnoreCase(workspaceName)
-                        && rule.getLayer().equalsIgnoreCase(oldName)) rulesToUpdate.add(rule);
-            } else if (catalogInfo instanceof LayerGroupInfo) {
-                LayerGroupInfo resourceInfo = (LayerGroupInfo) catalogInfo;
-                String workspaceName = resourceInfo.getWorkspace().getName();
-                if (rule.getRoot().equalsIgnoreCase(workspaceName)
-                        && rule.getLayer().equalsIgnoreCase(oldName)) rulesToUpdate.add(rule);
-            } else if (catalogInfo instanceof LayerInfo) {
-                LayerInfo resourceInfo = (LayerInfo) catalogInfo;
-                String workspaceName =
-                        resourceInfo.getResource().getStore().getWorkspace().getName();
-                if (rule.getRoot().equalsIgnoreCase(workspaceName)
-                        && rule.getLayer().equalsIgnoreCase(oldName)) rulesToUpdate.add(rule);
-            }
-        }
-        return rulesToUpdate;
+    private List<DataAccessRule> getDataAccessRules(Predicate<DataAccessRule> filter) {
+        return this.dao.getRules().stream().filter(filter).collect(Collectors.toList());
     }
 }

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -872,6 +872,7 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
         DataAccessRule rule = new DataAccessRule();
         rule.setRoot(workspace);
         rule.setLayer(layer);
+        rule.setGlobalGroupRule(layer == null);
         rule.setAccessMode(mode);
         rule.getRoles().addAll(Arrays.asList(roles));
         dao.addRule(rule);


### PR DESCRIPTION
[![GEOS-10371](https://badgen.net/badge/JIRA/GEOS-10371/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10371)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When a `LayerGroup` that belongs to a `Workspace` is removed,
its associated data access rules are removed.

When a root `LayerGropup` (i.e. null workspace) is removed,
its associated data access rules are not removed. Instead,
a `NullPointerException` is logged.

`SecuredResourceNameChangeListener` doesn’t check if a
`LayerGroup.getWorkspace()` is null, resuling in an NPE,
logged as a warning.

This patch simplifies the logic in `SecuredResourceNameChangeListener` that
would otherwise result in even more if-else clauses, makes sure
root layer group rules are treated properly, and adds test cases
for that, and for the rename cases, which weren't covered at all.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- N/A [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- N/A The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->