### PR TITLE
[GEOS-10649] Concurrent modification to GWC style parameter filter can lead to OOM

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
@@ -157,7 +157,7 @@ public class StyleParameterFilter extends ParameterFilter {
                 super.getDefaultValue()); // Want to get the configured value so use super
         clone.setKey(getKey());
         clone.allowedStyles = getStyles();
-        clone.availableStyles = availableStyles;
+        clone.availableStyles = new TreeSet<>(availableStyles);
         clone.defaultStyle = defaultStyle;
         return clone;
     }
@@ -165,7 +165,7 @@ public class StyleParameterFilter extends ParameterFilter {
     /** Get the names of all the styles supported by the layer */
     public Set<String> getLayerStyles() {
         checkInitialized();
-        return availableStyles;
+        return Collections.unmodifiableSet(availableStyles);
     }
 
     @Override
@@ -191,11 +191,14 @@ public class StyleParameterFilter extends ParameterFilter {
 
     /** Set/update the availableStyles and defaultStyle based on the given GeoServer layer. */
     public void setLayer(LayerInfo layer) {
-        availableStyles = new TreeSet<>();
+        Set<String> newStyles = new TreeSet<>();
 
         for (StyleInfo style : layer.getStyles()) {
-            availableStyles.add(style.prefixedName());
+            newStyles.add(style.prefixedName());
         }
+
+        availableStyles = newStyles;
+
         if (layer.getDefaultStyle() != null) {
             defaultStyle = layer.getDefaultStyle().prefixedName();
         } else {

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/StyleParameterFilter.java
@@ -157,7 +157,7 @@ public class StyleParameterFilter extends ParameterFilter {
                 super.getDefaultValue()); // Want to get the configured value so use super
         clone.setKey(getKey());
         clone.allowedStyles = getStyles();
-        clone.availableStyles = new TreeSet<>(availableStyles);
+        clone.availableStyles = availableStyles != null ? new TreeSet<>(availableStyles) : null;
         clone.defaultStyle = defaultStyle;
         return clone;
     }

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
@@ -34,17 +34,16 @@ public class StyleParameterFilterTest {
     public void testConcurrentModification() throws Exception {
         StyleParameterFilter filter = new StyleParameterFilter();
 
-        String[] styleNames =
-                new String[] {
-                    UUID.randomUUID().toString(),
-                    UUID.randomUUID().toString(),
-                    UUID.randomUUID().toString(),
-                    UUID.randomUUID().toString(),
-                    UUID.randomUUID().toString(),
-                    UUID.randomUUID().toString(),
-                    UUID.randomUUID().toString(),
-                    UUID.randomUUID().toString()
-                };
+        String[] styleNames = {
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString()
+        };
 
         LayerInfo layerInfo =
                 GWCTestHelpers.mockLayer(

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
@@ -1,15 +1,14 @@
 package org.geoserver.gwc.layer;
 
-import org.geoserver.catalog.LayerInfo;
-import org.geoserver.catalog.PublishedType;
-import org.geoserver.gwc.GWCTestHelpers;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedType;
+import org.geoserver.gwc.GWCTestHelpers;
+import org.junit.Test;
 
 /**
  * Covers functionality of {@link StyleParameterFilter}.
@@ -18,15 +17,16 @@ import static org.junit.Assert.assertEquals;
  */
 public class StyleParameterFilterTest {
     /**
-     * Test covers a scenario where multiple threads are concurrently invoking {@link StyleParameterFilter#setLayer(LayerInfo)}
-     * method. Purpose of the test is to make sure that concurrent modification will not lead to corruption of
-     * internal state of the parameter filter class (TreeSet is not thread-safe and does not support concurrent
-     * modifications).
+     * Test covers a scenario where multiple threads are concurrently invoking {@link
+     * StyleParameterFilter#setLayer(LayerInfo)} method. Purpose of the test is to make sure that
+     * concurrent modification will not lead to corruption of internal state of the parameter filter
+     * class (TreeSet is not thread-safe and does not support concurrent modifications).
      *
-     * Corruption manifests it-self as infinite loop in the internal tree set structure which leads to
-     * out of memory errors when attempts are made to iterate through the set.
+     * <p>Corruption manifests it-self as infinite loop in the internal tree set structure which
+     * leads to out of memory errors when attempts are made to iterate through the set.
      *
-     * See more at: https://ivoanjo.me/blog/2018/07/21/writing-to-a-java-treemap-concurrently-can-lead-to-an-infinite-loop-during-reads/
+     * <p>See more at:
+     * https://ivoanjo.me/blog/2018/07/21/writing-to-a-java-treemap-concurrently-can-lead-to-an-infinite-loop-during-reads/
      *
      * @throws Exception
      */
@@ -34,34 +34,38 @@ public class StyleParameterFilterTest {
     public void testConcurrentModification() throws Exception {
         StyleParameterFilter filter = new StyleParameterFilter();
 
-        String[] styleNames = new String[]{
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString()
-        };
+        String[] styleNames =
+                new String[] {
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString()
+                };
 
-        LayerInfo layerInfo = GWCTestHelpers.mockLayer(UUID.randomUUID().toString(), styleNames, PublishedType.WMS);
+        LayerInfo layerInfo =
+                GWCTestHelpers.mockLayer(
+                        UUID.randomUUID().toString(), styleNames, PublishedType.WMS);
 
         int concurrency = 10;
         int opsPerThread = 1000;
 
-
         List<Thread> modifierThreads = new ArrayList<>(concurrency);
 
         for (int i = 0; i < concurrency; i++) {
-            Thread thread = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < opsPerThread; j++) {
-                        filter.setLayer(layerInfo);
-                    }
-                }
-            });
+            Thread thread =
+                    new Thread(
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    for (int j = 0; j < opsPerThread; j++) {
+                                        filter.setLayer(layerInfo);
+                                    }
+                                }
+                            });
             modifierThreads.add(thread);
         }
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
@@ -1,0 +1,80 @@
+package org.geoserver.gwc.layer;
+
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedType;
+import org.geoserver.gwc.GWCTestHelpers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Covers functionality of {@link StyleParameterFilter}.
+ *
+ * @author jbegic
+ */
+public class StyleParameterFilterTest {
+    /**
+     * Test covers a scenario where multiple threads are concurrently invoking {@link StyleParameterFilter#setLayer(LayerInfo)}
+     * method. Purpose of the test is to make sure that concurrent modification will not lead to corruption of
+     * internal state of the parameter filter class (TreeSet is not thread-safe and does not support concurrent
+     * modifications).
+     *
+     * Corruption manifests it-self as infinite loop in the internal tree set structure which leads to
+     * out of memory errors when attempts are made to iterate through the set.
+     *
+     * See more at: https://ivoanjo.me/blog/2018/07/21/writing-to-a-java-treemap-concurrently-can-lead-to-an-infinite-loop-during-reads/
+     *
+     * @throws Exception
+     */
+    @Test(timeout = 10000L)
+    public void testConcurrentModification() throws Exception {
+        StyleParameterFilter filter = new StyleParameterFilter();
+
+        String[] styleNames = new String[]{
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString()
+        };
+
+        LayerInfo layerInfo = GWCTestHelpers.mockLayer(UUID.randomUUID().toString(), styleNames, PublishedType.WMS);
+
+        int concurrency = 10;
+        int opsPerThread = 1000;
+
+
+        List<Thread> modifierThreads = new ArrayList<>(concurrency);
+
+        for (int i = 0; i < concurrency; i++) {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    for (int j = 0; j < opsPerThread; j++) {
+                        filter.setLayer(layerInfo);
+                    }
+                }
+            });
+            modifierThreads.add(thread);
+        }
+
+        for (Thread modifierThread : modifierThreads) {
+            modifierThread.start();
+        }
+
+        for (Thread modifierThread : modifierThreads) {
+            modifierThread.join();
+        }
+
+        String value = styleNames[0];
+
+        assertEquals(value, filter.apply(value));
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/StyleParameterFilterTest.java
@@ -1,3 +1,7 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.gwc.layer;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
[![GEOS-10649](https://badgen.net/badge/JIRA/GEOS-10649/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10649)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fixes the issue in `StyleParameterFilter#setLayer()` method which is being called concurrently and can cause out of memory problems due to the corruption of `TreeHashMap` that can occur in scenarios when map is being modified by more than one thread.

I did not go into analysis of why the instances of this class are being concurrently updated in the first place, however the changes made in this PR are at least fixing the OOM that its current implementation can cause.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->