### PR TITLE
[GEOS-10419] NullPointerException from GeoServerOAuthAuthenticationFi…

### DIFF
--- a/src/community/security/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuthAuthenticationFilter.java
+++ b/src/community/security/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuthAuthenticationFilter.java
@@ -20,6 +20,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import org.geoserver.security.GeoServerUserGroupService;
 import org.geoserver.security.SecurityUtils;
 import org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource;
@@ -131,7 +132,10 @@ public abstract class GeoServerOAuthAuthenticationFilter
                     accessTokenRequest.remove("access_token");
                 } finally {
                     SecurityContextHolder.clearContext();
-                    httpRequest.getSession(false).invalidate();
+                    HttpSession session = httpRequest.getSession(false);
+                    if (session != null) {
+                        session.invalidate();
+                    }
                     try {
                         httpRequest.logout();
                         authentication = null;


### PR DESCRIPTION
This introduces a null check on HttpSession object to avoid NullPointerException on HttpSession.invalidate()

JIRA ticket [GEOS-10419](https://osgeo-org.atlassian.net/browse/GEOS-10419) 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).
- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).
