### PR TITLE
[GEOS-10610] Selective cache reset on stores and resources, via REST API

### DIFF
--- a/doc/en/api/1.0.0/coverages.yaml
+++ b/doc/en/api/1.0.0/coverages.yaml
@@ -859,7 +859,7 @@ paths:
             $ref: "#/definitions/CoverageInfo"
         - name: calculate
           in: query
-          description: 'Comma-separated list of optional fields to calculate. Optional fields include: "nativebbox", "latlonbbox".'
+          description: 'Comma-separated list of optional fields to calculate. Optional fields include: "nativebbox", "latlonbbox", "dimensions" (that is, bands).'
           required: false
           type: array
           collectionFormat: csv
@@ -901,6 +901,58 @@ paths:
       responses:
         200:
           description: Successfully deleted.
+          
+  /workspaces/{workspace}/coveragestores/{store}/coverages/{coverage}/reset:
+    put:
+      operationId: putCoverageReset
+      tags:
+        - "Coverages"
+      summary: Reset the caches related to this specific coverage.
+      description: Resets raster caches for this coverage. This operation is used to force GeoServer to drop caches associated to this coverage, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime. Warning, the band structure is stored as part of the coverage configuration and won't be modified by this call, in case of need it should be modified issuing a PUT request against the coverage resource itself.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store containing the target coverage.
+          type: string      
+        - name: coverage
+          in: path
+          required: true
+          description: The name of the target coverage.
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postCoverageReset
+      tags:
+        - "Coverages"
+      summary: Reset the caches related to this specific coverage.
+      description: Resets raster caches for this coverage. This operation is used to force GeoServer to drop caches associated to this coverage, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime. Warning, the band structure is stored as part of the coverage configuration and won't be modified by this call, in case of need it should be modified issuing a PUT request against the coverage resource itself.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store containing the target coverage.
+          type: string
+        - name: coverage
+          in: path
+          required: true
+          description: The name of the target coverage.
+          type: string
+      responses:
+        200:
+          description: OK
 
 definitions:
   CoverageInfo:

--- a/doc/en/api/1.0.0/coveragestores.yaml
+++ b/doc/en/api/1.0.0/coveragestores.yaml
@@ -386,6 +386,48 @@ paths:
         405:
           description: Method Not Allowed
 
+  /workspaces/{workspace}/coveragestores/{store}/reset:
+    put:
+      operationId: putCoverageStoreReset
+      tags:
+        - "CoverageStores"
+      summary: Reset the caches related to this specific coverage store.
+      description: Resets raster caches for this coverage store. This operation is used to force GeoServer to drop caches associated to this coverage store, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store to modify.
+          type: string      
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postCoverageStoreReset
+      tags:
+        - "CoverageStores"
+      summary: Reset the caches related to this specific coverage store.
+      description: Resets raster caches for this coverage store. This operation is used to force GeoServer to drop caches associated to this coverage store, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store to modify.
+          type: string
+      responses:
+        200:
+          description: OK
+
 parameters:
   CoverageStorePost:
     name: coverageStoreBody

--- a/doc/en/api/1.0.0/datastores.yaml
+++ b/doc/en/api/1.0.0/datastores.yaml
@@ -207,6 +207,49 @@ paths:
         200:
           description: OK
 
+  /workspaces/{workspaceName}/datastores/{storeName}/reset:
+    put:
+      operationId: putDataStoreReset
+      tags:
+        - "DataStores"
+      summary: Reset the caches related to this specific data store.
+      description: Resets caches for this data store. This operation is used to force GeoServer to drop caches associated to this data store, and reconnect to the vector source the next time it is needed by a request. This is useful as the store can keep state, such as a connection pool, and the structure of the feature types it's serving.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store to modify.
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postDataStoreReset
+      tags:
+        - "DataStores"
+      summary: Reset the caches related to this specific data store.
+      description: Resets caches for this data store. This operation is used to force GeoServer to drop caches associated to this data store, and reconnect to the vector source the next time it is needed by a request. This is useful as the store can keep state, such as a connection pool, and the structure of the feature types it's serving.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store to modify.
+          type: string      
+      responses:
+        200:
+          description: OK
+
+
   /workspaces/{workspaceName}/datastores/{storeName}/{method}.{format}:
     get:
       operationId: getDataStoreUpload

