### PR TITLE
[2.20.x backport] [GEOS-10610] Selective cache reset on stores and resources, via REST API

### DIFF
--- a/doc/en/api/1.0.0/coverages.yaml
+++ b/doc/en/api/1.0.0/coverages.yaml
@@ -859,7 +859,7 @@ paths:
             $ref: "#/definitions/CoverageInfo"
         - name: calculate
           in: query
-          description: 'Comma-separated list of optional fields to calculate. Optional fields include: "nativebbox", "latlonbbox".'
+          description: 'Comma-separated list of optional fields to calculate. Optional fields include: "nativebbox", "latlonbbox", "dimensions" (that is, bands).'
           required: false
           type: array
           collectionFormat: csv
@@ -901,6 +901,58 @@ paths:
       responses:
         200:
           description: Successfully deleted.
+          
+  /workspaces/{workspace}/coveragestores/{store}/coverages/{coverage}/reset:
+    put:
+      operationId: putCoverageReset
+      tags:
+        - "Coverages"
+      summary: Reset the caches related to this specific coverage.
+      description: Resets raster caches for this coverage. This operation is used to force GeoServer to drop caches associated to this coverage, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime. Warning, the band structure is stored as part of the coverage configuration and won't be modified by this call, in case of need it should be modified issuing a PUT request against the coverage resource itself.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store containing the target coverage.
+          type: string      
+        - name: coverage
+          in: path
+          required: true
+          description: The name of the target coverage.
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postCoverageReset
+      tags:
+        - "Coverages"
+      summary: Reset the caches related to this specific coverage.
+      description: Resets raster caches for this coverage. This operation is used to force GeoServer to drop caches associated to this coverage, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime. Warning, the band structure is stored as part of the coverage configuration and won't be modified by this call, in case of need it should be modified issuing a PUT request against the coverage resource itself.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store containing the target coverage.
+          type: string
+        - name: coverage
+          in: path
+          required: true
+          description: The name of the target coverage.
+          type: string
+      responses:
+        200:
+          description: OK
 
 definitions:
   CoverageInfo:

--- a/doc/en/api/1.0.0/coveragestores.yaml
+++ b/doc/en/api/1.0.0/coveragestores.yaml
@@ -386,6 +386,48 @@ paths:
         405:
           description: Method Not Allowed
 
+  /workspaces/{workspace}/coveragestores/{store}/reset:
+    put:
+      operationId: putCoverageStoreReset
+      tags:
+        - "CoverageStores"
+      summary: Reset the caches related to this specific coverage store.
+      description: Resets raster caches for this coverage store. This operation is used to force GeoServer to drop caches associated to this coverage store, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store to modify.
+          type: string      
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postCoverageStoreReset
+      tags:
+        - "CoverageStores"
+      summary: Reset the caches related to this specific coverage store.
+      description: Resets raster caches for this coverage store. This operation is used to force GeoServer to drop caches associated to this coverage store, and reconnect to the raster source the next time it is needed by a request. This is useful as the readers often cache some information about the bounds, coordinate system and image structure that might have changed in the meantime.
+      parameters:
+        - name: workspace
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the coverage store.
+        - name: store
+          in: path
+          required: true
+          description: The name of the coverage store to modify.
+          type: string
+      responses:
+        200:
+          description: OK
+
 parameters:
   CoverageStorePost:
     name: coverageStoreBody

--- a/doc/en/api/1.0.0/datastores.yaml
+++ b/doc/en/api/1.0.0/datastores.yaml
@@ -207,6 +207,49 @@ paths:
         200:
           description: OK
 
+  /workspaces/{workspaceName}/datastores/{storeName}/reset:
+    put:
+      operationId: putDataStoreReset
+      tags:
+        - "DataStores"
+      summary: Reset the caches related to this specific data store.
+      description: Resets caches for this data store. This operation is used to force GeoServer to drop caches associated to this data store, and reconnect to the vector source the next time it is needed by a request. This is useful as the store can keep state, such as a connection pool, and the structure of the feature types it's serving.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store to modify.
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postDataStoreReset
+      tags:
+        - "DataStores"
+      summary: Reset the caches related to this specific data store.
+      description: Resets caches for this data store. This operation is used to force GeoServer to drop caches associated to this data store, and reconnect to the vector source the next time it is needed by a request. This is useful as the store can keep state, such as a connection pool, and the structure of the feature types it's serving.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store to modify.
+          type: string      
+      responses:
+        200:
+          description: OK
+
+
   /workspaces/{workspaceName}/datastores/{storeName}/{method}.{format}:
     get:
       operationId: getDataStoreUpload

