### PR TITLE
[GEOS-10388] STAC cannot extract queryables/sortables when a dynamic includeFlat is used in the items template

### DIFF
--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicIncludeFlatBuilder.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/builders/impl/DynamicIncludeFlatBuilder.java
@@ -147,4 +147,27 @@ public class DynamicIncludeFlatBuilder extends DynamicValueBuilder {
     public boolean checkNotNullValue(TemplateBuilderContext context) {
         return includingNode != null;
     }
+
+    /**
+     * Returns a TemplateBuilder representing the including node of this dynamic include flat
+     * builder, or null, if the including node is not an object.
+     *
+     * @param key
+     * @return
+     */
+    public TemplateBuilder getIncludingNodeBuilder(String key) {
+        if (!includingNode.isObject()) return null;
+
+        TemplateReaderConfiguration configuration =
+                new TemplateReaderConfiguration(getNamespaces());
+        TemplateBuilderMaker maker = configuration.getBuilderMaker();
+        maker.namespaces(configuration.getNamespaces());
+        JSONTemplateReader jsonTemplateReader =
+                new JSONTemplateReader(includingNode, configuration, new ArrayList<>());
+
+        CompositeBuilder result = new CompositeBuilder(key, getNamespaces(), false);
+        jsonTemplateReader.getBuilderFromJson(null, includingNode, result, maker);
+
+        return result;
+    }
 }

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/JSONIncludesTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/JSONIncludesTest.java
@@ -1,3 +1,7 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.featurestemplating.readers;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -6,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
@@ -193,9 +198,12 @@ public class JSONIncludesTest {
         Resource included = store.get("object.json");
         File file = included.file();
         file.setLastModified(new Date().getTime());
-        Thread.sleep(1000);
 
-        assertTrue(rootBuilder.needsReload());
+        for (int i = 0; i < 600; i++) {
+            if (rootBuilder.needsReload()) return; // ok worked
+            Thread.sleep(100);
+        }
+        fail("Should have found a reload 60 seconds, but did not");
     }
 
     @Test

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/JSONMergesTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/JSONMergesTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -126,9 +127,22 @@ public class JSONMergesTest {
         Resource mergeBase = store.get("simpleBase.json");
         File file = mergeBase.file();
         file.setLastModified(new Date().getTime());
-        Thread.sleep(1000);
 
-        assertTrue(rootBuilder.needsReload());
+        assertReloadNeeded(rootBuilder);
+    }
+
+    /**
+     * Utility method that waits up to a minute for the builder to figure out
+     *
+     * @param rootBuilder
+     * @throws InterruptedException
+     */
+    public static void assertReloadNeeded(RootBuilder rootBuilder) throws InterruptedException {
+        for (int i = 0; i < 600; i++) {
+            if (rootBuilder.needsReload()) return;
+            Thread.sleep(100);
+        }
+        fail("Should have found a reload 60 seconds, but did not");
     }
 
     @Test

