### PR TITLE
[GEOS-10635] GeoFence: area reprojection tests are failing

### DIFF
--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeoFenceAreaHelper.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeoFenceAreaHelper.java
@@ -141,6 +141,8 @@ class GeoFenceAreaHelper {
      * @return the reprojected geometry.
      */
     Geometry reprojectGeometry(Geometry geometry, CoordinateReferenceSystem targetCRS) {
+        if (geometry == null) return null;
+
         try {
             CoordinateReferenceSystem geomCrs = CRS.decode("EPSG:" + geometry.getSRID(), true);
             if ((targetCRS != null) && !CRS.equalsIgnoreMetadata(geomCrs, targetCRS)) {

--- a/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -522,8 +522,13 @@ public class GeofenceAccessManager
             intersectsArea = resultLimits.getIntersectArea();
             clipArea = resultLimits.getClipArea();
         } else {
+            CoordinateReferenceSystem crs = helper.getCRSFromInfo(info);
+
             intersectsArea = helper.parseAllowedArea(rule.getAreaWkt());
+            intersectsArea = helper.reprojectGeometry(intersectsArea, crs);
+
             clipArea = helper.parseAllowedArea(rule.getClipAreaWkt());
+            clipArea = helper.reprojectGeometry(clipArea, crs);
         }
         CatalogMode catalogMode = getCatalogMode(rule, resultLimits);
         LOGGER.log(


### PR DESCRIPTION
[![GEOS-10635](https://badgen.net/badge/JIRA/GEOS-10635/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10635)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Tests `testArea900913Vector` and `testArea900913Raster` are failing since 9cda0eb5.

These are the test that are now fixed
https://github.com/geoserver/geoserver/blob/9cda0eb558a4301f9ad22632f8caf29013188166/src/extension/geofence/src/test/java/org/geoserver/geofence/GeofenceAccessManagerTest.java#L237-L318

They assume that a standalone test GeoFene is running, according to https://github.com/geoserver/geofence/wiki/Devs%3A-running-integration-tests#geoserver-integration-geofence-standalone


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).