### PR TITLE
[2.21.x backport][GEOS-10568] Fix module modularity for GWC (#6021)

### DIFF
--- a/src/gwc-rest/pom.xml
+++ b/src/gwc-rest/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.geoserver</groupId>
+    <artifactId>geoserver</artifactId>
+    <version>2.21-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver</groupId>
+  <artifactId>gs-gwc-rest</artifactId>
+  <packaging>jar</packaging>
+  <name>GeoWebCache (GWC) Rest Module</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geowebcache</groupId>
+      <artifactId>gwc-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc</artifactId>
+      <version>${gs.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/gwc-rest/src/main/java/org.geoserver.gwc.layer/GWCGeoServerRESTConfigurationProvider.java
+++ b/src/gwc-rest/src/main/java/org.geoserver.gwc.layer/GWCGeoServerRESTConfigurationProvider.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.

--- a/src/gwc-rest/src/main/resources/applicationContext.xml
+++ b/src/gwc-rest/src/main/resources/applicationContext.xml
@@ -12,6 +12,13 @@
     <constructor-arg ref="gwcAppCtx" />
   </bean>
 
-  <context:component-scan base-package="org.geowebcache.rest, org.geowebcache.diskquota.rest.controller, org.geowebcache.service.wmts" />
+  <bean id="GWCGeoServerRESTConfigurationProvider" class="org.geoserver.gwc.layer.GWCGeoServerRESTConfigurationProvider">
+    <description>
+      XmlConfiguration contributor to set up XStream with GeoServer provided configuration objects for GWC's REST API
+    </description>
+    <constructor-arg ref="catalog"/>
+  </bean>
+
+  <context:component-scan base-package="org.geowebcache.rest, org.geowebcache.diskquota.rest.controller" />
 
 </beans>

--- a/src/gwc-rest/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
+++ b/src/gwc-rest/src/test/java/org/geoserver/gwc/RESTIntegrationTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2022 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -66,6 +66,15 @@ public class RESTIntegrationTest extends GeoServerSystemTestSupport {
     }
 
     @Test
+    public void testReloadConfiguration() throws Exception {
+        String path = "/gwc/rest/reload";
+        String content = "reload_configuration=1";
+        String contentType = "application/x-www-form-urlencoded";
+        MockHttpServletResponse response = postAsServletResponse(path, content, contentType);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
     public void testGetLayersList() throws Exception {
         final String url = "gwc/rest/layers.xml";
         MockHttpServletResponse sr = getAsServletResponse(url);
@@ -73,7 +82,6 @@ public class RESTIntegrationTest extends GeoServerSystemTestSupport {
         assertTrue(sr.getContentType(), sr.getContentType().startsWith("application/xml"));
 
         Document dom = getAsDOM(url);
-        // print(dom);
 
         ArrayList<String> tileLayerNames = Lists.newArrayList(GWC.get().getTileLayerNames());
         Collections.sort(tileLayerNames);

--- a/src/gwc/pom.xml
+++ b/src/gwc/pom.xml
@@ -62,10 +62,6 @@
     </dependency>
     <dependency>
       <groupId>org.geowebcache</groupId>
-      <artifactId>gwc-rest</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.geowebcache</groupId>
       <artifactId>gwc-tms</artifactId>
     </dependency>
     <dependency>

--- a/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
@@ -72,12 +72,6 @@
       XmlConfiguration contributor to set up XStream with GeoServer provided configuration objects for GWC configuration storage
     </description>
   </bean>
-  <bean id="GWCGeoServerRESTConfigurationProvider" class="org.geoserver.gwc.layer.GWCGeoServerRESTConfigurationProvider">
-    <description>
-      XmlConfiguration contributor to set up XStream with GeoServer provided configuration objects for GWC's REST API
-    </description>
-    <constructor-arg ref="catalog"/>
-  </bean>
 
   <bean id="gwcCatalogConfiguration" class="org.geoserver.gwc.layer.CatalogConfiguration">
     <constructor-arg ref="rawCatalog" />

--- a/src/gwc/src/main/resources/geowebcache-servlet.xml
+++ b/src/gwc/src/main/resources/geowebcache-servlet.xml
@@ -15,7 +15,6 @@
   <import resource="geowebcache-georss-context.xml"/>
   <import resource="geowebcache-gmaps-context.xml"/>
   <import resource="geowebcache-kmlservice-context.xml"/>
-  <import resource="geowebcache-rest-context.xml"/>
   <import resource="geowebcache-tmsservice-context.xml"/>
   <import resource="geowebcache-virtualearth-context.xml"/>
   <import resource="geowebcache-wmsservice-context.xml"/>

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -1159,15 +1159,6 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
     }
 
     @Test
-    public void testReloadConfiguration() throws Exception {
-        String path = "/gwc/rest/reload";
-        String content = "reload_configuration=1";
-        String contentType = "application/x-www-form-urlencoded";
-        MockHttpServletResponse response = postAsServletResponse(path, content, contentType);
-        assertEquals(200, response.getStatus());
-    }
-
-    @Test
     public void testBasicIntegration() throws Exception {
         Catalog cat = getCatalog();
         TileLayerDispatcher tld = GeoWebCacheExtensions.bean(TileLayerDispatcher.class);

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -39,6 +39,7 @@
     <module>kml</module>
     <module>ows</module>
     <module>gwc</module>
+    <module>gwc-rest</module>
     <module>rest</module>
     <module>restconfig</module>
     <module>restconfig-wcs</module>
@@ -239,6 +240,11 @@
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-gwc</artifactId>
+        <version>${gs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geoserver</groupId>
+        <artifactId>gs-gwc-rest</artifactId>
         <version>${gs.version}</version>
       </dependency>
       <dependency>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -125,6 +125,11 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc-rest</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
       <artifactId>gs-rest</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
[![GEOS-10568](https://badgen.net/badge/JIRA/GEOS-10568/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10568)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->