### PR TITLE
[GEOS-10528] Empty groupList tag remains after group deletion

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
@@ -210,7 +210,7 @@ public abstract class AbstractRoleStore implements GeoServerRoleStore {
             roles.remove(role);
             setModified(true);
         }
-        if (helper.group_roleMap.get(groupname) != null && roles != null && roles.size() == 0) {
+        if (helper.group_roleMap.get(groupname) != null && roles != null && roles.isEmpty()) {
             helper.group_roleMap.remove(groupname);
         }
     }

--- a/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
@@ -210,6 +210,9 @@ public abstract class AbstractRoleStore implements GeoServerRoleStore {
             roles.remove(role);
             setModified(true);
         }
+        if (helper.group_roleMap.get(groupname) != null && roles != null && roles.size() == 0) {
+            helper.group_roleMap.remove(groupname);
+        }
     }
 
     /* (non-Javadoc)

--- a/src/security/security-tests/src/test/java/org/geoserver/security/xml/XMLRoleServiceTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/xml/XMLRoleServiceTest.java
@@ -305,4 +305,43 @@ public class XMLRoleServiceTest extends AbstractRoleServiceTest {
             xmlFile.delete();
         }
     }
+
+    @Test
+    public void testDisAssociateRoleFromGroup() throws Exception {
+        Files.schedule(200, TimeUnit.MILLISECONDS);
+        File xmlFile = File.createTempFile("roles2", ".xml");
+        try {
+            FileUtils.copyURLToFile(getClass().getResource("rolesTemplate.xml"), xmlFile);
+            GeoServerRoleService service1 =
+                    createRoleService("disassociateRoleFromGroup", xmlFile.getCanonicalPath());
+
+            GeoServerRoleStore store1 = createStore(service1);
+
+            GeoServerRole role_test1 = store1.createRoleObject("ROLE_TEST1");
+            GeoServerRole role_test2 = store1.createRoleObject("ROLE_TEST2");
+
+            checkEmpty(service1);
+
+            store1.addRole(role_test1);
+            store1.addRole(role_test2);
+            store1.store();
+            assertEquals(2, service1.getRoles().size());
+
+            String group = "group1";
+            store1.associateRoleToGroup(role_test1, group);
+            store1.associateRoleToGroup(role_test2, group);
+            store1.store();
+
+            store1.disAssociateRoleFromGroup(role_test1, group);
+            store1.disAssociateRoleFromGroup(role_test2, group);
+            store1.store();
+            String xmlContent = new String(java.nio.file.Files.readAllBytes(xmlFile.toPath()));
+            // check for empty grouplist
+            assertTrue(xmlContent.contains("<groupList/>"));
+
+        } finally {
+            Files.schedule(10, TimeUnit.SECONDS);
+            xmlFile.delete();
+        }
+    }
 }


### PR DESCRIPTION
[![GEOS-10528](https://badgen.net/badge/JIRA/GEOS-10528/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10528)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We noticed that, in when using XML storage for roles, pressing `Remove Selected and remove role associations`, truly removes the group and role associations, but on inspecting the `roles.xml` file, we found an empty user groups tag is still there.

This can create confusion for the system administrators, since the empty tag need not be there anymore.

In this PR, we remove the `groupList` in the above-mentioned case.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->