### PR TITLE
[GEOS-10418] Bad request sent to GeoFence when matching roles only

### DIFF
--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceGetMapIntegrationTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceGetMapIntegrationTest.java
@@ -22,6 +22,8 @@ import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.data.test.MockData;
+import org.geoserver.geofence.config.GeoFenceConfiguration;
+import org.geoserver.geofence.config.GeoFenceConfigurationManager;
 import org.geoserver.geofence.core.model.enums.CatalogMode;
 import org.geoserver.geofence.core.model.enums.GrantType;
 import org.geoserver.geofence.core.model.enums.LayerType;
@@ -31,6 +33,8 @@ import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
+
+    private GeoFenceConfigurationManager configurationManager;
 
     @Test
     public void testLimitRuleWithAllowedAreaLayerGroup() throws Exception {
@@ -74,6 +78,50 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
             deleteRules(ruleService, ruleId1, ruleId2);
             logout();
             removeLayerGroup(group);
+        }
+    }
+
+    /**
+     * Tests that the user cannot access based on the roles of other users
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRoleOnlyMatch() throws Exception {
+
+        configurationManager =
+                applicationContext.getBean(
+                        "geofenceConfigurationManager", GeoFenceConfigurationManager.class);
+        GeoFenceConfiguration config = configurationManager.getConfiguration();
+        config.setUseRolesToFilter(true);
+        config.getRoles().add("ROLE_USER");
+
+        LayerGroupInfo group =
+                addLakesPlacesLayerGroup(LayerGroupInfo.Mode.NAMED, "lakes_and_places");
+
+        Long ruleId1 = null;
+        Long ruleId2 = null;
+        try {
+            ruleId1 =
+                    addRule(GrantType.DENY, "john", null, "WMS", null, null, null, 1, ruleService);
+            ruleId2 =
+                    addRule(GrantType.ALLOW, "jane", null, "WMS", null, null, null, 0, ruleService);
+
+            login("john", "", "ROLE_USER");
+            String url =
+                    "wms?request=getmap&service=wms"
+                            + "&layers=Lakes"
+                            + "&width=100&height=100&format=image/png"
+                            + "&srs=epsg:4326&bbox=-0.002,-0.003,0.005,0.002";
+            MockHttpServletResponse resp = getAsServletResponse(url);
+
+            assertTrue(resp.getContentAsString().contains("Could not find layer Lakes"));
+        } finally {
+            deleteRules(ruleService, ruleId1, ruleId2);
+            config.setUseRolesToFilter(false);
+            config.getRoles().remove("ROLE_USER");
+            removeLayerGroup(group);
+            logout();
         }
     }
 

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -577,6 +577,8 @@ public class GeofenceAccessManager
                 for (GrantedAuthority authority : user.getAuthorities()) {
                     if (config.getRoles().contains(authority.getAuthority())) {
                         role = authority.getAuthority();
+                        ruleFilter.setUser(RuleFilter.SpecialFilterType.DEFAULT);
+                        break;
                     }
                 }
                 LOGGER.log(Level.FINE, "Setting role for filter: {0}", new Object[] {role});


### PR DESCRIPTION
[![GEOS-10418](https://badgen.net/badge/JIRA/GEOS-10418/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10418)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->