### PR TITLE
[2.20.x][GEOS-10401] WPS GetExecutionResult doesn't validate the mimetype parameter

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/resource/WPSResourceManager.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/resource/WPSResourceManager.java
@@ -8,6 +8,7 @@ package org.geoserver.wps.resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
 import net.opengis.wps10.ExecuteType;
+import org.apache.commons.io.IOUtils;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.DispatcherCallback;
 import org.geoserver.ows.Request;
@@ -206,6 +208,13 @@ public class WPSResourceManager extends ProcessListenerAdapter
             baseUrl = execute.getBaseUrl();
         }
         String url = ResponseUtils.buildURL(baseUrl, "ows", kvp, URLType.SERVICE);
+
+        Resource mimeResource = getOutputResource(getExecutionId(executionId), name + ".mime");
+        try (OutputStream output = mimeResource.out()) {
+            IOUtils.write(mimeType, output, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new WPSException("Error storing the output resource mime type", e);
+        }
 
         return url;
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/response/StoredResourceResponse.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/response/StoredResourceResponse.java
@@ -9,10 +9,12 @@ package org.geoserver.wps.response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.geoserver.ows.Response;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resource.Type;
 import org.geoserver.wps.GetExecutionResultType;
 import org.geoserver.wps.GetExecutionStatusType;
 import org.geoserver.wps.WPSException;
@@ -46,11 +48,26 @@ public class StoredResourceResponse extends Response {
             return "text/xml";
         } else if (request instanceof GetExecutionResultType) {
             GetExecutionResultType ger = (GetExecutionResultType) request;
-            if (ger.getMimeType() != null) {
-                return ger.getMimeType();
-            } else {
-                // generic binary output...
-                return "application/octet-stream";
+            Resource mimeResource =
+                    manager.getOutputResource(ger.getExecutionId(), ger.getOutputId() + ".mime");
+            if (mimeResource == null || mimeResource.getType() == Type.UNDEFINED) {
+                throw new WPSException(
+                        "Unknown output "
+                                + ger.getOutputId()
+                                + " for execution id "
+                                + ger.getExecutionId()
+                                + ", either the execution was never submitted or too much time "
+                                + "elapsed since the process completed");
+            }
+            try (InputStream input = mimeResource.in()) {
+                String mimeType = IOUtils.toString(input, StandardCharsets.UTF_8);
+                if (ger.getMimeType() == null || ger.getMimeType().equals(mimeType)) {
+                    return mimeType;
+                }
+                throw new WPSException(
+                        "Requested mime type does not match the output resource mime type");
+            } catch (IOException e) {
+                throw new WPSException("Error validating the output resource mime type", e);
             }
         } else {
             throw new WPSException(

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetExecutionResultTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/GetExecutionResultTest.java
@@ -1,0 +1,81 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
+
+import java.io.ByteArrayInputStream;
+import org.geoserver.ows.util.ResponseUtils;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+
+public class GetExecutionResultTest extends WPSTestSupport {
+
+    @Test
+    public void testGetExecutionResultWithoutMime() throws Exception {
+        String request = getGetExecutionResultHref();
+        request = request.substring(0, request.indexOf("&mimetype="));
+        MockHttpServletResponse response = getAsServletResponse(request);
+        assertEquals("text/csv", response.getContentType());
+        assertEquals("inline; filename=result.csv", response.getHeader(CONTENT_DISPOSITION));
+        assertEquals("foo", response.getContentAsString().trim());
+    }
+
+    @Test
+    public void testGetExecutionResultWithDecodedMime() throws Exception {
+        String request = getGetExecutionResultHref();
+        MockHttpServletResponse response = getAsServletResponse(request);
+        assertEquals("text/csv", response.getContentType());
+        assertEquals("inline; filename=result.csv", response.getHeader(CONTENT_DISPOSITION));
+        assertEquals("foo", response.getContentAsString().trim());
+    }
+
+    @Test
+    public void testGetExecutionResultWithEncodedMime() throws Exception {
+        String request = getGetExecutionResultHref();
+        request = request.replace("text/csv", "text%2Fcsv");
+        MockHttpServletResponse response = getAsServletResponse(request);
+        assertEquals("text/csv", response.getContentType());
+        assertEquals("inline; filename=result.csv", response.getHeader(CONTENT_DISPOSITION));
+        assertEquals("foo", response.getContentAsString().trim());
+    }
+
+    @Test
+    public void testGetExecutionResultWithInvalidMime() throws Exception {
+        String request = getGetExecutionResultHref();
+        request = request.replace("text/csv", "text/html");
+        MockHttpServletResponse response = getAsServletResponse(request);
+        assertEquals("application/xml", response.getContentType());
+        assertNull(response.getHeader(CONTENT_DISPOSITION));
+        Document dom = dom(new ByteArrayInputStream(response.getContentAsByteArray()));
+        assertXpathExists("/ows:ExceptionReport/ows:Exception/ows:ExceptionText", dom);
+        assertXpathEvaluatesTo(
+                "Requested mime type does not match the output resource mime type",
+                "/ows:ExceptionReport/ows:Exception/ows:ExceptionText",
+                dom);
+    }
+
+    private String getGetExecutionResultHref() throws Exception {
+        String request =
+                "wps?service=WPS&version=1.0.0&request=Execute&Identifier=vec:Reproject"
+                        + "&DataInputs=features=foo@mimetype=text/csv"
+                        + "&ResponseDocument=result=@asReference=true@mimetype=text/csv";
+        String expression =
+                "/wps:ExecuteResponse/wps:ProcessOutputs/wps:Output/wps:Reference/@href";
+        Document dom = getAsDOM(request);
+        assertXpathExists(expression, dom);
+        String href = xp.evaluate(expression, dom);
+        href = "wps" + ResponseUtils.urlDecode(href.substring(href.indexOf("?")));
+        assertThat(href, endsWith("&mimetype=text/csv"));
+        return href;
+    }
+}


### PR DESCRIPTION
[![GEOS-10401](https://badgen.net/badge/JIRA/GEOS-10401/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10401)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

2.20.x backport for https://github.com/geoserver/geoserver/pull/5701


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->