### PR TITLE
[2.20.x] [GEOS-10362] Remove selected and remove role associations removes user and the roles from roles.xml

### DIFF
--- a/doc/en/user/source/security/webadmin/ugr.rst
+++ b/doc/en/user/source/security/webadmin/ugr.rst
@@ -238,6 +238,20 @@ The Groups tab provides configuration options for groups in this user/group serv
 
 .. _security_webadmin_groups:
 
+Remove User
+~~~~~~~~~~~
+
+There are two related buttons that are responsible for removing users: :guilabel:`Remove Selected`, and :guilabel:`Remove Selected and remove role associations`. 
+
+* :guilabel:`Remove Selected` removes user from `users.xml <https://github.com/geoserver/geoserver/blob/main/data/release/security/usergroup/default/users.xml>`_ and leave untouched `roles.xml <https://github.com/geoserver/geoserver/blob/main/data/release/security/role/default/roles.xml>`_.
+* :guilabel:`Remove Selected and remove role associations` removes user from `users.xml <https://github.com/geoserver/geoserver/blob/main/data/release/security/usergroup/default/users.xml>`_ and also removes user and associated role to user from `roles.xml <https://github.com/geoserver/geoserver/blob/main/data/release/security/role/default/roles.xml>`_.
+
+
+.. figure:: images/ugr_ugusers.png
+   :align: center
+
+   *Users tab*
+
 Add group
 ~~~~~~~~~
 

--- a/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
@@ -254,6 +254,9 @@ public abstract class AbstractRoleStore implements GeoServerRoleStore {
             roles.remove(role);
             setModified(true);
         }
+        if (helper.user_roleMap.get(username) != null && roles != null && roles.size() == 0) {
+            helper.user_roleMap.remove(username);
+        }
     }
 
     /* (non-Javadoc)

--- a/src/security/security-tests/src/test/java/org/geoserver/security/xml/XMLRoleServiceTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/xml/XMLRoleServiceTest.java
@@ -266,4 +266,43 @@ public class XMLRoleServiceTest extends AbstractRoleServiceTest {
             xmlFile.delete();
         }
     }
+
+    @Test
+    public void testDisAssociateRoleFromUser() throws Exception {
+        Files.schedule(200, TimeUnit.MILLISECONDS);
+        File xmlFile = File.createTempFile("roles", ".xml");
+        try {
+            FileUtils.copyURLToFile(getClass().getResource("rolesTemplate.xml"), xmlFile);
+            GeoServerRoleService service1 =
+                    createRoleService("disassociateRole", xmlFile.getCanonicalPath());
+
+            GeoServerRoleStore store1 = createStore(service1);
+
+            GeoServerRole role_test1 = store1.createRoleObject("ROLE_TEST1");
+            GeoServerRole role_test2 = store1.createRoleObject("ROLE_TEST2");
+
+            checkEmpty(service1);
+
+            store1.addRole(role_test1);
+            store1.addRole(role_test2);
+            store1.store();
+            assertEquals(2, service1.getRoles().size());
+
+            String user = "user1";
+            store1.associateRoleToUser(role_test1, user);
+            store1.associateRoleToUser(role_test2, user);
+            store1.store();
+
+            store1.disAssociateRoleFromUser(role_test1, user);
+            store1.disAssociateRoleFromUser(role_test2, user);
+            store1.store();
+            String xmlContent = new String(java.nio.file.Files.readAllBytes(xmlFile.toPath()));
+            // check for empty userlist
+            assertTrue(xmlContent.contains("<userList/>"));
+
+        } finally {
+            Files.schedule(10, TimeUnit.SECONDS);
+            xmlFile.delete();
+        }
+    }
 }


### PR DESCRIPTION
2.20.x backport of https://github.com/geoserver/geoserver/pull/5598

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
