### PR TITLE
[GEOS-10646] OAuth access tokens

### DIFF
--- a/doc/en/user/source/community/oauth2/index.rst
+++ b/doc/en/user/source/community/oauth2/index.rst
@@ -327,7 +327,7 @@ To Use:
 The Access Token (JWT) is validated;
 
 #. The Access Token is used to get the "userinfo" endpoint.  The underlying IDP will verify the token (i.e. signature and expiry)
-#. The Audience of the Token is checked that it is the same as the Geoserver configured Client Id.  This make sure an Access Token for another application is not being inappropriately reused in Geoserver (cf. `AudienceAccessTokenValidator.java`).
+#. The Audience of the Token is checked that it is the same as the GeoServer configured Client Id.  This make sure an Access Token for another application is not being inappropriately reused in GeoServer (cf. `AudienceAccessTokenValidator.java`).
 #. The Subject of the `userinfo` and Access Token are verified to be about the same person.  The OpenID specification recommends checking this (cf. `SubjectTokenValidator.java`).
 
 

--- a/doc/en/user/source/community/oauth2/index.rst
+++ b/doc/en/user/source/community/oauth2/index.rst
@@ -306,6 +306,53 @@ From UI it is also possible to set the ``Response Mode`` value. The field can be
 
 Finally the admin can allow the sending of the client_secret during an access_token request trough the ``Send Client Secret in Token Request``. Some OpenId implementation requires it for the Authorization Code flow when the client app is a confidential client and can safely store the client_secret.
 
