### PR TITLE
[GEOS-10665] - Parametrize Users' passwords

### DIFF
--- a/doc/en/user/source/security/passwd.rst
+++ b/doc/en/user/source/security/passwd.rst
@@ -120,3 +120,6 @@ Each user/group service uses a password policy to enforce these rules. The defau
 * Password minimum length
 * Password maximum length
 
+Parametrized Passwords
+-----------------------
+It is possible to parametrize users' passwords in a similar way to the catalog settings (see :ref:`datadir_configtemplate`). Parametrization is supported when the encryption method used to store the place holder in the password field is plain text or is reversible (pbe, strong pbe). Non reverisble encoding for the placeholder (eg. digest) is not supported. On the contrary the actual value can be defined in the ``geoserver-environment.properties`` with any password encoding method supported by GeoServer. 

--- a/doc/en/user/source/security/passwd.rst
+++ b/doc/en/user/source/security/passwd.rst
@@ -122,4 +122,10 @@ Each user/group service uses a password policy to enforce these rules. The defau
 
 Parametrized Passwords
 -----------------------
-It is possible to parametrize users' passwords in a similar way to the catalog settings (see :ref:`datadir_configtemplate`). Parametrization is supported when the encryption method used to store the place holder in the password field is plain text or is reversible (pbe, strong pbe). Non reverisble encoding for the placeholder (eg. digest) is not supported. On the contrary the actual value can be defined in the ``geoserver-environment.properties`` with any password encoding method supported by GeoServer. 
+It is possible to parametrize users' passwords in a similar way to the catalog settings (see :ref:`datadir_configtemplate`). Parametrization is supported when the encryption method used to store the place holder in the password field is plain text or is reversible (pbe, strong pbe). Non reversible encoding for the placeholder (e.g. digest) is not supported. On the contrary the actual value can be defined in the ``geoserver-environment.properties`` with any password encoding method supported by GeoServer. Examples are provided below:
+
+.. code-block:: properties
+
+ pwd.one=plain:clear_text_password
+ pwd.two=digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw
+ pwd.three=crypt1:xZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw

