### PR TITLE
[GEOS-10404]-OGCAPI Support `filter-crs` query parameter

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -285,7 +285,18 @@ public class FeatureService {
             @PathVariable(name = "itemId") String itemId,
             @RequestParam(name = "crs", required = false) String crs)
             throws Exception {
-        return items(collectionId, startIndex, limit, bbox, bboxCRS, crs, time, null, null, itemId);
+        return items(
+                collectionId,
+                startIndex,
+                limit,
+                bbox,
+                bboxCRS,
+                crs,
+                time,
+                null,
+                null,
+                null,
+                itemId);
     }
 
     @GetMapping(path = "collections/{collectionId}/items", name = "getFeatures")
@@ -301,6 +312,7 @@ public class FeatureService {
             @RequestParam(name = "datetime", required = false) String datetime,
             @RequestParam(name = "filter", required = false) String filter,
             @RequestParam(name = "filter-lang", required = false) String filterLanguage,
+            @RequestParam(name = "filter-crs", required = false) String filterCRS,
             @RequestParam(name = "crs", required = false) String crs,
             String itemId)
             throws Exception {
@@ -324,8 +336,16 @@ public class FeatureService {
         if (itemId != null) {
             filters.add(FF.id(FF.featureId(itemId)));
         }
+
         if (filter != null) {
-            Filter parsedFilter = filterParser.parse(filter, filterLanguage);
+            CoordinateReferenceSystem queryCRS = DefaultGeographicCRS.WGS84;
+            if (filterCRS != null) {
+                queryCRS = CRS.decode(filterCRS);
+            }
+
+            Filter parsedFilter =
+                    filterParser.parse(filter, filterLanguage, queryCRS, ft.getFeatureType());
+
             filters.add(parsedFilter);
         }
         query.setFilter(mergeFiltersAnd(filters));

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -338,14 +338,7 @@ public class FeatureService {
         }
 
         if (filter != null) {
-            CoordinateReferenceSystem queryCRS = DefaultGeographicCRS.WGS84;
-            if (filterCRS != null) {
-                queryCRS = CRS.decode(filterCRS);
-            }
-
-            Filter parsedFilter =
-                    filterParser.parse(filter, filterLanguage, queryCRS, ft.getFeatureType());
-
+            Filter parsedFilter = filterParser.parse(filter, filterLanguage, filterCRS);
             filters.add(parsedFilter);
         }
         query.setFilter(mergeFiltersAnd(filters));

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
@@ -150,6 +150,7 @@ paths:
         - $ref: '#/components/parameters/datetime'
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/filter-lang'
+        - $ref: '#/components/parameters/filter-crs'
         - $ref: '#/components/parameters/crs'
         - $ref: '#/components/parameters/bbox-crs'
         - $ref: '#/components/parameters/otherParameters'
@@ -297,6 +298,15 @@ components:
         enum:
           - cql-text
         default: cql-text
+    filter-crs:
+      name: filter-crs
+      in: query
+      required: false
+      schema:
+        type: string
+        format: uri-reference
+      style: form
+      explode: false
     otherParameters:
       style: form
       in: query
@@ -799,7 +809,7 @@ components:
       type: string
       format: date-time
       example: '2017-08-17T08:05:32Z'
-      
+
     functions:
       type: object
       required:

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
@@ -160,6 +160,7 @@ public class ApiTest extends FeaturesTestSupport {
                         "#/components/parameters/datetime",
                         "#/components/parameters/filter",
                         "#/components/parameters/filter-lang",
+                        "#/components/parameters/filter-crs",
                         "#/components/parameters/crs",
                         "#/components/parameters/bbox-crs",
                         "#/components/parameters/otherParameters"));

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
@@ -288,7 +288,9 @@ public class FeatureTest extends FeaturesTestSupport {
                         "ogc/features/collections/"
                                 + roadSegments
                                 + "/items?filter=BBOX(pointProperty,38,1,40,3)&"
-                                + "filter-crs=" + CRS_PREFIX + "0",
+                                + "filter-crs="
+                                + CRS_PREFIX
+                                + "0",
                         400);
         assertEquals("InvalidParameterValue", json.read("code", String.class));
         assertThat(json.read("description", String.class), Matchers.containsString("EPSG:0"));

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
@@ -280,6 +280,21 @@ public class FeatureTest extends FeaturesTestSupport {
     }
 
     @Test
+    public void testCqlFilterInvalidCrs() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/collections/"
+                                + roadSegments
+                                + "/items?filter=BBOX(pointProperty,38,1,40,3)&"
+                                + "filter-crs=" + CRS_PREFIX + "0",
+                        400);
+        assertEquals("InvalidParameterValue", json.read("code", String.class));
+        assertThat(json.read("description", String.class), Matchers.containsString("EPSG:0"));
+    }
+
+    @Test
     public void testCqlFilterInvalidLanguage() throws Exception {
         String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
@@ -239,6 +239,47 @@ public class FeatureTest extends FeaturesTestSupport {
     }
 
     @Test
+    public void testCqlSpatialFilterWithFilterCrs() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        ReferencedEnvelope bbox = new ReferencedEnvelope(38, 40, 1, 3, DefaultGeographicCRS.WGS84);
+        ReferencedEnvelope wmBox = bbox.transform(CRS.decode("EPSG:3857", true), true);
+
+        System.out.println(filterCrsQueryParameters(wmBox));
+
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/collections/"
+                                + roadSegments
+                                + "/items?"
+                                + filterCrsQueryParameters(wmBox),
+                        200);
+        assertEquals("FeatureCollection", json.read("type", String.class));
+        // should return only f001
+        assertEquals(1, (int) json.read("features.length()", Integer.class));
+        assertEquals(
+                1, json.read("features[?(@.id == 'PrimitiveGeoFeature.f001')]", List.class).size());
+    }
+
+    private String filterCrsQueryParameters(ReferencedEnvelope re) throws FactoryException {
+        String boxValue =
+                "BBOX(pointProperty,"
+                        + re.getMinX()
+                        + ","
+                        + re.getMinY()
+                        + ","
+                        + re.getMaxX()
+                        + ","
+                        + re.getMaxY()
+                        + ")";
+        String crsValue =
+                CRS.equalsIgnoreMetadata(
+                                re.getCoordinateReferenceSystem(), DefaultGeographicCRS.WGS84)
+                        ? FeatureService.DEFAULT_CRS
+                        : CRS_PREFIX + CRS.lookupEpsgCode(re.getCoordinateReferenceSystem(), true);
+        return "filter=" + boxValue + "&filter-crs=" + crsValue + "&filter-lang=cql-text";
+    }
+
+    @Test
     public void testCqlFilterInvalidLanguage() throws Exception {
         String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =


### PR DESCRIPTION
[![GEOS-10404](https://badgen.net/badge/JIRA/GEOS-10404/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10404)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

This PR adds support for the `filter-crs` query parameter for `OGC API - Features` service.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->