### PR TITLE
Fix GEOS_10577: AttributeTypeInfoImpl.getSource() quoting failed

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
@@ -141,7 +141,7 @@ public class AttributeTypeInfoImpl implements AttributeTypeInfo {
                 return name;
             } catch (CQLException e) {
                 // quoting to avoid reserved keyword issues
-                return "'" + name + "'";
+                return "'" + name.replace("'", "''") + "'";
             }
         }
         return source;

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
@@ -141,7 +141,7 @@ public class AttributeTypeInfoImpl implements AttributeTypeInfo {
                 return name;
             } catch (CQLException e) {
                 // quoting to avoid reserved keyword issues
-                return "\"" + name + "\"";
+                return "'" + name + "'";
             }
         }
         return source;


### PR DESCRIPTION
In the context of [GEOS-10356: Allow feature type customization](https://osgeo-org.atlassian.net/browse/GEOS-10356#icft=GEOS-10356) the method [AttributeTypeInfoImpl.getSource()](https://github.com/geoserver/geoserver/blob/1a215a1ba16ff1bfd10a6c8463ee3715c1264dd6/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java#L144) tries to decode the name as an ECQL expression. If this fails the name is returned "quoted". 

This seems not to work well. Instead single 'quotes'  are needed.

Wrote a unit test to show the problem.

The quoting must also duplicate all embedded single quotes from the incoming string.

See: [GEOS-10577](https://osgeo-org.atlassian.net/browse/GEOS-10577)