### PR TITLE
[GEOS-10384] Change GetMap to URIKvpParser

### DIFF
--- a/src/community/mbtiles/src/main/java/org/geoserver/mbtiles/gs/wps/MBTilesProcess.java
+++ b/src/community/mbtiles/src/main/java/org/geoserver/mbtiles/gs/wps/MBTilesProcess.java
@@ -280,7 +280,7 @@ public class MBTilesProcess implements GeoServerProcess {
 
             // Add a style
             if (stylePath != null) {
-                request.setStyleUrl(stylePath);
+                request.setStyleUrl(stylePath.toURI());
             } else if (styleBody != null && !styleBody.isEmpty()) {
                 request.setStyleBody(styleBody);
             } else {

--- a/src/ows/src/main/java/org/geoserver/ows/KvpParser.java
+++ b/src/ows/src/main/java/org/geoserver/ows/KvpParser.java
@@ -88,6 +88,12 @@ public abstract class KvpParser {
     /** The request to bind to */
     String request;
 
+    /**
+     * Setup key-value-pair for a service, binding key to a specific Java class.
+     *
+     * @param key key, non-case sensitive
+     * @param binding java type
+     */
     public KvpParser(String key, Class<?> binding) {
         this.key = key;
         this.binding = binding;
@@ -141,4 +147,18 @@ public abstract class KvpParser {
      * @throws Exception In the event of an unsuccesful parse.
      */
     public abstract Object parse(String value) throws Exception;
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer();
+        sb.append(getClass().getSimpleName()).append('{');
+
+        sb.append(service).append(' ');
+        sb.append(version).append(' ');
+        sb.append(request).append(": ");
+        sb.append(key).append('=');
+        sb.append(binding.getSimpleName());
+        sb.append('}');
+        return sb.toString();
+    }
 }

--- a/src/ows/src/main/java/org/geoserver/ows/kvp/URIKvpParser.java
+++ b/src/ows/src/main/java/org/geoserver/ows/kvp/URIKvpParser.java
@@ -1,0 +1,66 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows.kvp;
+
+import java.net.URI;
+import org.geoserver.ows.KvpParser;
+
+/**
+ * Parse URI key value pair parameter of the form <code>'key=&lt;uri&gt;'</code>.
+ *
+ * <p>This implementation should be used to reference external resource, using {@link URI#toURL()}
+ * to obtain URL when connecting.
+ */
+public class URIKvpParser extends KvpParser {
+
+    /**
+     * Creates the parser specifying the name of the key to latch to.
+     *
+     * @param key The key whose associated value to parse.
+     */
+    public URIKvpParser(String key) {
+        super(key, URI.class);
+    }
+
+    @Override
+    public URI parse(String value) throws Exception {
+        try {
+            return new URI(value);
+        } catch (Exception t) {
+            return URI.create(uriEncode(value));
+        }
+    }
+
+    /**
+     * URLEncoder.encode does not respect the URI RFC 2396, so we rolled our own little encoder.
+     * It's not complete, but should work in most cases.
+     *
+     * <p>Use of URIKvpParser recommended as a direct implementation of RFC 2396.
+     *
+     * @param uri String representation of uri
+     * @return URL with fixes applied for URI RFC 2396
+     */
+    public static String uriEncode(String uri) {
+        StringBuffer sb = new StringBuffer();
+
+        for (int i = 0; i < uri.length(); i++) {
+            char c = uri.charAt(i);
+
+            // From URI RFC, "Only alphanumerics [0-9a-zA-Z], the special
+            // characters "$-_.+!*'(),", and reserved characters used
+            // for their reserved purposes may be used unencoded within a URL
+            // Here we keep all the good ones, and remove the few unneeded in their
+            // ascii range. We also keep / and : to make sure basic URL elements
+            // don't get encoded
+            if ((c > ' ') && (c < '{') && ("\"\\<>%^[]`+$,".indexOf(c) == -1)) {
+                sb.append(c);
+            } else {
+                sb.append("%").append(Integer.toHexString(c));
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/ows/src/main/java/org/geoserver/ows/kvp/URLKvpParser.java
+++ b/src/ows/src/main/java/org/geoserver/ows/kvp/URLKvpParser.java
@@ -13,6 +13,7 @@ import org.geoserver.ows.KvpParser;
  * Parses url kvp's of the form 'key=&lt;url&gt;'.
  *
  * @author Justin Deoliveira, The Open Planning Project, jdeolive@openplans.org
+ * @deprecated Use URIKvpParser
  */
 public class URLKvpParser extends KvpParser {
     /**
@@ -34,28 +35,15 @@ public class URLKvpParser extends KvpParser {
     }
 
     /**
-     * URLEncoder.encode does not respect the RFC 2396, so we rolled our own little encoder. It's
-     * not complete, but should work in most cases
+     * URLEncoder.encode does not respect the URI RFC 2396, so we rolled our own little encoder.
+     * It's not complete, but should work in most cases.
+     *
+     * <p>Use of URIKvpParser recommended as a direct implementation of RFC 2396.
+     *
+     * @param url String representation of url
+     * @return URL with fixes applied for URI RFC 2396
      */
     public static String fixURL(String url) {
-        StringBuffer sb = new StringBuffer();
-
-        for (int i = 0; i < url.length(); i++) {
-            char c = url.charAt(i);
-
-            // From RFC, "Only alphanumerics [0-9a-zA-Z], the special
-            // characters "$-_.+!*'(),", and reserved characters used
-            // for their reserved purposes may be used unencoded within a URL
-            // Here we keep all the good ones, and remove the few uneeded in their
-            // ascii range. We also keep / and : to make sure basic URL elements
-            // don't get encoded
-            if ((c > ' ') && (c < '{') && ("\"\\<>%^[]`+$,".indexOf(c) == -1)) {
-                sb.append(c);
-            } else {
-                sb.append("%").append(Integer.toHexString(c));
-            }
-        }
-
-        return sb.toString();
+        return URIKvpParser.uriEncode(url);
     }
 }

--- a/src/ows/src/test/java/org/geoserver/ows/kvp/URIKvpParserTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/kvp/URIKvpParserTest.java
@@ -1,4 +1,4 @@
-/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -8,18 +8,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
+import java.net.URI;
 import java.net.URL;
 import org.junit.Before;
 import org.junit.Test;
 
-@SuppressWarnings("deprecation")
-public class URLKvpParserTest {
-
-    URLKvpParser parser;
+public class URIKvpParserTest {
+    URIKvpParser parser;
 
     @Before
     public void setUp() {
-        parser = new URLKvpParser("url");
+        parser = new URIKvpParser("uri");
     }
 
     @Test
@@ -27,13 +26,16 @@ public class URLKvpParserTest {
         try {
             String validUrl =
                     "http://localhost:8080/geoserver/rest/sldservice/topp:states/classify.xml?attribute=PERSONS&intervals=8&method=quantile&ramp=custom&colors=%23000000%2C%23240000%2C%23490000%2C%236d0000%2C%23920000%2C%23b60000%2C%23db0000%2C%23ff0000&open=false&strokeWeight=-1&strokeColor=%23ff0000&customClasses=1.1011%2C22.518%2C%23000000%3B22.518%2C48.445%2C%23240000%3B48.445%2C81.193%2C%23490000%3B81.193%2C118.905%2C%236D0000%3B118.905%2C168.246%2C%23920000%3B168.246%2C232.83%2C%23B60000%3B232.83%2C338.04%2C%23DB0000%3B338.04%2C16597.660000000003%2C%23FF0000&fullSLD=true";
-            URL url = (URL) parser.parse(validUrl);
+
+            URI uri = parser.parse(validUrl);
+            URL url = uri.toURL();
             assertEquals(
                     "http://localhost:8080/geoserver/rest/sldservice/topp:states/classify.xml?attribute=PERSONS&intervals=8&method=quantile&ramp=custom&colors=%23000000%2C%23240000%2C%23490000%2C%236d0000%2C%23920000%2C%23b60000%2C%23db0000%2C%23ff0000&open=false&strokeWeight=-1&strokeColor=%23ff0000&customClasses=1.1011%2C22.518%2C%23000000%3B22.518%2C48.445%2C%23240000%3B48.445%2C81.193%2C%23490000%3B81.193%2C118.905%2C%236D0000%3B118.905%2C168.246%2C%23920000%3B168.246%2C232.83%2C%23B60000%3B232.83%2C338.04%2C%23DB0000%3B338.04%2C16597.660000000003%2C%23FF0000&fullSLD=true",
                     url.toExternalForm());
+            // double check this against our own implementation of URI RFC 2396
             assertNotEquals(URIKvpParser.uriEncode(validUrl), url.toExternalForm());
         } catch (Exception e) {
-            fail();
+            fail("parse was expected to be URI encoded");
         }
     }
 }

--- a/src/wms/src/main/java/applicationContext.xml
+++ b/src/wms/src/main/java/applicationContext.xml
@@ -277,7 +277,7 @@
  	<bean id="validateSldKvpParser" class="org.geoserver.ows.kvp.BooleanKvpParser">
  		<constructor-arg value="validateschema"/>
  	</bean>
-    <bean id="sldKvpParser" class="org.geoserver.ows.kvp.URLKvpParser">
+    <bean id="sldKvpParser" class="org.geoserver.ows.kvp.URIKvpParser">
         <constructor-arg value="sld"/>
     </bean>
  	<bean id="startIndexKvpParser" class="org.geoserver.ows.kvp.IntegerKvpParser">

--- a/src/wms/src/main/java/org/geoserver/wms/GetMapRequest.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMapRequest.java
@@ -8,6 +8,7 @@ package org.geoserver.wms;
 import java.awt.Color;
 import java.awt.geom.Point2D;
 import java.awt.image.IndexColorModel;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -144,11 +145,11 @@ public class GetMapRequest extends WMSRequest implements Cloneable {
     }
 
     /**
-     * Gets the url specified by the "SLD" parameter.
+     * Gets the uri specified by the "SLD" parameter.
      *
      * <p>This parameter is an alias for "STYLE_URL".
      */
-    public URL getSld() {
+    public URI getSld() {
         return getStyleUrl();
     }
 
@@ -157,7 +158,7 @@ public class GetMapRequest extends WMSRequest implements Cloneable {
      *
      * <p>This parameter is used to point to a remote style via url.
      */
-    public URL getStyleUrl() {
+    public URI getStyleUrl() {
         return this.optionalParams.styleUrl;
     }
 
@@ -210,8 +211,8 @@ public class GetMapRequest extends WMSRequest implements Cloneable {
     }
 
     /**
-     * Gets the value of the "VALIDATESCHEMA" parameter which controls wether the value of the "SLD
-     * paramter is schema validated.
+     * Gets the value of the "VALIDATESCHEMA" parameter which controls wether the value of the
+     * "SLD_BODY" paramter is schema validated.
      */
     public Boolean getValidateSchema() {
         return this.optionalParams.validateSLD;
@@ -374,22 +375,50 @@ public class GetMapRequest extends WMSRequest implements Cloneable {
                 interpolations == null ? Collections.emptyList() : interpolations;
     }
 
-    /** Sets the url specified by the "SLD" parameter. */
-    public void setSld(URL sld) {
+    /**
+     * Style resource defined by the "SLD" parameter.
+     *
+     * <p>The style resource can be provided by either {@link #setSld(URI)} or {@link
+     * #setStyleUrl(URI)}.
+     *
+     * @param sld Style resource defined by "SLD" parameter.
+     */
+    public void setSld(URI sld) {
         setStyleUrl(sld);
     }
 
-    /** Sets the url specified by the "STYLE_URL" parameter. */
-    public void setStyleUrl(URL styleUrl) {
-        this.optionalParams.styleUrl = styleUrl;
+    /**
+     * Style resource defined by the "STYLE_URL" parameter.
+     *
+     * <p>The style resource can be provided by either {@link #setSld(URI)} or {@link
+     * #setStyleUrl(URI)}.
+     *
+     * @param styleUri Style resource defined by "STYLE_URL" parameter.
+     */
+    public void setStyleUrl(URI styleUri) {
+        this.optionalParams.styleUrl = styleUri;
     }
 
-    /** Sets the string specified by the "SLD_BODY" parameter */
+    /**
+     * Style document defined by the "SLD_BODY" parameter.
+     *
+     * <p>The sld document contents can be provided by either {@link #setSldBody(String)} or {@link
+     * #setStyleBody(String)}.
+     *
+     * @param sldBody Contents forming SLD document to use
+     */
     public void setSldBody(String sldBody) {
         setStyleBody(sldBody);
     }
 
-    /** Sets the url specified by the "STYLE_BODY" parameter. */
+    /**
+     * Style documented defined by the "STYLE_BODY" parameter.
+     *
+     * <p>The style document contents can be provided by either {@link #setSldBody(String)} or
+     * {@link #setStyleBody(String)}.
+     *
+     * @param styleBody Contents forming style document to use
+     */
     public void setStyleBody(String styleBody) {
         this.optionalParams.styleBody = styleBody;
     }
@@ -399,17 +428,21 @@ public class GetMapRequest extends WMSRequest implements Cloneable {
         setStyleVersion(sldVersion);
     }
 
-    /** Sets the url specified by the "STYLE_VERSION" parameter. */
+    /** Sets the style document version specified by the "STYLE_VERSION" parameter. */
     public void setStyleVersion(String styleVersion) {
         this.optionalParams.styleVersion = styleVersion;
     }
 
-    /** Sets the string specified by the "STYLE_FORMAT" parameter */
+    /** Sets the style document format specified by the "STYLE_FORMAT" parameter */
     public void setStyleFormat(String styleFormat) {
         this.optionalParams.styleFormat = styleFormat;
     }
 
-    /** Sets the flag to validate the "SLD" parameter or not. //TODO */
+    /**
+     * Sets the flag to validate the style document.
+     *
+     * @param validateSLD Use true to enable style document validation
+     */
     public void setValidateSchema(Boolean validateSLD) {
         this.optionalParams.validateSLD = validateSLD;
     }
@@ -671,10 +704,10 @@ public class GetMapRequest extends WMSRequest implements Cloneable {
          */
         List<Object> elevation = Collections.emptyList();
 
-        /** STYLE_URL parameter */
-        URL styleUrl;
+        /** URI provided by STYLE_URL parameter or (SLD_URL parameter). */
+        URI styleUrl;
 
-        /** STYLE_BODY parameter */
+        /** Style document provided by STYLE_BODY parameter (or SLD_BODY parameter). */
         String styleBody;
 
         /** STYLE_VERSION parameter */

--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -723,7 +724,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
             LOGGER.fine("Getting layers and styles from reomte SLD");
         }
 
-        URL styleUrl = getMap.getStyleUrl();
+        URI styleUrl = getMap.getStyleUrl();
 
         try (InputStream input = getStream(styleUrl)) {
             if (input != null) {
@@ -815,6 +816,10 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                         WMSErrorCode.INVALID_CRS.get(getMap.getVersion()));
             }
         }
+    }
+
+    private InputStream getStream(URI styleUrl) throws IOException {
+        return getStream(styleUrl.toURL());
     }
 
     private InputStream getStream(URL styleUrl) throws IOException {

--- a/src/wms/src/test/java/org/geoserver/wms/WMSRequestsTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSRequestsTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -97,7 +98,7 @@ public class WMSRequestsTest extends WMSTestSupport {
         request.setStartIndex(25);
         request.setMaxFeatures(50);
         request.setStyleVersion("1.1.0");
-        request.setSld(new URL("http://localhost/test.sld"));
+        request.setSld(new URI("http://localhost/test.sld"));
         request.setValidateSchema(true);
         List<String> urls = getGetMapUrls(request);
         assertEquals(2, urls.size());

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -51,7 +51,7 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.GeoServerLoader;
 import org.geoserver.data.test.MockData;
 import org.geoserver.ows.Dispatcher;
-import org.geoserver.ows.kvp.URLKvpParser;
+import org.geoserver.ows.kvp.URIKvpParser;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.test.RemoteOWSTestSupport;
 import org.geoserver.test.ows.KvpRequestReaderTestSupport;
@@ -498,7 +498,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         request = reader.read(request, parseKvp(kvp), caseInsensitiveKvp(kvp));
 
         assertNotNull(request.getSld());
-        assertEquals(URLKvpParser.fixURL(decoded), request.getSld().toExternalForm());
+        assertEquals(URIKvpParser.uriEncode(decoded), request.getSld().toURL().toExternalForm());
         final Style style = request.getStyles().get(0);
         assertNotNull(style);
         assertEquals("BasicPolygons", style.getName());
@@ -519,7 +519,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         request = reader.read(request, parseKvp(kvp), kvp);
 
         assertNotNull(request.getSld());
-        assertEquals(URLKvpParser.fixURL(decoded), request.getSld().toExternalForm());
+        assertEquals(URIKvpParser.uriEncode(decoded), request.getSld().toURL().toExternalForm());
         final Style style = request.getStyles().get(0);
         assertNotNull(style);
         assertEquals("TheLibraryModeStyle", style.getName());
@@ -675,7 +675,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         request = reader.read(request, parseKvp(kvp), kvp);
 
         assertNotNull(request.getSld());
-        assertEquals(URLKvpParser.fixURL(decoded), request.getSld().toExternalForm());
+        assertEquals(URIKvpParser.uriEncode(decoded), request.getSld().toURL().toExternalForm());
         final Style style = request.getStyles().get(0);
         assertNotNull(style);
         assertEquals("TheLibraryModeStyle", style.getName());
@@ -808,7 +808,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         request = reader.read(request, parseKvp(kvp), kvp);
 
         assertNotNull(request.getSld());
-        assertEquals(URLKvpParser.fixURL(decoded), request.getSld().toExternalForm());
+        assertEquals(URIKvpParser.uriEncode(decoded), request.getSld().toURL().toExternalForm());
         // check the style
         final Style style = request.getStyles().get(0);
         assertNotNull(style);
@@ -841,7 +841,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
         request = reader.read(request, parseKvp(kvp), kvp);
 
         assertNotNull(request.getSld());
-        assertEquals(URLKvpParser.fixURL(decoded), request.getSld().toExternalForm());
+        assertEquals(URIKvpParser.uriEncode(decoded), request.getSld().toURL().toExternalForm());
         // check the style
         final Style style = request.getStyles().get(0);
         assertNotNull(style);


### PR DESCRIPTION
[![GEOS-10384](https://badgen.net/badge/JIRA/GEOS-10384/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10384)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

By using URI we can avoid creating URL until needed for connection.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->