### PR TITLE
[GEOS-9785] Wps download fails estimate

### DIFF
--- a/doc/en/user/source/community/index.rst
+++ b/doc/en/user/source/community/index.rst
@@ -12,51 +12,53 @@ officially part of the GeoServer releases. They are however built along with the
    Community modules are generally considered experimental in nature and are often under constant development. For that reason documentation in this section should not be considered solid or final and will be subject to change.
 
 
+.. please keep the following list sorted alphabetically 
+
 .. toctree::
    :maxdepth: 1
 
-   oauth2/index
-   keycloak/index
-   keycloak/keycloak_role_service
-   dds/index
+   backuprestore/index
+   cog/index
    colormap/index
-   jdbcconfig/index
-   mbtiles/index
-   geopkg/index
-   pgraster/pgraster
-   jms-cluster/index
-   solr/index
+   cov-json/index
+   csw-iso/index
+   dds/index
    elasticsearch/index
-   geomesa/index
-   gwc-distributed/index
+   features-templating/index
    flatgeobuf/index
    gdal/index
-   gwc-azure-blob/index
-   gwc-sqlite/index
-   remote-wps/index
-   jdbcstore/index
-   ncwms/index
-   backuprestore/index
-   saml/index
-   notification/index
-   opensearch-eo/index
-   s3-geotiff/index
-   netcdf-ghrsst/index
-   monitor-hibernate/index
-   taskmanager/index
-   metadata/index
-   ogr-store/index
+   geomesa/index
+   geopkg/index
    geostyler/index
-   csw-iso/index
-   importer-jdbc/index
-   hana/index
-   features-templating/index
-   ogc-api/index
    gsr/index
-   cog/index
-   cov-json/index
-   smart-data-loader/index
-   schemaless-features/index
-   web-service-auth/index
+   gwc-azure-blob/index
+   gwc-distributed/index
    gwc-mbtiles/index
+   gwc-sqlite/index
+   hana/index
+   importer-jdbc/index
+   jdbcconfig/index
+   jdbcstore/index
+   jms-cluster/index
+   keycloak/index
+   keycloak/keycloak_role_service
+   mbtiles/index
+   metadata/index
+   monitor-hibernate/index
+   ncwms/index
+   netcdf-ghrsst/index
+   notification/index
+   oauth2/index
+   ogc-api/index
+   ogr-store/index
+   opensearch-eo/index
+   pgraster/pgraster
+   remote-wps/index
+   s3-geotiff/index
+   saml/index
+   schemaless-features/index
+   smart-data-loader/index
+   solr/index
+   taskmanager/index
    vsi/index
+   web-service-auth/index

--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterEstimator.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterEstimator.java
@@ -5,15 +5,7 @@
  */
 package org.geoserver.wps.gs.download;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.apache.wicket.model.CompoundPropertyModel;
 import org.geoserver.catalog.*;
-import org.geoserver.web.GeoServerApplication;
-import org.geoserver.web.data.resource.CoverageBandsConfigurationPanel;
 import org.geotools.coverage.TypeMap;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
@@ -28,10 +20,10 @@ import org.locationtech.jts.geom.PrecisionModel;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.util.ProgressListener;
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
 
-import static org.apache.wicket.ThreadContext.getApplication;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This class check whether or not the provided download request goes beyond the provided limits for

--- a/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
+++ b/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
@@ -2257,10 +2257,9 @@ public class DownloadProcessTest extends WPSTestSupport {
      * Test download estimator for raster data. The estimate must work even when dimension type not present
      * in a saved Coverage. See GEOS-9785
      *
-     * @throws Exception the exception
      */
     @Test(expected = Test.None.class)
-    public void testDownloadEstimatorReloadsCoverageDimensionsWhenNull() throws Exception {
+    public void testDownloadEstimatorReloadsCoverageDimensionsWhenNull() {
         CoverageInfo mycoverage = getCatalog().getCoverageByName(MockData.USA_WORLDIMG.getLocalPart());
         mycoverage.getDimensions().get(0).setDimensionType(null);
         getCatalog().save(mycoverage);


### PR DESCRIPTION
[![GEOS-9785](https://badgen.net/badge/JIRA/GEOS-9785/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9785)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

WPS download fails to estimate either the response result will exceed the size limit configured or not. Then no download process is executed.

This bug occurs when there is a Coverage saved in catalog wich has missing info regarding the pixel dimension type in one or more bands. Unluckily this happens for the default geoserver coverages included in demo data.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->