--- a/doc/en/api/1.0.0/featuretypes.yaml
+++ b/doc/en/api/1.0.0/featuretypes.yaml
@@ -295,6 +295,7 @@ paths:
       responses:
         405:
           description: Method not allowed.
+          
   /workspaces/{workspaceName}/datastores/{storeName}/featuretypes/{featureTypeName}:
     get:    
       operationId: getFeatureType
@@ -631,7 +632,7 @@ paths:
           type: string
         - name: recalculate
           in: query
-          description: Specifies whether to recalculate any bounding boxes for a feature type. Some properties of feature types are automatically recalculated when necessary. In particular, the native bounding box is recalculated when the projection or projection policy are changed, and the lat/lon bounding box is recalculated when the native bounding box is recalculated, or when a new native bounding box is explicitly provided in the request. (The native and lat/lon bounding boxes are not automatically recalculated when they are explicitly included in the request.) In addition, the client may explicitly request a fixed set of fields to calculate, by including a comma-separated list of their names in the recalculate parameter.  The empty parameter 'recalculate=' is useful avoid slow recalculation when operating against large datasets as 'recalculate=' avoids calculating any fields, regardless of any changes to projection, projection policy, etc. The nativebbox parameter 'recalculate=nativebbox' is used recalculates the native bounding box, while avoiding recalculating the lat/lon bounding box. Recalculate parameters can be used in together - 'recalculate=nativebbox,latlonbbox' can be used after a bulk import to recalculate both the native bounding box and the lat/lon bounding box.
+          description: Specifies whether to recalculate properties for a feature type. Some properties of feature types are automatically recalculated when necessary. In particular, the native bounding box is recalculated when the projection or projection policy are changed, and the lat/lon bounding box is recalculated when the native bounding box is recalculated, or when a new native bounding box is explicitly provided in the request. (The native and lat/lon bounding boxes are not automatically recalculated when they are explicitly included in the request.) In addition, the client may explicitly request a fixed set of fields to calculate, by including a comma-separated list of their names in the recalculate parameter.  The empty parameter 'recalculate=' is useful avoid slow recalculation when operating against large datasets as 'recalculate=' avoids calculating any fields, regardless of any changes to projection, projection policy, etc. The nativebbox parameter 'recalculate=nativebbox' is used recalculates the native bounding box, while avoiding recalculating the lat/lon bounding box. Recalculate parameters can be used in together - 'recalculate=nativebbox,latlonbbox' can be used after a bulk import to recalculate both the native bounding box and the lat/lon bounding box. Finally, 'recalculate=attributes' can be  used to reset the attributes and reload them from the original vector source. Pay attention to its usage, if attributes were explicity configured to perform attribute selection, renaming, and other transformations, such configuration will be lost, resetting the feature type to the list of attributes found in the vector data source. 
           required: false
           type: array
           collectionFormat: csv
@@ -1049,6 +1050,101 @@ paths:
       responses:
         200:
           description: The feature type was successfully deleted.
+          
+  /workspaces/{workspaceName}/datastores/{storeName}/featuretypes/{featureTypeName}/reset:
+    put:
+      operationId: putFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type.
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store.
+          type: string
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store.
+          type: string
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string          
+      responses:
+        200:
+          description: OK
+
+
+  /workspaces/{workspaceName}/featuretypes/{featureTypeName}/reset:
+    put:
+      operationId: putFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type.
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
 
 definitions:
   FeatureTypeInfo:

--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 import javax.measure.Unit;
 import javax.media.jai.ImageLayout;
 import javax.media.jai.PlanarImage;
+import org.geoserver.catalog.impl.CoverageInfoImpl;
 import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.StoreInfoImpl;
