### PR TITLE
[GEOS-10446] Upgrade commons-codec version

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -789,7 +789,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.9</version>
+        <version>1.15</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
[![GEOS-10446](https://badgen.net/badge/JIRA/GEOS-10446/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10446)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Bumps commons-codec from 1.9 to 1.15 (current release). https://commons.apache.org/proper/commons-codec/changes-report.html shows the changes per release.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [N/A] New unit tests have been added covering the changes.
- [N/A] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [N/A] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).