### PR TITLE
[GEOS-10498] STAC API Search implementation looks for an intersection property in the request, while it should be intersects (2.21.x)

### DIFF
--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
@@ -462,7 +462,7 @@ public class STACService {
                         templates, accessProvider, filterParser, sampleFeatures, collectionsCache);
         resultBuilder
                 .collectionIds(sq.getCollections())
-                .intersects(sq.getIntersection())
+                .intersects(sq.getIntersects())
                 .startIndex(sq.getStartIndex())
                 .requestedLimit(sq.getLimit())
                 .bbox(sq.getBbox())

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/SearchQuery.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/SearchQuery.java
@@ -19,7 +19,7 @@ public class SearchQuery {
     private String datetime;
     private String filter;
     private Integer startIndex;
-    Geometry intersection;
+    Geometry intersects;
 
     @JsonProperty("filter-lang")
     String filterLang;
@@ -85,11 +85,11 @@ public class SearchQuery {
         this.startIndex = startIndex;
     }
 
-    public Geometry getIntersection() {
-        return intersection;
+    public Geometry getIntersects() {
+        return intersects;
     }
 
-    public void setIntersection(Geometry intersection) {
-        this.intersection = intersection;
+    public void setIntersects(Geometry intersects) {
+        this.intersects = intersects;
     }
 }

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/SearchTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/SearchTest.java
@@ -253,7 +253,7 @@ public class SearchTest extends STACTestSupport {
         // only SAS and LANDSAT intersecting this point
         String request =
                 "{\n"
-                        + "  \"intersection\": {\n"
+                        + "  \"intersects\": {\n"
                         + "    \"type\": \"Point\",\n"
                         + "    \"coordinates\": [\n"
                         + "      16.5,\n"


### PR DESCRIPTION
[![GEOS-10498](https://badgen.net/badge/JIRA/GEOS-10498/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10498)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->