@@ -1136,6 +1137,34 @@ public class CatalogBuilder {
         cinfo.getParameters().putAll(CoverageUtils.getParametersKVP(readParams));
 
         return cinfo;
+    }
+
+    /**
+     * Reloads the {@link CoverageInfo} dimensions from the reader. Can be used to gather the
+     * current band definitions from the reader
+     */
+    public void reloadDimensions(CoverageInfo ci) throws Exception {
+        String nativeName = ci.getNativeCoverageName();
+        setStore(ci.getStore());
+        MetadataMap metadata = ci.getMetadata();
+        CoverageInfo rebuilt;
+        if (metadata != null && metadata.containsKey(CoverageView.COVERAGE_VIEW)) {
+            GridCoverage2DReader reader =
+                    (GridCoverage2DReader)
+                            catalog.getResourcePool()
+                                    .getGridCoverageReader(
+                                            ci, nativeName, GeoTools.getDefaultHints());
+            rebuilt = buildCoverage(reader, nativeName, null);
+        } else {
+            rebuilt = buildCoverage(nativeName);
+        }
+        if (ci instanceof CoverageInfoImpl) {
+            // null safe path, if ci was loaded via XStream
+            ((CoverageInfoImpl) ci).setDimensions(rebuilt.getDimensions());
+        } else {
+            ci.getDimensions().clear();
+            ci.getDimensions().addAll(rebuilt.getDimensions());
+        }
     }
 
     private GridSampleDimension[] getCoverageSampleDimensions(

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageDimensionCustomizerReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageDimensionCustomizerReader.java
@@ -893,4 +893,9 @@ public class CoverageDimensionCustomizerReader implements GridCoverage2DReader {
         checkCoverageName(coverageName);
         return delegate.getDatasetLayout(coverageName);
     }
+
+    /** Made available for testing purposes only */
+    public GridCoverage2DReader getDelegate() {
+        return delegate;
+    }
 }

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -784,6 +784,10 @@ public class ResourcePool {
     public void clear(DataStoreInfo info) {
         String id = info.getId();
         if (id != null) dataStoreCache.remove(id);
+        // the new instance of the store might generate new feature types, clear the cache
+        for (FeatureTypeInfo ft : catalog.getFeatureTypesByDataStore(info)) {
+            clear(ft);
+        }
     }
 
     public List<AttributeTypeInfo> getAttributes(FeatureTypeInfo info) throws IOException {
@@ -1244,6 +1248,23 @@ public class ResourcePool {
             featureTypeCache.remove(id2);
             featureTypeCache.remove(id3);
             featureTypeAttributeCache.remove(id);
+            flushDataStore(info);
+        }
+    }
+
+    /**
+     * Clears a coverage resource from cache. In the current implementation, it resets the
+     * underlying reader, as it's the only bit that's actually cached, to allow discovering new
+     * information potentially available in the source (the reader caches information such as the
+     * bounds, native CRS and the image structure, which affect the coverage itself).
+     */
+    public void clear(CoverageInfo info) {
+        String id = info.getId();
+        if (id != null && info.getStore() != null) {
+            String storeId = info.getStore().getId();
+            coverageCacheKeys.stream()
+                    .filter(k -> storeId.equals(k.id))
+                    .forEach(k -> hintCoverageReaderCache.remove(k));
         }
     }
 
@@ -2572,7 +2593,6 @@ public class ResourcePool {
         @Override
         public void visit(FeatureTypeInfo featureType) {
             pool.clear(featureType);
-            pool.flushDataStore(featureType);
         }
 
         @Override

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/AbstractCatalogController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/AbstractCatalogController.java
@@ -10,7 +10,9 @@ import java.util.Arrays;
 import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.rest.RestBaseController;
@@ -91,6 +93,21 @@ public abstract class AbstractCatalogController extends RestBaseController {
                         "Error while calculating lat/lon bounds for featuretype: " + message;
                 throw new RestException(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR, e);
             }
+        }
+        if (fieldsToCalculate.contains("dimensions") && message instanceof CoverageInfo) {
+            CatalogBuilder cb = new CatalogBuilder(catalog);
+            try {
+                CoverageInfo ci = (CoverageInfo) message;
+                cb.reloadDimensions(ci);
+            } catch (Exception e) {
+                String errorMessage = "Error while calculating bands for coverage: " + message;
+                throw new RestException(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR, e);
+            }
+        }
+        if (fieldsToCalculate.contains("attributes") && message instanceof FeatureTypeInfoImpl) {
+            FeatureTypeInfoImpl ft = (FeatureTypeInfoImpl) message;
+            catalog.getResourcePool().clear(ft);
+            ft.setAttributes(new ArrayList<>());
         }
     }
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageController.java
@@ -45,6 +45,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponents;
@@ -256,6 +257,19 @@ public class CoverageController extends AbstractCatalogController {
         catalog.remove(c);
         catalog.getResourcePool().clear(c.getStore());
         LOGGER.info("DELETE coverage " + storeName + "," + coverageName);
+    }
+
+    @RequestMapping(
+            value = "coveragestores/{storeName}/coverages/{coverageName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(
+            @PathVariable String workspaceName,
+            @PathVariable String storeName,
+            @PathVariable String coverageName) {
+        CoverageStoreInfo cs = catalog.getCoverageStoreByName(workspaceName, storeName);
+        CoverageInfo original = catalog.getCoverageByCoverageStore(cs, coverageName);
+        checkCoverageExists(original, workspaceName, coverageName);
+        catalog.getResourcePool().clear(original);
     }
 
     private List<String> getStoreCoverages(CoverageStoreInfo coverageStore) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreController.java
