### PR TITLE
[GEOS-10584] Do not close origional inputstream when logging request body

### DIFF
--- a/src/main/src/main/java/org/geoserver/filters/BufferedRequestStream.java
+++ b/src/main/src/main/java/org/geoserver/filters/BufferedRequestStream.java
@@ -8,6 +8,7 @@ package org.geoserver.filters;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.logging.Logger;
 import javax.servlet.ServletInputStream;
 
 /**
@@ -31,6 +32,9 @@ public class BufferedRequestStream extends ServletInputStream {
 
     @Override
     public int readLine(byte[] b, int off, int len) throws IOException {
+        if (myInputStream == null) {
+            throw new IOException("Stream closed");
+        }
         int read;
         int index = off;
         int end = off + len;
@@ -48,11 +52,63 @@ public class BufferedRequestStream extends ServletInputStream {
 
     @Override
     public int read() throws IOException {
+        if (myInputStream == null) {
+            throw new IOException("Stream closed");
+        }
         return myInputStream.read();
     }
 
     @Override
+    public long skip(long n) throws IOException {
+        if (myInputStream == null) {
+            throw new IOException("Stream closed");
+        }
+        return myInputStream.skip(n);
+    }
+
+    @Override
     public int available() throws IOException {
+        if (myInputStream == null) {
+            throw new IOException("Stream closed");
+        }
         return myInputStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (myInputStream != null) {
+            try {
+                myInputStream.close();
+            } finally {
+                myInputStream = null;
+            }
+        } else {
+            Logger LOGGER =
+                    org.geotools.util.logging.Logging.getLogger(BufferedRequestStream.class);
+            LOGGER.finer("Stream already closed");
+        }
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        if (myInputStream != null) {
+            myInputStream.mark(readlimit);
+        }
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        if (myInputStream == null) {
+            throw new IOException("Stream closed");
+        }
+        myInputStream.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        if (myInputStream == null) {
+            return false;
+        }
+        return myInputStream.markSupported();
     }
 }

--- a/src/main/src/main/java/org/geoserver/filters/BufferedRequestWrapper.java
+++ b/src/main/src/main/java/org/geoserver/filters/BufferedRequestWrapper.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import org.geotools.util.Converters;
 
+/** Used to wrap HttpServletRequest to apply {@link BufferedInputStream} on content access. */
 public class BufferedRequestWrapper extends HttpServletRequestWrapper {
     protected HttpServletRequest myWrappedRequest;
 
@@ -36,7 +37,8 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
     protected ServletInputStream myStream = null;
     protected BufferedReader myReader = null;
     protected Map<String, List<String>> myParameterMap;
-    protected Logger logger = org.geotools.util.logging.Logging.getLogger("org.geoserver.filters");
+    private static final Logger LOGGER =
+            org.geotools.util.logging.Logging.getLogger(BufferedRequestWrapper.class);
 
     public BufferedRequestWrapper(HttpServletRequest req, String charset, byte[] buff) {
         super(req);
@@ -191,7 +193,7 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
             myParameterMap.get(key).add(value);
 
         } catch (UnsupportedEncodingException e) {
-            logger.severe("Failed to decode form values in LoggingFilter");
+            LOGGER.severe("Failed to decode form values in LoggingFilter");
             // we have the encoding hard-coded for now so no exceptions should be thrown...
         }
     }

--- a/src/main/src/test/java/org/geoserver/filters/BufferedRequestStreamTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/BufferedRequestStreamTest.java
@@ -6,7 +6,9 @@
 package org.geoserver.filters;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,6 +34,38 @@ public class BufferedRequestStreamTest {
         int len = 1024;
         int amountRead = myBRS.readLine(b, off, len);
         String s = new String(b, 0, amountRead);
-        assertEquals(s, myTestString);
+        assertEquals(myTestString, s);
+    }
+
+    @Test
+    public void closeClose() throws IOException {
+        byte[] b = new byte[1024];
+        int off = 0;
+        int len = 1024;
+        int amountRead = myBRS.readLine(b, off, len);
+        String s = new String(b, 0, amountRead);
+        assertEquals(myTestString, s);
+        myBRS.reset();
+
+        amountRead = myBRS.readLine(b, off, len);
+        String s2 = new String(b, 0, amountRead);
+        assertEquals(myTestString, s2);
+
+        myBRS.close();
+
+        try {
+            amountRead = myBRS.readLine(b, off, len);
+            String s3 = new String(b, 0, amountRead);
+            assertEquals(myTestString, s3);
+            fail("Buffered Request Stream should already be closed");
+        } catch (IOException closed) {
+            assertEquals("Stream closed", closed.getMessage());
+        }
+
+        try {
+            myBRS.close();
+        } catch (Throwable t) {
+            fail("Calling close a second time should log a message but not produce an exception");
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-10584](https://badgen.net/badge/JIRA/GEOS-10584/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10584)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

BufferedRequestStream now respects close() clearing internal myInputStream reference.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->