### PR TITLE
[GEOS-10502] Backport to 2.20.x - Honour verbose setting for GML output

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
@@ -191,7 +191,10 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat
 
         WFSInfo wfs = getInfo();
 
-        transformer.setIndentation(wfs.isVerbose() ? INDENT_SIZE : (NO_FORMATTING));
+        transformer.setIndentation(
+                (wfs.isVerbose() || geoServer.getSettings().isVerbose())
+                        ? INDENT_SIZE
+                        : (NO_FORMATTING));
         transformer.setNumDecimals(numDecimals);
         transformer.setPadWithZeros(padWithZeros);
         transformer.setForceDecimalEncoding(forcedDecimal);

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
@@ -244,7 +244,7 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat
 
         encoder.setEncoding(Charset.forName(geoServer.getSettings().getCharset()));
         if (wfs.isVerbose() || geoServer.getSettings().isVerbose()) {
-            geoServer.getSettings().setVerbose(true);
+
             encoder.setIndenting(true);
         } else {
             encoder.setIndenting(false);

--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML3OutputFormat.java
@@ -243,6 +243,12 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat
         Encoder encoder = createEncoder(configuration, ns2metas, gft);
 
         encoder.setEncoding(Charset.forName(geoServer.getSettings().getCharset()));
+        if (wfs.isVerbose() || geoServer.getSettings().isVerbose()) {
+            geoServer.getSettings().setVerbose(true);
+            encoder.setIndenting(true);
+        } else {
+            encoder.setIndenting(false);
+        }
         Request dispatcherRequest = Dispatcher.REQUEST.get();
         if (dispatcherRequest != null) {
             encoder.setOmitXMLDeclaration(dispatcherRequest.isSOAP());
@@ -267,7 +273,7 @@ public class GML3OutputFormat extends WFSGetFeatureOutputFormat
                         "request",
                         "DescribeFeatureType");
         for (Map.Entry<String, Set<ResourceInfo>> stringSetEntry : ns2metas.entrySet()) {
-            Map.Entry entry = (Map.Entry) stringSetEntry;
+            Map.Entry entry = stringSetEntry;
 
             String namespaceURI = (String) entry.getKey();
             Set metas = (Set) entry.getValue();

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
@@ -8,7 +8,9 @@ package org.geoserver.wfs.xml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.wfs.WFSTestSupport;
@@ -129,6 +131,36 @@ public class GMLOutputFormatTest extends WFSTestSupport {
     }
 
     @Test
+    public void testGML2Formatting() throws Exception {
+        enableFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml2&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        print(dom, bos);
+        assertTrue(bos.toString().contains("\n        <gml"));
+    }
+
+    private void enableFormatting() {
+        FeatureTypeInfo info =
+                getGeoServer()
+                        .getCatalog()
+                        .getResourceByName(
+                                new NameImpl(
+                                        MockData.BASIC_POLYGONS.getPrefix(),
+                                        MockData.BASIC_POLYGONS.getLocalPart()),
+                                FeatureTypeInfo.class);
+        info.setNumDecimals(4);
+        info.setForcedDecimal(true);
+        info.setPadWithZeros(true);
+        getGeoServer().getSettings().setVerbose(true);
+        getGeoServer().getCatalog().save(info);
+    }
+
+    @Test
     public void testGML2GZIP() throws Exception {
         //        InputStream input = get(
         // "wfs?request=getfeature&version=1.0.0&outputFormat=gml2-gzip&typename=" +
@@ -202,6 +234,21 @@ public class GMLOutputFormatTest extends WFSTestSupport {
     }
 
     @Test
+    public void testGML3Formatting() throws Exception {
+        enableFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml3&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        print(dom, bos);
+        assertTrue(bos.toString().contains("\n        <gml"));
+    }
+
+    @Test
     public void testGML32() throws Exception {
         Document dom =
                 getAsDOM(
@@ -225,5 +272,19 @@ public class GMLOutputFormatTest extends WFSTestSupport {
         assertEquals(
                 "0.0000 -1.0000 1.0000 0.0000 0.0000 1.0000 -1.0000 0.0000 0.0000 -1.0000",
                 dom.getElementsByTagName("gml:posList").item(0).getTextContent());
+    }
+
+    @Test
+    public void testGML32Formatting() throws Exception {
+        enableFormatting();
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml32&typename="
+                                + MockData.BASIC_POLYGONS.getPrefix()
+                                + ":"
+                                + MockData.BASIC_POLYGONS.getLocalPart());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        print(dom, bos);
+        assertTrue(bos.toString().contains("\n        <gml"));
     }
 }


### PR DESCRIPTION
[![GEOS-10502](https://badgen.net/badge/JIRA/GEOS-10502/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10502)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->