@@ -51,6 +51,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponents;
@@ -197,6 +198,14 @@ public class CoverageStoreController extends AbstractCatalogController {
                 ((StructuredGridCoverage2DReader) reader).delete(deleteData);
             }
         }
+    }
+
+    @RequestMapping(
+            value = "{storeName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(@PathVariable String workspaceName, @PathVariable String storeName) {
+        CoverageStoreInfo cs = getExistingCoverageStore(workspaceName, storeName);
+        catalog.getResourcePool().clear(cs);
     }
 
     void clear(CoverageStoreInfo info) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreController.java
@@ -52,6 +52,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponents;
@@ -214,6 +215,14 @@ public class DataStoreController extends AbstractCatalogController {
         }
 
         LOGGER.info("DELETE datastore " + workspaceName + ":s" + workspaceName);
+    }
+
+    @RequestMapping(
+            value = "{storeName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(@PathVariable String workspaceName, @PathVariable String storeName) {
+        DataStoreInfo ds = getExistingDataStore(workspaceName, storeName);
+        catalog.getResourcePool().clear(ds);
     }
 
     private DataStoreInfo getExistingDataStore(String workspaceName, String storeName) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
@@ -57,6 +57,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -411,6 +412,20 @@ public class FeatureTypeController extends AbstractCatalogController {
 
         catalog.remove(ftInfo);
         LOGGER.info("DELETE feature type" + storeName + "," + featureTypeName);
+    }
+
+    @RequestMapping(
+            value = "{featureTypeName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(
+            @PathVariable String workspaceName,
+            @PathVariable(required = false) String storeName,
+            @PathVariable String featureTypeName) {
+        DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
+        FeatureTypeInfo ftInfo = catalog.getFeatureTypeByDataStore(dsInfo, featureTypeName);
+        checkFeatureTypeExists(ftInfo, workspaceName, storeName, featureTypeName);
+
+        catalog.getResourcePool().clear(ftInfo);
     }
 
     /** If the feature type doesn't exists throws a REST exception with HTTP 404 code. */

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/CatalogRESTTestSupport.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/CatalogRESTTestSupport.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.rest.catalog;
 
