### PR TITLE
[Backport-2.21.x] [GEOS-10569] Features API support sortby query parameter

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceClass.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceClass.java
@@ -26,6 +26,10 @@ public class ConformanceClass {
     public static final String FILTER =
             "http://www.opengis.net/spec/ogcapi-features-3/1.0/req/filter";
 
+    /** Sorting conformance class from OGC API - Records. */
+    public static final String SORTBY =
+            "http://www.opengis.net/spec/ogcapi-records-1/1.0/req/sorting";
+
     /**
      * A custom conformance class for GeoServer own ECQL, not further split into parts (as only
      * GeoServer implements it anyways

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -16,7 +16,9 @@ import static org.geoserver.ogcapi.ConformanceClass.ECQL;
 import static org.geoserver.ogcapi.ConformanceClass.ECQL_TEXT;
 import static org.geoserver.ogcapi.ConformanceClass.FEATURES_FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.FILTER;
+import static org.geoserver.ogcapi.ConformanceClass.SORTBY;
 
+import com.google.common.collect.ImmutableList;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -66,6 +68,7 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -265,9 +268,9 @@ public class FeatureService {
                         CQL2_FUNCTIONS,
                         /* CQL2_TEMPORAL excluded for now, no support for all operators */
                         /* CQL2_ARRAY excluded, no support for array operations now */
-                        CQL2_TEXT
+                        CQL2_TEXT,
                         /* CQL2_JSON very different from the binding we have */
-                        );
+                        SORTBY);
         return new ConformanceDocument(DISPLAY_NAME, classes);
     }
 
@@ -296,6 +299,7 @@ public class FeatureService {
                 null,
                 null,
                 null,
+                null,
                 itemId);
     }
 
@@ -313,6 +317,7 @@ public class FeatureService {
             @RequestParam(name = "filter", required = false) String filter,
             @RequestParam(name = "filter-lang", required = false) String filterLanguage,
             @RequestParam(name = "filter-crs", required = false) String filterCRS,
+            @RequestParam(name = "sortby", required = false) SortBy[] sortBy,
             @RequestParam(name = "crs", required = false) String crs,
             String itemId)
             throws Exception {
@@ -342,6 +347,9 @@ public class FeatureService {
             filters.add(parsedFilter);
         }
         query.setFilter(mergeFiltersAnd(filters));
+        if (sortBy != null) {
+            query.setSortBy(ImmutableList.copyOf(sortBy));
+        }
         if (crs != null) {
             query.setSrsName(new URI(crs));
         } else {

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
@@ -151,6 +151,7 @@ paths:
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/filter-lang'
         - $ref: '#/components/parameters/filter-crs'
+        - $ref: '#/components/parameters/sortby'
         - $ref: '#/components/parameters/crs'
         - $ref: '#/components/parameters/bbox-crs'
         - $ref: '#/components/parameters/otherParameters'
@@ -297,14 +298,29 @@ components:
         type: string
         enum:
           - cql-text
+          - cql2-text
         default: cql-text
     filter-crs:
       name: filter-crs
       in: query
+      description: Filter CRS which is being used to encode geometries in the filter parameter
       required: false
       schema:
         type: string
         format: uri-reference
+      style: form
+      explode: false
+    sortby:
+      name: sortby
+      in: query
+      description: Defines how features in a response should be ordered for presentation.
+      required: false
+      schema:
+        type: array
+        minItems: 1
+        items:
+          type: string
+          pattern: '[+|-]?[A-Za-z_].*'
       style: form
       explode: false
     otherParameters:

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
@@ -161,6 +161,7 @@ public class ApiTest extends FeaturesTestSupport {
                         "#/components/parameters/filter",
                         "#/components/parameters/filter-lang",
                         "#/components/parameters/filter-crs",
+                        "#/components/parameters/sortby",
                         "#/components/parameters/crs",
                         "#/components/parameters/bbox-crs",
                         "#/components/parameters/otherParameters"));

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ConformanceTest.java
@@ -16,6 +16,7 @@ import static org.geoserver.ogcapi.ConformanceClass.ECQL;
 import static org.geoserver.ogcapi.ConformanceClass.ECQL_TEXT;
 import static org.geoserver.ogcapi.ConformanceClass.FEATURES_FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.FILTER;
+import static org.geoserver.ogcapi.ConformanceClass.SORTBY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -58,7 +59,8 @@ public class ConformanceTest extends FeaturesTestSupport {
             CQL2_BASIC_SPATIAL,
             CQL2_SPATIAL,
             CQL2_FUNCTIONS,
-            CQL2_TEXT
+            CQL2_TEXT,
+            SORTBY
         };
     }
 

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/FeatureTest.java
@@ -278,8 +278,6 @@ public class FeatureTest extends FeaturesTestSupport {
         ReferencedEnvelope bbox = new ReferencedEnvelope(38, 40, 1, 3, DefaultGeographicCRS.WGS84);
         ReferencedEnvelope wmBox = bbox.transform(CRS.decode("EPSG:3857", true), true);
 
-        System.out.println(filterCrsQueryParameters(wmBox));
-
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/collections/"
@@ -404,6 +402,65 @@ public class FeatureTest extends FeaturesTestSupport {
         assertEquals(1, (int) json.read("features.length()", Integer.class));
         assertEquals(
                 1, json.read("features[?(@.id == 'PrimitiveGeoFeature.f002')]", List.class).size());
+    }
+
+    @Test
+    public void testSortByWithDefaultSortOrder() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/collections/" + roadSegments + "/items?sortby=name&limit=2",
+                        200);
+        assertEquals("FeatureCollection", json.read("type", String.class));
+        assertEquals(2, (int) json.read("features.length()", Integer.class));
+        assertEquals(null, json.read("features[0].properties.name", String.class));
+        assertEquals("name-f001", json.read("features[1].properties.name", String.class));
+    }
+
+    @Test
+    public void testSortByWithAscendingSortOrder() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/collections/"
+                                + roadSegments
+                                + "/items?sortby=%2Bname&limit=2",
+                        200);
+        assertEquals("FeatureCollection", json.read("type", String.class));
+        assertEquals(2, (int) json.read("features.length()", Integer.class));
+        assertEquals(null, json.read("features[0].properties.name", String.class));
+        assertEquals("name-f001", json.read("features[1].properties.name", String.class));
+    }
+
+    @Test
+    public void testSortByWithDescendingSortOrder() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/collections/" + roadSegments + "/items?sortby=-name&limit=2",
+                        200);
+        assertEquals("FeatureCollection", json.read("type", String.class));
+        assertEquals(2, (int) json.read("features.length()", Integer.class));
+        assertEquals("name-f008", json.read("features[0].properties.name", String.class));
+        assertEquals("name-f003", json.read("features[1].properties.name", String.class));
+    }
+
+    @Test
+    public void testSortByMultipleProperties() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/collections/"
+                                + roadSegments
+                                + "/items?sortby=booleanProperty,-intProperty",
+                        200);
+        assertEquals("FeatureCollection", json.read("type", String.class));
+        assertEquals(5, (int) json.read("features.length()", Integer.class));
+        assertEquals(null, json.read("features[0].properties.name", String.class));
+        assertEquals("name-f002", json.read("features[1].properties.name", String.class));
+        assertEquals("name-f008", json.read("features[2].properties.name", String.class));
+        assertEquals("name-f003", json.read("features[3].properties.name", String.class));
+        assertEquals("name-f001", json.read("features[4].properties.name", String.class));
     }
 
     @Test

