### PR TITLE
[GEOS-10451] Support in OSEO for POST queries with CQL

### DIFF
--- a/src/community/oseo/oseo-service/src/test/java/org/geoserver/opensearch/eo/SearchTest.java
+++ b/src/community/oseo/oseo-service/src/test/java/org/geoserver/opensearch/eo/SearchTest.java
@@ -1028,7 +1028,7 @@ public class SearchTest extends OSEOTestSupport {
                 dom,
                 hasXPath(
                         "/at:feed/at:entry[1]/at:summary",
-                        containsString("Jan 17, 2016 10:10:30")));
+                        containsString("Jan 17, 2016, 10:10:30")));
     }
 
     @Test

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/SearchQuery.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/SearchQuery.java
@@ -5,6 +5,8 @@
 package org.geoserver.ogcapi.stac;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import org.locationtech.jts.geom.Geometry;
 
@@ -58,8 +60,13 @@ public class SearchQuery {
         return filter;
     }
 
-    public void setFilter(String filter) {
-        this.filter = filter;
+    // Using JsonNode to prevent Jackson from trying to parse into object if is CQL2-JSON
+    public void setFilter(JsonNode node) {
+        if (node instanceof ObjectNode) {
+            this.filter = node.toString();
+        } else {
+            this.filter = node.textValue();
+        }
     }
 
     public String getFilterLang() {

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/SearchTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/SearchTest.java
@@ -125,6 +125,38 @@ public class SearchTest extends STACTestSupport {
         checkCollectionsSinglePage(doc, 1, containsInAnyOrder("LANDSAT8"));
     }
 
+    @Test
+    public void testCollectionsCql2TextPost() throws Exception {
+        // two SAS1, one Landsat, but the filter matches constellation to landsat8 only
+        String request =
+                "{\n"
+                        + "  \"collections\": [\n"
+                        + "    \"SAS1\",\n"
+                        + "    \"LANDSAT8\"\n"
+                        + "  ],\n"
+                        + "  \"filter\": \"constellation='landsat8'\",\n"
+                        + "  \"filter-lang\": \"cql2-text\"\n"
+                        + "}";
+        DocumentContext doc = postAsJSONPath("ogc/stac/search", request, 200);
+        checkCollectionsSinglePage(doc, 1, containsInAnyOrder("LANDSAT8"));
+    }
+
+    @Test
+    public void testCollectionsCql2JsonPost() throws Exception {
+        // two SAS1, one Landsat, but the filter matches constellation to landsat8 only
+        String request =
+                "{\n"
+                        + "  \"collections\": [\n"
+                        + "    \"SAS1\",\n"
+                        + "    \"LANDSAT8\"\n"
+                        + "  ],\n"
+                        + "  \"filter\":{\"op\":\"=\",\"args\":[{\"property\":\"constellation\"},\"landsat8\"]},\n"
+                        + "  \"filter-lang\": \"cql2-json\"\n"
+                        + "}";
+        DocumentContext doc = postAsJSONPath("ogc/stac/search", request, 200);
+        checkCollectionsSinglePage(doc, 1, containsInAnyOrder("LANDSAT8"));
+    }
+
     private void checkCollectionsSinglePage(
             DocumentContext doc,
             int matched,


### PR DESCRIPTION
[![GEOS-10451](https://badgen.net/badge/JIRA/GEOS-10451/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10451)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

added tests


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x]  Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->