### PR TITLE
Fix GeoWebCache URL

### DIFF
--- a/doc/en/user/source/geowebcache/index.rst
+++ b/doc/en/user/source/geowebcache/index.rst
@@ -9,7 +9,7 @@ GeoWebCache is a tiling server. It runs as a proxy between a map client and map 
 
 This section will discuss the version of GeoWebCache integrated with GeoServer. The first part will be show how GeoWebCache can be configured through the web admin interface, followed by a detailed discussion of the concepts of the.
 
-For information about the standalone product, please see the `GeoWebCache homepage <http://geowebcache.org>`_.
+For information about the standalone product, please see the `GeoWebCache homepage <https://www.geowebcache.org>`_.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The link for GeoWebCache wasn't correct and lead to a non-existent website. This fixes it.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).