### PR TITLE
[GEOS-10377] Emitting an empty Abstract element when no abstract set on Layer or LayerGroup.

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1878,11 +1878,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                 } else {
                     element("Title", publishedInfo.getTitle());
                 }
-                if (StringUtils.isEmpty(publishedInfo.getAbstract())) {
-                    element("Abstract", "Layer-Group type layer: " + layerName);
-                } else {
-                    element("Abstract", publishedInfo.getAbstract());
-                }
+                element("Abstract", publishedInfo.getAbstract());
             } else {
                 String title = internationalContentHelper.getTitle(publishedInfo);
                 String abstrct = internationalContentHelper.getAbstract(publishedInfo);

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -1836,11 +1836,8 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                 } else {
                     element("Title", publishedInfo.getTitle());
                 }
-                if (StringUtils.isEmpty(publishedInfo.getAbstract())) {
-                    element("Abstract", "Layer-Group type layer: " + layerName);
-                } else {
-                    element("Abstract", publishedInfo.getAbstract());
-                }
+
+                element("Abstract", publishedInfo.getAbstract());
             } else {
                 String title = internationalContentHelper.getTitle(publishedInfo);
                 String abstrct = internationalContentHelper.getAbstract(publishedInfo);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
@@ -11,6 +11,8 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 import static org.custommonkey.xmlunit.XMLUnit.newXpathEngine;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Proxy;
@@ -41,6 +43,7 @@ import org.geoserver.catalog.impl.NamespaceInfoImpl;
 import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServerInfo;
+import org.geoserver.data.test.CiteTestData;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.json.JSONType;
@@ -53,6 +56,7 @@ import org.geotools.util.decorate.AbstractDecorator;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
@@ -941,6 +945,42 @@ public class CapabilitiesIntegrationTest extends WMSTestSupport {
                 catalog.remove(globalLayerGroup);
             }
         }
+    }
+
+    @Test
+    public void testDefaultAbstract() throws Exception {
+        Document dom = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+
+        Element el = findAbstractForLayerWithName(CiteTestData.BASIC_POLYGONS.getLocalPart(), dom);
+        assertNotNull(el);
+        assertNotNull(el.getFirstChild());
+        assertEquals(
+                getCatalog()
+                        .getLayerByName(CiteTestData.BASIC_POLYGONS.getLocalPart())
+                        .getAbstract(),
+                el.getFirstChild().getNodeValue());
+
+        el = findAbstractForLayerWithName(CiteTestData.TASMANIA_BM.getLocalPart(), dom);
+        assertNotNull(el);
+        assertNull(el.getFirstChild());
+    }
+
+    /** Helper to fetch the abstract for a given layer in the capabilities doc. */
+    private Element findAbstractForLayerWithName(String name, Document dom) {
+        NodeList nodeList = dom.getElementsByTagName("Layer");
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            Node node = nodeList.item(i);
+            if (node instanceof Element && node.getLocalName().equals("Layer")) {
+                Element el = (Element) node;
+                Node title = getFirstElementByTagName(el, "Title");
+                if (title != null
+                        && title.getFirstChild() != null
+                        && name.equals(title.getFirstChild().getTextContent())) {
+                    return getFirstElementByTagName(el, "Abstract");
+                }
+            }
+        }
+        return null;
     }
 
     /** Check that the global bounding box matches the expected envelope */


### PR DESCRIPTION
[![GEOS-10377](https://badgen.net/badge/JIRA/GEOS-10377/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10377)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is a backport to 2.20.x.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).