### PR TITLE
[2.20.x backport][GEOS-10507] GeoFence Internal - Support Batch operations for Rules and AdminRules (#6072)

### DIFF
--- a/doc/en/user/source/extensions/geofence-server/index.rst
+++ b/doc/en/user/source/extensions/geofence-server/index.rst
@@ -14,5 +14,6 @@ In the integrated version, the users and roles service configured in geoserver a
    gui
    rest
    rest-adminrule
+   rest-batch-op
    tutorial
    migration

--- a/doc/en/user/source/extensions/geofence-server/rest-batch-op.rst
+++ b/doc/en/user/source/extensions/geofence-server/rest-batch-op.rst
@@ -1,0 +1,113 @@
+.. _rest_api_geofence_server_batch:
+
+Batch Rest API
+===================
+
+Batch operations allow to run multiple insert, update and delete at the same time over rules and admin rules. All the operations are executed in a single transaction: this means that either all of them are successful or all the operations are rolled back.
+
+Security
+--------
+
+The Geofence REST API is only accessible to users with the role ``ROLE_ADMIN``.
+
+Input/Output
+------------
+
+Data Object Transfer
+~~~~~~~~~~~~~~~~~~~~
+Both XML and JSON are supported for transfer of data objects. The default is XML. Alternatively, JSON may be used by setting the ``Content-Type`` and ``Accept`` HTTP headers to ``application/json`` in your requests.
+
+A ``Batch`` data object transfer must declare a list of ``operations``. Each operation needs to declare:
+
+* The ``service`` name (``rules`` for a Rule operation or ``adminrules`` for an AdminRule operation).
+
+* The ``type`` of the operation (``insert``, ``update``, ``delete``).
+
+* The ``id`` of the entity over which the operation is being performed in case of an ``update`` or ``delete`` types.
+
+* The ``Rule`` or ``AdminRule`` data object transfer in case of ``insert`` or ``update`` operation.
+
+Encoding of a Batch in XML::
+
+	<Batch>
+   <operations service="rules" id="2" type="update">
+      <Rule id="2">
+         <access>ALLOW</access>
+         <layer>layer</layer>
+         <priority>5</priority>
+         <request>GETMAP</request>
+         <roleName>ROLE_AUTHENTICATED</roleName>
+         <service>WMS</service>
+         <workspace>ws</workspace>
+      </Rule>
+   </operations>
+   <operations service="rules" id="5" type="delete" />
+   <operations service="adminrules" type="insert">
+      <RuleAdmin>
+         <priority>2</priority>
+         <roleName>ROLE_USER</roleName>
+         <workspace>ws</workspace>
+         <access>ADMIN</access>
+      </RuleAdmin>
+   </operations>
+ </Batch>
+
+Encoding of a Batch in JSON::
+
+	{
+   "Batch":{
+      "operations":[
+         {
+            "@service":"adminrules",
+            "@type":"update",
+            "@id":"3",
+            "Rule":{
+               "access":"ALLOW",
+               "layer":"layer",
+               "priority":5,
+               "request":"GETMAP",
+               "service":"WMS",
+               "roleName":"ROLE_AUTHENTICATED",
+               "workspace":"ws"
+            }
+         },
+         {
+            "@service":"rules",
+            "@type":"delete",
+            "@id":5
+         },
+         {
+            "@service":"adminrules",
+            "@type":"insert",
+            "AdminRule":{
+               "priority":2,
+               "roleName":"ROLE_USER",
+               "workspace":"ws",
+               "access":"ADMIN"
+            }
+         }
+      ]
+   }
+ }
+
+
+Requests
+--------
+
+``/rest/geofence/batch/exec``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Issue a Batch operation executing all the declared operations.
+
++------------+-----------------+--------------+-------------------------------------------------------------+
+| Method     | Action          | Response code| Response                                                    |
++============+=================+==============+=============================================================+
+| POST       | Execute a batch | 200          | OK                                                          |
+|            |                 +--------------+-------------------------------------------------------------+
+|            |                 | 400          | BadRequest: malformed request body, duplicate rule addition |
+|            |                 +--------------+-------------------------------------------------------------+
+|            |                 | 404          | NotFound: rule not found                                    |
+|            |                 +--------------+-------------------------------------------------------------+
+|            |                 | 500          | InternalServerError: unexpected error                       |
++------------+-----------------+--------------+-------------------------------------------------------------+
+

--- a/src/extension/geofence-server/src/main/java/org/geoserver/geofence/server/rest/BatchRestController.java
+++ b/src/extension/geofence-server/src/main/java/org/geoserver/geofence/server/rest/BatchRestController.java
@@ -1,0 +1,212 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.server.rest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.geoserver.geofence.core.dao.DuplicateKeyException;
+import org.geoserver.geofence.rest.xml.AbstractPayload;
+import org.geoserver.geofence.rest.xml.Batch;
+import org.geoserver.geofence.rest.xml.BatchOperation;
+import org.geoserver.geofence.rest.xml.JaxbAdminRule;
+import org.geoserver.geofence.rest.xml.JaxbRule;
+import org.geoserver.geofence.services.exception.BadRequestServiceEx;
+import org.geoserver.geofence.services.exception.InternalErrorServiceEx;
+import org.geoserver.geofence.services.exception.NotFoundServiceEx;
+import org.geoserver.geofence.services.exception.WebApplicationException;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.util.MediaTypeExtensions;
+import org.geotools.util.logging.Logging;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ControllerAdvice
+@RequestMapping(path = RestBaseController.ROOT_PATH + "/geofence/batch")
+@Scope(proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class BatchRestController extends RestBaseController {
+
+    private static final Logger LOGGER = Logging.getLogger(BatchRestController.class);
+
+    @Autowired private AdminRulesRestController adminRulesRestController;
+
+    @Autowired private RulesRestController rulesRestController;
+
+    /**
+     * Exception handle to hanlde the {@link NotFoundServiceEx} exceptiont throw by the service.
+     *
+     * @param exception the exception to handle.
+     * @param request the request.
+     * @param response the response.
+     * @throws IOException
+     */
+    @ExceptionHandler(NotFoundServiceEx.class)
+    public void notFound(
+            NotFoundServiceEx exception, HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        response.sendError(404, exception.getMessage());
+    }
+
+    @ExceptionHandler(BadRequestServiceEx.class)
+    public void badRequest(
+            BadRequestServiceEx exception, HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        response.sendError(400, exception.getMessage());
+    }
+
+    @ExceptionHandler(InternalErrorServiceEx.class)
+    public void internalServerError(
+            BadRequestServiceEx exception, HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        response.sendError(500, exception.getMessage());
+    }
+
+    /**
+     * Execute a Batch with all the operations it includes.
+     *
+     * @param batch the batch to execute.
+     * @return 200 when successful error otherwise.
+     */
+    @RequestMapping(
+            value = "/exec",
+            method = RequestMethod.POST,
+            consumes = {
+                MediaType.TEXT_XML_VALUE,
+                MediaType.APPLICATION_XML_VALUE,
+                MediaType.APPLICATION_JSON_VALUE,
+                MediaTypeExtensions.TEXT_JSON_VALUE
+            })
+    @Transactional(value = "geofenceTransactionManager")
+    public HttpStatus exec(@RequestBody(required = true) Batch batch) {
+        try {
+            List<BatchOperation> operations = batch.getOperations();
+            for (BatchOperation op : operations) {
+                execBatchOp(op);
+            }
+            return HttpStatus.OK;
+        } catch (DuplicateKeyException e) {
+            throw new BadRequestServiceEx(
+                    "The operation is trying to add a duplicate rule or adminrule");
+        } catch (WebApplicationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Unexpected error: " + ex.getMessage(), ex);
+            throw new InternalErrorServiceEx("Unexpected exception: " + ex.getMessage());
+        }
+    }
+
+    private void execBatchOp(BatchOperation op) {
+        BatchOperation.ServiceName sn = op.getService();
+        ensureService(sn);
+        switch (sn) {
+            case rules:
+                executeRuleOp(op);
+                break;
+            case adminrules:
+                executeAdminRuleOp(op);
+                break;
+            default:
+                throw new NotFoundServiceEx(
+                        "No service found for name " + sn != null ? sn.name() : "");
+        }
+    }
+
+    private void executeRuleOp(BatchOperation op) {
+        BatchOperation.TypeName type = op.getType();
+        ensureType(type);
+        switch (type) {
+            case insert:
+                ensureRulePayload(op);
+                rulesRestController.insert((JaxbRule) op.getPayload());
+                break;
+            case delete:
+                ensureId(op, BatchOperation.TypeName.delete.name());
+                rulesRestController.delete(op.getId());
+                break;
+            case update:
+                ensureRulePayload(op);
+                ensureId(op, BatchOperation.TypeName.update.name());
+                rulesRestController.update(op.getId(), (JaxbRule) op.getPayload());
+                break;
+            default:
+                throw new BadRequestServiceEx(
+                        "No batch op found in context of rule service, for type " + type != null
+                                ? type.name()
+                                : "");
+        }
+    }
+
+    private void executeAdminRuleOp(BatchOperation op) {
+        BatchOperation.TypeName type = op.getType();
+        ensureType(type);
+        switch (type) {
+            case insert:
+                ensureAdminRulePayload(op);
+                adminRulesRestController.insert((JaxbAdminRule) op.getPayload());
+                break;
+            case delete:
+                ensureId(op, BatchOperation.TypeName.delete.name());
+                adminRulesRestController.delete(op.getId());
+                break;
+            case update:
+                ensureAdminRulePayload(op);
+                ensureId(op, BatchOperation.TypeName.update.name());
+                adminRulesRestController.update(op.getId(), (JaxbAdminRule) op.getPayload());
+                break;
+            default:
+                throw new BadRequestServiceEx(
+                        "No batch op found in context of adminrule service, for type " + type
+                                        != null
+                                ? type.name()
+                                : "");
+        }
+    }
+
+    private void ensureRulePayload(BatchOperation op) {
+        AbstractPayload jaxbPayload = op.getPayload();
+        if (!(jaxbPayload instanceof JaxbRule)) {
+            throw new BadRequestServiceEx("An operation requiring a Rule payload doesn't have it");
+        }
+    }
+
+    private void ensureAdminRulePayload(BatchOperation op) {
+        AbstractPayload jaxbPayload = op.getPayload();
+        if (!(jaxbPayload instanceof JaxbAdminRule)) {
+            throw new BadRequestServiceEx(
+                    "An operation requiring an AdminRule payload doesn't have it");
+        }
+    }
+
+    private void ensureId(BatchOperation op, String type) {
+        if (op.getId() == null)
+            throw new BadRequestServiceEx("An id is required for operation type " + type);
+    }
+
+    private void ensureType(BatchOperation.TypeName typeName) {
+        if (typeName == null)
+            throw new BadRequestServiceEx(
+                    "The operation type is mandatory but on or more operation elements doesn't have it");
+    }
+
+    private void ensureService(BatchOperation.ServiceName serviceName) {
+        if (serviceName == null)
+            throw new BadRequestServiceEx(
+                    "The operation service is mandatory but on or more operation elements doesn't have it");
+    }
+}

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/BatchRestControllerTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/BatchRestControllerTest.java
@@ -1,0 +1,466 @@
+package org.geoserver.geofence.rest;
+
+import static net.sf.ezmorph.test.ArrayAssertions.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.geofence.GeofenceBaseTest;
+import org.geoserver.geofence.core.model.AdminRule;
+import org.geoserver.geofence.core.model.Rule;
+import org.geoserver.geofence.core.model.enums.AdminGrantType;
+import org.geoserver.geofence.core.model.enums.GrantType;
+import org.geoserver.geofence.rest.xml.Batch;
+import org.geoserver.geofence.rest.xml.BatchOperation;
+import org.geoserver.geofence.rest.xml.JaxbAdminRule;
+import org.geoserver.geofence.rest.xml.JaxbRule;
+import org.geoserver.geofence.server.rest.BatchRestController;
+import org.geoserver.geofence.services.AdminRuleAdminService;
+import org.geoserver.geofence.services.RuleAdminService;
+import org.geoserver.geofence.services.dto.ShortAdminRule;
+import org.geoserver.geofence.services.dto.ShortRule;
+import org.geoserver.geofence.services.exception.BadRequestServiceEx;
+import org.geoserver.geofence.services.exception.NotFoundServiceEx;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+public class BatchRestControllerTest extends GeofenceBaseTest {
+
+    private BatchRestController controller;
+
+    private RuleAdminService ruleService;
+
+    private AdminRuleAdminService ruleAdminService;
+
+    @Before
+    public void initGeoFenceControllers() {
+        controller = (BatchRestController) applicationContext.getBean("batchRestController");
+        ruleService = (RuleAdminService) applicationContext.getBean("ruleAdminService");
+        ruleAdminService =
+                (AdminRuleAdminService) applicationContext.getBean("adminRuleAdminService");
+    }
+
+    @Test
+    public void testRuleBatch() {
+        List<Long> idsToDel = new ArrayList<>();
+        try {
+            JaxbRule rule = new JaxbRule();
+            rule.setPriority(2l);
+            rule.setRoleName("ROLE_USER");
+            rule.setWorkspace("ws");
+            rule.setLayer("layer");
+            rule.setAccess("ALLOW");
+
+            // insert first rule to test update with batch.
+            long id = ruleService.insert(rule.toRule());
+
+            JaxbRule rule2 = new JaxbRule();
+            rule2.setPriority(2l);
+            rule2.setRoleName("ROLE_USER");
+            rule2.setWorkspace("ws");
+            rule2.setLayer("layer");
+            rule2.setAccess("LIMIT");
+            JaxbRule.Limits limits = new JaxbRule.Limits();
+            limits.setCatalogMode("MIXED");
+            rule2.setLimits(limits);
+            // insert another rule for delete
+            long id2 = ruleService.insert(rule2.toRule());
+            ruleService.setLimits(id2, rule2.getLimits().toRuleLimits(null));
+
+            // third rule for insert.
+            JaxbRule rule3 = new JaxbRule();
+            rule3.setPriority(99l);
+            rule3.setRoleName("ROLE_ANONYMOUS");
+            rule3.setWorkspace("ws");
+            rule3.setLayer("layer");
+            rule3.setAccess("DENY");
+
+            Batch batch = new Batch();
+            // insert op.
+            BatchOperation op = new BatchOperation();
+            op.setPayload(rule3);
+            op.setService(BatchOperation.ServiceName.rules);
+            op.setType(BatchOperation.TypeName.insert);
+            batch.add(op);
+
+            // delete op.
+            BatchOperation op2 = new BatchOperation();
+            op2.setService(BatchOperation.ServiceName.rules);
+            op2.setType(BatchOperation.TypeName.delete);
+            op2.setId(id2);
+            batch.add(op2);
+
+            // update op.
+            BatchOperation op3 = new BatchOperation();
+            op3.setService(BatchOperation.ServiceName.rules);
+            op3.setType(BatchOperation.TypeName.update);
+            op3.setId(id);
+            rule.setAccess("DENY");
+            op3.setPayload(rule);
+            batch.add(op3);
+
+            HttpStatus status = controller.exec(batch);
+            assertEquals(200, status.value());
+            Rule deleted = null;
+            try {
+                deleted = ruleService.get(id2);
+            } catch (Exception e) {
+            }
+            // rule was deleted.
+            assertNull(deleted);
+
+            // rule was updated
+            Rule updated = ruleService.get(id);
+            assertEquals(GrantType.DENY, updated.getAccess());
+            assertEquals("ROLE_USER", updated.getRolename());
+
+            // rule was inserted.
+            ShortRule inserted = ruleService.getRuleByPriority(99L);
+            assertEquals(GrantType.DENY, inserted.getAccess());
+            assertEquals("ROLE_ANONYMOUS", inserted.getRoleName());
+
+            // clean up.
+            idsToDel.add(id);
+            idsToDel.add(inserted.getId());
+        } finally {
+            deleteRules(idsToDel);
+        }
+    }
+
+    @Test
+    public void testAdminRuleBatch() {
+        List<Long> idsToDel = new ArrayList<>();
+        try {
+            // insert to test the update
+            JaxbAdminRule adminRule = new JaxbAdminRule();
+            adminRule.setRoleName("ROLE_USER");
+            adminRule.setWorkspace("ws00");
+            adminRule.setAccess(AdminGrantType.USER.name());
+            Long id = ruleAdminService.insert(adminRule.toRule());
+
+            // insert to test the delete.
+            AdminRule adminRule2 = new AdminRule();
+            adminRule2.setRolename("ROLE_USER2");
+            adminRule2.setWorkspace("ws22");
+            adminRule2.setAccess(AdminGrantType.ADMIN);
+            Long id2 = ruleAdminService.insert(adminRule2);
+
+            // to test insertion
+            JaxbAdminRule adminRule3 = new JaxbAdminRule();
+            adminRule3.setRoleName("ROLE_USER3");
+            adminRule3.setWorkspace("ws33");
+            adminRule3.setPriority(999L);
+            adminRule3.setAccess(AdminGrantType.ADMIN.name());
+
+            Batch batch = new Batch();
+            // insert op.
+            BatchOperation operation = new BatchOperation();
+            operation.setService(BatchOperation.ServiceName.adminrules);
+            operation.setType(BatchOperation.TypeName.insert);
+            operation.setPayload(adminRule3);
+            batch.add(operation);
+
+            // delete op.
+            BatchOperation operation2 = new BatchOperation();
+            operation2.setService(BatchOperation.ServiceName.adminrules);
+            operation2.setType(BatchOperation.TypeName.delete);
+            operation2.setId(id2);
+            batch.add(operation2);
+
+            // update op.
+            BatchOperation operation3 = new BatchOperation();
+            operation3.setService(BatchOperation.ServiceName.adminrules);
+            operation3.setType(BatchOperation.TypeName.update);
+            operation3.setId(id);
+            adminRule.setWorkspace("ws012");
+            operation3.setPayload(adminRule);
+            batch.add(operation3);
+
+            controller.exec(batch);
+
+            // rule was updated
+            AdminRule rule = ruleAdminService.get(id);
+            assertEquals("ws012", rule.getWorkspace());
+            assertEquals(AdminGrantType.USER, rule.getAccess());
+            assertEquals("ROLE_USER", rule.getRolename());
+
+            // rule was deleted
+            AdminRule deleted = null;
+            try {
+                deleted = ruleAdminService.get(id2);
+            } catch (Exception e) {
+            }
+            assertNull(deleted);
+
+            // rule was inserted.
+            ShortAdminRule inserted = ruleAdminService.getRuleByPriority(999L);
+            assertEquals("ws33", inserted.getWorkspace());
+            assertEquals("ROLE_USER3", inserted.getRoleName());
+            assertEquals(AdminGrantType.ADMIN, inserted.getAccess());
+
+            // clean up
+            idsToDel.add(id);
+            idsToDel.add(inserted.getId());
+        } finally {
+            deleteAdminRules(idsToDel);
+        }
+    }
+
+    @Test
+    public void testMixedServiceBatch() {
+        // test mixed service (Rule and AdminRule)
+        Long adminId = null;
+        Long ruleId = null;
+        try {
+            JaxbRule rule = new JaxbRule();
+            rule.setPriority(2l);
+            rule.setRoleName("ROLE_USER4");
+            rule.setWorkspace("ws");
+            rule.setLayer("layer");
+            rule.setAccess("ALLOW");
+            long id = ruleService.insert(rule.toRule());
+
+            Batch batch = new Batch();
+            BatchOperation op = new BatchOperation();
+            op.setService(BatchOperation.ServiceName.rules);
+            op.setType(BatchOperation.TypeName.update);
+            op.setId(id);
+            rule.setAccess("DENY");
+            rule.setRoleName("ROLE_USER5");
+            op.setPayload(rule);
+            batch.add(op);
+
+            JaxbAdminRule adminRule = new JaxbAdminRule();
+            adminRule.setPriority(9999L);
+            adminRule.setRoleName("ROLE_USER6");
+            adminRule.setAccess("ADMIN");
+            adminRule.setWorkspace("ws99");
+
+            BatchOperation op2 = new BatchOperation();
+            op2.setService(BatchOperation.ServiceName.adminrules);
+            op2.setType(BatchOperation.TypeName.insert);
+            op2.setPayload(adminRule);
+            batch.add(op2);
+
+            HttpStatus status = controller.exec(batch);
+            assertEquals(200, status.value());
+            Rule updated = ruleService.get(id);
+            assertEquals(GrantType.DENY, updated.getAccess());
+            assertEquals("ROLE_USER5", updated.getRolename());
+            ShortAdminRule inserted = ruleAdminService.getRuleByPriority(9999L);
+            assertEquals(AdminGrantType.ADMIN, inserted.getAccess());
+            assertEquals("ws99", inserted.getWorkspace());
+            assertEquals("ROLE_USER6", inserted.getRoleName());
+            ruleId = id;
+            adminId = inserted.getId();
+        } finally {
+            if (adminId != null) ruleAdminService.delete(adminId);
+            if (ruleId != null) ruleService.delete(ruleId);
+        }
+    }
+
+    @Test
+    public void testGlobalRollback() {
+        Long ruleId = null;
+        try {
+            JaxbRule rule = new JaxbRule();
+            rule.setPriority(2l);
+            rule.setRoleName("ROLE_USER4");
+            rule.setWorkspace("ws44");
+            rule.setLayer("layer");
+            rule.setAccess("ALLOW");
+            long id = ruleService.insert(rule.toRule());
+            ruleId = id;
+            Batch batch = new Batch();
+            BatchOperation op = new BatchOperation();
+            op.setService(BatchOperation.ServiceName.rules);
+            op.setType(BatchOperation.TypeName.update);
+            op.setId(id);
+            rule.setAccess("DENY");
+            rule.setRoleName("ROLE_USER5");
+            op.setPayload(rule);
+            batch.add(op);
+
+            JaxbRule dup = new JaxbRule();
+            dup.setPriority(1l);
+            dup.setRoleName("ROLE_USER9");
+            dup.setWorkspace("ws99");
+            dup.setLayer("layer99");
+            dup.setAccess("ALLOW");
+
+            ruleService.insert(dup.toRule());
+
+            BatchOperation op2 = new BatchOperation();
+            op2.setService(BatchOperation.ServiceName.rules);
+            op2.setType(BatchOperation.TypeName.insert);
+            dup.setPriority(99999L);
+            op2.setPayload(dup);
+            batch.add(op2);
+
+            // the second operation will fail since the rule is duplicated.
+            String message = null;
+            try {
+                controller.exec(batch);
+            } catch (Exception e) {
+                assertTrue(e instanceof BadRequestServiceEx);
+                message = e.getMessage();
+            }
+
+            assertEquals("The operation is trying to add a duplicate rule or adminrule", message);
+
+            // check that the updated rule is as it was before batch.
+            Rule updated = ruleService.get(id);
+            assertEquals(GrantType.ALLOW, updated.getAccess());
+            assertEquals("ROLE_USER4", updated.getRolename());
+
+            // check we don't actually have the new rule.
+            ShortRule inserted = null;
+            try {
+                inserted = ruleService.getRuleByPriority(99999L);
+            } catch (Exception e) {
+            }
+            assertNull(inserted);
+        } finally {
+            if (ruleId != null) ruleService.delete(ruleId);
+        }
+    }
+
+    @Test
+    public void testMissingServiceName() {
+        JaxbRule rule = new JaxbRule();
+        rule.setPriority(1l);
+        rule.setRoleName("ROLE_USER9");
+        rule.setWorkspace("ws99");
+        rule.setLayer("layer99");
+        rule.setAccess("ALLOW");
+
+        Batch batch = new Batch();
+        BatchOperation op = new BatchOperation();
+        op.setType(BatchOperation.TypeName.update);
+        op.setPayload(rule);
+        batch.add(op);
+
+        String message = null;
+        try {
+            controller.exec(batch);
+        } catch (Exception e) {
+            assertTrue(e instanceof BadRequestServiceEx);
+            message = e.getMessage();
+        }
+
+        assertEquals(
+                "The operation service is mandatory but on or more operation elements doesn't have it",
+                message);
+    }
+
+    @Test
+    public void testMissingTypeName() {
+        JaxbRule rule = new JaxbRule();
+        rule.setPriority(1l);
+        rule.setRoleName("ROLE_USER9");
+        rule.setWorkspace("ws99");
+        rule.setLayer("layer99");
+        rule.setAccess("ALLOW");
+
+        Batch batch = new Batch();
+        BatchOperation op = new BatchOperation();
+        op.setService(BatchOperation.ServiceName.rules);
+        op.setPayload(rule);
+        batch.add(op);
+
+        String message = null;
+        try {
+            controller.exec(batch);
+        } catch (Exception e) {
+            assertTrue(e instanceof BadRequestServiceEx);
+            message = e.getMessage();
+        }
+
+        assertEquals(
+                "The operation type is mandatory but on or more operation elements doesn't have it",
+                message);
+    }
+
+    @Test
+    public void testMissingId() {
+        JaxbRule rule = new JaxbRule();
+        rule.setPriority(1l);
+        rule.setRoleName("ROLE_USER9");
+        rule.setWorkspace("ws99");
+        rule.setLayer("layer99");
+        rule.setAccess("ALLOW");
+
+        Batch batch = new Batch();
+        BatchOperation op = new BatchOperation();
+        op.setService(BatchOperation.ServiceName.rules);
+        op.setType(BatchOperation.TypeName.update);
+        op.setPayload(rule);
+        batch.add(op);
+
+        String message = null;
+        try {
+            controller.exec(batch);
+        } catch (Exception e) {
+            assertTrue(e instanceof BadRequestServiceEx);
+            message = e.getMessage();
+        }
+
+        assertEquals("An id is required for operation type update", message);
+    }
+
+    @Test
+    public void testMissingPayload() {
+
+        Batch batch = new Batch();
+        BatchOperation op = new BatchOperation();
+        op.setService(BatchOperation.ServiceName.rules);
+        op.setType(BatchOperation.TypeName.update);
+        op.setId(10L);
+        batch.add(op);
+
+        String message = null;
+        try {
+            controller.exec(batch);
+        } catch (Exception e) {
+            assertTrue(e instanceof BadRequestServiceEx);
+            message = e.getMessage();
+        }
+
+        assertEquals("An operation requiring a Rule payload doesn't have it", message);
+    }
+
+    @Test
+    public void testNotFound() {
+
+        Batch batch = new Batch();
+        BatchOperation op = new BatchOperation();
+        op.setService(BatchOperation.ServiceName.rules);
+        op.setType(BatchOperation.TypeName.delete);
+        op.setId(1000000L);
+        batch.add(op);
+
+        String message = null;
+        try {
+            controller.exec(batch);
+        } catch (Exception e) {
+            assertTrue(e instanceof NotFoundServiceEx);
+            message = e.getMessage();
+        }
+
+        assertEquals("Rule not found (id:1000000)", message);
+    }
+
+    private void deleteRules(List<Long> ids) {
+        for (Long id : ids) {
+            ruleService.delete(id);
+        }
+    }
+
+    private void deleteAdminRules(List<Long> ids) {
+        for (Long id : ids) {
+            ruleAdminService.delete(id);
+        }
+    }
+}

--- a/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/RulesRestControllerTest.java
+++ b/src/extension/geofence-server/src/test/java/org/geoserver/geofence/rest/RulesRestControllerTest.java
@@ -33,7 +33,7 @@ import org.geoserver.geofence.server.rest.RulesRestController;
 import org.geoserver.geofence.services.RuleAdminService;
 import org.geoserver.geofence.services.dto.ShortRule;
 import org.geoserver.geofence.services.exception.NotFoundServiceEx;
-import org.geoserver.geoserver.authentication.GeoFenceXStreamPersisterInitializer;
+import org.geoserver.geoserver.xstream.GeoFenceXStreamPersisterInitializer;
 import org.geoserver.rest.RestBaseController;
 import org.geotools.gml3.bindings.GML3MockData;
 import org.junit.Before;

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/AbstractPayload.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/AbstractPayload.java
@@ -1,0 +1,8 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.rest.xml;
+
+/** This class is meant to be used as a commom parent type for Batch payload. */
+public abstract class AbstractPayload {}

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/Batch.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/Batch.java
@@ -1,0 +1,46 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.rest.xml;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** This class represent a Batch operation to be consumed by the rest endpoint /batch/exec. */
+public class Batch {
+
+    private List<BatchOperation> operations;
+
+    public Batch() {
+        operations = new LinkedList<>();
+    }
+
+    /** @return the list of operations. */
+    public List<BatchOperation> getOperations() {
+        return operations;
+    }
+
+    /**
+     * Sets the list of operations.
+     *
+     * @param operations the list of operations.
+     */
+    public void setOperations(List<BatchOperation> operations) {
+        this.operations = operations;
+    }
+
+    /**
+     * Add an operation to the list.
+     *
+     * @param op the {@link BatchOperation} to add.
+     */
+    public void add(BatchOperation op) {
+        operations.add(op);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + operations.size() + " ops]";
+    }
+}

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/BatchOperation.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/BatchOperation.java
@@ -1,0 +1,102 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.rest.xml;
+
+/**
+ * Represents a single BatchOperation. A batch operation can either use rules or adminrules services
+ * and can be of one of these types: insert, update, delete.
+ */
+public class BatchOperation {
+
+    /** Enum of available service names. */
+    public enum ServiceName {
+        rules,
+        adminrules
+    }
+
+    /** Enum of available op Type names. */
+    public enum TypeName {
+        insert,
+        update,
+        delete,
+    }
+
+    private ServiceName service;
+
+    private TypeName type;
+    private Long id;
+
+    private AbstractPayload payload;
+
+    public BatchOperation() {}
+
+    /** @return the id of the op. */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set the id of the operation.
+     *
+     * @param id the id to set.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /** @return the service name of the operation. */
+    public ServiceName getService() {
+        return service;
+    }
+
+    /**
+     * Sets the service name of the operation.
+     *
+     * @param service the service name to set.
+     */
+    public void setService(ServiceName service) {
+        this.service = service;
+    }
+
+    /** @return the type name of the operation. */
+    public TypeName getType() {
+        return type;
+    }
+
+    /**
+     * Sets the type name.
+     *
+     * @param type the type name to set.
+     */
+    public void setType(TypeName type) {
+        this.type = type;
+    }
+
+    /** @return the payload of the operation. Can be {@link JaxbRule} or a {@link JaxbAdminRule}. */
+    public AbstractPayload getPayload() {
+        return payload;
+    }
+
+    /**
+     * Sets the payload of the operation.
+     *
+     * @param payload the payload to set. Can be a {@link JaxbRule} or a {@link JaxbAdminRule}
+     */
+    public void setPayload(AbstractPayload payload) {
+        this.payload = payload;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName()
+                + "["
+                + service
+                + "."
+                + type
+                + (id != null ? " id:" + id : "")
+                + (payload != null ? " payload is a " + payload.getClass().getSimpleName() : "")
+                + "]";
+    }
+}

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/JaxbAdminRule.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/JaxbAdminRule.java
@@ -12,7 +12,7 @@ import org.geoserver.geofence.core.model.IPAddressRange;
 import org.geoserver.geofence.core.model.enums.AdminGrantType;
 
 @XmlRootElement(name = "AdminRule")
-public class JaxbAdminRule {
+public class JaxbAdminRule extends AbstractPayload {
 
     private Long id;
 

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/JaxbRule.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/rest/xml/JaxbRule.java
@@ -23,7 +23,7 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
 @XmlRootElement(name = "Rule")
-public class JaxbRule {
+public class JaxbRule extends AbstractPayload {
 
     /** Specification for "LIMIT" rules. */
     public static class Limits {

--- a/src/extension/geofence/src/main/java/org/geoserver/geoserver/xstream/BatchOpXtreamConverter.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geoserver/xstream/BatchOpXtreamConverter.java
@@ -1,0 +1,64 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geoserver.xstream;
+
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter;
+import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.mapper.Mapper;
+import org.apache.commons.lang3.StringUtils;
+import org.geoserver.geofence.rest.xml.AbstractPayload;
+import org.geoserver.geofence.rest.xml.BatchOperation;
+import org.geoserver.geofence.rest.xml.JaxbAdminRule;
+import org.geoserver.geofence.rest.xml.JaxbRule;
+
+/** Converter for a {@link BatchOperation} instance. */
+public class BatchOpXtreamConverter extends AbstractReflectionConverter {
+
+    public BatchOpXtreamConverter(Mapper mapper, ReflectionProvider reflectionProvider) {
+        super(mapper, reflectionProvider);
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return BatchOperation.class.isAssignableFrom(type);
+    }
+
+    @Override
+    protected Object instantiateNewInstance(
+            HierarchicalStreamReader reader, UnmarshallingContext context) {
+        return new BatchOperation();
+    }
+
+    @Override
+    public Object doUnmarshal(
+            Object result, HierarchicalStreamReader reader, UnmarshallingContext context) {
+
+        BatchOperation operation = (BatchOperation) result;
+        String srv = reader.getAttribute("service");
+        String type = reader.getAttribute("type");
+        String id = reader.getAttribute("id");
+
+        if (!StringUtils.isBlank(srv))
+            operation.setService(BatchOperation.ServiceName.valueOf(srv));
+        if (!StringUtils.isBlank(type)) operation.setType(BatchOperation.TypeName.valueOf(type));
+        if (!StringUtils.isBlank(id)) operation.setId(Long.valueOf(id));
+        while (reader.hasMoreChildren()) {
+            reader.moveDown();
+            String nodeName = reader.getNodeName();
+            Object payload = null;
+            if (nodeName.equals("Rule")) {
+                payload = context.convertAnother(operation, JaxbRule.class);
+            } else if (nodeName.equals("AdminRule")) {
+                payload = context.convertAnother(operation, JaxbAdminRule.class);
+            }
+            operation.setPayload((AbstractPayload) payload);
+            reader.moveUp();
+        }
+
+        return result;
+    }
+}

--- a/src/extension/geofence/src/main/java/org/geoserver/geoserver/xstream/GeoFenceXStreamPersisterInitializer.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geoserver/xstream/GeoFenceXStreamPersisterInitializer.java
@@ -3,11 +3,14 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.geoserver.authentication;
+package org.geoserver.geoserver.xstream;
 
 import com.thoughtworks.xstream.XStream;
+import org.geoserver.config.util.CollectionConverter;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterInitializer;
+import org.geoserver.geofence.rest.xml.Batch;
+import org.geoserver.geofence.rest.xml.BatchOperation;
 import org.geoserver.geofence.rest.xml.JaxbAdminRule;
 import org.geoserver.geofence.rest.xml.JaxbAdminRuleList;
 import org.geoserver.geofence.rest.xml.JaxbRule;
@@ -28,7 +31,13 @@ public class GeoFenceXStreamPersisterInitializer implements XStreamPersisterInit
         xs.alias("AdminRule", JaxbAdminRule.class);
         xs.alias("Rules", JaxbRuleList.class);
         xs.alias("AdminRules", JaxbAdminRuleList.class);
-
+        xs.alias("Batch", Batch.class);
+        xs.alias("BatchOperation", BatchOperation.class);
+        xs.registerLocalConverter(
+                Batch.class, "operations", new CollectionConverter(xs.getMapper()));
+        xs.addImplicitCollection(Batch.class, "operations", BatchOperation.class);
+        xs.registerConverter(
+                new BatchOpXtreamConverter(xs.getMapper(), xs.getReflectionProvider()));
         xs.allowTypes(
                 new Class[] {
                     GeoFenceAuthenticationProviderConfig.class,
@@ -36,7 +45,12 @@ public class GeoFenceXStreamPersisterInitializer implements XStreamPersisterInit
                     JaxbAdminRule.class,
                     JaxbRuleList.class,
                     JaxbAdminRuleList.class,
-                    MultiPolygonAdapter.class
+                    MultiPolygonAdapter.class,
+                    JaxbRule.Limits.class,
+                    JaxbRule.LayerDetails.class,
+                    JaxbRule.LayerAttribute.class,
+                    Batch.class,
+                    BatchOperation.class
                 });
     }
 }

--- a/src/extension/geofence/src/main/resources/applicationContext.xml
+++ b/src/extension/geofence/src/main/resources/applicationContext.xml
@@ -125,7 +125,7 @@
     </bean>
 
     <bean id="geoFenceXStreamInitializer" 
-          class="org.geoserver.geoserver.authentication.GeoFenceXStreamPersisterInitializer"
+          class="org.geoserver.geoserver.xstream.GeoFenceXStreamPersisterInitializer"
           lazy-init="false">
     </bean>
 

--- a/src/extension/geofence/src/test/resources/org/geoserver/geoserver/xstream/batch.json
+++ b/src/extension/geofence/src/test/resources/org/geoserver/geoserver/xstream/batch.json
@@ -1,0 +1,35 @@
+{
+  "Batch": {
+    "operations": [
+      {
+        "@service": "rules",
+        "@type": "update",
+        "@id": "3",
+        "Rule": {
+          "access": "ALLOW",
+          "layer": "layer",
+          "priority": 5,
+          "request": "GETMAP",
+          "service": "WMS",
+          "roleName": "ROLE_AUTHENTICATED",
+          "workspace": "ws"
+        }
+      },
+      {
+        "@service": "rules",
+        "@type": "delete",
+        "@id": 5
+      },
+      {
+        "@service": "adminrules",
+        "@type": "insert",
+        "AdminRule": {
+          "priority": 2,
+          "roleName": "ROLE_USER",
+          "workspace": "ws",
+          "access": "ADMIN"
+        }
+      }
+    ]
+  }
+}

--- a/src/extension/geofence/src/test/resources/org/geoserver/geoserver/xstream/batch.xml
+++ b/src/extension/geofence/src/test/resources/org/geoserver/geoserver/xstream/batch.xml
@@ -1,0 +1,22 @@
+<Batch>
+    <operations service="rules" id="3" type="update">
+        <Rule>
+            <access>ALLOW</access>
+            <layer>layer</layer>
+            <priority>5</priority>
+            <request>GETMAP</request>
+            <roleName>ROLE_AUTHENTICATED</roleName>
+            <service>WMS</service>
+            <workspace>ws</workspace>
+        </Rule>
+    </operations>
+    <operations service="rules" id="5" type="delete"></operations>
+    <operations service="adminrules" type="insert">
+        <AdminRule>
+            <priority>2</priority>
+            <roleName>ROLE_USER</roleName>
+            <workspace>ws</workspace>
+            <access>ADMIN</access>
+        </AdminRule>
+    </operations>
+</Batch>


### PR DESCRIPTION
[![GEOS-10507](https://badgen.net/badge/JIRA/GEOS-10507/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10507)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* [GEOS-10507] GeoFence Internal - Support Batch operations for Rules and AdminRules

* review feedback

* Minor improvements to rst doc

* fix qa failure

Co-authored-by: Emanuele Tajariol <e.tajariol@gmail.com>


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->