### PR TITLE
[GEOS-10477] validation error on normalize node

### DIFF
--- a/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
+++ b/src/main/src/main/resources/schemas/sld/StyledLayerDescriptor.xsd
@@ -919,10 +919,18 @@
     </xsd:complexType>
   </xsd:element>
   <xsd:element name="Normalize">
-    <xsd:complexType/>
+    <xsd:complexType>
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="sld:VendorOption"></xsd:element>
+      </xsd:sequence>
+    </xsd:complexType>
   </xsd:element>
   <xsd:element name="Histogram">
-    <xsd:complexType/>
+    <xsd:complexType>
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="sld:VendorOption"></xsd:element>
+      </xsd:sequence>
+    </xsd:complexType>
   </xsd:element>
   <xsd:element name="GammaValue" type="xsd:double"/>
 

--- a/src/main/src/test/java/org/geoserver/catalog/StylesTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/StylesTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
+import java.util.List;
 import java.util.Properties;
 import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.MemoryLockProvider;
@@ -100,6 +101,20 @@ public class StylesTest extends GeoServerSystemTestSupport {
             String message = e.getMessage();
             assertThat(message, containsString("Entity resolution disallowed"));
             assertThat(message, containsString("/this/file/does/not/exist"));
+        }
+    }
+
+    @Test
+    public void testVendorOptionsInNormalize() throws Exception {
+        URL url = getClass().getResource("../data/test/normalized.sld");
+        try {
+            List<Exception> exceptions =
+                    Styles.handler("SLD")
+                            .validate(
+                                    url, null, getCatalog().getResourcePool().getEntityResolver());
+            assertThat("Exceptions found", exceptions.isEmpty());
+        } catch (Exception e) {
+            fail("Should allow normaize to contain vendor options");
         }
     }
 }

--- a/src/main/src/test/java/org/geoserver/data/test/normalized.sld
+++ b/src/main/src/test/java/org/geoserver/data/test/normalized.sld
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld
+http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
+  <NamedLayer>
+    <Name></Name>
+    <UserStyle>
+      <Title>A raster style</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <RasterSymbolizer>
+            <Opacity>1.0</Opacity>
+            <ContrastEnhancement>   
+              <Normalize>    
+                <VendorOption name="algorithm">StretchToMinimumMaximum</VendorOption>    
+                <VendorOption name="minValue">50</VendorOption>    
+                <VendorOption name="maxValue">100</VendorOption>   
+              </Normalize>
+            </ContrastEnhancement>
+          </RasterSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-10477](https://badgen.net/badge/JIRA/GEOS-10477/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10477)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->