### PR TITLE
The github edit URL should use blob, rather than tree

### DIFF
--- a/doc/en/themes/geoserver/layout.html
+++ b/doc/en/themes/geoserver/layout.html
@@ -64,7 +64,7 @@
         <h3>This Page</h3>
         <ul class="this-page-menu">
         {% if display_github %}
-        <li><a href="https://github.com/{{github_user}}/{{ github_repo }}/tree/{{ github_version }}/{{ conf_py_path }}/{{ pagename }}{{ page_source_suffix }}">Edit</a></li>
+        <li><a href="https://github.com/{{github_user}}/{{ github_repo }}/blob/{{ github_version }}/{{ conf_py_path }}/{{ pagename }}{{ page_source_suffix }}">Edit</a></li>
         {%- endif %}
         {%- if show_source and has_source and sourcename %}
           <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}">Source</a></li>


### PR DESCRIPTION
Not a functional change, should be backported.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->