### PR TITLE
[GEOS-10479] Improve TestWfsPost URL validation

### DIFF
--- a/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
+++ b/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
@@ -4,6 +4,8 @@
  */
 package org.vfny.geoserver.wfs.servlets;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -46,34 +48,156 @@ public class TestWfsPostTest {
     }
 
     @Test
-    public void testDisallowOpenProxy() throws Exception {
+    public void testDisallowNonHttpProtocols() throws Exception {
         TestWfsPost servlet = buildMockServlet();
         MockHttpServletRequest request = buildMockRequest();
-        request.setParameter("url", "http://www.google.com");
+        request.setParameter("url", "file:///");
         request.setMethod("GET");
         MockHttpServletResponse response = new MockHttpServletResponse();
         servlet.service(request, response);
-        // checking that reqauest is disallowed
-        assertTrue(
-                response.getContentAsString()
-                        .contains(
-                                "Invalid url requested, the demo requests should be hitting: http://localhost:8080/geoserver"));
+        assertThat(
+                response.getContentAsString(),
+                containsString("Invalid url requested; not an HTTP or HTTPS URL: file:///"));
     }
 
     @Test
-    public void testDisallowOpenProxyWithProxyBase() throws Exception {
-        TestWfsPost servlet = buildMockServlet("http://geoserver.org/geoserver");
+    public void testDisallowPathTraversalUnescaped() throws Exception {
+        TestWfsPost servlet = buildMockServlet();
         MockHttpServletRequest request = buildMockRequest();
-        request.setParameter("url", "http://localhost:1234/internalApp");
+        request.setParameter("url", "http://localhost:8080/geoserver/..");
         request.setMethod("GET");
-
         MockHttpServletResponse response = new MockHttpServletResponse();
         servlet.service(request, response);
-        // checking that reqauest is disallowed
-        assertTrue(
-                response.getContentAsString()
-                        .contains(
-                                "Invalid url requested, the demo requests should be hitting: http://geoserver.org/geoserver"));
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested; illegal sequence &apos;..&apos; in URL: http://localhost:8080/geoserver/.."));
+    }
+
+    @Test
+    public void testDisallowPathTraversalEscaped() throws Exception {
+        TestWfsPost servlet = buildMockServlet();
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "http://localhost:8080/geoserver/%2E%2E");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested; illegal sequence &apos;..&apos; in URL: http://localhost:8080/geoserver/%2E%2E"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWrongProtocol() throws Exception {
+        TestWfsPost servlet = buildMockServlet();
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "https://localhost:8080/geoserver/wfs");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: http://localhost:8080/geoserver"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWrongHost() throws Exception {
+        TestWfsPost servlet = buildMockServlet();
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "http://geoserver.org:8080/geoserver/wfs");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: http://localhost:8080/geoserver"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWrongPort() throws Exception {
+        TestWfsPost servlet = buildMockServlet();
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "https://localhost/geoserver/wfs");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: http://localhost:8080/geoserver"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWrongPath() throws Exception {
+        TestWfsPost servlet = buildMockServlet();
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "https://localhost:8080/foo");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: http://localhost:8080/geoserver"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWithProxyBaseWrongProtocol() throws Exception {
+        TestWfsPost servlet = buildMockServlet("https://geoserver.org/geoserver");
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "http://geoserver.org/geoserver/wfs");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: https://geoserver.org/geoserver"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWithProxyBaseWrongHost() throws Exception {
+        TestWfsPost servlet = buildMockServlet("https://geoserver.org/geoserver");
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "https://localhost/geoserver/wfs");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: https://geoserver.org/geoserver"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWithProxyBaseWrongPort() throws Exception {
+        TestWfsPost servlet = buildMockServlet("https://geoserver.org/geoserver");
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "https://geoserver.org:1234/geoserver/wfs");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: https://geoserver.org/geoserver"));
+    }
+
+    @Test
+    public void testDisallowOpenProxyWithProxyBaseWrongPath() throws Exception {
+        TestWfsPost servlet = buildMockServlet("https://geoserver.org/geoserver");
+        MockHttpServletRequest request = buildMockRequest();
+        request.setParameter("url", "https://geoserver.org/foo");
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.service(request, response);
+        assertThat(
+                response.getContentAsString(),
+                containsString(
+                        "Invalid url requested, the demo requests should be hitting: https://geoserver.org/geoserver"));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10229](https://badgen.net/badge/JIRA/GEOS-10229/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10229)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR blocks using the ".." sequence in the URL and also reverts some weakening of the URL validation from https://github.com/geoserver/geoserver/commit/5facd7a786b817a08036e9a8d07776bc7b5b5f97 by adding back validation of the URL protocol, port and path instead of only validating the host.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->