### PR TITLE
[2.20.x backport][GEOS-10548] GeoFence layer group handling is inconsistent (#5969)

### DIFF
--- a/doc/en/user/source/extensions/geofence-server/gui.rst
+++ b/doc/en/user/source/extensions/geofence-server/gui.rst
@@ -63,18 +63,17 @@ Layer groups are also supported. If no workspace has been specified, the layer d
 
 The read and write filters text areas as well as the style palette in the layer details tab are disabled when the layer group is being configured.
 
-If an allowed area WKT is specified it will be applied to all contained layers.
+When a LayerGroup is request the contained resource will be handled in the following way:
 
-When a layer contained in a layer group is directly accessed in the context of a WMS request, the following rules apply:
+* a limit applied to the layer groups (allowed area or grant type) will be applied to all the contained layers.
+* if the access rule a contained layer is denying the access to the layer for the user requesting group, the layer will not be present in the output.
+* if the access rule of the layer has limits on its own, they will be merged in a restrictive way (intersection) with the one of the layer group if both the limits have been defined for the same role.
+* if the access rule of the layer has limits on its own, they will be merged in a permissive way (union) with the one of the layer group if both the limits have been defined for the different roles.
 
-* If the layer group has mode **SINGLE**, the access rule of the layer being requested will be applied.
+When a layer contained in one or more layer group is directly accessed in the context of a WMS request, the following rules apply:
 
-* If the layer group has mode **OPAQUE**, the layer will not be visible.
+* If any of the layer groups containing the requested resource has mode **SINGLE** no limits eventually defined for any of the layer groups will be applied.
 
-* If the layer group has another mode, different from **SINGLE** and **OPAQUE**, the layer group access rule will be applied.
+* If all the layer groups containing the requested resource have mode **OPAQUE**, the layer will not be visible.
 
-When a layer belongs to more then one layer group, the less restrictive rule is applied. If the containing layer groups have all a **LIMIT** grant type:
-
-* If at least one layer group has no allowed area defined, then no geometry filter is applied to the contained layer.
-
-* If all the containing layer group have an allowed area defined, then the spatial filter will apply a geometry that is the result of the union of all the allowed areas.
+* If all the layer groups containing the resource has mode different from **SINGLE** and **OPAQUE**, the layer groups limits will be applied and merged with the one defined for the resource if present. For each layer group, the limits will be merged in a restrictive way with the ones defined for the resource if the rule was defined for the same role. On the contrary the limits will be merged with an enlargement logic, if coming from rules defined for different roles.

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceAccessManagerIntegrationTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceAccessManagerIntegrationTest.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.geofence.integration;
 
+import static org.geoserver.catalog.LayerGroupInfo.Mode.NAMED;
+import static org.geoserver.catalog.LayerGroupInfo.Mode.SINGLE;
 import static org.geoserver.geofence.core.model.enums.AdminGrantType.ADMIN;
 import static org.geoserver.geofence.core.model.enums.AdminGrantType.USER;
 import static org.junit.Assert.assertEquals;
@@ -34,6 +36,7 @@ import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.geotools.util.Converters;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,6 +68,12 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
     private static final String AREA_WKT_2 =
             "MULTIPOLYGON(((0.0011204391479413545 -0.0006405065746780663,0.0015764146804730927 -0.0006405065746780663,0.0015764146804730927 -0.0014612625330857614,0.0011204391479413545 -0.0014612625330857614,0.0011204391479413545 -0.0006405065746780663)))";
 
+    private static final String AREA_WKT_INTERSECT_1 =
+            "MULTIPOLYGON (((-0.15605493133583015 0.52434456928838946, 0.22097378277153568 0.51435705368289641, 0.22846441947565554 0.2247191011235955, -0.06866416978776524 0.23470661672908866, -0.15605493133583015 0.52434456928838946)))";
+
+    private static final String AREA_WKT_INTERSECT_2 =
+            "MULTIPOLYGON (((-0.2359550561797753 0.36704119850187267, 0.37328339575530589 0.33957553058676659, 0.37328339575530589 0.25468164794007497, -0.16104868913857673 0.25717852684144826, -0.2359550561797753 0.36704119850187267)))";
+
     @Before
     public void setUp() {
         support =
@@ -94,7 +103,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
     }
 
     @Test
-    public void testAllowedAreaLayerInTwoGroups() throws Exception {
+    public void testAllowedAreaLayerInTwoGroupsEnlargement() throws Exception {
         // tests that when a Layer is directly accessed for WMS request
         // if it is belonging to more then one LayerGroup, if one of the container
         // LayerGroup doesn't have an allowed area, there will be no allowedArea in the final
@@ -110,20 +119,8 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             LayerInfo places = catalog.getLayerByName(getLayerId(MockData.NAMED_PLACES));
             LayerInfo forests = catalog.getLayerByName(getLayerId(MockData.FORESTS));
 
-            group1 =
-                    createsLayerGroup(
-                            catalog,
-                            "group21",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(places, forests));
-            group2 =
-                    createsLayerGroup(
-                            catalog,
-                            "group22",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(places, forests));
+            group1 = createsLayerGroup("group21", NAMED, null, Arrays.asList(places, forests));
+            group2 = createsLayerGroup("group22", NAMED, null, Arrays.asList(places, forests));
             // limit rule for anonymousUser on LayerGroup group1
             idRule =
                     support.addRule(
@@ -171,10 +168,11 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
     }
 
     @Test
-    public void testAllowedAreaLayerInTwoGroups2() throws Exception {
+    public void testAllowedAreaLayerInTwoGroupsRestrictAccess() throws Exception {
         // tests that when a Layer is directly accessed for WMS request
         // if it is belonging to more then one LayerGroup, the allowedArea
-        // applied to the filter is the union of the allowed area of each LayerGroup
+        // applied to the filter is the intersection of the allowed area of each LayerGroup
+        // if the groups' rules were defined for the same role.
         Long idRule = null;
         Long idRule2 = null;
         LayerGroupInfo group1 = null;
@@ -185,20 +183,8 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             Catalog catalog = getCatalog();
             LayerInfo bridges = catalog.getLayerByName(getLayerId(MockData.BRIDGES));
             LayerInfo buildings = catalog.getLayerByName(getLayerId(MockData.BUILDINGS));
-            group1 =
-                    createsLayerGroup(
-                            catalog,
-                            "group1",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(bridges, buildings));
-            group2 =
-                    createsLayerGroup(
-                            catalog,
-                            "group2",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(bridges, buildings));
+            group1 = createsLayerGroup("group1", NAMED, null, Arrays.asList(bridges, buildings));
+            group2 = createsLayerGroup("group2", NAMED, null, Arrays.asList(bridges, buildings));
             // limit rule for anonymousUser on LayerGroup group1
             idRule =
                     support.addRule(
@@ -211,7 +197,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
                             "group1",
                             2);
             // add allowed Area
-            support.addRuleLimits(idRule, CatalogMode.HIDE, AREA_WKT, 4326);
+            support.addRuleLimits(idRule, CatalogMode.HIDE, AREA_WKT_INTERSECT_1, 4326);
 
             // limit rule for anonymousUser on LayerGroup group2
             idRule2 =
@@ -226,7 +212,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
                             3);
 
             // add allowed Area to layer groups rules
-            support.addRuleLimits(idRule2, CatalogMode.HIDE, AREA_WKT_2, 4326);
+            support.addRuleLimits(idRule2, CatalogMode.HIDE, AREA_WKT_INTERSECT_2, 4326);
             // mock a WMS request to check contained layers direct access
             Request req = new Request();
             req.setService("WMS");
@@ -238,23 +224,24 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             VectorAccessLimits vl =
                     (VectorAccessLimits) accessManager.getAccessLimits(user, bridges);
 
-            // Merge the allowed areas
-            Geometry allowedArea1 = new WKTReader().read(AREA_WKT);
-            Geometry allowedArea2 = new WKTReader().read(AREA_WKT_2);
-            MultiPolygon totalArea = (MultiPolygon) allowedArea1.union(allowedArea2);
+            // intersects the allowed areas for test
+            Geometry allowedArea1 = new WKTReader().read(AREA_WKT_INTERSECT_1);
+            Geometry allowedArea2 = new WKTReader().read(AREA_WKT_INTERSECT_2);
+            MultiPolygon intersectionArea =
+                    Converters.convert(allowedArea1.intersection(allowedArea2), MultiPolygon.class);
             Intersects intersects = (Intersects) vl.getReadFilter();
             MultiPolygon readFilterArea =
                     intersects.getExpression2().evaluate(null, MultiPolygon.class);
             Intersects intersects2 = (Intersects) vl.getWriteFilter();
             MultiPolygon writeFilterArea =
                     intersects2.getExpression2().evaluate(null, MultiPolygon.class);
-            totalArea.normalize();
+            intersectionArea.normalize();
             // normalize geometries to avoids assertion failures for
             // a different internal order of the polygons
             readFilterArea.normalize();
             writeFilterArea.normalize();
-            assertTrue(totalArea.equalsExact(readFilterArea, 10.0E-15));
-            assertTrue(totalArea.equalsExact(writeFilterArea, 10.0E-15));
+            assertTrue(intersectionArea.equalsExact(readFilterArea, 10.0E-15));
+            assertTrue(intersectionArea.equalsExact(writeFilterArea, 10.0E-15));
             logout();
         } finally {
             removeLayerGroup(group1, group2);
@@ -262,34 +249,21 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
     }
 
     @Test
-    public void testAllowedAreaLayerInTwoGroupsModeSingle() throws Exception {
+    public void testAllowedAreaLayerInTwoGroupsEnlargement2() throws Exception {
         // tests that when a Layer is directly accessed for WMS request
-        // if it is belonging to LayerGroups with SINGLE mode, the LayerGroup
-        // is not applied
+        // if it is belonging to more then one group the two areas are applied.
         Long idRule = null;
         Long idRule2 = null;
         LayerGroupInfo group1 = null;
         LayerGroupInfo group2 = null;
         try {
-            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS");
+            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS", "ROLE_ANONYMOUS2");
             login("admin", "geoserver", new String[] {"ROLE_ADMINISTRATOR"});
             Catalog catalog = getCatalog();
             LayerInfo lakes = catalog.getLayerByName(getLayerId(MockData.LAKES));
             LayerInfo fifteen = catalog.getLayerByName(getLayerId(MockData.FIFTEEN));
-            group1 =
-                    createsLayerGroup(
-                            catalog,
-                            "group31",
-                            LayerGroupInfo.Mode.SINGLE,
-                            null,
-                            Arrays.asList(lakes, fifteen));
-            group2 =
-                    createsLayerGroup(
-                            catalog,
-                            "group32",
-                            LayerGroupInfo.Mode.SINGLE,
-                            null,
-                            Arrays.asList(lakes, fifteen));
+            group1 = createsLayerGroup("group31", NAMED, null, Arrays.asList(lakes, fifteen));
+            group2 = createsLayerGroup("group32", NAMED, null, Arrays.asList(lakes, fifteen));
             // limit rule for anonymousUser on LayerGroup group1
             idRule =
                     support.addRule(
@@ -307,7 +281,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
                     support.addRule(
                             GrantType.LIMIT,
                             "anonymousUser",
-                            "ROLE_ANONYMOUS",
+                            "ROLE_ANONYMOUS2",
                             "WMS",
                             null,
                             null,
@@ -318,6 +292,10 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             support.addRuleLimits(idRule, CatalogMode.HIDE, AREA_WKT, 4326);
             support.addRuleLimits(idRule2, CatalogMode.HIDE, AREA_WKT_2, 4326);
 
+            // Merge the allowed areas
+            Geometry allowedArea1 = new WKTReader().read(AREA_WKT);
+            Geometry allowedArea2 = new WKTReader().read(AREA_WKT_2);
+            MultiPolygon unionedArea = (MultiPolygon) allowedArea1.union(allowedArea2);
             // mock a WMS request to check contained layers direct access
             Request req = new Request();
             req.setService("WMS");
@@ -325,11 +303,20 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             Dispatcher.REQUEST.set(req);
             logout();
 
-            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS"});
+            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS", "ROLE_ANONYMOUS2"});
 
+            unionedArea.normalize();
             VectorAccessLimits vl = (VectorAccessLimits) accessManager.getAccessLimits(user, lakes);
-            assertEquals(vl.getReadFilter(), Filter.INCLUDE);
-            assertEquals(vl.getWriteFilter(), Filter.INCLUDE);
+            Intersects readFilter = (Intersects) vl.getReadFilter();
+            MultiPolygon readFilterArea =
+                    readFilter.getExpression2().evaluate(null, MultiPolygon.class);
+            readFilterArea.normalize();
+            Intersects writeFilter = (Intersects) vl.getWriteFilter();
+            MultiPolygon writeFilterArea =
+                    writeFilter.getExpression2().evaluate(null, MultiPolygon.class);
+            writeFilterArea.normalize();
+            assertTrue(unionedArea.equalsExact(readFilterArea, 10.0E-15));
+            assertTrue(unionedArea.equalsExact(writeFilterArea, 10.0E-15));
             logout();
         } finally {
             removeLayerGroup(group1, group2);
@@ -350,11 +337,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             LayerInfo fifteen = catalog.getLayerByName(getLayerId(MockData.FIFTEEN));
             group1 =
                     createsLayerGroup(
-                            catalog,
-                            "group41",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(basicPolygons, fifteen));
+                            "group41", NAMED, null, Arrays.asList(basicPolygons, fifteen));
             // limit rule for anonymousUser on LayerGroup group1
             idRule =
                     support.addRule(
@@ -411,18 +394,12 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
         LayerGroupInfo group2 = null;
 
         try {
-            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS");
+            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS", "ROLE_ANONYMOUS2");
             login("admin", "geoserver", new String[] {"ROLE_ADMINISTRATOR"});
             Catalog catalog = getCatalog();
             LayerInfo lakes = catalog.getLayerByName(getLayerId(MockData.LAKES));
             LayerInfo namedPlaces = catalog.getLayerByName(getLayerId(MockData.NAMED_PLACES));
-            group1 =
-                    createsLayerGroup(
-                            catalog,
-                            "group51",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(lakes, namedPlaces));
+            group1 = createsLayerGroup("group51", NAMED, null, Arrays.asList(lakes, namedPlaces));
             // limit rule for anonymousUser on LayerGroup group1
             idRule =
                     support.addRule(
@@ -435,19 +412,13 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
                             "group51",
                             8);
 
-            group2 =
-                    createsLayerGroup(
-                            catalog,
-                            "group52",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(lakes, namedPlaces));
+            group2 = createsLayerGroup("group52", NAMED, null, Arrays.asList(lakes, namedPlaces));
             // limit rule for anonymousUser on LayerGroup group1
             idRule2 =
                     support.addRule(
                             GrantType.LIMIT,
                             "anonymousUser",
-                            "ROLE_ANONYMOUS",
+                            "ROLE_ANONYMOUS2",
                             "WMS",
                             null,
                             null,
@@ -465,7 +436,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             Dispatcher.REQUEST.set(req);
             logout();
 
-            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS"});
+            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS", "ROLE_ANONYMOUS2"});
 
             VectorAccessLimits vl = (VectorAccessLimits) accessManager.getAccessLimits(user, lakes);
             Intersects intersects = (Intersects) vl.getReadFilter();
@@ -509,13 +480,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             Catalog catalog = getCatalog();
             LayerInfo droutes = catalog.getLayerByName(getLayerId(MockData.DIVIDED_ROUTES));
             LayerInfo ponds = catalog.getLayerByName(getLayerId(MockData.PONDS));
-            group1 =
-                    createsLayerGroup(
-                            catalog,
-                            "group61",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(droutes, ponds));
+            group1 = createsLayerGroup("group61", NAMED, null, Arrays.asList(droutes, ponds));
             // limit rule for anonymousUser on LayerGroup group1
             idRule =
                     support.addRule(
@@ -539,13 +504,7 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
                             "group61",
                             11);
 
-            group2 =
-                    createsLayerGroup(
-                            catalog,
-                            "group62",
-                            LayerGroupInfo.Mode.NAMED,
-                            null,
-                            Arrays.asList(droutes, ponds));
+            group2 = createsLayerGroup("group62", NAMED, null, Arrays.asList(droutes, ponds));
             // limit rule for anonymousUser on LayerGroup group1
             idRule3 =
                     support.addRule(
@@ -612,16 +571,16 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
             Geometry geom4 = new WKTReader().read(areaWKT4);
             geom2.setSRID(4326);
 
-            Geometry intersectUnion = geom.union(geom3);
-            intersectUnion.setSRID(4326);
-            intersectUnion.normalize();
+            Geometry intersectIntersection = geom.intersection(geom3);
+            intersectIntersection.setSRID(4326);
+            intersectIntersection.normalize();
 
-            Geometry clipUnion = geom2.union(geom4);
-            clipUnion.setSRID(4326);
-            clipUnion.normalize();
+            Geometry clipIntersection = geom2.intersection(geom4);
+            clipIntersection.setSRID(4326);
+            clipIntersection.normalize();
 
-            assertTrue(intersectsArea.equalsExact(intersectUnion, 10.0E-15));
-            assertTrue(clipArea.equalsExact(clipUnion, 10.0E-15));
+            assertTrue(intersectsArea.equalsExact(intersectIntersection, 10.0E-15));
+            assertTrue(clipArea.equalsExact(clipIntersection, 10.0E-15));
             logout();
         } finally {
             removeLayerGroup(group1, group2);
@@ -708,6 +667,282 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
         assertAdminAccess(sfAdmin, sf, true);
     }
 
+    @Test
+    public void testAllowedAreaLayerInTwoGroupsEnlargementWithSingle() throws Exception {
+        // tests that when a Layer is directly accessed for WMS request
+        // if it is belonging to more then one LayerGroup, if one of the container
+        // LayerGroup is SINGLE, there will be no allowedArea in the final
+        // filter.
+        Long idRule = null;
+        LayerGroupInfo group1 = null;
+        LayerGroupInfo group2 = null;
+        try {
+            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS");
+            login("admin", "geoserver", new String[] {"ROLE_ADMINISTRATOR"});
+            Catalog catalog = getCatalog();
+
+            LayerInfo places = catalog.getLayerByName(getLayerId(MockData.NAMED_PLACES));
+            LayerInfo forests = catalog.getLayerByName(getLayerId(MockData.FORESTS));
+
+            group1 = createsLayerGroup("group21", SINGLE, null, Arrays.asList(places, forests));
+            group2 = createsLayerGroup("group22", NAMED, null, Arrays.asList(places, forests));
+            // limit rule for anonymousUser on LayerGroup group1
+            idRule =
+                    support.addRule(
+                            GrantType.LIMIT,
+                            "anonymousUser",
+                            "ROLE_ANONYMOUS",
+                            "WMS",
+                            null,
+                            null,
+                            "group21",
+                            0);
+
+            // limit rule for anonymousUser on LayerGroup group2
+            support.addRule(
+                    GrantType.LIMIT,
+                    "anonymousUser",
+                    "ROLE_ANONYMOUS",
+                    "WMS",
+                    null,
+                    null,
+                    "group22",
+                    1);
+
+            // add allowed Area only to the first layer group
+            support.addRuleLimits(idRule, CatalogMode.HIDE, AREA_WKT, 4326);
+
+            // mock a WMS request to check contained layers direct access
+            Request req = new Request();
+            req.setService("WMS");
+            req.setRequest("GetMap");
+            Dispatcher.REQUEST.set(req);
+            logout();
+
+            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS"});
+
+            VectorAccessLimits vl =
+                    (VectorAccessLimits) accessManager.getAccessLimits(user, places);
+
+            assertEquals(vl.getReadFilter(), Filter.INCLUDE);
+            assertEquals(vl.getWriteFilter(), Filter.INCLUDE);
+            logout();
+        } finally {
+            removeLayerGroup(group1, group2);
+        }
+    }
+
+    @Test
+    public void testLayerInGroupAreaEnlargement() throws Exception {
+        // tests that when a Layer is directly accessed in a WMS request if it is belonging to a
+        // group and both groups and layer have rules with allowed areas, if the areas are for
+        // different roles, union is applied.
+        Long idRule = null;
+        Long idRule2 = null;
+
+        LayerGroupInfo group1 = null;
+        try {
+            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS", "ROLE_ANONYMOUS2");
+            login("admin", "geoserver", new String[] {"ROLE_ADMINISTRATOR"});
+            Catalog catalog = getCatalog();
+            LayerInfo lakes = catalog.getLayerByName(getLayerId(MockData.LAKES));
+            LayerInfo fifteen = catalog.getLayerByName(getLayerId(MockData.FIFTEEN));
+            group1 = createsLayerGroup("group31", NAMED, null, Arrays.asList(lakes, fifteen));
+            // limit rule for anonymousUser on LayerGroup group1
+            idRule =
+                    support.addRule(
+                            GrantType.LIMIT,
+                            null,
+                            "ROLE_ANONYMOUS",
+                            "WMS",
+                            null,
+                            null,
+                            "group31",
+                            3);
+
+            // limit rule for anonymousUser on LayerGroup group2
+            idRule2 =
+                    support.addRule(
+                            GrantType.LIMIT,
+                            null,
+                            "ROLE_ANONYMOUS2",
+                            "WMS",
+                            null,
+                            "cite",
+                            "Lakes",
+                            2);
+
+            // add allowed Area to layer groups rules
+            support.addRuleLimits(idRule, CatalogMode.HIDE, AREA_WKT, 4326);
+            support.addRuleLimits(idRule2, CatalogMode.HIDE, AREA_WKT_2, 4326);
+
+            // Merge the allowed areas
+            Geometry allowedArea1 = new WKTReader().read(AREA_WKT);
+            Geometry allowedArea2 = new WKTReader().read(AREA_WKT_2);
+            MultiPolygon unionedArea = (MultiPolygon) allowedArea1.union(allowedArea2);
+            // mock a WMS request to check contained layers direct access
+            Request req = new Request();
+            req.setService("WMS");
+            req.setRequest("GetMap");
+            Dispatcher.REQUEST.set(req);
+            logout();
+
+            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS", "ROLE_ANONYMOUS2"});
+
+            unionedArea.normalize();
+            VectorAccessLimits vl = (VectorAccessLimits) accessManager.getAccessLimits(user, lakes);
+            Intersects intersects = (Intersects) vl.getReadFilter();
+            MultiPolygon readFilterArea =
+                    intersects.getExpression2().evaluate(null, MultiPolygon.class);
+            readFilterArea.normalize();
+            Intersects intersects2 = (Intersects) vl.getWriteFilter();
+            MultiPolygon writeFilterArea =
+                    intersects2.getExpression2().evaluate(null, MultiPolygon.class);
+            writeFilterArea.normalize();
+            assertTrue(unionedArea.equalsExact(readFilterArea, 10.0E-15));
+            assertTrue(unionedArea.equalsExact(writeFilterArea, 10.0E-15));
+            logout();
+        } finally {
+            removeLayerGroup(group1);
+        }
+    }
+
+    @Test
+    public void testLayerInGroupAreaRestriction() throws Exception {
+        // tests that when a Layer is directly accessed for WMS request
+        // if it is belonging to a group and both the group and the layer have rule with allowed
+        // area,
+        // if the areas are for same role, intersection is applied.
+        Long idRule = null;
+        Long idRule2 = null;
+
+        LayerGroupInfo group1 = null;
+        try {
+            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS");
+            login("admin", "geoserver", new String[] {"ROLE_ADMINISTRATOR"});
+            Catalog catalog = getCatalog();
+            LayerInfo lakes = catalog.getLayerByName(getLayerId(MockData.LAKES));
+            LayerInfo fifteen = catalog.getLayerByName(getLayerId(MockData.FIFTEEN));
+            group1 = createsLayerGroup("group31", NAMED, null, Arrays.asList(lakes, fifteen));
+            // limit rule for anonymousUser on LayerGroup group1
+            idRule =
+                    support.addRule(
+                            GrantType.LIMIT,
+                            null,
+                            "ROLE_ANONYMOUS",
+                            "WMS",
+                            null,
+                            null,
+                            "group31",
+                            3);
+
+            // limit rule for anonymousUser on LayerGroup group2
+            idRule2 =
+                    support.addRule(
+                            GrantType.LIMIT,
+                            null,
+                            "ROLE_ANONYMOUS",
+                            "WMS",
+                            null,
+                            "cite",
+                            "Lakes",
+                            2);
+
+            // add allowed Area to layer groups rules
+            support.addRuleLimits(idRule, CatalogMode.HIDE, AREA_WKT_INTERSECT_1, 4326);
+            support.addRuleLimits(idRule2, CatalogMode.HIDE, AREA_WKT_INTERSECT_2, 4326);
+
+            // Merge the allowed areas
+            Geometry allowedArea1 = new WKTReader().read(AREA_WKT_INTERSECT_1);
+            Geometry allowedArea2 = new WKTReader().read(AREA_WKT_INTERSECT_2);
+            MultiPolygon intersectedArea =
+                    Converters.convert(allowedArea1.intersection(allowedArea2), MultiPolygon.class);
+            intersectedArea.normalize();
+            // mock a WMS request to check contained layers direct access
+            Request req = new Request();
+            req.setService("WMS");
+            req.setRequest("GetMap");
+            Dispatcher.REQUEST.set(req);
+            logout();
+
+            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS"});
+
+            VectorAccessLimits vl = (VectorAccessLimits) accessManager.getAccessLimits(user, lakes);
+            Intersects intersects = (Intersects) vl.getReadFilter();
+            MultiPolygon readFilterArea =
+                    intersects.getExpression2().evaluate(null, MultiPolygon.class);
+            readFilterArea.normalize();
+            Intersects intersects2 = (Intersects) vl.getWriteFilter();
+            MultiPolygon writeFilterArea =
+                    intersects2.getExpression2().evaluate(null, MultiPolygon.class);
+            writeFilterArea.normalize();
+            assertTrue(intersectedArea.equalsExact(readFilterArea, 10.0E-15));
+            assertTrue(intersectedArea.equalsExact(writeFilterArea, 10.0E-15));
+            logout();
+        } finally {
+            removeLayerGroup(group1);
+        }
+    }
+
+    @Test
+    public void testLayerDeniedInGroup() throws Exception {
+        Long idRule = null;
+
+        LayerGroupInfo group1 = null;
+        try {
+            Authentication user = getUser("anonymousUser", "", "ROLE_ANONYMOUS");
+            login("admin", "geoserver", new String[] {"ROLE_ADMINISTRATOR"});
+            Catalog catalog = getCatalog();
+            LayerInfo lakes = catalog.getLayerByName(getLayerId(MockData.LAKES));
+            LayerInfo fifteen = catalog.getLayerByName(getLayerId(MockData.FIFTEEN));
+            group1 = createsLayerGroup("group31", NAMED, null, Arrays.asList(lakes, fifteen));
+            // limit rule for anonymousUser on LayerGroup group1
+
+            idRule =
+                    support.addRule(
+                            GrantType.LIMIT,
+                            null,
+                            "ROLE_ANONYMOUS",
+                            "WMS",
+                            null,
+                            null,
+                            "group31",
+                            3);
+
+            // limit rule for anonymousUser on LayerGroup group2
+
+            support.addRule(
+                    GrantType.DENY, null, "ROLE_ANONYMOUS", "WMS", null, "cite", "Lakes", 2);
+
+            // add allowed Area to layer groups rules
+            support.addRuleLimits(idRule, CatalogMode.HIDE, AREA_WKT_INTERSECT_1, 4326);
+
+            // Merge the allowed areas
+            Geometry allowedArea1 = new WKTReader().read(AREA_WKT_INTERSECT_1);
+            Geometry allowedArea2 = new WKTReader().read(AREA_WKT_INTERSECT_2);
+            MultiPolygon intersectedArea =
+                    Converters.convert(allowedArea1.intersection(allowedArea2), MultiPolygon.class);
+            intersectedArea.normalize();
+            // mock a WMS request to check contained layers direct access
+            Request req = new Request();
+            req.setService("WMS");
+            req.setRequest("GetMap");
+            Dispatcher.REQUEST.set(req);
+            logout();
+
+            login("anonymousUser", "", new String[] {"ROLE_ANONYMOUS"});
+
+            VectorAccessLimits vl =
+                    (VectorAccessLimits)
+                            accessManager.getAccessLimits(user, lakes, Arrays.asList(group1));
+            assertEquals(Filter.EXCLUDE, vl.getReadFilter());
+            assertEquals(Filter.EXCLUDE, vl.getWriteFilter());
+            logout();
+        } finally {
+            removeLayerGroup(group1);
+        }
+    }
+
     private void assertAdminAccess(Authentication user, WorkspaceInfo ws, boolean expectedAdmin) {
         WorkspaceAccessLimits userAccess = accessManager.getAccessLimits(user, ws);
         assertEquals(expectedAdmin, userAccess.isAdminable());
@@ -728,23 +963,19 @@ public class GeofenceAccessManagerIntegrationTest extends GeoServerSystemTestSup
     }
 
     protected LayerGroupInfo createsLayerGroup(
-            Catalog catalog,
-            String name,
-            LayerGroupInfo.Mode mode,
-            LayerInfo rootLayer,
-            List<LayerInfo> layers)
+            String name, LayerGroupInfo.Mode mode, LayerInfo rootLayer, List<LayerInfo> layers)
             throws Exception {
-        return createsLayerGroup(catalog, name, mode, rootLayer, layers, null);
+        return createsLayerGroup(name, mode, rootLayer, layers, null);
     }
 
     protected LayerGroupInfo createsLayerGroup(
-            Catalog catalog,
             String name,
             LayerGroupInfo.Mode mode,
             LayerInfo rootLayer,
             List<LayerInfo> layers,
             CoordinateReferenceSystem groupCRS)
             throws Exception {
+        Catalog catalog = getCatalog();
         LayerGroupInfo group = catalog.getFactory().createLayerGroup();
         group.setName(name);
 

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceGetMapIntegrationTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/integration/GeofenceGetMapIntegrationTest.java
@@ -5,6 +5,9 @@
 
 package org.geoserver.geofence.integration;
 
+import static org.geoserver.catalog.LayerGroupInfo.Mode.NAMED;
+import static org.geoserver.catalog.LayerGroupInfo.Mode.OPAQUE_CONTAINER;
+import static org.geoserver.catalog.LayerGroupInfo.Mode.SINGLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -61,7 +64,7 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
                     "MULTIPOLYGON (((0.0006 -0.0018, 0.001 -0.0006, 0.0024 -0.0001, 0.0031 -0.0015, 0.0006 -0.0018), (0.0017 -0.0011, 0.0025 -0.0011, 0.0025 -0.0006, 0.0017 -0.0006, 0.0017 -0.0011)))";
             addRuleLimits(ruleId2, CatalogMode.HIDE, areWKT, 4326, ruleService);
             // check the group works without workspace qualification;
-            group = addLakesPlacesLayerGroup(LayerGroupInfo.Mode.SINGLE, "lakes_and_places");
+            group = addLakesPlacesLayerGroup(SINGLE, "lakes_and_places");
 
             login("anonymousUser", "", "ROLE_ANONYMOUS");
             String url =
@@ -96,8 +99,7 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
         config.setUseRolesToFilter(true);
         config.getRoles().add("ROLE_USER");
 
-        LayerGroupInfo group =
-                addLakesPlacesLayerGroup(LayerGroupInfo.Mode.NAMED, "lakes_and_places");
+        LayerGroupInfo group = addLakesPlacesLayerGroup(NAMED, "lakes_and_places");
 
         Long ruleId1 = null;
         Long ruleId2 = null;
@@ -139,8 +141,7 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
         GeoFenceConfiguration config = configurationManager.getConfiguration();
         config.setUseRolesToFilter(true);
 
-        LayerGroupInfo group =
-                addLakesPlacesLayerGroup(LayerGroupInfo.Mode.NAMED, "lakes_and_places");
+        LayerGroupInfo group = addLakesPlacesLayerGroup(NAMED, "lakes_and_places");
 
         Long ruleId1 = null;
         try {
@@ -250,7 +251,7 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
                     "MULTIPOLYGON (((0.0006 -0.0018, 0.001 -0.0006, 0.0024 -0.0001, 0.0031 -0.0015, 0.0006 -0.0018), (0.0017 -0.0011, 0.0025 -0.0011, 0.0025 -0.0006, 0.0017 -0.0006, 0.0017 -0.0011)))";
             addRuleLimits(ruleId2, CatalogMode.HIDE, areWKT, 4326, ruleService);
             // check the group works without workspace qualification;
-            group = addLakesPlacesLayerGroup(LayerGroupInfo.Mode.NAMED, "lakes_and_places");
+            group = addLakesPlacesLayerGroup(NAMED, "lakes_and_places");
 
             login("anonymousUser", "", "ROLE_ANONYMOUS");
             String url =
@@ -359,9 +360,7 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
             addRuleLimits(ruleId2, CatalogMode.HIDE, areWKT, 4326, ruleService);
             // check the group works without workspace qualification;
             WorkspaceInfo ws = getCatalog().getWorkspaceByName(MockData.CITE_PREFIX);
-            group =
-                    createLakesPlacesLayerGroup(
-                            getCatalog(), "lakes_and_places", ws, LayerGroupInfo.Mode.NAMED, null);
+            group = createLakesPlacesLayerGroup(getCatalog(), "lakes_and_places", ws, NAMED, null);
 
             login("anonymousUser", "", "ROLE_ANONYMOUS");
             String url =
@@ -389,9 +388,9 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
         try {
             ruleId1 = addRule(GrantType.ALLOW, null, null, null, null, null, null, 1, ruleService);
 
-            addLakesPlacesLayerGroup(LayerGroupInfo.Mode.SINGLE, "nested");
+            addLakesPlacesLayerGroup(SINGLE, "nested");
 
-            addLakesPlacesLayerGroup(LayerGroupInfo.Mode.OPAQUE_CONTAINER, "container");
+            addLakesPlacesLayerGroup(OPAQUE_CONTAINER, "container");
 
             login("admin", "geoserver", "ROLE_ADMINISTRATOR");
             group = getCatalog().getLayerGroupByName("container");
@@ -453,7 +452,7 @@ public class GeofenceGetMapIntegrationTest extends GeofenceWMSTestSupport {
                     null,
                     LayerType.VECTOR);
 
-            addLakesPlacesLayerGroup(LayerGroupInfo.Mode.SINGLE, layerGroupName);
+            addLakesPlacesLayerGroup(SINGLE, layerGroupName);
 
             login("admin", "geoserver", "ROLE_ADMINISTRATOR");
             group = getCatalog().getLayerGroupByName(layerGroupName);

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/ContainerLimitResolver.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/ContainerLimitResolver.java
@@ -1,0 +1,491 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.geofence.services.RuleReaderService;
+import org.geoserver.geofence.services.dto.AccessInfo;
+import org.geoserver.geofence.services.dto.CatalogModeDTO;
+import org.geoserver.geofence.services.dto.RuleFilter;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.Request;
+import org.geoserver.security.impl.LayerGroupContainmentCache;
+import org.geotools.util.logging.Logging;
+import org.locationtech.jts.geom.Geometry;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * This class is responsible to handle the limit resolving (allowed areas and catalog mode) for a
+ * resource when it is contained in one or more layer groups. The methods in this class ensure that
+ * if we restrict access when rule are found for the same role, and we enlarge when rules are
+ * defined for different roles.
+ */
+class ContainerLimitResolver {
+
+    private RuleReaderService ruleService;
+
+    private List<LayerGroupInfo> groupList;
+
+    private Collection<LayerGroupContainmentCache.LayerGroupSummary> groupSummaries;
+
+    private Authentication authentication;
+
+    private String layer;
+
+    private String workspace;
+
+    private String callerIp;
+
+    private String instanceName;
+
+    private GeoFenceAreaHelper areasHelper;
+
+    private static final Logger LOGGER = Logging.getLogger(ContainerLimitResolver.class);
+
+    /**
+     * @param groups the layer groups containing the resource in the context of a WMS request
+     *     targeting a layer group.
+     * @param ruleService the GeoFence rule service.
+     * @param authentication the Authentication object bounded to this request.
+     * @param layer the layer being requested.
+     * @param workspace the workspace of the layer being requested.
+     * @param callerIp the ip of the user.
+     * @param instanceName the instance name.
+     */
+    ContainerLimitResolver(
+            List<LayerGroupInfo> groups,
+            RuleReaderService ruleService,
+            Authentication authentication,
+            String layer,
+            String workspace,
+            String callerIp,
+            String instanceName) {
+        this(ruleService, authentication, layer, workspace, callerIp, instanceName);
+        this.groupList = groups;
+    }
+
+    /**
+     * @param groups the layer groups containing the resource in the context of a WMS request
+     *     directly targeting a layer contained in one or more layer groups.
+     * @param ruleService the GeoFence rule service.
+     * @param authentication the Authentication object bounded to this request.
+     * @param layer the layer being requested.
+     * @param workspace the workspace of the layer being requested.
+     * @param callerIp the ip of the user.
+     * @param instanceName the instance name.
+     */
+    ContainerLimitResolver(
+            Collection<LayerGroupContainmentCache.LayerGroupSummary> groups,
+            RuleReaderService ruleService,
+            Authentication authentication,
+            String layer,
+            String workspace,
+            String callerIp,
+            String instanceName) {
+        this(ruleService, authentication, layer, workspace, callerIp, instanceName);
+        this.groupSummaries = groups;
+    }
+
+    private ContainerLimitResolver(
+            RuleReaderService ruleService,
+            Authentication authentication,
+            String layer,
+            String workspace,
+            String callerIp,
+            String instanceName) {
+        this.areasHelper = new GeoFenceAreaHelper();
+        this.ruleService = ruleService;
+        this.authentication = authentication;
+        this.layer = layer;
+        this.workspace = workspace;
+        this.instanceName = instanceName;
+        this.callerIp = callerIp;
+    }
+
+    /**
+     * Resolve the resource limits taking in consideration the limits of a layer group.
+     *
+     * @return the result of the resolving containing the catalog mode, the allowed area and the
+     *     clip area.
+     */
+    ProcessingResult resolveResourceInGroupLimits() {
+        Map<String, AccessInfo> publishedAccessByRole = new HashMap<>();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        for (GrantedAuthority authority : authorities) {
+            RuleFilter filter =
+                    ruleFilterByRole(authority, instanceName, workspace, layer, callerIp);
+            AccessInfo accessInfo = ruleService.getAccessInfo(filter);
+            if (accessInfo != null) publishedAccessByRole.put(authority.getAuthority(), accessInfo);
+        }
+        // retrieve the AccessInfo grouped by role
+        ListMultimap<String, AccessInfo> groupsByRoleAccess =
+                collectContainersAccessInfoByRole(authorities);
+        // first we restrict the access
+        ListMultimap<RestrictionType, ProcessingResult> restrictionResults =
+                intersectAccesses(publishedAccessByRole, groupsByRoleAccess);
+        // enlarge and return the result
+        return unionAccesses(restrictionResults);
+    }
+
+    private ProcessingResult unionAccesses(
+            ListMultimap<RestrictionType, ProcessingResult> restrictionResults) {
+        // get all the results
+        List<ProcessingResult> both = restrictionResults.get(RestrictionType.GROUP_BOTH);
+        List<ProcessingResult> intersectsOnly =
+                restrictionResults.get(RestrictionType.GROUP_INTERSECT);
+        List<ProcessingResult> clipOnly = restrictionResults.get(RestrictionType.GROUP_CLIP);
+        List<ProcessingResult> none = restrictionResults.get(RestrictionType.NONE);
+
+        // enlarge each result type separately
+        ProcessingResult intersectProcess = enlargeGroupProcessingResult(intersectsOnly);
+        ProcessingResult clipProcess = enlargeGroupProcessingResult(clipOnly);
+        ProcessingResult bothProcess = enlargeGroupProcessingResult(both);
+        ProcessingResult noneProcess = enlargeGroupProcessingResult(none);
+
+        // do the final merge
+        Geometry intersectArea = null;
+        Geometry clipArea = null;
+        CatalogModeDTO catalogModeDTO = null;
+        if (intersectProcess != null) {
+            intersectArea = intersectProcess.getIntersectArea();
+            catalogModeDTO = getLarger(null, intersectProcess.getCatalogModeDTO());
+        }
+        if (clipProcess != null) {
+            clipArea = clipProcess.getClipArea();
+            catalogModeDTO = getLarger(catalogModeDTO, clipProcess.getCatalogModeDTO());
+        }
+        // if we are in context of direct access to a layer
+        // we apply limit only if none of the group has null limits.
+        boolean lessRestrictive = groupSummaries != null;
+        if (bothProcess != null) {
+            intersectArea =
+                    unionOrReturnIfNull(
+                            () -> bothProcess.getIntersectArea(), intersectArea, lessRestrictive);
+            clipArea =
+                    unionOrReturnIfNull(() -> bothProcess.getClipArea(), clipArea, lessRestrictive);
+            catalogModeDTO = getLarger(catalogModeDTO, bothProcess.getCatalogModeDTO());
+        }
+        if (noneProcess != null) {
+            intersectArea =
+                    unionOrReturnIfNull(
+                            () -> noneProcess.getIntersectArea(), intersectArea, lessRestrictive);
+            clipArea =
+                    unionOrReturnIfNull(() -> noneProcess.getClipArea(), clipArea, lessRestrictive);
+            catalogModeDTO = getLarger(catalogModeDTO, noneProcess.getCatalogModeDTO());
+        }
+        return new ProcessingResult(intersectArea, clipArea, catalogModeDTO);
+    }
+
+    private Geometry unionOrReturnIfNull(
+            Supplier<Geometry> supplier, Geometry area, boolean lessRestrictive) {
+        if (area != null)
+            area = this.areasHelper.reprojectAndUnion(supplier.get(), area, lessRestrictive);
+        else area = supplier.get();
+        return area;
+    }
+
+    // enlarge a processing result
+    private ProcessingResult enlargeGroupProcessingResult(List<ProcessingResult> processingResult) {
+        if (processingResult == null || processingResult.isEmpty()) return null;
+        CatalogModeDTO catalogModeDTO = null;
+        Geometry intersectArea = null;
+        Geometry clipArea = null;
+        boolean lessRestrictive = groupSummaries != null;
+        for (int i = 0; i < processingResult.size(); i++) {
+            ProcessingResult pr = processingResult.get(i);
+            catalogModeDTO = getLarger(catalogModeDTO, pr.getCatalogModeDTO());
+            Geometry allowedArea = pr.getIntersectArea();
+            Geometry allowedAreaClip = pr.getClipArea();
+            if (i == 0) {
+                intersectArea = allowedArea;
+                clipArea = allowedAreaClip;
+            } else {
+                intersectArea =
+                        areasHelper.reprojectAndUnion(intersectArea, allowedArea, lessRestrictive);
+                clipArea =
+                        areasHelper.reprojectAndUnion(clipArea, allowedAreaClip, lessRestrictive);
+            }
+        }
+
+        return new ProcessingResult(intersectArea, clipArea, catalogModeDTO);
+    }
+
+    /**
+     * Resolve all the AccessInfo beloging to the same role restricting the access for allowed areas
+     * (intersection) and catalog mode.
+     *
+     * @param resourceAccessInfo the resource access infos by role
+     * @param groupAccessInfoByRole groups access infos by role.
+     * @return a Multimap<String,AccessInfo> gathering all the AccessInfo grouped by role.
+     */
+    private ListMultimap<RestrictionType, ProcessingResult> intersectAccesses(
+            Map<String, AccessInfo> resourceAccessInfo,
+            ListMultimap<String, AccessInfo> groupAccessInfoByRole) {
+        ListMultimap<RestrictionType, ProcessingResult> multiMap = ArrayListMultimap.create();
+        for (String key : resourceAccessInfo.keySet()) {
+            List<AccessInfo> infos = groupAccessInfoByRole.get(key);
+            intersectAccesses(resourceAccessInfo.get(key), infos, multiMap);
+        }
+        return multiMap;
+    }
+
+    /**
+     * Restrict the access for all the access info being passed.
+     *
+     * @param resAccessInfo the resource accessInfo. Provide the base point from which resolve the
+     *     container limits.
+     * @param groupsAccessInfo the groups access info for same role. To be resolved on top of the
+     *     resource access info.
+     * @param multiMap to be filled with the result.
+     */
+    private void intersectAccesses(
+            AccessInfo resAccessInfo,
+            List<AccessInfo> groupsAccessInfo,
+            ListMultimap<RestrictionType, ProcessingResult> multiMap) {
+        Geometry resIntersectArea = areasHelper.parseAllowedArea(resAccessInfo.getAreaWkt());
+        Geometry resClipArea = areasHelper.parseAllowedArea(resAccessInfo.getClipAreaWkt());
+        CatalogModeDTO catalogMode = resAccessInfo.getCatalogMode();
+        boolean groupOnIntersect = false;
+        boolean groupOnClip = false;
+        boolean lessRestrictive = groupSummaries != null;
+        if (groupsAccessInfo != null && !groupsAccessInfo.isEmpty()) {
+            for (int i = 0; i < groupsAccessInfo.size(); i++) {
+                AccessInfo accessInfo = groupsAccessInfo.get(i);
+                catalogMode = getStricter(catalogMode, accessInfo.getCatalogMode());
+                String allowedArea = accessInfo.getAreaWkt();
+                String clipAllowedArea = accessInfo.getClipAreaWkt();
+                if (!groupOnIntersect) groupOnIntersect = allowedArea != null;
+                if (!groupOnClip) groupOnClip = clipAllowedArea != null;
+                Geometry area = areasHelper.parseAllowedArea(allowedArea);
+                Geometry clipArea = areasHelper.parseAllowedArea(clipAllowedArea);
+
+                if (i == 0) {
+                    // be sure we have an initial value.
+                    if (resIntersectArea == null) resIntersectArea = area;
+                    else
+                        resIntersectArea =
+                                areasHelper.reprojectAndIntersect(
+                                        resIntersectArea, area, lessRestrictive);
+                    if (resClipArea == null) resClipArea = clipArea;
+                    else
+                        resClipArea =
+                                areasHelper.reprojectAndIntersect(
+                                        resClipArea, clipArea, lessRestrictive);
+                } else {
+                    resIntersectArea =
+                            areasHelper.reprojectAndIntersect(
+                                    resIntersectArea, area, lessRestrictive);
+                    resClipArea =
+                            areasHelper.reprojectAndIntersect(
+                                    resClipArea, clipArea, lessRestrictive);
+                }
+            }
+        }
+        ProcessingResult result = new ProcessingResult(resIntersectArea, resClipArea, catalogMode);
+        // dived the results according to the fact that an intersect or clip, or both or none
+        // were found in the layer group. This is needed to properly handle the enlarging of access
+        // to avoid layer group limit to be not considered.
+        if (groupOnClip && groupOnIntersect) multiMap.put(RestrictionType.GROUP_BOTH, result);
+        else if (groupOnClip) multiMap.put(RestrictionType.GROUP_CLIP, result);
+        else if (groupOnIntersect) multiMap.put(RestrictionType.GROUP_INTERSECT, result);
+        else multiMap.put(RestrictionType.NONE, result);
+    }
+
+    // collect the containers area by role.
+    private ListMultimap<String, AccessInfo> collectContainersAccessInfoByRole(
+            Collection<? extends GrantedAuthority> authorities) {
+        ListMultimap<String, AccessInfo> groupAccessInfoByRole = ArrayListMultimap.create();
+        if (groupSummaries == null)
+            collectGroupAccessInfoByRole(groupList, authorities, groupAccessInfoByRole);
+        else
+            // in context of a direct access to a layer contained in some tree group
+            collectGroupSummaryAccessInfoByRole(groupSummaries, authorities, groupAccessInfoByRole);
+        return groupAccessInfoByRole;
+    }
+
+    // collects the AccessInfo by role for all the layer groups as summary (direct access of a
+    // contained layer).
+    private void collectGroupSummaryAccessInfoByRole(
+            Collection<LayerGroupContainmentCache.LayerGroupSummary> summaries,
+            Collection<? extends GrantedAuthority> authorities,
+            ListMultimap<String, AccessInfo> groupAccessInfoByRole) {
+        for (LayerGroupContainmentCache.LayerGroupSummary summary : summaries) {
+            LayerGroupInfo.Mode mode = summary.getMode();
+            if (!mode.equals(LayerGroupInfo.Mode.OPAQUE_CONTAINER)) {
+                String layer = summary.getName();
+                String workspace = summary.getWorkspace();
+                // temporary map to do additional checks before adding access info
+                // to multimap.
+                Map<String, AccessInfo> map = new HashMap<>(authorities.size());
+                int wktCounter = 0;
+                for (GrantedAuthority authority : authorities) {
+                    RuleFilter filter =
+                            ruleFilterByRole(authority, instanceName, workspace, layer, callerIp);
+                    AccessInfo accessInfo = ruleService.getAccessInfo(filter);
+                    if (accessInfo.getAreaWkt() != null || accessInfo.getClipAreaWkt() != null)
+                        wktCounter++;
+                    map.put(authority.getAuthority(), accessInfo);
+                }
+                // if not all the access info had a wkt area of any type
+                // we remove the one without the area to allow the enlarging of access
+                // when one of the named tree involved doesn't have any area defined
+                if (wktCounter != 0 && wktCounter < map.size())
+                    map.values()
+                            .removeIf(v -> v.getClipAreaWkt() == null && v.getAreaWkt() == null);
+                map.keySet().forEach(k -> groupAccessInfoByRole.put(k, map.get(k)));
+            }
+        }
+    }
+
+    // collects group AccessInfo by Role (when layer group is requested)
+    private void collectGroupAccessInfoByRole(
+            List<LayerGroupInfo> groupList,
+            Collection<? extends GrantedAuthority> authorities,
+            ListMultimap<String, AccessInfo> groupAccessInfoByRole) {
+        for (LayerGroupInfo group : groupList) {
+            String[] nameParts = group.prefixedName().split(":");
+            String layer = null;
+            String workspace = null;
+            if (nameParts.length == 1) {
+                layer = nameParts[0];
+            } else {
+                workspace = nameParts[0];
+                layer = nameParts[1];
+            }
+            for (GrantedAuthority authority : authorities) {
+                RuleFilter filter =
+                        ruleFilterByRole(authority, instanceName, workspace, layer, callerIp);
+                AccessInfo accessInfo = ruleService.getAccessInfo(filter);
+                groupAccessInfoByRole.put(authority.getAuthority(), accessInfo);
+            }
+        }
+    }
+
+    private CatalogModeDTO getStricter(CatalogModeDTO m1, CatalogModeDTO m2) {
+
+        if (m1 == null) return m2;
+        if (m2 == null) return m1;
+
+        if (CatalogModeDTO.HIDE == m1 || CatalogModeDTO.HIDE == m2) return CatalogModeDTO.HIDE;
+
+        if (CatalogModeDTO.MIXED == m1 || CatalogModeDTO.MIXED == m2) return CatalogModeDTO.MIXED;
+
+        return CatalogModeDTO.CHALLENGE;
+    }
+
+    private CatalogModeDTO getLarger(CatalogModeDTO m1, CatalogModeDTO m2) {
+
+        if (m1 == null) return m2;
+        if (m2 == null) return m1;
+
+        if (CatalogModeDTO.CHALLENGE == m1 || CatalogModeDTO.CHALLENGE == m2)
+            return CatalogModeDTO.CHALLENGE;
+
+        if (CatalogModeDTO.MIXED == m1 || CatalogModeDTO.MIXED == m2) return CatalogModeDTO.MIXED;
+
+        return CatalogModeDTO.HIDE;
+    }
+
+    /** Data class meant to return a result for the whole limit resolution. */
+    static class ProcessingResult {
+        private Geometry intersectArea;
+        private Geometry clipArea;
+        private CatalogModeDTO catalogModeDTO;
+
+        ProcessingResult(Geometry intersectArea, Geometry clipArea, CatalogModeDTO catalogModeDTO) {
+            this.intersectArea = intersectArea;
+            this.clipArea = clipArea;
+            this.catalogModeDTO = catalogModeDTO;
+        }
+
+        Geometry getIntersectArea() {
+            return intersectArea;
+        }
+
+        Geometry getClipArea() {
+            return clipArea;
+        }
+
+        CatalogModeDTO getCatalogModeDTO() {
+            return catalogModeDTO;
+        }
+
+        void setIntersectArea(Geometry intersectArea) {
+            this.intersectArea = intersectArea;
+        }
+
+        void setClipArea(Geometry clipArea) {
+            this.clipArea = clipArea;
+        }
+    }
+
+    private enum RestrictionType {
+        GROUP_INTERSECT,
+        GROUP_CLIP,
+        GROUP_BOTH,
+        NONE
+    }
+
+    private RuleFilter ruleFilterByRole(
+            GrantedAuthority grantedAuthority,
+            String instanceName,
+            String workspace,
+            String layer,
+            String ipAddress) {
+        RuleFilter ruleFilter = new RuleFilter(RuleFilter.SpecialFilterType.ANY);
+        ruleFilter.setRole(grantedAuthority.getAuthority());
+        ruleFilter.setInstance(instanceName);
+        ruleFilter.setUser(RuleFilter.SpecialFilterType.ANY);
+        // get info from the current request
+        String service = null;
+        String request = null;
+        Request owsRequest = Dispatcher.REQUEST.get();
+        if (owsRequest != null) {
+            service = owsRequest.getService();
+            request = owsRequest.getRequest();
+        }
+        if (service != null) {
+            if ("*".equals(service)) {
+                ruleFilter.setService(RuleFilter.SpecialFilterType.ANY);
+            } else {
+                ruleFilter.setService(service);
+            }
+        } else {
+            ruleFilter.setService(RuleFilter.SpecialFilterType.DEFAULT);
+        }
+
+        if (request != null) {
+            if ("*".equals(request)) {
+                ruleFilter.setRequest(RuleFilter.SpecialFilterType.ANY);
+            } else {
+                ruleFilter.setRequest(request);
+            }
+        } else {
+            ruleFilter.setRequest(RuleFilter.SpecialFilterType.DEFAULT);
+        }
+        ruleFilter.setWorkspace(workspace);
+        ruleFilter.setLayer(layer);
+        if (ipAddress != null) {
+            ruleFilter.setSourceAddress(ipAddress);
+        } else {
+            LOGGER.log(Level.WARNING, "No source IP address found");
+            ruleFilter.setSourceAddress(RuleFilter.SpecialFilterType.DEFAULT);
+        }
+
+        LOGGER.log(Level.FINE, "ResourceInfo filter: {0}", ruleFilter);
+
+        return ruleFilter;
+    }
+}

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeoFenceAreaHelper.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeoFenceAreaHelper.java
@@ -1,0 +1,179 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence;
+
+import java.util.function.BiFunction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
+import org.geotools.util.logging.Logging;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+
+/**
+ * Class grouping methods to handle areas union and intersection needed to merge limit together when
+ * dealing with layer groups.
+ */
+class GeoFenceAreaHelper {
+
+    private static final Logger LOGGER = Logging.getLogger(GeoFenceAreaHelper.class);
+
+    /**
+     * Parse a wkt string to a Geometry object.
+     *
+     * @param allowedArea the allowed area, can be null.
+     * @return the geometry corresponding to the wkt or null if none is passed.
+     */
+    Geometry parseAllowedArea(String allowedArea) {
+        Geometry result = null;
+        if (allowedArea != null) {
+            WKTReader wktReader = new WKTReader();
+            try {
+                if (allowedArea.indexOf("SRID") != -1) {
+                    String[] allowedAreaParts = allowedArea.split(";");
+                    result = wktReader.read(allowedAreaParts[1]);
+                    int srid = Integer.valueOf(allowedAreaParts[0].split("=")[1]);
+                    result.setSRID(srid);
+                } else {
+                    result = wktReader.read(allowedArea);
+                    result.setSRID(4326);
+                }
+            } catch (ParseException e) {
+                throw new RuntimeException("Failed to unmarshal the restricted area wkt", e);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Reproject and intersects two geometries.
+     *
+     * @param first the first geometry to merge.
+     * @param second the other geometry as a WKT.
+     * @param lessRestrictive if true when one of the geometry is null, null will be returned.
+     *     Otherwise the other geometry will be returned.
+     * @return the result of intersection.
+     */
+    Geometry reprojectAndUnion(Geometry first, Geometry second, boolean lessRestrictive) {
+        BiFunction<Geometry, Geometry, Geometry> union = (g1, g2) -> g1.union(g2);
+        if (lessRestrictive) return reprojectAndApplyOpLessRestrictive(first, second, union);
+        else return reprojectAndApplyOperation(first, second, union);
+    }
+
+    /**
+     * Reproject and intersects two geometries.
+     *
+     * @param first the first geometry to merge.
+     * @param second the other geometry as a WKT.
+     * @param lessRestrictive if true when one of the geometry is null, null will be returned.
+     *     Otherwise the other geometry will be returned.
+     * @return the result of intersection.
+     */
+    Geometry reprojectAndIntersect(Geometry first, Geometry second, boolean lessRestrictive) {
+        BiFunction<Geometry, Geometry, Geometry> intersection = (g1, g2) -> g1.intersection(g2);
+        if (lessRestrictive) return reprojectAndApplyOpLessRestrictive(first, second, intersection);
+        else return reprojectAndApplyOperation(first, second, intersection);
+    }
+
+    /**
+     * Reproject and intersects two geometries. If one of the two parameters is null returns null.
+     *
+     * @param first the first geometry to merge.
+     * @param second the other geometry.
+     * @param operation a bifunction with the operation to apply to the geometries.
+     * @return the result of intersection.
+     */
+    Geometry reprojectAndApplyOpLessRestrictive(
+            Geometry first, Geometry second, BiFunction<Geometry, Geometry, Geometry> operation) {
+        if (first == null || second == null) return null;
+        return reprojectAndApplyOperation(first, second, operation);
+    }
+
+    /**
+     * Reproject and intersects two geometries.
+     *
+     * @param first the first geometry to merge.
+     * @param second the other geometry as a WKT.
+     * @param operation a BiFunction accepting Geometry parameters and returning a Geometry.
+     * @return the result of intersection.
+     */
+    Geometry reprojectAndApplyOperation(
+            Geometry first, Geometry second, BiFunction<Geometry, Geometry, Geometry> operation) {
+        if (first == null) return second;
+        if (second == null) return first;
+        if (first.getSRID() != second.getSRID()) {
+            try {
+                CoordinateReferenceSystem target = CRS.decode("EPSG:" + first.getSRID(), true);
+                CoordinateReferenceSystem source = CRS.decode("EPSG:" + second.getSRID(), true);
+                MathTransform transformation = CRS.findMathTransform(source, target);
+                second = JTS.transform(second, transformation);
+                second.setSRID(first.getSRID());
+            } catch (FactoryException | TransformException e) {
+                throw new RuntimeException(
+                        "Unable to intersect allowed areas: error during transformation from "
+                                + second.getSRID()
+                                + " to "
+                                + first.getSRID());
+            }
+        }
+        Geometry result = operation.apply(first, second);
+        result.setSRID(first.getSRID());
+        return result;
+    }
+
+    /**
+     * Reproject a geometry to target CRS.
+     *
+     * @param geometry the geometry.
+     * @param targetCRS the target CRS.
+     * @return the reprojected geometry.
+     */
+    Geometry reprojectGeometry(Geometry geometry, CoordinateReferenceSystem targetCRS) {
+        try {
+            CoordinateReferenceSystem geomCrs = CRS.decode("EPSG:" + geometry.getSRID(), true);
+            if ((targetCRS != null) && !CRS.equalsIgnoreMetadata(geomCrs, targetCRS)) {
+                MathTransform mt = CRS.findMathTransform(geomCrs, targetCRS, true);
+                geometry = JTS.transform(geometry, mt);
+                Integer srid = CRS.lookupEpsgCode(targetCRS, false);
+                geometry.setSRID(srid);
+            }
+            return geometry;
+        } catch (FactoryException | TransformException e) {
+            LOGGER.log(Level.SEVERE, "Error while reprojecting geometry: " + e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Retrieve CRS from a CatalogInfo object.
+     *
+     * @param info from which retrieve the crs.
+     * @return the crs or null.
+     */
+    CoordinateReferenceSystem getCRSFromInfo(CatalogInfo info) {
+        CoordinateReferenceSystem crs = null;
+        if (info instanceof LayerInfo) {
+            crs = ((LayerInfo) info).getResource().getCRS();
+        } else if (info instanceof ResourceInfo) {
+            crs = ((ResourceInfo) info).getCRS();
+        } else if (info instanceof LayerGroupInfo) {
+            crs = ((LayerGroupInfo) info).getBounds().getCoordinateReferenceSystem();
+        } else {
+            throw new RuntimeException(
+                    "Cannot retrieve CRS from info " + info.getClass().getSimpleName());
+        }
+        return crs;
+    }
+}


### PR DESCRIPTION
[![GEOS-10548](https://badgen.net/badge/JIRA/GEOS-10548/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10548)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* [GEOS-10548] GeoFence layer group handling is inconsistent

* review feedback applied


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->