### PR TITLE
Dependency upgrade: xstream 1.4.11.1 -> 1.4.19, jettison 1.0.1 -> 1.4.1

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -1346,8 +1346,8 @@ public class XStreamPersister {
             } else if (writer instanceof JettisonStaxWriter) {
                 /*
                  * GEOS-7771 / GEOS-7873
-                 * Workaround for an array serialization bug in jettison 1.0.1
-                 * Can be removed when we upgrade to jettison 1.2
+                 * Required even with Jettinson 1.4.1
+                 * (at some point we thought an upgrade to 1.2 would have solved it)
                  */
                 writer.setValue("null");
                 try {

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -744,7 +744,7 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.0.1</version>
+        <version>1.4.1</version>
       </dependency>
       <dependency>
         <groupId>lucene</groupId>
@@ -1226,7 +1226,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.11.1</version>
+        <version>1.4.19</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>

--- a/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
+++ b/src/rest/src/main/java/org/geoserver/rest/converters/XStreamCatalogListConverter.java
@@ -14,6 +14,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.io.json.JettisonMappedXmlDriver;
 import java.io.IOException;
 import java.util.Collection;
+import org.codehaus.jettison.mapped.Configuration;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.config.util.SecureXStream;
 import org.geoserver.config.util.XStreamPersister;
@@ -58,6 +59,7 @@ public abstract class XStreamCatalogListConverter
                 getClass().getName() + " does not support deserialization of catalog lists",
                 inputMessage);
     }
+
     //
     // writing
     //
@@ -65,7 +67,6 @@ public abstract class XStreamCatalogListConverter
     public void writeInternal(RestListWrapper<?> wrapper, HttpOutputMessage outputMessage)
             throws IOException, HttpMessageNotWritableException {
         XStream xstream = this.createXStreamInstance();
-
         Class<?> targetClass = wrapper.getObjectClass();
         Collection<?> data = wrapper.getCollection();
         this.aliasCollection(data, xstream, targetClass, wrapper);
@@ -73,7 +74,7 @@ public abstract class XStreamCatalogListConverter
         xstream.toXML(data, outputMessage.getBody());
     }
 
