### PR TITLE
Allow OGC API and REST to coexist

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIConfigurationSupport.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIConfigurationSupport.java
@@ -12,9 +12,9 @@ import org.geoserver.ows.DispatcherCallback;
 import org.geoserver.ows.Request;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.Operation;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.config.annotation.DelegatingWebMvcConfiguration;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
@@ -25,7 +25,9 @@ import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHan
  * Subclass of {@link WebMvcConfigurationSupport} adding support for dispatching {@link
  * DispatcherCallback#operationDispatched} events to callbacks
  */
-@Configuration
+// Not @Configuration on purpose, or it will interfere with the REST API.
+// @Component is good enough to allow auto-wiring.
+@Component
 public class APIConfigurationSupport extends DelegatingWebMvcConfiguration {
 
     static final Logger LOGGER =

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIDispatcher.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIDispatcher.java
@@ -42,11 +42,13 @@ import org.geoserver.platform.ServiceException;
 import org.geotools.util.Version;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.MethodParameter;
+import org.springframework.format.support.FormattingConversionService;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.cbor.MappingJackson2CborHttpMessageConverter;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.validation.Validator;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -131,7 +133,13 @@ public class APIDispatcher extends AbstractController {
         APIConfigurationSupport configurationSupport =
                 context.getBean(APIConfigurationSupport.class);
         configurationSupport.setCallbacks(callbacks);
-        handlerAdapter = context.getBean(RequestMappingHandlerAdapter.class);
+
+        handlerAdapter =
+                configurationSupport.requestMappingHandlerAdapter(
+                        context.getBean(
+                                "mvcContentNegotiationManager", ContentNegotiationManager.class),
+                        context.getBean("mvcConversionService", FormattingConversionService.class),
+                        context.getBean("mvcValidator", Validator.class));
         handlerAdapter.setApplicationContext(context);
         handlerAdapter.afterPropertiesSet();
         // force GeoServer version of jackson as the first choice


### PR DESCRIPTION
With this change the OGC API and REST API seem to be both functional.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->