### PR TITLE
[GEOS-10433] Fix tests that rely on poorly written like filters

### DIFF
--- a/src/extension/csw/core/src/test/java/org/geoserver/csw/GetRecordsTest.java
+++ b/src/extension/csw/core/src/test/java/org/geoserver/csw/GetRecordsTest.java
@@ -31,6 +31,7 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.util.EntityResolverProvider;
 import org.geotools.csw.CSWConfiguration;
 import org.geotools.xml.XmlConverterFactory;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Not;
@@ -590,6 +591,7 @@ public class GetRecordsTest extends CSWSimpleTestSupport {
     }
 
     @Test
+    @Ignore("We no longer allow empty escapes")
     public void testLikeNoEscape() throws Exception {
         String request = getResourceAsString("GetRecordsAnyTextNoEscape.xml");
         Document d = postAsDOM("csw", request);


### PR DESCRIPTION
[![GEOS-10433](https://badgen.net/badge/JIRA/GEOS-10433/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10433)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->