### PR TITLE
[GEOS-7606] Manage httpclient version using dependency managaement and httpclient.version property

### DIFF
--- a/src/community/security/keycloak/pom.xml
+++ b/src/community/security/keycloak/pom.xml
@@ -67,7 +67,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -99,6 +99,7 @@
     <poi.version>4.0.0</poi.version>
     <wicket.version>7.18.0</wicket.version>
     <ant.version>1.10.11</ant.version>
+    <httpclient.version>4.5.13</httpclient.version>
     <imageio-ext.version>1.3.11</imageio-ext.version>
     <jaiext.version>1.1.21</jaiext.version>
     <java.awt.headless>true</java.awt.headless>
@@ -858,12 +859,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
+        <version>${httpclient.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient-cache</artifactId>
-        <version>4.5.13</version>
+        <version>${httpclient.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
[![GEOS-7606](https://badgen.net/badge/JIRA/GEOS-7606/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-7606)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The current version 4.5.13 remains unchanged, the community keycloak module had hardcoded a prior version by accident.

Note gs-main continues to require classic commons-httpclient 3.1 for some reason.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->