### PR TITLE
[GEOS-10547] Integrated WMS caching without the tiled parameter might…

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/PassThroughMethodInvocation.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/PassThroughMethodInvocation.java
@@ -1,0 +1,46 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+import org.aopalliance.intercept.MethodInvocation;
+
+public class PassThroughMethodInvocation implements MethodInvocation {
+    private Method method;
+    private Object[] arguments;
+    private Object targetObject;
+
+    public PassThroughMethodInvocation(Object targetObject, Method method, Object... arguments) {
+        this.targetObject = targetObject;
+        this.method = method;
+        this.arguments = arguments;
+    }
+
+    @Override
+    public Method getMethod() {
+        return method;
+    }
+
+    @Override
+    public Object[] getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public Object proceed() throws Throwable {
+        return method.invoke(targetObject, arguments);
+    }
+
+    @Override
+    public Object getThis() {
+        return targetObject;
+    }
+
+    @Override
+    public AccessibleObject getStaticPart() {
+        return null;
+    }
+}


### PR DESCRIPTION
[![GEOS-10547](https://badgen.net/badge/JIRA/GEOS-10547/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10547)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… result in deep recursion

cleanup


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->