+OpenID Connect With Attached Access Bearer Tokens
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The OpenID Connect plugin allows the use of Attached Bearer Access Tokens. This is typically used by automated (i.e. desktop or external Web Service) to access the Geoserver REST API.
+
+The setup process is as follows:
+
+#. Setup your OAuth2 OpenID Connect configuration as normal
+#. On the OpenID Connect configuration screen (bottom), makes sure "Allow Attached Bearer Tokens" is checked
+#. You can not use ID Tokens as a Role Source for the attached Bearer Tokens (see below)
+
+To Use:
+
+#. Obtain an Access Token from the underlying IDP
+#. Attach the access token to your HTTP request headers
+
+`Authorization: Bearer <token>`
+
+The Access Token (JWT) is validated;
+
+#. The Access Token is used to get the "userinfo" endpoint.  The underlying IDP will verify the token (i.e. signature and expiry)
+#. The Audience of the Token is checked that it is the same as the Geoserver configured Client Id.  This make sure an Access Token for another application is not being inappropriately reused in Geoserver (cf. `AudienceAccessTokenValidator.java`).
+#. The Subject of the `userinfo` and Access Token are verified to be about the same person.  The OpenID specification recommends checking this (cf. `SubjectTokenValidator.java`).
+
+
+For KeyCloak, consider using the "userinfo endpoint" role source and configure Keycloak to put groups in the "userinfo."
+
+For Azure AD, configure Azure to allow access to the MS Graph API (memberOf) and use the "Microsoft Graph API (Azure AD)" role source. 
+
+To configure Azure AD for "memberOf" ("GroupMember.Read.All" permission) access;
+
+#. go to your application in Azure AD (in the portal) 
+#. On the left, go to "API permissions" 
+#. click "Add a permission" 
+#. press "Microsoft Graph" 
+#. press "Delegated permission" 
+#. Scroll down to "GroupMember" 
+#. Choose "GroupMemeber.Read.All" 
+#. press "Add permission" 
+#. on the API Permission screen, press the "Grant admin consent for ..." text
+
+This has been tested with KeyCloak (with groups in the `userinfo` endpoint response), and with MS Azure AD (with the groups from the GraphAPI).  This should work with other IDPs - however, make sure that the Subject and Audience token verification works with their tokens. 
+  
+
+If you do not need Bearer Token functionality, it is recommended to turn this off.
+
+
 Azure AD and ADFS setup
 ^^^^^^^^^^^^^^^^^^^^^^^
 To make the OpenIdConnect filter to work properly with an Azure AD or ADFS server via the OpenId protocol, the user must set, in addition to the other configuration parameters, the ``Response Mode`` to query (otherwise by default ADFS will return a url fragment) and check the checkbox ``Send Client Secret in Token Request`` (the client_secret is mandatory in token request according to the `Microsoft documentation <https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-openid-connect-oauth-flows-scenarios#request-an-access-token>`_).

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
@@ -18,7 +18,9 @@ import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 /**
- * make sure your Azure AD application has "GroupMember.Read.All" permission: a) go to your
+ * Verify role using Azure graph.
+ * 
+ * Make sure your Azure AD application has "GroupMember.Read.All" permission: a) go to your
  * application in Azure AD (in the portal) b) On the left, go to "API permissions" c) click "Add a
  * permission" d) press "Microsoft Graph" e) press "Delegated permission" f) Scroll down to
  * "GroupMember" g) Choose "GroupMemeber.Read.All" h) press "Add permission" i) on the API

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
@@ -1,0 +1,111 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+
+/**
+ * make sure your Azure AD application has "GroupMember.Read.All" permission: a) go to your
+ * application in Azure AD (in the portal) b) On the left, go to "API permissions" c) click "Add a
+ * permission" d) press "Microsoft Graph" e) press "Delegated permission" f) Scroll down to
+ * "GroupMember" g) Choose "GroupMemeber.Read.All" h) press "Add permission" i) on the API
+ * Permission screen, press the "Grant admin consent for ..." text
+ *
+ * <p>This class will go to the "https://graph.microsoft.com/v1.0/me/memberOf" and attach your
+ * access token. It will then read the response and find all the user's groups.
+ *
+ * <p>NOTE: to be consistent with the rest of Azure, we use the Groups OID (guid) NOT its name.
+ */
+public class MSGraphRolesResolver {
+
+    static URL memberOfEndpoint;
+
+    static {
+        try {
+            memberOfEndpoint = new URL("https://graph.microsoft.com/v1.0/me/memberOf");
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // for testing, we make this package readable
+    String authorizationHeaderName = "Authorization";
+
+    public HttpURLConnection createHTTPRequest(String accessToken) throws IOException {
+        String tokenHeaderValue = "Bearer " + accessToken;
+
+        HttpURLConnection http = (HttpURLConnection) memberOfEndpoint.openConnection();
+        http.setRequestProperty("Accept", "application/json");
+        http.setRequestProperty(authorizationHeaderName, tokenHeaderValue);
+
+        return http;
+    }
+
+    /**
+     * talk to the actual azure graph api to get user's group memberships. 1. attaches the access
+     * token to the request. 2. sets the Accepts header to "application/json" (required)
+     *
+     * @param accessToken
+     * @return
+     * @throws IOException
+     */
+    private String resolveUrl(String accessToken) throws IOException {
+        HttpURLConnection http = null;
+
+        try {
+            http = createHTTPRequest(accessToken);
+            String result =
+                    new BufferedReader(new InputStreamReader(http.getInputStream()))
+                            .lines()
+                            .collect(Collectors.joining("\n"));
+            return result;
+        } finally {
+            if (http != null) http.disconnect();
+        }
+    }
+
+    // parses the resulting json from the user's group memberships json result.
+    // returns a list of the groups (object id) that the user is a member of.
+    public List<String> parseJson(String jsonString) throws JSONException {
+        List<String> result = new ArrayList<>();
+        JSONObject json = JSONObject.fromObject(jsonString);
+        JSONArray values = json.getJSONArray("value");
+        for (int i = 0; i < values.size(); i++) {
+            JSONObject object = (JSONObject) values.get(i);
+            if (!object.get("@odata.type").equals("#microsoft.graph.group")) continue;
+            result.add(object.get("id").toString());
+        }
+        return result;
+    }
+
+    /**
+     * call the MS Graph API and get a list of object ids (guid strings) - one for each group the
+     * user is a member of.
+     *
+     * @param accessToken - access token (from MS azure ad)
+     * @return list of groups (guid strings) the user is a member of
+     * @throws Exception
+     */
+    public List<String> resolveRoles(String accessToken) throws Exception {
+        try {
+            String jsonStr = resolveUrl(accessToken);
+            List<String> result = parseJson(jsonStr);
+            return result;
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
@@ -19,8 +19,8 @@ import net.sf.json.JSONObject;
 
 /**
  * Verify role using Azure graph.
- * 
- * Make sure your Azure AD application has "GroupMember.Read.All" permission: a) go to your
+ *
+ * <p>Make sure your Azure AD application has "GroupMember.Read.All" permission: a) go to your
  * application in Azure AD (in the portal) b) On the left, go to "API permissions" c) click "Add a
  * permission" d) press "Microsoft Graph" e) press "Delegated permission" f) Scroll down to
  * "GroupMember" g) Choose "GroupMemeber.Read.All" h) press "Add permission" i) on the API

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/MSGraphRolesResolver.java
@@ -12,10 +12,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
+import org.geotools.util.logging.Logging;
 
 /**
  * Verify role using Azure graph.
@@ -33,13 +36,16 @@ import net.sf.json.JSONObject;
  */
 public class MSGraphRolesResolver {
 
+    private static final Logger LOGGER = Logging.getLogger(MSGraphRolesResolver.class);
+
     static URL memberOfEndpoint;
 
     static {
         try {
             memberOfEndpoint = new URL("https://graph.microsoft.com/v1.0/me/memberOf");
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            // this shouldn't happen (unless typo in above line)
+            LOGGER.log(Level.WARNING, "Error parsing MS GRAPH API URL", e);
         }
     }
 

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
@@ -38,6 +38,9 @@ import org.springframework.security.oauth2.provider.authentication.OAuth2Authent
 import org.springframework.security.oauth2.provider.token.RemoteTokenServices;
 
 /** OpenID Connect authentication filter. */
+/**
+ * Authenticate using OpenID Connect.
+ */
 public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticationFilter {
 
     static final String ID_TOKEN_VALUE = "OpenIdConnect-IdTokenValue";

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
@@ -87,6 +87,13 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
         if ((type != null)
                 && (type.equals(OAuth2AuthenticationType.BEARER))
                 && (bearerTokenValidator != null)) {
+            if (!((OpenIdConnectFilterConfig) filterConfig).isAllowBearerTokens()) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "OIDC: received an attached Bearer token, but Bearer tokens aren't allowed!");
+                throw new IOException(
+                        "OIDC: received an attached Bearer token, but Bearer tokens aren't allowed!");
+            }
             // we must validate
             String accessToken =
                     (String) req.getAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_VALUE);

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
@@ -38,9 +38,7 @@ import org.springframework.security.oauth2.provider.authentication.OAuth2Authent
 import org.springframework.security.oauth2.provider.token.RemoteTokenServices;
 
 /** OpenID Connect authentication filter. */
-/**
- * Authenticate using OpenID Connect.
- */
+/** Authenticate using OpenID Connect. */
 public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticationFilter {
 
     static final String ID_TOKEN_VALUE = "OpenIdConnect-IdTokenValue";

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
@@ -37,7 +37,6 @@ import org.springframework.security.oauth2.client.token.grant.code.Authorization
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
 import org.springframework.security.oauth2.provider.token.RemoteTokenServices;
 
-/** OpenID Connect authentication filter. */
 /** Authenticate using OpenID Connect. */
 public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticationFilter {
 
@@ -179,6 +178,15 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
         }
     }
 
+    static Object extractFromJSON(Map json, String path) {
+        try {
+            return JsonPath.read(json, path);
+        } catch (Exception e) {
+            // do nothing - the ID Token doesn't have that attribute - handled later with o=null
+            return null;
+        }
+    }
+
     // since we've already requested the userinfo for an oidc bearer (or via code) to validate it.
     // We saved this information in the OAuth2Request extension so we don't have to request it
     // again.
@@ -199,13 +207,31 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
 
         String rolesAttributePath =
                 ((OpenIdConnectFilterConfig) this.filterConfig).getTokenRolesClaim();
-        Object o = JsonPath.read(userinfoMap, rolesAttributePath);
+        Object o = extractFromJSON(userinfoMap, rolesAttributePath);
 
+        List<GeoServerRole> result = getGeoServerRoles(rolesAttributePath, o);
+        return result;
+    }
+
+    /**
+     * Given a part of the json, jsonObject, (from rolesAttributePath in the main json object),
+     * generate GeoServerRole roles.
+     *
+     * <p>jsonObject can either be a single String or a list-of-Strings.
+     *
+     * @param rolesAttributePath for logging purposes - where are we looking for the role
+     *     information?
+     * @param jsonObject should be either a String or list-of-String
+     * @return
+     * @throws IOException
+     */
+    private List<GeoServerRole> getGeoServerRoles(String rolesAttributePath, Object jsonObject)
+            throws IOException {
         List<GeoServerRole> result = new ArrayList<>();
-        if (o instanceof String) {
-            result.add(new GeoServerRole((String) o));
-        } else if (o instanceof List) {
-            ((List) o).stream().forEach(v -> result.add(new GeoServerRole((String) v)));
+        if (jsonObject instanceof String) {
+            result.add(new GeoServerRole((String) jsonObject));
+        } else if (jsonObject instanceof List) {
+            ((List) jsonObject).stream().forEach(v -> result.add(new GeoServerRole((String) v)));
         } else {
             LOGGER.log(
                     Level.FINE,
@@ -229,27 +255,7 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
         String rolesAttributePath =
                 ((OpenIdConnectFilterConfig) this.filterConfig).getTokenRolesClaim();
         Object o = extractFromJSON(claims, rolesAttributePath);
-        List<GeoServerRole> result = new ArrayList<>();
-        if (o instanceof String) {
-            result.add(new GeoServerRole((String) o));
-        } else if (o instanceof List) {
-            ((List) o).stream().forEach(v -> result.add(new GeoServerRole((String) v)));
-        } else if (o != null) {
-            LOGGER.log(
-                    Level.WARNING,
-                    "Was expecting to find a list of strings or a single value in "
-                            + rolesAttributePath
-                            + ", but it was something else: "
-                            + o);
-        } else {
-            LOGGER.log(
-                    Level.FINE,
-                    "Did not find "
-                            + rolesAttributePath
-                            + "in the token, returning an empty role list");
-        }
-
-        if (!result.isEmpty()) enrichWithRoleCalculator(result);
+        List<GeoServerRole> result = getGeoServerRoles(rolesAttributePath, o);
 
         return result;
     }

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationProvider.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationProvider.java
@@ -10,19 +10,26 @@ import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.filter.GeoServerSecurityFilter;
+import org.geoserver.security.oauth2.bearer.TokenValidator;
 
 public class OpenIdConnectAuthenticationProvider extends GeoServerOAuthAuthenticationProvider {
+
+    TokenValidator bearerTokenValidator;
 
     public OpenIdConnectAuthenticationProvider(
             GeoServerSecurityManager securityManager,
             String tokenServices,
             String oauth2SecurityConfiguration,
-            String geoServerOauth2RestTemplate) {
+            String geoServerOauth2RestTemplate,
+            String bearTokenValidatorBeanName) {
         super(
                 securityManager,
                 tokenServices,
                 oauth2SecurityConfiguration,
                 geoServerOauth2RestTemplate);
+        if ((bearTokenValidatorBeanName != null) && (!bearTokenValidatorBeanName.isEmpty())) {
+            bearerTokenValidator = (TokenValidator) context.getBean(bearTokenValidatorBeanName);
+        }
     }
 
     @Override
@@ -38,6 +45,10 @@ public class OpenIdConnectAuthenticationProvider extends GeoServerOAuthAuthentic
     @Override
     public GeoServerSecurityFilter createFilter(SecurityNamedServiceConfig config) {
         return new OpenIdConnectAuthenticationFilter(
-                config, tokenServices, oauth2SecurityConfiguration, geoServerOauth2RestTemplate);
+                config,
+                tokenServices,
+                oauth2SecurityConfiguration,
+                geoServerOauth2RestTemplate,
+                bearerTokenValidator);
     }
 }

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationProvider.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationProvider.java
@@ -12,9 +12,7 @@ import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.filter.GeoServerSecurityFilter;
 import org.geoserver.security.oauth2.bearer.TokenValidator;
 
-/**
- * AuthenticationProvider for OpenId Connect.
- */
+/** AuthenticationProvider for OpenId Connect. */
 public class OpenIdConnectAuthenticationProvider extends GeoServerOAuthAuthenticationProvider {
 
     TokenValidator bearerTokenValidator;

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationProvider.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationProvider.java
@@ -12,6 +12,9 @@ import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.filter.GeoServerSecurityFilter;
 import org.geoserver.security.oauth2.bearer.TokenValidator;
 
+/**
+ * AuthenticationProvider for OpenId Connect.
+ */
 public class OpenIdConnectAuthenticationProvider extends GeoServerOAuthAuthenticationProvider {
 
     TokenValidator bearerTokenValidator;

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
@@ -23,7 +23,8 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
     /** Supports extraction of roles among the token claims */
     public static enum OpenIdRoleSource implements RoleSource {
         IdToken,
-        AccessToken;
+        AccessToken,
+        UserInfo;
 
         @Override
         public boolean equals(RoleSource other) {

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
@@ -19,7 +19,7 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
     String tokenRolesClaim;
     String responseMode;
     boolean sendClientSecret = false;
-    boolean allowBearerTokens = false;
+    boolean allowBearerTokens = true;
 
     /** Supports extraction of roles among the token claims */
     public static enum OpenIdRoleSource implements RoleSource {

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
@@ -19,11 +19,13 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
     String tokenRolesClaim;
     String responseMode;
     boolean sendClientSecret = false;
+    boolean allowBearerTokens = false;
 
     /** Supports extraction of roles among the token claims */
     public static enum OpenIdRoleSource implements RoleSource {
         IdToken,
         AccessToken,
+        MSGraphAPI,
         UserInfo;
 
         @Override
@@ -80,6 +82,14 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
 
     public void setSendClientSecret(boolean sendClientSecret) {
         this.sendClientSecret = sendClientSecret;
+    }
+
+    public boolean isAllowBearerTokens() {
+        return allowBearerTokens;
+    }
+
+    public void setAllowBearerTokens(boolean allowBearerTokens) {
+        this.allowBearerTokens = allowBearerTokens;
     }
 
     @Override

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
@@ -21,6 +21,11 @@ import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
  */
 public class AudienceAccessTokenValidator implements TokenValidator {
 
+
+    private final String AUDIENCE_CLAIM_NAME = "aud";
+    private final String APPID_CLAIM_NAME = "appid";
+    private final String KEYCLOAK_AUDIENCE_CLAIM_NAME = "azp";
+
     /**
      * "aud" must be our client id OR "azp" must be our client id (or, if its a list, contain our
      * client id) OR "appid" must be our client id.
@@ -37,20 +42,27 @@ public class AudienceAccessTokenValidator implements TokenValidator {
     public void verifyToken(OpenIdConnectFilterConfig config, Map claimsJWT, Map userInfoClaims)
             throws Exception {
         String clientId = config.getCliendId();
-        if ((claimsJWT.get("aud") != null) && claimsJWT.get("aud").equals(clientId)) return;
+        if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null) && claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
+            return;
+        }
 
-        if ((claimsJWT.get("appid") != null) && claimsJWT.get("appid").equals(clientId))
+        if ((claimsJWT.get(APPID_CLAIM_NAME) != null) && claimsJWT.get(APPID_CLAIM_NAME).equals(clientId)) {
             return; // azure specific
+        }
 
         // azp - keycloak
-        Object azp = claimsJWT.get("azp");
+        Object azp = claimsJWT.get(KEYCLOAK_AUDIENCE_CLAIM_NAME);
         if (azp != null) {
             if (azp instanceof String) {
-                if (((String) azp).equals(config.getCliendId())) return;
+                if (((String) azp).equals(config.getCliendId())) {
+                    return;
+                }
             } else if (azp instanceof List) {
                 List azps = (List) azp;
                 for (Object o : azps) {
-                    if ((o instanceof String) && (o.equals(clientId))) return;
+                    if ((o instanceof String) && (o.equals(clientId))) {
+                        return;
+                    }
                 }
             }
         }

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
@@ -1,0 +1,59 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.bearer;
+
+import java.util.List;
+import java.util.Map;
+import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
+
+/**
+ * This checks that the token is connected to this application. This will prevent a token for
+ * another application being used by us.
+ *
+ * <p>NOTE: Azure AD's JWT AccessToken has a fixed "aud", no "azp", but an "appid" (should be our
+ * client id). example; "aud": "00000003-0000-0000-c000-000000000000", "appid":
+ * "b9e8d05a-08b6-48a5-81c8-9590a0f550f3",
+ *
+ * <p>NOTE: Keycloak has the audience as "account", no "appid", but "azp" should be our client id.
+ * example; "aud": "account", "azp": "live-key",
+ */
+public class AudienceAccessTokenValidator implements TokenValidator {
+
+    /**
+     * "aud" must be our client id OR "azp" must be our client id (or, if its a list, contain our
+     * client id) OR "appid" must be our client id.
+     *
+     * <p>Otherwise, its a token not for us...
+     *
+     * <p>This checks that the audience of the JWT access token is us. The main attack this tries to
+     * prevent is someone getting an access token (i.e. from keycloak or azure) that was meant for
+     * another application (say a silly calendar app), and then using that token here. The IDP
+     * provider (keycloak/azure) will validate the token as "good", but it wasn't generated for us.
+     * This does a check of the token that OUR client ID is mentioned (not another app).
+     */
+    @Override
+    public void verifyToken(OpenIdConnectFilterConfig config, Map claimsJWT, Map userInfoClaims)
+            throws Exception {
+        String clientId = config.getCliendId();
+        if ((claimsJWT.get("aud") != null) && claimsJWT.get("aud").equals(clientId)) return;
+
+        if ((claimsJWT.get("appid") != null) && claimsJWT.get("appid").equals(clientId))
+            return; // azure specific
+
+        // azp - keycloak
+        Object azp = claimsJWT.get("azp");
+        if (azp != null) {
+            if (azp instanceof String) {
+                if (((String) azp).equals(config.getCliendId())) return;
+            } else if (azp instanceof List) {
+                List azps = (List) azp;
+                for (Object o : azps) {
+                    if ((o instanceof String) && (o.equals(clientId))) return;
+                }
+            }
+        }
+        throw new Exception("JWT Bearer token - probably not meant for this application");
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
@@ -21,7 +21,6 @@ import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
  */
 public class AudienceAccessTokenValidator implements TokenValidator {
 
-
     private final String AUDIENCE_CLAIM_NAME = "aud";
     private final String APPID_CLAIM_NAME = "appid";
     private final String KEYCLOAK_AUDIENCE_CLAIM_NAME = "azp";
@@ -42,11 +41,13 @@ public class AudienceAccessTokenValidator implements TokenValidator {
     public void verifyToken(OpenIdConnectFilterConfig config, Map claimsJWT, Map userInfoClaims)
             throws Exception {
         String clientId = config.getCliendId();
-        if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null) && claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
+        if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null)
+                && claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
             return;
         }
 
-        if ((claimsJWT.get(APPID_CLAIM_NAME) != null) && claimsJWT.get(APPID_CLAIM_NAME).equals(clientId)) {
+        if ((claimsJWT.get(APPID_CLAIM_NAME) != null)
+                && claimsJWT.get(APPID_CLAIM_NAME).equals(clientId)) {
             return; // azure specific
         }
 

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/MultiTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/MultiTokenValidator.java
@@ -1,0 +1,34 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.bearer;
+
+import java.util.List;
+import java.util.Map;
+import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
+
+/**
+ * This is a simple token validator that runs a list of TokenValidators. This doesn't do any
+ * validation on its own...
+ */
+public class MultiTokenValidator implements TokenValidator {
+
+    List<TokenValidator> validators;
+
+    public MultiTokenValidator(List<TokenValidator> validators) {
+        this.validators = validators;
+    }
+
+    @Override
+    public void verifyToken(
+            OpenIdConnectFilterConfig config, Map accessTokenClaims, Map userInfoClaims)
+            throws Exception {
+        if (validators == null) {
+            return; // nothing to do
+        }
+        for (TokenValidator validator : validators) {
+            validator.verifyToken(config, accessTokenClaims, userInfoClaims);
+        }
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/MultiTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/MultiTokenValidator.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
 
 /**
- * This is a simple token validator that runs a list of TokenValidators. This doesn't do any
- * validation on its own...
+ * This is a token validator that runs a list of TokenValidators. This doesn't do any validation on
+ * its own...
  */
 public class MultiTokenValidator implements TokenValidator {
 

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidator.java
@@ -19,19 +19,22 @@ import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
  */
 public class SubjectTokenValidator implements TokenValidator {
 
+    private final String SUBJECT_CLAIM_NAME = "sub";
+    private final String AZURE_SUBJECT_CONTAINER_NAME = "xms_st";
+
     @Override
     public void verifyToken(OpenIdConnectFilterConfig config, Map claims, Map userInfoClaims)
             throws Exception {
         // normal case - subjects are the same
-        if ((claims.get("sub") != null) && (userInfoClaims.get("sub") != null)) {
-            if (claims.get("sub").equals(userInfoClaims.get("sub"))) return;
+        if ((claims.get(SUBJECT_CLAIM_NAME) != null) && (userInfoClaims.get(SUBJECT_CLAIM_NAME) != null)) {
+            if (claims.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME))) return;
         }
 
         // Azure AD case - use accesstoken.xms_st.sub vs userinfo.sub
-        if ((claims.get("xms_st") != null) && (claims.get("xms_st") instanceof Map)) {
-            Map xmls_st = (Map) claims.get("xms_st");
-            if (xmls_st.get("sub") != null) {
-                if (xmls_st.get("sub").equals(userInfoClaims.get("sub"))) return;
+        if ((claims.get(AZURE_SUBJECT_CONTAINER_NAME) != null) && (claims.get(AZURE_SUBJECT_CONTAINER_NAME) instanceof Map)) {
+            Map xmls_st = (Map) claims.get(AZURE_SUBJECT_CONTAINER_NAME);
+            if (xmls_st.get(SUBJECT_CLAIM_NAME) != null) {
+                if (xmls_st.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME))) return;
             }
         }
         throw new Exception("JWT Bearer token VS UserInfo - subjects dont match");

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidator.java
@@ -1,0 +1,39 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.bearer;
+
+import java.util.Map;
+import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
+
+/**
+ * This verifies that the token is about our user (i.e. the access token and userinfo endpoint agree
+ * on who).
+ *
+ * <p>for keycloak, the "sub" of the JWT and userInfo are the same. for Azure AD, the "sub" of the
+ * userInfo is in the JWT "xms_st" claim. "xms_st": { "sub":
+ * "982kuI1hxIANLB__lrKejDgDnyjPnhbKLdPUF0JmOD1" },
+ *
+ * <p>The spec suggests verifying the user vs token subjects match, so this does that check.
+ */
+public class SubjectTokenValidator implements TokenValidator {
+
+    @Override
+    public void verifyToken(OpenIdConnectFilterConfig config, Map claims, Map userInfoClaims)
+            throws Exception {
+        // normal case - subjects are the same
+        if ((claims.get("sub") != null) && (userInfoClaims.get("sub") != null)) {
+            if (claims.get("sub").equals(userInfoClaims.get("sub"))) return;
+        }
+
+        // Azure AD case - use accesstoken.xms_st.sub vs userinfo.sub
+        if ((claims.get("xms_st") != null) && (claims.get("xms_st") instanceof Map)) {
+            Map xmls_st = (Map) claims.get("xms_st");
+            if (xmls_st.get("sub") != null) {
+                if (xmls_st.get("sub").equals(userInfoClaims.get("sub"))) return;
+            }
+        }
+        throw new Exception("JWT Bearer token VS UserInfo - subjects dont match");
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidator.java
@@ -26,15 +26,19 @@ public class SubjectTokenValidator implements TokenValidator {
     public void verifyToken(OpenIdConnectFilterConfig config, Map claims, Map userInfoClaims)
             throws Exception {
         // normal case - subjects are the same
-        if ((claims.get(SUBJECT_CLAIM_NAME) != null) && (userInfoClaims.get(SUBJECT_CLAIM_NAME) != null)) {
-            if (claims.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME))) return;
+        if ((claims.get(SUBJECT_CLAIM_NAME) != null)
+                && (userInfoClaims.get(SUBJECT_CLAIM_NAME) != null)) {
+            if (claims.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME)))
+                return;
         }
 
         // Azure AD case - use accesstoken.xms_st.sub vs userinfo.sub
-        if ((claims.get(AZURE_SUBJECT_CONTAINER_NAME) != null) && (claims.get(AZURE_SUBJECT_CONTAINER_NAME) instanceof Map)) {
+        if ((claims.get(AZURE_SUBJECT_CONTAINER_NAME) != null)
+                && (claims.get(AZURE_SUBJECT_CONTAINER_NAME) instanceof Map)) {
             Map xmls_st = (Map) claims.get(AZURE_SUBJECT_CONTAINER_NAME);
             if (xmls_st.get(SUBJECT_CLAIM_NAME) != null) {
-                if (xmls_st.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME))) return;
+                if (xmls_st.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME)))
+                    return;
             }
         }
         throw new Exception("JWT Bearer token VS UserInfo - subjects dont match");

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/TokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/TokenValidator.java
@@ -1,0 +1,23 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.bearer;
+
+import java.util.Map;
+import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
+
+/**
+ * Bearer tokens should be checked to make sure they are applicable to this application (to prevent
+ * token reuse from another application)
+ */
+public interface TokenValidator {
+
+    /**
+     * @param accessTokenClaims - map of claims in the Access Token
+     * @param userInfoClaims - map of claims from the oidc "userInfo" endpoint
+     * @throws Exception - if there is a problem, throw an exception.
+     */
+    void verifyToken(OpenIdConnectFilterConfig config, Map accessTokenClaims, Map userInfoClaims)
+            throws Exception;
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/resources/applicationContext.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/resources/applicationContext.xml
@@ -28,12 +28,22 @@
 		class="org.geoserver.security.oauth2.services.OpenIdConnectTokenServices">
 	</bean>
 
+	<bean id="openIdConnectBearerTokenValidator" class="org.geoserver.security.oauth2.bearer.MultiTokenValidator">
+		<constructor-arg>
+			<list>
+				<bean class="org.geoserver.security.oauth2.bearer.AudienceAccessTokenValidator"/>
+				<bean class="org.geoserver.security.oauth2.bearer.SubjectTokenValidator"/>
+			</list>
+		</constructor-arg>
+	</bean>
+
 	<bean id="openidConnectAuthenticationProvider"
 		class="org.geoserver.security.oauth2.OpenIdConnectAuthenticationProvider">
 		<constructor-arg ref="authenticationManager" />
 		<constructor-arg value="openIdConnectTokenServices" />
 		<constructor-arg value="openIdConnectSecurityConfiguration" />
 		<constructor-arg value="openIdConnectRestTemplate" />
+		<constructor-arg value="openIdConnectBearerTokenValidator" />
 	</bean>
 
 </beans>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/MSGraphRolesResolverTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/MSGraphRolesResolverTest.java
@@ -1,0 +1,133 @@
+package org.geoserver.security.oauth2;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.List;
+import org.junit.Test;
+
+public class MSGraphRolesResolverTest {
+
+    @Test
+    public void testMSGraphAPIEndpoint() throws IOException {
+        MSGraphRolesResolver resolver = new MSGraphRolesResolver();
+        assertEquals(
+                "https://graph.microsoft.com/v1.0/me/memberOf",
+                resolver.memberOfEndpoint.toString());
+    }
+
+    @Test
+    public void testHTTPConnection() throws IOException {
+        MSGraphRolesResolver resolver = new MSGraphRolesResolver();
+        // HttpURLConnection treats "Authorization" request header as private so we cannot verify
+        // it.  We change its name so we can access it!
+        resolver.authorizationHeaderName = "AuthorizationZZZ";
+        HttpURLConnection http = resolver.createHTTPRequest("accesstoken");
+        try {
+
+            assertEquals("https://graph.microsoft.com/v1.0/me/memberOf", http.getURL().toString());
+            assertEquals("Bearer accesstoken", http.getRequestProperty("AuthorizationZZZ"));
+            assertEquals("application/json", http.getRequestProperty("Accept"));
+        } finally {
+            if (http != null) http.disconnect();
+        }
+    }
+
+    // typical MSGraph response
+    String json1 =
+            "{\n"
+                    + "  \"@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#directoryObjects\",\n"
+                    + "  \"value\": [\n"
+                    + "    {\n"
+                    + "      \"@odata.type\": \"#microsoft.graph.directoryRole\",\n"
+                    + "      \"id\": \"fced5395-6be6-436c-a7f9-5c638cbdeb20\",\n"
+                    + "      \"deletedDateTime\": null,\n"
+                    + "      \"description\": null,\n"
+                    + "      \"displayName\": null,\n"
+                    + "      \"roleTemplateId\": null\n"
+                    + "    },\n"
+                    + "    {\n"
+                    + "      \"@odata.type\": \"#microsoft.graph.group\",\n"
+                    + "      \"id\": \"d93c6444-feee-4b67-8c0f-15d6796370cb\",\n"
+                    + "      \"deletedDateTime\": null,\n"
+                    + "      \"classification\": null,\n"
+                    + "      \"createdDateTime\": \"2022-05-04T17:57:04Z\",\n"
+                    + "      \"creationOptions\": [],\n"
+                    + "      \"description\": \"geoserverAdmin\",\n"
+                    + "      \"displayName\": \"geoserverAdmin\",\n"
+                    + "      \"expirationDateTime\": null,\n"
+                    + "      \"groupTypes\": [],\n"
+                    + "      \"isAssignableToRole\": null,\n"
+                    + "      \"mail\": null,\n"
+                    + "      \"mailEnabled\": false,\n"
+                    + "      \"mailNickname\": \"e93d884d-3\",\n"
+                    + "      \"membershipRule\": null,\n"
+                    + "      \"membershipRuleProcessingState\": null,\n"
+                    + "      \"onPremisesDomainName\": null,\n"
+                    + "      \"onPremisesLastSyncDateTime\": null,\n"
+                    + "      \"onPremisesNetBiosName\": null,\n"
+                    + "      \"onPremisesSamAccountName\": null,\n"
+                    + "      \"onPremisesSecurityIdentifier\": null,\n"
+                    + "      \"onPremisesSyncEnabled\": null,\n"
+                    + "      \"preferredDataLocation\": null,\n"
+                    + "      \"preferredLanguage\": null,\n"
+                    + "      \"proxyAddresses\": [],\n"
+                    + "      \"renewedDateTime\": \"2022-05-04T17:57:04Z\",\n"
+                    + "      \"resourceBehaviorOptions\": [],\n"
+                    + "      \"resourceProvisioningOptions\": [],\n"
+                    + "      \"securityEnabled\": true,\n"
+                    + "      \"securityIdentifier\": \"S-1-12-1-3644613700-1265106670-3591704460-3413140345\",\n"
+                    + "      \"theme\": null,\n"
+                    + "      \"visibility\": null,\n"
+                    + "      \"onPremisesProvisioningErrors\": []\n"
+                    + "    },\n"
+                    + "    {\n"
+                    + "      \"@odata.type\": \"#microsoft.graph.group\",\n"
+                    + "      \"id\": \"3a94275f-7d53-4205-8d78-11f39e9ffa5a\",\n"
+                    + "      \"deletedDateTime\": null,\n"
+                    + "      \"classification\": null,\n"
+                    + "      \"createdDateTime\": \"2022-05-18T20:21:11Z\",\n"
+                    + "      \"creationOptions\": [],\n"
+                    + "      \"description\": \"geonetworkAdmin\",\n"
+                    + "      \"displayName\": \"geonetworkAdmin\",\n"
+                    + "      \"expirationDateTime\": null,\n"
+                    + "      \"groupTypes\": [],\n"
+                    + "      \"isAssignableToRole\": null,\n"
+                    + "      \"mail\": null,\n"
+                    + "      \"mailEnabled\": false,\n"
+                    + "      \"mailNickname\": \"52fa2d5e-5\",\n"
+                    + "      \"membershipRule\": null,\n"
+                    + "      \"membershipRuleProcessingState\": null,\n"
+                    + "      \"onPremisesDomainName\": null,\n"
+                    + "      \"onPremisesLastSyncDateTime\": null,\n"
+                    + "      \"onPremisesNetBiosName\": null,\n"
+                    + "      \"onPremisesSamAccountName\": null,\n"
+                    + "      \"onPremisesSecurityIdentifier\": null,\n"
+                    + "      \"onPremisesSyncEnabled\": null,\n"
+                    + "      \"preferredDataLocation\": null,\n"
+                    + "      \"preferredLanguage\": null,\n"
+                    + "      \"proxyAddresses\": [],\n"
+                    + "      \"renewedDateTime\": \"2022-05-18T20:21:11Z\",\n"
+                    + "      \"resourceBehaviorOptions\": [],\n"
+                    + "      \"resourceProvisioningOptions\": [],\n"
+                    + "      \"securityEnabled\": true,\n"
+                    + "      \"securityIdentifier\": \"S-1-12-1-982787935-1107656019-4078008461-1526374302\",\n"
+                    + "      \"theme\": null,\n"
+                    + "      \"visibility\": null,\n"
+                    + "      \"onPremisesProvisioningErrors\": []\n"
+                    + "    } \n"
+                    + "  ]\n"
+                    + "}";
+
+    @Test
+    public void testParse() {
+        MSGraphRolesResolver resolver = new MSGraphRolesResolver();
+
+        List<String> groups = resolver.parseJson(json1);
+
+        assertEquals(2, groups.size());
+        assertEquals("d93c6444-feee-4b67-8c0f-15d6796370cb", groups.get(0));
+        assertEquals("3a94275f-7d53-4205-8d78-11f39e9ffa5a", groups.get(1));
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/MSGraphRolesResolverTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/MSGraphRolesResolverTest.java
@@ -1,3 +1,9 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ *
+ */
 package org.geoserver.security.oauth2;
 
 import static org.junit.Assert.assertEquals;

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidatorTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidatorTest.java
@@ -1,0 +1,92 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.bearer;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
+import org.junit.Test;
+
+public class AudienceAccessTokenValidatorTest {
+
+    String clientId = "MYCLIENTID";
+
+    public AudienceAccessTokenValidator getValidator() {
+        AudienceAccessTokenValidator validator = new AudienceAccessTokenValidator();
+        return validator;
+    }
+
+    public OpenIdConnectFilterConfig getConfig() {
+        OpenIdConnectFilterConfig result = new OpenIdConnectFilterConfig();
+        result.setCliendId(clientId);
+        return result;
+    }
+
+    @Test
+    public void testAzureGood() throws Exception {
+        Map claims = new HashMap();
+        claims.put("appid", clientId);
+
+        AudienceAccessTokenValidator validator = getValidator();
+        OpenIdConnectFilterConfig config = getConfig();
+
+        validator.verifyToken(config, claims, null);
+    }
+
+    @Test
+    public void testKeyCloakGood() throws Exception {
+        Map claims = new HashMap();
+        claims.put("azp", clientId);
+
+        AudienceAccessTokenValidator validator = getValidator();
+        OpenIdConnectFilterConfig config = getConfig();
+
+        validator.verifyToken(config, claims, null);
+    }
+
+    @Test
+    public void testSelfCreatedGood() throws Exception {
+        Map claims = new HashMap();
+        claims.put("aud", clientId);
+
+        AudienceAccessTokenValidator validator = getValidator();
+        OpenIdConnectFilterConfig config = getConfig();
+
+        validator.verifyToken(config, claims, null);
+    }
+
+    @Test(expected = Exception.class)
+    public void testBad1() throws Exception {
+        Map claims = new HashMap();
+        claims.put("aud", "badaud");
+
+        AudienceAccessTokenValidator validator = getValidator();
+        OpenIdConnectFilterConfig config = getConfig();
+
+        validator.verifyToken(config, claims, null);
+    }
+
+    @Test(expected = Exception.class)
+    public void testBad2() throws Exception {
+        Map claims = new HashMap();
+        claims.put("azp", "badaud");
+
+        AudienceAccessTokenValidator validator = getValidator();
+        OpenIdConnectFilterConfig config = getConfig();
+
+        validator.verifyToken(config, claims, null);
+    }
+
+    @Test(expected = Exception.class)
+    public void testBad3() throws Exception {
+        Map claims = new HashMap();
+        claims.put("appid", "badaud");
+
+        AudienceAccessTokenValidator validator = getValidator();
+        OpenIdConnectFilterConfig config = getConfig();
+
+        validator.verifyToken(config, claims, null);
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/MultiTokenValidatorTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/MultiTokenValidatorTest.java
@@ -1,0 +1,74 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.bearer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
+import org.junit.Test;
+
+public class MultiTokenValidatorTest {
+
+    TokenValidator alwaysThrows =
+            new TokenValidator() {
+                @Override
+                public void verifyToken(
+                        OpenIdConnectFilterConfig config, Map accessTokenClaims, Map userInfoClaims)
+                        throws Exception {
+                    throw new Exception("bad");
+                }
+            };
+
+    TokenValidator neverThrows =
+            new TokenValidator() {
+                @Override
+                public void verifyToken(
+                        OpenIdConnectFilterConfig config, Map accessTokenClaims, Map userInfoClaims)
+                        throws Exception {}
+            };
+
+    // null - should run fine
+    @Test
+    public void testNull() throws Exception {
+        MultiTokenValidator validator = new MultiTokenValidator(null);
+        validator.verifyToken(null, null, null);
+    }
+
+    // empty - should run fine
+    @Test
+    public void testEmpty() throws Exception {
+        MultiTokenValidator validator = new MultiTokenValidator(new ArrayList<>());
+        validator.verifyToken(null, null, null);
+    }
+
+    // doesn't throw
+    @Test
+    public void testRunsGood() throws Exception {
+        List<TokenValidator> validators =
+                Arrays.asList(new TokenValidator[] {neverThrows, neverThrows});
+        MultiTokenValidator validator = new MultiTokenValidator(validators);
+        validator.verifyToken(null, null, null);
+    }
+
+    //  throws on first
+    @Test(expected = Exception.class)
+    public void testRunsBad1() throws Exception {
+        List<TokenValidator> validators =
+                Arrays.asList(new TokenValidator[] {alwaysThrows, neverThrows});
+        MultiTokenValidator validator = new MultiTokenValidator(validators);
+        validator.verifyToken(null, null, null);
+    }
+
+    //  throws on last
+    @Test(expected = Exception.class)
+    public void testRunsBad2() throws Exception {
+        List<TokenValidator> validators =
+                Arrays.asList(new TokenValidator[] {neverThrows, alwaysThrows});
+        MultiTokenValidator validator = new MultiTokenValidator(validators);
+        validator.verifyToken(null, null, null);
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidatorTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/SubjectTokenValidatorTest.java
@@ -1,0 +1,70 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.bearer;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class SubjectTokenValidatorTest {
+
+    String userName = "MYUSERNAME";
+
+    public SubjectTokenValidator getValidator() {
+        SubjectTokenValidator validator = new SubjectTokenValidator();
+        return validator;
+    }
+
+    @Test
+    public void testAzureGood() throws Exception {
+        Map jwt = new HashMap();
+        Map userInfo = new HashMap();
+
+        jwt.put("sub", userName);
+        userInfo.put("sub", userName);
+
+        SubjectTokenValidator validator = getValidator();
+        validator.verifyToken(null, jwt, userInfo);
+    }
+
+    @Test
+    public void testKeyCloakGood() throws Exception {
+        Map jwt = new HashMap();
+        Map xms_st = new HashMap();
+
+        Map userInfo = new HashMap();
+
+        xms_st.put("sub", userName);
+        jwt.put("xms_st", xms_st);
+        userInfo.put("sub", userName);
+
+        SubjectTokenValidator validator = getValidator();
+        validator.verifyToken(null, jwt, userInfo);
+    }
+
+    @Test(expected = Exception.class)
+    public void testbad1() throws Exception {
+        Map jwt = new HashMap();
+        Map userInfo = new HashMap();
+
+        SubjectTokenValidator validator = getValidator();
+        validator.verifyToken(null, jwt, userInfo);
+    }
+
+    @Test(expected = Exception.class)
+    public void testbad2() throws Exception {
+        Map jwt = new HashMap();
+        Map xms_st = new HashMap();
+
+        Map userInfo = new HashMap();
+
+        xms_st.put("sub", "baduser");
+        jwt.put("xms_st", xms_st);
+        userInfo.put("sub", userName);
+
+        SubjectTokenValidator validator = getValidator();
+        validator.verifyToken(null, jwt, userInfo);
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.html
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.html
@@ -30,6 +30,22 @@
                 <input id="sendClientSecret" wicket:id="sendClientSecret" type="checkbox"/>
                 <a href="#" wicket:id="sendClientSecretHelp" class="help-link"></a>
             </li>
+
+            <br>
+            <fieldset>
+                <legend>
+                    <span> <wicket:message key="bearerTokens">Bearer Tokens</wicket:message> </span>
+                    <a href="#" wicket:id="allowBearerTokensHelp" class="help-link"></a>
+                </legend>
+                <li>
+                    <label for="allowBearerTokens"><span><wicket:message
+                            key="allowBearerTokens"></wicket:message></span></label>
+                </li>
+                <li>
+                    <input id="allowBearerTokens" wicket:id="allowBearerTokens" type="checkbox"/>
+                </li>
+            </fieldset>
+
         </wicket:extend>
     </body>
 </html>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.java
@@ -15,6 +15,7 @@ package org.geoserver.web.security.oauth2;
 
 import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.AccessToken;
 import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.IdToken;
+import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.MSGraphAPI;
 import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.UserInfo;
 
 import java.util.ArrayList;
@@ -26,7 +27,9 @@ import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.form.validation.AbstractFormValidator;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -50,6 +53,84 @@ import org.geoserver.web.wicket.ParamResourceModel;
 public class OpenIdConnectAuthProviderPanel
         extends GeoServerOAuth2AuthProviderPanel<OpenIdConnectFilterConfig> {
 
+    /**
+     * If they have chosen MSGraphAPI as the RoleProvider, we need to make sure that the userinfo
+     * endpoint is also an MS Graph URL. If not, they've probably made a misconfiguration - the
+     * bearer token is from another IDP and this will cause issues access the MS graph endpoint.
+     * Let's fail early.
+     */
+    class MSGraphRoleProviderOnlyWithMSGraphSystem extends AbstractFormValidator {
+
+        @Override
+        public FormComponent<?>[] getDependentFormComponents() {
+            return null;
+        }
+
+        @Override
+        public void validate(Form<?> form) {
+            DropDownChoice roleSource = (DropDownChoice) form.get("panel").get("roleSource");
+            if (roleSource == null) {
+                return;
+            }
+            if (!MSGraphAPI.equals(roleSource.getConvertedInput())) {
+                return;
+            }
+
+            TextField userInfoTextField =
+                    (TextField) form.get("panel").get("checkTokenEndpointUrl");
+
+            String userInfoEndpointUrl = (String) userInfoTextField.getConvertedInput();
+
+            if (!userInfoEndpointUrl.startsWith("https://graph.microsoft.com/")) {
+                form.error(form.getString("OpenIdConnectAuthProviderPanel.invalidMSGraphURL"));
+            }
+        }
+    }
+
+    /**
+     * Attached Bearer Tokens are NOT compatible with ID Tokens roles source. This is because there
+     * isn't an ID Token available when the Access Token is attached to the HTTP request. User
+     * should choose a different role Source (which may require setting up the IDP to put roles in a
+     * different location).
+     */
+    class BearerTokenNoIDTokensValidator extends AbstractFormValidator {
+
+        @Override
+        public FormComponent<?>[] getDependentFormComponents() {
+            return null;
+        }
+
+        /**
+         * if Bearer Tokens are on, and role source is ID Token, then give an error message
+         *
+         * @param form
+         */
+        @Override
+        public void validate(Form<?> form) {
+            CheckBox allowBearerTokensCheckbox =
+                    (CheckBox) form.get("panel").get("allowBearerTokens");
+            if (allowBearerTokensCheckbox == null) {
+                return; // this happens when the "discovery" button is pressed
+            }
+            if (!allowBearerTokensCheckbox.getConvertedInput())
+                return; // bearer tokens not allowed -> no issues
+
+            DropDownChoice roleSource = (DropDownChoice) form.get("panel").get("roleSource");
+
+            if (IdToken.equals(roleSource.getConvertedInput())) {
+                form.error(
+                        form.getString("OpenIdConnectAuthProviderPanel.invalidBearerRoleSource"));
+            }
+        }
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+        getForm().add(new BearerTokenNoIDTokensValidator());
+        getForm().add(new MSGraphRoleProviderOnlyWithMSGraphSystem());
+    }
+
     public OpenIdConnectAuthProviderPanel(String id, IModel<OpenIdConnectFilterConfig> model) {
         super(id, model);
 
@@ -63,6 +144,8 @@ public class OpenIdConnectAuthProviderPanel
         add(new TextField<String>("responseMode"));
         add(new HelpLink("sendClientSecretHelp", this).setDialog(dialog));
         add(new CheckBox("sendClientSecret"));
+        add(new HelpLink("allowBearerTokensHelp", this).setDialog(dialog));
+        add(new CheckBox("allowBearerTokens"));
     }
 
     @Override

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.java
@@ -15,6 +15,7 @@ package org.geoserver.web.security.oauth2;
 
 import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.AccessToken;
 import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.IdToken;
+import static org.geoserver.security.oauth2.OpenIdConnectFilterConfig.OpenIdRoleSource.UserInfo;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +67,7 @@ public class OpenIdConnectAuthProviderPanel
 
     @Override
     protected Panel getRoleSourcePanel(RoleSource model) {
-        if (IdToken.equals(model) || AccessToken.equals(model)) {
+        if (IdToken.equals(model) || AccessToken.equals(model) || UserInfo.equals(model)) {
             return new TokenClaimPanel("panel");
         }
         return super.getRoleSourcePanel(model);

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication.properties
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication.properties
@@ -91,5 +91,6 @@ OpenIdConnectAuthProviderPanel.sendClientSecretHelp= Check this option if the Op
 
 RoleSource.IdToken=ID Token
 RoleSource.AccessToken=Access Token
+RoleSource.UserInfo=UserInfo Endpoint
 
 TokenClaimPanel=Token roles claim

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication.properties
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication.properties
@@ -89,8 +89,20 @@ OpenIdConnectAuthProviderPanel.sendClientSecretHelp.title=Send Client Secret in 
 OpenIdConnectAuthProviderPanel.sendClientSecretHelp= Check this option if the OpenId server requires a confidential client \
   to send the client_secret in the token response (eg. ADFS and Azure AD).
 
+OpenIdConnectAuthProviderPanel.bearerTokens=Bearer Tokens
+OpenIdConnectAuthProviderPanel.allowBearerTokens=Allow Attached Bearer Tokens
+OpenIdConnectAuthProviderPanel.allowBearerTokensHelp.title=Allow Attached Bearer Tokens
+OpenIdConnectAuthProviderPanel.allowBearerTokensHelp=Allow Bearer Tokens to be attached to the HTTP requests for access. <br>  \
+  This is typically used by automated (i.e. desktop or external Web Service) to access the Geoserver REST API. <br> \
+  Bearer Tokens are Access Tokens created by the Open ID Connect system (defined above). <br> \
+  Since ID Tokens are not present in this mode, do NOT select "ID Token" for the Role Source. <br> <br>  \
+  If you do not need Bearer Token functionality, it is recommended to turn this off.
+OpenIdConnectAuthProviderPanel.invalidBearerRoleSource=Bearer Tokens are not compatible with ID Token Role Source
+OpenIdConnectAuthProviderPanel.invalidMSGraphURL=You specified MSGraphAPI as the Role Provider, but your "userinfo" endpoint doesn't look like an MS Graph endpoint.
+
 RoleSource.IdToken=ID Token
 RoleSource.AccessToken=Access Token
 RoleSource.UserInfo=UserInfo Endpoint
+RoleSource.MSGraphAPI=Microsoft Graph API (Azure AD)
 
 TokenClaimPanel=Token roles claim

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication_ko.properties
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication_ko.properties
@@ -61,3 +61,20 @@ OpenIdConnectAuthProviderPanel.clientSecretHelp=OAuth2 \uacf5\uae09\uc790\uac00 
 OpenIdConnectAuthProviderPanel.principalKey=\uc8fc\uccb4 \ud0a4
 OpenIdConnectAuthProviderPanel.principalKeyHelp.title=\uc8fc\uccb4\ub97c \uc2dd\ubcc4\ud558\ub294 \ud0a4
 OpenIdConnectAuthProviderPanel.principalKeyHelp=Oauth2 \uc11c\ubc84\ub294 JSON \ubb38\uc11c\ub85c \uc0ac\uc6a9\uc790 \ud655\uc778\uc5d0 \uc751\ub2f5\ud558\uba70, \uc774 \ud56d\ubaa9\uc740 JSON \ud0a4\uac00 GeoServer\uc5d0\uc11c \uc8fc\uccb4 \ub610\ub294 \uc0ac\uc6a9\uc790 \uc774\ub984\uc73c\ub85c \uc0ac\uc6a9\ub418\uc5b4\uc57c \ud55c\ub2e4\uace0 \uc9c0\uc815\ud569\ub2c8\ub2e4.
+
+
+OpenIdConnectAuthProviderPanel.bearerTokens=Bearer Tokens
+OpenIdConnectAuthProviderPanel.allowBearerTokens=Allow Attached Bearer Tokens
+OpenIdConnectAuthProviderPanel.allowBearerTokensHelp.title=Allow Attached Bearer Tokens
+OpenIdConnectAuthProviderPanel.allowBearerTokensHelp=Allow Bearer Tokens to be attached to the HTTP requests for access. <br>  \
+  This is typically used by automated (i.e. desktop or external Web Service) to access the Geoserver REST API. <br> \
+  Bearer Tokens are Access Tokens created by the Open ID Connect system (defined above). <br> \
+  Since ID Tokens are not present in this mode, do NOT select "ID Token" for the Role Source. <br> <br>  \
+  If you do not need Bearer Token functionality, it is recommended to turn this off.
+OpenIdConnectAuthProviderPanel.invalidBearerRoleSource=Bearer Tokens are not compatible with ID Token Role Source
+OpenIdConnectAuthProviderPanel.invalidMSGraphURL=You specified MSGraphAPI as the Role Provider, but your "userinfo" endpoint doesn't look like an MS Graph endpoint.
+
+RoleSource.UserInfo=UserInfo Endpoint
+RoleSource.MSGraphAPI=Microsoft Graph API (Azure AD)
+
+TokenClaimPanel=Token roles claim

--- a/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerAccessTokenConverter.java
+++ b/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerAccessTokenConverter.java
@@ -11,12 +11,16 @@
  */
 package org.geoserver.security.oauth2;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geotools.util.logging.Logging;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
@@ -29,6 +33,11 @@ import org.springframework.security.oauth2.provider.token.UserAuthenticationConv
  * @author Alessio Fabiani, GeoSolutions S.A.S.
  */
 public class GeoServerAccessTokenConverter extends DefaultAccessTokenConverter {
+    private static final Logger LOG = Logging.getLogger(GeoServerAccessTokenConverter.class);
+
+    // for oidc, this will be the userinfo.  For oauth2, the result of the "token check" endpoint.
+    // This is attached to the request's extensions once it's been retrieved.
+    public static String ACCESS_TOKEN_CHECK_KEY = "oauth2.AccessTokenCheckResponse";
 
     protected UserAuthenticationConverter userTokenConverter;
 
@@ -60,10 +69,27 @@ public class GeoServerAccessTokenConverter extends DefaultAccessTokenConverter {
         Authentication user = userTokenConverter.extractAuthentication(map);
         String clientId = (String) map.get(CLIENT_ID);
         parameters.put(CLIENT_ID, clientId);
+
+        Map<String, Serializable> extensionParameters = new HashMap<>();
+        try {
+            extensionParameters.put(ACCESS_TOKEN_CHECK_KEY, (Serializable) map);
+        } catch (Exception e) {
+            //
+            LOG.log(Level.FINER, "Exception while trying to record the access token check info", e);
+        }
+
         Set<String> resourceIds = new LinkedHashSet<>(getAud(map));
         OAuth2Request request =
                 new OAuth2Request(
-                        parameters, clientId, null, true, scope, resourceIds, null, null, null);
+                        parameters,
+                        clientId,
+                        null,
+                        true,
+                        scope,
+                        resourceIds,
+                        null,
+                        null,
+                        extensionParameters);
         return new OAuth2Authentication(request, user);
     }
 

--- a/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerAccessTokenConverter.java
+++ b/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerAccessTokenConverter.java
@@ -1,14 +1,10 @@
 /*
- * (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2016-2022 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  *
  */
 
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
- * This code is licensed under the GPL 2.0 license, available at the root
- * application directory.
- */
 package org.geoserver.security.oauth2;
 
 import java.io.Serializable;


### PR DESCRIPTION
[![GEOS-10646](https://badgen.net/badge/JIRA/GEOS-10646/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10646)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is improving the support for Bearer Tokens.  See the updated GS OpenID documentation for setup and usage.

Issue: https://osgeo-org.atlassian.net/browse/GEOS-10646 

Summary: attach an Access Token to your HTTP requests - useful for automated (i.e. desktop/remote web) access of the REST api.

There was already some partial support for Bearer tokens.  This PR improves it.


1. There is now better token validation (see GS doc + OIDC specification).  This improves security.
2. Since you cannot use ID Tokens with attached access tokens, I added two new ways to get user groups:
    a) from the "userinfo" endpoint (recommended for KeyCloak)
    b) from the MS Graph API (only for MS Azure AD)
3. There is a configuration on the OIDC web page to turn on/off bearer tokens
4. I added some minor validation to the OIDC web page
5. Added a few test cases
6. Updated documentation for Attached Bearer Tokens
7. Tested with Keycloak and Azure AD
8. I attach the "userinfo" results to the incomming request (in the same manner as the ID/Access tokens + other spring stuff)
9. I attach a flag to the incomming request indicating if the authentication is BEARER or USER (in the same manner as the ID/Access tokens + other spring stuff)

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [n/a] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [GEOS-10646] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [squash on merge] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->