### PR TITLE
[GEOS-10546] Invalid time expressions used in WCS 2.0 subset return a code 200 with generic exception

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsSubsetHelper.java
@@ -421,39 +421,7 @@ public class WCSDimensionsSubsetHelper {
                 }
 
                 // now decide what to do
-                if (dim instanceof DimensionTrimType) {
-
-                    // TRIMMING
-                    final DimensionTrimType trim = (DimensionTrimType) dim;
-                    final Date low = PARSER.parseDateTime(trim.getTrimLow());
-                    final Date high = PARSER.parseDateTime(trim.getTrimHigh());
-
-                    // low > high???
-                    if (low.compareTo(high) > 0) {
-                        throw new WCS20Exception(
-                                "Low greater than High: "
-                                        + trim.getTrimLow()
-                                        + ", "
-                                        + trim.getTrimHigh(),
-                                WCS20Exception.WCS20ExceptionCode.InvalidSubsetting,
-                                "subset");
-                    }
-
-                    timeSubset = new DateRange(low, high);
-                } else if (dim instanceof DimensionSliceType) {
-
-                    // SLICING
-                    final DimensionSliceType slicing = (DimensionSliceType) dim;
-                    final String slicePointS = slicing.getSlicePoint();
-                    final Date slicePoint = PARSER.parseDateTime(slicePointS);
-                    timeSubset = new DateRange(slicePoint, slicePoint);
-                } else {
-                    throw new WCS20Exception(
-                            "Invalid element found while attempting to parse dimension subsetting request: "
-                                    + dim.getClass().toString(),
-                            WCS20Exception.WCS20ExceptionCode.InvalidSubsetting,
-                            "subset");
-                }
+                timeSubset = parseTimeSubset(dim);
             }
 
             // right now we don't support trimming
@@ -485,6 +453,48 @@ public class WCSDimensionsSubsetHelper {
             }
         }
         return timeSubset;
+    }
+
+    private DateRange parseTimeSubset(DimensionSubsetType dim) {
+        try {
+            if (dim instanceof DimensionTrimType) {
+                // TRIMMING
+                final DimensionTrimType trim = (DimensionTrimType) dim;
+                final Date low = PARSER.parseDateTime(trim.getTrimLow());
+                final Date high = PARSER.parseDateTime(trim.getTrimHigh());
+
+                // low > high???
+                if (low.compareTo(high) > 0) {
+                    throw new WCS20Exception(
+                            "Low greater than High: "
+                                    + trim.getTrimLow()
+                                    + ", "
+                                    + trim.getTrimHigh(),
+                            WCS20Exception.WCS20ExceptionCode.InvalidSubsetting,
+                            "subset");
+                }
+
+                return new DateRange(low, high);
+            } else if (dim instanceof DimensionSliceType) {
+                // SLICING
+                final DimensionSliceType slicing = (DimensionSliceType) dim;
+                final String slicePointS = slicing.getSlicePoint();
+                final Date slicePoint = PARSER.parseDateTime(slicePointS);
+                return new DateRange(slicePoint, slicePoint);
+            } else {
+                throw new WCS20Exception(
+                        "Invalid element found while attempting to parse dimension subsetting request: "
+                                + dim.getClass().toString(),
+                        WCS20Exception.WCS20ExceptionCode.InvalidSubsetting,
+                        "subset");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new WCS20Exception(
+                    "Invalid time subset",
+                    WCS20Exception.WCS20ExceptionCode.InvalidEncodingSyntax,
+                    "subset",
+                    e);
+        }
     }
 
     private List<Object> getNearestTimeMatch(

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/GetCoverageTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/GetCoverageTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.wcs2_0;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -36,6 +37,7 @@ import org.geoserver.wcs2_0.util.EnvelopeAxesLabelsMapper;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridCoverage;
@@ -43,6 +45,7 @@ import org.opengis.coverage.grid.GridEnvelope;
 import org.opengis.geometry.Envelope;
 import org.opengis.referencing.datum.PixelInCell;
 import org.opengis.referencing.operation.MathTransform;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * Testing WCS 2.0 Core {@link GetCoverage}
@@ -236,5 +239,29 @@ public class GetCoverageTest extends WCSTestSupport {
         raw.put("coverageId", "sf__rain");
         raw.put("format", "image/tiff");
         return raw;
+    }
+
+    @Test
+    public void testInvalidTimeSpecification() throws Exception {
+        // day is expressed as a single number instead of 2
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                                + "&coverageId=timeseries&subset=time(\"2018-01-1T00:00:00Z\")");
+        String error = checkOws20Exception(response, 400, "InvalidEncodingSyntax", "subset");
+        assertThat(error, CoreMatchers.containsString("Invalid time subset"));
+        assertThat(error, CoreMatchers.containsString("2018-01-1T00:00:00Z"));
+    }
+
+    @Test
+    public void testInvalidLongSpecification() throws Exception {
+        // longitude expressed as a string
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wcs?request=GetCoverage&service=WCS&version=2.0.1"
+                                + "&coverageId=timeseries&subset=Long(abc)");
+        String error = checkOws20Exception(response, 400, "InvalidEncodingSyntax", "subset");
+        assertThat(error, CoreMatchers.containsString("Invalid point value"));
+        assertThat(error, CoreMatchers.containsString("abc"));
     }
 }


### PR DESCRIPTION
See ticket

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
