### PR TITLE
[GEOS-10363] Upgrade to mapfish-print 2.2.0 and use of OpenPDF

### DIFF
--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -48,7 +48,12 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
-      <version>2.1.5</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1059,6 +1059,11 @@
         <version>${wicket.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.mapfish.print</groupId>
+        <artifactId>print-lib</artifactId>
+        <version>2.2.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.librepdf</groupId>
         <artifactId>openpdf</artifactId>
         <version>1.3.26</version>

--- a/src/release/ext-printing.xml
+++ b/src/release/ext-printing.xml
@@ -9,10 +9,9 @@
       <directory>release/target/dependency</directory>
       <outputDirectory></outputDirectory>
       <includes>
-        <include>itextpdf*</include>
+        <include>openpdf*</include>
         <include>metrics-*</include>
         <include>jyaml*</include>
-        <include>mapfish-geo-lib*</include>
         <include>gs-printing-*.jar</include>
         <include>print-lib-*.jar</include>
         <include>xercesImpl-*.jar</include>


### PR DESCRIPTION
[![GEOS-10363](https://badgen.net/badge/JIRA/GEOS-10363/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10363)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The use of OpenPDF replaces the transitive dependency of iText library; this is a non-functional change covered by existing test cases.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->