### PR TITLE
[GEOS-10484] JDK 17 failure in ResourceControllerTest#testDirectoryJSON_multiple_children (2.21.x)

### DIFF
--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
+import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.text.DateFormat;
@@ -364,7 +365,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
     }
 
     @Test
-    public void testDirectoryJSON_multiple_children() throws Exception {
+    public void testDirectoryJSONMultipleChildren() throws Exception {
         Resource mydir2 = getDataDirectory().get("/mydir2");
         String lastModified = FORMAT.format(mydir2.lastmodified());
 
@@ -419,6 +420,9 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
                         + "    }\n"
                         + "  ]}\n"
                         + "}}";
+        // starting with JDK 17 (v3?) json is correctly recognized, the test output
+        String jsonType = URLConnection.guessContentTypeFromName("test.json");
+        if (jsonType != null) expected = expected.replace("application/octet-stream", jsonType);
         JSONAssert.assertEquals(expected, (JSONObject) json);
     }
 


### PR DESCRIPTION
[![GEOS-10484](https://badgen.net/badge/JIRA/GEOS-10484/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10484)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->