### PR TITLE
[GEOS-9978] WMS vendor parameter CLIP - ignores TIME/CQL_FILTER and other parameters when using with ImageMosaic ( 2.20.x backport)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/clip/ClipWMSGetMapCallBack.java
+++ b/src/wms/src/main/java/org/geoserver/wms/clip/ClipWMSGetMapCallBack.java
@@ -76,7 +76,10 @@ public class ClipWMSGetMapCallBack implements GetMapCallback {
                 CroppedGridCoverage2DReader croppedGridReader =
                         new CroppedGridCoverage2DReader(gr.getReader(), wktGeom);
                 CachedGridReaderLayer croppedGridLayer =
-                        new CachedGridReaderLayer(croppedGridReader, layer.getStyle());
+                        new CachedGridReaderLayer(
+                                croppedGridReader,
+                                layer.getStyle(),
+                                ((GridReaderLayer) layer).getParams());
                 BeanUtilsBean2.getInstance().copyProperties(croppedGridLayer, gr);
                 croppedGridLayer.getUserData().putAll(layer.getUserData());
                 return croppedGridLayer;

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
@@ -172,12 +172,28 @@ public class GetMapIntegrationTest extends WMSTestSupport {
         assertEquals("image/png", response.getContentType());
 
         // check we got the
-        RenderedImage image = ImageIO.read(getBinaryInputStream(response));
-        int[] pixel = new int[3];
-        image.getData().getPixel(0, 0, pixel);
-        assertEquals(255, pixel[0]);
-        assertEquals(0, pixel[1]);
-        assertEquals(0, pixel[2]);
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertEquals(Color.RED, getPixelColor(image, 5, 10));
+    }
+
+    /**
+     * Clip on rasters used to lose the request parameters, that included the CQL_FILTER, among the
+     * others
+     */
+    @Test
+    public void testRasterFilterRedClip() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
+                                + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=0,0,1,1&WIDTH=150&HEIGHT=150&transparent=false&CQL_FILTER=location like 'red%25'&clip=POLYGON((0 0, 1 0, 0 1, 0 0))");
+
+        assertEquals("image/png", response.getContentType());
+
+        // check we got the right color
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertEquals(Color.RED, getPixelColor(image, 5, 10));
+        // and that the clip happened
+        assertEquals(Color.BLACK, getPixelColor(image, 15, 10));
     }
 
     @Test
@@ -189,12 +205,28 @@ public class GetMapIntegrationTest extends WMSTestSupport {
 
         assertEquals("image/png", response.getContentType());
 
-        RenderedImage image = ImageIO.read(getBinaryInputStream(response));
-        int[] pixel = new int[3];
-        image.getData().getPixel(0, 0, pixel);
-        assertEquals(0, pixel[0]);
-        assertEquals(255, pixel[1]);
-        assertEquals(0, pixel[2]);
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertEquals(Color.GREEN, getPixelColor(image, 5, 10));
+    }
+
+    /**
+     * Clip on rasters used to lose the request parameters, that included the CQL_FILTER, among the
+     * others
+     */
+    @Test
+    public void testRasterFilterGreenClip() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
+                                + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=0,0,1,1&WIDTH=150&HEIGHT=150&transparent=false&CQL_FILTER=location like 'green%25'&clip=POLYGON((0 0, 1 0, 0 1, 0 0))");
+
+        assertEquals("image/png", response.getContentType());
+
+        // check we got the right color
+        BufferedImage image = ImageIO.read(getBinaryInputStream(response));
+        assertEquals(Color.GREEN, getPixelColor(image, 5, 10));
+        // and that the clip happened
+        assertEquals(Color.BLACK, getPixelColor(image, 15, 10));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-9978](https://badgen.net/badge/JIRA/GEOS-9978/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-9978)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->