--- a/src/main/src/main/java/org/geoserver/security/auth/EnvPwdResolverUserGroupServiceWrapper.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/EnvPwdResolverUserGroupServiceWrapper.java
@@ -1,0 +1,95 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.auth;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang.StringUtils;
+import org.geoserver.platform.GeoServerEnvironment;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.GeoServerUserGroupService;
+import org.geoserver.security.impl.GeoServerUser;
+import org.geoserver.security.password.GeoServerPasswordEncoder;
+import org.geotools.util.logging.Logging;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+/**
+ * A UserGroupService wrapper able to resolve password that have been parametrized. The placeholder
+ * can be encoded in plain txt or any reversible encoding.
+ */
+class EnvPwdResolverUserGroupServiceWrapper implements UserDetailsService {
+
+    private GeoServerUserGroupService delegate;
+    private final GeoServerEnvironment environment;
+
+    private static Logger LOGGER = Logging.getLogger(EnvPwdResolverUserGroupServiceWrapper.class);
+
+    EnvPwdResolverUserGroupServiceWrapper(GeoServerUserGroupService userDetailsService) {
+        this.delegate = userDetailsService;
+        environment = GeoServerExtensions.bean(GeoServerEnvironment.class);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserDetails userDetails = delegate.loadUserByUsername(username);
+        if (environment != null && GeoServerEnvironment.allowEnvParametrization()) {
+            if (userDetails instanceof GeoServerUser) {
+                GeoServerUser user = (GeoServerUser) userDetails;
+                String password = user.getPassword();
+                GeoServerSecurityManager manager = delegate.getSecurityManager();
+                List<GeoServerPasswordEncoder> encoders =
+                        manager.loadPasswordEncoders(null, true, null);
+                String decodedPwd = decode(password, encoders);
+                return returnOrGetResolvedPwdUser(decodedPwd, user);
+            }
+        }
+        return userDetails;
+    }
+
+    // copy the user and set the pwd value if it was parametrized in env properties.
+    // otherwise returns the user passed as a parameter.
+    private GeoServerUser returnOrGetResolvedPwdUser(String decodedPwd, GeoServerUser user) {
+        if (isParametrized(decodedPwd)) {
+            String resolved = (String) environment.resolveValue(decodedPwd);
+            if (!resolved.equals(decodedPwd)) {
+                user = user.copy();
+                user.setPassword(resolved);
+            }
+        }
+        return user;
+    }
+
+    private boolean isParametrized(String pwd) {
+        return StringUtils.isNotBlank(pwd) && pwd.startsWith("${") && pwd.endsWith("}");
+    }
+
+    private String decode(String value, List<GeoServerPasswordEncoder> encoders) {
+        // doesn't directly use the pwdEncoder helper because the
+        // PBE encoders needs to be init for the wrapped user group service.
+        for (GeoServerPasswordEncoder encoder : encoders) {
+            if (!encoder.isReversible()) continue; // should not happen
+            if (encoder.isResponsibleForEncoding(value)) {
+                try {
+                    encoder.initializeFor(delegate);
+                    return encoder.decode(value);
+                } catch (IOException e) {
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Error initializing password encoder "
+                                    + encoder.getName()
+                                    + ", in context of "
+                                    + "user pwd env resolution.",
+                            e);
+                }
+            }
+        }
+        return value;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import org.geoserver.platform.GeoServerEnvironment;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.GeoServerAuthenticationProvider;
 import org.geoserver.security.GeoServerUserGroupService;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
@@ -21,6 +23,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 /**
  * Authentication provider that delegates to a {@link GeoServerUserGroupService}.
@@ -49,8 +52,11 @@ public class UsernamePasswordAuthenticationProvider extends GeoServerAuthenticat
 
         // create delegate auth provider
         authProvider = new DaoAuthenticationProvider();
-
-        authProvider.setUserDetailsService(new EnvPwdResolverUserGroupServiceWrapper(ugService));
+        UserDetailsService userDetailsService = ugService;
+        GeoServerEnvironment environment = GeoServerExtensions.bean(GeoServerEnvironment.class);
+        if (GeoServerEnvironment.allowEnvParametrization() && environment != null)
+            userDetailsService = new EnvironmentUserDetailService(ugService, environment);
+        authProvider.setUserDetailsService(userDetailsService);
 
         // set up the password encoder
         // multiplex password encoder actually allows us to handle all types of passwords for

--- a/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
@@ -49,7 +49,8 @@ public class UsernamePasswordAuthenticationProvider extends GeoServerAuthenticat
 
         // create delegate auth provider
         authProvider = new DaoAuthenticationProvider();
-        authProvider.setUserDetailsService(ugService);
+
+        authProvider.setUserDetailsService(new EnvPwdResolverUserGroupServiceWrapper(ugService));
 
         // set up the password encoder
         // multiplex password encoder actually allows us to handle all types of passwords for

--- a/src/main/src/main/java/org/geoserver/security/impl/GeoServerUser.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/GeoServerUser.java
@@ -83,6 +83,7 @@ public class GeoServerUser implements UserDetails, CredentialsContainer, Compara
         this.accountNonExpired = other.isAccountNonExpired();
         this.accountNonLocked = other.isAccountNonLocked();
         this.credentialsNonExpired = other.isCredentialsNonExpired();
+        this.enabled = other.isEnabled();
         this.authorities =
                 other.getAuthorities() != null ? new ArrayList<>(other.getAuthorities()) : null;
     }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/auth/PwdEnvParametrizationTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/auth/PwdEnvParametrizationTest.java
@@ -1,0 +1,247 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.auth;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerEnvironment;
+import org.geoserver.security.GeoServerUserGroupService;
+import org.geoserver.security.GeoServerUserGroupStore;
+import org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig;
+import org.geoserver.security.impl.GeoServerUser;
+import org.geoserver.security.validation.PasswordPolicyException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+public class PwdEnvParametrizationTest extends AbstractAuthenticationProviderTest {
+
+    private static final String PLAIN_TXT_PRV = "plainProvider";
+    private static final String PBE_PRV = "pbeProvider";
+    private static final String STRONG_PBE_PRV = "strongProvider";
+
+    private static final String PLAIN_UG_SRV = "plainTextUgSrv";
+
+    private static final String PBE_UG_SRV = "pbeUgSrv";
+
+    private static final String STRONG_PBE_UG_SRV = "strongPbeUgSrv";
+
+    @BeforeClass
+    public static void setupClass() {
+        System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
+        GeoServerEnvironment.reloadAllowEnvParametrization();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        System.clearProperty("ALLOW_ENV_PARAMETRIZATION");
+        GeoServerEnvironment.reloadAllowEnvParametrization();
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        createUserGroupService(PLAIN_UG_SRV, getPlainTextPasswordEncoder().getName());
+        createUserGroupService(PBE_UG_SRV, getPBEPasswordEncoder().getName());
+        createUserGroupService(STRONG_PBE_UG_SRV, getStrongPBEPasswordEncoder().getName());
+        UsernamePasswordAuthenticationProviderConfig plainTxt =
+                new UsernamePasswordAuthenticationProviderConfig();
+        plainTxt.setUserGroupServiceName(PLAIN_UG_SRV);
+        plainTxt.setName(PLAIN_TXT_PRV);
+        plainTxt.setClassName(UsernamePasswordAuthenticationProvider.class.getName());
+        getSecurityManager().saveAuthenticationProvider(plainTxt);
+        UsernamePasswordAuthenticationProviderConfig pbe =
+                new UsernamePasswordAuthenticationProviderConfig();
+        pbe.setUserGroupServiceName(PBE_UG_SRV);
+        pbe.setName(PBE_PRV);
+        pbe.setClassName(UsernamePasswordAuthenticationProvider.class.getName());
+        getSecurityManager().saveAuthenticationProvider(pbe);
+
+        UsernamePasswordAuthenticationProviderConfig strongPbe =
+                new UsernamePasswordAuthenticationProviderConfig();
+        strongPbe.setUserGroupServiceName(STRONG_PBE_UG_SRV);
+        strongPbe.setName(STRONG_PBE_PRV);
+        strongPbe.setClassName(UsernamePasswordAuthenticationProvider.class.getName());
+        getSecurityManager().saveAuthenticationProvider(strongPbe);
+    }
+
+    @Test
+    public void testPbeUgSrvWithPlainTxtPwd() throws IOException, PasswordPolicyException {
+        String key = "env.pwd1";
+        System.setProperty(key, "plain:my_password");
+        try {
+            createGeoServerUser("test_env1", "${env.pwd1}", PBE_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PBE_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env1", "my_password");
+            authentication = provider.authenticate(authentication);
+            assertNotNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testPbeUgSrvWithDigestPwd() throws IOException, PasswordPolicyException {
+        String key = "env.pwd2";
+        System.setProperty(
+                key, "digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw");
+        try {
+            createGeoServerUser("test_env2", "${env.pwd2}", PBE_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PBE_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env2", "geoserver");
+            authentication = provider.authenticate(authentication);
+            assertNotNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testPlainTxtUgSrvWithPlainTxtPwd() throws IOException, PasswordPolicyException {
+        String key = "env.pwd3";
+        System.setProperty(key, "plain:my_password");
+        try {
+            createGeoServerUser("test_env3", "${env.pwd3}", PLAIN_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PLAIN_TXT_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env3", "my_password");
+            authentication = provider.authenticate(authentication);
+            assertNotNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testPlainTxtUgSrvWithDigestPwd() throws IOException, PasswordPolicyException {
+        String key = "env.pwd4";
+        System.setProperty(
+                key, "digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw");
+        try {
+            createGeoServerUser("test_env4", "${env.pwd4}", PLAIN_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PLAIN_TXT_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env4", "geoserver");
+            authentication = provider.authenticate(authentication);
+            assertNotNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testStrongPBETxtUgSrvWithPlainTxtPwd() throws IOException, PasswordPolicyException {
+        String key = "env.pwd5";
+        System.setProperty(key, "plain:my_password");
+        try {
+            createGeoServerUser("test_env5", "${env.pwd5}", STRONG_PBE_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(STRONG_PBE_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env5", "my_password");
+            authentication = provider.authenticate(authentication);
+            assertNotNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testStrongPBEUgSrvWithDigestPwd() throws IOException, PasswordPolicyException {
+        String key = "env.pwd6";
+        System.setProperty(
+                key, "digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw");
+        try {
+            createGeoServerUser("test_env6", "${env.pwd6}", PLAIN_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PLAIN_TXT_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env6", "geoserver");
+            authentication = provider.authenticate(authentication);
+            assertNotNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testStrongPBEUgSrvAuthFails() throws IOException, PasswordPolicyException {
+        String key = "env.pwd7";
+        System.setProperty(
+                key, "digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw");
+        try {
+            createGeoServerUser("test_env7", "${env.pwd7}", PLAIN_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PLAIN_TXT_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env7", "wrong");
+            authentication = provider.authenticate(authentication);
+            assertNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testPlainTxtUgSrvAuthFails() throws IOException, PasswordPolicyException {
+        String key = "env.pwd8";
+        System.setProperty(
+                key, "digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw");
+        try {
+            createGeoServerUser("test_env8", "${env.pwd8}", PLAIN_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PLAIN_TXT_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env8", "wrong");
+            authentication = provider.authenticate(authentication);
+            assertNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    @Test
+    public void testPbeUgSrvAuthFails() throws IOException, PasswordPolicyException {
+        String key = "env.pwd9";
+        System.setProperty(key, "plain:my_password");
+        try {
+            createGeoServerUser("test_env9", "${env.pwd9}", PBE_UG_SRV);
+            AuthenticationProvider provider =
+                    getSecurityManager().loadAuthenticationProvider(PBE_PRV);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken("test_env9", "wrong");
+            authentication = provider.authenticate(authentication);
+            assertNull(authentication);
+        } finally {
+            removePwdEnv(key);
+        }
+    }
+
+    private void createGeoServerUser(String username, String pwd, String ugSrvName)
+            throws IOException, PasswordPolicyException {
+        GeoServerUserGroupService groupService =
+                getSecurityManager().loadUserGroupService(ugSrvName);
+        GeoServerUserGroupStore userGroupStore = groupService.createStore();
+        GeoServerUser user = userGroupStore.createUserObject(username, pwd, true);
+        userGroupStore.addUser(user);
+        userGroupStore.store();
+    }
+
+    private void removePwdEnv(String env_var) {
+        System.clearProperty(env_var);
+    }
+}


### PR DESCRIPTION
[![GEOS-10655](https://badgen.net/badge/JIRA/GEOS-10655/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10655)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Allow to use env parametrization for users' passwords.
See related jira ticket for details.  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->