### PR TITLE
[GEOS-10492] GeoFence InternalServer - InternalUserResolver unnecessarily reload Roles from services (2.21.x)

### DIFF
--- a/src/extension/geofence-server/pom.xml
+++ b/src/extension/geofence-server/pom.xml
@@ -198,6 +198,11 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/extension/geofence-server/src/main/java/org/geoserver/geofence/internal/InternalUserResolver.java
+++ b/src/extension/geofence-server/src/main/java/org/geoserver/geofence/internal/InternalUserResolver.java
@@ -31,6 +31,7 @@ import org.springframework.core.env.Environment;
  *
  * @author Niels Charlier
  */
+@Deprecated
 @PropertySource("classpath*:application.properties")
 public class InternalUserResolver implements UserResolver {
 

--- a/src/extension/geofence-server/src/main/java/org/geoserver/geofence/internal/SecurityContextUserResolver.java
+++ b/src/extension/geofence-server/src/main/java/org/geoserver/geofence/internal/SecurityContextUserResolver.java
@@ -1,0 +1,45 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.internal;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.geoserver.geofence.spi.UserResolver;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Links GeoServer users/roles to internal Geofence server
+ *
+ * @author Niels Charlier
+ */
+@PropertySource("classpath*:application.properties")
+public class SecurityContextUserResolver implements UserResolver {
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean existsUser(String username) {
+        throw new IllegalStateException("This method is deprecated and should not be invoked");
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean existsRole(String rolename) {
+        throw new IllegalStateException("This method is deprecated and should not be invoked");
+    }
+
+    @Override
+    public Set<String> getRoles(String username) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return (authentication != null && authentication.getAuthorities() != null)
+                ? authentication.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .collect(Collectors.toSet())
+                : Collections.emptySet();
+    }
+}

--- a/src/extension/geofence-server/src/main/resources/applicationContext.xml
+++ b/src/extension/geofence-server/src/main/resources/applicationContext.xml
@@ -75,11 +75,9 @@
     </bean>
 
     <!-- use the internal user resolver so geofence uses geoserver users and roles rather than its own -->
-    <bean id="internalUserResolver" class="org.geoserver.geofence.internal.InternalUserResolver" >
-	   <constructor-arg index="0" ref="geoServerSecurityManager"/>
-	</bean>
-	
-	<alias name="internalUserResolver" alias="defaultUserResolver" />
+    <bean id="securityContextUserResolver" class="org.geoserver.geofence.internal.SecurityContextUserResolver" />
+
+	  <alias name="securityContextUserResolver" alias="defaultUserResolver" />
     
     <!-- web admin page -->
     <bean id="geofenceServerPage" class="org.geoserver.web.MenuPageInfo">

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/internal/InternalUserResolverTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/internal/InternalUserResolverTest.java
@@ -91,6 +91,7 @@ public class InternalUserResolverTest extends AbstractSecurityServiceTest {
     }
 
     @Before
+    @SuppressWarnings("deprecation")
     public void setDefaultUserService() throws Exception {
         service = createRoleService("test");
         service = getSecurityManager().loadRoleService("test");
@@ -137,6 +138,7 @@ public class InternalUserResolverTest extends AbstractSecurityServiceTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testInternalUserResolver() throws Exception {
         InternalUserResolver resolver = new InternalUserResolver(getSecurityManager());
 

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/internal/SecurityContextUserResolverTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/internal/SecurityContextUserResolverTest.java
@@ -1,0 +1,72 @@
+package org.geoserver.geofence.internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.geoserver.security.impl.GeoServerRole;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityContextUserResolverTest {
+
+    @Test
+    public void existsUser() {
+        // Given
+        SecurityContextUserResolver securityContextUserResolver = new SecurityContextUserResolver();
+
+        // When and Then
+        Assert.assertThrows(
+                IllegalStateException.class,
+                () -> securityContextUserResolver.existsUser("some-user"));
+    }
+
+    @Test
+    public void existsRole() {
+        // Given
+        SecurityContextUserResolver securityContextUserResolver = new SecurityContextUserResolver();
+
+        // When and Then
+        Assert.assertThrows(
+                IllegalStateException.class,
+                () -> securityContextUserResolver.existsRole("some-role"));
+    }
+
+    @Test
+    public void getRolesEmpty() {
+        // Given
+        SecurityContextUserResolver securityContextUserResolver = new SecurityContextUserResolver();
+        Authentication authentication = Mockito.mock(Authentication.class);
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+        Mockito.when(authentication.getAuthorities()).thenReturn(Collections.emptyList());
+        SecurityContextHolder.setContext(securityContext);
+
+        // When
+        securityContextUserResolver.getRoles("some-user");
+
+        // Then
+        Mockito.verify(authentication, Mockito.atLeastOnce()).getAuthorities();
+    }
+
+    @Test
+    public void getRoles() {
+        // Given
+        SecurityContextUserResolver securityContextUserResolver = new SecurityContextUserResolver();
+        Authentication authentication = Mockito.mock(Authentication.class);
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+        Mockito.<Collection<? extends GrantedAuthority>>when(authentication.getAuthorities())
+                .thenReturn(Collections.singletonList(GeoServerRole.AUTHENTICATED_ROLE));
+        SecurityContextHolder.setContext(securityContext);
+
+        // When
+        securityContextUserResolver.getRoles("some-user");
+
+        // Then
+        Mockito.verify(authentication, Mockito.atLeastOnce()).getAuthorities();
+    }
+}


### PR DESCRIPTION
[![GEOS-10492](https://badgen.net/badge/JIRA/GEOS-10492/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10492)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR contains a fix for slowness in retrieving role for the logged in user. Instead of depending on the backend to get the role, we will get the user role from the Spring security context as the user is already logged in.

Here is the corresponding JIRA: https://osgeo-org.atlassian.net/browse/GEOS-10492

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->