### PR TITLE
[GEOS-10526] Parallel REST API calls failures

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/AbstractRoleStore.java
@@ -17,8 +17,8 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Logger;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.security.GeoServerRoleService;
@@ -319,10 +319,12 @@ public abstract class AbstractRoleStore implements GeoServerRoleStore {
         ByteArrayInputStream in = new ByteArrayInputStream(byteArray);
         ObjectInputStream oin = new ObjectInputStream(in);
         try {
-            helper.roleMap = (TreeMap<String, GeoServerRole>) oin.readObject();
+            helper.roleMap = (ConcurrentSkipListMap<String, GeoServerRole>) oin.readObject();
             helper.role_parentMap = (HashMap<GeoServerRole, GeoServerRole>) oin.readObject();
-            helper.user_roleMap = (TreeMap<String, SortedSet<GeoServerRole>>) oin.readObject();
-            helper.group_roleMap = (TreeMap<String, SortedSet<GeoServerRole>>) oin.readObject();
+            helper.user_roleMap =
+                    (ConcurrentSkipListMap<String, SortedSet<GeoServerRole>>) oin.readObject();
+            helper.group_roleMap =
+                    (ConcurrentSkipListMap<String, SortedSet<GeoServerRole>>) oin.readObject();
         } catch (ClassNotFoundException e) {
             throw new IOException(e);
         }

--- a/src/main/src/main/java/org/geoserver/security/impl/RoleStoreHelper.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/RoleStoreHelper.java
@@ -12,8 +12,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedSet;
-import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * This class is common helper for {@link AbstractRoleService} and {@link AbstractRoleStore} to
@@ -22,10 +22,10 @@ import java.util.TreeSet;
  * @author christian
  */
 public class RoleStoreHelper {
-    public TreeMap<String, GeoServerRole> roleMap = new TreeMap<>();
-    public TreeMap<String, SortedSet<GeoServerRole>> group_roleMap = new TreeMap<>();
-    public TreeMap<String, SortedSet<GeoServerRole>> user_roleMap = new TreeMap<>();
-    public HashMap<GeoServerRole, GeoServerRole> role_parentMap = new HashMap<>();
+    public Map<String, GeoServerRole> roleMap = new ConcurrentSkipListMap<>();
+    public Map<String, SortedSet<GeoServerRole>> group_roleMap = new ConcurrentSkipListMap<>();
+    public Map<String, SortedSet<GeoServerRole>> user_roleMap = new ConcurrentSkipListMap<>();
+    public Map<GeoServerRole, GeoServerRole> role_parentMap = new HashMap<>();
 
     public void clearMaps() {
         roleMap.clear();

--- a/src/main/src/test/java/org/geoserver/security/impl/MemoryRoleService.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/MemoryRoleService.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.HashMap;
 import java.util.SortedSet;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import org.geoserver.security.GeoServerRoleStore;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.config.impl.MemoryRoleServiceConfigImpl;
@@ -50,10 +50,12 @@ public class MemoryRoleService extends AbstractRoleService {
         ByteArrayInputStream in = new ByteArrayInputStream(byteArray);
         ObjectInputStream oin = new ObjectInputStream(in);
         try {
-            helper.roleMap = (TreeMap<String, GeoServerRole>) oin.readObject();
+            helper.roleMap = (ConcurrentSkipListMap<String, GeoServerRole>) oin.readObject();
             helper.role_parentMap = (HashMap<GeoServerRole, GeoServerRole>) oin.readObject();
-            helper.user_roleMap = (TreeMap<String, SortedSet<GeoServerRole>>) oin.readObject();
-            helper.group_roleMap = (TreeMap<String, SortedSet<GeoServerRole>>) oin.readObject();
+            helper.user_roleMap =
+                    (ConcurrentSkipListMap<String, SortedSet<GeoServerRole>>) oin.readObject();
+            helper.group_roleMap =
+                    (ConcurrentSkipListMap<String, SortedSet<GeoServerRole>>) oin.readObject();
         } catch (ClassNotFoundException e) {
             throw new IOException(e);
         }

--- a/src/main/src/test/java/org/geoserver/security/impl/MemoryRoleStore.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/MemoryRoleStore.java
@@ -13,7 +13,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.SortedSet;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * Implementation for testing uses serialization into a byte array
@@ -46,10 +46,12 @@ public class MemoryRoleStore extends AbstractRoleStore {
         ByteArrayInputStream in = new ByteArrayInputStream(bytes);
         ObjectInputStream oin = new ObjectInputStream(in);
         try {
-            helper.roleMap = (TreeMap<String, GeoServerRole>) oin.readObject();
+            helper.roleMap = (ConcurrentSkipListMap<String, GeoServerRole>) oin.readObject();
             helper.role_parentMap = (HashMap<GeoServerRole, GeoServerRole>) oin.readObject();
-            helper.user_roleMap = (TreeMap<String, SortedSet<GeoServerRole>>) oin.readObject();
-            helper.group_roleMap = (TreeMap<String, SortedSet<GeoServerRole>>) oin.readObject();
+            helper.user_roleMap =
+                    (ConcurrentSkipListMap<String, SortedSet<GeoServerRole>>) oin.readObject();
+            helper.group_roleMap =
+                    (ConcurrentSkipListMap<String, SortedSet<GeoServerRole>>) oin.readObject();
         } catch (ClassNotFoundException e) {
             throw new IOException(e);
         }

--- a/src/main/src/test/java/org/geoserver/security/impl/RoleStoreHelperTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/RoleStoreHelperTest.java
@@ -1,0 +1,74 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2022 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */ package org.geoserver.security.impl;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.junit.Test;
+
+public class RoleStoreHelperTest {
+
+    @Test
+    public void ensureConcurrentAccessToRolesDoesNotCauseConcurrencyException() {
+        // Given
+        RoleStoreHelper roleStoreHelper = new RoleStoreHelper();
+        roleStoreHelper.roleMap.put("key1", new GeoServerRole("role1"));
+        roleStoreHelper.roleMap.put("key2", new GeoServerRole("role2"));
+        roleStoreHelper.roleMap.put("key3", new GeoServerRole("role3"));
+        roleStoreHelper.roleMap.put("key4", new GeoServerRole("role4"));
+        roleStoreHelper.roleMap.put("key5", new GeoServerRole("role5"));
+
+        Iterator<Map.Entry<String, GeoServerRole>> iterator =
+                roleStoreHelper.roleMap.entrySet().iterator();
+
+        // When
+        roleStoreHelper.roleMap.put("key6", new GeoServerRole("role6"));
+        while (iterator.hasNext()) {
+            iterator.next();
+        }
+    }
+
+    @Test
+    public void ensureConcurrentAccessToGroupRolesDoesNotCauseConcurrencyException() {
+        // Given
+        RoleStoreHelper roleStoreHelper = new RoleStoreHelper();
+        roleStoreHelper.group_roleMap.put("key1", new TreeSet<>());
+        roleStoreHelper.group_roleMap.put("key2", new TreeSet<>());
+        roleStoreHelper.group_roleMap.put("key3", new TreeSet<>());
+        roleStoreHelper.group_roleMap.put("key4", new TreeSet<>());
+        roleStoreHelper.group_roleMap.put("key5", new TreeSet<>());
+
+        Iterator<Map.Entry<String, SortedSet<GeoServerRole>>> iterator =
+                roleStoreHelper.group_roleMap.entrySet().iterator();
+
+        // When
+        roleStoreHelper.group_roleMap.put("key6", new TreeSet<>());
+        while (iterator.hasNext()) {
+            iterator.next();
+        }
+    }
+
+    @Test
+    public void ensureConcurrentAccessToUserRolesDoesNotCauseConcurrencyException() {
+        // Given
+        RoleStoreHelper roleStoreHelper = new RoleStoreHelper();
+        roleStoreHelper.user_roleMap.put("key1", new TreeSet<>());
+        roleStoreHelper.user_roleMap.put("key2", new TreeSet<>());
+        roleStoreHelper.user_roleMap.put("key3", new TreeSet<>());
+        roleStoreHelper.user_roleMap.put("key4", new TreeSet<>());
+        roleStoreHelper.user_roleMap.put("key5", new TreeSet<>());
+
+        Iterator<Map.Entry<String, SortedSet<GeoServerRole>>> iterator =
+                roleStoreHelper.user_roleMap.entrySet().iterator();
+
+        // When
+        roleStoreHelper.user_roleMap.put("key6", new TreeSet<>());
+        while (iterator.hasNext()) {
+            iterator.next();
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-10526](https://badgen.net/badge/JIRA/GEOS-10526/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10526)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In this PR, we are changing the internal representation of on map for users, groups and users. `ConcurrentModificationException` has been reported, and is attributed
of using not synchronized implementation of maps internally. We use ConcurrentSkipListMap.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->