### PR TITLE
[GEOS-9785] Wps download fails estimate (2.19.X)

### DIFF
--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterEstimator.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterEstimator.java
@@ -9,14 +9,18 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageView;
+import org.geoserver.catalog.MetadataMap;
 import org.geotools.coverage.TypeMap;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.util.FeatureUtilities;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -201,6 +205,11 @@ class RasterEstimator {
 
         // Use sample info type for each output band to estimate size
         List<CoverageDimensionInfo> coverageDimensionInfoList = coverageInfo.getDimensions();
+
+        if (coverageDimensionInfoList.stream().anyMatch(cdi -> cdi.getDimensionType() == null)) {
+            LOGGER.log(Level.FINE, "Recalculating Band Dimensions Types");
+            coverageDimensionInfoList = getBandDimensionsFromCoverageInfo(coverageInfo);
+        }
         int accumulatedPixelSizeInBits = 0;
 
         // Use only selected bands for output, if specified
@@ -250,5 +259,25 @@ class RasterEstimator {
                             + ")");
         }
         return true;
+    }
+
+    private List<CoverageDimensionInfo> getBandDimensionsFromCoverageInfo(CoverageInfo ci)
+            throws Exception {
+        String nativeName = ci.getNativeCoverageName();
+        CatalogBuilder cb = new CatalogBuilder(catalog);
+        cb.setStore(ci.getStore());
+        MetadataMap metadata = ci.getMetadata();
+        CoverageInfo rebuilt;
+        if (metadata != null && metadata.containsKey(CoverageView.COVERAGE_VIEW)) {
+            GridCoverage2DReader reader =
+                    (GridCoverage2DReader)
+                            catalog.getResourcePool()
+                                    .getGridCoverageReader(
+                                            ci, nativeName, GeoTools.getDefaultHints());
+            rebuilt = cb.buildCoverage(reader, nativeName, null);
+        } else {
+            rebuilt = cb.buildCoverage(nativeName);
+        }
+        return rebuilt.getDimensions();
     }
 }

--- a/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
+++ b/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
@@ -2253,6 +2253,54 @@ public class DownloadProcessTest extends WPSTestSupport {
     }
 
     /**
+     * Test download estimator for raster data. The estimate must work even when dimension type not
+     * present in a saved Coverage. See GEOS-9785
+     */
+    @Test(expected = Test.None.class)
+    public void testDownloadEstimatorReloadsCoverageDimensionsWhenNull() {
+        CoverageInfo mycoverage =
+                getCatalog().getCoverageByName(MockData.USA_WORLDIMG.getLocalPart());
+        mycoverage.getDimensions().get(0).setDimensionType(null);
+        getCatalog().save(mycoverage);
+        final WPSResourceManager resourceManager = getResourceManager();
+        DownloadEstimatorProcess limits =
+                new DownloadEstimatorProcess(
+                        new StaticDownloadServiceConfiguration(
+                                new DownloadServiceConfiguration(
+                                        DownloadServiceConfiguration.NO_LIMIT,
+                                        DownloadServiceConfiguration.NO_LIMIT,
+                                        DownloadServiceConfiguration.NO_LIMIT,
+                                        DownloadServiceConfiguration.NO_LIMIT,
+                                        DownloadServiceConfiguration.DEFAULT_COMPRESSION_LEVEL,
+                                        DownloadServiceConfiguration.NO_LIMIT)),
+                        getGeoServer());
+        DownloadProcess downloadProcess =
+                new DownloadProcess(getGeoServer(), limits, resourceManager);
+        // ROI as polygon
+
+        // Download the data with ROI. It should throw an exception
+        downloadProcess.execute(
+                getLayerId(MockData.USA_WORLDIMG), // layerName
+                null, // filter
+                "image/tiff", // outputFormat
+                "image/tiff",
+                null, // targetCRS
+                null, // roiCRS
+                null, // roi
+                true, // cropToGeometry
+                null, // interpolation
+                null, // targetSizeX
+                null, // targetSizeY
+                null, // bandSelectIndices
+                null, // Writing params
+                false,
+                false,
+                0d,
+                null,
+                new NullProgressListener() // progressListener
+                );
+    }
+    /**
      * Test download estimator for raster data. The result should exceed the limits
      *
      * @throws Exception the exception


### PR DESCRIPTION
[![GEOS-9785](https://badgen.net/badge/JIRA/GEOS-9785/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9785)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-9785]Wps download fails estimate (Invalid argument type=null when trying to use gs:Download WPS identifier)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).