### PR TITLE
[GEOS-10471] WMTS MultiDim - Support also endAttribute

### DIFF
--- a/doc/en/user/source/extensions/wmts-multidimensional/usage.rst
+++ b/doc/en/user/source/extensions/wmts-multidimensional/usage.rst
@@ -8,7 +8,7 @@ All described operations including is optional parameters and other extensions w
 The ``GetFeature`` operation only supports the profile GML 3.1 as feature info format ("application/gml+xml; version=3.1") and the ``GetHistogram`` operation only supports ``text/xml`` as output format.
 
 
-This module support well defined dimensions like elevation, time and also custom dimensions. 
+This module support well defined dimensions like elevation and time, but also custom dimensions. 
 
 GetCapabilities
 ---------------
@@ -515,7 +515,7 @@ filtering on elevations between 0 and 15 will return this instead:
   </Histogram>
 
 
-Note that if an end attribute is specified the bucket matching will be applied on ranges rather than on single values. In this case buckets are filled by intersection of ranges' values with bucket limits and not by containment within buckets. This is done in order to avoid that some range values are falling outside every bucket but as a side effects the same range can match more than one bucket. 
+Note that if an end attribute is specified the bucket matching will be applied on ranges rather than on single values. In this case, buckets are filled by the intersection of ranges' values with bucket limits and not by containment. This is done in order to avoid some range values falling outside every bucket, but as a side effect, the same range can match more than one bucket.
 
 GetFeature
 ^^^^^^^^^^

--- a/doc/en/user/source/extensions/wmts-multidimensional/usage.rst
+++ b/doc/en/user/source/extensions/wmts-multidimensional/usage.rst
@@ -8,7 +8,7 @@ All described operations including is optional parameters and other extensions w
 The ``GetFeature`` operation only supports the profile GML 3.1 as feature info format ("application/gml+xml; version=3.1") and the ``GetHistogram`` operation only supports ``text/xml`` as output format.
 
 
-This module support well defined dimensions like elevation and time and also custom dimensions.
+This module support well defined dimensions like elevation, time and also custom dimensions. 
 
 GetCapabilities
 ---------------
@@ -167,6 +167,35 @@ and the result will be similar to this:
     </DimensionDomain>
   </Domains>
 
+
+Note that if an end attribute has been defined in the layer dimension configuration page, the result will show ranges in place of single values. The result in this case will look like the following:
+
+.. code-block:: xml
+
+  <Domains xmlns="http://demo.geo-solutions.it/share/wmts-multidim/wmts_multi_dimensional.xsd" xmlns:ows="http://www.opengis.net/ows/1.1">
+    <SpaceDomain>
+      <BoundingBox CRS="EPSG:4326" 
+       maxx="179.875" maxy="89.9375" minx="-180.125" miny="-90.125"/>
+    </SpaceDomain>
+    <DimensionDomain>
+      <ows:Identifier>elevation</ows:Identifier>
+      <Domain>0.0/50.0,200.0/300.0,400.0/500.0</Domain>
+      <Size>6</Size>
+    </DimensionDomain>
+    <DimensionDomain>
+      <ows:Identifier>REFERENCE_TIME</ows:Identifier>
+      <Domain>2016-02-23T00:00:00.000Z/2016-02-23T23:00:00.000Z,2016-02-24T00:00:00.000Z/2016-02-24T12:00:00.000Z</Domain>
+      <Size>2</Size>
+    </DimensionDomain>
+    <DimensionDomain>
+      <ows:Identifier>time</ows:Identifier>
+      <Domain>2016-02-23T03:00:00.000Z/2016-02-23T06:00:00.000Z,2016-02-23T06:00:00.000Z/2016-02-23T12:00:00.000Z</Domain>
+      <Size>2</Size>
+    </DimensionDomain>
+  </Domains>
+
+
+
 From the information above we can see that we have three dimensions ``time``, ``elevation`` and ``REFERENCE_TIME`` and the respective domains values.
 
 Now let's see how elevations relate to time dimension by asking which elevations under 500.0 meters are available at time 2016-02-23T03:00:00.000Z:
@@ -257,6 +286,9 @@ is too large for DescribeDomain to return them in a single shot.
    * - FromValue
      - No
      - Sets the beginning of domain enumeration, for paging purposes. It's not included in the result
+   * - FromEnd
+     - No
+     - If equals to true specifies that the beginning of domain enumeration, set by the FromValue, should be applied to the end attribute. When set to true results will be sorted by end attribute.
    * - Sort
      - No
      - Can be "asc" or "desc", determines if the enumeration is from low to high, or from high to low
@@ -360,6 +392,28 @@ between client and server migth then look as follows:
       <Size>0</Size>
     </DomainValues>
 
+
+Assume now that along with the values 1,2,3,5 we have end attribute values respectively equal to 5,3,4,6.
+
+The following request:
+
+.. code-block:: guess
+
+  http://localhost:8080/geoserver/gwc/service/wmts?request=GetDomainValues&Version=1.0.0&Layer=sampleLayer&domain=elevation&limit=2&fromValue=3.5&fromEnd=true
+          
+
+will return
+
+.. code-block:: xml
+
+    <DomainValues xmlns="http://demo.geo-solutions.it/share/wmts-multidim/wmts_multi_dimensional.xsd" xmlns:ows="http://www.opengis.net/ows/1.1">
+      <ows:Identifier>elevation</ows:Identifier>
+      <Limit>2</Limit>
+      <Sort>asc</Sort>
+      <Domain>3.0/4.0,1.0/5.0,5.0/6.0</Domain>
+      <Size>2</Size>
+    </DomainValues>
+
 The paging approach might seem odd for those used to using "limit" and "offset". The main reason it's done
 this way it's performance, paging through unique values via limit and offset means that the data source
 has to compute and collect the unique values that are not needed (the ones in previous pages) in order to
@@ -459,6 +513,9 @@ filtering on elevations between 0 and 15 will return this instead:
     <Domain>0/20/10</Domain>
     <Values>5,3</Values>
   </Histogram>
+
+
+Note that if an end attribute is specified the bucket matching will be applied on ranges rather than on single values. In this case buckets are filled by intersection of ranges' values with bucket limits and not by containment within buckets. This is done in order to avoid that some range values are falling outside every bucket but as a side effects the same range can match more than one bucket. 
 
 GetFeature
 ^^^^^^^^^^

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/DescribeDomainsTransformer.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/DescribeDomainsTransformer.java
@@ -53,7 +53,7 @@ class DescribeDomainsTransformer extends TransformerBase {
                                 "xmlns:ows",
                                 "http://www.opengis.net/ows/1.1",
                                 "version",
-                                "1.1"
+                                "1.2"
                             });
             start("Domains", attributes);
             Map<String, Tuple<Integer, List<String>>> domainsValues = new HashMap<>();

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
@@ -334,10 +334,7 @@ public final class MultiDimensionalExtension extends WMTSExtensionImpl {
                             + dimension.getDimensionType().getSimpleName());
         }
         Tuple<String, String> attributes = DimensionsUtils.getAttributes(resource, dimension);
