### PR TITLE
[GEOS-10454] Backport Make LanguageUrl mangler using rawKvp instead of HttpSer…

### DIFF
--- a/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/LanguageURLMangler.java
@@ -4,57 +4,72 @@
  */
 package org.geoserver.ows;
 
-import java.util.Collections;
-import java.util.Enumeration;
+import java.util.Arrays;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.util.function.Predicate;
 
-/** Mangles service URL's based on the AcceptLanguages and Languages parameters */
+/**
+ * Mangles service for i18n AcceptLanguages and Languages parameters.
+ *
+ * <p>Based on the documentation
+ * https://docs.geoserver.org/latest/en/user/services/internationalization/index.html this class
+ * provide the capability to handle the AcceptLanguages and also the custom INSPIRE extension
+ * Language parameter
+ * (https://docs.geoserver.org/stable/en/user/extensions/inspire/using.html#internationalization-support)
+ * for support capabilities in multiple languages
+ */
 public class LanguageURLMangler implements URLMangler {
 
     public static final String ACCEPT_LANGUAGES = "AcceptLanguages";
     public static final String LANGUAGE = "Language";
 
+    private final Predicate<Object> filterEmtpyString = language -> !((String) language).isEmpty();
+
     @Override
     public void mangleURL(
             StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
-        if (Dispatcher.REQUEST.get() == null || !type.equals(URLType.SERVICE)) return;
-
-        String languageParameter = null;
-        String acceptLanguagesParameter = null;
-
-        HttpServletRequest httpRequest = Dispatcher.REQUEST.get().getHttpRequest();
-        Enumeration<String> parameterNames = httpRequest.getParameterNames();
-
-        for (String parameter : Collections.list(parameterNames)) {
-            if (parameter.equalsIgnoreCase(LANGUAGE)) {
-                languageParameter = parameter;
-            } else if (parameter.equalsIgnoreCase(ACCEPT_LANGUAGES)) {
-                acceptLanguagesParameter = parameter;
-            }
+        if (URLType.SERVICE.equals(type)) {
+            processLanguageParam()
+                    .ifPresent(maybeLanguage -> kvp.put(LANGUAGE, (String) maybeLanguage));
         }
+    }
 
-        String language = "";
+    /**
+     * @return Getting the rawKvp from the Request inside the thread local search for parameter
+     *     Language or AcceptLanguages and return the first one if present or the first occurrence
+     *     of a language code (if present) inside the second one
+     */
+    protected Optional<Object> processLanguageParam() {
+        return Optional.ofNullable(Dispatcher.REQUEST.get())
+                .map(Request::getRawKvp)
+                .map(rawKvp -> getLanguage(rawKvp).orElse(getAcceptLanguages(rawKvp).orElse("")))
+                .filter(filterEmtpyString);
+    }
 
-        if (acceptLanguagesParameter != null) {
-            String acceptLanguages = httpRequest.getParameter(acceptLanguagesParameter);
-            if (acceptLanguages != null) {
-                String commaSplit = acceptLanguages.split(",")[0];
-                String spaceSplit = commaSplit.split(" ")[0];
-                if (spaceSplit.length() >= 1) {
-                    language = spaceSplit;
-                } else {
-                    language = commaSplit;
-                }
-            }
-        }
+    /**
+     * @param rawKvp Map of request parameter
+     * @return the value of Language parameter inside the {@link Request#rawKvp} map or an
+     *     Optional.empty
+     */
+    protected Optional<Object> getLanguage(Map<String, Object> rawKvp) {
+        return Optional.ofNullable(rawKvp.get(LANGUAGE)).filter(filterEmtpyString);
+    }
 
-        if (languageParameter != null) {
-            language = httpRequest.getParameter(languageParameter);
-        }
-
-        if (language != null && language.length() > 0) {
-            kvp.put("Language", language.trim());
-        }
+    /**
+     * If exists, take the AcceptLanguages parameter from the rawKvp map parameter, splitting it
+     * using the regular expression [\\s,]+ which split by space and comma then take the first one
+     * if exists
+     *
+     * @param rawKvp Map of request parameter
+     * @return the first language code found in AcceptLanguages otherwise an Optional.empty
+     */
+    protected Optional<String> getAcceptLanguages(Map<String, Object> rawKvp) {
+        return Optional.ofNullable(rawKvp.get(ACCEPT_LANGUAGES))
+                .flatMap(
+                        value ->
+                                Arrays.stream(((String) value).split("[\\s,]+"))
+                                        .findFirst()
+                                        .filter(language -> !language.isEmpty()));
     }
 }

--- a/src/main/src/test/java/org/geoserver/ows/LanguageURLManglerTest.java
+++ b/src/main/src/test/java/org/geoserver/ows/LanguageURLManglerTest.java
@@ -1,0 +1,84 @@
+package org.geoserver.ows;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geoserver.test.SystemTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(SystemTest.class)
+public class LanguageURLManglerTest extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testLanguageParam() {
+        final LanguageURLMangler languageURLMangler = new LanguageURLMangler();
+        final Request wrappedRequest = new Request();
+        wrappedRequest.setRawKvp(Collections.singletonMap(LanguageURLMangler.LANGUAGE, "it"));
+        Dispatcher.REQUEST.set(wrappedRequest);
+
+        final Map<String, String> accumulator = new HashMap<>();
+        languageURLMangler.mangleURL(null, null, accumulator, URLMangler.URLType.SERVICE);
+
+        assertEquals("it", accumulator.get(LanguageURLMangler.LANGUAGE));
+    }
+
+    @Test
+    public void testAcceptLanguagesCommaParam() {
+        final LanguageURLMangler languageURLMangler = new LanguageURLMangler();
+        final Request wrappedRequest = new Request();
+        wrappedRequest.setRawKvp(
+                Collections.singletonMap(LanguageURLMangler.ACCEPT_LANGUAGES, "en, it, de"));
+        Dispatcher.REQUEST.set(wrappedRequest);
+
+        final Map<String, String> accumulator = new HashMap<>();
+        languageURLMangler.mangleURL(null, null, accumulator, URLMangler.URLType.SERVICE);
+
+        assertEquals("en", accumulator.get(LanguageURLMangler.LANGUAGE));
+    }
+
+    @Test
+    public void testAcceptLanguagesSpaceParam() {
+        final LanguageURLMangler languageURLMangler = new LanguageURLMangler();
+        final Request wrappedRequest = new Request();
+        wrappedRequest.setRawKvp(
+                Collections.singletonMap(LanguageURLMangler.ACCEPT_LANGUAGES, "de fr it"));
+        Dispatcher.REQUEST.set(wrappedRequest);
+
+        final Map<String, String> accumulator = new HashMap<>();
+        languageURLMangler.mangleURL(null, null, accumulator, URLMangler.URLType.SERVICE);
+
+        assertEquals("de", accumulator.get(LanguageURLMangler.LANGUAGE));
+    }
+
+    @Test
+    public void testNoLanguagesParams() {
+        final LanguageURLMangler languageURLMangler = new LanguageURLMangler();
+        final Request wrappedRequest = new Request();
+        Dispatcher.REQUEST.set(wrappedRequest);
+
+        final Map<String, String> accumulator = new HashMap<>();
+        languageURLMangler.mangleURL(null, null, accumulator, URLMangler.URLType.SERVICE);
+
+        assertTrue(accumulator.isEmpty());
+    }
+
+    @Test
+    public void testPriorityLanguageParam() {
+        final LanguageURLMangler languageURLMangler = new LanguageURLMangler();
+        final Request wrappedRequest = new Request();
+        Dispatcher.REQUEST.set(wrappedRequest);
+        wrappedRequest.setRawKvp(
+                Collections.singletonMap(LanguageURLMangler.ACCEPT_LANGUAGES, "de fr it"));
+        wrappedRequest.setRawKvp(Collections.singletonMap(LanguageURLMangler.LANGUAGE, "it"));
+
+        final Map<String, String> accumulator = new HashMap<>();
+        languageURLMangler.mangleURL(null, null, accumulator, URLMangler.URLType.SERVICE);
+
+        assertEquals("it", accumulator.get(LanguageURLMangler.LANGUAGE));
+    }
+}

