### PR TITLE
[GEOS-10632] Make sure GetLegendGraphics honors the WMS memory limits

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
@@ -15,7 +15,6 @@ import java.awt.image.RenderedImage;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -126,7 +125,9 @@ public class BufferedImageLegendGraphicBuilder extends LegendGraphicBuilder {
         // a layer group is given)
         setup(request);
 
-        List<RenderedImage> layersImages = new ArrayList<>();
+        Tally tally = new Tally(request.getWms().getMaxRequestMemory());
+        TalliedList<RenderedImage> layersImages = new TalliedList<>(tally);
+
         for (LegendRequest legend : layers) {
             FeatureType layer = legend.getFeatureType();
             // style and rule to use for the current layer
@@ -176,7 +177,7 @@ public class BufferedImageLegendGraphicBuilder extends LegendGraphicBuilder {
             } else if (buildRasterLegend) {
                 final RasterLayerLegendHelper rasterLegendHelper =
                         new RasterLayerLegendHelper(request, gt2Style, ruleName);
-                final BufferedImage image = rasterLegendHelper.getLegend();
+                final BufferedImage image = rasterLegendHelper.getLegend(tally);
                 if (image != null) {
                     if (titleImage != null) {
                         layersImages.add(titleImage);
@@ -223,7 +224,7 @@ public class BufferedImageLegendGraphicBuilder extends LegendGraphicBuilder {
                  * A legend graphic is produced for each applicable rule. They're being held here
                  * until the process is done and then painted on a "stack" like legend.
                  */
-                final List<RenderedImage> legendsStack = new ArrayList<>(ruleCount);
+                final TalliedList<RenderedImage> legendsStack = new TalliedList<>(tally);
 
                 final SLDStyleFactory styleFactory = new SLDStyleFactory();
 
@@ -301,7 +302,7 @@ public class BufferedImageLegendGraphicBuilder extends LegendGraphicBuilder {
     /** */
     private void renderRules(
             GetLegendGraphicRequest request,
-            List<RenderedImage> layersImages,
+            TalliedList<RenderedImage> layersImages,
             boolean forceLabelsOn,
             boolean forceLabelsOff,
             boolean forceTitlesOff,
@@ -313,7 +314,7 @@ public class BufferedImageLegendGraphicBuilder extends LegendGraphicBuilder {
             Rule[] applicableRules,
             final NumberRange<Double> scaleRange,
             final int ruleCount,
-            final List<RenderedImage> legendsStack,
+            final TalliedList<RenderedImage> legendsStack,
             final SLDStyleFactory styleFactory,
             double minimumSymbolSize,
             boolean rescalingRequired,
@@ -534,7 +535,7 @@ public class BufferedImageLegendGraphicBuilder extends LegendGraphicBuilder {
      * @throws IllegalArgumentException if the list is empty
      */
     private BufferedImage mergeGroups(
-            List<RenderedImage> imageStack,
+            TalliedList<RenderedImage> imageStack,
             Rule[] rules,
             GetLegendGraphicRequest req,
             boolean forceLabelsOn,

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/ColorMapLegendCreator.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/ColorMapLegendCreator.java
@@ -599,7 +599,7 @@ public class ColorMapLegendCreator {
         this.wrap = builder.isWrap();
     }
 
-    public synchronized BufferedImage getLegend() {
+    public synchronized BufferedImage getLegend(Tally tally) {
 
         // do we already have a legend
         if (legend == null) {
@@ -617,18 +617,18 @@ public class ColorMapLegendCreator {
             //
             // body
             //
-            final Queue<BufferedImage> body = createBody();
+            final TalliedQueue<BufferedImage> body = createBody(tally);
 
             //
             // footer
             //
             if (bandInformation) {
-                final Queue<BufferedImage> footer = createFooter();
+                final TalliedQueue<BufferedImage> footer = createFooter(tally);
                 body.addAll(footer);
             }
 
             // now merge them
-            legend = mergeRows(body);
+            legend = mergeRows(body, tally);
         }
         return legend;
     }
@@ -767,7 +767,7 @@ public class ColorMapLegendCreator {
         }
     }
 
-    private Queue<BufferedImage> createFooter() {
+    private TalliedQueue<BufferedImage> createFooter(Tally tally) {
 
         // creating a backbuffer image on which we should draw the bkgColor for this colormap
         // element
@@ -777,7 +777,7 @@ public class ColorMapLegendCreator {
                 ImageUtils.prepareTransparency(transparent, backgroundColor, image, hintsMap);
 
         // list where we store the rows for the footer
-        final Queue<BufferedImage> queue = new LinkedList<>();
+        final TalliedQueue<BufferedImage> queue = new TalliedQueue<>(tally);
         // //the height is already fixed
         // final int rowHeight=(int)Math.round(rowH);
         final int rowWidth = (int) Math.round(footerW);
@@ -812,9 +812,9 @@ public class ColorMapLegendCreator {
         return queue; // mergeRows(queue);
     }
 
-    private Queue<BufferedImage> createBody() {
+    private TalliedQueue<BufferedImage> createBody(Tally tally) {
 
-        final Queue<BufferedImage> queue = new LinkedList<>();
+        final TalliedQueue<BufferedImage> queue = new TalliedQueue<>(tally);
 
         //
         // draw the various elements
@@ -935,7 +935,7 @@ public class ColorMapLegendCreator {
         return queue; // mergeRows(queue);
     }
 
-    private BufferedImage mergeRows(Queue<BufferedImage> legendsQueue) {
+    private BufferedImage mergeRows(TalliedQueue<BufferedImage> legendsQueue, Tally tally) {
         // I am doing a straight cast since I know that I built this
         // dimension object by using the widths and heights of the various
         // bufferedimages for the various bkgColor map entries.
@@ -982,7 +982,7 @@ public class ColorMapLegendCreator {
                 finalGraphics.dispose();
             }
         } else {
-            List<RenderedImage> imgs = new ArrayList<>(legendsQueue);
+            TalliedList<RenderedImage> imgs = new TalliedList<>(tally, legendsQueue);
 
             LegendMerger.MergeOptions options =
                     new LegendMerger.MergeOptions(

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/ImageSizeComputable.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/ImageSizeComputable.java
@@ -1,0 +1,20 @@
+/* (c) 2014 - 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2022 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.legendgraphic;
+
+import java.awt.image.RenderedImage;
+import java.util.stream.IntStream;
+
+public interface ImageSizeComputable<T> {
+    default int computeImageSize(T image) {
+        if (image instanceof RenderedImage) {
+            RenderedImage renderedImage = (RenderedImage) image;
+            int pixelSize = IntStream.of(renderedImage.getSampleModel().getSampleSize()).sum() / 8;
+            return renderedImage.getWidth() * renderedImage.getHeight() * (pixelSize);
+        }
+        throw new RuntimeException("Unsupported image class: " + image.getClass().getName());
+    }
+}

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendMerger.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/LegendMerger.java
@@ -35,7 +35,7 @@ public class LegendMerger {
      * @author mauro.bartolomeoli@geo-solutions.it
      */
     public static class MergeOptions {
-        List<RenderedImage> imageStack;
+        TalliedList imageStack;
         int dx;
         int dy;
         int margin;
@@ -75,7 +75,7 @@ public class LegendMerger {
          * @param forceTitlesOff force titles to be never rendered
          */
         public MergeOptions(
-                List<RenderedImage> imageStack,
+                TalliedList<RenderedImage> imageStack,
                 int dx,
                 int dy,
                 int margin,
@@ -125,7 +125,7 @@ public class LegendMerger {
          * @param forceTitlesOff force titles to be never rendered
          */
         public MergeOptions(
-                List<RenderedImage> imageStack,
+                TalliedList<RenderedImage> imageStack,
                 int dx,
                 int dy,
                 int margin,
@@ -154,11 +154,12 @@ public class LegendMerger {
                     forceTitlesOff);
         }
 
-        public List<RenderedImage> getImageStack() {
+        @SuppressWarnings("unchecked")
+        public TalliedList<RenderedImage> getImageStack() {
             return imageStack;
         }
 
-        public void setImageStack(List<RenderedImage> imageStack) {
+        public void setImageStack(TalliedList<RenderedImage> imageStack) {
             this.imageStack = imageStack;
         }
 
@@ -291,7 +292,7 @@ public class LegendMerger {
         }
 
         public static MergeOptions createFromRequest(
-                List<RenderedImage> imageStack,
+                TalliedList<RenderedImage> imageStack,
                 int dx,
                 int dy,
                 int margin,
@@ -321,11 +322,11 @@ public class LegendMerger {
      * @return the legend image with all the images on the argument list.
      */
     public static BufferedImage mergeRasterLegends(MergeOptions mergeOptions) {
-        List<RenderedImage> imageStack = mergeOptions.getImageStack();
+        TalliedList<RenderedImage> imageStack = mergeOptions.getImageStack();
         LegendLayout layout = mergeOptions.getLayout();
 
         List<BufferedImage> nodes = new ArrayList<>();
-        for (RenderedImage renderedImage : imageStack) {
+        for (RenderedImage renderedImage : imageStack.get()) {
             nodes.add((BufferedImage) renderedImage);
         }
 
@@ -362,7 +363,7 @@ public class LegendMerger {
      */
     public static BufferedImage mergeLegends(
             Rule[] rules, GetLegendGraphicRequest req, MergeOptions mergeOptions) {
-        List<RenderedImage> imageStack = mergeOptions.getImageStack();
+        List<RenderedImage> imageStack = mergeOptions.getImageStack().get();
 
         // Builds legend nodes (graphics + label)
         final int imgCount = imageStack.size();
@@ -426,7 +427,7 @@ public class LegendMerger {
      * @return the image with all the images on the argument list.
      */
     public static BufferedImage mergeGroups(Rule[] rules, MergeOptions mergeOptions) {
-        List<RenderedImage> imageStack = mergeOptions.getImageStack();
+        List<RenderedImage> imageStack = mergeOptions.getImageStack().get();
 
         final int imgCount = imageStack.size();
         if (imgCount == 1 && (!mergeOptions.isForceLabelsOn() || rules == null)) {

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/RasterLayerLegendHelper.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/RasterLayerLegendHelper.java
@@ -227,21 +227,21 @@ public class RasterLayerLegendHelper {
      *
      * @return a {@link BufferedImage} that represents the legend for the provided request.
      */
-    public BufferedImage getLegend() {
+    public BufferedImage getLegend(Tally tally) {
         if (rasterSymbolizer == null) {
             return null;
         }
-        return createResponse();
+        return createResponse(tally);
     }
 
-    private synchronized BufferedImage createResponse() {
+    private synchronized BufferedImage createResponse(Tally tally) {
 
         if (image == null) {
 
             if (cMapLegendCreator != null)
 
                 // creating a legend
-                image = cMapLegendCreator.getLegend();
+                image = cMapLegendCreator.getLegend(tally);
             else {
                 image = ImageUtils.createImage(width, height, null, transparent);
                 final Graphics2D graphics =

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/TalliedList.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/TalliedList.java
@@ -1,0 +1,50 @@
+/* (c) 2014 - 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2022 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.legendgraphic;
+
+import java.awt.image.RenderedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TalliedList<T> implements ImageSizeComputable {
+
+    private final List<T> list = new ArrayList<>();
+
+    private final Tally tally;
+
+    public TalliedList(Tally tally) {
+        this.tally = tally;
+    }
+
+    public TalliedList(Tally tally, TalliedQueue<? extends T> legendsQueue) {
+        this.tally = tally;
+        for (int i = 0; i < legendsQueue.size(); i++) {
+            T image = legendsQueue.poll();
+            list.add(image);
+        }
+    }
+
+    public void add(T image) {
+        increaseUsedMemory(image);
+        list.add(image);
+    }
+
+    public List<T> get() {
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void increaseUsedMemory(T image) {
+        RenderedImage renderedImage = (RenderedImage) image;
+        int imageSize = computeImageSize(renderedImage);
+        int usedMemory = tally.getUsedMemory();
+        int maxMemory = tally.getMaxMemory();
+        if (usedMemory + imageSize > maxMemory) {
+            throw new IllegalArgumentException("Max memory per request exceeded.");
+        }
+        tally.setMaxMemory(usedMemory + imageSize);
+    }
+}

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/TalliedQueue.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/TalliedQueue.java
@@ -1,0 +1,58 @@
+/* (c) 2014 - 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2022 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.legendgraphic;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class TalliedQueue<T> implements ImageSizeComputable {
+
+    private final Queue<T> queue = new LinkedList<>();
+
+    private final Tally tally;
+
+    public TalliedQueue(Tally tally) {
+        this.tally = tally;
+    }
+
+    public void add(T image) {
+        increaseUsedMemory(image);
+        queue.add(image);
+    }
+
+    public void addAll(TalliedQueue<T> talliedQueue) {
+        for (int i = 0; i < talliedQueue.size(); i++) {
+            queue.add(talliedQueue.poll());
+        }
+    }
+
+    public T remove() {
+        return queue.remove();
+    }
+
+    public T poll() {
+        return queue.poll();
+    }
+
+    public int size() {
+        return queue.size();
+    }
+
+    public Queue<T> get() {
+        return queue;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void increaseUsedMemory(T image) {
+        int imageSize = computeImageSize(image);
+        int usedMemory = tally.getUsedMemory();
+        int maxMemory = tally.getMaxMemory();
+        if (usedMemory + imageSize > maxMemory) {
+            throw new IllegalArgumentException("Max memory per request exceeded.");
+        }
+        tally.setMaxMemory(usedMemory + imageSize);
+    }
+}

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/Tally.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/Tally.java
@@ -1,0 +1,34 @@
+/* (c) 2014 - 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2022 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.legendgraphic;
+
+public class Tally {
+
+    private int maxMemory;
+
+    private int usedMemory;
+
+    public Tally(int maxMemory) {
+        this.maxMemory = maxMemory;
+        this.usedMemory = 0;
+    }
+
+    public int getMaxMemory() {
+        return maxMemory;
+    }
+
+    public void setMaxMemory(int maxMemory) {
+        this.maxMemory = maxMemory;
+    }
+
+    public int getUsedMemory() {
+        return usedMemory;
+    }
+
+    public void setUsedMemory(int usedMemory) {
+        this.usedMemory = usedMemory;
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/TalliedListTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/TalliedListTest.java
@@ -1,0 +1,53 @@
+/* (c) 2014 - 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2022 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.legendgraphic;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TalliedListTest {
+
+    @Test
+    public void testAddingToTalliedListWithoutExceedingMemoryLimit() {
+        // Given
+        Tally tally = new Tally(100000);
+        TalliedList<RenderedImage> talliedList = new TalliedList<>(tally);
+        RenderedImage renderedImage = Mockito.mock(RenderedImage.class);
+        SampleModel sampleModel = Mockito.mock(SampleModel.class);
+        int[] sampleSize = {100, 100, 200, 500};
+        Mockito.when(renderedImage.getSampleModel()).thenReturn(sampleModel);
+        Mockito.when(sampleModel.getSampleSize()).thenReturn(sampleSize);
+        Mockito.when(renderedImage.getWidth()).thenReturn(10);
+        Mockito.when(renderedImage.getHeight()).thenReturn(10);
+
+        // When
+        talliedList.add(renderedImage);
+
+        // Then
+        assertEquals(1, talliedList.get().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExceedingMaxMemoryWhenAddingToTalliedList() {
+        // Given
+        Tally tally = new Tally(1000);
+        TalliedList<RenderedImage> talliedList = new TalliedList<>(tally);
+        RenderedImage renderedImage = Mockito.mock(RenderedImage.class);
+        SampleModel sampleModel = Mockito.mock(SampleModel.class);
+        int[] sampleSize = {100, 100, 200, 500};
+        Mockito.when(renderedImage.getSampleModel()).thenReturn(sampleModel);
+        Mockito.when(sampleModel.getSampleSize()).thenReturn(sampleSize);
+        Mockito.when(renderedImage.getWidth()).thenReturn(10);
+        Mockito.when(renderedImage.getHeight()).thenReturn(10);
+
+        // When
+        talliedList.add(renderedImage);
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/TalliedQueueTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/TalliedQueueTest.java
@@ -1,0 +1,53 @@
+/* (c) 2014 - 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2022 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.legendgraphic;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TalliedQueueTest {
+
+    @Test
+    public void testAddingToTalliedQueueWithoutExceedingMemoryLimit() {
+        // Given
+        Tally tally = new Tally(100000);
+        TalliedQueue<RenderedImage> talliedQueue = new TalliedQueue<>(tally);
+        RenderedImage renderedImage = Mockito.mock(RenderedImage.class);
+        SampleModel sampleModel = Mockito.mock(SampleModel.class);
+        int[] sampleSize = {100, 100, 200, 500};
+        Mockito.when(renderedImage.getSampleModel()).thenReturn(sampleModel);
+        Mockito.when(sampleModel.getSampleSize()).thenReturn(sampleSize);
+        Mockito.when(renderedImage.getWidth()).thenReturn(10);
+        Mockito.when(renderedImage.getHeight()).thenReturn(10);
+
+        // When
+        talliedQueue.add(renderedImage);
+
+        // Then
+        assertEquals(1, talliedQueue.get().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExceedingMaxMemoryWhenAddingToTallieQueue() {
+        // Given
+        Tally tally = new Tally(1000);
+        TalliedQueue<RenderedImage> talliedQueue = new TalliedQueue<>(tally);
+        RenderedImage renderedImage = Mockito.mock(RenderedImage.class);
+        SampleModel sampleModel = Mockito.mock(SampleModel.class);
+        int[] sampleSize = {100, 100, 200, 500};
+        Mockito.when(renderedImage.getSampleModel()).thenReturn(sampleModel);
+        Mockito.when(sampleModel.getSampleSize()).thenReturn(sampleSize);
+        Mockito.when(renderedImage.getWidth()).thenReturn(10);
+        Mockito.when(renderedImage.getHeight()).thenReturn(10);
+
+        // When
+        talliedQueue.add(renderedImage);
+    }
+}


### PR DESCRIPTION
[![GEOS-10632](https://badgen.net/badge/JIRA/GEOS-10632/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10632)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The legend graphic building happening BufferedImageLegendGraphicBuilder is complicated, and generally inconsistent... however there is a common trait, legends are build of of list of images, one per layer, and each layer image is built out of a list of smaller images. These collections of images are accumulated, to be then merged

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->