### PR TITLE
[GEOS-10487] Log4J custom logging XML configuration is case-insenstive

### DIFF
--- a/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
+++ b/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.logging;
 
+import static org.geoserver.logging.GeoServerXMLConfiguration.attributeGet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -18,6 +19,7 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.MemoryLockProvider;
@@ -173,5 +175,29 @@ public class LoggingStartupContextListenerTest {
                 "logs/geoserver.log",
                 GeoServerXMLConfiguration.applyPathTemplate(
                         "${baseDir}/logs/logging.log", "logs/geoserver.log"));
+    }
+
+    @Test
+    public void testNodeAttributes() {
+        Node node = new Node();
+        node.getAttributes().put("fileName", "logs/geoserver.log");
+
+        assertNotNull("attribute name lookup", attributeGet(node, "fileName"));
+        assertNotNull("attribute case-insensitive lookup", attributeGet(node, "filename"));
+
+        assertEquals("attribute style", "logs/geoserver.log", attributeGet(node, "fileName"));
+        assertEquals("element style", "logs/geoserver.log", attributeGet(node, "FileName"));
+        assertEquals("quick style", "logs/geoserver.log", attributeGet(node, "filename"));
+
+        node.getAttributes().remove("fileName");
+        assertNull("attribute style", attributeGet(node, "fileName"));
+        assertNull("element style", attributeGet(node, "FileName"));
+        assertNull("quick style", attributeGet(node, "filename"));
+
+        GeoServerXMLConfiguration.attributePut(node, "filename", "history.txt");
+        assertEquals("store direct", "history.txt", node.getAttributes().get("filename"));
+
+        GeoServerXMLConfiguration.attributePut(node, "fileName", "geoserver.log");
+        assertEquals("store match", "geoserver.log", node.getAttributes().get("filename"));
     }
 }


### PR DESCRIPTION
[![GEOS-10487](https://badgen.net/badge/JIRA/GEOS-10487/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10487)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The log4j configuration is case-insenstive, adjusting GeoServerXmlConfiguration to pre-process in a case-insenstive manner.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->