--- a/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/XmlTemplateReaderTest.java
+++ b/src/community/features-templating/features-templating-core/src/test/java/org/geoserver/featurestemplating/readers/XmlTemplateReaderTest.java
@@ -1,3 +1,7 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.featurestemplating.readers;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -7,6 +11,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -97,9 +102,12 @@ public class XmlTemplateReaderTest {
         assertFalse(rootBuilder.needsReload());
         File file = store.get("includedGeologicUnit.xml").file();
         file.setLastModified(new Date().getTime());
-        Thread.sleep(1000);
 
-        assertTrue(rootBuilder.needsReload());
+        for (int i = 0; i < 600; i++) {
+            if (rootBuilder.needsReload()) return; // ok worked
+            Thread.sleep(100);
+        }
+        fail("Should have found a reload 60 seconds, but did not");
     }
 
     private RuntimeException checkThrowingTemplate(String s) {

--- a/src/community/oseo/oseo-core/src/test/resources/product_test_data.sql
+++ b/src/community/oseo/oseo-core/src/test/resources/product_test_data.sql
@@ -1,5 +1,6 @@
 ALTER TABLE public.product_ogclink
     add column "intTest" integer, add column "floatTest" float, add column "booleanTest" boolean, add column "dateTest" date, add column "varcharTest" varchar;
+ALTER TABLE public.product add column "extraProperties" json;
 -- product data, without geometries
 INSERT INTO product
 ("id", "timeStart", "timeEnd", "originalPackageLocation", "thumbnailURL", "quicklookURL", "eoIdentifier", "eoParentIdentifier", "eoProductionStatus", "eoAcquisitionType", "eoOrbitNumber", "eoOrbitDirection", "eoTrack", "eoFrame", "eoSwathIdentifier", "optCloudCover", "optSnowCover", "eoProductQualityStatus", "eoProductQualityDegradationStatus", "eoProcessorName", "eoProcessingCenter", "eoCreationDate", "eoModificationDate", "eoProcessingDate", "eoSensorMode", "eoArchivingCenter", "eoProcessingMode", "eoAvailabilityTime", "eoAcquisitionStation", "eoAcquisitionSubtype", "eoStartTimeFromAscendingNode", "eoCompletionTimeFromAscendingNode", "eoIlluminationAzimuthAngle", "eoIlluminationZenithAngle", "eoIlluminationElevationAngle", "sarPolarisationMode", "sarPolarisationChannels", "sarAntennaLookDirection", "sarMinimumIncidenceAngle", "sarMaximumIncidenceAngle", "sarDopplerFrequency", "sarIncidenceAngleVariation", "eoResolution", "eoProductPlatform")

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACQueryablesBuilder.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACQueryablesBuilder.java
@@ -126,6 +126,7 @@ public class STACQueryablesBuilder {
     private Schema getGenericSchema() {
         Schema schema = new Schema();
         schema.setType(AttributeType.STRING.getType());
+        schema.setDescription(AttributeType.STRING.getType());
         return schema;
     }
 }

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACSortablesMapperTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACSortablesMapperTest.java
@@ -64,4 +64,27 @@ public class STACSortablesMapperTest {
         // one custom, and nested, property
         assertThat(sortables, hasEntry("one.two.three", "eop:illuminationAzimuthAngle"));
     }
+
+    @Test
+    public void testSortablesIncludeFlat() throws Exception {
+        FileSystemResourceStore resourceStore =
+                new FileSystemResourceStore(new File("./src/test/resources"));
+        Resource templateDefinition = resourceStore.get("items-SAS1.json");
+        FeatureSource<FeatureType, Feature> products = data.getProductSource();
+        TemplateReaderConfiguration config =
+                new TemplateReaderConfiguration(STACTemplates.getNamespaces(products));
+        Template template = new Template(templateDefinition, config);
+        STACSortablesMapper builder =
+                new STACSortablesMapper(template.getRootBuilder(), products.getSchema());
+        Map<String, String> sortables = builder.getSortablesMap();
+
+        // common sortables from spec
+        assertThat(sortables, hasEntry("collection", "parentIdentifier"));
+        assertThat(sortables, hasEntry("datetime", "timeStart"));
+        assertThat(sortables, hasEntry("id", "identifier"));
+
+        // custom sortables from template
+        assertThat(sortables, hasEntry("view:sun_azimuth", "eop:illuminationAzimuthAngle"));
+        assertThat(sortables, hasEntry("custom:clouds", "opt:cloudCover"));
+    }
 }

--- a/src/community/oseo/oseo-stac/src/test/resources/items-SAS1.json
+++ b/src/community/oseo/oseo-stac/src/test/resources/items-SAS1.json
@@ -28,8 +28,10 @@
         "view:sun_azimuth": "${eop:illuminationAzimuthAngle}",
         "view:sun_elevation": "${eop:illuminationElevationAngle}",
         "sat:orbit_state": "$${strToLowerCase(eop:orbitDirection)}",
+        "custom:clouds": "${opt:cloudCover}",
         "sat:absolute_orbit": "${eop:orbitNumber}",
-        "sat:anx_datetime": "${eop:startTimeFromAscendingNode}"
+        "sat:anx_datetime": "${eop:startTimeFromAscendingNode}",
+        "$includeFlat":"${extraProperties}"
       },
       "collection": "${eop:parentIdentifier}",
       "assets": "${assets}",


### PR DESCRIPTION
[![GEOS-10388](https://badgen.net/badge/JIRA/GEOS-10388/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10388)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket. Also includes a build fix in features templating test.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->