### PR TITLE
[GEOS-10641] OGC API - Features - Failure on feature item CRS

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -294,12 +294,12 @@ public class FeatureService {
                 limit,
                 bbox,
                 bboxCRS,
-                crs,
                 time,
-                null,
-                null,
-                null,
-                null,
+                null, /* filter */
+                null, /* filter-lang */
+                null, /* filter-crs */
+                null, /* sortby */
+                crs,
                 itemId);
     }
 


### PR DESCRIPTION
[![GEOS-10641](https://badgen.net/badge/JIRA/GEOS-10641/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10641)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The method arguments were in the wrong order.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [N/A] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [N/A] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).