### PR TITLE
[GEOS-10513] Coverage API Temporal Problems With Input and Retrieval

### DIFF
--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/DomainSetBuilder.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/DomainSetBuilder.java
@@ -1,0 +1,166 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.coverages;
+
+import static org.geoserver.ogcapi.coverages.CoveragesService.CRS_PREFIX;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.ogcapi.APIException;
+import org.geoserver.ogcapi.coverages.cis.Axis;
+import org.geoserver.ogcapi.coverages.cis.DomainSet;
+import org.geoserver.ogcapi.coverages.cis.GeneralGrid;
+import org.geoserver.ogcapi.coverages.cis.GridLimits;
+import org.geoserver.ogcapi.coverages.cis.IndexAxis;
+import org.geoserver.ogcapi.coverages.cis.IrregularAxis;
+import org.geoserver.ogcapi.coverages.cis.RegularAxis;
+import org.geoserver.wcs2_0.util.EnvelopeAxesLabelsMapper;
+import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.opengis.coverage.grid.GridEnvelope;
+import org.opengis.coverage.grid.GridGeometry;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.cs.CoordinateSystem;
+import org.opengis.referencing.cs.CoordinateSystemAxis;
+import org.springframework.http.HttpStatus;
+import tech.units.indriya.format.SimpleUnitFormat;
+
+class DomainSetBuilder {
+
+    private static final String TIME_AXIS = "Time";
+    private final CoverageInfo coverage;
+
+    public DomainSetBuilder(CoverageInfo coverage) {
+        this.coverage = coverage;
+    }
+
+    public DomainSet build() throws IOException, FactoryException {
+        EnvelopeAxesLabelsMapper mapper = new EnvelopeAxesLabelsMapper();
+        CoordinateReferenceSystem crs = coverage.getCRS();
+        String srsName = CRS_PREFIX + CRS.lookupEpsgCode(crs, false);
+
+        // check coordinate system is supported
+        CoordinateSystem cs = crs.getCoordinateSystem();
+        if (cs.getDimension() > 2)
+            throw new APIException(
+                    APIException.NO_APPLICABLE_CODE,
+                    "Too many dimensions, cannot describe domain",
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+
+        // map CRS to domain axis
+        List<Axis> domainAxes = new ArrayList<>();
+        for (int i = 0; i < cs.getDimension(); i++) {
+            domainAxes.add(toRegularAxis(cs.getAxis(i), mapper, coverage, i));
+        }
+
+        // map CRS to index axis
+        List<IndexAxis> indexAxes = new ArrayList<>();
+        for (int i = 0; i < cs.getDimension(); i++) {
+            indexAxes.add(toIndexAxis(i, coverage));
+        }
+
+        // handle time as well
+        DimensionInfo time = coverage.getMetadata().get(ResourceInfo.TIME, DimensionInfo.class);
+        if (time != null) {
+            GridCoverage2DReader reader =
+                    (GridCoverage2DReader) coverage.getGridCoverageReader(null, null);
+            TimeDimensionHelper helper = new TimeDimensionHelper(time, reader);
+            switch (time.getPresentation()) {
+                case CONTINUOUS_INTERVAL:
+                case DISCRETE_INTERVAL:
+                    RegularAxis regular = toRegularTimeAxis(helper);
+                    domainAxes.add(regular);
+                    indexAxes.add(toIndexAxis(indexAxes.size(), helper));
+                    break;
+                default:
+                    IrregularAxis irregular = toIrregularTimeAxis(helper);
+                    domainAxes.add(irregular);
+                    indexAxes.add(toIndexAxis(indexAxes.size(), irregular));
+            }
+        }
+
+        List<String> domainAxisLabels =
+                domainAxes.stream().map(a -> a.getAxisLabel()).collect(Collectors.toList());
+        List<String> indexAxisLabels =
+                indexAxes.stream().map(a -> a.getAxisLabel()).collect(Collectors.toList());
+        GridLimits limits = new GridLimits(indexAxisLabels, indexAxes);
+        GeneralGrid gg = new GeneralGrid(srsName, domainAxisLabels, domainAxes, limits);
+        return new DomainSet(gg);
+    }
+
+    private IrregularAxis toIrregularTimeAxis(TimeDimensionHelper helper) throws IOException {
+        return new IrregularAxis(TIME_AXIS, helper.getFormattedDomain(), "s");
+    }
+
+    private RegularAxis toRegularTimeAxis(TimeDimensionHelper helper) throws IOException {
+        return new RegularAxis(
+                TIME_AXIS,
+                helper.getFormattedBegin(),
+                helper.getFormattedEnd(),
+                helper.getResolutionValue(),
+                helper.getResolutionUnit());
+    }
+
+    private RegularAxis toRegularAxis(
+            CoordinateSystemAxis axis,
+            EnvelopeAxesLabelsMapper mapper,
+            CoverageInfo coverage,
+            int axisIndex) {
+        double lowerBound, upperBound, resolution;
+        ReferencedEnvelope envelope = coverage.getNativeBoundingBox();
+        GridGeometry grid = coverage.getGrid();
+        if (axisIndex == 0 || axisIndex == 1) {
+            lowerBound = envelope.getMinimum(axisIndex);
+            upperBound = envelope.getMaximum(axisIndex);
+            resolution = (upperBound - lowerBound) / grid.getGridRange().getSpan(axisIndex);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Cannot describe a coverage with a CRS having "
+                            + (axisIndex + 1)
+                            + " dimensions");
+        }
+
+        return new RegularAxis(
+                mapper.getAxisLabel(axis),
+                lowerBound,
+                upperBound,
+                resolution,
+                SimpleUnitFormat.getInstance().format(axis.getUnit()));
+    }
+
+    private IndexAxis toIndexAxis(int axisIndex, CoverageInfo coverage) {
+        String name = indexAxisName(axisIndex);
+        GridEnvelope range = coverage.getGrid().getGridRange();
+        return new IndexAxis(name, range.getLow(axisIndex), range.getHigh(axisIndex));
+    }
+
+    private String indexAxisName(int axisIndex) {
+        return new String(new char[] {(char) ('i' + axisIndex)});
+    }
+
+    private IndexAxis toIndexAxis(int axisIndex, IrregularAxis axis) {
+        String name = indexAxisName(axisIndex);
+        return new IndexAxis(name, 0, axis.getCoordinate().size());
+    }
+
+    private IndexAxis toIndexAxis(int axisIndex, TimeDimensionHelper helper) throws IOException {
+        String name = indexAxisName(axisIndex);
+        long range = helper.getEnd().getTime() - helper.getBegin().getTime();
+        BigDecimal rm = helper.getResolutionMillis();
+        if (rm == null) {
+            // assume second resolution
+            rm = BigDecimal.valueOf(1000);
+        }
+        return new IndexAxis(name, 0, (int) (range / rm.longValue()));
+    }
+}

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/TimeDimensionHelper.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/TimeDimensionHelper.java
@@ -3,18 +3,22 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.wcs2_0.response;
+package org.geoserver.ogcapi.coverages;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.catalog.util.ReaderDimensionsAccessor;
 import org.geoserver.util.ISO8601Formatter;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.util.DateRange;
 import org.geotools.util.logging.Logging;
 import org.vfny.geoserver.wcs.WcsException;
 
