### PR TITLE
GEOS-10390 Concurrency issues with SecuredResourceNameChangeListener …

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/AbstractAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/AbstractAccessRuleDAO.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resource.Lock;
 import org.geoserver.platform.resource.Resource.Type;
 import org.geoserver.security.PropertyFileWatcher;
 import org.geoserver.util.IOUtils;
@@ -70,6 +71,10 @@ public abstract class AbstractAccessRuleDAO<R extends Comparable<R>> {
         this.propertyFileName = propertyFileName;
         this.dd = GeoServerExtensions.bean(GeoServerDataDirectory.class);
         // this.dd = org.vfny.geoserver.global.GeoserverDataDirectory.accessor();
+    }
+
+    public Lock lock() {
+        return watcher.getResource().lock();
     }
 
     /**

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/RuleSyncedNameChangeConcurrencyTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/RuleSyncedNameChangeConcurrencyTest.java
@@ -1,0 +1,87 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.security.AccessMode;
+import org.geoserver.security.SecuredResourceNameChangeListener;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+
+/** Test for verifying if SecuredResourceNameChangeListener is thread-safe. */
+public class RuleSyncedNameChangeConcurrencyTest extends GeoServerSystemTestSupport {
+
+    protected SecuredResourceNameChangeListener securedResourceNameChangeListener;
+
+    static DataAccessRuleDAO dao;
+    static Catalog catalog;
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        catalog = getCatalog();
+        // create RULE
+        setRules();
+        dao = DataAccessRuleDAO.get();
+        securedResourceNameChangeListener = new SecuredResourceNameChangeListener(catalog, dao);
+    }
+
+    @Test
+    public void testConcurrentChanges() throws Exception {
+
+        String oldLayerName1 = "Lines";
+        String newLayerName1 = "Lines_123";
+        String oldLayerName2 = "MLines";
+        String newLayerName2 = "MLines_123";
+
+        ResourceInfo resourceInfo1 = catalog.getLayerByName(oldLayerName1).getResource();
+        ResourceInfo resourceInfo2 = catalog.getLayerByName(oldLayerName2).getResource();
+        resourceInfo1.setName(newLayerName1);
+        resourceInfo2.setName(newLayerName2);
+
+        ExecutorService es = Executors.newCachedThreadPool();
+
+        es.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        // save to invoke listner
+                        catalog.save(resourceInfo1);
+                    }
+                });
+        es.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        // save to invoke listner
+                        catalog.save(resourceInfo2);
+                    }
+                });
+        es.shutdown();
+        assertTrue(es.awaitTermination(1, TimeUnit.MINUTES));
+
+        // should update 2 rules p1
+        int countOfRulesUpdated = 0;
+        for (DataAccessRule rule : dao.getRules()) {
+            if (rule.getLayer().equalsIgnoreCase(newLayerName1)
+                    || rule.getLayer().equalsIgnoreCase(newLayerName2)) countOfRulesUpdated++;
+        }
+        assertEquals(2, countOfRulesUpdated);
+    }
+
+    private void setRules() throws Exception {
+        addLayerAccessRule("cgf", "*", AccessMode.WRITE, "*");
+        addLayerAccessRule("cgf", "Lines", AccessMode.WRITE, "*");
+        addLayerAccessRule("cgf", "MLines", AccessMode.WRITE, "*");
+    }
+}


### PR DESCRIPTION
[![GEOS-10390](https://badgen.net/badge/JIRA/GEOS-10390/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10390)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…when renaming layers simultaneously


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->