### PR TITLE
[GEOS-10534] a badly formed delete transaction will get a NPE instead of an informative error message

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/DeleteElementHandler.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/DeleteElementHandler.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
 import org.geoserver.config.GeoServer;
@@ -79,6 +80,7 @@ public class DeleteElementHandler extends AbstractTransactionElementHandler {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void execute(
             TransactionElement delete,
@@ -92,7 +94,15 @@ public class DeleteElementHandler extends AbstractTransactionElementHandler {
         String handle = delete.getHandle();
 
         long deleted = response.getTotalDeleted().longValue();
-
+        if (!featureStores.containsKey(elementName)) {
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("failed to find " + elementName + " in:");
+                for (QName key : (Set<QName>) featureStores.keySet()) {
+                    LOGGER.finer("\t" + key.toString());
+                }
+            }
+            throw new WFSException("Unable to locate a featureStore for " + elementName);
+        }
         SimpleFeatureStore store =
                 DataUtilities.simple((FeatureStore) featureStores.get(elementName));
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/TransactionTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/TransactionTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -1067,5 +1068,31 @@ public class TransactionTest extends WFSTestSupport {
                 + "    </xxx_all_service_city>\n"
                 + "  </Insert>\n"
                 + "</Transaction>";
+    }
+
+    @Test
+    public void testBrokenDelete() throws Exception {
+        try {
+            // perform a delete
+            String delete =
+                    "<wfs:Transaction service=\"WFS\" version=\"1.0.0\" "
+                            + "xmlns:cgf=\"Not a URI\" "
+                            + "xmlns:ogc=\"http://www.opengis.net/ogc\" "
+                            + "xmlns:wfs=\"http://www.opengis.net/wfs\"> "
+                            + "<wfs:Delete typeName=\"cgf:Points\"> "
+                            + "<ogc:Filter> "
+                            + "<ogc:PropertyIsEqualTo> "
+                            + "<ogc:PropertyName>cgf:id</ogc:PropertyName> "
+                            + "<ogc:Literal>t0000</ogc:Literal> "
+                            + "</ogc:PropertyIsEqualTo> "
+                            + "</ogc:Filter> "
+                            + "</wfs:Delete> "
+                            + "</wfs:Transaction>";
+
+            Document dom = postAsDOM("wfs", delete);
+            assertEquals("ServiceExceptionReport", dom.getDocumentElement().getLocalName());
+        } catch (Exception e) {
+            fail("Should not throw an exception");
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-10534](https://badgen.net/badge/JIRA/GEOS-10534/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10534)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->