### PR TITLE
ogcapi-images: Avoid ServiceException in WFS GetCapabilities

### DIFF
--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/STACItemFeaturesResponse.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/STACItemFeaturesResponse.java
@@ -23,6 +23,7 @@ import org.geoserver.ows.URLMangler;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
+import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.json.GeoJSONBuilder;
 import org.geoserver.wfs.json.GeoJSONGetFeatureResponse;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
@@ -279,10 +280,15 @@ public class STACItemFeaturesResponse extends GeoJSONGetFeatureResponse {
         // not needed in STAC
     }
 
-    /** capabilities output format string. */
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code null}, making {@link WFSGetFeatureOutputFormat#getCapabilitiesElementNames()}
+     *     not contributing a result format on the GetCapabilities document for this output format.
+     */
     @Override
     public String getCapabilitiesElementName() {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
`STACItemFeaturesResponse.getCapabilitiesElementName()` throws
an `UnsupportedOperationException` instead of returning `null`,
producing a `ServiceExceptionReport` when requesting a WFS 1.0.0
`GetCapabilities` document.

`null` is a valid return value for this method, that results
in `WFSGetFeatureOutputFormat.getCapabilitiesElementNames()`
not contributing an output format name for the
`WFSGetFeatureOutputFormat` in question.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->