### PR TITLE
gather keycloak docs so they do not appear as two modules

### DIFF
--- a/doc/en/user/source/community/index.rst
+++ b/doc/en/user/source/community/index.rst
@@ -47,7 +47,6 @@ officially part of the GeoServer releases. They are however built along with the
    jdbcstore/index
    jms-cluster/index
    keycloak/index
-   keycloak/keycloak_role_service
    mbtiles/index
    metadata/index
    monitor-hibernate/index

--- a/doc/en/user/source/community/keycloak/authentication.rst
+++ b/doc/en/user/source/community/keycloak/authentication.rst
@@ -1,0 +1,107 @@
+.. _security_tutorials_keycloak:
+
+Authentication with Keycloak
+============================
+
+This tutorial introduces GeoServer Keycloak support and walks through the process of
+setting up authentication against an Keycloak provider. It is recommended that the
+:ref:`security_auth_chain` section be read before proceeding.
+
+The GeoServer Keycloak-authn/authz plugin will allow you to use an instance of Keycloak to control access to resources within GeoServer.
+
+Configuration Instructions
+--------------------------
+
+**As the Keycloak Admin:**
+
+.. note:: In this example the Keycloak service runs on port `8080` while GeoServer runs on port `8181`
+
+1. Create a `new client <http://www.keycloak.org/docs/3.3/authorization_services/topics/resource-server/create-client.html>`_ for GeoServer named `geoserver-client`. 
+
+    .. figure:: images/keycloak_client001.png
+       :align: center
+
+2. Make sure to add the base URL of GeoServer to the list of acceptable redirect paths, and add also the Keycloak OIDC endpoint base URI.
+
+   eg: 
+     - http://localhost:8181/geoserver*
+     - http://localhost:8080/auth/realms/demo/broker/keycloak-oidc/endpoint*
+     
+    .. figure:: images/keycloak_client002.png
+       :align: center
+
+3. Set the `access-type` of client as appropriate. If your GeoServer instance is depending on another service for authentication (eg: NGINX auth plugin) then you should probably select *bearer-only*.
+   Otherwise, you should probably select *confidential*.
+
+    .. figure:: images/keycloak_client003.png
+       :align: center
+
+4. Add the the *ADMINISTRATOR* and *AUTHENTICATED* `client-role <http://www.keycloak.org/docs/2.5/server_admin/topics/roles/client-roles.html>`_ to the `geoserver-client` in Keycloak.
+
+    .. figure:: images/keycloak_client004.png
+       :align: center
+
+   In this phase you will need to map GeoServer Roles to the `geoserver-client` ones in Keycloak.   
+
+    .. figure:: images/keycloak_client005.png
+       :align: center
+
+   Use the *AUTHENTICATED* one for generic users. Assign this role *ADMINISTRATOR* to the users/groups who should have administrative access to GeoServer.
+
+    .. figure:: images/keycloak_client006.png
+       :align: center
+
+5. Obtain the `installation-configuration <http://www.keycloak.org/docs/3.2/server_admin/topics/clients/installation.html>`_ for the `geoserver-client` in JSON, and provide this to the GeoServer Admin for the next steps.
+
+    .. figure:: images/keycloak_client007.png
+       :align: center
+
+**As the GeoServer Admin:**
+
+.. note:: In this example the Keycloak service runs on port `8080` while GeoServer runs on port `8181`
+
+1. Under the Authentication UI, add a new `authentication-filter`. Select `Keycloak` from the list of provided options, and name your new filter *keycloak_adapter*.
+   Paste the installation-configuration from the Keycloak-server in the text area provided.
+
+   If not present, be sure to add the following options before clicking `Save`:
+
+    .. code::
+    
+        "use-resource-role-mappings": true
+
+    .. figure:: images/keycloak_adapter001.png
+       :align: center
+
+2. Add the `keycloak_adapter` to the *web* `filter-chain` if you want to protect the Admin GUI, as an instance. If you want to be redirected everytime to Keycloak, then remove all of the others `chain filters` (basic, form, rememberme, anonymous), otherwise you will need to access directly the login url on Keycloak.
+
+    .. figure:: images/keycloak_adapter002.png
+       :align: center
+
+3. Check your work so far by navigating to the GeoServer UI. You should be redirected to the Keycloak `login-page`, and after logging-in you should be redirected back to the actual GUI page.
+
+    .. figure:: images/keycloak_adapter003.png
+       :align: center
+
+   You should verify that the message `logged in as <USERNAME>` is posted in the top right corner before continuing.
+
+    .. figure:: images/keycloak_adapter004.png
+       :align: center
+
+.. warning:: Workaround in the event of a 403 unauthorized response after logging-in.
+
+    Enforce the algorithm RS256 in the keycloak client.
+
+    .. figure:: images/keycloak_client008.png
+        :align: center
+
+    Copy the public key for the RS256 algorithm from the Realm Settings into the adapter config as:
+
+    .. code::
+    
+        "realm-public-key": XXXXXXX
+
+    .. figure:: images/keycloak_client009.png
+        :align: center
+
+    .. figure:: images/keycloak_adapter005.png
+        :align: center

