### PR TITLE
[GEOS-10561] CatalogImpl.save(StoreInfo) business rule to handle ResourceInfo.namespace

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/Catalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Catalog.java
@@ -167,7 +167,17 @@ public interface Catalog extends CatalogInfo {
     /** Removes an existing store. */
     void remove(StoreInfo store);
 
-    /** Saves a store that has been modified. */
+    /**
+     * Saves a store that has been modified.
+     *
+     * <p>If the store has been moved to another {@link StoreInfo#getWorkspace() workspace}, then
+     * when this method returns it is guaranteed that all its {@link ResourceInfo}s have been
+     * "moved" to the namespace whose {@link NamespaceInfo#getPrefix() prefix} matches the store's
+     * workspace name.
+     *
+     * <p>If anything fails while saving the store or while moving its resources to the new
+     * namespace, any change applied is rolled back and a {@link RuntimeException} is thrown.
+     */
     void save(StoreInfo store);
 
     /**

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -2849,6 +2849,20 @@ public class ResourcePool {
         return target;
     }
 
+    @SuppressWarnings("unchecked")
+    public <S extends StoreInfo> S clone(S store, boolean allowEnvParametrization) {
+        Objects.requireNonNull(store);
+        if (store instanceof DataStoreInfo)
+            return (S) clone((DataStoreInfo) store, allowEnvParametrization);
+        if (store instanceof CoverageStoreInfo)
+            return (S) clone((CoverageStoreInfo) store, allowEnvParametrization);
+        if (store instanceof WMSStoreInfo)
+            return (S) clone((WMSStoreInfo) store, allowEnvParametrization);
+        if (store instanceof WMTSStoreInfo)
+            return (S) clone((WMTSStoreInfo) store, allowEnvParametrization);
+        throw new IllegalArgumentException("Unknown store type: " + store);
+    }
+
     /** */
     private void setConnectionParameters(final WMSStoreInfo source, WMSStoreInfo target) {
         target.setCapabilitiesURL(source.getCapabilitiesURL());

--- a/src/main/src/test/java/org/geoserver/config/GeoServerPersistersTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerPersistersTest.java
@@ -153,6 +153,11 @@ public class GeoServerPersistersTest extends GeoServerSystemTestSupport {
         nws.setName("topp");
         catalog.add(nws);
 
+        NamespaceInfo nns = catalog.getFactory().createNamespace();
+        nns.setPrefix(nws.getName());
+        nns.setURI(nws.getName() + "_uri");
+        catalog.add(nns);
+
         DataStoreInfo ds = catalog.getDataStoreByName("acme", "foostore");
         ds.setWorkspace(nws);
         catalog.save(ds);

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/CoverageStoreEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/CoverageStoreEditPage.java
@@ -6,15 +6,12 @@
 package org.geoserver.web.data.store;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.logging.Level;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
-import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourcePool;
 import org.geoserver.web.wicket.GeoServerDialog;
 import org.geoserver.web.wicket.ParamResourceModel;
@@ -104,8 +101,6 @@ public class CoverageStoreEditPage extends AbstractCoverageStorePage {
         final ResourcePool resourcePool = catalog.getResourcePool();
         resourcePool.clear(info);
 
-        // Map<String, Serializable> connectionParameters = info.getConnectionParameters();
-
         if (info.isEnabled()) {
             // store's enabled, make sure it works
             LOGGER.finer(
@@ -189,21 +184,11 @@ public class CoverageStoreEditPage extends AbstractCoverageStorePage {
     /**
      * Performs the save of the store.
      *
-     * <p>This method may be subclasses to provide custom save functionality.
+     * <p>This method may be subclassed to provide custom save functionality.
      */
     protected void doSaveStore(final CoverageStoreInfo info) {
         try {
             Catalog catalog = getCatalog();
-
-            final String prefix = info.getWorkspace().getName();
-            final NamespaceInfo namespace = catalog.getNamespaceByPrefix(prefix);
-
-            List<CoverageInfo> alreadyConfigured =
-                    catalog.getResourcesByStore(info, CoverageInfo.class);
-
-            for (CoverageInfo coverage : alreadyConfigured) {
-                coverage.setNamespace(namespace);
-            }
 
             ResourcePool resourcePool = catalog.getResourcePool();
             resourcePool.clear(info);
@@ -213,10 +198,6 @@ public class CoverageStoreEditPage extends AbstractCoverageStorePage {
             catalog.validate(expandedStore, false).throwIfInvalid();
 
             catalog.save(info);
-
-            for (CoverageInfo coverage : alreadyConfigured) {
-                catalog.save(coverage);
-            }
             LOGGER.finer("Saved store " + info.getName());
         } catch (RuntimeException e) {
             LOGGER.log(Level.WARNING, "Saving the store for " + info.getURL(), e);

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/DataAccessEditPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/DataAccessEditPage.java
@@ -7,7 +7,6 @@ package org.geoserver.web.data.store;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.List;
 import java.util.logging.Level;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -15,8 +14,6 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
-import org.geoserver.catalog.FeatureTypeInfo;
-import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourcePool;
 import org.geoserver.web.wicket.GeoServerDialog;
 import org.geoserver.web.wicket.ParamResourceModel;
@@ -103,7 +100,7 @@ public class DataAccessEditPage extends AbstractDataAccessPage implements Serial
     }
 
     /**
-     * Callback method called when the submit button have been hit and the parameters validation has
+     * Callback method called when the submit button was hit and the parameters validation has
      * succeed.
      *
      * @see AbstractDataAccessPage#onSaveDataStore(Form)
@@ -206,14 +203,6 @@ public class DataAccessEditPage extends AbstractDataAccessPage implements Serial
         try {
             final Catalog catalog = getCatalog();
 
-            // The namespace may have changed, in which case we need to update the store resources
-            NamespaceInfo namespace = catalog.getNamespaceByPrefix(info.getWorkspace().getName());
-            List<FeatureTypeInfo> configuredResources =
-                    catalog.getResourcesByStore(info, FeatureTypeInfo.class);
-            for (FeatureTypeInfo alreadyConfigured : configuredResources) {
-                alreadyConfigured.setNamespace(namespace);
-            }
-
             ResourcePool resourcePool = catalog.getResourcePool();
             resourcePool.clear(info);
 
@@ -223,10 +212,7 @@ public class DataAccessEditPage extends AbstractDataAccessPage implements Serial
             catalog.validate(expandedStore, false).throwIfInvalid();
 
             catalog.save(info);
-            // save the resources after saving the store
-            for (FeatureTypeInfo alreadyConfigured : configuredResources) {
-                catalog.save(alreadyConfigured);
-            }
+
             LOGGER.finer("Saved store " + info.getName());
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error saving data store to catalog", e);


### PR DESCRIPTION
[![GEOS-10561](https://badgen.net/badge/JIRA/GEOS-10561/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10561)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`CoverageStoreEditPage` and `DataStoreEditPage` duplicate code
for a poor job trying to maintain the consistency between a
`StoreInfo` workspaces and its children `ResourceInfo` namespace
properties.

Going through, and saving all the `StoreInfo`'s resources disregarding
whether the store has been assigned a different workspace doesn't only
waste resources and slows down the update store operations in both
web and rest, but produce as many update events as resources in the
store, which are no-ops, but can trigger unnecessary side effects
from catalog listeners.

Keeping the resources namespace in sync with their store's workspace
is clearly a Catalog business rule instead.

Remove the duplicate eager resource update code from CoverageStore
and DataStore edit pages, and implement the consistency enforcement
as a `Catalog.save(StoreInfo)` business rule, avoiding going through
the list of child resources if not needed, and ensuring the operation
is rolled back with counter-actions if anything fails.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->