### PR TITLE
[2.19.x backport][GEOS-10413] Schemaless Features- Allow usage of . separator for PropertyName evaluation - [GEOS-10417] Schemaless PropertyName issue with unbounded nested features

### DIFF
--- a/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
+++ b/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
@@ -1,0 +1,83 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.schemalessfeatures.mongodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geotools.data.FeatureSource;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.FeatureIterator;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.PropertyName;
+
+public class SchemalessCollectionTest extends AbstractMongoDBOnlineTestSupport {
+
+    private static final String DATA_STORE_NAME = "stationsMongoWfs";
+
+    private static MongoTestSetup testSetup;
+
+    private static FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Catalog cat = getCatalog();
+        DataStoreInfo storeInfo = cat.getDataStoreByName(DATA_STORE_NAME);
+        if (storeInfo == null) {
+            WorkspaceInfo wi = cat.getDefaultWorkspace();
+            storeInfo = addMongoSchemalessStore(wi, DATA_STORE_NAME);
+            addMongoSchemalessLayer(wi, storeInfo, StationsTestSetup.COLLECTION_NAME);
+        }
+    }
+
+    @Override
+    protected MongoTestSetup createTestSetups() {
+        StationsTestSetup setup = new StationsTestSetup(databaseName);
+        testSetup = setup;
+        return setup;
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (testSetup != null) testSetup.tearDown();
+    }
+
+    @Test
+    public void testPropertyNameWithDotSeparator() throws Exception {
+        FeatureTypeInfo fti =
+                getCatalog().getFeatureTypeByName("gs:" + StationsTestSetup.COLLECTION_NAME);
+        @SuppressWarnings("unchecked")
+        FeatureSource<FeatureType, Feature> source =
+                (FeatureSource<FeatureType, Feature>) fti.getFeatureSource(null, null);
+        Filter eq1 = FF.equals(FF.property("name"), FF.literal("station 2"));
+        FeatureIterator<Feature> it = source.getFeatures(eq1).features();
+        // use dot separators in the property name
+        PropertyName pn = FF.property("measurements.values.value");
+        while (it.hasNext()) {
+            Feature f = it.next();
+            Object result = pn.evaluate(f);
+            if (result instanceof List) {
+                List listRes = (List) result;
+                assertEquals(5, listRes.size());
+                assertTrue(listRes.containsAll(Arrays.asList(35, 25, 80, 1019, 1015)));
+            }
+        }
+    }
+}

--- a/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
+++ b/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
@@ -80,4 +80,24 @@ public class SchemalessCollectionTest extends AbstractMongoDBOnlineTestSupport {
             }
         }
     }
+
+    @Test
+    public void testPropertyNameReturningNestedFeaturesList() throws Exception {
+        FeatureTypeInfo fti =
+                getCatalog().getFeatureTypeByName("gs:" + StationsTestSetup.COLLECTION_NAME);
+        @SuppressWarnings("unchecked")
+        FeatureSource<FeatureType, Feature> source =
+                (FeatureSource<FeatureType, Feature>) fti.getFeatureSource(null, null);
+        Filter eq1 = FF.equals(FF.property("name"), FF.literal("station 2"));
+        FeatureIterator<Feature> it = source.getFeatures(eq1).features();
+        // will return the values nested features.
+        PropertyName pn = FF.property("measurements.values");
+        Feature f = it.next();
+        Object result = pn.evaluate(f);
+        if (result instanceof List) {
+            List listRes = (List) result;
+            assertEquals(5, listRes.size());
+            ((List) result).forEach(e -> assertTrue(e instanceof Feature));
+        }
+    }
 }

--- a/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
+++ b/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
@@ -124,6 +124,8 @@ public class SchemalessPropertyAccessorFactory implements PropertyAccessorFactor
         }
 
         private List<Object> walkList(List<Object> attributes, String[] path, int currentIndex) {
+            boolean lastPathPart = (currentIndex + 1) == path.length;
+            if (lastPathPart) return attributes;
             List<Object> results = new ArrayList<>();
             for (Object value : attributes) {
                 if (value == null) continue;

--- a/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
+++ b/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
@@ -77,7 +77,7 @@ public class SchemalessPropertyAccessorFactory implements PropertyAccessorFactor
             if (object instanceof ComplexAttribute) {
                 String[] pathParts;
                 if (xpath.indexOf('/') != -1) pathParts = xpath.split("/");
-                else pathParts = xpath.split(":");
+                else pathParts = xpath.split("\\.");
                 return (T) walkComplexAttribute((ComplexAttribute) object, pathParts);
             } else if (object instanceof DynamicComplexType) {
                 return (T) ANYTYPE_TYPE;


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
