### PR TITLE
[Backport to 2.21.x][GEOS-10514]: Better capture catalog configuration issue on layergroup with a layer without resource

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1067,14 +1067,15 @@ public class CatalogImpl implements Catalog {
                             + layerGroup.getWorkspace().getName());
         }
 
-        checkLayerGroupResourceIsInWorkspace(layerGroup.getRootLayer(), ws);
+        checkLayerGroupResourceIsInWorkspace(layerGroup, layerGroup.getRootLayer(), ws);
         checkLayerGroupResourceIsInWorkspace(layerGroup.getRootLayerStyle(), ws);
-        if (layerGroup.getLayers() != null) {
-            for (PublishedInfo p : layerGroup.getLayers()) {
+        List<PublishedInfo> layers = layerGroup.getLayers();
+        if (layers != null) {
+            for (PublishedInfo p : layers) {
                 if (p instanceof LayerGroupInfo) {
                     checkLayerGroupResourceIsInWorkspace((LayerGroupInfo) p, ws);
                 } else if (p instanceof LayerInfo) {
-                    checkLayerGroupResourceIsInWorkspace((LayerInfo) p, ws);
+                    checkLayerGroupResourceIsInWorkspace(layerGroup, (LayerInfo) p, ws);
                 }
             }
         }
@@ -1098,10 +1099,20 @@ public class CatalogImpl implements Catalog {
         }
     }
 
-    private void checkLayerGroupResourceIsInWorkspace(LayerInfo layer, WorkspaceInfo ws) {
+    private void checkLayerGroupResourceIsInWorkspace(
+            LayerGroupInfo layerGroup, LayerInfo layer, WorkspaceInfo ws) {
         if (layer == null) return;
 
         ResourceInfo r = layer.getResource();
+
+        if (r == null) {
+            throw new IllegalArgumentException(
+                    "Layer group "
+                            + layerGroup.getName()
+                            + " references a layer ("
+                            + layer.getId()
+                            + ") without a proper Resource attached");
+        }
         if (r.getStore().getWorkspace() != null && !ws.equals(r.getStore().getWorkspace())) {
             throw new IllegalArgumentException(
                     "Layer group within a workspace ("

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2147,6 +2148,21 @@ public class CatalogImplTest extends GeoServerSystemTestSupport {
             fail();
         } catch (IllegalArgumentException expected) {
         }
+    }
+
+    @Test
+    public void testAddLayerGroupWithMissingResource() throws Exception {
+        addLayerGroup();
+
+        LayerGroupInfo lg2 = catalog.getFactory().createLayerGroup();
+        lg2.setName("layerGroup2");
+        lg2.getLayers().add(l);
+
+        CatalogFactory factory = catalog.getFactory();
+        LayerInfo l2 = factory.createLayer();
+        lg2.setWorkspace(ws);
+        lg2.getLayers().add(l2);
+        assertThrows(IllegalArgumentException.class, () -> catalog.add(lg2));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10514](https://badgen.net/badge/JIRA/GEOS-10514/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10514)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backporting GEOS-10514 to 2.21.x