--- a/doc/en/api/1.0.0/featuretypes.yaml
+++ b/doc/en/api/1.0.0/featuretypes.yaml
@@ -295,6 +295,7 @@ paths:
       responses:
         405:
           description: Method not allowed.
+          
   /workspaces/{workspaceName}/datastores/{storeName}/featuretypes/{featureTypeName}:
     get:    
       operationId: getFeatureType
@@ -631,7 +632,7 @@ paths:
           type: string
         - name: recalculate
           in: query
-          description: Specifies whether to recalculate any bounding boxes for a feature type. Some properties of feature types are automatically recalculated when necessary. In particular, the native bounding box is recalculated when the projection or projection policy are changed, and the lat/lon bounding box is recalculated when the native bounding box is recalculated, or when a new native bounding box is explicitly provided in the request. (The native and lat/lon bounding boxes are not automatically recalculated when they are explicitly included in the request.) In addition, the client may explicitly request a fixed set of fields to calculate, by including a comma-separated list of their names in the recalculate parameter.  The empty parameter 'recalculate=' is useful avoid slow recalculation when operating against large datasets as 'recalculate=' avoids calculating any fields, regardless of any changes to projection, projection policy, etc. The nativebbox parameter 'recalculate=nativebbox' is used recalculates the native bounding box, while avoiding recalculating the lat/lon bounding box. Recalculate parameters can be used in together - 'recalculate=nativebbox,latlonbbox' can be used after a bulk import to recalculate both the native bounding box and the lat/lon bounding box.
+          description: Specifies whether to recalculate properties for a feature type. Some properties of feature types are automatically recalculated when necessary. In particular, the native bounding box is recalculated when the projection or projection policy are changed, and the lat/lon bounding box is recalculated when the native bounding box is recalculated, or when a new native bounding box is explicitly provided in the request. (The native and lat/lon bounding boxes are not automatically recalculated when they are explicitly included in the request.) In addition, the client may explicitly request a fixed set of fields to calculate, by including a comma-separated list of their names in the recalculate parameter.  The empty parameter 'recalculate=' is useful avoid slow recalculation when operating against large datasets as 'recalculate=' avoids calculating any fields, regardless of any changes to projection, projection policy, etc. The nativebbox parameter 'recalculate=nativebbox' is used recalculates the native bounding box, while avoiding recalculating the lat/lon bounding box. Recalculate parameters can be used in together - 'recalculate=nativebbox,latlonbbox' can be used after a bulk import to recalculate both the native bounding box and the lat/lon bounding box. Finally, 'recalculate=attributes' can be  used to reset the attributes and reload them from the original vector source. Pay attention to its usage, if attributes were explicity configured to perform attribute selection, renaming, and other transformations, such configuration will be lost, resetting the feature type to the list of attributes found in the vector data source. 
           required: false
           type: array
           collectionFormat: csv
@@ -1049,6 +1050,101 @@ paths:
       responses:
         200:
           description: The feature type was successfully deleted.
+          
+  /workspaces/{workspaceName}/datastores/{storeName}/featuretypes/{featureTypeName}/reset:
+    put:
+      operationId: putFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type.
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store.
+          type: string
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: storeName
+          in: path
+          required: true
+          description: The name of the data store.
+          type: string
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string          
+      responses:
+        200:
+          description: OK
+
+
+  /workspaces/{workspaceName}/featuretypes/{featureTypeName}/reset:
+    put:
+      operationId: putFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type.
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postFeatureTypeReset
+      tags:
+        - "FeatureTypes"
+      summary: Reset the caches related to this specific feature type
+      description: Resets caches for this feature type. This operation is used to force GeoServer to drop cached feature type structures, and eventually re-compute them the next time it is needed by a request. This is useful as both GeoServer and the underlying data store can keep state information about a feature type attributes. Warning, if an explicit list of attributes is configured in the feature type, to support attribute selection, renaming, data type conversion and calculation of new attributes, the reset itself won't change such configuration, an explicit PUT on the feature type resource is required.
+      parameters:
+        - name: workspaceName
+          in: path
+          type: string
+          required: true
+          description: The name of the workspace containing the data store.
+        - name: featureTypeName
+          in: path
+          description: The name of the feature type
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
 
 definitions:
   FeatureTypeInfo:

