### PR TITLE
[GEOS-10631] AccessManager will not be looked up if multiple beans are of type DefaultResourceAccessManager

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -104,16 +104,20 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         List<ResourceAccessManager> managers =
                 GeoServerExtensions.extensions(ResourceAccessManager.class);
         ResourceAccessManager manager = null;
-        if (managers.size() == 1) {
+        int size = managers.size();
+        if (size == 1) {
             manager = managers.get(0);
         } else {
             for (ResourceAccessManager resourceAccessManager : managers) {
-                if (!(resourceAccessManager instanceof DefaultResourceAccessManager)) {
+                if (!DefaultResourceAccessManager.class.equals(resourceAccessManager.getClass())) {
                     manager = resourceAccessManager;
                     break;
                 }
             }
         }
+        // should never happen,just in case we have multiple singleton beans
+        // of type DefaultResourceAccessManager
+        if (manager == null) manager = managers.get(size - 1);
 
         CatalogFilterAccessManager lwManager = new CatalogFilterAccessManager();
         lwManager.setDelegate(manager);

--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -117,7 +117,7 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
         }
         // should never happen,just in case we have multiple singleton beans
         // of type DefaultResourceAccessManager
-        if (manager == null) manager = managers.get(size - 1);
+        if (manager == null) manager = managers.get(0);
 
         CatalogFilterAccessManager lwManager = new CatalogFilterAccessManager();
         lwManager.setDelegate(manager);

--- a/src/main/src/test/java/org/geoserver/security/impl/ResourceAccessManagerLookupTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/ResourceAccessManagerLookupTest.java
@@ -1,0 +1,78 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.impl;
+
+import static org.junit.Assert.assertTrue;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.ResourceAccessManager;
+import org.geoserver.security.ResourceAccessManagerWrapper;
+import org.geoserver.security.SecureCatalogImpl;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
+public class ResourceAccessManagerLookupTest extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testLookupOfDefaultAccessManagerSubclass() throws Exception {
+        String name = "customManager";
+        try {
+            Catalog catalog = (Catalog) GeoServerExtensions.bean("rawCatalog");
+            DataAccessRuleDAO dao = (DataAccessRuleDAO) GeoServerExtensions.bean("accessRulesDao");
+            TestLookupAccessManager testMan = new TestLookupAccessManager(dao, catalog);
+            registerManagerBean(testMan, name);
+            SecureCatalogImpl secureCatalog = new SecureCatalogImpl(catalog);
+            ResourceAccessManager accessManager = secureCatalog.getResourceAccessManager();
+            while (accessManager instanceof ResourceAccessManagerWrapper) {
+                accessManager = ((ResourceAccessManagerWrapper) accessManager).unwrap();
+            }
+            assertTrue(accessManager instanceof TestLookupAccessManager);
+        } finally {
+            destroyManagerBean(name);
+        }
+    }
+
+    @Test
+    public void testDuplicateDefaultAccessManagerLookup() throws Exception {
+        String name = "defaultAccessManager2";
+        try {
+            Catalog catalog = (Catalog) GeoServerExtensions.bean("rawCatalog");
+            DataAccessRuleDAO dao = (DataAccessRuleDAO) GeoServerExtensions.bean("accessRulesDao");
+            DefaultResourceAccessManager testMan = new DefaultResourceAccessManager(dao, catalog);
+            registerManagerBean(testMan, name);
+
+            SecureCatalogImpl secureCatalog = new SecureCatalogImpl(catalog);
+            ResourceAccessManager accessManager = secureCatalog.getResourceAccessManager();
+            while (accessManager instanceof ResourceAccessManagerWrapper)
+                accessManager = ((ResourceAccessManagerWrapper) accessManager).unwrap();
+
+            assertTrue(accessManager instanceof DefaultResourceAccessManager);
+        } finally {
+            destroyManagerBean(name);
+        }
+    }
+
+    private void registerManagerBean(ResourceAccessManager manager, String name) {
+        ConfigurableBeanFactory factory = applicationContext.getBeanFactory();
+        factory.registerSingleton(name, manager);
+    }
+
+    private void destroyManagerBean(String name) {
+        DefaultListableBeanFactory factory =
+                (DefaultListableBeanFactory) applicationContext.getBeanFactory();
+        factory.destroySingleton(name);
+    }
+
+    // extends the DefaultAccessManager to test lookup
+    static class TestLookupAccessManager extends DefaultResourceAccessManager {
+
+        public TestLookupAccessManager(DataAccessRuleDAO dao, Catalog rawCatalog) {
+            super(dao, rawCatalog);
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-10631](https://badgen.net/badge/JIRA/GEOS-10631/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10631)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->