--- a/doc/en/user/source/community/keycloak/index.rst
+++ b/doc/en/user/source/community/keycloak/index.rst
@@ -1,107 +1,13 @@
-.. _security_tutorials_keycloak:
+.. _community_keycloak:
 
-Authentication with Keycloak
-============================
+Keycloak extension
+==================
 
-This tutorial introduces GeoServer Keycloak support and walks through the process of
-setting up authentication against an Keycloak provider. It is recommended that the
-:ref:`security_auth_chain` section be read before proceeding.
+The ``Keycloak module`` allows GeoServer to work with a `keycloak service <https://www.keycloak.org/>`__ to authenticate users and establish authorization using roles.
 
-The GeoServer Keycloak-authn/authz plugin will allow you to use an instance of Keycloak to control access to resources within GeoServer.
+.. toctree::
+   :maxdepth: 2
 
-Installation Instructions
---------------------------
-
-**As the Keycloak Admin:**
-
-.. note:: In this example the Keycloak service runs on port `8080` while GeoServer runs on port `8181`
-
-1. Create a `new client <http://www.keycloak.org/docs/3.3/authorization_services/topics/resource-server/create-client.html>`_ for GeoServer named `geoserver-client`. 
-
-    .. figure:: images/keycloak_client001.png
-       :align: center
-
-2. Make sure to add the base URL of GeoServer to the list of acceptable redirect paths, and add also the Keycloak OIDC endpoint base URI.
-
-   eg: 
-     - http://localhost:8181/geoserver*
-     - http://localhost:8080/auth/realms/demo/broker/keycloak-oidc/endpoint*
-     
-    .. figure:: images/keycloak_client002.png
-       :align: center
-
-3. Set the `access-type` of client as appropriate. If your GeoServer instance is depending on another service for authentication (eg: NGINX auth plugin) then you should probably select *bearer-only*.
-   Otherwise, you should probably select *confidential*.
-
-    .. figure:: images/keycloak_client003.png
-       :align: center
-
-4. Add the the *ADMINISTRATOR* and *AUTHENTICATED* `client-role <http://www.keycloak.org/docs/2.5/server_admin/topics/roles/client-roles.html>`_ to the `geoserver-client` in Keycloak.
-
-    .. figure:: images/keycloak_client004.png
-       :align: center
-
-   In this phase you will need to map GeoServer Roles to the `geoserver-client` ones in Keycloak.   
-
-    .. figure:: images/keycloak_client005.png
-       :align: center
-
-   Use the *AUTHENTICATED* one for generic users. Assign this role *ADMINISTRATOR* to the users/groups who should have administrative access to GeoServer.
-
-    .. figure:: images/keycloak_client006.png
-       :align: center
-
-5. Obtain the `installation-configuration <http://www.keycloak.org/docs/3.2/server_admin/topics/clients/installation.html>`_ for the `geoserver-client` in JSON, and provide this to the GeoServer Admin for the next steps.
-
-    .. figure:: images/keycloak_client007.png
-       :align: center
-
-**As the GeoServer Admin:**
-
-.. note:: In this example the Keycloak service runs on port `8080` while GeoServer runs on port `8181`
-
-1. Under the Authentication UI, add a new `authentication-filter`. Select `Keycloak` from the list of provided options, and name your new filter *keycloak_adapter*.
-   Paste the installation-configuration from the Keycloak-server in the text area provided.
-
-   If not present, be sure to add the following options before clicking `Save`:
-
-    .. code::
-    
-        "use-resource-role-mappings": true
-
-    .. figure:: images/keycloak_adapter001.png
-       :align: center
-
-2. Add the `keycloak_adapter` to the *web* `filter-chain` if you want to protect the Admin GUI, as an instance. If you want to be redirected everytime to Keycloak, then remove all of the others `chain filters` (basic, form, rememberme, anonymous), otherwise you will need to access directly the login url on Keycloak.
-
-    .. figure:: images/keycloak_adapter002.png
-       :align: center
-
-3. Check your work so far by navigating to the GeoServer UI. You should be redirected to the Keycloak `login-page`, and after logging-in you should be redirected back to the actual GUI page.
-
-    .. figure:: images/keycloak_adapter003.png
-       :align: center
-
-   You should verify that the message `logged in as <USERNAME>` is posted in the top right corner before continuing.
-
-    .. figure:: images/keycloak_adapter004.png
-       :align: center
-
-.. warning:: Workaround in the event of a 403 unauthorized response after logging-in.
-
-    Enforce the algorithm RS256 in the keycloak client.
-
-    .. figure:: images/keycloak_client008.png
-        :align: center
-
-    Copy the public key for the RS256 algorithm from the Realm Settings into the adapter config as:
-
-    .. code::
-    
-        "realm-public-key": XXXXXXX
-
-    .. figure:: images/keycloak_client009.png
-        :align: center
-
-    .. figure:: images/keycloak_adapter005.png
-        :align: center
+   installation
+   authentication
+   keycloak_role_service

