### PR TITLE
[GEOS-10532] FreeMarkerTemplateManager: a few changes for subclassing

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
@@ -49,7 +49,7 @@ public abstract class FreeMarkerTemplateManager {
     /** Config key determining the restrictions for accessing static members */
     static final String KEY_STATIC_MEMBER_ACCESS = "org.geoserver.htmlTemplates.staticMemberAccess";
 
-    enum OutputFormat {
+    public enum OutputFormat {
         JSON("application/json"),
         HTML("text/html");
 
@@ -206,9 +206,13 @@ public abstract class FreeMarkerTemplateManager {
             return true;
 
         } finally {
-            // close any open iterators
-            tfcFactory.purge();
+            cleanup();
         }
+    }
+
+    public void cleanup() {
+        // close any open iterators
+        tfcFactory.purge();
     }
 
     /**
@@ -253,7 +257,8 @@ public abstract class FreeMarkerTemplateManager {
         return content;
     }
 
-    private Template getTemplate(ResourceInfo ri, Charset charset, String name) throws IOException {
+    protected Template getTemplate(ResourceInfo ri, Charset charset, String name)
+            throws IOException {
         String templateName = getTemplateFileName(name);
         return getTemplate(ri, templateName, charset);
     }


### PR DESCRIPTION
[![GEOS-10532](https://badgen.net/badge/JIRA/GEOS-10532/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10532)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10532]: FreemarkerTemplateManager changes for subclassing

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->