### PR TITLE
[2.20.x][GEOS-10427] Improve access check in ImportProcess

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
@@ -31,10 +31,9 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
-import org.geoserver.security.AccessLevel;
+import org.geoserver.security.AdminRequest;
 import org.geoserver.security.SecureCatalogImpl;
-import org.geoserver.security.SecureCatalogImpl.MixedModeBehavior;
-import org.geoserver.security.WrapperPolicy;
+import org.geoserver.security.WorkspaceAccessLimits;
 import org.geoserver.wps.WPSException;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
@@ -153,7 +152,8 @@ public class ImportProcess implements GeoServerProcess {
         listener.started();
         listener.progress(0);
 
-        // first off, decide what is the target store
+        // first off, decide what is the target workspace
+        // call getWorkspaceByName before setting the AdminRequest
         WorkspaceInfo ws;
         if (workspace != null) {
             ws = catalog.getWorkspaceByName(workspace);
@@ -167,7 +167,39 @@ public class ImportProcess implements GeoServerProcess {
                         "The catalog is empty, could not find a default workspace");
             }
         }
-        checkWriteAccess(ws);
+
+        // set the AdminRequest thread local for the rest of this request
+        try {
+            AdminRequest.start(this);
+            return executeAsAdminRequest(
+                    features,
+                    coverage,
+                    workspace,
+                    ws,
+                    store,
+                    name,
+                    srs,
+                    srsHandling,
+                    styleName,
+                    listener);
+        } finally {
+            AdminRequest.finish();
+        }
+    }
+
+    private String executeAsAdminRequest(
+            SimpleFeatureCollection features,
+            GridCoverage2D coverage,
+            String workspace,
+            WorkspaceInfo ws,
+            String store,
+            String name,
+            CoordinateReferenceSystem srs,
+            ProjectionPolicy srsHandling,
+            String styleName,
+            ProgressListener listener) {
+        // verify that the user has admin privileges for the target workspace
+        checkAdminAccess(ws);
 
         // create a builder to help build catalog objects
         CatalogBuilder cb = new CatalogBuilder(catalog);
@@ -254,17 +286,13 @@ public class ImportProcess implements GeoServerProcess {
         return null;
     }
 
-    private static void checkWriteAccess(WorkspaceInfo workspace) {
-        // This is essentially the same code to check the access level as used by
-        // org.geoserver.security.SecureCatalogImpl.getDataStoreByName(String, String)
-        WrapperPolicy policy =
+    private static void checkAdminAccess(WorkspaceInfo info) {
+        WorkspaceAccessLimits wl =
                 GeoServerExtensions.bean(SecureCatalogImpl.class)
-                        .buildWrapperPolicy(
-                                SecurityContextHolder.getContext().getAuthentication(),
-                                workspace,
-                                workspace.getName(),
-                                MixedModeBehavior.CHALLENGE);
-        if (policy.level != AccessLevel.READ_WRITE) {
+                        .getResourceAccessManager()
+                        .getAccessLimits(
+                                SecurityContextHolder.getContext().getAuthentication(), info);
+        if (wl == null || !wl.isAdminable()) {
             throw new ProcessException("Operation unallowed with the current privileges");
         }
     }

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -25,6 +26,8 @@ import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.security.AccessMode;
+import org.geoserver.security.impl.DataAccessRuleDAO;
 import org.geoserver.wps.WPSTestSupport;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.DataUtilities;
@@ -51,9 +54,12 @@ public class ImportProcessTest extends WPSTestSupport {
     @After
     public void removeNewLayers() {
         removeLayer(SystemTestData.CITE_PREFIX, "Buildings2");
+        removeLayer(SystemTestData.CITE_PREFIX, "Buildings3");
         removeLayer(SystemTestData.CITE_PREFIX, "Buildings4");
         removeLayer(SystemTestData.CITE_PREFIX, "Buildings5");
         removeLayer(SystemTestData.CITE_PREFIX, "Buildings6");
+        removeLayer(SystemTestData.CITE_PREFIX, "Buildings7");
+        removeLayer(SystemTestData.CITE_PREFIX, "Buildings8");
         removeStore(SystemTestData.CITE_PREFIX, SystemTestData.CITE_PREFIX + "data");
         removeStore(SystemTestData.CITE_PREFIX, SystemTestData.CITE_PREFIX + "raster");
     }
@@ -61,6 +67,7 @@ public class ImportProcessTest extends WPSTestSupport {
     /** Try to re-import buildings as another layer (different name, different projection) */
     @Test
     public void testImportBuildings() throws Exception {
+        setUpAccess(false, false);
         FeatureTypeInfo ti =
                 getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
         SimpleFeatureCollection rawSource =
@@ -86,6 +93,7 @@ public class ImportProcessTest extends WPSTestSupport {
 
     @Test
     public void testImportBuildingsProgress() throws Exception {
+        setUpAccess(false, false);
         FeatureTypeInfo ti =
                 getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
         SimpleFeatureCollection rawSource =
@@ -124,6 +132,7 @@ public class ImportProcessTest extends WPSTestSupport {
     @Test
     public void testImportBuildingsCancellation() throws Exception {
         Assume.assumeFalse(System.getProperty("macos-github-build") != null);
+        setUpAccess(false, false);
         FeatureTypeInfo ti =
                 getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
         SimpleFeatureCollection rawSource =
@@ -184,6 +193,7 @@ public class ImportProcessTest extends WPSTestSupport {
     /** Try to re-import buildings as another layer (different name, different projection) */
     @Test
     public void testImportBuildingsForceCRS() throws Exception {
+        setUpAccess(false, false);
         FeatureTypeInfo ti =
                 getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
         SimpleFeatureCollection rawSource =
@@ -241,6 +251,7 @@ public class ImportProcessTest extends WPSTestSupport {
     /** Test creating a coverage store when a store name is specified but does not exist */
     @Test
     public void testCreateCoverageStore() throws Exception {
+        setUpAccess(false, false);
         String storeName = SystemTestData.CITE_PREFIX + "raster";
         // use Coverage2RenderedImageAdapterTest's method, just need any sample raster
         GridCoverage2D sampleCoverage =
@@ -263,9 +274,62 @@ public class ImportProcessTest extends WPSTestSupport {
         assertEquals(result, SystemTestData.CITE_PREFIX + ":" + "Buildings4");
     }
 
+    @Test
+    public void testCreateCoverageStoreWithLogin() throws Exception {
+        setUpAccess(true, true);
+        String storeName = SystemTestData.CITE_PREFIX + "raster";
+        // use Coverage2RenderedImageAdapterTest's method, just need any sample raster
+        GridCoverage2D sampleCoverage =
+                Coverage2RenderedImageAdapterTest.createTestCoverage(500, 500, 0, 0, 10, 10);
+        CoverageStoreInfo storeInfo = catalog.getCoverageStoreByName(storeName);
+        assertNull("Store already exists " + storeInfo, storeInfo);
+        ImportProcess importer = new ImportProcess(getCatalog());
+        String result =
+                importer.execute(
+                        null,
+                        sampleCoverage,
+                        SystemTestData.CITE_PREFIX,
+                        storeName,
+                        "Buildings7",
+                        CRS.decode("EPSG:4326"),
+                        null,
+                        null,
+                        null);
+        // expect workspace:layername
+        assertEquals(result, SystemTestData.CITE_PREFIX + ":" + "Buildings7");
+    }
+
+    @Test
+    public void testCreateCoverageStoreAccessDenied() throws Exception {
+        setUpAccess(true, false);
+        String storeName = SystemTestData.CITE_PREFIX + "raster";
+        // use Coverage2RenderedImageAdapterTest's method, just need any sample raster
+        GridCoverage2D sampleCoverage =
+                Coverage2RenderedImageAdapterTest.createTestCoverage(500, 500, 0, 0, 10, 10);
+        CoverageStoreInfo storeInfo = catalog.getCoverageStoreByName(storeName);
+        assertNull("Store already exists " + storeInfo, storeInfo);
+        ImportProcess importer = new ImportProcess(getCatalog());
+        ProcessException exception =
+                assertThrows(
+                        ProcessException.class,
+                        () ->
+                                importer.execute(
+                                        null,
+                                        sampleCoverage,
+                                        SystemTestData.CITE_PREFIX,
+                                        storeName,
+                                        "Buildings7",
+                                        CRS.decode("EPSG:4326"),
+                                        null,
+                                        null,
+                                        null));
+        assertEquals("Operation unallowed with the current privileges", exception.getMessage());
+    }
+
     /** Test creating a vector store when a store name is specified but does not exist */
     @Test
     public void testCreateDataStore() throws Exception {
+        setUpAccess(false, false);
         FeatureTypeInfo ti =
                 getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
         SimpleFeatureCollection rawSource =
@@ -289,5 +353,76 @@ public class ImportProcessTest extends WPSTestSupport {
                         null);
         // expect workspace:layername
         assertEquals(result, SystemTestData.CITE_PREFIX + ":" + "Buildings5");
+    }
+
+    @Test
+    public void testCreateDataStoreWithLogin() throws Exception {
+        setUpAccess(true, true);
+        FeatureTypeInfo ti =
+                getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
+        SimpleFeatureCollection rawSource =
+                (SimpleFeatureCollection) ti.getFeatureSource(null, null).getFeatures();
+        ForceCoordinateSystemFeatureResults sampleData =
+                new ForceCoordinateSystemFeatureResults(rawSource, CRS.decode("EPSG:4326"));
+        String storeName = SystemTestData.CITE_PREFIX + "data";
+        DataStoreInfo storeInfo = catalog.getDataStoreByName(storeName);
+        assertNull("Store already exists " + storeInfo, storeInfo);
+        ImportProcess importer = new ImportProcess(getCatalog());
+        String result =
+                importer.execute(
+                        sampleData,
+                        null,
+                        SystemTestData.CITE_PREFIX,
+                        storeName,
+                        "Buildings8",
+                        CRS.decode("EPSG:4326"),
+                        null,
+                        null,
+                        null);
+        // expect workspace:layername
+        assertEquals(result, SystemTestData.CITE_PREFIX + ":" + "Buildings8");
+    }
+
+    @Test
+    public void testCreateDataStoreAccessDenied() throws Exception {
+        setUpAccess(true, false);
+        FeatureTypeInfo ti =
+                getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.BUILDINGS));
+        SimpleFeatureCollection rawSource =
+                (SimpleFeatureCollection) ti.getFeatureSource(null, null).getFeatures();
+        ForceCoordinateSystemFeatureResults sampleData =
+                new ForceCoordinateSystemFeatureResults(rawSource, CRS.decode("EPSG:4326"));
+        String storeName = SystemTestData.CITE_PREFIX + "data";
+        DataStoreInfo storeInfo = catalog.getDataStoreByName(storeName);
+        assertNull("Store already exists " + storeInfo, storeInfo);
+        ImportProcess importer = new ImportProcess(getCatalog());
+        ProcessException exception =
+                assertThrows(
+                        ProcessException.class,
+                        () ->
+                                importer.execute(
+                                        sampleData,
+                                        null,
+                                        SystemTestData.CITE_PREFIX,
+                                        storeName,
+                                        "Buildings8",
+                                        CRS.decode("EPSG:4326"),
+                                        null,
+                                        null,
+                                        null));
+        assertEquals("Operation unallowed with the current privileges", exception.getMessage());
+    }
+
+    private void setUpAccess(boolean limitWrite, boolean login) throws IOException {
+        DataAccessRuleDAO.get().clear();
+        addLayerAccessRule("*", "*", AccessMode.READ, "*");
+        if (limitWrite) {
+            addLayerAccessRule("*", "*", AccessMode.WRITE, "ROLE_TEST");
+            if (login) {
+                login("test", "test", "ROLE_TEST");
+            }
+        } else {
+            addLayerAccessRule("*", "*", AccessMode.WRITE, "*");
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-10427](https://badgen.net/badge/JIRA/GEOS-10427/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10427)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

2.20.x backport for https://github.com/geoserver/geoserver/pull/5735
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->