### PR TITLE
typo in doc - fix copy-paste typo (shapefile --> database)

### DIFF
--- a/doc/en/user/source/gettingstarted/postgis-quickstart/index.rst
+++ b/doc/en/user/source/gettingstarted/postgis-quickstart/index.rst
@@ -65,7 +65,7 @@ The next step is to create a workspace for the data. A workspace is a container 
 Creating a store
 ----------------
 
-Once the workspace is created, we are ready to add a new store. The store tells GeoServer how to connect to the shapefile. 
+Once the workspace is created, we are ready to add a new store. The store tells GeoServer how to connect to the database. 
 
 #. Navigate to :menuselection:`Data-->Stores`.
     


### PR DESCRIPTION
Fix typo in doc.

- [X] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).