### PR TITLE
[GEOS-10566] Coverage API time range calculation needs to be hardened

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/TimeExtentCalculatorTest.java
+++ b/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/TimeExtentCalculatorTest.java
@@ -1,0 +1,141 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi;
+
+import static org.geoserver.catalog.DimensionPresentation.LIST;
+import static org.geoserver.catalog.ResourceInfo.TIME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+import java.util.List;
+import javax.xml.namespace.QName;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.util.Converters;
+import org.geotools.util.DateRange;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TimeExtentCalculatorTest extends GeoServerSystemTestSupport {
+
+    protected QName V_TIME_ELEVATION =
+            new QName(MockData.SF_URI, "TimeElevation", MockData.SF_PREFIX);
+
+    protected QName V_TIME_ELEVATION_EMPTY =
+            new QName(MockData.SF_URI, "TimeElevationEmpty", MockData.SF_PREFIX);
+
+    protected static QName TIMESERIES =
+            new QName(MockData.SF_URI, "timeseries", MockData.SF_PREFIX);
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        Catalog catalog = getCatalog();
+
+        testData.addVectorLayer(
+                V_TIME_ELEVATION,
+                null,
+                "TimeElevation.properties",
+                TimeExtentCalculatorTest.class,
+                catalog);
+
+        testData.addVectorLayer(
+                V_TIME_ELEVATION_EMPTY,
+                null,
+                "TimeElevationEmpty.properties",
+                TimeExtentCalculatorTest.class,
+                catalog);
+    }
+
+    @Before
+    public void cleanupDimensions() throws Exception {
+
+        getTestData()
+                .addRasterLayer(
+                        TIMESERIES,
+                        "timeseries.zip",
+                        null,
+                        null,
+                        SystemTestData.class,
+                        getCatalog());
+
+        Catalog catalog = getCatalog();
+        List<ResourceInfo> resources = catalog.getResources(ResourceInfo.class);
+        for (ResourceInfo resource : resources) {
+            if (resource.getMetadata().containsKey(TIME)) {
+                resource.getMetadata().remove(TIME);
+                catalog.save(resource);
+            }
+        }
+    }
+
+    @Test
+    public void testVectorTimeMissing() throws Exception {
+        FeatureTypeInfo ft = getCatalog().getFeatureTypeByName(getLayerId(V_TIME_ELEVATION));
+        assertNull(TimeExtentCalculator.getTimeExtent(ft));
+    }
+
+    @Test
+    public void testRasterTimeMissing() throws Exception {
+        CoverageInfo ci = getCatalog().getCoverageByName(getLayerId(TIMESERIES));
+        assertNull(TimeExtentCalculator.getTimeExtent(ci));
+    }
+
+    @Test
+    public void testVectorTimeDisabled() throws Exception {
+        setupVectorDimension(getLayerId(V_TIME_ELEVATION), TIME, "time", LIST, null, null, null);
+        Catalog catalog = getCatalog();
+        FeatureTypeInfo ft = catalog.getFeatureTypeByName(getLayerId(V_TIME_ELEVATION));
+        DimensionInfo di = ft.getMetadata().get(TIME, DimensionInfo.class);
+        di.setEnabled(false);
+        catalog.save(ft);
+        assertNull(TimeExtentCalculator.getTimeExtent(ft));
+    }
+
+    @Test
+    public void testRasterTimeDisabled() throws Exception {
+        setupRasterDimension(TIMESERIES, TIME, LIST, null, null, null);
+        Catalog catalog = getCatalog();
+        CoverageInfo ci = catalog.getCoverageByName(getLayerId(TIMESERIES));
+        DimensionInfo di = ci.getMetadata().get(TIME, DimensionInfo.class);
+        di.setEnabled(false);
+        catalog.save(ci);
+        assertNull(TimeExtentCalculator.getTimeExtent(ci));
+    }
+
+    @Test
+    public void testVectorTimeEmpty() throws Exception {
+        setupVectorDimension(
+                getLayerId(V_TIME_ELEVATION_EMPTY), TIME, "time", LIST, null, null, null);
+        Catalog catalog = getCatalog();
+        FeatureTypeInfo ft = catalog.getFeatureTypeByName(getLayerId(V_TIME_ELEVATION_EMPTY));
+        catalog.save(ft);
+        assertNull(TimeExtentCalculator.getTimeExtent(ft));
+    }
+
+    @Test
+    public void testVectorTime() throws Exception {
+        setupVectorDimension(getLayerId(V_TIME_ELEVATION), TIME, "time", LIST, null, null, null);
+        FeatureTypeInfo ft = getCatalog().getFeatureTypeByName(getLayerId(V_TIME_ELEVATION));
+        DateRange extent = TimeExtentCalculator.getTimeExtent(ft);
+        assertEquals(Converters.convert("2011-05-01Z", Date.class), extent.getMinValue());
+        assertEquals(Converters.convert("2011-05-04Z", Date.class), extent.getMaxValue());
+    }
+
+    @Test
+    public void testRasterTime() throws Exception {
+        setupRasterDimension(TIMESERIES, TIME, LIST, null, null, null);
+        CoverageInfo ci = getCatalog().getCoverageByName(getLayerId(TIMESERIES));
+        DateRange extent = TimeExtentCalculator.getTimeExtent(ci);
+        assertEquals(Converters.convert("2014-01-01Z", Date.class), extent.getMinValue());
+        assertEquals(Converters.convert("2019-01-01Z", Date.class), extent.getMaxValue());
+    }
+}

--- a/src/community/ogcapi/ogcapi-core/src/test/resources/org/geoserver/ogcapi/TimeElevation.properties
+++ b/src/community/ogcapi/ogcapi-core/src/test/resources/org/geoserver/ogcapi/TimeElevation.properties
@@ -1,0 +1,5 @@
+_=geom:Polygon:srid=4326,time:java.util.Date,elevation:double,shared_key:String,enabled:Boolean,lwidth:int
+TimeElevation.0=POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))|2011-05-01Z|0.0|str0|false|1
+TimeElevation.1=POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))|2011-05-02Z|1.0|str1|true|4
+TimeElevation.2=POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))|2011-05-03Z|2.0|str2|false|3
+TimeElevation.3=POLYGON((0 -90, 180 -90, 180 0, 0 0, 0 -90))|2011-05-04Z|3.0|str3|false|2

--- a/src/community/ogcapi/ogcapi-core/src/test/resources/org/geoserver/ogcapi/TimeElevationEmpty.properties
+++ b/src/community/ogcapi/ogcapi-core/src/test/resources/org/geoserver/ogcapi/TimeElevationEmpty.properties
@@ -1,0 +1,1 @@
+_=geom:Polygon:srid=4326,time:java.sql.Date,elevation:double


### PR DESCRIPTION
[![GEOS-10566](https://badgen.net/badge/JIRA/GEOS-10566/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10566)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->