### PR TITLE
[GEOS-10522] RestControllerAdvice report exception with null message

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemWatcher.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemWatcher.java
@@ -365,7 +365,7 @@ public class FileSystemWatcher implements ResourceNotificationDispatcher, Dispos
 
                 private void notify(Watch watch, Delta delta) {
                     if (LOGGER.isLoggable(Level.INFO)) {
-                        LOGGER.info(
+                        LOGGER.config(
                                 String.format(
                                         "Notifying %s change on %s. Created: %,d, removed: %,d, modified: %,d",
                                         delta.kind,

--- a/src/rest/src/test/java/org/geoserver/rest/ExceptionHandlingTest.java
+++ b/src/rest/src/test/java/org/geoserver/rest/ExceptionHandlingTest.java
@@ -6,6 +6,7 @@ package org.geoserver.rest;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.logging.Level;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.junit.Test;
@@ -18,6 +19,20 @@ public class ExceptionHandlingTest extends GeoServerSystemTestSupport {
         // no data needed for this test
     }
 
+    /*
+     * Override getAsServletResponse(path) to quiet RestControllerAdvice logger.
+     */
+    @Override
+    protected MockHttpServletResponse getAsServletResponse(String path) throws Exception {
+        Level level = RestControllerAdvice.LOGGER.getLevel();
+        RestControllerAdvice.LOGGER.setLevel(Level.OFF);
+        try {
+            return super.getAsServletResponse(path);
+        } finally {
+            RestControllerAdvice.LOGGER.setLevel(level);
+        }
+    }
+
     @Test
     public void testRestException() throws Exception {
         MockHttpServletResponse response =
@@ -25,6 +40,8 @@ public class ExceptionHandlingTest extends GeoServerSystemTestSupport {
                         RestBaseController.ROOT_PATH + "/exception?code=400&message=error");
         assertEquals(400, response.getStatus());
         assertEquals("text/plain", response.getContentType());
+        String txt = response.getContentAsString();
+        assertEquals("error", txt);
     }
 
     @Test
@@ -33,6 +50,8 @@ public class ExceptionHandlingTest extends GeoServerSystemTestSupport {
                 getAsServletResponse(RestBaseController.ROOT_PATH + "/error");
         assertEquals(500, response.getStatus());
         assertEquals("text/plain", response.getContentType());
+        String txt = response.getContentAsString();
+        assertEquals("An internal error occurred", txt);
     }
 
     @Test
@@ -41,5 +60,17 @@ public class ExceptionHandlingTest extends GeoServerSystemTestSupport {
                 getAsServletResponse(RestBaseController.ROOT_PATH + "/notfound");
         assertEquals(404, response.getStatus());
         assertEquals("text/plain", response.getContentType());
+        String txt = response.getContentAsString();
+        assertEquals("I'm not there", txt);
+    }
+
+    @Test
+    public void testNullPointerException() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(RestBaseController.ROOT_PATH + "/npe");
+        assertEquals(500, response.getStatus());
+        assertEquals("text/plain", response.getContentType());
+        String txt = response.getContentAsString();
+        assertEquals("", txt);
     }
 }

--- a/src/rest/src/test/java/org/geoserver/rest/ExceptionThrowingController.java
+++ b/src/rest/src/test/java/org/geoserver/rest/ExceptionThrowingController.java
@@ -36,4 +36,10 @@ public class ExceptionThrowingController {
     public void handleNotFound() {
         throw new ResourceNotFoundException("I'm not there");
     }
+
+    @GetMapping
+    @RequestMapping(path = RestBaseController.ROOT_PATH + "/npe")
+    public void handleNPE() {
+        throw new NullPointerException();
+    }
 }


### PR DESCRIPTION
[![GEOS-10522](https://badgen.net/badge/JIRA/GEOS-10522/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10522)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Check RestControllerAdvise handling of exceptions with null message, added an example to ExceptionHandlingTest (and quieted log messages for this test).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->