### PR TITLE
Update documentation on WMTS Store & WMTS Layer

### DIFF
--- a/doc/en/user/source/rest/stores.rst
+++ b/doc/en/user/source/rest/stores.rst
@@ -340,3 +340,63 @@ Given the following content saved as :file:`annotations.xml`:
    201 Created
 
 A new and empty table named "annotations" in the "nyc" database will be created as well.
+
+
+Adding an external WMTS Store
+-----------------------------
+
+**Create a new WMTS store "Basemap-Nat-Geo-Datastore"**
+
+*Request*
+
+.. admonition:: curl
+
+   ::
+
+       curl -v -u admin:geoserver -XPOST -H "Content-type: text/xml" 
+         -d "<wmtsStore><name>basemap-nat-geo-datastore</name><description>esri-street-map</description><capabilitiesURL>https://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer/WMTS/1.0.0/WMTSCapabilities.xml</capabilitiesURL><type>WMTS</type></wmtsStore>" 
+         http://localhost:8080/geoserver/rest/workspaces/acme/wmtsstores
+
+.. admonition:: python
+
+   TBD
+
+.. admonition:: java
+
+   TBD
+
+*Response*
+
+::
+
+   201 Created
+
+
+Adding an external WMTS Layer 
+-----------------------------
+
+**Publish a new WMTS Layer "NatGeo_World_Map" from the WMTS store "Basemap-Nat-Geo-Datastore"**
+
+*Request*
+
+.. admonition:: curl
+
+   ::
+
+       curl -v -u admin:geoserver -XPOST -H "Content-type: text/xml" 
+         -d "<wmtsLayer><name>NatGeo_World_Map</name></wmtsLayer>" 
+         http://localhost:8080/geoserver/rest/workspaces/acme/wmtsstores/Basemap-Nat-Geo-Datastore/layers
+
+.. admonition:: python
+
+   TBD
+
+.. admonition:: java
+
+   TBD
+
+*Response*
+
+::
+
+   201 Created

--- a/doc/en/user/source/rest/stores.rst
+++ b/doc/en/user/source/rest/stores.rst
@@ -349,14 +349,6 @@ Adding an external WMTS Store
          -d "<wmtsStore><name>basemap-nat-geo-datastore</name><description>esri-street-map</description><capabilitiesURL>https://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer/WMTS/1.0.0/WMTSCapabilities.xml</capabilitiesURL><type>WMTS</type></wmtsStore>" 
          http://localhost:8080/geoserver/rest/workspaces/acme/wmtsstores
 
-.. admonition:: python
-
-   TBD
-
-.. admonition:: java
-
-   TBD
-
 *Response*
 
 ::
@@ -378,14 +370,6 @@ Adding an external WMTS Layer
        curl -v -u admin:geoserver -XPOST -H "Content-type: text/xml" 
          -d "<wmtsLayer><name>NatGeo_World_Map</name></wmtsLayer>" 
          http://localhost:8080/geoserver/rest/workspaces/acme/wmtsstores/Basemap-Nat-Geo-Datastore/layers
-
-.. admonition:: python
-
-   TBD
-
-.. admonition:: java
-
-   TBD
 
 *Response*
 

--- a/doc/en/user/source/rest/stores.rst
+++ b/doc/en/user/source/rest/stores.rst
@@ -18,14 +18,6 @@ Uploading a shapefile
          --data-binary @roads.zip 
          http://localhost:8080/geoserver/rest/workspaces/acme/datastores/roads/file.shp
 
-.. admonition:: python
-
-   TBD
-
-.. admonition:: java
-
-   TBD
-
 *Response*
 
 ::


### PR DESCRIPTION
Documentation on Adding an external WMTS & Configuring external WMTS layers via REST for this reference
https://docs.geoserver.org/stable/en/user/data/cascaded/wmts.html


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->