-    private void configureXStream(XStream xstream, Class<?> clazz, RestListWrapper<?> wrapper) {
+    protected void configureXStream(XStream xstream, Class<?> clazz, RestListWrapper<?> wrapper) {
         XStreamPersister xp = xpf.createXMLPersister();
         wrapper.configurePersister(xp, this);
         final String name = getItemName(xp, clazz);
@@ -82,7 +83,7 @@ public abstract class XStreamCatalogListConverter
         xstream.registerConverter(
                 new CollectionConverter(xstream.getMapper()) {
                     @Override
-                    public boolean canConvert(Class type) {
+                    public boolean canConvert(@SuppressWarnings("rawtypes") Class type) {
                         return Collection.class.isAssignableFrom(type);
                     }
 
@@ -214,9 +215,28 @@ public abstract class XStreamCatalogListConverter
             writer.setValue(href(link));
         }
 
+        /**
+         * Calls {@link #writeSingleElementCollection} for single-element collections, to ensure
+         * backwards compatibility with Jettison 1.0 output, and {@code super.writeInternal()}
+         * otherwise
+         */
+        @Override
+        public void writeInternal(RestListWrapper<?> wrapper, HttpOutputMessage outputMessage)
+                throws IOException, HttpMessageNotWritableException {
+
+            if (wrapper.getCollection().size() == 1) {
+                writeSingleElementCollection(wrapper, outputMessage);
+            } else {
+                super.writeInternal(wrapper, outputMessage);
+            }
+        }
+
         @Override
         protected XStream createXStreamInstance() {
-            return new SecureXStream(new JettisonMappedXmlDriver());
+            // preserve legacy single-element-array-as-object serialization
+            // called by super.writeInternal() for non-single element collections
+            boolean useSerializeAsArray = false;
+            return createXStreamInstance(useSerializeAsArray);
         }
 
         @Override
@@ -227,6 +247,107 @@ public abstract class XStreamCatalogListConverter
         @Override
         public String getMediaType() {
             return MediaType.APPLICATION_JSON_VALUE;
+        }
+
+        private XStream createXStreamInstance(boolean useSerializeAsArray) {
+            // needed for Jettison 1.4.1
+            Configuration configuration = new Configuration();
+            configuration.setRootElementArrayWrapper(false);
+            return new SecureXStream(
+                    new JettisonMappedXmlDriver(configuration, useSerializeAsArray));
+        }
+
+        /**
+         * Special treatment for single-element collections in {@link
+         * RestListWrapper#getCollection()} to ensure encoding matches Jettison 1.0.1 (prior to
+         * XStream 1.4.18 / Jettison 1.4.1 upgrade).
+         *
+         * <p>Expected output being like:
+         *
+         * <pre>
+         * <code>
+         * {"coverages": {"coverage": [{ "name": "tazdem", ... }]}}
+         *  </code>
+         *  </pre>
+         *
+         * Otherwise we'd get one of:
+         *
+         * <pre>
+         * <code>
+         *  {"coverages": {"coverage": { "name": "tazdem", ... }}}
+         *  </code>
+         *  </pre>
+         *
+         * or
+         *
+         * <pre>
+         * <code>
+         *  {"coverages": [{"coverage": { "name": "tazdem", ... }}]}
+         *  </code>
+         *  </pre>
+         *
+         * instead.
+         */
+        private void writeSingleElementCollection(
+                RestListWrapper<?> wrapper, HttpOutputMessage outputMessage) throws IOException {
+
+            final boolean useSerializeAsArray = true;
+            XStream xstream = this.createXStreamInstance(useSerializeAsArray);
+            XStreamPersister xp = xpf.createXMLPersister();
+            wrapper.configurePersister(xp, this);
+            final Class<?> targetClass = wrapper.getObjectClass();
+            final String itemName = getItemName(xp, targetClass);
+            final String collectionAlias = itemName + "s";
+            this.configureSingleElementCollectionXStream(xstream, targetClass, wrapper);
+
+            ListRoot data = new ListRoot(wrapper.getCollection());
+            xstream.alias(collectionAlias, ListRoot.class);
+            xstream.aliasField(itemName, ListRoot.class, "values");
+            xstream.alias(itemName, targetClass);
+
+            // do not generate an @class: list JSON attribute
+            xstream.aliasSystemAttribute(null, "class");
+            xstream.toXML(data, outputMessage.getBody());
+        }
+
+        static class ListRoot {
+            private Collection<?> values;
+
+            ListRoot(Collection<?> values) {
+                this.values = values;
+            }
+
+            public Collection<?> getValues() {
+                return values;
+            }
+        }
+
+        /**
+         * Uses a {@link CollectionConverter} for single-element collection JSON encoding without
+         * calling {@code writer.start/endNode(name)}, but a single call to {@link
+         * CollectionConverter#writeBareItem writeBareItem()}, since the element name is handled by
+         * the encoding of {@link ListRoot}.
+         */
+        protected void configureSingleElementCollectionXStream(
+                XStream xstream, Class<?> clazz, RestListWrapper<?> wrapper) {
+
+            super.configureXStream(xstream, clazz, wrapper);
+            xstream.registerConverter(
+                    new CollectionConverter(xstream.getMapper()) {
+                        @Override
+                        public boolean canConvert(@SuppressWarnings("rawtypes") Class type) {
+                            return Collection.class.isAssignableFrom(type);
+                        }
+
+                        @Override
+                        protected void writeCompleteItem(
+                                Object item,
+                                MarshallingContext context,
+                                HierarchicalStreamWriter writer) {
+
+                            super.writeBareItem(item, context, writer);
+                        }
+                    });
         }
     }
 }

--- a/src/rest/src/main/java/org/geoserver/rest/converters/XStreamJSONMessageConverter.java
+++ b/src/rest/src/main/java/org/geoserver/rest/converters/XStreamJSONMessageConverter.java
@@ -6,9 +6,7 @@ package org.geoserver.rest.converters;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
-import com.thoughtworks.xstream.io.json.JettisonMappedXmlDriver;
 import java.io.IOException;
-import org.geoserver.config.util.SecureXStream;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.rest.wrapper.RestHttpInputWrapper;
 import org.geoserver.rest.wrapper.RestListWrapper;
@@ -99,6 +97,6 @@ public class XStreamJSONMessageConverter extends XStreamMessageConverter<Object>
 
     @Override
     protected XStream createXStreamInstance() {
-        return new SecureXStream(new JettisonMappedXmlDriver());
+        throw new UnsupportedOperationException("unused");
     }
 }

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceDirectoryInfoJSONConverter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceDirectoryInfoJSONConverter.java
@@ -1,0 +1,127 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.rest.converters.XStreamJSONMessageConverter;
+import org.geoserver.rest.resources.ResourceController.ResourceChildInfo;
+import org.geoserver.rest.resources.ResourceController.ResourceDirectoryInfo;
+import org.geoserver.rest.resources.ResourceController.ResourceParentInfo;
+import org.geoserver.rest.wrapper.RestListWrapper;
+import org.geoserver.rest.wrapper.RestWrapper;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Message converter to maintain backwards compatibility on JSON encoding of {@link
+ * ResourceDirectoryInfo} for single-element {@link ResourceDirectoryInfo#getChildren() children}.
+ *
+ * <p>The upgrade to XStream 1.4.19/Jettison 1.4.1 changes the deafult Jettison 1.0.1 behavior when
+ * encoding single-element collections as JSON. While it used to encode such collections as a JSON
+ * object, it now (correctly) encodes them as single-element JSON arrays.
+ *
+ * <p>This converter preserves the legacy behavior for {@link ResourceController}'s {@link
+ * ResourceDirectoryInfo#getChildren()} to avoid any possible breakage in GeoServer REST clients
+ * that depend on the legacy behavior.
+ */
+@Component
+public class ResourceDirectoryInfoJSONConverter extends XStreamJSONMessageConverter {
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return RestWrapper.class.isAssignableFrom(clazz)
+                && !RestListWrapper.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return supports(clazz) && canWrite(mediaType);
+    }
+
+    @Override
+    public void writeInternal(Object o, HttpOutputMessage outputMessage)
+            throws IOException, HttpMessageNotWritableException {
+
+        RestWrapper<?> restWrapper = (RestWrapper<?>) o;
+        Object object = restWrapper.getObject();
+        if (object instanceof ResourceDirectoryInfo) {
+            ResourceDirectoryInfo dirInfo = (ResourceDirectoryInfo) object;
+            if (1 == dirInfo.getChildren().size()) {
+                boolean alwaysSerializeCollectionsAsArrays = true;
+                XStreamPersister xmlPersister =
+                        xpf.createJSONPersister(alwaysSerializeCollectionsAsArrays);
+                restWrapper.configurePersister(xmlPersister, this);
+                writeSingleChildrenDirectoryInfo(dirInfo, xmlPersister, outputMessage.getBody());
+                return;
+            }
+        }
+        super.writeInternal(o, outputMessage);
+    }
+
+    private void writeSingleChildrenDirectoryInfo(
+            ResourceDirectoryInfo dirInfo, XStreamPersister xmlPersister, OutputStream out)
+            throws IOException {
+
+        SingleChildDirInfo info = new SingleChildDirInfo(dirInfo);
+        XStream xstream = xmlPersister.getXStream();
+        xstream.alias("ResourceDirectory", SingleChildDirInfo.class);
+
+        Converter conv =
+                new CollectionConverter(xstream.getMapper()) {
+                    @Override
+                    public boolean canConvert(@SuppressWarnings("rawtypes") Class type) {
+                        return Collection.class.isAssignableFrom(type);
+                    }
+
+                    @Override
+                    protected void writeCompleteItem(
+                            Object item,
+                            MarshallingContext context,
+                            HierarchicalStreamWriter writer) {
+
+                        super.writeBareItem(item, context, writer);
+                    }
+                };
+
+        xstream.registerLocalConverter(Children.class, "child", conv);
+        xmlPersister.save(info, out);
+    }
+
+    static class SingleChildDirInfo {
+        String name;
+        ResourceParentInfo parent;
+        String type;
+        Date lastModified;
+        Children children;
+
+        public SingleChildDirInfo(ResourceDirectoryInfo info) {
+            this.lastModified = info.getLastModified();
+            this.name = info.getName();
+            this.parent = info.getParent();
+            this.type = info.getType();
+            this.children = new Children(info.getChildren());
+        }
+    }
+
+    static class Children {
+        List<ResourceChildInfo> child;
+
+        Children(List<ResourceChildInfo> child) {
+            this.child = child;
+        }
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageControllerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import java.net.URL;
 import java.util.List;
+import javax.xml.namespace.QName;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -70,6 +71,29 @@ public class CoverageControllerTest extends CatalogRESTTestSupport {
         assertEquals(
                 catalog.getCoveragesByNamespace(catalog.getNamespaceByPrefix("wcs")).size(),
                 coverages.size());
+    }
+
+    @Test
+    public void testGetAllByWorkspaceJSON_no_coverages() throws Exception {
+        JSONObject json =
+                (JSONObject)
+                        getAsJSON(RestBaseController.ROOT_PATH + "/workspaces/cite/coverages.json");
+        // returns {"coverages": ""}
+        assertEquals("", json.getString("coverages"));
+    }
+
+    @Test
+    public void testGetAllByWorkspaceJSON_single_element() throws Exception {
+        QName tazDem = new QName(SystemTestData.CDF_URI, "tazdem", SystemTestData.CDF_PREFIX);
+        getTestData().addRasterLayer(tazDem, "tazdem.tiff", null, getCatalog());
+
+        JSONObject json =
+                (JSONObject)
+                        getAsJSON(RestBaseController.ROOT_PATH + "/workspaces/cdf/coverages.json");
+
+        JSONArray coverages = json.getJSONObject("coverages").getJSONArray("coverage");
+        assertEquals(1, coverages.size());
+        assertEquals("tazdem", coverages.getJSONObject(0).getString("name"));
     }
 
     void addCoverageStore(boolean autoConfigureCoverage) throws Exception {

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
@@ -91,6 +91,7 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
     @Test
     public void testGetAllASJSON() throws Exception {
         JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/styles.json");
+        print(json);
 
         List<StyleInfo> styles = catalog.getStyles();
         assertEquals(

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
@@ -310,35 +310,114 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
     }
 
     @Test
-    public void testDirectoryJSON() throws Exception {
-        JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/resource/mydir?format=json");
-        print(json);
+    public void testDirectoryJSON_no_children() throws Exception {
+        Resource emptyDir = getDataDirectory().get("/emptyDir");
+        emptyDir.dir();
+        JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/resource/emptyDir?format=json");
+        // print(json);
         String expected =
-                "{\"ResourceDirectory\": {"
-                        + "\"name\": \"mydir\","
-                        + "\"parent\":   {"
-                        + "  \"path\": \"/\","
-                        + "    \"link\":     {"
-                        + "      \"href\": \"http://localhost:8080/geoserver"
-                        + RestBaseController.ROOT_PATH
-                        + "/resource/\","
-                        + "      \"rel\": \"alternate\","
-                        + "      \"type\": \"application/json\""
+                "{'ResourceDirectory': {\n"
+                        + "  'name': 'emptyDir',\n"
+                        + "  'parent':   {\n"
+                        + "    'path': '/',\n"
+                        + "    'link':     {\n"
+                        + "      'href': 'http://localhost:8080/geoserver/rest/resource/',\n"
+                        + "      'rel': 'alternate',\n"
+                        + "      'type': 'application/json'\n"
+                        + "    }\n"
+                        + "  },\n"
+                        + "'lastModified': '"
+                        + FORMAT.format(emptyDir.lastmodified())
+                        + "'\n"
+                        + "}}";
+        JSONAssert.assertEquals(expected, (JSONObject) json);
+    }
+
+    @Test
+    public void testDirectoryJSON_single_child() throws Exception {
+        JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/resource/mydir?format=json");
+        // print(json);
+        String expected =
+                "{'ResourceDirectory': {"
+                        + "'name': 'mydir',"
+                        + "'parent':   {"
+                        + "  'path': '/',"
+                        + "    'link':     {"
+                        + "      'href': 'http://localhost:8080/geoserver/rest/resource/',"
+                        + "      'rel': 'alternate',"
+                        + "      'type': 'application/json'"
                         + "  }"
                         + "},"
-                        + "\"lastModified\": \""
+                        + "'lastModified': '"
                         + FORMAT.format(myRes.parent().lastmodified())
-                        + "\","
-                        + "  \"children\": {\"child\": [  {"
-                        + "    \"name\": \"myres\","
-                        + "    \"link\":     {"
-                        + "      \"href\": \"http://localhost:8080/geoserver"
-                        + RestBaseController.ROOT_PATH
-                        + "/resource/mydir/myres\","
-                        + "      \"rel\": \"alternate\","
-                        + "      \"type\": \"application/octet-stream\""
+                        + "',"
+                        + "  'children': {'child': [  {"
+                        + "    'name': 'myres',"
+                        + "    'link':     {"
+                        + "      'href': 'http://localhost:8080/geoserver/rest/resource/mydir/myres',"
+                        + "      'rel': 'alternate',"
+                        + "      'type': 'application/octet-stream'"
                         + "    }"
                         + "  }]}"
+                        + "}}";
+        JSONAssert.assertEquals(expected, (JSONObject) json);
+    }
+
+    @Test
+    public void testDirectoryJSON_multiple_children() throws Exception {
+        Resource mydir2 = getDataDirectory().get("/mydir2");
+        String lastModified = FORMAT.format(mydir2.lastmodified());
+
+        JSON json = getAsJSON(RestBaseController.ROOT_PATH + "/resource/mydir2?format=json");
+        print(json);
+        String expected =
+                "{'ResourceDirectory': {\n"
+                        + "  'name': 'mydir2',\n"
+                        + "  'parent':   {\n"
+                        + "    'path': '/',\n"
+                        + "    'link':     {\n"
+                        + "      'href': 'http://localhost:8080/geoserver/rest/resource/',\n"
+                        + "      'rel': 'alternate',\n"
+                        + "      'type': 'application/json'\n"
+                        + "    }\n"
+                        + "  },\n"
+                        + "  'lastModified': '"
+                        + lastModified
+                        + "',\n"
+                        + "  'children': {'child':   [\n"
+                        + "        {\n"
+                        + "      'name': 'fake.png',\n"
+                        + "      'link':       {\n"
+                        + "        'href': 'http://localhost:8080/geoserver/rest/resource/mydir2/fake.png',\n"
+                        + "        'rel': 'alternate',\n"
+                        + "        'type': 'image/png'\n"
+                        + "      }\n"
+                        + "    },\n"
+                        + "        {\n"
+                        + "      'name': 'imagewithoutextension',\n"
+                        + "      'link':       {\n"
+                        + "        'href': 'http://localhost:8080/geoserver/rest/resource/mydir2/imagewithoutextension',\n"
+                        + "        'rel': 'alternate',\n"
+                        + "        'type': 'image/png'\n"
+                        + "      }\n"
+                        + "    },\n"
+                        + "        {\n"
+                        + "      'name': 'myres.json',\n"
+                        + "      'link':       {\n"
+                        + "        'href': 'http://localhost:8080/geoserver/rest/resource/mydir2/myres.json',\n"
+                        + "        'rel': 'alternate',\n"
+                        + "        'type': 'application/octet-stream'\n"
+                        + "      }\n"
+                        + "    },\n"
+                        + "        {\n"
+                        + "      'name': 'myres.xml',\n"
+                        + "      'link':       {\n"
+                        + "        'href': 'http://localhost:8080/geoserver/rest/resource/mydir2/myres.xml',\n"
+                        + "        'rel': 'alternate',\n"
+                        + "        'type': 'application/xml'\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "  ]}\n"
                         + "}}";
         JSONAssert.assertEquals(expected, (JSONObject) json);
     }

--- a/src/restconfig/src/test/java/org/geoserver/rest/security/XStreamParserTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/security/XStreamParserTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertNotNull;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.json.JettisonMappedXmlDriver;
 import java.io.IOException;
+import org.codehaus.jettison.mapped.Configuration;
 import org.geoserver.rest.security.xml.JaxbUser;
 import org.geoserver.security.GeoServerUserGroupService;
 import org.geoserver.security.impl.GeoServerUser;
@@ -35,9 +36,17 @@ public class XStreamParserTest extends SecurityRESTTestSupport {
     @Test
     public void jsonReadWriteTest() throws Exception, IOException {
         // basic marshalling / unmarshalling
-        XStream xstream = new XStream(new JettisonMappedXmlDriver());
+        // needed for Jettison 1.4.1
+        Configuration configuration = new Configuration();
+        configuration.setRootElementArrayWrapper(false);
+        // preserve legacy single-element-array-as-object serialization
+        boolean useSerializeAsArray = false;
+
+        XStream xstream =
+                new XStream(new JettisonMappedXmlDriver(configuration, useSerializeAsArray));
         xstream.setMode(XStream.NO_REFERENCES);
         xstream.alias("user", JaxbUser.class);
+        xstream.allowTypes(new Class[] {JaxbUser.class});
 
         JaxbUser user = new JaxbUser();
         user.setUserName("test");

--- a/src/restconfig/src/test/java/org/geoserver/rest/system/status/MonitorRestTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/system/status/MonitorRestTest.java
@@ -43,6 +43,7 @@ public class MonitorRestTest extends GeoServerSystemTestSupport {
         xs.alias("metric", MetricValue.class);
         xs.alias("metrics", Metrics.class);
         xs.addImplicitCollection(Metrics.class, "metrics");
+        xs.allowTypes(new Class[] {Metrics.class, MetricValue.class});
         Metrics metrics = (Metrics) xs.fromXML(response.getContentAsString());
         assertTrue(metrics.getMetrics().size() >= MetricInfo.values().length);
     }
@@ -57,6 +58,7 @@ public class MonitorRestTest extends GeoServerSystemTestSupport {
         xs.alias("metric", MetricValue.class);
         xs.alias("metrics", Metrics.class);
         xs.addImplicitCollection(Metrics.class, "metrics");
+        xs.allowTypes(new Class[] {Metrics.class, MetricValue.class});
         Metrics metrics = (Metrics) xs.fromXML(response.getContentAsString());
         assertTrue(metrics.getMetrics().size() >= MetricInfo.values().length);
     }
@@ -72,6 +74,7 @@ public class MonitorRestTest extends GeoServerSystemTestSupport {
         xs.alias("metric", MetricValue.class);
         xs.alias("metrics", Metrics.class);
         xs.addImplicitCollection(Metrics.class, "metrics");
+        xs.allowTypes(new Class[] {Metrics.class, MetricValue.class});
         Metrics metrics = (Metrics) xs.fromXML(response.getContentAsString());
         assertTrue(metrics.getMetrics().size() >= MetricInfo.values().length);
     }


### PR DESCRIPTION
Upgrading to XStream 1.4.19/Jettison 1.4.1.

Jettison 1.4.1 changes its deafult behavior when
encoding single-element collections as JSON.
While it used to encode such collections as a JSON
object, it now (correctly/consistently) encodes
them as single-element JSON arrays.

Such change would break backwards compatibility
in several GeoServer REST API responses, despite
JSON collection encoding being consistent, we can't
know for sure it wouldn't break exising API clients.

Therefore, measures are taken to preserve the old
behavior where single-element collections are serialized
as a JSON object instead of a single-element JSON array.

For instance:

- `XStreamCatalogListConverter$JSONXStreamListConverter` will
recognize a single-element list, and use a surrogate object to
force serialization preserving Jettison's legacy encoding format.
For example, to get the expected:
`{"coverages": {"coverage": [{ "name": "tazdem", ... }]}}`,
instead of
`{"coverages": {"coverage": { "name": "tazdem", ... }}}`
or
`{"coverages": [{"coverage": { "name": "tazdem", ... }}]}`
if just configuring the `JettisonMappedXmlDriver` with `useSerializeAsArray = false`
or `useSerializeAsArray = true`, respectively.

- A new `ResourceDirectoryInfoJSONConverter` to handle the same issue
with `ResourceController`'s `ResourceDirectoryInfo.getChildren()`.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->