--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 import javax.measure.Unit;
 import javax.media.jai.ImageLayout;
 import javax.media.jai.PlanarImage;
+import org.geoserver.catalog.impl.CoverageInfoImpl;
 import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.StoreInfoImpl;
@@ -1136,6 +1137,34 @@ public class CatalogBuilder {
         cinfo.getParameters().putAll(CoverageUtils.getParametersKVP(readParams));
 
         return cinfo;
+    }
+
+    /**
+     * Reloads the {@link CoverageInfo} dimensions from the reader. Can be used to gather the
+     * current band definitions from the reader
+     */
+    public void reloadDimensions(CoverageInfo ci) throws Exception {
+        String nativeName = ci.getNativeCoverageName();
+        setStore(ci.getStore());
+        MetadataMap metadata = ci.getMetadata();
+        CoverageInfo rebuilt;
+        if (metadata != null && metadata.containsKey(CoverageView.COVERAGE_VIEW)) {
+            GridCoverage2DReader reader =
+                    (GridCoverage2DReader)
+                            catalog.getResourcePool()
+                                    .getGridCoverageReader(
+                                            ci, nativeName, GeoTools.getDefaultHints());
+            rebuilt = buildCoverage(reader, nativeName, null);
+        } else {
+            rebuilt = buildCoverage(nativeName);
+        }
+        if (ci instanceof CoverageInfoImpl) {
+            // null safe path, if ci was loaded via XStream
+            ((CoverageInfoImpl) ci).setDimensions(rebuilt.getDimensions());
+        } else {
+            ci.getDimensions().clear();
+            ci.getDimensions().addAll(rebuilt.getDimensions());
+        }
     }
 
     private GridSampleDimension[] getCoverageSampleDimensions(

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageDimensionCustomizerReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageDimensionCustomizerReader.java
@@ -894,4 +894,9 @@ public class CoverageDimensionCustomizerReader implements GridCoverage2DReader {
         checkCoverageName(coverageName);
         return delegate.getDatasetLayout(coverageName);
     }
+
+    /** Made available for testing purposes only */
+    public GridCoverage2DReader getDelegate() {
+        return delegate;
+    }
 }

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/AbstractCatalogController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/AbstractCatalogController.java
@@ -10,7 +10,9 @@ import java.util.Arrays;
 import java.util.List;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.rest.RestBaseController;
@@ -91,6 +93,21 @@ public abstract class AbstractCatalogController extends RestBaseController {
                         "Error while calculating lat/lon bounds for featuretype: " + message;
                 throw new RestException(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR, e);
             }
+        }
+        if (fieldsToCalculate.contains("dimensions") && message instanceof CoverageInfo) {
+            CatalogBuilder cb = new CatalogBuilder(catalog);
+            try {
+                CoverageInfo ci = (CoverageInfo) message;
+                cb.reloadDimensions(ci);
+            } catch (Exception e) {
+                String errorMessage = "Error while calculating bands for coverage: " + message;
+                throw new RestException(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR, e);
+            }
+        }
+        if (fieldsToCalculate.contains("attributes") && message instanceof FeatureTypeInfoImpl) {
+            FeatureTypeInfoImpl ft = (FeatureTypeInfoImpl) message;
+            catalog.getResourcePool().clear(ft);
+            ft.setAttributes(new ArrayList<>());
         }
     }
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageController.java
@@ -45,6 +45,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponents;
@@ -256,6 +257,19 @@ public class CoverageController extends AbstractCatalogController {
         catalog.remove(c);
         catalog.getResourcePool().clear(c.getStore());
         LOGGER.info("DELETE coverage " + storeName + "," + coverageName);
+    }
+
+    @RequestMapping(
+            value = "coveragestores/{storeName}/coverages/{coverageName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(
+            @PathVariable String workspaceName,
+            @PathVariable String storeName,
+            @PathVariable String coverageName) {
+        CoverageStoreInfo cs = catalog.getCoverageStoreByName(workspaceName, storeName);
+        CoverageInfo original = catalog.getCoverageByCoverageStore(cs, coverageName);
+        checkCoverageExists(original, workspaceName, coverageName);
+        catalog.getResourcePool().clear(original);
     }
 
     private List<String> getStoreCoverages(CoverageStoreInfo coverageStore) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreController.java
