### PR TITLE
[GEOS-10447] support Metadata for Services (SRV) in csw-iso (backport)

### DIFF
--- a/src/community/csw-iso/src/main/java/org/geoserver/csw/records/iso/MetaDataDescriptor.java
+++ b/src/community/csw-iso/src/main/java/org/geoserver/csw/records/iso/MetaDataDescriptor.java
@@ -52,6 +52,7 @@ public class MetaDataDescriptor extends AbstractRecordDescriptor {
     public static final String NAMESPACE_GCO = "http://www.isotc211.org/2005/gco";
     public static final String NAMESPACE_GMD = "http://www.isotc211.org/2005/gmd";
     public static final String NAMESPACE_APISO = "http://www.opengis.net/cat/csw/apiso/1.0";
+    public static final String NAMESPACE_SRV = "http://www.isotc211.org/2005/srv";
 
     public static final String NAMESPACE_XLINK = "http://www.w3.org/1999/xlink";
 
@@ -80,6 +81,7 @@ public class MetaDataDescriptor extends AbstractRecordDescriptor {
         NAMESPACES.declarePrefix("xlink", NAMESPACE_XLINK);
         NAMESPACES.declarePrefix("gfc", NAMESPACE_GFC);
         NAMESPACES.declarePrefix("gml", NAMESPACE_GML);
+        NAMESPACES.declarePrefix("srv", NAMESPACE_SRV);
 
         FeatureTypeFactory typeFactory = new FeatureTypeFactoryImpl();
 
@@ -87,6 +89,7 @@ public class MetaDataDescriptor extends AbstractRecordDescriptor {
 
         SchemaIndex index = null;
         SchemaIndex indexGMX = null;
+        SchemaIndex indexService = null;
         try {
             index =
                     reader.parse(
@@ -94,6 +97,10 @@ public class MetaDataDescriptor extends AbstractRecordDescriptor {
             indexGMX =
                     reader.parse(
                             new URL("http://schemas.opengis.net/iso/19139/20070417/gmx/gmx.xsd"));
+            indexService =
+                    reader.parse(
+                            new URL(
+                                    "http://schemas.opengis.net/iso/19139/20070417/srv/serviceMetadata.xsd"));
         } catch (IOException e) {
             // this is fatal
             throw new RuntimeException(e);
@@ -116,6 +123,7 @@ public class MetaDataDescriptor extends AbstractRecordDescriptor {
 
         featureTypeRegistry.addSchemas(index);
         featureTypeRegistry.addSchemas(indexGMX);
+        featureTypeRegistry.addSchemas(indexService);
 
         METADATA_TYPE =
                 (FeatureType)

--- a/src/community/csw-iso/src/main/resources/net/opengis/schemas/iso/19139/20070417/srv/serviceMetadata.xsd
+++ b/src/community/csw-iso/src/main/resources/net/opengis/schemas/iso/19139/20070417/srv/serviceMetadata.xsd
@@ -1,0 +1,196 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" targetNamespace="http://www.isotc211.org/2005/srv" elementFormDefault="qualified" version="0.1">
+ <!-- ================================= Annotation ================================ -->
+ <xs:annotation>
+  <xs:documentation>This file was generated from ISO TC/211 UML class diagrams == 10-13-2006 11:14:04 ====== </xs:documentation>
+ </xs:annotation>
+ <!-- ================================== Imports ================================== -->
+ <xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="../gmd/identification.xsd"/>
+ <xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="../gco/gco.xsd"/>
+ <xs:include schemaLocation="../srv/serviceModel.xsd"/>
+ <!-- ########################################################################### -->
+ <!-- ########################################################################### -->
+ <!-- ================================== Classes ================================= -->
+ <xs:complexType name="SV_Parameter_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:MemberName_Type"/>
+     <xs:element name="direction" type="srv:SV_ParameterDirection_PropertyType" minOccurs="0"/>
+     <xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="optionality" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="repeatability" type="gco:Boolean_PropertyType"/>
+     <xs:element name="valueType" type="gco:TypeName_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Parameter" type="srv:SV_Parameter_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Parameter_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Parameter" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_OperationMetadata_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="operationName" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="DCP" type="srv:DCPList_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="operationDescription" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="invocationName" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="parameters" type="srv:SV_Parameter_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="connectPoint" type="gmd:CI_OnlineResource_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="dependsOn" type="srv:SV_OperationMetadata_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationMetadata" type="srv:SV_OperationMetadata_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationMetadata_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationMetadata" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_ServiceIdentification_Type">
+  <xs:complexContent>
+   <xs:extension base="gmd:AbstractMD_Identification_Type">
+    <xs:sequence>
+     <xs:element name="serviceType" type="gco:GenericName_PropertyType"/>
+     <xs:element name="serviceTypeVersion" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="accessProperties" type="gmd:MD_StandardOrderProcess_PropertyType" minOccurs="0"/>
+     <xs:element name="restrictions" type="gmd:MD_Constraints_PropertyType" minOccurs="0"/>
+     <xs:element name="keywords" type="gmd:MD_Keywords_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="extent" type="gmd:EX_Extent_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="coupledResource" type="srv:SV_CoupledResource_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="couplingType" type="srv:SV_CouplingType_PropertyType"/>
+     <xs:element name="containsOperations" type="srv:SV_OperationMetadata_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="operatesOn" type="gmd:MD_DataIdentification_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ServiceIdentification" type="srv:SV_ServiceIdentification_Type" substitutionGroup="gmd:AbstractMD_Identification"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ServiceIdentification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ServiceIdentification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_OperationChain_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="operation" type="srv:SV_Operation_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationChain" type="srv:SV_OperationChain_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationChain_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationChain" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_OperationChainMetadata_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="operation" type="srv:SV_OperationMetadata_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationChainMetadata" type="srv:SV_OperationChainMetadata_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationChainMetadata_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationChainMetadata" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_CoupledResource_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="operationName" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="identifier" type="gco:CharacterString_PropertyType"/>
+     <xs:element ref="gco:ScopedName" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_CoupledResource" type="srv:SV_CoupledResource_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_CoupledResource_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_CoupledResource" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:simpleType name="SV_ParameterDirection_Type">
+  <xs:restriction base="xs:string">
+   <xs:enumeration value="in"/>
+   <xs:enumeration value="out"/>
+   <xs:enumeration value="in/out"/>
+  </xs:restriction>
+ </xs:simpleType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ParameterDirection" type="srv:SV_ParameterDirection_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ParameterDirection_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ParameterDirection" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <!-- ........................................................................ -->
+ <xs:element name="DCPList" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="DCPList_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:DCPList" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <!-- ........................................................................ -->
+ <xs:element name="SV_CouplingType" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_CouplingType_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_CouplingType" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+</xs:schema>

--- a/src/community/csw-iso/src/main/resources/net/opengis/schemas/iso/19139/20070417/srv/serviceModel.xsd
+++ b/src/community/csw-iso/src/main/resources/net/opengis/schemas/iso/19139/20070417/srv/serviceModel.xsd
@@ -1,0 +1,218 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:srv="http://www.isotc211.org/2005/srv" targetNamespace="http://www.isotc211.org/2005/srv" elementFormDefault="qualified" version="0.1">
+ <!-- ================================= Annotation ================================ -->
+ <xs:annotation>
+  <xs:documentation>This file was generated from ISO TC/211 UML class diagrams == 10-13-2006 11:14:04 ====== </xs:documentation>
+ </xs:annotation>
+ <!-- ================================== Imports ================================== -->
+ <xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="../gmd/gmd.xsd"/>
+ <xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="../gco/gco.xsd"/>
+ <xs:include schemaLocation="../srv/serviceMetadata.xsd"/>
+ <!-- ########################################################################### -->
+ <!-- ########################################################################### -->
+ <!-- ================================== Classes ================================= -->
+ <xs:complexType name="SV_ServiceSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="opModel" type="srv:SV_OperationModel_PropertyType"/>
+     <xs:element name="typeSpec" type="srv:SV_PlatformNeutralServiceSpecification_PropertyType"/>
+     <xs:element name="theSV_Interface" type="srv:SV_Interface_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ServiceSpecification" type="srv:SV_ServiceSpecification_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ServiceSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ServiceSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_PlatformNeutralServiceSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="srv:SV_ServiceSpecification_Type">
+    <xs:sequence>
+     <xs:element name="serviceType" type="srv:SV_ServiceType_PropertyType"/>
+     <xs:element name="implSpec" type="srv:SV_PlatformSpecificServiceSpecification_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_PlatformNeutralServiceSpecification" type="srv:SV_PlatformNeutralServiceSpecification_Type" substitutionGroup="srv:SV_ServiceSpecification"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_PlatformNeutralServiceSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_PlatformNeutralServiceSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_PlatformSpecificServiceSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="srv:SV_PlatformNeutralServiceSpecification_Type">
+    <xs:sequence>
+     <xs:element name="DCP" type="srv:DCPList_PropertyType"/>
+     <xs:element name="implementation" type="srv:SV_Service_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_PlatformSpecificServiceSpecification" type="srv:SV_PlatformSpecificServiceSpecification_Type" substitutionGroup="srv:SV_PlatformNeutralServiceSpecification"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_PlatformSpecificServiceSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_PlatformSpecificServiceSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_ServiceType_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ServiceType" type="srv:SV_ServiceType_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ServiceType_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ServiceType" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Port_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="theSV_Interface" type="srv:SV_Interface_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Port" type="srv:SV_Port_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Port_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Port" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Service_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="specification" type="srv:SV_PlatformSpecificServiceSpecification_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="theSV_Port" type="srv:SV_Port_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Service" type="srv:SV_Service_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Service_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Service" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Interface_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="typeName" type="gco:TypeName_PropertyType"/>
+     <xs:element name="theSV_Port" type="srv:SV_Port_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="operation" type="srv:SV_Operation_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Interface" type="srv:SV_Interface_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Interface_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Interface" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_PortSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="binding" type="srv:DCPList_PropertyType"/>
+     <xs:element name="address" type="gmd:URL_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_PortSpecification" type="srv:SV_PortSpecification_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_PortSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_PortSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Operation_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="operationName" type="gco:MemberName_PropertyType"/>
+     <xs:element name="dependsOn" type="srv:SV_Operation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="parameter" type="srv:SV_Parameter_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Operation" type="srv:SV_Operation_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Operation_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Operation" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:simpleType name="SV_OperationModel_Type">
+  <xs:restriction base="xs:string">
+   <xs:enumeration value="object"/>
+   <xs:enumeration value="message"/>
+  </xs:restriction>
+ </xs:simpleType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationModel" type="srv:SV_OperationModel_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationModel_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationModel" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+</xs:schema>

--- a/src/community/csw-iso/src/main/resources/schemas/iso/19139/20070417/srv/serviceMetadata.xsd
+++ b/src/community/csw-iso/src/main/resources/schemas/iso/19139/20070417/srv/serviceMetadata.xsd
@@ -1,0 +1,196 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" targetNamespace="http://www.isotc211.org/2005/srv" elementFormDefault="qualified" version="0.1">
+ <!-- ================================= Annotation ================================ -->
+ <xs:annotation>
+  <xs:documentation>This file was generated from ISO TC/211 UML class diagrams == 10-13-2006 11:14:04 ====== </xs:documentation>
+ </xs:annotation>
+ <!-- ================================== Imports ================================== -->
+ <xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="../gmd/identification.xsd"/>
+ <xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="../gco/gco.xsd"/>
+ <xs:include schemaLocation="../srv/serviceModel.xsd"/>
+ <!-- ########################################################################### -->
+ <!-- ########################################################################### -->
+ <!-- ================================== Classes ================================= -->
+ <xs:complexType name="SV_Parameter_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:MemberName_Type"/>
+     <xs:element name="direction" type="srv:SV_ParameterDirection_PropertyType" minOccurs="0"/>
+     <xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="optionality" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="repeatability" type="gco:Boolean_PropertyType"/>
+     <xs:element name="valueType" type="gco:TypeName_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Parameter" type="srv:SV_Parameter_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Parameter_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Parameter" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_OperationMetadata_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="operationName" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="DCP" type="srv:DCPList_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="operationDescription" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="invocationName" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="parameters" type="srv:SV_Parameter_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="connectPoint" type="gmd:CI_OnlineResource_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="dependsOn" type="srv:SV_OperationMetadata_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationMetadata" type="srv:SV_OperationMetadata_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationMetadata_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationMetadata" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_ServiceIdentification_Type">
+  <xs:complexContent>
+   <xs:extension base="gmd:AbstractMD_Identification_Type">
+    <xs:sequence>
+     <xs:element name="serviceType" type="gco:GenericName_PropertyType"/>
+     <xs:element name="serviceTypeVersion" type="gco:CharacterString_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="accessProperties" type="gmd:MD_StandardOrderProcess_PropertyType" minOccurs="0"/>
+     <xs:element name="restrictions" type="gmd:MD_Constraints_PropertyType" minOccurs="0"/>
+     <xs:element name="keywords" type="gmd:MD_Keywords_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="extent" type="gmd:EX_Extent_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="coupledResource" type="srv:SV_CoupledResource_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="couplingType" type="srv:SV_CouplingType_PropertyType"/>
+     <xs:element name="containsOperations" type="srv:SV_OperationMetadata_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="operatesOn" type="gmd:MD_DataIdentification_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ServiceIdentification" type="srv:SV_ServiceIdentification_Type" substitutionGroup="gmd:AbstractMD_Identification"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ServiceIdentification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ServiceIdentification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_OperationChain_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="operation" type="srv:SV_Operation_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationChain" type="srv:SV_OperationChain_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationChain_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationChain" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_OperationChainMetadata_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="description" type="gco:CharacterString_PropertyType" minOccurs="0"/>
+     <xs:element name="operation" type="srv:SV_OperationMetadata_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationChainMetadata" type="srv:SV_OperationChainMetadata_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationChainMetadata_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationChainMetadata" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_CoupledResource_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="operationName" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="identifier" type="gco:CharacterString_PropertyType"/>
+     <xs:element ref="gco:ScopedName" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_CoupledResource" type="srv:SV_CoupledResource_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_CoupledResource_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_CoupledResource" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:simpleType name="SV_ParameterDirection_Type">
+  <xs:restriction base="xs:string">
+   <xs:enumeration value="in"/>
+   <xs:enumeration value="out"/>
+   <xs:enumeration value="in/out"/>
+  </xs:restriction>
+ </xs:simpleType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ParameterDirection" type="srv:SV_ParameterDirection_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ParameterDirection_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ParameterDirection" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <!-- ........................................................................ -->
+ <xs:element name="DCPList" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="DCPList_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:DCPList" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <!-- ........................................................................ -->
+ <xs:element name="SV_CouplingType" type="gco:CodeListValue_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_CouplingType_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_CouplingType" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+</xs:schema>

--- a/src/community/csw-iso/src/main/resources/schemas/iso/19139/20070417/srv/serviceModel.xsd
+++ b/src/community/csw-iso/src/main/resources/schemas/iso/19139/20070417/srv/serviceModel.xsd
@@ -1,0 +1,218 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:srv="http://www.isotc211.org/2005/srv" targetNamespace="http://www.isotc211.org/2005/srv" elementFormDefault="qualified" version="0.1">
+ <!-- ================================= Annotation ================================ -->
+ <xs:annotation>
+  <xs:documentation>This file was generated from ISO TC/211 UML class diagrams == 10-13-2006 11:14:04 ====== </xs:documentation>
+ </xs:annotation>
+ <!-- ================================== Imports ================================== -->
+ <xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="../gmd/gmd.xsd"/>
+ <xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="../gco/gco.xsd"/>
+ <xs:include schemaLocation="../srv/serviceMetadata.xsd"/>
+ <!-- ########################################################################### -->
+ <!-- ########################################################################### -->
+ <!-- ================================== Classes ================================= -->
+ <xs:complexType name="SV_ServiceSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="name" type="gco:CharacterString_PropertyType"/>
+     <xs:element name="opModel" type="srv:SV_OperationModel_PropertyType"/>
+     <xs:element name="typeSpec" type="srv:SV_PlatformNeutralServiceSpecification_PropertyType"/>
+     <xs:element name="theSV_Interface" type="srv:SV_Interface_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ServiceSpecification" type="srv:SV_ServiceSpecification_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ServiceSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ServiceSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_PlatformNeutralServiceSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="srv:SV_ServiceSpecification_Type">
+    <xs:sequence>
+     <xs:element name="serviceType" type="srv:SV_ServiceType_PropertyType"/>
+     <xs:element name="implSpec" type="srv:SV_PlatformSpecificServiceSpecification_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_PlatformNeutralServiceSpecification" type="srv:SV_PlatformNeutralServiceSpecification_Type" substitutionGroup="srv:SV_ServiceSpecification"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_PlatformNeutralServiceSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_PlatformNeutralServiceSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_PlatformSpecificServiceSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="srv:SV_PlatformNeutralServiceSpecification_Type">
+    <xs:sequence>
+     <xs:element name="DCP" type="srv:DCPList_PropertyType"/>
+     <xs:element name="implementation" type="srv:SV_Service_PropertyType" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_PlatformSpecificServiceSpecification" type="srv:SV_PlatformSpecificServiceSpecification_Type" substitutionGroup="srv:SV_PlatformNeutralServiceSpecification"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_PlatformSpecificServiceSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_PlatformSpecificServiceSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_ServiceType_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_ServiceType" type="srv:SV_ServiceType_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_ServiceType_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_ServiceType" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Port_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="theSV_Interface" type="srv:SV_Interface_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Port" type="srv:SV_Port_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Port_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Port" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Service_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="specification" type="srv:SV_PlatformSpecificServiceSpecification_PropertyType" maxOccurs="unbounded"/>
+     <xs:element name="theSV_Port" type="srv:SV_Port_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Service" type="srv:SV_Service_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Service_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Service" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Interface_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="typeName" type="gco:TypeName_PropertyType"/>
+     <xs:element name="theSV_Port" type="srv:SV_Port_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="operation" type="srv:SV_Operation_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Interface" type="srv:SV_Interface_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Interface_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Interface" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_PortSpecification_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="binding" type="srv:DCPList_PropertyType"/>
+     <xs:element name="address" type="gmd:URL_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_PortSpecification" type="srv:SV_PortSpecification_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_PortSpecification_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_PortSpecification" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:complexType name="SV_Operation_Type">
+  <xs:complexContent>
+   <xs:extension base="gco:AbstractObject_Type">
+    <xs:sequence>
+     <xs:element name="operationName" type="gco:MemberName_PropertyType"/>
+     <xs:element name="dependsOn" type="srv:SV_Operation_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+     <xs:element name="parameter" type="srv:SV_Parameter_PropertyType"/>
+    </xs:sequence>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_Operation" type="srv:SV_Operation_Type"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_Operation_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_Operation" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="gco:ObjectReference"/>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+ <xs:simpleType name="SV_OperationModel_Type">
+  <xs:restriction base="xs:string">
+   <xs:enumeration value="object"/>
+   <xs:enumeration value="message"/>
+  </xs:restriction>
+ </xs:simpleType>
+ <!-- ........................................................................ -->
+ <xs:element name="SV_OperationModel" type="srv:SV_OperationModel_Type" substitutionGroup="gco:CharacterString"/>
+ <!-- ........................................................................ -->
+ <xs:complexType name="SV_OperationModel_PropertyType">
+  <xs:sequence>
+   <xs:element ref="srv:SV_OperationModel" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute ref="gco:nilReason"/>
+ </xs:complexType>
+ <!-- =========================================================================== -->
+</xs:schema>

--- a/src/community/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordByIdTest.java
+++ b/src/community/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordByIdTest.java
@@ -83,6 +83,24 @@ public class GetRecordByIdTest extends MDTestSupport {
                 "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition",
                 d);
 
+        // test SRV
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation",
+                d);
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:serviceType/gco:LocalName/@codeSpace",
+                d);
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:serviceTypeVersion/gco:CharacterString",
+                d);
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:couplingType/srv:SV_CouplingType/@codeListValue",
+                d);
+
         // check that resourceConstraints are separate tags
         // assertXpathEvaluatesTo("2", "count(//gmd:resourceConstraints)", d);
 

--- a/src/community/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordsTest.java
+++ b/src/community/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordsTest.java
@@ -167,6 +167,24 @@ public class GetRecordsTest extends MDTestSupport {
                 "http://localhost:8080/geoserver/wcs",
                 "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[3]/gmd:linkage/gmd:URL",
                 d);
+
+        // test SRV
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation",
+                d);
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:serviceType/gco:LocalName/@codeSpace",
+                d);
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:serviceTypeVersion/gco:CharacterString",
+                d);
+        assertXpathEvaluatesTo(
+                "srv_works",
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:couplingType/srv:SV_CouplingType/@codeListValue",
+                d);
     }
 
     @Test

