### PR TITLE
[GEOS-10502] GML3 output is not pretty printed when pretty print is turned on in global settings.

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
@@ -19,9 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
-
 import javax.xml.transform.TransformerException;
-
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.ResourceInfo;
@@ -193,8 +191,10 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat
 
         WFSInfo wfs = getInfo();
 
-        transformer
-            .setIndentation((wfs.isVerbose() || geoServer.getSettings().isVerbose()) ? INDENT_SIZE : (NO_FORMATTING));
+        transformer.setIndentation(
+                (wfs.isVerbose() || geoServer.getSettings().isVerbose())
+                        ? INDENT_SIZE
+                        : (NO_FORMATTING));
         transformer.setNumDecimals(numDecimals);
         transformer.setPadWithZeros(padWithZeros);
         transformer.setForceDecimalEncoding(forcedDecimal);

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
@@ -19,7 +19,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+
 import javax.xml.transform.TransformerException;
+
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.ResourceInfo;
@@ -191,7 +193,8 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat
 
         WFSInfo wfs = getInfo();
 
-        transformer.setIndentation(wfs.isVerbose() ? INDENT_SIZE : (NO_FORMATTING));
+        transformer
+            .setIndentation((wfs.isVerbose() || geoServer.getSettings().isVerbose()) ? INDENT_SIZE : (NO_FORMATTING));
         transformer.setNumDecimals(numDecimals);
         transformer.setPadWithZeros(padWithZeros);
         transformer.setForceDecimalEncoding(forcedDecimal);

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.ErrorListener;
@@ -37,7 +38,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import net.opengis.wfs.FeatureCollectionType;
+
 import org.eclipse.xsd.XSDSchema;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -66,6 +67,8 @@ import org.geotools.xsd.Encoder;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
 import org.w3c.dom.Document;
