### PR TITLE
[GEOS-10420] GeoFence group list is too limiting

### DIFF
--- a/doc/en/user/source/extensions/geofence/configuration.rst
+++ b/doc/en/user/source/extensions/geofence/configuration.rst
@@ -30,6 +30,7 @@ Configure the following settings here:
 
 - Comma delimited list of mutually exclusive roles for authorization
 
+   - To match any role use the '*' symbol
 
 Cache
 -----

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceGetMapIntegrationTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceGetMapIntegrationTest.java
@@ -125,6 +125,67 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
         }
     }
 
+    /**
+     * Tests that the user can access based on any role
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAnyRoleMatch() throws Exception {
+
+        configurationManager =
+                applicationContext.getBean(
+                        "geofenceConfigurationManager", GeoFenceConfigurationManager.class);
+        GeoFenceConfiguration config = configurationManager.getConfiguration();
+        config.setUseRolesToFilter(true);
+        config.getRoles().add("*");
+
+        LayerGroupInfo group =
+                addLakesPlacesLayerGroup(LayerGroupInfo.Mode.NAMED, "lakes_and_places");
+
+        Long ruleId1 = null;
+        try {
+            ruleId1 =
+                    addRule(
+                            GrantType.ALLOW,
+                            null,
+                            "ROLE_WMS",
+                            null,
+                            null,
+                            null,
+                            null,
+                            0,
+                            ruleService);
+
+            login("john", "", "ROLE_WMS");
+            String url =
+                    "wms?request=getmap&service=wms"
+                            + "&layers=Lakes"
+                            + "&width=100&height=100&format=image/png"
+                            + "&srs=epsg:4326&bbox=-0.002,-0.003,0.005,0.002";
+            MockHttpServletResponse resp = getAsServletResponse(url);
+
+            assertEquals(200, resp.getStatus());
+
+            // check that user is able to access the layer
+            assertEquals("image/png", resp.getContentType());
+            logout();
+
+            login("jane", "", "ROLE_USER");
+            MockHttpServletResponse resp2 = getAsServletResponse(url);
+
+            assertEquals(200, resp2.getStatus());
+            // check that user is not allowed to access the layer
+            assertTrue(resp2.getContentAsString().contains("Could not find layer Lakes"));
+        } finally {
+            deleteRules(ruleService, ruleId1);
+            config.setUseRolesToFilter(false);
+            config.getRoles().remove("*");
+            removeLayerGroup(group);
+            logout();
+        }
+    }
+
     @Test
     public void testDenyRuleOnLayerGroup() throws Exception {
         // test deny rule on layerGroup

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -575,7 +575,8 @@ public class GeofenceAccessManager
 
                 String role = "UNKNOWN";
                 for (GrantedAuthority authority : user.getAuthorities()) {
-                    if (config.getRoles().contains(authority.getAuthority())) {
+                    if (config.getRoles().contains(authority.getAuthority())
+                            || config.getRoles().contains("*")) {
                         role = authority.getAuthority();
                         ruleFilter.setUser(RuleFilter.SpecialFilterType.DEFAULT);
                         break;


### PR DESCRIPTION
[![GEOS-10420](https://badgen.net/badge/JIRA/GEOS-10420/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10420)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->