### PR TITLE
[2.20.x backport] [GEOS-10545] Layer Group cache not initialized (#5985)

### DIFF
--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -134,6 +134,15 @@ public class GeofenceAccessManager
         this.helper = new GeoFenceAreaHelper();
     }
 
+    /**
+     * sets the layer group cache
+     *
+     * @param groupsCache
+     */
+    public void setGroupsCache(LayerGroupContainmentCache groupsCache) {
+        this.groupsCache = groupsCache;
+    }
+
     boolean isAdmin(Authentication user) {
         if (user.getAuthorities() != null) {
             for (GrantedAuthority authority : user.getAuthorities()) {

--- a/src/extension/geofence/src/main/resources/applicationContext.xml
+++ b/src/extension/geofence/src/main/resources/applicationContext.xml
@@ -85,6 +85,7 @@
             <constructor-arg index="0" ref="${ruleReaderFrontend}" />
             <constructor-arg index="1" ref="rawCatalog" />
             <constructor-arg index="2" ref="geofenceConfigurationManager" />
+            <property name="groupsCache" ref="layerGroupContainmentCache"/>
     </bean>
 
     <bean id="geofenceConfigurationController" class="org.geoserver.geofence.config.GeoFenceConfigurationController">

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -264,6 +264,16 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -334,4 +334,15 @@
   <bean id="coverageReaderFileConverter" class="org.geoserver.catalog.CoverageReaderFileConverter">
     <constructor-arg ref="catalog"/>
   </bean>
+
+  <bean id="defaultResourceAccessManager" class="org.geoserver.security.impl.DefaultResourceAccessManager">
+    <constructor-arg ref="accessRulesDao"/>
+    <constructor-arg ref="rawCatalog"/>
+    <property name="groupsCache" ref="layerGroupContainmentCache"/>
+  </bean>
+
+  <bean id="layerGroupContainmentCache" class="org.geoserver.security.impl.LayerGroupContainmentCache">
+    <constructor-arg ref="rawCatalog"/>
+  </bean>
+
 </beans>

--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -56,7 +56,6 @@ import org.geoserver.security.decorators.SecuredWMSLayerInfo;
 import org.geoserver.security.decorators.SecuredWMSStoreInfo;
 import org.geoserver.security.decorators.SecuredWMTSLayerInfo;
 import org.geoserver.security.decorators.SecuredWMTSStoreInfo;
-import org.geoserver.security.impl.DataAccessRuleDAO;
 import org.geoserver.security.impl.DefaultResourceAccessManager;
 import org.geotools.util.decorate.AbstractDecorator;
 import org.opengis.feature.type.Name;
@@ -102,19 +101,23 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
     }
 
     static ResourceAccessManager lookupResourceAccessManager() throws Exception {
-        ResourceAccessManager manager = GeoServerExtensions.bean(ResourceAccessManager.class);
-        if (manager == null) {
-            manager = buildDefaultResourceAccessManager();
+        List<ResourceAccessManager> managers =
+                GeoServerExtensions.extensions(ResourceAccessManager.class);
+        ResourceAccessManager manager = null;
+        if (managers.size() == 1) {
+            manager = managers.get(0);
+        } else {
+            for (ResourceAccessManager resourceAccessManager : managers) {
+                if (!(resourceAccessManager instanceof DefaultResourceAccessManager)) {
+                    manager = resourceAccessManager;
+                    break;
+                }
+            }
         }
+
         CatalogFilterAccessManager lwManager = new CatalogFilterAccessManager();
         lwManager.setDelegate(manager);
         return lwManager;
-    }
-
-    private static DefaultResourceAccessManager buildDefaultResourceAccessManager() {
-        return new DefaultResourceAccessManager(
-                GeoServerExtensions.bean(DataAccessRuleDAO.class),
-                (Catalog) GeoServerExtensions.bean("rawCatalog"));
     }
 
     public SecureCatalogImpl(Catalog catalog, ResourceAccessManager manager) {

--- a/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
@@ -32,6 +32,7 @@ import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.AccessMode;
 import org.geoserver.security.AdminRequest;
 import org.geoserver.security.CatalogMode;
@@ -119,7 +120,15 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
         this.dao = dao;
         this.rawCatalog = rawCatalog;
         this.root = buildAuthorizationTree(dao);
-        this.groupsCache = new LayerGroupContainmentCache(rawCatalog);
+    }
+
+    /**
+     * Sets the layer group cache
+     *
+     * @param groupsCache
+     */
+    public void setGroupsCache(LayerGroupContainmentCache groupsCache) {
+        this.groupsCache = groupsCache;
     }
 
     public CatalogMode getMode() {
@@ -206,7 +215,8 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
 
         // grab the groups containing the resource, if any. If none, there is no group related logic
         // to apply
-        Collection<LayerGroupSummary> containers = groupsCache.getContainerGroupsFor(resource);
+        Collection<LayerGroupSummary> containers =
+                getLayerGroupsCache().getContainerGroupsFor(resource);
         if (containers.isEmpty()) {
             return rulesAllowAccess;
         }
@@ -470,7 +480,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
             // grab the groups containing the group, if any. If none, there is no group related
             // logic to apply
             Collection<LayerGroupSummary> directContainers =
-                    groupsCache.getContainerGroupsFor(layerGroup);
+                    getLayerGroupsCache().getContainerGroupsFor(layerGroup);
             if (directContainers.isEmpty()) {
                 allowAccess = true;
             } else {
@@ -678,5 +688,17 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
     @Override
     public LayerGroupAccessLimits getAccessLimits(Authentication user, LayerGroupInfo layerGroup) {
         return getAccessLimits(user, layerGroup, Collections.emptyList());
+    }
+
+    /**
+     * Retrieves the layer group containment cache. If empty, it will fetch it from the context
+     *
+     * @return The layer group cantainment cache
+     */
+    protected LayerGroupContainmentCache getLayerGroupsCache() {
+        if (groupsCache == null) {
+            groupsCache = GeoServerExtensions.bean(LayerGroupContainmentCache.class);
+        }
+        return groupsCache;
     }
 }

--- a/src/main/src/main/java/org/geoserver/security/impl/LayerGroupContainmentCache.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/LayerGroupContainmentCache.java
@@ -29,6 +29,8 @@ import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geoserver.catalog.impl.LayerGroupStyleListener;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
 
 /**
  * A cache for layer group containment, it speeds up looking up layer groups containing a particular
@@ -36,7 +38,7 @@ import org.geoserver.catalog.impl.LayerGroupStyleListener;
  *
  * @author Andrea Aime - GeoSolutions
  */
-public class LayerGroupContainmentCache {
+public class LayerGroupContainmentCache implements ApplicationListener {
 
     /** Builds a concurrent set wrapping a {@link ConcurrentHashMap} */
     static final Function<? super String, ? extends Set<LayerGroupSummary>> CONCURRENT_SET_BUILDER =
@@ -188,6 +190,11 @@ public class LayerGroupContainmentCache {
                 collectContainers(container, groups);
             }
         }
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationEvent applicationEvent) {
+        buildLayerGroupCaches();
     }
 
     /**

--- a/src/main/src/test/java/org/geoserver/security/impl/LayerGroupContainmentCacheTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/LayerGroupContainmentCacheTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.net.URL;
@@ -44,6 +45,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.feature.type.Name;
+import org.springframework.context.event.ContextRefreshedEvent;
 
 /** Tests {@link LayerGroupContainmentCache} udpates in face of catalog setup and changes */
 public class LayerGroupContainmentCacheTest {
@@ -181,6 +183,17 @@ public class LayerGroupContainmentCacheTest {
 
     private String getLayerId(QName name) {
         return "ws:" + name.getLocalPart();
+    }
+
+    @Test
+    public void buildLayerGroupCaches() {
+        LayerGroupContainmentCache layerGroupContainmentCache =
+                new LayerGroupContainmentCache(catalog);
+        ContextRefreshedEvent contextRefreshedEvent = mock(ContextRefreshedEvent.class);
+
+        layerGroupContainmentCache.onApplicationEvent(contextRefreshedEvent);
+
+        assertEquals(2, layerGroupContainmentCache.groupCache.size());
     }
 
     @Test

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/AbstractAuthorizationTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/AbstractAuthorizationTest.java
@@ -494,8 +494,11 @@ public abstract class AbstractAuthorizationTest extends SecureObjectsTest {
             throws Exception {
         Properties props = new Properties();
         props.load(getClass().getResourceAsStream(propertyFile));
-        return new DefaultResourceAccessManager(
-                new MemoryDataAccessRuleDAO(catalog, props), catalog);
+        DefaultResourceAccessManager defaultResourceAccessManager =
+                new DefaultResourceAccessManager(
+                        new MemoryDataAccessRuleDAO(catalog, props), catalog);
+        defaultResourceAccessManager.setGroupsCache(new LayerGroupContainmentCache(catalog));
+        return defaultResourceAccessManager;
     }
 
     /** Sets up a mock catalog. */

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplGroupsTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplGroupsTest.java
@@ -58,6 +58,7 @@ public class SecureCatalogImplGroupsTest extends AbstractAuthorizationTest {
         DefaultResourceAccessManager manager =
                 new DefaultResourceAccessManager(
                         new MemoryDataAccessRuleDAO(catalog, props), catalog);
+        manager.setGroupsCache(new LayerGroupContainmentCache(catalog));
 
         sc =
                 new SecureCatalogImpl(catalog, manager) {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
@@ -58,6 +58,7 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.TestHttpClientProvider;
 import org.geoserver.catalog.impl.DataStoreInfoImpl;
 import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
+import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.impl.LegendInfoImpl;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
@@ -1858,16 +1859,19 @@ public class GetMapIntegrationTest extends WMSTestSupport {
         getCatalog().add(ftInfo);
 
         // setting mock feature type as resource of Layer from Test Data
-        LayerInfo layerInfo = getCatalog().getLayerByName(MockData.ROAD_SEGMENTS.getLocalPart());
+        LayerInfo layerInfo = new LayerInfoImpl();
         layerInfo.setResource(ftInfo);
+        layerInfo.setName(ftInfo.getName());
+        layerInfo.setTitle(ftInfo.getTitle());
         layerInfo.setDefaultStyle(getCatalog().getStyleByName("line"));
+
+        getCatalog().add(layerInfo);
+
         // Injecting Mock Http client in WFS Data Store to read mock respones from XML
         DataAccess dac = ftInfo.getStore().getDataStore(null);
         RetypingDataStore retypingDS = (RetypingDataStore) dac;
         WFSDataStore wfsDS = (WFSDataStore) retypingDS.getWrapped();
         wfsDS.getWfsClient().setHttpClient(client);
-
-        getCatalog().save(layerInfo);
 
         // test starts now
         // a WMS request with EPSG:4326 should result in a remote WFS call with EPSG:4326 filter and


### PR DESCRIPTION
[![GEOS-10545](https://badgen.net/badge/JIRA/GEOS-10545/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10545)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* [GEOS-10545] Layer Group cache not initialized


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->