+
+import net.opengis.wfs.FeatureCollectionType;
 
 public class GML3OutputFormat extends WFSGetFeatureOutputFormat
         implements ComplexFeatureAwareFormat {
@@ -243,6 +246,12 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat
         Encoder encoder = createEncoder(configuration, ns2metas, gft);
 
         encoder.setEncoding(Charset.forName(geoServer.getSettings().getCharset()));
+        if (wfs.isVerbose() || geoServer.getSettings().isVerbose()) {
+          geoServer.getSettings().setVerbose(true);
+          encoder.setIndenting(true);
+        } else {
+          encoder.setIndenting(false);
+        }
         Request dispatcherRequest = Dispatcher.REQUEST.get();
         if (dispatcherRequest != null) {
             encoder.setOmitXMLDeclaration(dispatcherRequest.isSOAP());
@@ -267,7 +276,7 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat
                         "request",
                         "DescribeFeatureType");
         for (Map.Entry<String, Set<ResourceInfo>> stringSetEntry : ns2metas.entrySet()) {
-            Map.Entry entry = (Map.Entry) stringSetEntry;
+            Map.Entry entry = stringSetEntry;
 
             String namespaceURI = (String) entry.getKey();
             Set metas = (Set) entry.getValue();

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
-
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.ErrorListener;
@@ -38,7 +37,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
+import net.opengis.wfs.FeatureCollectionType;
 import org.eclipse.xsd.XSDSchema;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -67,8 +66,6 @@ import org.geotools.xsd.Encoder;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
 import org.w3c.dom.Document;
-
-import net.opengis.wfs.FeatureCollectionType;
 
 public class GML3OutputFormat extends WFSGetFeatureOutputFormat
         implements ComplexFeatureAwareFormat {
@@ -247,10 +244,10 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat
 
         encoder.setEncoding(Charset.forName(geoServer.getSettings().getCharset()));
         if (wfs.isVerbose() || geoServer.getSettings().isVerbose()) {
-          geoServer.getSettings().setVerbose(true);
-          encoder.setIndenting(true);
+            geoServer.getSettings().setVerbose(true);
+            encoder.setIndenting(true);
         } else {
-          encoder.setIndenting(false);
+            encoder.setIndenting(false);
         }
         Request dispatcherRequest = Dispatcher.REQUEST.get();
         if (dispatcherRequest != null) {

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
-
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.wfs.WFSTestSupport;
@@ -133,24 +132,34 @@ public class GMLOutputFormatTest extends WFSTestSupport {
 
     @Test
     public void testGML2Formatting() throws Exception {
-      enableFormatting();
-      Document dom = getAsDOM("wfs?request=getfeature&version=1.0.0&outputFormat=gml2&typename="
-          + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
-      ByteArrayOutputStream bos = new ByteArrayOutputStream();
-      print(dom, bos);
-      assertTrue(bos.toString().contains("\n        <gml"));
+        enableFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml2&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        print(dom, bos);
+        assertTrue(bos.toString().contains("\n        <gml"));
     }
 
     private void enableFormatting() {
-      FeatureTypeInfo info = getGeoServer().getCatalog().getResourceByName(
-          new NameImpl(MockData.BASIC_POLYGONS.getPrefix(), MockData.BASIC_POLYGONS.getLocalPart()),
-          FeatureTypeInfo.class);
-      info.setNumDecimals(4);
-      info.setForcedDecimal(true);
-      info.setPadWithZeros(true);
-      getGeoServer().getSettings().setVerbose(true);
-      getGeoServer().getCatalog().save(info);
+        FeatureTypeInfo info =
+                getGeoServer()
+                        .getCatalog()
+                        .getResourceByName(
+                                new NameImpl(
+                                        MockData.BASIC_POLYGONS.getPrefix(),
+                                        MockData.BASIC_POLYGONS.getLocalPart()),
+                                FeatureTypeInfo.class);
+        info.setNumDecimals(4);
+        info.setForcedDecimal(true);
+        info.setPadWithZeros(true);
+        getGeoServer().getSettings().setVerbose(true);
+        getGeoServer().getCatalog().save(info);
     }
+
     @Test
     public void testGML2GZIP() throws Exception {
         //        InputStream input = get(
@@ -223,15 +232,20 @@ public class GMLOutputFormatTest extends WFSTestSupport {
                 "-1.0000 0.0000 0.0000 1.0000 1.0000 0.0000 0.0000 -1.0000 -1.0000 0.0000",
                 dom.getElementsByTagName("gml:posList").item(0).getTextContent());
     }
+
     @Test
     public void testGML3Formatting() throws Exception {
-      enableFormatting();
-      Document dom = getAsDOM("wfs?request=getfeature&version=1.0.0&outputFormat=gml3&typename="
-          + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
-      ByteArrayOutputStream bos = new ByteArrayOutputStream();
-      print(dom);
-      print(dom, bos);
-      assertTrue(bos.toString().contains("\n        <gml"));
+        enableFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml3&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        print(dom, bos);
+        assertTrue(bos.toString().contains("\n        <gml"));
     }
 
     @Test
@@ -262,11 +276,15 @@ public class GMLOutputFormatTest extends WFSTestSupport {
 
     @Test
     public void testGML32Formatting() throws Exception {
-      enableFormatting();
-      Document dom = getAsDOM("wfs?request=getfeature&version=1.0.0&outputFormat=gml32&typename="
-          + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
-      ByteArrayOutputStream bos = new ByteArrayOutputStream();
-      print(dom, bos);
-      assertTrue(bos.toString().contains("\n        <gml"));
+        enableFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml32&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        print(dom, bos);
+        assertTrue(bos.toString().contains("\n        <gml"));
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
@@ -8,6 +8,9 @@ package org.geoserver.wfs.xml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
 
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
@@ -129,6 +132,26 @@ public class GMLOutputFormatTest extends WFSTestSupport {
     }
 
     @Test
+    public void testGML2Formatting() throws Exception {
+      enableFormatting();
+      Document dom = getAsDOM("wfs?request=getfeature&version=1.0.0&outputFormat=gml2&typename="
+          + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      print(dom, bos);
+      assertTrue(bos.toString().contains("\n        <gml"));
+    }
+
+    private void enableFormatting() {
+      FeatureTypeInfo info = getGeoServer().getCatalog().getResourceByName(
+          new NameImpl(MockData.BASIC_POLYGONS.getPrefix(), MockData.BASIC_POLYGONS.getLocalPart()),
+          FeatureTypeInfo.class);
+      info.setNumDecimals(4);
+      info.setForcedDecimal(true);
+      info.setPadWithZeros(true);
+      getGeoServer().getSettings().setVerbose(true);
+      getGeoServer().getCatalog().save(info);
+    }
+    @Test
     public void testGML2GZIP() throws Exception {
         //        InputStream input = get(
         // "wfs?request=getfeature&version=1.0.0&outputFormat=gml2-gzip&typename=" +
@@ -200,6 +223,16 @@ public class GMLOutputFormatTest extends WFSTestSupport {
                 "-1.0000 0.0000 0.0000 1.0000 1.0000 0.0000 0.0000 -1.0000 -1.0000 0.0000",
                 dom.getElementsByTagName("gml:posList").item(0).getTextContent());
     }
+    @Test
+    public void testGML3Formatting() throws Exception {
+      enableFormatting();
+      Document dom = getAsDOM("wfs?request=getfeature&version=1.0.0&outputFormat=gml3&typename="
+          + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      print(dom);
+      print(dom, bos);
+      assertTrue(bos.toString().contains("\n        <gml"));
+    }
 
     @Test
     public void testGML32() throws Exception {
@@ -225,5 +258,15 @@ public class GMLOutputFormatTest extends WFSTestSupport {
         assertEquals(
                 "0.0000 -1.0000 1.0000 0.0000 0.0000 1.0000 -1.0000 0.0000 0.0000 -1.0000",
                 dom.getElementsByTagName("gml:posList").item(0).getTextContent());
+    }
+
+    @Test
+    public void testGML32Formatting() throws Exception {
+      enableFormatting();
+      Document dom = getAsDOM("wfs?request=getfeature&version=1.0.0&outputFormat=gml32&typename="
+          + MockData.BASIC_POLYGONS.getPrefix() + ":" + MockData.BASIC_POLYGONS.getLocalPart());
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      print(dom, bos);
+      assertTrue(bos.toString().contains("\n        <gml"));
     }
 }


### PR DESCRIPTION
[![GEOS-10502](https://badgen.net/badge/JIRA/GEOS-10502/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10502)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR makes the GMLFormatters (both 2 and 3.0/3.2) honour the verbose/Pretty print setting in the global settings page.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->