### PR TITLE
[GEOS-9770] Cascading WMS server sets invalid I and J when doing GetFeatureInfo calls

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/WMSCascadeTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/WMSCascadeTest.java
@@ -97,8 +97,8 @@ public class WMSCascadeTest extends WMSCascadeTestSupport {
                 new URL(
                         wms13BaseURL
                                 + "?SERVICE=WMS&INFO_FORMAT=application/vnd.ogc.gml&LAYERS=world4326"
-                                + "&CRS=EPSG:4326&FEATURE_COUNT=50&FORMAT=image%2Fpng&HEIGHT=101&TRANSPARENT=TRUE&J=-609621&REQUEST=GetFeatureInfo"
-                                + "&I=-875268&WIDTH=101&BBOX=-103.829117187,44.3898919295,-103.804563429,44.4069939679&STYLES=&QUERY_LAYERS=world4326&VERSION=1.3.0"),
+                                + "&CRS=EPSG:4326&FEATURE_COUNT=50&FORMAT=image%2Fpng&HEIGHT=101&TRANSPARENT=TRUE&J=50&REQUEST=GetFeatureInfo"
+                                + "&I=50&WIDTH=101&BBOX=44.3898919295,-103.829117187,44.4069939679,-103.804563429&STYLES=&QUERY_LAYERS=world4326&VERSION=1.3.0"),
                 new MockHttpResponse(featureInfo, "application/vnd.ogc.gml"));
     }
 
@@ -154,7 +154,7 @@ public class WMSCascadeTest extends WMSCascadeTestSupport {
                         + "&STYLES&LAYERS="
                         + WORLD4326_130
                         + "&INFO_FORMAT=text/xml; subtype=gml/3.1.1"
-                        + "&FEATURE_COUNT=50&X=50&Y=50&SRS=EPSG:4326&WIDTH=101&HEIGHT=101&BBOX=-103.829117187,44.3898919295,-103.804563429,44.4069939679";
+                        + "&FEATURE_COUNT=50&X=50&Y=50&CRS=EPSG:4326&WIDTH=101&HEIGHT=101&BBOX=44.3898919295,-103.829117187,44.4069939679,-103.804563429";
         Document result = getAsDOM(url);
         // setup XPATH engine namespaces
         Map<String, String> namespaces = new HashMap<>();


### PR DESCRIPTION
[![GEOS-9770](https://badgen.net/badge/JIRA/GEOS-9770/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9770)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This changes are made to fix GEOS-9770.

- The fix is made in geotools but there is a test adaptation to this fix. The old test had unreasonable I and J values, they would have been way outside of the GetMap extents.
- A mocked httpClient has to respond to a different GET parameters

Depends on https://github.com/geotools/geotools/pull/3777, build won't be green until that one is merged.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules: (not applicable for this PL)

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).