### PR TITLE
[GEOS-10560] Make GeoServerConfigurationLock reentrant

### DIFF
--- a/src/main/src/main/java/org/geoserver/GeoServerConfigurationLock.java
+++ b/src/main/src/main/java/org/geoserver/GeoServerConfigurationLock.java
@@ -26,11 +26,17 @@ import org.geotools.util.logging.Logging;
  */
 public class GeoServerConfigurationLock {
 
-    /** DEFAULT_TRY_LOCK_TIMEOUT_MS */
-    public static long DEFAULT_TRY_LOCK_TIMEOUT_MS =
-            (GeoServerExtensions.getProperty("CONFIGURATION_TRYLOCK_TIMEOUT") != null
-                    ? Long.valueOf(GeoServerExtensions.getProperty("CONFIGURATION_TRYLOCK_TIMEOUT"))
-                    : 30000);
+    /**
+     * Environment property resolved according to {@link GeoServerExtensions#getProperty(String)}
+     */
+    static final String TRYLOCK_TIMEOUT_SYSTEM_PROPERTY = "CONFIGURATION_TRYLOCK_TIMEOUT";
+
+    /**
+     * DEFAULT_TRY_LOCK_TIMEOUT_MS.
+     *
+     * @see #getLockTimeoutMillis()
+     */
+    public static long DEFAULT_TRY_LOCK_TIMEOUT_MS = 30000;
 
     private static final Level LEVEL = Level.FINE;
 
@@ -58,12 +64,37 @@ public class GeoServerConfigurationLock {
         LOGGER.config("GeoServer configuration lock is " + (enabled ? "enabled" : "disabled"));
     }
 
+    private long getLockTimeoutMillis() {
+        String configValue = GeoServerExtensions.getProperty(TRYLOCK_TIMEOUT_SYSTEM_PROPERTY);
+        return configValue == null || configValue.isEmpty()
+                ? DEFAULT_TRY_LOCK_TIMEOUT_MS
+                : Long.valueOf(configValue);
+    }
+
+    /**
+     * Queries if the write lock is held by any thread. This method is designed for use in
+     * monitoring system state, not for synchronization control.
+     *
+     * @return {@code true} if any thread holds the write lock and {@code false} otherwise
+     */
+    public boolean isWriteLocked() {
+        return readWriteLock.isWriteLocked();
+    }
+
     /**
      * Opens a lock in the specified mode. To avoid deadlocks make sure the corresponding unlock
-     * method is called as well before the code exits
+     * method is called as well before the code exits.
+     *
+     * <p>If a write lock is already held by the current thread, and a read lock is requested, the
+     * write lock is preserved.
      */
     public void lock(LockType type) {
         if (!enabled) {
+            return;
+        }
+
+        if (LockType.READ == type && readWriteLock.isWriteLockedByCurrentThread()) {
+            // preserve the write lock
             return;
         }
 
@@ -102,6 +133,9 @@ public class GeoServerConfigurationLock {
      * This usage ensures that the lock is unlocked if it was acquired, and doesn't try to unlock if
      * the lock was not acquired.
      *
+     * <p>If a write lock is already held by the current thread, and a read lock is requested, the
+     * write lock is preserved.
+     *
      * @return true if the lock was acquired and false otherwise
      */
     public boolean tryLock(LockType type) {
@@ -109,11 +143,16 @@ public class GeoServerConfigurationLock {
             return true;
         }
 
+        if (LockType.READ == type && readWriteLock.isWriteLockedByCurrentThread()) {
+            // preserve the write lock
+            return true;
+        }
+
         Lock lock = getLock(type);
 
         boolean res = false;
         try {
-            res = lock.tryLock(DEFAULT_TRY_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            res = lock.tryLock(getLockTimeoutMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             LOGGER.log(
                     Level.WARNING,
@@ -200,7 +239,15 @@ public class GeoServerConfigurationLock {
             }
             lock.unlock();
         } finally {
-            currentLock.set(null);
+            final int currThreadReentrantReadLockCount = readWriteLock.getReadHoldCount();
+            final int currThreadReentrantWriteLockCount = readWriteLock.getWriteHoldCount();
+            // reentrancy check
+            final boolean canUnset =
+                    (LockType.READ == type && currThreadReentrantReadLockCount == 0)
+                            || (LockType.WRITE == type && currThreadReentrantWriteLockCount == 0);
+            if (canUnset) {
+                currentLock.set(null);
+            }
         }
     }
 

--- a/src/main/src/test/java/org/geoserver/GeoServerConfigurationLockTest.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerConfigurationLockTest.java
@@ -1,0 +1,261 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver;
+
+import static org.geoserver.GeoServerConfigurationLock.LockType.READ;
+import static org.geoserver.GeoServerConfigurationLock.LockType.WRITE;
+import static org.geoserver.GeoServerConfigurationLock.TRYLOCK_TIMEOUT_SYSTEM_PROPERTY;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.geoserver.GeoServerConfigurationLock.LockType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Hint: all tests are annotated with {@code @Test(timeout = 1000)}. If one fails, will most
+ * probably result in a cascade failure, so look at the first one that failed or the immediate
+ * previous one that succeeded in case it didn't unlock and fix it.
+ */
+public class GeoServerConfigurationLockTest {
+
+    private final GeoServerConfigurationLock lock = new GeoServerConfigurationLock();
+
+    @Before
+    public void beforeEach() {
+        System.setProperty(TRYLOCK_TIMEOUT_SYSTEM_PROPERTY, "100");
+    }
+
+    @After
+    public void afterEach() {
+        // //abuse the idempotency of unlock() to clean up after a failed test
+        // lock.unlock();
+        System.clearProperty(TRYLOCK_TIMEOUT_SYSTEM_PROPERTY);
+        assertFalse("all locks shall have been released", lock.isWriteLocked());
+    }
+
+    @Test(timeout = 1000)
+    public void testLock_WriteLock() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(WRITE);
+        assertEquals(WRITE, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test(timeout = 1000)
+    public void testLock_ReadLock() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(READ);
+        assertEquals(READ, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test(timeout = 1000)
+    public void testLock_ReadLock_preserves_write_lock_if_alread_held() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(WRITE);
+        assertEquals(WRITE, lock.getCurrentLock());
+
+        lock.lock(READ);
+        assertEquals(
+                "A read lock request shall preserve the write lock if already held",
+                WRITE,
+                lock.getCurrentLock());
+        lock.unlock();
+    }
+
+    @Test(timeout = 1000)
+    public void testTryUpgradeLock_fais_if_no_previous_lock_is_held() {
+        assertNull(lock.getCurrentLock());
+        IllegalStateException ex = assertThrows(IllegalStateException.class, lock::tryUpgradeLock);
+        assertThat(ex.getMessage(), containsString("No lock currently held"));
+    }
+
+    @Test(timeout = 1000)
+    public void testTryUpgradeLock_fails_if_already_holds_a_write_lock() {
+        assertNull(lock.getCurrentLock());
+        lock.lock(WRITE);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, lock::tryUpgradeLock);
+        assertThat(ex.getMessage(), containsString("Already owning a write lock"));
+        // this case, contrary to when a read lock is held, but tryUpgradeLock() fails, does not
+        // release the currently held lock
+        assertEquals(WRITE, lock.getCurrentLock());
+        lock.unlock();
+    }
+
+    @Test(timeout = 1000)
+    public void testTryUpgradeLock() throws InterruptedException, ExecutionException {
+        ExecutorService secondThread = Executors.newSingleThreadExecutor();
+        try {
+            lock.lock(READ);
+
+            secondThread
+                    .submit(
+                            () -> {
+                                assertTrue(lock.tryLock(READ));
+                            })
+                    .get();
+
+            assertEquals(READ, lock.getCurrentLock());
+
+            RuntimeException ex = assertThrows(RuntimeException.class, () -> lock.tryUpgradeLock());
+            assertThat(
+                    ex.getMessage(),
+                    containsString("Failed to upgrade lock from read to write state"));
+
+            assertNull(
+                    "lock should have been lost after a failed tryUpgradeLock()",
+                    lock.getCurrentLock());
+
+            lock.lock(READ);
+
+            secondThread.submit(lock::unlock).get();
+
+            lock.tryUpgradeLock();
+            assertEquals(WRITE, lock.getCurrentLock());
+        } finally {
+            secondThread.shutdownNow();
+            lock.unlock();
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void testTryLock() {
+        assertTrue(lock.tryLock(READ));
+        assertEquals(READ, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+
+        assertTrue(lock.tryLock(WRITE));
+        assertEquals(WRITE, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test(timeout = 1000)
+    public void testTryLock_false_if_write_lock_requested_while_holding_a_read_lock() {
+        assertNull(lock.getCurrentLock());
+
+        assertTrue(lock.tryLock(READ));
+        assertEquals(READ, lock.getCurrentLock());
+
+        assertFalse(lock.tryLock(WRITE));
+        assertEquals(READ, lock.getCurrentLock());
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test(timeout = 1000)
+    public void testTryLock_true_if_read_lock_requested_while_holding_a_write_lock() {
+        assertTrue(lock.tryLock(WRITE));
+        assertEquals(WRITE, lock.getCurrentLock());
+
+        assertTrue(lock.tryLock(READ));
+        assertEquals(
+                "tryLock(READ) while holding a write lock shall preserve the write lock",
+                WRITE,
+                lock.getCurrentLock());
+
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+        assertFalse(lock.isWriteLocked());
+    }
+
+    @Test(timeout = 1000)
+    public void testUnlock() {
+        assertNull(lock.getCurrentLock());
+        lock.unlock();
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+
+        lock.lock(READ);
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+
+        lock.lock(WRITE);
+        lock.unlock();
+        assertNull(lock.getCurrentLock());
+    }
+
+    @Test(timeout = 1000)
+    public void testLock_ReadLockIsReentrant() {
+        testLockIsReentrant(READ);
+    }
+
+    @Test(timeout = 1000)
+    public void testLock_WriteLockIsReentrant() {
+        testLockIsReentrant(WRITE);
+    }
+
+    private void testLockIsReentrant(LockType lockType) {
+        assertNull(lock.getCurrentLock());
+        // first time
+        lock.lock(lockType);
+        try {
+            assertEquals(lockType, lock.getCurrentLock());
+            try {
+                // second acquire
+                lock.lock(lockType);
+                assertEquals(lockType, lock.getCurrentLock());
+            } finally {
+                // first release
+                lock.unlock();
+                assertEquals(
+                        lockType + " lock should still be held", lockType, lock.getCurrentLock());
+            }
+        } finally {
+            // second release
+            lock.unlock();
+            assertNull(lock.getCurrentLock());
+        }
+        assertFalse(lock.isWriteLocked());
+    }
+
+    @Test(timeout = 1000)
+    public void testTryReadLockIsReentrant() {
+        testTryLockIsReentrant(READ);
+    }
+
+    @Test(timeout = 1000)
+    public void testTryWriteLockIsReentrant() {
+        testTryLockIsReentrant(WRITE);
+    }
+
+    private void testTryLockIsReentrant(final LockType lockType) {
+        assertNull(lock.getCurrentLock());
+        // common case scenario from nested calls:
+
+        // first time
+        try {
+            assertTrue(lock.tryLock(lockType));
+            assertEquals(lockType, lock.getCurrentLock());
+            try {
+                assertTrue(lock.tryLock(lockType));
+                assertEquals(lockType, lock.getCurrentLock());
+            } finally {
+                // first release
+                lock.unlock();
+                assertEquals(
+                        lockType + " lock should still be held", lockType, lock.getCurrentLock());
+            }
+        } finally {
+            // second release
+            lock.unlock();
+            assertNull(lock.getCurrentLock());
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-10560](https://badgen.net/badge/JIRA/GEOS-10560/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10560)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`GeoServerConfigurationLock` uses reentrant read/write locks
internally but does not preserve that behavior.

Since the lock can't know about the call chain that results
in a lock request, it's important that reentrancy is preserved.

A typical scenario is component A acquires a write lock to
perform a bunch of operations through component B, which also
acquires a write lock to perform more granular operations.

Component B unlocks, and then component A unlocks. Currently,
the `ThreadLocal<LockType>` is cleared on the first unlock,
leaving open locks when the next call to
`GeoServerConfigurationLock.unlock()` arrives.

Also, if a write lock is already held, and a read lock is requested
down the stream, the write lock shall be preserved.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->