### PR TITLE
GEOS-10559 Lazy initialization of GetMapKvpRequestReader's HTTP client used to fetch remote styles

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -174,7 +174,7 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
 
             // test no custom entity resolver will be used
             GetMapKvpRequestReader reader = new GetMapKvpRequestReader(wms);
-            assertNull(reader.entityResolverProvider.getEntityResolver());
+            assertNull(reader.getEntityResolverProvider().getEntityResolver());
 
             // disable entities
             geoserverInfo.setXmlExternalEntitiesEnabled(false);
@@ -183,14 +183,14 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
             // since XML entities are disabled for external SLD files
             // I need an entity resolver which enforce this
             reader = new GetMapKvpRequestReader(wms);
-            assertNotNull(reader.entityResolverProvider.getEntityResolver());
+            assertNotNull(reader.getEntityResolverProvider().getEntityResolver());
 
             // try default value: entities should be disabled
             geoserverInfo.setXmlExternalEntitiesEnabled(null);
             getGeoServer().save(geoserverInfo);
 
             reader = new GetMapKvpRequestReader(wms);
-            assertNotNull(reader.entityResolverProvider.getEntityResolver());
+            assertNotNull(reader.getEntityResolverProvider().getEntityResolver());
         } finally {
             // reset to default
             geoserverInfo.setXmlExternalEntitiesEnabled(null);
@@ -802,7 +802,6 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
                             return response;
                         }
                     };
-
             reqReader.read(spyRequest, parseKvp(kvp), caseInsensitiveKvp(kvp));
         }
     }


### PR DESCRIPTION
[![GEOS-10559](https://badgen.net/badge/JIRA/GEOS-10559/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10559)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`GetMapKvpRequestReader` creates an apache
`CloseableHttpClient` on its constructor.

To do so, it needs to get the stles cache configuration from the
`org.geoserver.wms.WMS facade.`

Depending on the bootstrap conditions, this triggers an eager initialization
of beans, that can lead to a circular reference error.
This issue is observed in GeoServer Cloud.

Also, the eager initialization of the HTTP client can result in a waste
of resources, because it may never use it, and because there are subclasses
that definitely won’t use it.

Some of these subclasses are not spring beans, but created on-demand,
such as `WMSRequests.LayerParser`, which currently adds a
`ConfigurationListener` to `org.geoserver.config.GeoServer`
on each invocation of `WMSRequests.getGetMapParams()`, that is never
removed, hence being a memory leak.

As a solution, the HTTP client used by `GetMapKvpRequestReader` is now
lazily initialized, and the `ConfigurationListener` it uses to update
the cache configuration whenever `WMSInfo` is changed, removed whenever
the HTTP client is closed.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->