### PR TITLE
[GEOS-10654] app-schema GetFeature numberMatched fails with ID filter:…

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GetFeatureNumberMatchedGMLTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/GetFeatureNumberMatchedGMLTest.java
@@ -202,6 +202,16 @@ public class GetFeatureNumberMatchedGMLTest extends AbstractAppSchemaTestSupport
         assertNumberMathcedAndNumberReturned(doc, 1, 1);
     }
 
+    @Test
+    public void testGetMappedNumberMatchedWithIdFilter() {
+        Document doc =
+                getAsDOM(
+                        "ows?service=WFS&version=2.0.0&outputFormat=gml3&request=GetFeature&typeNames=gsml:MappedFeature&resulttype=hits&&cql_filter=IN('mf1')");
+        LOGGER.info("WFS GetFeature, typename=gsml:MappedFeature response:\n" + prettyString(doc));
+
+        assertNumberMathcedAndNumberReturned(doc, 1, 0);
+    }
+
     private void assertNumberMathcedAndNumberReturned(
             Document doc, int numberMatched, int numberReturned) {
         assertXpathEvaluatesTo(


### PR DESCRIPTION
[![GEOT-7214](https://badgen.net/badge/JIRA/GEOT-7214/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7214)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… test


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->