### PR TITLE
[Fixes GEOS-10563] XStream persister serializer exception on JMS clustering messages exchange

### DIFF
--- a/src/community/jms-cluster/jms-commons/pom.xml
+++ b/src/community/jms-cluster/jms-commons/pom.xml
@@ -24,6 +24,12 @@
       <artifactId>gs-platform</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-restconfig</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- http://x-stream.github.io/jira/571/ -->
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/src/community/jms-cluster/jms-commons/src/main/java/org/geoserver/cluster/JMSXStreamPersisterInitializer.java
+++ b/src/community/jms-cluster/jms-commons/src/main/java/org/geoserver/cluster/JMSXStreamPersisterInitializer.java
@@ -1,0 +1,20 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cluster;
+
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.config.util.XStreamPersisterInitializer;
+
+/** Extension point to enable emsa package name in the SecureXStream. */
+public class JMSXStreamPersisterInitializer implements XStreamPersisterInitializer {
+
+    @Override
+    public void init(XStreamPersister persister) {
+        persister
+                .getXStream()
+                .allowTypesByWildcard(new String[] {"org.geoserver.cluster.impl.events.**"});
+    }
+}

--- a/src/community/jms-cluster/jms-commons/src/main/java/org/geoserver/cluster/JMSXStreamPersisterInitializer.java
+++ b/src/community/jms-cluster/jms-commons/src/main/java/org/geoserver/cluster/JMSXStreamPersisterInitializer.java
@@ -8,7 +8,7 @@ package org.geoserver.cluster;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterInitializer;
 
-/** Extension point to enable emsa package name in the SecureXStream. */
+/** Extension point to enable JSM packages name in the SecureXStream. */
 public class JMSXStreamPersisterInitializer implements XStreamPersisterInitializer {
 
     @Override

--- a/src/community/jms-cluster/jms-commons/src/main/resources/applicationContext.xml
+++ b/src/community/jms-cluster/jms-commons/src/main/resources/applicationContext.xml
@@ -78,6 +78,9 @@
 		<constructor-arg index="0" ref="JMSManager" />
 	</bean>
 
+	<bean id="JMSXStreamInitializer"
+		  class="org.geoserver.cluster.JMSXStreamPersisterInitializer" />
+
     <!-- turn of default webui redirect -->
     <bean class="org.springframework.beans.factory.config.PropertyOverrideConfigurer" >
         <property name="properties"> 


### PR DESCRIPTION
[![GEOS-10563](https://badgen.net/badge/JIRA/GEOS-10563/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10563)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

References: [GEOS-10563](https://osgeo-org.atlassian.net/browse/GEOS-10563)

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->