### PR TITLE
[2.20.x backport] [GEOS-10274] Geofence follow up LayerGroup Style addition

### DIFF
--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceWMSTestSupport.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceWMSTestSupport.java
@@ -4,11 +4,15 @@
  */
 package org.geoserver.geofence.integration;
 
+import java.util.Set;
 import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.geofence.core.model.LayerAttribute;
+import org.geoserver.geofence.core.model.LayerDetails;
 import org.geoserver.geofence.core.model.Rule;
 import org.geoserver.geofence.core.model.RuleLimits;
 import org.geoserver.geofence.core.model.enums.CatalogMode;
 import org.geoserver.geofence.core.model.enums.GrantType;
+import org.geoserver.geofence.core.model.enums.LayerType;
 import org.geoserver.geofence.core.model.enums.SpatialFilterType;
 import org.geoserver.geofence.services.RuleAdminService;
 import org.geoserver.wms.WMSTestSupport;
@@ -99,5 +103,25 @@ public class GeofenceWMSTestSupport extends WMSTestSupport {
             }
         }
         logout();
+    }
+
+    static void addLayerDetails(
+            RuleAdminService ruleService,
+            Long ruleId,
+            Set<String> allowedStyles,
+            Set<LayerAttribute> attributes,
+            CatalogMode mode,
+            String cqlRead,
+            String cqlWrite,
+            LayerType layerType)
+            throws org.locationtech.jts.io.ParseException {
+        LayerDetails details = new LayerDetails();
+        details.setType(layerType);
+        details.setAttributes(attributes);
+        details.setAllowedStyles(allowedStyles);
+        details.setCatalogMode(mode);
+        details.setCqlFilterWrite(cqlWrite);
+        details.setCqlFilterRead(cqlRead);
+        ruleService.setDetails(ruleId, details);
     }
 }

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GetLegendGraphicGeofenceTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GetLegendGraphicGeofenceTest.java
@@ -7,9 +7,20 @@ package org.geoserver.geofence.integration;
 
 import static org.geoserver.geofence.integration.GeofenceGetMapIntegrationTest.deleteRules;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.geofence.core.model.enums.CatalogMode;
 import org.geoserver.geofence.core.model.enums.GrantType;
+import org.geoserver.geofence.core.model.enums.LayerType;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -50,6 +61,81 @@ public class GetLegendGraphicGeofenceTest extends GeofenceWMSTestSupport {
             logout();
             removeLayerGroup(group);
             removeLayerGroup(nested);
+        }
+    }
+
+    @Test
+    public void testLegendGraphicLayerGroupStyle() throws Exception {
+        Long ruleId1 = null;
+        Long ruleId2 = null;
+        LayerGroupInfo group = null;
+        String layerGroupName = "lakes_and_places_legend";
+        try {
+            ruleId1 = addRule(GrantType.ALLOW, null, null, null, null, null, null, 1, ruleService);
+            ruleId2 =
+                    addRule(
+                            GrantType.ALLOW,
+                            null,
+                            "ROLE_ANONYMOUS",
+                            "WMS",
+                            null,
+                            "cite",
+                            "Forests",
+                            0,
+                            ruleService);
+
+            List<String> allowedStyles = Arrays.asList("Lakes", "NamedPlaces");
+            addLayerDetails(
+                    ruleService,
+                    ruleId2,
+                    new HashSet<>(allowedStyles),
+                    Collections.emptySet(),
+                    CatalogMode.HIDE,
+                    null,
+                    null,
+                    LayerType.VECTOR);
+
+            addLakesPlacesLayerGroup(LayerGroupInfo.Mode.SINGLE, layerGroupName);
+
+            login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+            group = getCatalog().getLayerGroupByName(layerGroupName);
+
+            // not among the allowed styles, adding it to a layergroup style
+            StyleInfo polygonStyle = getCatalog().getStyleByName("polygon");
+            LayerInfo forest = getCatalog().getLayerByName(getLayerId(MockData.FORESTS));
+            forest.getStyles().add(polygonStyle);
+            getCatalog().save(forest);
+            List<StyleInfo> styles = new ArrayList<>();
+            styles.add(polygonStyle);
+            addLayerGroupStyle(group, "forests_style", Arrays.asList(forest), styles);
+            logout();
+
+            login("anonymousUser", "", "ROLE_ANONYMOUS");
+            String url =
+                    "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                            + "&layer="
+                            + group.getName()
+                            + "&style="
+                            + "&format=image/png&width=20&height=20";
+            MockHttpServletResponse response = getAsServletResponse(url);
+            // default lg style should not fail
+            assertEquals(response.getContentType(), "image/png");
+
+            url =
+                    "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                            + "&layer="
+                            + group.getName()
+                            + "&style=forests_style"
+                            + "&format=image/png&width=20&height=20";
+            response = getAsServletResponse(url);
+            // should fail the forests_style contains the not allowed polygon style
+            assertEquals(response.getContentType(), "application/vnd.ogc.se_xml");
+            assertTrue(
+                    response.getContentAsString().contains("style is not available on this layer"));
+        } finally {
+            deleteRules(ruleService, ruleId1, ruleId2);
+            logout();
+            removeLayerGroup(group);
         }
     }
 }

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -1018,8 +1018,9 @@ public class GeofenceAccessManager
         if (candidateLayer == null) {
             LayerGroupInfo layerGroup = catalog.getLayerGroupByName(layerName);
             if (layerGroup != null) {
-                layers.addAll(layerGroup.layers());
-                addGroupStyles(layerGroup, styles);
+                boolean emptyStyleName = reqStyle == null || "".equals(reqStyle);
+                layers.addAll(emptyStyleName ? layerGroup.layers() : layerGroup.layers(reqStyle));
+                addGroupStyles(layerGroup, styles, reqStyle);
             }
         } else {
             layers.add(candidateLayer);
@@ -1197,7 +1198,8 @@ public class GeofenceAccessManager
         for (Object layer : parseLayersParameter(gsRequest, getMap)) {
             boolean outOfBound = styleIndex >= parsedStyles.size();
             if (layer instanceof LayerGroupInfo) {
-                addGroupStyles((LayerGroupInfo) layer, requestedStyles);
+                String styleName = outOfBound ? null : parsedStyles.get(styleIndex);
+                addGroupStyles((LayerGroupInfo) layer, requestedStyles, styleName);
             } else {
                 // the layer is a LayerInfo or MapLayerInfo (if it is a remote layer)
                 if (outOfBound) {
@@ -1211,8 +1213,12 @@ public class GeofenceAccessManager
         return requestedStyles;
     }
 
-    private void addGroupStyles(LayerGroupInfo groupInfo, List<String> requestedStyles) {
-        List<StyleInfo> groupStyles = groupInfo.styles();
+    private void addGroupStyles(
+            LayerGroupInfo groupInfo, List<String> requestedStyles, String styleName) {
+        List<StyleInfo> groupStyles;
+        if (styleName != null && !"".equals(styleName)) groupStyles = groupInfo.styles(styleName);
+        else groupStyles = groupInfo.styles();
+
         requestedStyles.addAll(
                 groupStyles.stream()
                         .map(s -> s != null ? s.prefixedName() : null)


### PR DESCRIPTION
[![GEOS-10274](https://badgen.net/badge/JIRA/GEOS-10274/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10274)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->