--- a/src/community/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/MDTestSupport.java
+++ b/src/community/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/MDTestSupport.java
@@ -45,6 +45,7 @@ public class MDTestSupport extends CSWInternalTestSupport {
         namespaces.put("gco", MetaDataDescriptor.NAMESPACE_GCO);
         namespaces.put("dc", DC.NAMESPACE);
         namespaces.put("gmx", MetaDataDescriptor.NAMESPACE_GMX);
+        namespaces.put("srv", MetaDataDescriptor.NAMESPACE_SRV);
         namespaces.put("gfc", MetaDataDescriptor.NAMESPACE_GFC);
         namespaces.put("gml", GML.NAMESPACE);
 

--- a/src/community/csw-iso/src/test/resources/org/geoserver/csw/store/internal/MD_Metadata.properties
+++ b/src/community/csw-iso/src/test/resources/org/geoserver/csw/store/internal/MD_Metadata.properties
@@ -19,3 +19,9 @@ contentInfo.MD_FeatureCatalogueDescription.featureCatalogueCitation.@uuidref=if_
 identificationInfo.MD_DataIdentification.pointOfContact.CI_ResponsibleParty%.organisationName=list('theones', 'notelephone', 'theothers')
 identificationInfo.MD_DataIdentification.pointOfContact.CI_ResponsibleParty%.contactInfo.CI_Contact.phone.CI_Telephone.voice.CharacterString=list('0123', "Expression/NIL", '4567')
 identificationInfo.MD_DataIdentification.pointOfContact.CI_ResponsibleParty%.contactInfo.CI_Contact.address.CI_Address.deliveryPoint.CharacterString=list('here', 'there', 'everywhere')
+identificationInfo.SV_ServiceIdentification.citation='srv_works'
+identificationInfo.SV_ServiceIdentification.serviceType.LocalName.@codeSpace='srv_works'
+identificationInfo.SV_ServiceIdentification.serviceTypeVersion.CharacterString='srv_works'
+identificationInfo.SV_ServiceIdentification.couplingType.SV_CouplingType.@codeListValue='srv_works'
+
+


### PR DESCRIPTION
[![GEOS-10447](https://badgen.net/badge/JIRA/GEOS-10447/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10447)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->