### PR TITLE
[GEOS-10598] XSS vulnerability in the email address field - fix too eager escape (2.21.x backport)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -863,11 +863,6 @@
         <version>1.3</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>1.4</version>
-      </dependency>
-      <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
         <version>2.4.0</version>

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -11,6 +11,7 @@ import com.google.common.base.Stopwatch;
 import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
@@ -70,13 +71,15 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
             params.put("version", version);
             params.put(
                     "contactEmail",
-                    (contactEmail == null ? "geoserver@example.org" : contactEmail));
+                    (contactEmail == null
+                            ? "geoserver@example.org"
+                            : StringEscapeUtils.escapeHtml4(contactEmail)));
             Label label =
                     new Label(
                             "footerMessage",
                             new StringResourceModel(
                                     "GeoServerHomePage.footer", this, new Model(params)));
-            label.setEscapeModelStrings(true);
+            label.setEscapeModelStrings(false);
             add(label);
         }
 

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
@@ -172,7 +172,6 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
                     }
                 });
         tester.executeAjaxEvent(page, "ondblclick");
-        print(tester.getLastRenderedPage(), true, true);
 
         // verify contents were updated
         tester.assertContains("the_geom");
@@ -367,8 +366,6 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
 
         login();
         tester.startPage(new ResourceConfigurationPage(layer, false));
-
-        print(tester.getLastRenderedPage(), true, true);
 
         FormTester ft = tester.newFormTester("publishedinfo");
         String newTitle = "A test title";


### PR DESCRIPTION
[![GEOS-10598](https://badgen.net/badge/JIRA/GEOS-10598/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10598)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->