@@ -30,37 +34,38 @@ class TimeDimensionHelper {
     /** Duration in ms of well know time periods */
     static final BigDecimal[] DURATIONS = {
         new BigDecimal(31536000000L),
-        new BigDecimal(2628000000L),
         new BigDecimal(86400000L),
         new BigDecimal(3600000L),
         new BigDecimal(60000),
         new BigDecimal(1000L)
     };
 
+    private static final String SECONDS = "s";
+    private static final String DAY = "d";
     /** Labels for teh above time periods */
-    static final String[] DURATION_UNITS = {"year", "month", "day", "hour", "minute", "second"};
+    static final String[] DURATION_UNITS = {"y", DAY, "h", "min", SECONDS};
 
     DimensionInfo timeDimension;
 
     ReaderDimensionsAccessor accessor;
 
-    ISO8601Formatter formatter = new ISO8601Formatter();
+    ISO8601Formatter timeStampFormatter = new ISO8601Formatter();
+    SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
 
     String resolutionUnit;
 
     long resolutionValue;
 
-    String coverageId;
-
-    public TimeDimensionHelper(
-            DimensionInfo timeDimension, GridCoverage2DReader reader, String coverageId)
+    public TimeDimensionHelper(DimensionInfo timeDimension, GridCoverage2DReader reader)
             throws IOException {
         this.timeDimension = timeDimension;
         this.accessor = new ReaderDimensionsAccessor(reader);
-        this.coverageId = coverageId;
 
         if (timeDimension.getResolution() != null) {
             setupResolution(timeDimension.getResolution());
+        } else {
+            resolutionValue = 1;
+            resolutionUnit = SECONDS;
         }
     }
 
@@ -76,7 +81,7 @@ class TimeDimensionHelper {
         // uh oh? it's a value in milliseconds?
         throw new WcsException(
                 "Dimension's resolution requires milliseconds for full representation, "
-                        + "but this cannot be represented in WCS 2.0 describe coverage output");
+                        + "but this cannot be represented in the domain set output");
     }
 
     public DimensionInfo getTimeDimension() {
@@ -87,22 +92,51 @@ class TimeDimensionHelper {
         return accessor.getTimeDomain();
     }
 
+    public List<String> getFormattedDomain() throws IOException {
+        return accessor.getTimeDomain().stream().map(t -> format(t)).collect(Collectors.toList());
+    }
+
     /** Returns the minimum time, formatted according to ISO8601 */
-    public String getBeginPosition() throws IOException {
-        Date minTime = accessor.getMinTime();
+    public String getFormattedBegin() throws IOException {
+        Date minTime = getBegin();
         return format(minTime);
     }
 
+    public Date getBegin() throws IOException {
+        return accessor.getMinTime();
+    }
+
     /** Returns the maximum time, formatted according to ISO8601 */
-    public String getEndPosition() throws IOException {
-        Date maxTime = accessor.getMaxTime();
+    public String getFormattedEnd() throws IOException {
+        Date maxTime = getEnd();
         return format(maxTime);
+    }
+
+    public Date getEnd() throws IOException {
+        return accessor.getMaxTime();
+    }
+
+    private String format(Object time) {
+        if (time instanceof Date) {
+            return format((Date) time);
+        } else if (time instanceof DateRange) {
+            // hack, we should probably look into description of partitioned coverages?
+            // or report the mid time?
+            DateRange range = (DateRange) time;
+            return timeStampFormatter.format(range.getMinValue())
+                    + "/"
+                    + timeStampFormatter.format(range.getMaxValue());
+        }
+
+        return null;
     }
 
     /** Formats a Date into ISO86011 */
     public String format(Date time) {
-        if (time != null) {
-            return formatter.format(time);
+        if (time instanceof java.sql.Date) {
+            return dateFormatter.format(time);
+        } else if (time != null) {
+            return timeStampFormatter.format(time);
         } else {
             return null;
         }
@@ -126,8 +160,7 @@ class TimeDimensionHelper {
         return resolutionValue;
     }
 
-    /** The coverage identifier */
-    public String getCoverageId() {
-        return coverageId;
+    public BigDecimal getResolutionMillis() {
+        return timeDimension.getResolution();
     }
 }

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/GeneralGrid.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/GeneralGrid.java
@@ -15,14 +15,11 @@ public class GeneralGrid {
     private String type = "GeneralGridCoverageType";
     private String srsName;
     private List<String> axisLabels;
-    private List<RegularAxis> axis;
+    private List<Axis> axis;
     private GridLimits gridLimits;
 
     public GeneralGrid(
-            String srsName,
-            List<String> axisLabels,
-            List<RegularAxis> axis,
-            GridLimits gridLimits) {
+            String srsName, List<String> axisLabels, List<Axis> axis, GridLimits gridLimits) {
         this.srsName = srsName;
         this.axisLabels = axisLabels;
         this.axis = axis;
@@ -41,7 +38,7 @@ public class GeneralGrid {
         return axisLabels;
     }
 
-    public List<RegularAxis> getAxis() {
+    public List<Axis> getAxis() {
         return axis;
     }
 

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/IndexAxis.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/IndexAxis.java
@@ -11,7 +11,7 @@ public class IndexAxis extends Axis {
     Integer upperBound;
 
     public IndexAxis(String axisLabel, Integer lowerBound, Integer upperBound) {
-        super("IndexAxis", axisLabel);
+        super("IndexAxisType", axisLabel);
         this.lowerBound = lowerBound;
         this.upperBound = upperBound;
     }

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/IrregularAxis.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/IrregularAxis.java
@@ -1,0 +1,31 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.coverages.cis;
+
+import java.util.List;
+
+/**
+ * An irregular axis enumerates all possible direct position coordinates. Coordinates are Objects as
+ * they can be both numbers and ISO times too.
+ */
+public class IrregularAxis extends Axis {
+
+    private final List<?> coordinate;
+    private final String uomLabel;
+
+    public IrregularAxis(String axisLabel, List<?> coordinate, String uomLabel) {
+        super("IrregularAxisType", axisLabel);
+        this.coordinate = coordinate;
+        this.uomLabel = uomLabel;
+    }
+
+    public List<?> getCoordinate() {
+        return coordinate;
+    }
+
+    public String getUomLabel() {
+        return uomLabel;
+    }
+}

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/RegularAxis.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/cis/RegularAxis.java
@@ -6,7 +6,8 @@ package org.geoserver.ogcapi.coverages.cis;
 
 /**
  * A Regular Axis is an axis where all direct coordinates are at a common distance from its
- * immediate neighbors. Upper and lower bounds are strings as they can be ISO times too.
+ * immediate neighbors. Upper and lower bounds are Objects as they can be both numbers and ISO
+ * times.
  */
 public class RegularAxis extends Axis {
 
@@ -21,7 +22,7 @@ public class RegularAxis extends Axis {
             Object upperBound,
             double resolution,
             String uomLabel) {
-        super("RegularAxis", axisLabel);
+        super("RegularAxisType", axisLabel);
         this.lowerBound = lowerBound;
         this.upperBound = upperBound;
         this.resolution = resolution;

--- a/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/coverages/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/coverages/collection_include.ftl
@@ -7,13 +7,17 @@
       <li><b>Description</b>: <span id="${collection.htmlId}_description">${collection.description!}</span><br/></li>
       </#if>
       <#assign spatial = collection.extent.spatial>
-      <li><b>Geographic extents</b>:
+      <li id="${collection.htmlId}_spatial"><b>Geographic extents</b>:
       <ul>
       <#list spatial as se>
       <li>${se.getMinX()}, ${se.getMinY()}, ${se.getMaxX()}, ${se.getMaxY()}.</li>
       </#list>
       </ul>
       </li>
+      <#if collection.extent.temporal??>
+      <#assign temporal = collection.extent.temporal>
+      <li id="${collection.htmlId}_temporal"><b>Temporal extent</b>: ${temporal.minValue?datetime?iso_utc}/${temporal.maxValue?datetime?iso_utc}</li>
+      </#if>
   </ul>
 </div>
 <div class="card-footer">

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/CollectionTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.ogcapi.coverages;
 
+import static org.geoserver.catalog.ResourceInfo.TIME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -13,6 +14,7 @@ import com.jayway.jsonpath.DocumentContext;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.ogcapi.APIDispatcher;
 import org.geoserver.platform.GeoServerExtensions;
 import org.junit.Test;
@@ -86,7 +88,7 @@ public class CollectionTest extends CoveragesTestSupport {
     }
 
     @Test
-    public void testCollectionsHTML() throws Exception {
+    public void testCollectionHTML() throws Exception {
         org.jsoup.nodes.Document document = getAsJSoup("ogc/coverages/collections/rs:DEM?f=html");
 
         String tazDemName = "rs:DEM";
@@ -102,5 +104,28 @@ public class CollectionTest extends CoveragesTestSupport {
                 "http://localhost:8080/geoserver/ogc/coverages/collections/rs:DEM"
                         + "/coverage?f=image%2Fgeotiff",
                 document.select("#html_" + tazDemHtmlId + "_link").attr("href"));
+
+        // check temporal and spatial extent (time should not be there)
+        assertEquals(
+                "Geographic extents: 145, -43, 146, -41.",
+                document.select("#" + tazDemHtmlId + "_spatial").text());
+        assertEquals("", document.select("#" + tazDemHtmlId + "_temporal").text());
+    }
+
+    @Test
+    public void testTemporalCollectionHTML() throws Exception {
+        setupRasterDimension(TIMESERIES, TIME, DimensionPresentation.LIST, null, null, null);
+        org.jsoup.nodes.Document document =
+                getAsJSoup("ogc/coverages/collections/sf:timeseries?f=html");
+
+        String id = getLayerId(TIMESERIES).replace(":", "__");
+
+        // check temporal and spatial extent
+        assertEquals(
+                "Geographic extents: 0.237, 40.562, 14.593, 44.558.",
+                document.select("#" + id + "_spatial").text());
+        assertEquals(
+                "Temporal extent: 2014-01-01T00:00:00Z/2019-01-01T00:00:00Z",
+                document.select("#" + id + "_temporal").text());
     }
 }

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/CoveragesTestSupport.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/CoveragesTestSupport.java
@@ -5,9 +5,11 @@
 package org.geoserver.ogcapi.coverages;
 
 import java.util.Arrays;
+import javax.xml.namespace.QName;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.ogcapi.OGCApiTestSupport;
 
@@ -15,6 +17,8 @@ public class CoveragesTestSupport extends OGCApiTestSupport {
 
     protected static final String TAZDEM_TITLE = "Down under digital elevation model";
     protected static final String TAZDEM_DESCRIPTION = "So that you know where up and down are";
+    protected static final QName TIMESERIES =
+            new QName(MockData.SF_URI, "timeseries", MockData.SF_PREFIX);
 
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
@@ -39,5 +43,8 @@ public class CoveragesTestSupport extends OGCApiTestSupport {
         tazDem.setAbstract(TAZDEM_DESCRIPTION);
         tazDem.getResponseSRS().addAll(Arrays.asList("3857", "3003"));
         getCatalog().save(tazDem);
+
+        // add temporal layer
+        testData.addRasterLayer(TIMESERIES, "timeseries.zip", null, getCatalog());
     }
 }

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/DomainSetTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/DomainSetTest.java
@@ -4,10 +4,17 @@
  */
 package org.geoserver.ogcapi.coverages;
 
+import static org.geoserver.catalog.DimensionPresentation.CONTINUOUS_INTERVAL;
+import static org.geoserver.catalog.DimensionPresentation.DISCRETE_INTERVAL;
+import static org.geoserver.catalog.ResourceInfo.TIME;
 import static org.junit.Assert.assertEquals;
 
 import com.jayway.jsonpath.DocumentContext;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.geoserver.catalog.DimensionPresentation;
 import org.junit.Test;
 
 public class DomainSetTest extends CoveragesTestSupport {
@@ -28,7 +35,7 @@ public class DomainSetTest extends CoveragesTestSupport {
         assertEquals(Arrays.asList("Long", "Lat"), generalGrid.read("axisLabels"));
 
         DocumentContext longAxis = readContext(generalGrid, "axis[0]");
-        assertEquals("RegularAxis", longAxis.read("type"));
+        assertEquals("RegularAxisType", longAxis.read("type"));
         assertEquals("Long", longAxis.read("axisLabel"));
         assertEquals(145, longAxis.read("lowerBound", Double.class), EPS);
         assertEquals(146, longAxis.read("upperBound", Double.class), EPS);
@@ -36,7 +43,7 @@ public class DomainSetTest extends CoveragesTestSupport {
         assertEquals("deg", longAxis.read("uomLabel"));
 
         DocumentContext latAxis = readContext(generalGrid, "axis[1]");
-        assertEquals("RegularAxis", latAxis.read("type"));
+        assertEquals("RegularAxisType", latAxis.read("type"));
         assertEquals("Lat", latAxis.read("axisLabel"));
         assertEquals(-43, latAxis.read("lowerBound", Double.class), EPS);
         assertEquals(-41, latAxis.read("upperBound", Double.class), EPS);
@@ -49,15 +56,126 @@ public class DomainSetTest extends CoveragesTestSupport {
         assertEquals(Arrays.asList("i", "j"), gridLimits.read("axisLabels"));
 
         DocumentContext iAxis = readContext(gridLimits, "axis[0]");
-        assertEquals("IndexAxis", iAxis.read("type"));
+        assertEquals("IndexAxisType", iAxis.read("type"));
         assertEquals("i", iAxis.read("axisLabel"));
         assertEquals(0, (int) iAxis.read("lowerBound", Integer.class));
         assertEquals(119, (int) iAxis.read("upperBound", Integer.class));
 
         DocumentContext jAxis = readContext(gridLimits, "axis[1]");
-        assertEquals("IndexAxis", jAxis.read("type"));
+        assertEquals("IndexAxisType", jAxis.read("type"));
         assertEquals("j", jAxis.read("axisLabel"));
         assertEquals(0, (int) jAxis.read("lowerBound", Integer.class));
         assertEquals(239, (int) jAxis.read("upperBound", Integer.class));
+    }
+
+    @Test
+    public void testTimeListPresentation() throws Exception {
+        setupRasterDimension(TIMESERIES, TIME, DimensionPresentation.LIST, null, null, null);
+
+        DocumentContext domain =
+                getAsJSONPath("ogc/coverages/collections/sf:timeseries/coverage/domainset", 200);
+
+        // root properties
+        assertEquals("DomainSetType", domain.read("type"));
+
+        // model domain description
+        DocumentContext generalGrid = readContext(domain, "generalGrid");
+        assertEquals("http://www.opengis.net/def/crs/EPSG/0/4326", generalGrid.read("srsName"));
+        assertEquals(Arrays.asList("Long", "Lat", "Time"), generalGrid.read("axisLabels"));
+
+        // focus on the time axis
+        DocumentContext timeAxis = readContext(generalGrid, "axis[2]");
+        assertEquals("IrregularAxisType", timeAxis.read("type"));
+        assertEquals("Time", timeAxis.read("axisLabel"));
+        assertEquals("s", timeAxis.read("uomLabel"));
+        List<String> expectedTimes =
+                IntStream.range(2014, 2020)
+                        .mapToObj(y -> y + "-01-01T00:00:00.000Z")
+                        .collect(Collectors.toList());
+        assertEquals(expectedTimes, timeAxis.read("coordinate"));
+
+        // check the grid representation
+        DocumentContext gridLimits = readContext(generalGrid, "gridLimits");
+        assertEquals("http://www.opengis.net/def/crs/OGC/0/Index3D", gridLimits.read("srsName"));
+        assertEquals(Arrays.asList("i", "j", "k"), gridLimits.read("axisLabels"));
+
+        DocumentContext kAxis = readContext(gridLimits, "axis[2]");
+        assertEquals("IndexAxisType", kAxis.read("type"));
+        assertEquals("k", kAxis.read("axisLabel"));
+        assertEquals(0, (int) kAxis.read("lowerBound", Integer.class));
+        assertEquals(6, (int) kAxis.read("upperBound", Integer.class));
+    }
+
+    @Test
+    public void testTimeIntervalPresentation() throws Exception {
+        double oneYear = 1000d * 60 * 60 * 24 * 365;
+        setupRasterDimension(TIMESERIES, TIME, DISCRETE_INTERVAL, oneYear, null, "s");
+
+        DocumentContext domain =
+                getAsJSONPath("ogc/coverages/collections/sf:timeseries/coverage/domainset", 200);
+
+        // root properties
+        assertEquals("DomainSetType", domain.read("type"));
+
+        // model domain description
+        DocumentContext generalGrid = readContext(domain, "generalGrid");
+        assertEquals("http://www.opengis.net/def/crs/EPSG/0/4326", generalGrid.read("srsName"));
+        assertEquals(Arrays.asList("Long", "Lat", "Time"), generalGrid.read("axisLabels"));
+
+        // focus on the time axis
+        DocumentContext timeAxis = readContext(generalGrid, "axis[2]");
+        assertEquals("RegularAxisType", timeAxis.read("type"));
+        assertEquals("Time", timeAxis.read("axisLabel"));
+        assertEquals("y", timeAxis.read("uomLabel"));
+        assertEquals(1, (int) timeAxis.read("resolution", Integer.class));
+        assertEquals("2014-01-01T00:00:00.000Z", timeAxis.read("lowerBound"));
+        assertEquals("2019-01-01T00:00:00.000Z", timeAxis.read("upperBound"));
+
+        // check the grid representation
+        DocumentContext gridLimits = readContext(generalGrid, "gridLimits");
+        assertEquals("http://www.opengis.net/def/crs/OGC/0/Index3D", gridLimits.read("srsName"));
+        assertEquals(Arrays.asList("i", "j", "k"), gridLimits.read("axisLabels"));
+
+        DocumentContext kAxis = readContext(gridLimits, "axis[2]");
+        assertEquals("IndexAxisType", kAxis.read("type"));
+        assertEquals("k", kAxis.read("axisLabel"));
+        assertEquals(0, (int) kAxis.read("lowerBound", Integer.class));
+        assertEquals(5, (int) kAxis.read("upperBound", Integer.class));
+    }
+
+    @Test
+    public void testTimeContinuousIntervalPresentation() throws Exception {
+        setupRasterDimension(TIMESERIES, TIME, CONTINUOUS_INTERVAL, null, null, "s");
+
+        DocumentContext domain =
+                getAsJSONPath("ogc/coverages/collections/sf:timeseries/coverage/domainset", 200);
+
+        // root properties
+        assertEquals("DomainSetType", domain.read("type"));
+
+        // model domain description
+        DocumentContext generalGrid = readContext(domain, "generalGrid");
+        assertEquals("http://www.opengis.net/def/crs/EPSG/0/4326", generalGrid.read("srsName"));
+        assertEquals(Arrays.asList("Long", "Lat", "Time"), generalGrid.read("axisLabels"));
+
+        // focus on the time axis
+        DocumentContext timeAxis = readContext(generalGrid, "axis[2]");
+        assertEquals("RegularAxisType", timeAxis.read("type"));
+        assertEquals("Time", timeAxis.read("axisLabel"));
+        assertEquals("s", timeAxis.read("uomLabel"));
+        assertEquals("2014-01-01T00:00:00.000Z", timeAxis.read("lowerBound"));
+        assertEquals("2019-01-01T00:00:00.000Z", timeAxis.read("upperBound"));
+
+        // check the grid representation
+        DocumentContext gridLimits = readContext(generalGrid, "gridLimits");
+        assertEquals("http://www.opengis.net/def/crs/OGC/0/Index3D", gridLimits.read("srsName"));
+        assertEquals(Arrays.asList("i", "j", "k"), gridLimits.read("axisLabels"));
+
+        DocumentContext kAxis = readContext(gridLimits, "axis[2]");
+        assertEquals("IndexAxisType", kAxis.read("type"));
+        assertEquals("k", kAxis.read("axisLabel"));
+        assertEquals(0, (int) kAxis.read("lowerBound", Integer.class));
+        // 1826 days between the two dates, due to a leap year, 2016
+        assertEquals(157766400, (int) kAxis.read("upperBound", Integer.class));
     }
 }


### PR DESCRIPTION
[![GEOS-10513](https://badgen.net/badge/JIRA/GEOS-10513/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10513)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adds temporal representation in the CIS domain set and fixes an issue with low-resolution time specs in time retrieval

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->