--- a/src/main/src/test/java/org/geoserver/ows/URLManglersTest.java
+++ b/src/main/src/test/java/org/geoserver/ows/URLManglersTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import org.apache.commons.io.FileUtils;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.SystemTestData;
@@ -50,6 +51,7 @@ public class URLManglersTest extends GeoServerSystemTestSupport {
 
     @Before
     public void setup() {
+        Dispatcher.REQUEST.remove();
         GeoServerInfo gi = getGeoServer().getGlobal();
         gi.getSettings().setProxyBaseUrl(null);
         getGeoServer().save(gi);
@@ -70,6 +72,15 @@ public class URLManglersTest extends GeoServerSystemTestSupport {
                         Collections.singletonMap("param", "value()"),
                         URLType.SERVICE);
         assertEquals("http://localhost:8080/geoserver/test?param=value%28%29", url);
+    }
+
+    @Test
+    public void testUpdateRawKVP() {
+        Request wrappedRequest = new Request();
+        wrappedRequest.setRawKvp(Collections.singletonMap(LanguageURLMangler.LANGUAGE, "value"));
+        Dispatcher.REQUEST.set(wrappedRequest);
+        String url = buildURL(BASEURL, "test", new HashMap<>(), URLType.SERVICE);
+        assertEquals("http://localhost:8080/geoserver/test?Language=value", url);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10454](https://badgen.net/badge/JIRA/GEOS-10454/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10454)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…vletRequest params (#5790)

* [GEOS-10454] Make LanguageUrl mangler using rawKvp instead of HttpServletRequest params


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->