### PR TITLE
[GEOS-10536] Security - oauth2 oidc - changes for keycloak server

### DIFF
--- a/src/community/security/oauth2-core/pom.xml
+++ b/src/community/security/oauth2-core/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.0.16.RELEASE</version>
+      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2-openid-connect/pom.xml
+++ b/src/community/security/oauth2-openid-connect/pom.xml
@@ -38,11 +38,14 @@
       <artifactId>gs-sec-oauth2-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.0.16.RELEASE</version>
+      <version>2.5.2.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/src/community/security/oauth2-openid-connect/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
+++ b/src/community/security/oauth2-openid-connect/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
@@ -9,14 +9,13 @@ package org.geoserver.security.oauth2;
 import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.AccessToken;
 import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.IdToken;
 
+import com.jayway.jsonpath.JsonPath;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import javax.servlet.http.HttpServletRequest;
-import net.sf.json.JSONObject;
-import net.sf.json.JSONSerializer;
 import org.geoserver.security.config.RoleSource;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.impl.GeoServerRole;
@@ -69,6 +68,15 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
         return super.getRoles(request, principal);
     }
 
+    static Object extractFromJSON(String json, String path) {
+        try {
+            return JsonPath.read(json, path);
+        } catch (Exception e) {
+            // do nothing - the ID Token doesn't have that attribute - handled later with o=null
+            return null;
+        }
+    }
+
     private Collection<GeoServerRole> getRolesFromToken(String token) throws IOException {
         if (token == null) {
             LOGGER.warning("Token not found, cannot perform role extraction");
@@ -76,10 +84,9 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
         }
         Jwt decoded = JwtHelper.decode(token);
         String claims = decoded.getClaims();
-        JSONObject json = (JSONObject) JSONSerializer.toJSON(claims);
-        String rolesAttribute =
+        String rolesAttributePath =
                 ((OpenIdConnectFilterConfig) this.filterConfig).getTokenRolesClaim();
-        Object o = json.get(rolesAttribute);
+        Object o = extractFromJSON(claims, rolesAttributePath);
         List<GeoServerRole> result = new ArrayList<>();
         if (o instanceof String) {
             result.add(new GeoServerRole((String) o));
@@ -89,14 +96,14 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
             LOGGER.log(
                     Level.WARNING,
                     "Was expecting to find a list of strings or a single value in "
-                            + rolesAttribute
+                            + rolesAttributePath
                             + ", but it was something else: "
                             + o);
         } else {
             LOGGER.log(
                     Level.FINE,
                     "Did not find "
-                            + rolesAttribute
+                            + rolesAttributePath
                             + "in the token, returning an empty role list");
         }
 

--- a/src/community/security/oauth2-openid-connect/src/test/java/org/geoserver/security/oauth2/OAuth2FilterConfigValidatorTest.java
+++ b/src/community/security/oauth2-openid-connect/src/test/java/org/geoserver/security/oauth2/OAuth2FilterConfigValidatorTest.java
@@ -14,9 +14,14 @@
 package org.geoserver.security.oauth2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
+import junit.framework.TestCase;
 import org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource;
 import org.geoserver.security.validation.FilterConfigException;
 import org.geoserver.test.GeoServerMockTestSupport;
@@ -169,5 +174,25 @@ public class OAuth2FilterConfigValidatorTest extends GeoServerMockTestSupport {
         config.setScopes("email,profile");
 
         validator.validateOAuth2FilterConfig(config);
+    }
+
+    @Test
+    public void testExtractFromJSON() {
+        String json = "{\"a\":{\"b\":[\"d\",\"e\"]}}";
+
+        // bad path
+        Object o = OpenIdConnectAuthenticationFilter.extractFromJSON(json, "aaaaa");
+        assertNull(o);
+
+        // path to {"b":["d","e"]}
+        o = OpenIdConnectAuthenticationFilter.extractFromJSON(json, "a");
+        assertTrue(o instanceof Map);
+
+        // path to ["d","e"]
+        o = OpenIdConnectAuthenticationFilter.extractFromJSON(json, "a.b");
+        assertTrue(o instanceof List);
+        assertSame(2, ((List) o).size());
+        TestCase.assertEquals("d", ((List) o).get(0));
+        TestCase.assertEquals("e", ((List) o).get(1));
     }
 }


### PR DESCRIPTION
[![GEOS-10536](https://badgen.net/badge/JIRA/GEOS-10536/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10536)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I tested the current oauth2-openid-connect community module against keycloak acting as an oidc server.

There were two problems (GEOS-10536);

a) The spring oauth2 library was giving an error with the token that keycloak was returning - "enc (use) is currently not supported"
     + This is fixed in later spring oauth2 libraries (it ignores these types of tokens)
     + FIX: update to a newer (2.0.16.RELEASE -> 2.5.2.RELEASE) spring oauth2 library
     + The spring oauth2 module is only used in the oauth2 community modules, so this should be "safe" for the rest of GS

b) Keycloak, by default, will put the roles in the ID Token in a path like "resource_access.CLIENT_NAME.roles"
     + The current oauth2 library only supports a simple (one level) path for the roles list (i.e. "roles" or "group")
     + I added support for a json path
     + To do this, I added a dependency on  com.jayway.jsonpath (which I took from the main GS pom.xml)
     + I added a test case
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [n/a] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [n/a ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [GEOS-10536] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->