### PR TITLE
[GEOS-10308] GeoServer with OGCAPI fails to deploy (2.20.x)

### DIFF
--- a/src/community/metadata/pom.xml
+++ b/src/community/metadata/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.3.0</version>
     </dependency>
 
     <dependency>

--- a/src/community/ogcapi/ogcapi-core/pom.xml
+++ b/src/community/ogcapi/ogcapi-core/pom.xml
@@ -37,12 +37,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson2.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>${jackson2.version}</version>
     </dependency>
     <dependency>
       <!-- this is added to avoid https://github.com/FasterXML/jackson-dataformat-xml/issues/32 -->

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1139,6 +1139,16 @@
         <version>${jackson2.databind.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
+        <version>${jackson2.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>6.2.6</version>


### PR DESCRIPTION
[![GEOS-10308](https://badgen.net/badge/JIRA/GEOS-10308/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10308)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Centralizes versions management of a couple of Jackson jars.
Backport from main, it fixes both the OGC API and the COG issues reported by users:
* https://osgeo-org.atlassian.net/browse/GEOS-10459
* https://osgeo-org.atlassian.net/browse/GEOS-10461

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->