### PR TITLE
[GEOS-10604] Handling empty coverage data

### DIFF
--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/CustomDimensionsTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/CustomDimensionsTest.java
@@ -7,7 +7,6 @@ package org.geoserver.wcs;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
@@ -50,12 +49,12 @@ public class CustomDimensionsTest extends CoverageTestSupport {
         String request = getWaterTempRequest("bad_dimension_value");
         MockHttpServletResponse response = postAsServletResponse("wcs", request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
 
         request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toLowerCase());
         response = postAsServletResponse("wcs", request);
         image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
     }
 
     @Test
@@ -64,12 +63,12 @@ public class CustomDimensionsTest extends CoverageTestSupport {
         String request = getWaterTempRequestKVP("bad_dimension_value");
         MockHttpServletResponse response = getAsServletResponse(request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
 
         request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toLowerCase());
         response = getAsServletResponse(request);
         image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
     }
 
     @Test

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/DynamicDimensionsTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/DynamicDimensionsTest.java
@@ -7,7 +7,6 @@ package org.geoserver.wcs;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
@@ -54,12 +53,12 @@ public class DynamicDimensionsTest extends CoverageTestSupport {
         String request = getWaterTempRequest("bad_dimension_value");
         MockHttpServletResponse response = postAsServletResponse("wcs", request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
 
         request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toUpperCase());
         response = postAsServletResponse("wcs", request);
         image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
     }
 
     @Test
@@ -68,12 +67,12 @@ public class DynamicDimensionsTest extends CoverageTestSupport {
         String request = getWaterTempRequestKVP("bad_dimension_value");
         MockHttpServletResponse response = getAsServletResponse(request);
         BufferedImage image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
 
         request = request.replace(DIMENSION_NAME, DIMENSION_NAME.toUpperCase());
         response = getAsServletResponse(request);
         image = ImageIO.read(getBinaryInputStream(response));
-        assertNull(image);
+        assertNotNull(image);
     }
 
     @Test

--- a/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
+++ b/src/wcs1_0/src/test/java/org/geoserver/wcs/GetCoverageTest.java
@@ -620,12 +620,6 @@ public class GetCoverageTest extends WCSTestSupport {
         assertEquals("image/tiff", response.getContentType());
         checkPixelValue(response, 10, 10, 13.337999683572);
 
-        // middle hole, no data --> we should get back an exception
-        Document dom =
-                getAsDOM(baseUrl + "&TIME=2008-11-04T12:00:00.000Z/2008-11-04T16:00:00.000Z");
-        // print(dom);
-        XMLAssert.assertXpathEvaluatesTo("1", "count(//ServiceExceptionReport)", dom);
-
         // first range
         response =
                 getAsServletResponse(
@@ -777,11 +771,6 @@ public class GetCoverageTest extends WCSTestSupport {
         MockHttpServletResponse response = getAsServletResponse(baseUrl + "&ELEVATION=75.0/100.0");
         assertEquals("image/tiff", response.getContentType());
         checkPixelValue(response, 10, 10, 13.337999683572);
-
-        // middle hole, no data --> we should get back an exception
-        Document dom = getAsDOM(baseUrl + "&ELEVATION=25.0/75.0");
-        // print(dom);
-        XMLAssert.assertXpathEvaluatesTo("1", "count(//ServiceExceptionReport)", dom);
 
         // first range
         response = getAsServletResponse(baseUrl + "&ELEVATION=0.0/25.0");


### PR DESCRIPTION
[![GEOS-10604](https://badgen.net/badge/JIRA/GEOS-10604/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10604)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In this PR we return a fake image when there is no coverage info, instead of returning an exception. We use the grid coverage factory in order to create the image.   

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->