-        String attribute =
-                useEndValue
-                        ? attributes.second
-                        : attributes.first; // getDomain only uses first attribute to list values
+        String attribute = useEndValue ? attributes.second : attributes.first;
         if (sortOrder == SortOrder.ASCENDING) {
             return filterFactory.greater(
                     filterFactory.property(attribute), filterFactory.literal(converted));

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/MultiDimensionalExtension.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.gwc.wmts;
 
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,6 +57,8 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.TransformException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * WMTS extension that provides the necessary metadata and operations for handling multidimensional
@@ -96,6 +100,8 @@ public final class MultiDimensionalExtension extends WMTSExtensionImpl {
      * several times).
      */
     public static final String SIDECAR_TYPE = "wmtsMultidimSidecarType";
+
+    public static final String SORT_BY_END = "SORT_BY_END";
 
     private final FilterFactory filterFactory = CommonFactoryFinder.getFilterFactory();
     private final GeoServer geoServer;
@@ -269,7 +275,12 @@ public final class MultiDimensionalExtension extends WMTSExtensionImpl {
         // add the filter and the sorting
         SortOrder sortOrder = getSortOrder(conveyor);
         String fromValue = (String) conveyor.getParameter("fromValue", false);
-        Filter fromValueFilter = getStartValueFilter(fromValue, dimension, sortOrder, resource);
+        Boolean useEnd = Converters.convert(conveyor.getParameter("fromEnd", false), Boolean.class);
+        boolean useEndValue = useEnd == null ? false : useEnd.booleanValue();
+        RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
+        if (attrs != null) attrs.setAttribute(SORT_BY_END, useEndValue, SCOPE_REQUEST);
+        Filter fromValueFilter =
+                getStartValueFilter(fromValue, dimension, sortOrder, resource, useEndValue);
         if (!Filter.INCLUDE.equals(fromValueFilter)) {
             filter = filterFactory.and(filter, fromValueFilter);
         }
@@ -303,7 +314,11 @@ public final class MultiDimensionalExtension extends WMTSExtensionImpl {
     }
 
     private Filter getStartValueFilter(
-            String fromValue, Dimension dimension, SortOrder sortOrder, ResourceInfo resource)
+            String fromValue,
+            Dimension dimension,
+            SortOrder sortOrder,
+            ResourceInfo resource,
+            boolean useEndValue)
             throws OWSException {
         if (fromValue == null) {
             return Filter.INCLUDE;
@@ -319,7 +334,10 @@ public final class MultiDimensionalExtension extends WMTSExtensionImpl {
                             + dimension.getDimensionType().getSimpleName());
         }
         Tuple<String, String> attributes = DimensionsUtils.getAttributes(resource, dimension);
-        String attribute = attributes.first; // getDomain only uses first attribute to list values
+        String attribute =
+                useEndValue
+                        ? attributes.second
+                        : attributes.first; // getDomain only uses first attribute to list values
         if (sortOrder == SortOrder.ASCENDING) {
             return filterFactory.greater(
                     filterFactory.property(attribute), filterFactory.literal(converted));

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/ComparableRange.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/ComparableRange.java
@@ -1,0 +1,42 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.wmts.dimensions;
+
+import org.geotools.util.Range;
+
+/**
+ * A Range that implements Comparable to allow the WMTS module to work with ranges since it always
+ * expects to deal with comparators in order to sort the dimension values.
+ *
+ * @param <T>
+ */
+class ComparableRange<T extends Comparable<T>> extends Range<T>
+        implements Comparable<ComparableRange> {
+
+    ComparableRange(Class<T> elementClass, T value) {
+        super(elementClass, value);
+    }
+
+    ComparableRange(Class<T> elementClass, T minValue, T maxValue) {
+        super(elementClass, minValue, maxValue);
+    }
+
+    ComparableRange(
+            Class<T> elementClass,
+            T minValue,
+            boolean isMinIncluded,
+            T maxValue,
+            boolean isMaxIncluded) {
+        super(elementClass, minValue, isMinIncluded, maxValue, isMaxIncluded);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int compareTo(ComparableRange range) {
+        int result = getMinValue().compareTo((T) range.getMinValue());
+        if (result == 0) result = getMaxValue().compareTo((T) range.getMaxValue());
+        return result;
+    }
+}

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/CoverageDimensionsReader.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/CoverageDimensionsReader.java
@@ -83,7 +83,7 @@ abstract class CoverageDimensionsReader {
             return new TreeSet<>();
         }
         // extracting the values keeping the duplicates
-        return DimensionsUtils.getValuesWithoutDuplicates(values.first, values.second);
+        return DimensionsUtils.getValuesWithoutDuplicates(values.first, null, values.second);
     }
 
     /**

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/Dimension.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/Dimension.java
@@ -6,6 +6,7 @@ package org.geoserver.gwc.wmts.dimensions;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -14,6 +15,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.DimensionInfo;
@@ -21,22 +24,25 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.gwc.wmts.Tuple;
-import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.dimension.DimensionDefaultValueSelectionStrategy;
 import org.geotools.data.Query;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.visitor.Aggregate;
+import org.geotools.feature.visitor.CountVisitor;
 import org.geotools.feature.visitor.GroupByVisitor;
 import org.geotools.feature.visitor.GroupByVisitorBuilder;
 import org.geotools.util.Converters;
 import org.geotools.util.Range;
+import org.geotools.util.logging.Logging;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
+import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
 
 /**
@@ -61,6 +67,8 @@ public abstract class Dimension {
 
     protected final ResourceInfo resourceInfo;
 
+    private static final Logger LOGGER = Logging.getLogger(Dimension.class);
+
     public Dimension(
             WMS wms, String dimensionName, LayerInfo layerInfo, DimensionInfo dimensionInfo) {
         this.wms = wms;
@@ -79,19 +87,48 @@ public abstract class Dimension {
     /**
      * Returns the domain summary. If the count is lower than <code>expandLimit</code> then only the
      * count will be returned, otherwise min and max will also be returned
+     *
+     * @param features the featureCollection.
+     * @param attribute the dimension attribute name.
+     * @param expandLimit value determining if count or also min and max should be returned.
+     * @return the DomainSummary of the Resource.
      */
     protected DomainSummary getDomainSummary(
             FeatureCollection features, String attribute, int expandLimit) {
+        return getDomainSummary(features, attribute, null, expandLimit);
+    }
+
+    /**
+     * Returns the domain summary. If the count is lower than <code>expandLimit</code> then only the
+     * count will be returned, otherwise min and max will also be returned
+     *
+     * @param features the featureCollection.
+     * @param attribute the dimension attribute name.
+     * @param endAttributeName the dimension end attribute name. Can be null.
+     * @param expandLimit value determining if count or also min and max should be returned.
+     * @return the DomainSummary of the Resource.
+     */
+    protected DomainSummary getDomainSummary(
+            FeatureCollection features,
+            String attribute,
+            String endAttributeName,
+            int expandLimit) {
         // grab domain, but at most expandLimit + 1, to know if there are too many
         if (expandLimit != 0) {
             Set<Comparable> uniqueValues =
-                    DimensionsUtils.getUniqueValues(features, attribute, expandLimit + 1);
+                    DimensionsUtils.getUniqueValues(
+                            features, attribute, endAttributeName, expandLimit + 1);
             if (uniqueValues.size() <= expandLimit || expandLimit < 0) {
                 return new DomainSummary(new TreeSet<>(uniqueValues));
             }
         }
-        Map<Aggregate, Comparable> minMax =
-                DimensionsUtils.getAggregates(attribute, features, Aggregate.MIN, Aggregate.MAX);
+        Map<Aggregate, Comparable> minMax;
+        if (endAttributeName != null)
+            minMax = DimensionsUtils.getMinMaxAggregate(attribute, endAttributeName, features);
+        else
+            minMax =
+                    DimensionsUtils.getAggregates(
+                            attribute, features, Aggregate.MIN, Aggregate.MAX);
         // we return only the number of non null mix/max elements, as computing the whole count
         // might take just too much time on large datasets
         return new DomainSummary(
@@ -101,13 +138,39 @@ public abstract class Dimension {
     }
 
     /**
-     * Returns the domain summary. If the count is lower than <code>expandLimit</code> then only the
+     * Returns the domain summary. If the count is lower than <code>maxValues</code> then only the
      * count will be returned, otherwise min and max will also be returned
+     *
+     * @param features the featureCollection.
+     * @param attribute the dimension attribute name.
+     * @param maxValues the limit of values to return.
+     * @return the domain summary of the resource.
      */
     protected DomainSummary getPagedDomainValues(
             FeatureCollection features, String attribute, int maxValues) {
+        return getPagedDomainValues(features, attribute, null, maxValues, null);
+    }
+
+    /**
+     * Returns the domain summary. If the count is lower than <code>maxValues</code> then only the
+     * count will be returned, otherwise min and max will also be returned
+     *
+     * @param features the featureCollection.
+     * @param attribute the dimension attribute name.
+     * @param endAttribute the dimension end attribute name.
+     * @param maxValues the limit of values to return.
+     * @param sortBy the sortBy query. Used to properly sort ranges.
+     * @return the domain summary of the resource.
+     */
+    protected DomainSummary getPagedDomainValues(
+            FeatureCollection features,
+            String attribute,
+            String endAttribute,
+            int maxValues,
+            SortBy sortBy) {
         Set<Comparable> uniqueValues =
-                DimensionsUtils.getUniqueValues(features, attribute, maxValues);
+                DimensionsUtils.getUniqueValues(
+                        features, attribute, endAttribute, maxValues, sortBy);
         return new DomainSummary(uniqueValues);
     }
 
@@ -130,15 +193,20 @@ public abstract class Dimension {
      */
     public Tuple<String, List<Integer>> getHistogram(Filter filter, String resolutionSpec) {
         if (loadDataInMemory()) {
-            return HistogramUtils.buildHistogram(getDomainValues(filter, false), resolutionSpec);
+            boolean isRange = dimensionInfo.getEndAttribute() != null;
+            return HistogramUtils.buildHistogram(
+                    getDomainValues(filter, false), resolutionSpec, isRange);
         }
 
         FilterFactory2 ff = DimensionsUtils.FF;
         String dimensionAttributeName = getDimensionAttributeName();
         PropertyName dimensionProperty = ff.property(dimensionAttributeName);
         Query query = new Query(null, filter);
+
         if (Number.class.isAssignableFrom(getDimensionType())) {
+
             DomainSummary summary = getDomainSummary(query, 0);
+
             // empty domain case?
             if (summary.getMin() == null || summary.getMax() == null) {
                 return EMPTY_HISTOGRAM;
@@ -148,6 +216,14 @@ public abstract class Dimension {
 
             Tuple<String, List<Range>> specAndBuckets =
                     HistogramUtils.getNumericBuckets(min, max, resolutionSpec);
+
+            if (hasEndAttribute())
+                return getRangeHistogram(
+                        specAndBuckets,
+                        dimensionAttributeName,
+                        dimensionInfo.getEndAttribute(),
+                        query);
+
             List<Range> buckets = specAndBuckets.second;
             @SuppressWarnings("unchecked")
             Range<Double> referenceBucket = buckets.get(0);
@@ -172,16 +248,24 @@ public abstract class Dimension {
             }
             return Tuple.tuple(specAndBuckets.first, counts);
         } else if (Date.class.isAssignableFrom(getDimensionType())) {
+
             DomainSummary summary = getDomainSummary(query, 0);
-            Date min = (Date) summary.getMin();
-            Date max = (Date) summary.getMax();
-            // empty domain case?
-            if (min == null || max == null) {
+            if (summary.getMin() == null || summary.getMax() == null) {
                 return EMPTY_HISTOGRAM;
             }
+            Date min = (Date) summary.getMin();
+            Date max = (Date) summary.getMax();
 
             Tuple<String, List<Range>> specAndBuckets =
                     HistogramUtils.getTimeBuckets(min, max, resolutionSpec);
+
+            if (hasEndAttribute())
+                return getRangeHistogram(
+                        specAndBuckets,
+                        dimensionAttributeName,
+                        dimensionInfo.getEndAttribute(),
+                        query);
+
             List<Range> buckets = specAndBuckets.second;
             @SuppressWarnings("unchecked")
             Range<Date> referenceBucket = buckets.get(0);
@@ -230,6 +314,55 @@ public abstract class Dimension {
         }
     }
 
+    private Tuple<String, List<Integer>> getRangeHistogram(
+            Tuple<String, List<Range>> specAndBuckets,
+            String attributeName,
+            String endAttributeName,
+            Query query) {
+        List<Range> buckets = specAndBuckets.second;
+        List<Integer> counts = new ArrayList<>(buckets.size());
+        CountVisitor visitor = new CountVisitor();
+        Filter original = query.getFilter();
+        FilterFactory2 ff = DimensionsUtils.FF;
+        PropertyName startPn = ff.property(attributeName);
+        PropertyName endPn = ff.property(endAttributeName);
+        for (Range r : buckets) {
+            Filter rangeFilter = getRangeIntersectionFilter(original, r, startPn, endPn);
+            Query q = new Query();
+            q.setFilter(rangeFilter);
+            q.setProperties(Arrays.asList(startPn, endPn));
+            FeatureCollection domain = getDomain(q);
+            try {
+                domain.accepts(visitor, null);
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Error while counting ranges in bucket.", e);
+                throw new RuntimeException(e);
+            }
+            counts.add(visitor.getResult().toInt());
+            visitor.reset();
+        }
+        return Tuple.tuple(specAndBuckets.first, counts);
+    }
+
+    private Filter getRangeIntersectionFilter(
+            Filter original, Range bucket, PropertyName startPn, PropertyName endPn) {
+        Comparable min = bucket.getMinValue();
+        Comparable max = bucket.getMaxValue();
+        FilterFactory2 ff = DimensionsUtils.FF;
+        Literal maxLiteral = ff.literal(max);
+        Literal minLiteral = ff.literal(min);
+        Filter low =
+                bucket.isMaxIncluded()
+                        ? ff.lessOrEqual(startPn, maxLiteral)
+                        : ff.less(startPn, maxLiteral);
+        Filter upper =
+                bucket.isMinIncluded()
+                        ? ff.greaterOrEqual(endPn, minLiteral)
+                        : ff.greater(endPn, minLiteral);
+        Filter and = ff.and(low, upper);
+        return ff.and(and, original);
+    }
+
     /**
      * Should we load data in memory to compute histograms (fast for small datasets not having
      * indexes) or do we try to use visitor and perform one or more data scans instead? Small easter
@@ -239,8 +372,7 @@ public abstract class Dimension {
      * (completely missing right now, that would be a significant API change).
      */
     private boolean loadDataInMemory() {
-        String value = GeoServerExtensions.getProperty("WMTS_HISTOGRAM_IN_MEMORY");
-        return Boolean.getBoolean(value);
+        return Boolean.getBoolean("WMTS_HISTOGRAM_IN_MEMORY");
     }
 
     public TreeMap<Object, Object> groupByDomainOnExpression(
@@ -278,6 +410,10 @@ public abstract class Dimension {
                     sortedResults.put(classifierValue, v);
                 });
         return sortedResults;
+    }
+
+    protected boolean hasEndAttribute() {
+        return dimensionInfo.getEndAttribute() != null;
     }
 
     /** Returns the attribute name representing the dimension */

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/DimensionsUtils.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/DimensionsUtils.java
@@ -10,13 +10,16 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -37,6 +40,7 @@ import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.visitor.Aggregate;
+import org.geotools.feature.visitor.CalcResult;
 import org.geotools.feature.visitor.FeatureCalc;
 import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -46,6 +50,7 @@ import org.geotools.renderer.crs.ProjectionHandlerFinder;
 import org.geotools.util.Converters;
 import org.geotools.util.Range;
 import org.geotools.util.factory.GeoTools;
+import org.geotools.util.logging.Logging;
 import org.geowebcache.service.OWSException;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.type.FeatureType;
@@ -54,6 +59,8 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.TransformException;
@@ -66,6 +73,8 @@ public final class DimensionsUtils {
 
     /** No expansion limit provided */
     public static final int NO_LIMIT = Integer.MIN_VALUE;
+
+    public static final Logger LOGGER = Logging.getLogger(DimensionsUtils.class);
 
     /** Helper method that will extract a layer dimensions. */
     public static List<Dimension> extractDimensions(
@@ -192,7 +201,7 @@ public final class DimensionsUtils {
             // this domain value is a range, we use the min and max value
             Object minValue = ((Range) value).getMinValue();
             Object maxValue = ((Range) value).getMaxValue();
-            return formatDomainSimpleValue(minValue) + "--" + formatDomainSimpleValue(maxValue);
+            return formatDomainSimpleValue(minValue) + "/" + formatDomainSimpleValue(maxValue);
         }
         return formatDomainSimpleValue(value);
     }
@@ -227,9 +236,15 @@ public final class DimensionsUtils {
      * the maximum value of the range is returned.
      */
     private static Object getMaxValue(List<Comparable> values) {
-        Object maxValue = values.get(values.size() - 1);
+        int last = values.size() - 1;
+        Object maxValue = values.get(last);
         if (maxValue instanceof Range) {
-            return ((Range) maxValue).getMaxValue();
+            values =
+                    values.stream()
+                            .map(c -> ((Range) c).getMaxValue())
+                            .sorted()
+                            .collect(Collectors.toList());
+            maxValue = values.get(last);
         }
         return maxValue;
     }
@@ -246,30 +261,164 @@ public final class DimensionsUtils {
      * attribute removing duplicate values.
      */
     static Set<Comparable> getValuesWithoutDuplicates(
-            String attributeName, FeatureCollection featureCollection) {
-        Set<Comparable> uniques = getUniqueValues(featureCollection, attributeName, NO_LIMIT);
+            String attributeName, String endAttribute, FeatureCollection featureCollection) {
+        Set<Comparable> uniques =
+                getUniqueValues(featureCollection, attributeName, endAttribute, NO_LIMIT);
 
         // dimension values are dates/numbers/strings, all comparable, native sorting is fine
         Set<Comparable> values = new TreeSet<>(uniques);
         return values;
     }
 
+    static Set<Comparable> getUniqueValues(
+            FeatureCollection featureCollection,
+            String attributeName,
+            String endAttributeName,
+            int limit) {
+        return getUniqueValues(featureCollection, attributeName, endAttributeName, limit, null);
+    }
+
     @SuppressWarnings("unchecked")
     static Set<Comparable> getUniqueValues(
-            FeatureCollection featureCollection, String attributeName, int limit) {
+            FeatureCollection featureCollection,
+            String attributeName,
+            String endAttributeName,
+            int limit,
+            SortBy sortBy) {
         // using the unique visitor to remove duplicate values
-        UniqueVisitor uniqueVisitor = new UniqueVisitor(attributeName);
+        UniqueVisitor uniqueVisitor =
+                endAttributeName != null
+                        ? new UniqueVisitor(attributeName, endAttributeName)
+                        : new UniqueVisitor(attributeName);
+        uniqueVisitor.setPreserveOrder(true);
         if (limit > 0 && limit < Integer.MAX_VALUE) {
             uniqueVisitor.setMaxFeatures(limit);
         }
-        uniqueVisitor.setPreserveOrder(true);
         try {
             featureCollection.accepts(uniqueVisitor, null);
         } catch (Exception exception) {
             throw new RuntimeException("Error visiting collection with unique visitor.");
         }
+        if (uniqueVisitor.getAttrNames().size() > 1)
+            return resultToComparableSet(uniqueVisitor.getResult(), endAttributeName, sortBy);
         // all dimension values are comparable
         return uniqueVisitor.getUnique();
+    }
+
+    private static Set<Comparable> resultToComparableSet(
+            CalcResult result, String endAttributeName, SortBy sortBy) {
+        if (result == CalcResult.NULL_RESULT) return new HashSet<>();
+        @SuppressWarnings("unchecked")
+        Set<Object> values = result.toSet();
+        if (values.isEmpty()) return Collections.emptySet();
+        else return toComparableSet(values, endAttributeName, sortBy);
+    }
+
+    private static Set<Comparable> toComparableSet(
+            Set<Object> set, String endAttribute, SortBy sortBy) {
+        Set<Comparable> resultSet = getTreeSet(sortBy, endAttribute);
+        Iterator<Object> objects = set.iterator();
+
+        while (objects.hasNext()) {
+            Object val = objects.next();
+            @SuppressWarnings("unchecked")
+            List<Object> values = (List<Object>) val;
+            Object start = values.get(0);
+            Object end = values.get(1);
+            Comparable range = (Comparable) toRange(start, end);
+            if (range != null) resultSet.add(range);
+        }
+        return resultSet;
+    }
+
+    private static TreeSet<Comparable> getTreeSet(SortBy sortBy, String endAttribute) {
+        TreeSet<Comparable> resultSet = new TreeSet<>();
+        if (sortBy != null) {
+            if (isSortByEnd(endAttribute, sortBy)) {
+                Comparator<Comparable> comparator = comparatorSortByEnd();
+                if (sortBy.getSortOrder().equals(SortOrder.DESCENDING))
+                    comparator = comparatorSortByEnd().reversed();
+                resultSet = new TreeSet<>(comparator);
+            } else if (sortBy.getSortOrder().equals(SortOrder.DESCENDING)) {
+                resultSet = new TreeSet<>(comparatorSortByStart().reversed());
+            }
+        }
+        return resultSet;
+    }
+
+    private static boolean isSortByEnd(String endAttribute, SortBy sortBy) {
+        if (endAttribute == null) return false;
+        return sortBy.getPropertyName().getPropertyName().equals(endAttribute);
+    }
+
+    private static Comparator<Comparable> comparatorSortByEnd() {
+        return new Comparator<Comparable>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public int compare(Comparable o1, Comparable o2) {
+                if (o1 instanceof ComparableRange && o2 instanceof ComparableRange) {
+                    ComparableRange comp1 = (ComparableRange) o1;
+                    ComparableRange comp2 = (ComparableRange) o2;
+                    int result = comp1.getMaxValue().compareTo(comp2.getMaxValue());
+                    if (result == 0) result = comp1.getMinValue().compareTo(comp2.getMinValue());
+                    return result;
+                }
+                return o1.compareTo(o2);
+            }
+        };
+    }
+
+    private static Comparator<Comparable> comparatorSortByStart() {
+        return new Comparator<Comparable>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public int compare(Comparable o1, Comparable o2) {
+                if (o1 instanceof ComparableRange && o2 instanceof ComparableRange) {
+                    ComparableRange comp1 = (ComparableRange) o1;
+                    ComparableRange comp2 = (ComparableRange) o2;
+                    int result = comp1.getMinValue().compareTo(comp2.getMinValue());
+                    if (result == 0) result = comp1.getMaxValue().compareTo(comp2.getMaxValue());
+                    return result;
+                }
+                return o1.compareTo(o2);
+            }
+        };
+    }
+
+    private static Range<?> toRange(Object start, Object end) {
+        if (start == null && end == null) return null;
+
+        // if one of the two values is null
+        // we set the other right?
+        if (start == null) start = end;
+        else if (end == null) end = start;
+        @SuppressWarnings("unchecked")
+        Range<?> resultRange =
+                new ComparableRange(Comparable.class, (Comparable) start, (Comparable) end);
+        return resultRange;
+    }
+
+    static Map<Aggregate, Comparable> getMinMaxAggregate(
+            String attributeName, String endAttribute, FeatureCollection featureCollection) {
+        Map<Aggregate, Comparable> result = new HashMap<>();
+        PropertyName start = FF.property(attributeName);
+        PropertyName end = FF.property(endAttribute);
+        Aggregate min = Aggregate.MIN;
+        Aggregate max = Aggregate.MAX;
+        FeatureCalc minCalc = min.create(start);
+        FeatureCalc maxCalc = max.create(end);
+        try {
+            featureCollection.accepts(minCalc, null);
+            Comparable minVal = (Comparable) minCalc.getResult().getValue();
+            featureCollection.accepts(maxCalc, null);
+            Comparable maxVal = (Comparable) maxCalc.getResult().getValue();
+            result.put(min, minVal);
+            result.put(max, maxVal);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Failed to collect summary aggregates on attribute " + attributeName, e);
+        }
+        return result;
     }
 
     /**
@@ -301,13 +450,29 @@ public final class DimensionsUtils {
     @SuppressWarnings("unchecked")
     static List<Comparable> getValuesWithDuplicates(
             String attributeName, FeatureCollection featureCollection) {
+        return getValuesWithDuplicates(attributeName, null, featureCollection);
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<Comparable> getValuesWithDuplicates(
+            String attributeName, String endAttributeName, FeatureCollection featureCollection) {
         // full data values are returned including duplicate values
         List<Comparable> values = new ArrayList<>();
         try (FeatureIterator featuresIterator = featureCollection.features()) {
             while (featuresIterator.hasNext()) {
                 // extracting the feature attribute that contain our dimension value
                 SimpleFeature feature = (SimpleFeature) featuresIterator.next();
-                values.add((Comparable) feature.getAttribute(attributeName));
+                Object attr = feature.getAttribute(attributeName);
+                if (endAttributeName != null) {
+                    Comparable comparableRange =
+                            new ComparableRange(
+                                    attr.getClass(),
+                                    (Comparable) attr,
+                                    (Comparable) feature.getAttribute(endAttributeName));
+                    values.add(comparableRange);
+                } else {
+                    values.add((Comparable) attr);
+                }
             }
             Collections.sort(values, new ComparableComparator());
             return values;

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/HistogramUtils.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/HistogramUtils.java
@@ -320,23 +320,23 @@ final class HistogramUtils {
             Range r = buckets.get(i);
             Comparable min = value.getMinValue();
             Comparable max = value.getMaxValue();
-            if (isMinIncluded(r, min) && isMaxIncluded(r, max)) indexes.add(i);
+            if (intersectsMin(r, min) && intersectsMax(r, max)) indexes.add(i);
         }
         return indexes;
     }
 
-    private static boolean isMinIncluded(Range<?> range, Comparable min) {
+    private static boolean intersectsMin(Range<?> range, Comparable min) {
         Comparable maxBoundary = range.getMaxValue();
         @SuppressWarnings("unchecked")
-        int minInMax = min.compareTo(maxBoundary);
-        return range.isMaxIncluded() ? minInMax <= 0 : minInMax < 0;
+        int intersectsMin = min.compareTo(maxBoundary);
+        return range.isMaxIncluded() ? intersectsMin <= 0 : intersectsMin < 0;
     }
 
-    private static boolean isMaxIncluded(Range<?> range, Comparable max) {
+    private static boolean intersectsMax(Range<?> range, Comparable max) {
         Comparable minBoundary = range.getMinValue();
         @SuppressWarnings("unchecked")
-        int maxInMin = max.compareTo(minBoundary);
-        return range.isMinIncluded() ? maxInMin >= 0 : maxInMin > 0;
+        int intersectsMax = max.compareTo(minBoundary);
+        return range.isMinIncluded() ? intersectsMax >= 0 : intersectsMax > 0;
     }
 
     /**

--- a/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/HistogramUtils.java
+++ b/src/extension/wmts-multi-dimensional/src/main/java/org/geoserver/gwc/wmts/dimensions/HistogramUtils.java
@@ -66,18 +66,21 @@ final class HistogramUtils {
      * type.
      */
     static Tuple<String, List<Integer>> buildHistogram(
-            List<Comparable> domainValues, String resolution) {
+            List<Comparable> domainValues, String resolution, boolean isRange) {
         if (domainValues.isEmpty()) {
             // FIXME: How to represent a domain with no values ?
             return Tuple.tuple("", Collections.emptyList());
         }
         Tuple<String, List<Range>> buckets = computeBuckets(domainValues, resolution);
+
+        if (isRange) return buildRangeHistogram(domainValues, buckets);
+
         ArrayList<Integer> histogramValues = new ArrayList<>(buckets.second.size());
         for (int i = 0; i < buckets.second.size(); i++) {
             histogramValues.add(0);
         }
-        for (Object value : domainValues) {
-            int index = getBucketIndex(buckets.second, (Comparable) value);
+        for (Comparable value : domainValues) {
+            int index = getBucketIndex(buckets.second, value);
             if (index >= 0) {
                 histogramValues.set(index, histogramValues.get(index) + 1);
             } else if (LOGGER.isLoggable(Level.FINE)) {
@@ -86,6 +89,31 @@ final class HistogramUtils {
         }
 
         return Tuple.tuple(buckets.first, histogramValues);
+    }
+
+    static Tuple<String, List<Integer>> buildRangeHistogram(
+            List<Comparable> domainValues, Tuple<String, List<Range>> bucketsTuple) {
+        List<Range> buckets = bucketsTuple.second;
+        int bucketsSize = buckets.size();
+        ArrayList<Integer> histogramValues = new ArrayList<>(bucketsSize);
+        for (int i = 0; i < bucketsSize; i++) {
+            histogramValues.add(0);
+        }
+        for (Comparable value : domainValues) {
+            Range range = (Range) value;
+            List<Integer> indexes = getBucketIntervalIndex(buckets, range);
+            if (!indexes.isEmpty()) {
+                indexes.forEach(i -> histogramValues.set(i, histogramValues.get(i) + 1));
+            } else if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(
+                        Level.FINE,
+                        "No values found for interval: "
+                                + range.getMinValue()
+                                + "-"
+                                + range.getMaxValue());
+            }
+        }
+        return Tuple.tuple(bucketsTuple.first, histogramValues);
     }
 
     /** Compute the buckets for the given domain values and resolution. */
@@ -284,6 +312,31 @@ final class HistogramUtils {
             }
         }
         return -1;
+    }
+
+    private static List<Integer> getBucketIntervalIndex(List<Range> buckets, Range value) {
+        List<Integer> indexes = new ArrayList<>(buckets.size());
+        for (int i = 0; i < buckets.size(); i++) {
+            Range r = buckets.get(i);
+            Comparable min = value.getMinValue();
+            Comparable max = value.getMaxValue();
+            if (isMinIncluded(r, min) && isMaxIncluded(r, max)) indexes.add(i);
+        }
+        return indexes;
+    }
+
+    private static boolean isMinIncluded(Range<?> range, Comparable min) {
+        Comparable maxBoundary = range.getMaxValue();
+        @SuppressWarnings("unchecked")
+        int minInMax = min.compareTo(maxBoundary);
+        return range.isMaxIncluded() ? minInMax <= 0 : minInMax < 0;
+    }
+
+    private static boolean isMaxIncluded(Range<?> range, Comparable max) {
+        Comparable minBoundary = range.getMinValue();
+        @SuppressWarnings("unchecked")
+        int maxInMin = max.compareTo(minBoundary);
+        return range.isMinIncluded() ? maxInMin >= 0 : maxInMin > 0;
     }
 
     /**

--- a/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
+++ b/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
@@ -653,7 +653,7 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
 
     public void checkVectorElevationFullDomain(Document result) throws Exception {
         // check the space domain, should be regular whole world
-        assertXpathEvaluatesTo("1.1", "/md:Domains/@version", result);
+        assertXpathEvaluatesTo("1.2", "/md:Domains/@version", result);
         checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@CRS='EPSG:4326']", "1");
         checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@minx='-180.0']", "1");
         checkXpathCount(result, "/md:Domains/md:SpaceDomain/md:BoundingBox[@miny='-90.0']", "1");
@@ -1445,7 +1445,7 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
             assertXpathEvaluatesTo("time", "/md:DomainValues/ows:Identifier", dom);
             // sorted by end date too
             assertXpathEvaluatesTo(
-                    "2012-02-12T00:00:00.000Z/2012-02-12T09:00:00.000Z,2012-02-11T00:00:00.000Z/2012-02-13T00:00:00.000Z",
+                    "2012-02-12T00:00:00.000Z/2012-02-12T10:00:00.000Z,2012-02-11T00:00:00.000Z/2012-02-13T00:00:00.000Z",
                     "/md:DomainValues/md:Domain",
                     dom);
         } finally {

--- a/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
+++ b/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/MultiDimensionalExtensionTest.java
@@ -1076,11 +1076,22 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         return defaultValueSetting;
     }
 
+    private void registerLayerDimension(
+            ResourceInfo info,
+            String dimensionName,
+            String attributeName,
+            DimensionPresentation presentation,
+            DimensionDefaultValueSetting defaultValue) {
+        registerLayerDimension(
+                info, dimensionName, attributeName, null, presentation, defaultValue);
+    }
+
     /** Helper method that will register a dimension for some layer. */
     private void registerLayerDimension(
             ResourceInfo info,
             String dimensionName,
             String attributeName,
+            String endAttribute,
             DimensionPresentation presentation,
             DimensionDefaultValueSetting defaultValue) {
         DimensionInfo dimension = new DimensionInfoImpl();
@@ -1088,6 +1099,7 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         dimension.setPresentation(presentation);
         dimension.setDefaultValue(defaultValue);
         dimension.setAttribute(attributeName);
+        if (endAttribute != null) dimension.setEndAttribute(endAttribute);
         info.getMetadata().put(dimensionName, dimension);
         getCatalog().save(info);
     }
@@ -1407,5 +1419,77 @@ public class MultiDimensionalExtensionTest extends TestsSupport {
         // the call below  was used to throw an exception when dealing with different
         // TileLayer implementations
         extension.encodeLayer(xml, tileLayer);
+    }
+
+    @Test
+    public void testVectorGetDomainValuesTimeByEndAttribute() throws Exception {
+        FeatureTypeInfo vectorInfo =
+                getCatalog().getFeatureTypeByName(VECTOR_ELEVATION_TIME.getLocalPart());
+        try {
+            registerLayerDimension(
+                    vectorInfo,
+                    ResourceInfo.TIME,
+                    "startTime",
+                    "endTime",
+                    DimensionPresentation.LIST,
+                    minimumValue());
+
+            String baseRequest =
+                    "gwc/service/wmts?request=GetDomainValues&Version=1.0.0&Layer="
+                            + getLayerId(VECTOR_ELEVATION_TIME)
+                            + "&TileMatrixSet=EPSG:4326&domain=time";
+
+            Document dom =
+                    getAsDOM(baseRequest + "&fromValue=2012-02-12T09:00:00.000Z&fromEnd=true");
+
+            assertXpathEvaluatesTo("time", "/md:DomainValues/ows:Identifier", dom);
+            // sorted by end date too
+            assertXpathEvaluatesTo(
+                    "2012-02-12T00:00:00.000Z/2012-02-12T09:00:00.000Z,2012-02-11T00:00:00.000Z/2012-02-13T00:00:00.000Z",
+                    "/md:DomainValues/md:Domain",
+                    dom);
+        } finally {
+            registerLayerDimension(
+                    vectorInfo,
+                    ResourceInfo.TIME,
+                    "startTime",
+                    null,
+                    DimensionPresentation.LIST,
+                    minimumValue());
+        }
+    }
+
+    @Test
+    public void testVectorGetDomainValuesOnElevationsByEndAttribute() throws Exception {
+        FeatureTypeInfo vectorInfo =
+                getCatalog().getFeatureTypeByName(VECTOR_ELEVATION_TIME.getLocalPart());
+        try {
+            registerLayerDimension(
+                    vectorInfo,
+                    ResourceInfo.ELEVATION,
+                    "startElevation",
+                    "endElevation",
+                    DimensionPresentation.LIST,
+                    minimumValue());
+            // full domain (only 2 entries)
+            String baseRequest =
+                    "gwc/service/wmts?request=GetDomainValues&Version=1.0.0&Layer="
+                            + getLayerId(VECTOR_ELEVATION_TIME)
+                            + "&TileMatrixSet=EPSG:4326&domain=elevation";
+            Document dom = getAsDOM(baseRequest + "&fromValue=3.5&fromEnd=true&limit=3");
+            assertXpathEvaluatesTo("elevation", "/md:DomainValues/ows:Identifier", dom);
+            assertXpathEvaluatesTo("3", "/md:DomainValues/md:Limit", dom);
+            assertXpathEvaluatesTo("asc", "/md:DomainValues/md:Sort", dom);
+            assertXpathEvaluatesTo("2", "/md:DomainValues/md:Size", dom);
+            assertXpathEvaluatesTo("3.0/4.0,5.0/7.0", "/md:DomainValues/md:Domain", dom);
+        } finally {
+            registerLayerDimension(
+                    vectorInfo,
+                    ResourceInfo.ELEVATION,
+                    "startElevation",
+                    null,
+                    DimensionPresentation.LIST,
+                    minimumValue());
+        }
     }
 }

--- a/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/TestsSupport.java
+++ b/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/TestsSupport.java
@@ -123,14 +123,26 @@ public abstract class TestsSupport extends WMSTestSupport {
 
     protected abstract Dimension buildDimension(DimensionInfo dimensionInfo);
 
+    protected Dimension buildDimensionWithEndAttribute(DimensionInfo dimensionInfo) {
+        return buildDimension(dimensionInfo);
+    }
+
     protected void testDomainsValuesRepresentation(
-            int expandLimit, String... expectedDomainValues) {
+            int expandLimit, boolean useEndAttribute, String... expectedDomainValues) {
         DimensionInfo dimensionInfo = createDimension(true, null);
-        Dimension dimension = buildDimension(dimensionInfo);
+        Dimension dimension =
+                useEndAttribute
+                        ? buildDimensionWithEndAttribute(dimensionInfo)
+                        : buildDimension(dimensionInfo);
         List<String> valuesAsStrings =
                 dimension.getDomainValuesAsStrings(Query.ALL, expandLimit).second;
         assertThat(valuesAsStrings.size(), is(expectedDomainValues.length));
         assertThat(valuesAsStrings, containsInAnyOrder(expectedDomainValues));
+    }
+
+    protected void testDomainsValuesRepresentation(
+            int expandLimit, String... expectedDomainValues) {
+        testDomainsValuesRepresentation(expandLimit, false, expectedDomainValues);
     }
 
     protected void testDefaultValueStrategy(

--- a/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorElevationDimensionTest.java
+++ b/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorElevationDimensionTest.java
@@ -63,6 +63,19 @@ public class VectorElevationDimensionTest extends TestsSupport {
         testDomainsValuesRepresentation(7, "1.0", "2.0", "3.0", "5.0");
     }
 
+    @Test
+    public void testGetDomainsValuesRange() throws Exception {
+        testDomainsValuesRepresentation(2, true, "1.0--7.0");
+        testDomainsValuesRepresentation(4, true, "1.0/2.0", "2.0/3.0", "3.0/4.0", "5.0/7.0");
+        testDomainsValuesRepresentation(7, true, "1.0/2.0", "2.0/3.0", "3.0/4.0", "5.0/7.0");
+    }
+
+    @Override
+    protected Dimension buildDimensionWithEndAttribute(DimensionInfo dimensionInfo) {
+        dimensionInfo.setEndAttribute("endElevation");
+        return buildDimension(dimensionInfo);
+    }
+
     @Override
     protected Dimension buildDimension(DimensionInfo dimensionInfo) {
         dimensionInfo.setAttribute("startElevation");
@@ -89,6 +102,24 @@ public class VectorElevationDimensionTest extends TestsSupport {
         Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "0.75");
         assertThat(histogram.first, is("1.0/5.0/0.75"));
         assertThat(histogram.second, equalTo(Arrays.asList(1, 1, 1, 0, 0, 1)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValues() {
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "1");
+        assertThat(histogram.first, is("1.0/8.0/1.0"));
+        assertThat(histogram.second, equalTo(Arrays.asList(1, 2, 2, 1, 1, 1, 1)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValues2() {
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "3");
+        assertThat(histogram.first, is("1.0/10.0/3.0"));
+        assertThat(histogram.second, equalTo(Arrays.asList(3, 2, 1)));
     }
 
     /** Helper method that just returns the current layer info. */

--- a/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorTimeDimensionTest.java
+++ b/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorTimeDimensionTest.java
@@ -19,6 +19,7 @@ import org.geoserver.catalog.impl.DimensionInfoImpl;
 import org.geoserver.gwc.wmts.dimensions.Dimension;
 import org.geoserver.gwc.wmts.dimensions.DimensionsUtils;
 import org.geoserver.gwc.wmts.dimensions.VectorTimeDimension;
+import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.Filter;
 
@@ -27,6 +28,11 @@ import org.opengis.filter.Filter;
  * vector data.
  */
 public class VectorTimeDimensionTest extends VectorTimeTestSupport {
+
+    @Before
+    public void before() {
+        System.setProperty("WMTS_HISTOGRAM_IN_MEMORY", "false");
+    }
 
     @Test
     public void testDisabledDimension() throws Exception {
@@ -57,18 +63,40 @@ public class VectorTimeDimensionTest extends VectorTimeTestSupport {
     @Test
     public void testGetDomainsValues() throws Exception {
         testDomainsValuesRepresentation(
-                DimensionsUtils.NO_LIMIT, "2012-02-11T00:00:00.000Z", "2012-02-12T00:00:00.000Z");
+                DimensionsUtils.NO_LIMIT,
+                false,
+                "2012-02-11T00:00:00.000Z",
+                "2012-02-12T00:00:00.000Z");
         testDomainsValuesRepresentation(0, "2012-02-11T00:00:00.000Z--2012-02-12T00:00:00.000Z");
+    }
+
+    @Test
+    public void testGetDomainsValuesRange() throws Exception {
+        testDomainsValuesRepresentation(
+                3,
+                true,
+                "2012-02-11T00:00:00.000Z/2012-02-11T11:00:00.000Z",
+                "2012-02-11T00:00:00.000Z/2012-02-13T00:00:00.000Z",
+                "2012-02-12T00:00:00.000Z/2012-02-12T09:00:00.000Z");
+
+        testDomainsValuesRepresentation(
+                0, true, "2012-02-11T00:00:00.000Z--2012-02-13T00:00:00.000Z");
     }
 
     @Override
     protected Dimension buildDimension(DimensionInfo dimensionInfo) {
         dimensionInfo.setAttribute("startTime");
-        FeatureTypeInfo rasterInfo = getVectorInfo();
+        FeatureTypeInfo vectorInfo = getVectorInfo();
         Dimension dimension = new VectorTimeDimension(wms, getLayerInfo(), dimensionInfo);
-        rasterInfo.getMetadata().put(ResourceInfo.TIME, dimensionInfo);
-        getCatalog().save(rasterInfo);
+        vectorInfo.getMetadata().put(ResourceInfo.TIME, dimensionInfo);
+        getCatalog().save(vectorInfo);
         return dimension;
+    }
+
+    @Override
+    protected Dimension buildDimensionWithEndAttribute(DimensionInfo dimensionInfo) {
+        dimensionInfo.setEndAttribute("endTime");
+        return buildDimension(dimensionInfo);
     }
 
     @Test
@@ -78,5 +106,62 @@ public class VectorTimeDimensionTest extends VectorTimeTestSupport {
         Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "P1D");
         assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-13T00:00:00.000Z/P1D"));
         assertThat(histogram.second, equalTo(Arrays.asList(3, 1)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValues() {
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "P1D");
+        assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-14T00:00:00.000Z/P1D"));
+        assertThat(histogram.second, equalTo(Arrays.asList(3, 3, 2)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValues2() {
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "P2D");
+        assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-15T00:00:00.000Z/P2D"));
+        assertThat(histogram.second, equalTo(Arrays.asList(4, 2)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValues3() {
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "PT12H");
+        assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-13T12:00:00.000Z/PT12H"));
+        assertThat(histogram.second, equalTo(Arrays.asList(3, 2, 3, 2, 2)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValuesInMemory() {
+        System.setProperty("WMTS_HISTOGRAM_IN_MEMORY", "true");
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "P1D");
+        assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-14T00:00:00.000Z/P1D"));
+        assertThat(histogram.second, equalTo(Arrays.asList(3, 3, 2)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValuesInMemory2() {
+        System.setProperty("WMTS_HISTOGRAM_IN_MEMORY", "true");
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "P2D");
+        assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-15T00:00:00.000Z/P2D"));
+        assertThat(histogram.second, equalTo(Arrays.asList(4, 2)));
+    }
+
+    @Test
+    public void testGetHistogramWithRangeValuesInMemory3() {
+        System.setProperty("WMTS_HISTOGRAM_IN_MEMORY", "true");
+        DimensionInfo dimensionInfo = createDimension(true, null);
+        Dimension dimension = buildDimensionWithEndAttribute(dimensionInfo);
+        Tuple<String, List<Integer>> histogram = dimension.getHistogram(Filter.INCLUDE, "PT12H");
+        assertThat(histogram.first, is("2012-02-11T00:00:00.000Z/2012-02-13T12:00:00.000Z/PT12H"));
+        assertThat(histogram.second, equalTo(Arrays.asList(3, 2, 3, 2, 2)));
     }
 }

--- a/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorTimeDimensionTest.java
+++ b/src/extension/wmts-multi-dimensional/src/test/java/org/geoserver/gwc/wmts/VectorTimeDimensionTest.java
@@ -77,7 +77,7 @@ public class VectorTimeDimensionTest extends VectorTimeTestSupport {
                 true,
                 "2012-02-11T00:00:00.000Z/2012-02-11T11:00:00.000Z",
                 "2012-02-11T00:00:00.000Z/2012-02-13T00:00:00.000Z",
-                "2012-02-12T00:00:00.000Z/2012-02-12T09:00:00.000Z");
+                "2012-02-12T00:00:00.000Z/2012-02-12T10:00:00.000Z");
 
         testDomainsValuesRepresentation(
                 0, true, "2012-02-11T00:00:00.000Z--2012-02-13T00:00:00.000Z");

--- a/src/extension/wmts-multi-dimensional/src/test/resources/TimeElevationWithStartEnd.properties
+++ b/src/extension/wmts-multi-dimensional/src/test/resources/TimeElevationWithStartEnd.properties
@@ -1,5 +1,5 @@
-_=geom:Polygon:srid=4326,id:java.lang.Integer,startTime:java.sql.Date,endTime:java.sql.Date,startElevation:double,endElevation:double
+_=geom:Polygon:srid=4326,id:java.lang.Integer,startTime:java.sql.Timestamp,endTime:java.sql.Timestamp,startElevation:double,endElevation:double
 TimeElevation.0=POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))|0|2012-02-11T00:00:00.000Z|2012-02-11T11:00:00.000Z|1|2
-TimeElevation.1=POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))|1|2012-02-12|2012-02-12T09:00:00.000Z|2|3
-TimeElevation.2=POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))|2|2012-02-11|2012-02-13|3|4
-TimeElevation.3=POLYGON((0 -90, 180 -90, 180 0, 0 0, 0 -90))|2|2012-02-11|2012-02-13|5|7
+TimeElevation.1=POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))|1|2012-02-12T00:00:00.000Z|2012-02-12T10:00:00.000Z|2|3
+TimeElevation.2=POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))|2|2012-02-11T00:00:00.000Z|2012-02-13T00:00:00.000Z|3|4
+TimeElevation.3=POLYGON((0 -90, 180 -90, 180 0, 0 0, 0 -90))|2|2012-02-11T00:00:00.000Z|2012-02-13T00:00:00.000Z|5|7

--- a/src/extension/wmts-multi-dimensional/src/test/resources/TimeElevationWithStartEnd.properties
+++ b/src/extension/wmts-multi-dimensional/src/test/resources/TimeElevationWithStartEnd.properties
@@ -1,5 +1,5 @@
 _=geom:Polygon:srid=4326,id:java.lang.Integer,startTime:java.sql.Date,endTime:java.sql.Date,startElevation:double,endElevation:double
-TimeElevation.0=POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))|0|2012-02-11|2012-02-12|1|2
-TimeElevation.1=POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))|1|2012-02-12|2012-02-13|2|3
+TimeElevation.0=POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))|0|2012-02-11T00:00:00.000Z|2012-02-11T11:00:00.000Z|1|2
+TimeElevation.1=POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))|1|2012-02-12|2012-02-12T09:00:00.000Z|2|3
 TimeElevation.2=POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))|2|2012-02-11|2012-02-13|3|4
 TimeElevation.3=POLYGON((0 -90, 180 -90, 180 0, 0 0, 0 -90))|2|2012-02-11|2012-02-13|5|7


### PR DESCRIPTION
[![GEOS-10471](https://badgen.net/badge/JIRA/GEOS-10471/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10471)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->