+import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -16,12 +17,23 @@ import org.geoserver.config.CatalogTimeStampUpdater;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.security.AccessMode;
 import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.coverage.grid.GridCoverage2D;
 import org.junit.Before;
 
 public abstract class CatalogRESTTestSupport extends GeoServerSystemTestSupport {
 
     protected static Catalog catalog;
     protected static XpathEngine xp;
+
+    /** Clears up a coverage and its rendered image, important to get builds working on Windows */
+    protected static void dispose(GridCoverage2D coverage) {
+        try {
+            ImageIOUtilities.disposeImage(coverage.getRenderedImage());
+            coverage.dispose(true);
+        } catch (Throwable t) {
+            // Does nothing;
+        }
+    }
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageControllerTest.java
@@ -7,15 +7,18 @@ package org.geoserver.rest.catalog;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.geoserver.rest.RestBaseController.ROOT_PATH;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import it.geosolutions.imageio.utilities.ImageIOUtilities;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.util.List;
 import javax.xml.namespace.QName;
@@ -23,6 +26,7 @@ import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
@@ -36,6 +40,7 @@ import org.geotools.util.URLs;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridCoverageReader;
+import org.opengis.geometry.Envelope;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
@@ -510,12 +515,7 @@ public class CoverageControllerTest extends CatalogRESTTestSupport {
             assertEquals(1000.0, range.getMaximum(), DELTA);
         } finally {
             if (coverage != null) {
-                try {
-                    ImageIOUtilities.disposeImage(coverage.getRenderedImage());
-                    coverage.dispose(true);
-                } catch (Throwable t) {
-                    // Does nothing;
-                }
+                dispose(coverage);
             }
             if (reader != null) {
                 try {
@@ -525,5 +525,85 @@ public class CoverageControllerTest extends CatalogRESTTestSupport {
                 }
             }
         }
+    }
+
+    @Test
+    public void testCoverageReset() throws Exception {
+        // force coverage initialization
+        // read the coverage, check basic properties
+        CoverageInfo ci = catalog.getCoverageByName(getLayerId(SystemTestData.TASMANIA_BM));
+        assertNotNull(ci);
+        GridCoverage2D gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelope = gridCoverage.getEnvelope();
+        dispose(gridCoverage);
+
+        // now go and clear
+        MockHttpServletResponse response =
+                postAsServletResponse(
+                        ROOT_PATH
+                                + "/workspaces/wcs/coveragestores/BlueMarble/coverages/BlueMarble/reset",
+                        "",
+                        null);
+        assertEquals(200, response.getStatus());
+
+        // copy over a different file, will change the bounds
+        try (InputStream is = SystemTestData.class.getResourceAsStream("world.tiff");
+                OutputStream os = getDataDirectory().get("BlueMarble/tazbm.tiff").out()) {
+            IOUtils.copy(is, os);
+        }
+
+        // checking the envelope changed. Cannot check the bands, unlike features, their definition
+        // is part of the configuration, in case of modification it requires an explicit PUT
+        gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelopeNew = gridCoverage.getEnvelope();
+        assertNotEquals(envelopeNew, envelope);
+        dispose(gridCoverage);
+    }
+
+    @Test
+    public void testCoverageResetReloadBands() throws Exception {
+        // force coverage initialization
+        // read the coverage, check basic properties
+        CoverageInfo ci = catalog.getCoverageByName(getLayerId(SystemTestData.TASMANIA_BM));
+        assertNotNull(ci);
+        GridCoverage2D gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelope = gridCoverage.getEnvelope();
+        assertEquals(3, ci.getDimensions().size());
+        dispose(gridCoverage);
+
+        // now go and clear
+        MockHttpServletResponse response =
+                postAsServletResponse(
+                        ROOT_PATH
+                                + "/workspaces/wcs/coveragestores/BlueMarble/coverages/BlueMarble/reset",
+                        "",
+                        null);
+        assertEquals(200, response.getStatus());
+
+        // copy over a different file, will change the coverage type structure enough (bands
+        // included)
+        try (InputStream is = SystemTestData.class.getResourceAsStream("tazdem.tiff");
+                OutputStream os = getDataDirectory().get("BlueMarble/tazbm.tiff").out()) {
+            IOUtils.copy(is, os);
+        }
+
+        // force reload of the bands too
+        response =
+                putAsServletResponse(
+                        ROOT_PATH
+                                + "/workspaces/wcs/coveragestores/BlueMarble/coverages/BlueMarble?calculate=dimensions",
+                        "<coverage/>",
+                        "text/xml");
+        assertEquals(200, response.getStatus());
+
+        // checking the envelope changed. Cannot check the bands, unlike features, their definition
+        // is part of the configuration, in case of modification it requires an explicit PUT
+
+        ci = catalog.getCoverageByName(getLayerId(SystemTestData.TASMANIA_BM));
+        gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelopeNew = gridCoverage.getEnvelope();
+        assertNotEquals(envelopeNew, envelope);
+        assertEquals(1, ci.getDimensions().size());
+        dispose(gridCoverage);
     }
 }

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/FeatureTypeControllerTest.java
@@ -11,6 +11,7 @@ import static org.geoserver.data.test.MockData.SF_PREFIX;
 import static org.geoserver.rest.RestBaseController.ROOT_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -18,6 +19,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +33,7 @@ import java.util.zip.ZipOutputStream;
 import javax.xml.namespace.QName;
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -848,5 +852,92 @@ public class FeatureTypeControllerTest extends CatalogRESTTestSupport {
                         BASEPATH
                                 + "/workspaces/sf/datastores/sf/featuretypes/PrimitiveGeoFeature.xml");
         assertXpathEvaluatesTo("i18n title", "/featureType/internationalTitle/en", dom);
