### PR TITLE
Mask AWS Secret Key in S3 blobstore (was plain text)

### DIFF
--- a/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.html
+++ b/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.html
@@ -11,7 +11,7 @@
 			<input id="awsAccessKey" wicket:id="awsAccessKey" type="text" class="text" />
 				
 			<label for="awsSecretKey"><wicket:message key="awsSecretKey"/></label>
-			<input id="awsSecretKey" wicket:id="awsSecretKey" type="text" class="text" />
+			<input id="awsSecretKey" wicket:id="awsSecretKey" type="password" class="text" />
 						
 			<label for="prefix"><wicket:message key="prefix"/></label>
 			<input id="prefix" wicket:id="prefix" type="text" class="text" />

--- a/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.java
+++ b/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.java
@@ -9,6 +9,7 @@ import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Radio;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.form.PasswordTextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -35,7 +36,7 @@ public class S3BlobStorePanel extends Panel {
                         .setRequired(false)
                         .add(titleModifier("awsAccessKey.title")));
         add(
-                new TextField<>("awsSecretKey")
+                new PasswordTextField<>("awsSecretKey")
                         .setRequired(false)
                         .add(titleModifier("awsSecretKey.title")));
         add(new TextField<>("prefix").add(titleModifier("prefix.title")));

--- a/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.java
+++ b/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStorePanel.java
@@ -6,10 +6,10 @@ package org.geoserver.gwc.web.blob;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.PasswordTextField;
 import org.apache.wicket.markup.html.form.Radio;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.html.form.TextField;
-import org.apache.wicket.markup.html.form.PasswordTextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -36,7 +36,7 @@ public class S3BlobStorePanel extends Panel {
                         .setRequired(false)
                         .add(titleModifier("awsAccessKey.title")));
         add(
-                new PasswordTextField<>("awsSecretKey")
+                new PasswordTextField("awsSecretKey")
                         .setRequired(false)
                         .add(titleModifier("awsSecretKey.title")));
         add(new TextField<>("prefix").add(titleModifier("prefix.title")));

--- a/src/extension/gwc-s3/src/test/java/org/geoserver/gwc/web/blob/S3BlobStorePageTest.java
+++ b/src/extension/gwc-s3/src/test/java/org/geoserver/gwc/web/blob/S3BlobStorePageTest.java
@@ -95,7 +95,7 @@ public class S3BlobStorePageTest extends GeoServerWicketTestSupport {
         assertEquals("myblobstore", config.getName());
         assertEquals("mybucket", ((S3BlobStoreInfo) config).getBucket());
         assertEquals("myaccesskey", ((S3BlobStoreInfo) config).getAwsAccessKey());
-        assertEquals("mysecretkey", ((S3BlobStoreInfo) config).getAwsSecretKey());
+        assertEquals(null, ((S3BlobStoreInfo) config).getAwsSecretKey());
         assertEquals(50, ((S3BlobStoreInfo) config).getMaxConnections().intValue());
         assertEquals("PRIVATE", ((S3BlobStoreInfo) config).getAccess().toString());
 
@@ -124,7 +124,7 @@ public class S3BlobStorePageTest extends GeoServerWicketTestSupport {
         assertEquals("myblobstore", config.getName());
         assertEquals("mybucket", ((S3BlobStoreInfo) config).getBucket());
         assertEquals("myaccesskey", ((S3BlobStoreInfo) config).getAwsAccessKey());
-        assertEquals("mysecretkey", ((S3BlobStoreInfo) config).getAwsSecretKey());
+        assertEquals(null, ((S3BlobStoreInfo) config).getAwsSecretKey());
         assertEquals(50, ((S3BlobStoreInfo) config).getMaxConnections().intValue());
         assertEquals("PUBLIC", ((S3BlobStoreInfo) config).getAccess().toString());
 


### PR DESCRIPTION
Mask AWS Secret Key in S3 blobstore (currently it is shown in plain text)

I don't believe the AWS Access Key needs to be masked.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->