### PR TITLE
[GEOS-10481] KML PPIO does not set the entity resolver

### DIFF
--- a/src/extension/wps/wps-kml-ppio/src/main/java/org/geoserver/wps/ppio/KMLPPIO.java
+++ b/src/extension/wps/wps-kml-ppio/src/main/java/org/geoserver/wps/ppio/KMLPPIO.java
@@ -27,6 +27,7 @@ import org.geoserver.kml.decorator.KmlDecoratorFactory.KmlDecorator;
 import org.geoserver.kml.iterator.IteratorList;
 import org.geoserver.kml.iterator.WFSFeatureIteratorFactory;
 import org.geoserver.platform.ServiceException;
+import org.geoserver.util.EntityResolverProvider;
 import org.geotools.data.collection.ListFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.store.ReprojectingFeatureCollection;
@@ -52,14 +53,17 @@ public class KMLPPIO extends CDataPPIO {
 
     GeoServer gs;
 
+    EntityResolverProvider resolverProvider;
+
     Configuration xml;
 
     SimpleFeatureType type;
 
-    public KMLPPIO(GeoServer gs) {
+    public KMLPPIO(GeoServer gs, EntityResolverProvider resolverProvider) {
         super(FeatureCollection.class, FeatureCollection.class, KMLMapOutputFormat.MIME_TYPE);
 
         this.gs = gs;
+        this.resolverProvider = resolverProvider;
         this.xml = new KMLConfiguration();
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
 
@@ -104,6 +108,7 @@ public class KMLPPIO extends CDataPPIO {
     public Object decode(InputStream input) throws Exception {
         StreamingParser parser =
                 new StreamingParser(new KMLConfiguration(), input, SimpleFeature.class);
+        parser.setEntityResolver(resolverProvider.getEntityResolver());
         SimpleFeature f;
         ListFeatureCollection features = null;
         Map<Name, Class<?>> oldftype = null;

--- a/src/extension/wps/wps-kml-ppio/src/main/resources/applicationContext.xml
+++ b/src/extension/wps/wps-kml-ppio/src/main/resources/applicationContext.xml
@@ -11,5 +11,6 @@
   <!-- KML PPIO -->
   <bean id="KMLPPIO" class="org.geoserver.wps.ppio.KMLPPIO">
       <constructor-arg ref="geoServer"/>
+      <constructor-arg ref="entityResolverProvider"/>
   </bean>
 </beans>

--- a/src/extension/wps/wps-kml-ppio/src/test/java/org/geoserver/wps/ppio/KMLPPIOTest.java
+++ b/src/extension/wps/wps-kml-ppio/src/test/java/org/geoserver/wps/ppio/KMLPPIOTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.wps.ppio;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -21,7 +22,9 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.data.test.MockData;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.test.GeoServerTestSupport;
+import org.geoserver.util.EntityResolverProvider;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.junit.Test;
@@ -58,7 +61,7 @@ public class KMLPPIOTest extends GeoServerTestSupport {
         contact.setOnlineResource("http://www.geoserver.org");
         gs.save(global);
 
-        ppio = new KMLPPIO(gs);
+        ppio = new KMLPPIO(gs, GeoServerExtensions.bean(EntityResolverProvider.class));
     }
 
     @Test
@@ -141,5 +144,14 @@ public class KMLPPIOTest extends GeoServerTestSupport {
             assertEquals("pics/22037827-Ti.jpg", poi.getAttribute("THUMBNAIL"));
             assertEquals("pics/22037827-L.jpg", poi.getAttribute("MAINPAGE"));
         }
+    }
+
+    @Test
+    public void testDecodeXXE() throws Exception {
+        String kml =
+                "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///\" >]>"
+                        + "<kml><Placemark><name>&xxe;</name></Placemark></kml>";
+        // StreamingParser returns null if the parsing fails
+        assertNull(ppio.decode(kml));
     }
 }


### PR DESCRIPTION
[![GEOS-10481](https://badgen.net/badge/JIRA/GEOS-10481/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10481)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR sets the entity resolver in the KML PPIO.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->