### PR TITLE
[GEOS-10429] Style validation error using the VendorOption 'graphic-m…

### DIFF
--- a/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
+++ b/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
@@ -482,6 +482,7 @@
             <xsd:element ref="sld:Geometry" minOccurs="0"/>
             <xsd:element ref="sld:Fill" minOccurs="0"/>
             <xsd:element ref="sld:Stroke" minOccurs="0"/>
+            <xsd:element ref="sld:VendorOption" minOccurs="0" maxOccurs="unbounded" />
           </xsd:sequence>
         </xsd:extension>
       </xsd:complexContent>

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -1022,6 +1022,52 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
         tester.assertNoErrorMessage();
     }
 
+    @Test
+    public void testVendorOptionInsidePolygonSymbolizer() {
+        final String polygonSymbolizerXml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\"\n"
+                        + "                       xmlns:ogc=\"http://www.opengis.net/ogc\"\n"
+                        + "                       xmlns:xlink=\"http://www.w3.org/1999/xlink\"\n"
+                        + "                       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "                       version=\"1.0.0\"\n"
+                        + "                       xsi:schemaLocation=\"http://www.opengis.net/sld StyledLayerDescriptor.xsd\">\n"
+                        + "  <NamedLayer>\n"
+                        + "    <Name>test</Name>\n"
+                        + "    <UserStyle>\n"
+                        + "      <Name>test</Name>\n"
+                        + "      <Title>test</Title>\n"
+                        + "      <FeatureTypeStyle>\n"
+                        + "        <Rule>\n"
+                        + "          <Name>test</Name>\n"
+                        + "          <Title>test\n"
+                        + "          </Title>\n"
+                        + "          <PolygonSymbolizer>\n"
+                        + "            <Fill>\n"
+                        + "              <GraphicFill>\n"
+                        + "                <Graphic>\n"
+                        + "                  <ExternalGraphic>\n"
+                        + "                    <OnlineResource xlink:type=\"simple\" xlink:href=\"rectangle.png\"/>\n"
+                        + "                    <Format>image/png</Format>\n"
+                        + "                  </ExternalGraphic>\n"
+                        + "                </Graphic>\n"
+                        + "              </GraphicFill>\n"
+                        + "            </Fill>\n"
+                        + "            <VendorOption name=\"graphic-margin\">10</VendorOption>\n"
+                        + "          </PolygonSymbolizer>\n"
+                        + "        </Rule>\n"
+                        + "      </FeatureTypeStyle>\n"
+                        + "    </UserStyle>\n"
+                        + "  </NamedLayer>\n"
+                        + "</StyledLayerDescriptor>\n";
+
+        tester.newFormTester("styleForm")
+                .setValue("styleEditor:editorContainer:editorParent:editor", polygonSymbolizerXml);
+
+        tester.executeAjaxEvent("validate", "click");
+        tester.assertNoErrorMessage();
+    }
+
     public static class MockStyleComponentInfo extends StyleComponentInfo {
         public MockStyleComponentInfo(String id, AbstractStylePage clazz) {
             super("test", clazz);


### PR DESCRIPTION
[![GEOS-10429](https://badgen.net/badge/JIRA/GEOS-10429/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10429)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

added the VendorOption element to the SLD schema


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->