### PR TITLE
[GEOS-10521] Allow GetFeatureInfo over raster layers to identify both original raster and transformed vectors

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/RasterSymbolizerVisitor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/RasterSymbolizerVisitor.java
@@ -153,18 +153,20 @@ public class RasterSymbolizerVisitor implements StyleVisitor {
                         && (fts.featureTypeNames().isEmpty()
                                 || fts.featureTypeNames().stream()
                                         .anyMatch(tn -> FeatureTypes.matches(featureType, tn)))) {
-            Expression tx = fts.getTransformation();
-            if (tx != null && activeRules(fts)) {
-                boolean rasterTransformation = false;
-                if (tx instanceof CoverageReadingTransformation)
-                    this.coverageReadingTransformation = (CoverageReadingTransformation) tx;
-                else if (tx instanceof Function) {
-                    rasterTransformation = isRasterTransformation(tx, rasterTransformation);
+            if (activeRules(fts)) {
+                Expression tx = fts.getTransformation();
+                if (tx != null) {
+                    boolean rasterTransformation = false;
+                    if (tx instanceof CoverageReadingTransformation)
+                        this.coverageReadingTransformation = (CoverageReadingTransformation) tx;
+                    else if (tx instanceof Function) {
+                        rasterTransformation = isRasterTransformation(tx, rasterTransformation);
+                    }
+                    if (!rasterTransformation) otherRenderingTransformations.add(tx);
                 }
-                if (!rasterTransformation) otherRenderingTransformations.add(tx);
-            }
-            for (Rule r : fts.rules()) {
-                r.accept(this);
+                for (Rule r : fts.rules()) {
+                    r.accept(this);
+                }
             }
         }
     }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -103,6 +103,11 @@ public class GetFeatureInfoTest extends WMSTestSupport {
     private static final String FOOTPRINTS_STYLE = "footprints";
 
     @Override
+    protected String getLogConfiguration() {
+        return "DEFAULT_LOGGING";
+    }
+
+    @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         super.onSetUp(testData);
         Logging.getLogger("org.geoserver.ows").setLevel(Level.OFF);

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/footprintsRaster.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/footprintsRaster.sld
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       version="1.0.0"
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <Name>test_layer</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Transformation>
+                    <ogc:Function name="footprints"/>
+                </Transformation>
+                <Rule>
+                    <PolygonSymbolizer/>
+                </Rule>
+            </FeatureTypeStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <RasterSymbolizer/>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/rasterVector.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/rasterVector.sld
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <Name>dem</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Transformation>
+                    <ogc:Function name="ras:RasterAsPointCollection">
+                        <ogc:Function name="parameter">
+                            <ogc:Literal>data</ogc:Literal>
+                        </ogc:Function>
+                    </ogc:Function>
+                </Transformation>
+                <Rule>
+                    <PointSymbolizer/>
+                </Rule>
+            </FeatureTypeStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <RasterSymbolizer/>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-10521](https://badgen.net/badge/JIRA/GEOS-10521/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10521)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->