### PR TITLE
[GEOS-10514]: Better capture catalog configuration issue on layergroup with a layer without resource

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1067,14 +1067,15 @@ public class CatalogImpl implements Catalog {
                             + layerGroup.getWorkspace().getName());
         }
 
-        checkLayerGroupResourceIsInWorkspace(layerGroup.getRootLayer(), ws);
+        checkLayerGroupResourceIsInWorkspace(layerGroup, layerGroup.getRootLayer(), ws);
         checkLayerGroupResourceIsInWorkspace(layerGroup.getRootLayerStyle(), ws);
-        if (layerGroup.getLayers() != null) {
-            for (PublishedInfo p : layerGroup.getLayers()) {
+        List<PublishedInfo> layers = layerGroup.getLayers();
+        if (layers != null) {
+            for (PublishedInfo p : layers) {
                 if (p instanceof LayerGroupInfo) {
                     checkLayerGroupResourceIsInWorkspace((LayerGroupInfo) p, ws);
                 } else if (p instanceof LayerInfo) {
-                    checkLayerGroupResourceIsInWorkspace((LayerInfo) p, ws);
+                    checkLayerGroupResourceIsInWorkspace(layerGroup, (LayerInfo) p, ws);
                 }
             }
         }
@@ -1098,10 +1099,20 @@ public class CatalogImpl implements Catalog {
         }
     }
 
-    private void checkLayerGroupResourceIsInWorkspace(LayerInfo layer, WorkspaceInfo ws) {
+    private void checkLayerGroupResourceIsInWorkspace(
+            LayerGroupInfo layerGroup, LayerInfo layer, WorkspaceInfo ws) {
         if (layer == null) return;
 
         ResourceInfo r = layer.getResource();
+
+        if (r == null) {
+            throw new IllegalArgumentException(
+                    "Layer group "
+                            + layerGroup.getName()
+                            + " references a layer ("
+                            + layer.getId()
+                            + ") without a proper Resource attached");
+        }
         if (r.getStore().getWorkspace() != null && !ws.equals(r.getStore().getWorkspace())) {
             throw new IllegalArgumentException(
                     "Layer group within a workspace ("

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2147,6 +2148,21 @@ public class CatalogImplTest extends GeoServerSystemTestSupport {
             fail();
         } catch (IllegalArgumentException expected) {
         }
+    }
+
+    @Test
+    public void testAddLayerGroupWithMissingResource() throws Exception {
+        addLayerGroup();
+
+        LayerGroupInfo lg2 = catalog.getFactory().createLayerGroup();
+        lg2.setName("layerGroup2");
+        lg2.getLayers().add(l);
+
+        CatalogFactory factory = catalog.getFactory();
+        LayerInfo l2 = factory.createLayer();
+        lg2.setWorkspace(ws);
+        lg2.getLayers().add(l2);
+        assertThrows(IllegalArgumentException.class, () -> catalog.add(lg2));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10514](https://badgen.net/badge/JIRA/GEOS-10514/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10514)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->