--- a/src/wfs/src/main/java/org/geoserver/wfs/AliasedQuery.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/AliasedQuery.java
@@ -368,6 +368,11 @@ class AliasedQuery extends Query {
     }
 
     @Override
+    public void setSortBy(List<SortBy> sortBy) {
+        delegate.setSortBy(sortBy);
+    }
+
+    @Override
     public List<XlinkPropertyNameType> getXlinkPropertyNames() {
         return delegate.getXlinkPropertyNames();
     }

--- a/src/wfs/src/main/java/org/geoserver/wfs/request/Query.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/request/Query.java
@@ -65,6 +65,8 @@ public abstract class Query extends RequestObject {
 
     public abstract List<SortBy> getSortBy();
 
+    public abstract void setSortBy(List<SortBy> sortBy);
+
     public abstract List<XlinkPropertyNameType> getXlinkPropertyNames();
 
     public static class WFS11 extends Query {
@@ -104,6 +106,11 @@ public abstract class Query extends RequestObject {
         @SuppressWarnings("unchecked")
         public List<SortBy> getSortBy() {
             return eGet(adaptee, "sortBy", List.class);
+        }
+
+        @Override
+        public void setSortBy(List<SortBy> sortBy) {
+            eSet(adaptee, "sortBy", sortBy);
         }
 
         @Override
@@ -166,6 +173,11 @@ public abstract class Query extends RequestObject {
         @SuppressWarnings("unchecked")
         public List<SortBy> getSortBy() {
             return eGet(adaptee, "abstractSortingClause", List.class);
+        }
+
+        @Override
+        public void setSortBy(List<SortBy> sortBy) {
+            eSet(adaptee, "abstractSortingClause", sortBy);
         }
 
         @Override


### PR DESCRIPTION
[![GEOS-10569](https://badgen.net/badge/JIRA/GEOS-10569/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10569)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

Backport to 2.21.x for #6076.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->