### PR TITLE
[GEOS-10609] Fix Issue retrieving a workspace style without prefix on JDBCConfig

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/catalog/JDBCCatalogFacade.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/catalog/JDBCCatalogFacade.java
@@ -650,7 +650,11 @@ public class JDBCCatalogFacade implements CatalogFacade {
     /** @see org.geoserver.catalog.CatalogFacade#getStyleByName(java.lang.String) */
     @Override
     public StyleInfo getStyleByName(String name) {
-        return getStyleByName(NO_WORKSPACE, name);
+        StyleInfo match = getStyleByName(NO_WORKSPACE, name);
+        if (match == null) {
+            match = getStyleByName(ANY_WORKSPACE, name);
+        }
+        return match;
     }
 
     /** @see org.geoserver.catalog.CatalogFacade#getStyles() */

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
@@ -32,6 +32,7 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.jdbcconfig.JDBCConfigTestSupport;
@@ -429,5 +430,30 @@ public class CatalogImplWithJDBCFacadeTest extends org.geoserver.catalog.impl.Ca
         WMTSLayerInfo wmtsLayerByName =
                 catalog.getResourceByName(ns, layerName, WMTSLayerInfo.class);
         assertEquals(resource, wmtsLayerByName);
+    }
+
+    @Test
+    public void testGetStyleWithoutWorkspace() {
+        final FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+        addDataStore();
+        addNamespace();
+        catalog.add(wsB);
+
+        FeatureTypeInfo ft1 = newFeatureType("ft1", ds);
+        ft1.setAdvertised(false);
+        catalog.add(ft1);
+        StyleInfo s1 = newStyle("s1", "s1Filename", wsB);
+        catalog.add(s1);
+
+        StyleInfo style = catalog.getStyleByName("s1");
+        assertNotNull(style);
+    }
+
+    protected StyleInfo newStyle(String name, String fileName, WorkspaceInfo workspaceInfo) {
+        StyleInfo s2 = catalog.getFactory().createStyle();
+        s2.setName(name);
+        s2.setFilename(fileName);
+        s2.setWorkspace(workspaceInfo);
+        return s2;
     }
 }


### PR DESCRIPTION
[![GEOS-10609](https://badgen.net/badge/JIRA/GEOS-10609/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10609)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR introduces a fix for the reported issue:

https://osgeo-org.atlassian.net/browse/GEOS-10609

"We found an issue when GeoServer use JDBC config catalog implementation, making it unable to use a workspace based style without using the prefix.  JDBC config catalog should follow the same business logic as the default GeoServer catalog implementation."

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->