### PR TITLE
[GEOS-10448] GetTimeSeries does not limit number of dates when using a time range request (without period) (2.20.x)

### DIFF
--- a/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/NcWmsService.java
+++ b/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/NcWmsService.java
@@ -296,6 +296,8 @@ public class NcWmsService implements DisposableBean {
                             .collect(Collectors.toList());
 
             result.getFeature().add(new ListFeatureCollection(resultType, featureList));
+        } catch (ServiceException e) {
+            throw e;
         } catch (Exception e) {
             throw new ServiceException("Error processing the operation", e);
         } finally {
@@ -371,6 +373,20 @@ public class NcWmsService implements DisposableBean {
             DateFinder finder = nearestMatch ? DateFinder.NEAREST : DateFinder.QUERY;
             results = finder.findDates(wms, coverage, times);
         }
+
+        // check they are not too many
+        int maxDimensions = NcWmsService.getMaxDimensions(wms);
+
+        if (maxDimensions > 0 && results.size() > maxDimensions)
+            throw new ServiceException(
+                    "This request would process "
+                            + results.size()
+                            + " times, while the maximum allowed is "
+                            + maxDimensions
+                            + ". Please reduce the size of the requested time range.",
+                    "InvalidParameterValue",
+                    "time");
+
         return results;
     }
 


### PR DESCRIPTION
[![GEOS-10448](https://badgen.net/badge/JIRA/GEOS-10448/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10448)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->