### PR TITLE
[GEOS-10507] GeoFence - Inserting multiple GeoFence rules together

### DIFF
--- a/src/extension/geofence-server/src/main/java/org/geoserver/geofence/server/rest/AdminRulesRestController.java
+++ b/src/extension/geofence-server/src/main/java/org/geoserver/geofence/server/rest/AdminRulesRestController.java
@@ -5,6 +5,7 @@
 package org.geoserver.geofence.server.rest;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -118,6 +119,23 @@ public class AdminRulesRestController extends RestBaseController {
         }
 
         return new ResponseEntity<>(adminService.insert(rule.toRule()), HttpStatus.CREATED);
+    }
+
+    @RequestMapping(value = "/adminrules/all", method = RequestMethod.POST)
+    public ResponseEntity<Long> insertAll(@RequestBody JaxbAdminRuleList ruleList) {
+
+        for (JaxbAdminRule rule : ruleList.getRules()) {
+            long priority = rule.getPriority() == null ? 0 : rule.getPriority();
+            if (adminService.getRuleByPriority(priority) != null) {
+                adminService.shift(priority, 1);
+            }
+        }
+
+        List<AdminRule> adminRuleList = new ArrayList<>();
+        ruleList.getRules().forEach(jaxbAdminRule -> adminRuleList.add(jaxbAdminRule.toRule()));
+        adminService.insert(adminRuleList);
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @RequestMapping(

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/AdminRulesRestControllerTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/AdminRulesRestControllerTest.java
@@ -11,6 +11,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.geoserver.geofence.GeofenceBaseTest;
 import org.geoserver.geofence.core.dao.DuplicateKeyException;
@@ -37,6 +39,36 @@ public class AdminRulesRestControllerTest extends GeofenceBaseTest {
         controller =
                 (AdminRulesRestController) applicationContext.getBean("adminRulesRestController");
         adminService = (AdminRuleAdminService) applicationContext.getBean("adminRuleAdminService");
+    }
+
+    @Test
+    public void testInsertAll() {
+        // Given
+        AdminRule rule1 = new AdminRule();
+        rule1.setPriority(5L);
+        rule1.setUsername("test_user1");
+        rule1.setRolename("test_role1");
+        rule1.setWorkspace("workspace1");
+        rule1.setAccess(AdminGrantType.ADMIN);
+
+        AdminRule rule2 = new AdminRule();
+        rule2.setPriority(6L);
+        rule2.setUsername("test_user2");
+        rule2.setRolename("test_role2");
+        rule2.setWorkspace("workspace2");
+        rule2.setAccess(AdminGrantType.ADMIN);
+
+        List<AdminRule> adminRuleList = new ArrayList<>();
+        adminRuleList.add(rule1);
+        adminRuleList.add(rule2);
+
+        JaxbAdminRuleList jaxbAdminRuleList = new JaxbAdminRuleList(adminRuleList);
+
+        // When
+        ResponseEntity responseEntity = controller.insertAll(jaxbAdminRuleList);
+
+        // Then
+        assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode());
     }
 
     @Test

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/RulesRestControllerTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/RulesRestControllerTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -56,6 +58,37 @@ public class RulesRestControllerTest extends GeofenceBaseTest {
     public void initGeoFenceControllers() {
         controller = (RulesRestController) applicationContext.getBean("rulesRestController");
         adminService = (RuleAdminService) applicationContext.getBean("ruleAdminService");
+    }
+
+    @Test
+    public void testInsertAll() {
+        // Given
+        Rule rule1 = new Rule();
+        rule1.setUsername("user1");
+        rule1.setRolename("role1");
+        rule1.setService("wfs");
+        rule1.setRequest("getFeature1");
+        rule1.setWorkspace("workspace1");
+        rule1.setLayer("layer1");
+        rule1.setAccess(GrantType.ALLOW);
+        Rule rule2 = new Rule();
+        rule2.setUsername("user2");
+        rule2.setRolename("role2");
+        rule2.setService("wfs");
+        rule2.setRequest("getFeature2");
+        rule2.setWorkspace("workspace2");
+        rule2.setLayer("layer2");
+        rule2.setAccess(GrantType.ALLOW);
+        List<Rule> ruleList = new ArrayList<>();
+        ruleList.add(rule1);
+        ruleList.add(rule2);
+        JaxbRuleList jaxbRuleList = new JaxbRuleList(ruleList);
+
+        // When
+        String[] ruleIds = controller.insertAll(jaxbRuleList);
+
+        // Then
+        assertEquals(2, ruleIds.length);
     }
 
     @Test

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -120,7 +120,7 @@
     <image.tests>true</image.tests>
     <interactive.image>false</interactive.image>
     <windows.leniency>true</windows.leniency>
-    <gf.version>3.5.0</gf.version>
+    <gf.version>3.5-SNAPSHOT</gf.version>
     <jasypt.version>1.9.2</jasypt.version>
     <hibernate-version>3.6.9.Final</hibernate-version>
     <hibernate-generic-dao-version>1.1.0</hibernate-generic-dao-version>


### PR DESCRIPTION
[![GEOS-10507](https://badgen.net/badge/JIRA/GEOS-10507/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10507)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We would like to allows users to insert a set of GeoFence rules in one API call. Internally, the API will either succeed in inserting all the rules, or fail in inserting all of them. (We are not allowing insertion for only a subset of the passed rules to the API call).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->