### PR TITLE
[2.20.x][GEOS-10400] Disabling WMS dynamic styling does not affect GetLegendGraphic requests

### DIFF
--- a/doc/en/user/source/services/wms/webadmin.rst
+++ b/doc/en/user/source/services/wms/webadmin.rst
@@ -154,10 +154,10 @@ GetFeatureInfo requests. A GetMap/GetFeatureInfo request with a MIME type not al
 
 .. note:: Activating MIME type restriction and not allowing at least one MIME type disables the particular request.
 
-Disabling usage of dynamic styling in GetMap and GetFeatureInfo requests
-------------------------------------------------------------------------
+Disabling usage of dynamic styling in GetMap, GetFeatureInfo and GetLegendGraphic requests
+------------------------------------------------------------------------------------------
 
-Dynamic styles can be applied to layers in GetMap and GetFeatureInfo requests using the SLD or SLD_BODY parameters for GET requests.
+Dynamic styles can be applied to layers in GetMap, GetFeatureInfo and GetLegendGraphic requests using the SLD or SLD_BODY parameters for GET requests.
 
 In addition, GetMap POST requests can contain inline style definition for layers.
 
@@ -165,7 +165,7 @@ The usage of dynamic styling can be restricted on a global or per virtual servic
 
 .. figure:: img/service_WMS_disableDynamicStyling.png
 
-When the flag is checked, a GetMap/GetFeatureInfo request with a dynamic style will result in a service exception reporting the error.
+When the flag is checked, a GetMap/GetFeatureInfo/GetLegendGraphic request with a dynamic style will result in a service exception reporting the error.
 
 Disabling GetFeatureInfo requests results reprojection
 ------------------------------------------------------

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReader.java
@@ -460,6 +460,10 @@ public class GetLegendGraphicKvpReader extends KvpRequestReader {
         String sldUrl = (String) rawKvp.get("SLD");
         String sldBody = (String) rawKvp.get("SLD_BODY");
 
+        if ((sldBody != null || sldUrl != null) && wms.isDynamicStylingDisabled()) {
+            throw new ServiceException("Dynamic style usage is forbidden");
+        }
+
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine(new StringBuffer("looking for styles ").append(listOfStyles).toString());
         }

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/GetLegendGraphicKvpReaderTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -20,6 +21,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.GetLegendGraphicRequest;
 import org.geoserver.wms.WMS;
+import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSTestSupport;
 import org.geotools.feature.NameImpl;
 import org.geotools.styling.Style;
@@ -126,6 +128,25 @@ public class GetLegendGraphicKvpReaderTest extends WMSTestSupport {
         selectedStyle = request.getLegends().get(0).getStyle();
         assertNotNull(selectedStyle);
         assertEquals("Lakes", selectedStyle.getName());
+    }
+
+    @org.junit.Test
+    public void testRemoteSLDDisabled() {
+        WMSInfo info = wms.getServiceInfo();
+        info.setDynamicStylingDisabled(true);
+        wms.getGeoServer().save(info);
+        final URL remoteSldUrl = getClass().getResource("MultipleStyles.sld");
+        this.allParameters.put("SLD", remoteSldUrl.toExternalForm());
+        this.allParameters.put("LAYER", "cite:Ponds");
+        ServiceException exception =
+                assertThrows(
+                        ServiceException.class,
+                        () ->
+                                requestReader.read(
+                                        new GetLegendGraphicRequest(),
+                                        allParameters,
+                                        allParameters));
+        assertEquals("Dynamic style usage is forbidden", exception.getMessage());
     }
 
     @org.junit.Test


### PR DESCRIPTION
[![GEOS-10400](https://badgen.net/badge/JIRA/GEOS-10400/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10400)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

2.20.x backport for https://github.com/geoserver/geoserver/pull/5700


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->