### PR TITLE
[GEOS-10444]: Supporting REPLACE UpdateMode on rasters import

### DIFF
--- a/doc/en/user/source/extensions/importer/rest_reference.rst
+++ b/doc/en/user/source/extensions/importer/rest_reference.rst
@@ -447,9 +447,19 @@ Updating a task
 A PUT request over an existing task can be used to update its representation. The representation can be partial, and just contains
 the elements that need to be updated.
 
-The updateMode of a task normally starts as "CREATE", that is, create the target resource if missing. Other possible values are
-"REPLACE", that is, delete the existing features in the target layer and replace them with the task source ones, or "APPEND",
-to just add the features from the task source into an existing layer.
+The updateMode of a task may have different values. 
+
+.. list-table::
+   :header-rows: 1
+
+   * - UpdateMode
+     - Description
+   * - CREATE
+     - This is the default starting updateMode of a task, that is: create the target resource if missing.
+   * - REPLACE
+     - For vector stores: delete the existing features in the target layer and replace them with those from the task source. For raster stores: replace the underlying data. When dealing with StructuredGridCoverage reader (e.g. ImageMosaic) the new file will be harvested (replacing the old one). For single raster coverages (e.g. GeoTIFF) the name of the file should be the same so that the coverageStore layer will preserve the original name (the old file will be deleted).
+   * - APPEND
+     - Add the features from the task source into an existing layer.
 
 The following PUT request updates a task from "CREATE" to "APPEND" mode::
 


### PR DESCRIPTION
[![GEOS-10444](https://badgen.net/badge/JIRA/GEOS-10444/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10444)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Importer: Add support for UpdateMode.REPLACE  on raster too
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- x ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->