### PR TITLE
[GEOS-10403] new coverage via REST overwrites SRS and SRS handling wi…

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -872,7 +872,7 @@ public class CatalogBuilder {
 
         CoordinateReferenceSystem nativeCRS = cinfo.getNativeCRS();
 
-        if (nativeCRS != null) {
+        if (nativeCRS != null && cinfo.getSRS() == null) {
             try {
                 Integer code = CRS.lookupEpsgCode(nativeCRS, false);
                 if (code != null) {

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogBuilderTest.java
@@ -278,6 +278,22 @@ public class CatalogBuilderTest extends GeoServerMockTestSupport {
     }
 
     @Test
+    public void testInitCoverage_DoesntOverwriteSRS() throws Exception {
+        Catalog cat = getCatalog();
+        CatalogBuilder cb = new CatalogBuilder(cat);
+        cb.setStore(cat.getCoverageStoreByName(MockData.WORLD.getLocalPart()));
+        CoverageInfo cinfo = cb.buildCoverage();
+        // change SRS of Resource to random
+        cinfo.setNativeCRS(CRS.decode("EPSG:26713"));
+        cinfo.setSRS("EPSG:4230");
+        cinfo.setProjectionPolicy(ProjectionPolicy.REPROJECT_TO_DECLARED);
+        // catalog builder should return origin "EPSG:4236"
+        cb.initCoverage(cinfo, "srs given");
+        assertEquals("EPSG:4230", cinfo.getSRS());
+        assertEquals(ProjectionPolicy.REPROJECT_TO_DECLARED, cinfo.getProjectionPolicy());
+    }
+
+    @Test
     public void testCoverageNativeSRSLookup() throws Exception {
         Catalog cat = getCatalog();
 


### PR DESCRIPTION
[![GEOS-10403](https://badgen.net/badge/JIRA/GEOS-10403/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10403)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…th native srs.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->