@@ -51,6 +51,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponents;
@@ -197,6 +198,14 @@ public class CoverageStoreController extends AbstractCatalogController {
                 ((StructuredGridCoverage2DReader) reader).delete(deleteData);
             }
         }
+    }
+
+    @RequestMapping(
+            value = "{storeName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(@PathVariable String workspaceName, @PathVariable String storeName) {
+        CoverageStoreInfo cs = getExistingCoverageStore(workspaceName, storeName);
+        catalog.getResourcePool().clear(cs);
     }
 
     void clear(CoverageStoreInfo info) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreController.java
@@ -52,6 +52,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponents;
@@ -214,6 +215,14 @@ public class DataStoreController extends AbstractCatalogController {
         }
 
         LOGGER.info("DELETE datastore " + workspaceName + ":s" + workspaceName);
+    }
+
+    @RequestMapping(
+            value = "{storeName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(@PathVariable String workspaceName, @PathVariable String storeName) {
+        DataStoreInfo ds = getExistingDataStore(workspaceName, storeName);
+        catalog.getResourcePool().clear(ds);
     }
 
     private DataStoreInfo getExistingDataStore(String workspaceName, String storeName) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/FeatureTypeController.java
@@ -57,6 +57,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -411,6 +412,20 @@ public class FeatureTypeController extends AbstractCatalogController {
 
         catalog.remove(ftInfo);
         LOGGER.info("DELETE feature type" + storeName + "," + featureTypeName);
+    }
+
+    @RequestMapping(
+            value = "{featureTypeName}/reset",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reset(
+            @PathVariable String workspaceName,
+            @PathVariable(required = false) String storeName,
+            @PathVariable String featureTypeName) {
+        DataStoreInfo dsInfo = getExistingDataStore(workspaceName, storeName);
+        FeatureTypeInfo ftInfo = catalog.getFeatureTypeByDataStore(dsInfo, featureTypeName);
+        checkFeatureTypeExists(ftInfo, workspaceName, storeName, featureTypeName);
+
+        catalog.getResourcePool().clear(ftInfo);
     }
 
     /** If the feature type doesn't exists throws a REST exception with HTTP 404 code. */

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/CatalogRESTTestSupport.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/CatalogRESTTestSupport.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.rest.catalog;
 
+import it.geosolutions.imageio.utilities.ImageIOUtilities;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -16,12 +17,23 @@ import org.geoserver.config.CatalogTimeStampUpdater;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.security.AccessMode;
 import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.coverage.grid.GridCoverage2D;
 import org.junit.Before;
 
 public abstract class CatalogRESTTestSupport extends GeoServerSystemTestSupport {
 
     protected static Catalog catalog;
     protected static XpathEngine xp;
+
+    /** Clears up a coverage and its rendered image, important to get builds working on Windows */
+    protected static void dispose(GridCoverage2D coverage) {
+        try {
+            ImageIOUtilities.disposeImage(coverage.getRenderedImage());
+            coverage.dispose(true);
+        } catch (Throwable t) {
+            // Does nothing;
+        }
+    }
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageControllerTest.java
@@ -7,21 +7,25 @@ package org.geoserver.rest.catalog;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.geoserver.rest.RestBaseController.ROOT_PATH;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import it.geosolutions.imageio.utilities.ImageIOUtilities;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.util.List;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.CoverageDimensionInfo;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
@@ -35,6 +39,7 @@ import org.geotools.util.URLs;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridCoverageReader;
+import org.opengis.geometry.Envelope;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
@@ -486,12 +491,7 @@ public class CoverageControllerTest extends CatalogRESTTestSupport {
             assertEquals(1000.0, range.getMaximum(), DELTA);
         } finally {
             if (coverage != null) {
-                try {
-                    ImageIOUtilities.disposeImage(coverage.getRenderedImage());
-                    coverage.dispose(true);
-                } catch (Throwable t) {
-                    // Does nothing;
-                }
+                dispose(coverage);
             }
             if (reader != null) {
                 try {
@@ -501,5 +501,85 @@ public class CoverageControllerTest extends CatalogRESTTestSupport {
                 }
             }
         }
+    }
+
+    @Test
+    public void testCoverageReset() throws Exception {
+        // force coverage initialization
+        // read the coverage, check basic properties
+        CoverageInfo ci = catalog.getCoverageByName(getLayerId(SystemTestData.TASMANIA_BM));
+        assertNotNull(ci);
+        GridCoverage2D gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelope = gridCoverage.getEnvelope();
+        dispose(gridCoverage);
+
+        // now go and clear
+        MockHttpServletResponse response =
+                postAsServletResponse(
+                        ROOT_PATH
+                                + "/workspaces/wcs/coveragestores/BlueMarble/coverages/BlueMarble/reset",
+                        "",
+                        null);
+        assertEquals(200, response.getStatus());
+
+        // copy over a different file, will change the bounds
+        try (InputStream is = SystemTestData.class.getResourceAsStream("world.tiff");
+                OutputStream os = getDataDirectory().get("BlueMarble/tazbm.tiff").out()) {
+            IOUtils.copy(is, os);
+        }
+
+        // checking the envelope changed. Cannot check the bands, unlike features, their definition
+        // is part of the configuration, in case of modification it requires an explicit PUT
+        gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelopeNew = gridCoverage.getEnvelope();
+        assertNotEquals(envelopeNew, envelope);
+        dispose(gridCoverage);
+    }
+
+    @Test
+    public void testCoverageResetReloadBands() throws Exception {
+        // force coverage initialization
+        // read the coverage, check basic properties
+        CoverageInfo ci = catalog.getCoverageByName(getLayerId(SystemTestData.TASMANIA_BM));
+        assertNotNull(ci);
+        GridCoverage2D gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelope = gridCoverage.getEnvelope();
+        assertEquals(3, ci.getDimensions().size());
+        dispose(gridCoverage);
+
+        // now go and clear
+        MockHttpServletResponse response =
+                postAsServletResponse(
+                        ROOT_PATH
+                                + "/workspaces/wcs/coveragestores/BlueMarble/coverages/BlueMarble/reset",
+                        "",
+                        null);
+        assertEquals(200, response.getStatus());
+
+        // copy over a different file, will change the coverage type structure enough (bands
+        // included)
+        try (InputStream is = SystemTestData.class.getResourceAsStream("tazdem.tiff");
+                OutputStream os = getDataDirectory().get("BlueMarble/tazbm.tiff").out()) {
+            IOUtils.copy(is, os);
+        }
+
+        // force reload of the bands too
+        response =
+                putAsServletResponse(
+                        ROOT_PATH
+                                + "/workspaces/wcs/coveragestores/BlueMarble/coverages/BlueMarble?calculate=dimensions",
+                        "<coverage/>",
+                        "text/xml");
+        assertEquals(200, response.getStatus());
+
+        // checking the envelope changed. Cannot check the bands, unlike features, their definition
+        // is part of the configuration, in case of modification it requires an explicit PUT
+
+        ci = catalog.getCoverageByName(getLayerId(SystemTestData.TASMANIA_BM));
+        gridCoverage = (GridCoverage2D) ci.getGridCoverage(null, null);
+        Envelope envelopeNew = gridCoverage.getEnvelope();
+        assertNotEquals(envelopeNew, envelope);
+        assertEquals(1, ci.getDimensions().size());
+        dispose(gridCoverage);
     }
 }


### PR DESCRIPTION
Backport from main (authorization to merge pending on devel list)

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
