### PR TITLE
[GEOS-10608]:Stop flooding logs with InvalidDate (and similar) at Severe

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapIntegrationTest.java
@@ -548,6 +548,28 @@ public class GetMapIntegrationTest extends WMSTestSupport {
     }
 
     @Test
+    public void testInvalidDateNotLogged() throws Exception {
+        try (TestAppender appender =
+                TestAppender.createAppender("testInvalidDateNotLogged", null)) {
+            appender.startRecording("org.geoserver.ows");
+            appender.trigger("Invalid date");
+            MockHttpServletResponse response =
+                    getAsServletResponse(
+                            "wms?bbox=-9.6450076761637E7,-3.9566251818225E7,9.6450076761637E7,3.9566251818225E7"
+                                    + "&styles=&layers="
+                                    + layers
+                                    + "&Format=image/png"
+                                    + "&request=GetMap"
+                                    + "&width=550"
+                                    + "&height=250"
+                                    + "&srs=EPSG:900913"
+                                    + "&time=\"2022-6-20T5:30:0:00.000Z\"");
+            assertEquals("text/xml", response.getContentType());
+            appender.stopRecording("org.geoserver.ows");
+        }
+    }
+
+    @Test
     public void testPng8Opaque() throws Exception {
         MockHttpServletResponse response =
                 getAsServletResponse(


### PR DESCRIPTION
[![GEOS-10608](https://badgen.net/badge/JIRA/GEOS-10608/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10608)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->