--- a/doc/en/user/source/community/keycloak/installation.rst
+++ b/doc/en/user/source/community/keycloak/installation.rst
@@ -1,0 +1,32 @@
+.. _community_keycloak_installing:
+
+Installing Keycloak
+===================
+
+To install the keycloak module:
+
+#. To obtain the keycloak community module:
+
+   * If working with a |release| nightly build, download the module: :download_community:`keycloak`
+   
+     Verify that the version number in the filename corresponds to the version of GeoServer you are running (for example |release| above).
+     
+   * Community modules are not yet ready for distribution with GeoServer release.
+      
+     To compile the keycloak community module yourself download the src bundle for your GeoServer version and compile:
+
+     .. code-block:: bash
+     
+        cd src/community
+        mvn install -PcommunityRelease -DskipTests
+       
+     And package:
+     
+     .. code-block:: bash
+     
+        cd src/community
+        mvn assembly:single -N
+     
+#. Place the JARs in ``WEB-INF/lib``. 
+
+#. Restart GeoServer.

--- a/doc/en/user/source/community/keycloak/keycloak_role_service.rst
+++ b/doc/en/user/source/community/keycloak/keycloak_role_service.rst
@@ -79,7 +79,8 @@ Role syncing with Keycloak will be tied to the confidential client.
 
 GeoServer Configuration for Keycloak Authentication Filters
 -----------------------------------------------------------
+
 Under the Authentication section of GeoServer:
 
 * Add the Keycloak authentication filter to the top of the web and default filter chains.
-* Add geofence to the selected provider chains, and place it above the default.
+* Add keycloak to the selected provider chains, and place it above the default.


### PR DESCRIPTION
The two tutorials appeard as distinct community modules list the list

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->