+    }
+
+    @Test
+    public void testFeatureTypeReset() throws Exception {
+        testFeatureTypeStoreReset("/workspaces/sf/featuretypes/PrimitiveGeoFeature/reset");
+    }
+
+    @Test
+    public void testFeatureTypeStoreReset() throws Exception {
+        // force feature type initialization, check it has the expected structure
+        testFeatureTypeStoreReset(
+                "/workspaces/sf/datastores/sf/featuretypes/PrimitiveGeoFeature/reset");
+    }
+
+    private void testFeatureTypeStoreReset(String resetPath) throws Exception {
+        // force feature type initialization, check it has the expected structure
+        FeatureTypeInfo fti =
+                getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.PRIMITIVEGEOFEATURE));
+        FeatureType featureType = fti.getFeatureType();
+        assertNotNull(featureType.getDescriptor("description"));
+        assertNull(featureType.getDescriptor("identifier"));
+
+        // now go and clear
+        MockHttpServletResponse response = postAsServletResponse(ROOT_PATH + resetPath, "", null);
+        assertEquals(200, response.getStatus());
+
+        // copy over a different file, will change the feature type structure enough
+        try (InputStream is =
+                        SystemTestData.class.getResourceAsStream(
+                                "PrimitiveGeoFeatureId.properties");
+                OutputStream os =
+                        getDataDirectory().get("sf/PrimitiveGeoFeature.properties").out()) {
+            IOUtils.copy(is, os);
+        }
+
+        // feature type is not the same object, and has a different structure
+        fti = getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.PRIMITIVEGEOFEATURE));
+        FeatureType featureTypeNew = fti.getFeatureType();
+        assertNotSame(featureTypeNew, featureType);
+        assertNotNull(featureTypeNew.getDescriptor("description"));
+        assertNotNull(featureTypeNew.getDescriptor("identifier"));
+    }
+
+    @Test
+    public void testFeatureTypeResetAttributes() throws Exception {
+        // force feature type initialization, force the set of attributes as configured
+        FeatureTypeInfo fti =
+                getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.PRIMITIVEGEOFEATURE));
+        fti.getAttributes().clear();
+        fti.getAttributes().addAll(fti.attributes());
+        getCatalog().save(fti);
+        FeatureType featureType = fti.getFeatureType();
+        assertNotNull(featureType.getDescriptor("description"));
+        assertNull(featureType.getDescriptor("identifier"));
+
+        // now go and clear
+        MockHttpServletResponse response =
+                postAsServletResponse(
+                        ROOT_PATH + "/workspaces/sf/featuretypes/PrimitiveGeoFeature/reset",
+                        "",
+                        null);
+        assertEquals(200, response.getStatus());
+
+        // copy over a different file, will change the feature type structure enough
+        try (InputStream is =
+                        SystemTestData.class.getResourceAsStream(
+                                "PrimitiveGeoFeatureId.properties");
+                OutputStream os =
+                        getDataDirectory().get("sf/PrimitiveGeoFeature.properties").out()) {
+            IOUtils.copy(is, os);
+        }
+
+        // force recalc of the attributes
+        response =
+                putAsServletResponse(
+                        ROOT_PATH
+                                + "/workspaces/sf/featuretypes/PrimitiveGeoFeature?recalculate=attributes",
+                        "<featureType/>",
+                        "text/xml");
+        assertEquals(200, response.getStatus());
+
+        // feature type is not the same object, and has a different structure
+        fti = getCatalog().getFeatureTypeByName(getLayerId(SystemTestData.PRIMITIVEGEOFEATURE));
+        FeatureType featureTypeNew = fti.getFeatureType();
+        assertNotSame(featureTypeNew, featureType);
+        assertNotNull(featureTypeNew.getDescriptor("description"));
+        assertNotNull(featureTypeNew.getDescriptor("identifier"));
     }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/CoverageBandsConfigurationPanel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/CoverageBandsConfigurationPanel.java
