### PR TITLE
[GEOS-48940]-Externalized geoserver-environment.properties

### DIFF
--- a/doc/en/user/source/datadirectory/configtemplate.rst
+++ b/doc/en/user/source/datadirectory/configtemplate.rst
@@ -24,6 +24,29 @@ First of all to be able to use this feature, set the following flag via system v
 Then create a file called ``geoserver-environment.properties`` in the root of GeoServer's datadir. 
 This file will contain the definitions for the variables parameterized in the catalog configuration.
 
+We can also place the ``geoserver-environment.properties`` outside the root of GeoServer's datadir.To use this feature,set the following flag via system variable to GeoServer's environment:
+
+    ::
+
+        -DENV_PROPERTIES={properties filepath}
+
+  Then create a file called ``geoserver-environment.properties``. The file can then be made available for loading to GeoServer in one of the following ways:
+  * By placing it in the root folder of GeoServer's datadir.
+  * By provinding an environment variable named  ``ENV_PROPERTIES `` and the path to the properties file as value.
+  * By providing a system variable ``-DENV_PROPERTIES={properties filepath}``.
+  * By providing a context parameter in the ``WEB-INF/web.xml`` file for the GeoServer application.
+
+  .. code-block:: xml
+
+   <web-app>
+     ...
+     <context-param>
+       <param-name>ENV_PROPERTIES</param-name>
+       <param-value>/var/lib/geoserver_data</param-value>
+     </context-param>
+     ...
+   </web-app>
+
 Now edit GeoServer's configuration files of the source machine that you want to be parametric, for example let's parameterize the URL of a store 
 (this can also be done via GeoServer admin UI):
 

--- a/src/platform/src/test/java/org/geoserver/platform/GeoServerEnvironmentTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/GeoServerEnvironmentTest.java
@@ -5,7 +5,9 @@
 package org.geoserver.platform;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -43,6 +45,7 @@ public class GeoServerEnvironmentTest {
         EasyMock.expect(context.getInitParameter("GEOSERVER_DATA_ROOT")).andReturn(null);
         EasyMock.expect(context.getRealPath("/data")).andReturn("data");
         EasyMock.replay(context);
+
         System.setProperty("GEOSERVER_REQUIRE_FILE", "pom.xml");
         try {
             Assert.assertEquals(
@@ -93,5 +96,25 @@ public class GeoServerEnvironmentTest {
 
         assertEquals("ABC", genv.resolveValue("${TEST_SYS_PROPERTY}"));
         assertEquals("${TEST_PROPERTY}", genv.resolveValue("${TEST_PROPERTY}"));
+    }
+
+    @Test
+    public void testExternalEnvironmentPropertyFile() {
+        try {
+            URL url = getClass().getResource("GeoServerTesting.properties");
+            System.setProperty("ENV_PROPERTIES", url.getPath());
+            GeoServerEnvironment genv = new GeoServerEnvironment();
+            assertEquals("hello", genv.resolveValue("${TestParam1}"));
+            assertEquals("country", genv.resolveValue("${TestParam3}"));
+        } finally {
+            System.clearProperty("ENV_PROPERTIES");
+        }
+    }
+
+    @Test
+    public void testWithNoExternalEnvironmentPropertyFile() {
+        GeoServerEnvironment genv = new GeoServerEnvironment();
+        assertNotEquals("hello", genv.resolveValue("${TestParam1}"));
+        assertNotEquals("country", genv.resolveValue("${TestParam3}"));
     }
 }

--- a/src/platform/src/test/resources/org/geoserver/platform/GeoServerTesting.properties
+++ b/src/platform/src/test/resources/org/geoserver/platform/GeoServerTesting.properties
@@ -1,0 +1,3 @@
+TestParam1=hello
+TestParam2=world
+TestParam3=country


### PR DESCRIPTION
[![GES-48940](https://badgen.net/badge/JIRA/GES-48940/0052CC)](https://osgeo-org.atlassian.net/browse/GES-48940)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->