### PR TITLE
[GEOS-10411] encoding of language tags are fixed in INSPIRE

### DIFF
--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/ServicesUtils.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/ServicesUtils.java
@@ -87,9 +87,11 @@ public final class ServicesUtils {
         translator.end("inspire_common:DefaultLanguage");
         if (langList != null) {
             for (String lang : langList) {
-                if (!lang.equals(defaultLanguage)) {
+                if (!lang.equals(defaultLanguage) && !lang.equals("")) {
                     translator.start("inspire_common:SupportedLanguage");
+                    translator.start("inspire_common:Language");
                     translator.chars(lang);
+                    translator.end("inspire_common:Language");
                     translator.end("inspire_common:SupportedLanguage");
                 }
             }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
@@ -16,6 +16,7 @@ import static org.geoserver.inspire.InspireSchema.VS_SCHEMA;
 import static org.geoserver.inspire.InspireTestSupport.assertSchemaLocationContains;
 import static org.geoserver.inspire.InspireTestSupport.clearInspireMetadata;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Locale;
 import org.geoserver.catalog.MetadataMap;
@@ -228,6 +229,24 @@ public class WMSExtendedCapabilitiesTest extends ServicesTestSupport {
             if (isLangNode(el)) language = el.getTextContent();
         }
         assertEquals("fre", language);
+
+        String responseString = getAsServletResponse(WMS_1_3_0_GETCAPREQUEST).getContentAsString();
+        assertTrue(
+                responseString.contains("<inspire_common:Language>eng</inspire_common:Language>"));
+    }
+
+    @Test
+    public void testSupportedLanguageIsNull() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        getGeoServer().save(serviceInfo);
+        String responseString = getAsServletResponse(WMS_1_3_0_GETCAPREQUEST).getContentAsString();
+        assertTrue(responseString.contains("SupportedLanguage"));
     }
 
     private boolean isLangNode(Node el) {


### PR DESCRIPTION
When a getCapabilities request is done while INSPIRE is active

1. inspire_common tag is removed when no SupportedLanguage is present.

`<inspire_common:SupportedLanguage/>`

 2. When a SupportedLanguage is present it should be wrapped with inspire_common:Language.

Before Fix:
`<inspire_common:SupportedLanguage>eng</inspire_common:SupportedLanguage>`
After Fix:

```
<inspire_common:SupportedLanguage>
  <inspire_common:Language>eng</inspire_common:Language>
</inspire_common:SupportedLanguage>
```

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