@@ -25,8 +25,6 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageInfo;
-import org.geoserver.catalog.CoverageView;
-import org.geoserver.catalog.MetadataMap;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.DecimalListTextField;
 import org.geoserver.web.wicket.DecimalTextField;
@@ -35,11 +33,9 @@ import org.geoserver.web.wicket.GeoServerDataProvider;
 import org.geoserver.web.wicket.GeoServerDataProvider.Property;
 import org.geoserver.web.wicket.GeoServerTablePanel;
 import org.geoserver.web.wicket.ParamResourceModel;
-import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.measure.UnitFormat;
 import org.geotools.measure.UnitFormatter;
 import org.geotools.util.NumberRange;
-import org.geotools.util.factory.GeoTools;
 import org.geotools.util.logging.Logging;
 import org.opengis.coverage.SampleDimensionType;
 import si.uom.NonSI;
@@ -152,24 +148,9 @@ public class CoverageBandsConfigurationPanel extends ResourceConfigurationPanel 
     private void reloadBands() throws Exception {
         GeoServerApplication app = (GeoServerApplication) getApplication();
         CoverageInfo ci = (CoverageInfo) getResourceInfo();
-        String nativeName = ci.getNativeCoverageName();
         Catalog catalog = app.getCatalog();
         CatalogBuilder cb = new CatalogBuilder(catalog);
-        cb.setStore(ci.getStore());
-        MetadataMap metadata = ci.getMetadata();
-        CoverageInfo rebuilt;
-        if (metadata != null && metadata.containsKey(CoverageView.COVERAGE_VIEW)) {
-            GridCoverage2DReader reader =
-                    (GridCoverage2DReader)
-                            catalog.getResourcePool()
-                                    .getGridCoverageReader(
-                                            ci, nativeName, GeoTools.getDefaultHints());
-            rebuilt = cb.buildCoverage(reader, nativeName, null);
-        } else {
-            rebuilt = cb.buildCoverage(nativeName);
-        }
-        ci.getDimensions().clear();
-        ci.getDimensions().addAll(rebuilt.getDimensions());
+        cb.reloadDimensions(ci);
     }
 
     protected Component buildUnitField(String id, IModel<String> model) {


### PR DESCRIPTION
[![GEOS-10610](https://badgen.net/badge/JIRA/GEOS-10610/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10610)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See [GSIP-214](https://github.com/geoserver/geoserver/wiki/GSIP-214)

@jodygarnett regarding [GEOS-6637](https://osgeo-org.atlassian.net/browse/GEOS-6637), the ability to recalculate the bounding boxes was already built into the rest API, using a "calculate" attribute on coverages, and a "recalculate" one on feature types. I've added "attributes" and "dimensions" (aka bands) for completeness, and to address some asymmetry between feature types and coverages (feature types may have attributes configured, but often just reflect on the storage setup, coverages always have band configured instead, and won't reload them unless explicitly required... I've made sure one can force reload of such config for both vectors and rasters, while doing a PUT though, since that actually changes the config, it does not simply clear caches).

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->