### PR TITLE
[GEOS-10389] Use URI for AllowListEntityResolver

### DIFF
--- a/src/main/src/main/java/org/geoserver/util/AllowListEntityResolver.java
+++ b/src/main/src/main/java/org/geoserver/util/AllowListEntityResolver.java
@@ -7,7 +7,6 @@ package org.geoserver.util;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
-import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -137,12 +136,6 @@ public class AllowListEntityResolver implements EntityResolver2, Serializable {
                     uri = baseURI.substring(0, baseURI.lastIndexOf('/')) + '/' + systemId;
                 } else {
                     uri = baseURI + '/' + systemId;
-                }
-                // double check this is the same result as with URL
-                String check = new URL(new URL(baseURI), systemId).toString();
-                if (!uri.equals(check)) {
-                    LOGGER.finest("URL used to resolve systemId:" + check);
-                    uri = check;
                 }
             }
             // check if the absolute systemId is an allowed URI jar or vfs reference


### PR DESCRIPTION
[![GEOS-10389](https://badgen.net/badge/JIRA/GEOS-10389/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10389)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Checking URI vs URL is not required, and use of URL may cause DNS resolution

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->