### PR TITLE
[GEOS-10516] WMS GetCapabilities dimension representations ignores the end attribute

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -1294,7 +1294,11 @@ public class WMS implements ApplicationContextAware {
             // collection
             if (minResult != CalcResult.NULL_RESULT) {
                 result.add((Date) min.getMin());
-                final MaxVisitor max = new MaxVisitor(time.getAttribute());
+                final MaxVisitor max =
+                        new MaxVisitor(
+                                time.getEndAttribute() != null
+                                        ? time.getEndAttribute()
+                                        : time.getAttribute());
                 collection.accepts(max, null);
                 result.add((Date) max.getMax());
             }
@@ -1373,7 +1377,11 @@ public class WMS implements ApplicationContextAware {
             CalcResult calcResult = min.getResult();
             if (calcResult != CalcResult.NULL_RESULT) {
                 result.add(((Number) min.getMin()).doubleValue());
-                final MaxVisitor max = new MaxVisitor(elevation.getAttribute());
+                final MaxVisitor max =
+                        new MaxVisitor(
+                                elevation.getEndAttribute() != null
+                                        ? elevation.getEndAttribute()
+                                        : elevation.getAttribute());
                 collection.accepts(max, null);
                 result.add(((Number) max.getMax()).doubleValue());
             }
@@ -1520,7 +1528,13 @@ public class WMS implements ApplicationContextAware {
 
         // build query to grab the dimension values
         final Query dimQuery = new Query(source.getSchema().getName().getLocalPart());
-        dimQuery.setPropertyNames(Arrays.asList(dimension.getAttribute()));
+        List<String> propertyNames = new ArrayList<>();
+        propertyNames.add(dimension.getAttribute());
+        if (dimension.getEndAttribute() != null
+                && dimension.getPresentation() != DimensionPresentation.LIST) {
+            propertyNames.add(dimension.getEndAttribute());
+        }
+        dimQuery.setPropertyNames(propertyNames);
         return source.getFeatures(dimQuery);
     }
 
@@ -1787,7 +1801,11 @@ public class WMS implements ApplicationContextAware {
             final CalcResult minResult = minVisitor.getResult();
             if (minResult != CalcResult.NULL_RESULT) {
                 result.add(minResult.getValue());
-                final MaxVisitor maxVisitor = new MaxVisitor(dimensionInfo.getAttribute());
+                final MaxVisitor maxVisitor =
+                        new MaxVisitor(
+                                dimensionInfo.getEndAttribute() != null
+                                        ? dimensionInfo.getEndAttribute()
+                                        : dimensionInfo.getAttribute());
                 fcollection.accepts(maxVisitor, null);
                 result.add(maxVisitor.getMax());
             }

--- a/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
@@ -43,6 +43,8 @@ public abstract class WMSDimensionsTestSupport extends WMSTestSupport {
             new QName(MockData.SF_URI, "TimeElevationEmpty", MockData.SF_PREFIX);
     protected QName V_TIME_ELEVATION_STACKED =
             new QName(MockData.SF_URI, "TimeElevationStacked", MockData.SF_PREFIX);
+    protected QName V_TIME_ELEVATION_WITH_START_END =
+            new QName(MockData.SF_URI, "TimeElevationWithStartEnd", MockData.SF_PREFIX);
     protected static QName WATTEMP = new QName(MockData.SF_URI, "watertemp", MockData.SF_PREFIX);
     protected static QName TIMERANGES =
             new QName(MockData.SF_URI, "timeranges", MockData.SF_PREFIX);
@@ -170,6 +172,27 @@ public abstract class WMSDimensionsTestSupport extends WMSTestSupport {
             String unitSymbol) {
         setupVectorDimension(
                 "TimeElevation", metadata, attribute, presentation, resolution, units, unitSymbol);
+    }
+
+    protected void setupVectorDimensionWithEnd(
+            String metadata,
+            String attribute,
+            String endAttribute,
+            DimensionPresentation presentation,
+            Double resolution,
+            String units,
+            String unitSymbol) {
+        setupVectorDimension(
+                "TimeElevationWithStartEnd",
+                metadata,
+                attribute,
+                presentation,
+                resolution,
+                units,
+                unitSymbol);
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName("TimeElevationWithStartEnd");
+        info.getMetadata().get(metadata, DimensionInfo.class).setEndAttribute(endAttribute);
+        getCatalog().save(info);
     }
 
     protected void setupResourceDimensionDefaultValue(

--- a/src/wms/src/test/java/org/geoserver/wms/WMSTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 import java.awt.image.BufferedImage;
 import java.lang.reflect.Field;
 import java.net.URL;
-import java.sql.Date;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.DimensionPresentation;
@@ -84,50 +85,52 @@ public class WMSTest extends WMSTestSupport {
                 TIME_WITH_START_END.getLocalPart(), "elevation", "startElevation", "endElevation");
 
         /* Reference for test assertions
-        TimeElevation.0=0|2012-02-11|2012-02-12|1|2
-        TimeElevation.1=1|2012-02-12|2012-02-13|2|3
-        TimeElevation.2=2|2012-02-11|2012-02-14|1|3
+        TimeElevationWithStartEnd.0=0|2012-02-11Z|2012-02-12Z|1.0|2.0|POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))
+        TimeElevationWithStartEnd.1=1|2012-02-12Z|2012-02-13Z|2.0|3.0|POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))
+        TimeElevationWithStartEnd.2=2|2012-02-11Z|2012-02-14Z|1.0|3.0|POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))
          */
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-        doTimeElevationFilter(Date.valueOf("2012-02-10"), null);
-        doTimeElevationFilter(Date.valueOf("2012-02-11"), null, 0, 2);
-        doTimeElevationFilter(Date.valueOf("2012-02-12"), null, 0, 1, 2);
-        doTimeElevationFilter(Date.valueOf("2012-02-13"), null, 1, 2);
-        doTimeElevationFilter(Date.valueOf("2012-02-15"), null);
+        doTimeElevationFilter(format.parse("2012-02-10"), null);
+        doTimeElevationFilter(format.parse("2012-02-11"), null, 0, 2);
+        doTimeElevationFilter(format.parse("2012-02-12"), null, 0, 1, 2);
+        doTimeElevationFilter(format.parse("2012-02-13"), null, 1, 2);
+        doTimeElevationFilter(format.parse("2012-02-15"), null);
 
         // Test start and end before all ranges.
         doTimeElevationFilter(
-                new DateRange(Date.valueOf("2012-02-09"), Date.valueOf("2012-02-10")), null);
+                new DateRange(format.parse("2012-02-09"), format.parse("2012-02-10")), null);
         // Test start before and end during a range.
         doTimeElevationFilter(
-                new DateRange(Date.valueOf("2012-02-09"), Date.valueOf("2012-02-11")), null, 0, 2);
+                new DateRange(format.parse("2012-02-09"), format.parse("2012-02-11")), null, 0, 2);
         // Test start on and end after or during a range.
         doTimeElevationFilter(
-                new DateRange(Date.valueOf("2012-02-11"), Date.valueOf("2012-02-13")),
+                new DateRange(format.parse("2012-02-11"), format.parse("2012-02-13")),
                 null,
                 0,
                 1,
                 2);
         // Test start before and end after all ranges.
         doTimeElevationFilter(
-                new DateRange(Date.valueOf("2012-02-09"), Date.valueOf("2012-02-14")),
+                new DateRange(format.parse("2012-02-09"), format.parse("2012-02-14")),
                 null,
                 0,
                 1,
                 2);
         // Test start during and end after a range.
         doTimeElevationFilter(
-                new DateRange(Date.valueOf("2012-02-13"), Date.valueOf("2012-02-14")), null, 1, 2);
+                new DateRange(format.parse("2012-02-13"), format.parse("2012-02-14")), null, 1, 2);
         // Test start during and end during a range.
         doTimeElevationFilter(
-                new DateRange(Date.valueOf("2012-02-12"), Date.valueOf("2012-02-13")),
+                new DateRange(format.parse("2012-02-12"), format.parse("2012-02-13")),
                 null,
                 0,
                 1,
                 2);
         // Test start and end after all ranges.
         doTimeElevationFilter(
-                new DateRange(Date.valueOf("2012-02-15"), Date.valueOf("2012-02-16")), null);
+                new DateRange(format.parse("2012-02-15"), format.parse("2012-02-16")), null);
 
         doTimeElevationFilter(null, 0);
         doTimeElevationFilter(null, 1, 0, 2);
@@ -143,9 +146,9 @@ public class WMSTest extends WMSTestSupport {
         doTimeElevationFilter(null, new NumberRange<>(Integer.class, 4, 5));
 
         // combined date/elevation - this should be an 'and' filter
-        doTimeElevationFilter(Date.valueOf("2012-02-12"), 2, 0, 1, 2);
+        doTimeElevationFilter(format.parse("2012-02-12"), 2, 0, 1, 2);
         // disjunct verification
-        doTimeElevationFilter(Date.valueOf("2012-02-11"), 3, 2);
+        doTimeElevationFilter(format.parse("2012-02-11"), 3, 2);
     }
 
     public void doTimeElevationFilter(Object time, Object elevation, Integer... expectedIds)

--- a/src/wms/src/test/resources/org/geoserver/wms/TimeElevationWithStartEnd.properties
+++ b/src/wms/src/test/resources/org/geoserver/wms/TimeElevationWithStartEnd.properties
@@ -1,4 +1,4 @@
-_=id:java.lang.Integer,startTime:java.sql.Date,endTime:java.sql.Date,startElevation:double,endElevation:double
-TimeElevation.0=0|2012-02-11|2012-02-12|1|2
-TimeElevation.1=1|2012-02-12|2012-02-13|2|3
-TimeElevation.2=2|2012-02-11|2012-02-14|1|3
+_=id:java.lang.Integer,startTime:java.util.Date,endTime:java.util.Date,startElevation:double,endElevation:double,geom:Polygon:srid=4326
+TimeElevationWithStartEnd.0=0|2012-02-11Z|2012-02-12Z|1.0|2.0|POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))
+TimeElevationWithStartEnd.1=1|2012-02-12Z|2012-02-13Z|2.0|3.0|POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))
+TimeElevationWithStartEnd.2=2|2012-02-11Z|2012-02-14Z|1.0|3.0|POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))


### PR DESCRIPTION
[![GEOS-10516](https://badgen.net/badge/JIRA/GEOS-10516/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10516)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->
This PR updates WMS GetCapabilities dimension representations to use the end attribute for feature types with a configured end attribute when the dimension presentation is not List.  I had problems running the WMSTest that uses TimeElevationWithStartEnd.properties in a machine with a non-UTC timezone so I had to update that too for all of the tests to pass on my machine.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->