### PR TITLE
ogcapi's geo+json output formats cause NPE when request comes from WFS

### DIFF
--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/DGGSGeoJSONResponse.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/DGGSGeoJSONResponse.java
@@ -38,6 +38,10 @@ public class DGGSGeoJSONResponse extends RFCGeoJSONFeaturesResponse {
             GeoJSONBuilder jw,
             String featureId) {
         APIRequestInfo requestInfo = APIRequestInfo.get();
+        if (null == requestInfo) {
+            // request comes from WFS, not from ogcapi
+            return;
+        }
         GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
         String baseUrl = request.getBaseUrl();
         jw.key("links");

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIRequestInfo.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIRequestInfo.java
@@ -75,7 +75,10 @@ public class APIRequestInfo {
         return ResponseUtils.buildURL(baseURL, path, null, URLMangler.URLType.SERVICE);
     }
 
-    /** Returns the APIRequestInfo from the current {@link RequestContextHolder} */
+    /**
+     * Returns the APIRequestInfo from the current {@link RequestContextHolder}, or {@code null}
+     * indicating there's no OGC API request bound to the calling thread
+     */
     public static APIRequestInfo get() {
         RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
         if (requestAttributes == null) return null;

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/RFCGeoJSONFeaturesResponse.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/RFCGeoJSONFeaturesResponse.java
@@ -117,6 +117,10 @@ public class RFCGeoJSONFeaturesResponse extends GeoJSONGetFeatureResponse {
             GeoJSONBuilder jw,
             String featureId) {
         APIRequestInfo requestInfo = APIRequestInfo.get();
+        if (null == requestInfo) {
+            // request comes from WFS, not from ogcapi
+            return;
+        }
         GetFeatureRequest request = GetFeatureRequest.adapt(operation.getParameters()[0]);
         FeatureTypeInfo featureType = getFeatureType(request);
         String baseUrl = request.getBaseUrl();


### PR DESCRIPTION
ogc-features introduce two GeoJSON output formats:
- RFCGeoJSONFeaturesResponse
- DGGSGeoJSONResponse

As such, they're listed in WFS GetCapabilities as GetFeature
operation's output formats, besides the usual 'application/json'
one.

When feature collection is requested through WFS with output
format application/geo+json, an NPE exeption is thrown once
it streamed the features and calls writeLinks(), resulting
in an XML exception report mixed up with the JSON output.

This patch checks whether APIRequestInfo.get() returns null,
which means the response being produced by these new encoders
is not coming from an ogc-api endpoint, and avoids using
APIRequestInfo to write json links.

Longer term it'd probably be better for these ogcapi-specific output formats be
ignored by WFS, but that's at the discretion of the module maintainers.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->