### PR TITLE
[GEOS-10452] Fixed Role Services for LDAP/Active Directory.

### DIFF
--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
@@ -209,8 +209,8 @@ public class BindingLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
                     // Get ldap groups in form of Pair<String,String> -> Pair<name,dn>
                     final String formattedFilter =
                             MessageFormat.format(groupSearchFilter, userDn, username);
-                    // Replace "\" with "\5C" for search.
-                    String formattedFilterNew = formattedFilter.replace("\\", "\\5C"); 
+                    // Replace the escape token "\" with "\\" to search.
+                    String formattedFilterNew = LDAPUtils.escapeSearchString(formattedFilter);
                     userRolesNameDn.addAll(
                             authTemplate.search(
                                     getGroupSearchBase(),
@@ -280,8 +280,8 @@ public class BindingLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
                     // Get ldap groups in form of Pair<String,String> -> Pair<name,dn>
                     final String formattedFilter =
                             MessageFormat.format(nestedGroupSearchFilter, groupDn, groupName);
-                    // Replace "\" with "\5C" for search.
-                    String formattedFilterNew = formattedFilter.replace("\\", "\\5C"); 
+                    // Replace the escape token "\" with "\\" to search.
+                    String formattedFilterNew = LDAPUtils.escapeSearchString(formattedFilter);
                     groupRolesNameDn.addAll(
                             authTemplate.search(
                                     getGroupSearchBase(),

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
@@ -207,14 +207,14 @@ public class BindingLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
                             LDAPUtils.getLdapTemplateInContext(ctx, ldapTemplate);
 
                     // Get ldap groups in form of Pair<String,String> -> Pair<name,dn>
-                    final String formattedFilter =
+                    String formattedFilter =
                             MessageFormat.format(groupSearchFilter, userDn, username);
-                    // Replace the escape token "\" with "\\" to search.
-                    String formattedFilterNew = LDAPUtils.escapeSearchString(formattedFilter);
+                    // search requires an escaped string
+                    formattedFilter = LDAPUtils.escapeSearchString(formattedFilter);
                     userRolesNameDn.addAll(
                             authTemplate.search(
                                     getGroupSearchBase(),
-                                    formattedFilterNew,
+                                    formattedFilter,
                                     new AbstractContextMapper<Pair<String, String>>() {
                                         @Override
                                         protected Pair<String, String> doMapFromContext(
@@ -278,14 +278,14 @@ public class BindingLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
                     SpringSecurityLdapTemplate authTemplate =
                             LDAPUtils.getLdapTemplateInContext(ctx, ldapTemplate);
                     // Get ldap groups in form of Pair<String,String> -> Pair<name,dn>
-                    final String formattedFilter =
+                    String formattedFilter =
                             MessageFormat.format(nestedGroupSearchFilter, groupDn, groupName);
-                    // Replace the escape token "\" with "\\" to search.
-                    String formattedFilterNew = LDAPUtils.escapeSearchString(formattedFilter);
+                    // search requires an escaped string
+                    formattedFilter = LDAPUtils.escapeSearchString(formattedFilter);
                     groupRolesNameDn.addAll(
                             authTemplate.search(
                                     getGroupSearchBase(),
-                                    formattedFilterNew,
+                                    formattedFilter,
                                     new AbstractContextMapper<Pair<String, String>>() {
                                         @Override
                                         protected Pair<String, String> doMapFromContext(

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/BindingLdapAuthoritiesPopulator.java
@@ -209,10 +209,12 @@ public class BindingLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
                     // Get ldap groups in form of Pair<String,String> -> Pair<name,dn>
                     final String formattedFilter =
                             MessageFormat.format(groupSearchFilter, userDn, username);
+                    // Replace "\" with "\5C" for search.
+                    String formattedFilterNew = formattedFilter.replace("\\", "\\5C"); 
                     userRolesNameDn.addAll(
                             authTemplate.search(
                                     getGroupSearchBase(),
-                                    formattedFilter,
+                                    formattedFilterNew,
                                     new AbstractContextMapper<Pair<String, String>>() {
                                         @Override
                                         protected Pair<String, String> doMapFromContext(
@@ -278,10 +280,12 @@ public class BindingLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
                     // Get ldap groups in form of Pair<String,String> -> Pair<name,dn>
                     final String formattedFilter =
                             MessageFormat.format(nestedGroupSearchFilter, groupDn, groupName);
+                    // Replace "\" with "\5C" for search.
+                    String formattedFilterNew = formattedFilter.replace("\\", "\\5C"); 
                     groupRolesNameDn.addAll(
                             authTemplate.search(
                                     getGroupSearchBase(),
-                                    formattedFilter,
+                                    formattedFilterNew,
                                     new AbstractContextMapper<Pair<String, String>>() {
                                         @Override
                                         protected Pair<String, String> doMapFromContext(

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPRoleService.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPRoleService.java
@@ -355,12 +355,14 @@ public class LDAPRoleService extends LDAPBaseSecurityService implements GeoServe
     public int getRoleCount() throws IOException {
         AtomicInteger count = new AtomicInteger(0);
 
-        // Replace the escape token "\" with "\\" to search.
-        String allGroupsSearchFilterNew = LDAPUtils.escapeSearchString(allGroupsSearchFilter);
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(groupSearchBase, allGroupsSearchFilterNew, counter(count)));
+                                .search(
+                                        groupSearchBase,
+                                        LDAPUtils.escapeSearchString(allGroupsSearchFilter),
+                                        counter(count)));
         return count.get();
     }
 

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPRoleService.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPRoleService.java
@@ -354,10 +354,9 @@ public class LDAPRoleService extends LDAPBaseSecurityService implements GeoServe
     @Override
     public int getRoleCount() throws IOException {
         AtomicInteger count = new AtomicInteger(0);
-        
-        // Replace "\" with "\5C" for search.
-        String allGroupsSearchFilterNew = allGroupsSearchFilter.replace("\\", "\\5C");
-        
+
+        // Replace the escape token "\" with "\\" to search.
+        String allGroupsSearchFilterNew = LDAPUtils.escapeSearchString(allGroupsSearchFilter);
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPRoleService.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPRoleService.java
@@ -354,10 +354,14 @@ public class LDAPRoleService extends LDAPBaseSecurityService implements GeoServe
     @Override
     public int getRoleCount() throws IOException {
         AtomicInteger count = new AtomicInteger(0);
+        
+        // Replace "\" with "\5C" for search.
+        String allGroupsSearchFilterNew = allGroupsSearchFilter.replace("\\", "\\5C");
+        
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(groupSearchBase, allGroupsSearchFilter, counter(count)));
+                                .search(groupSearchBase, allGroupsSearchFilterNew, counter(count)));
         return count.get();
     }
 

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
@@ -170,13 +170,16 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public SortedSet<GeoServerUser> getUsers() {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
-        // Replace "\" with "\5C" for search.
-        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
-        
+        // Replace the escape token "\" with "\\" to search.
+        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
+
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(userSearchBase, allUsersSearchFilterNew, addToUsers(users)));
+                                .search(
+                                        userSearchBase,
+                                        allUsersSearchFilterNew,
+                                        addToUsers(users)));
 
         return Collections.unmodifiableSortedSet(users);
     }
@@ -434,9 +437,9 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public int getUserCount() {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace "\" with "\5C" for search.
-        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
-                
+        // Replace the escape token "\" with "\\" to search.
+        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
+
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
@@ -449,8 +452,8 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public int getGroupCount() {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace "\" with "\5C" for search.
-        String allGroupsSearchFilterNew = allGroupsSearchFilter.replace("\\", "\\5C");
+        // Replace the escape token "\" with "\\" to search.
+        String allGroupsSearchFilterNew = LDAPUtils.escapeSearchString(allGroupsSearchFilter);
 
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
@@ -485,15 +488,19 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public SortedSet<GeoServerUser> getUsersNotHavingProperty(String propname) {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
-        // Replace "\" with "\5C" for search.
-        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
+        // Replace the escape token "\" with "\\" to search.
+        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
 
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        "(&(!(" + propname + "=*))(" + allUsersSearchFilterNew + "))",
+                                        "(&(!("
+                                                + propname
+                                                + "=*))("
+                                                + allUsersSearchFilterNew
+                                                + "))",
                                         addToUsers(users)));
 
         return users;
@@ -503,15 +510,19 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public int getUserCountNotHavingProperty(String propname) {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace "\" with "\5C" for search.
-        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
+        // Replace the escape token "\" with "\\" to search.
+        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
 
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        "(&(!(" + propname + "=*))(" + allUsersSearchFilterNew + "))",
+                                        "(&(!("
+                                                + propname
+                                                + "=*))("
+                                                + allUsersSearchFilterNew
+                                                + "))",
                                         counter(size)));
         return size.get();
     }
@@ -521,8 +532,8 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
             throws IOException {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
-        // Replace "\" with "\5C" for search.
-        String propvalueNew = propvalue.replace("\\", "\\5C");
+        // Replace the escape token "\" with "\\" to search.
+        String propvalueNew = LDAPUtils.escapeSearchString(propvalue);
 
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
@@ -540,13 +551,16 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
             throws IOException {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace "\" with "\5C" for search.
-        String propvalueNew = propvalue.replace("\\", "\\5C");
+        // Replace the escape token "\" with "\\" to search.
+        String propvalueNew = LDAPUtils.escapeSearchString(propvalue);
 
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(userSearchBase, propname + "=" + propvalueNew, counter(size)));
+                                .search(
+                                        userSearchBase,
+                                        propname + "=" + propvalueNew,
+                                        counter(size)));
         return size.get();
     }
 }

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
@@ -170,15 +170,13 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public SortedSet<GeoServerUser> getUsers() {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
-        // Replace the escape token "\" with "\\" to search.
-        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
-
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        allUsersSearchFilterNew,
+                                        LDAPUtils.escapeSearchString(allUsersSearchFilter),
                                         addToUsers(users)));
 
         return Collections.unmodifiableSortedSet(users);
@@ -437,13 +435,14 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public int getUserCount() {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace the escape token "\" with "\\" to search.
-        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
-
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(userSearchBase, allUsersSearchFilterNew, counter(size)));
+                                .search(
+                                        userSearchBase,
+                                        LDAPUtils.escapeSearchString(allUsersSearchFilter),
+                                        counter(size)));
 
         return size.get();
     }
@@ -452,13 +451,14 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public int getGroupCount() {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace the escape token "\" with "\\" to search.
-        String allGroupsSearchFilterNew = LDAPUtils.escapeSearchString(allGroupsSearchFilter);
-
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(groupSearchBase, allGroupsSearchFilterNew, counter(size)));
+                                .search(
+                                        groupSearchBase,
+                                        LDAPUtils.escapeSearchString(allGroupsSearchFilter),
+                                        counter(size)));
         return size.get();
     }
 
@@ -488,9 +488,7 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public SortedSet<GeoServerUser> getUsersNotHavingProperty(String propname) {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
-        // Replace the escape token "\" with "\\" to search.
-        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
-
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
@@ -499,7 +497,7 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
                                         "(&(!("
                                                 + propname
                                                 + "=*))("
-                                                + allUsersSearchFilterNew
+                                                + LDAPUtils.escapeSearchString(allUsersSearchFilter)
                                                 + "))",
                                         addToUsers(users)));
 
@@ -510,9 +508,7 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public int getUserCountNotHavingProperty(String propname) {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace the escape token "\" with "\\" to search.
-        String allUsersSearchFilterNew = LDAPUtils.escapeSearchString(allUsersSearchFilter);
-
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
@@ -521,7 +517,7 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
                                         "(&(!("
                                                 + propname
                                                 + "=*))("
-                                                + allUsersSearchFilterNew
+                                                + LDAPUtils.escapeSearchString(allUsersSearchFilter)
                                                 + "))",
                                         counter(size)));
         return size.get();
@@ -532,15 +528,13 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
             throws IOException {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
-        // Replace the escape token "\" with "\\" to search.
-        String propvalueNew = LDAPUtils.escapeSearchString(propvalue);
-
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        propname + "=" + propvalueNew,
+                                        propname + "=" + LDAPUtils.escapeSearchString(propvalue),
                                         addToUsers(users)));
 
         return users;
@@ -551,15 +545,13 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
             throws IOException {
         AtomicInteger size = new AtomicInteger(0);
 
-        // Replace the escape token "\" with "\\" to search.
-        String propvalueNew = LDAPUtils.escapeSearchString(propvalue);
-
+        // search requires an escaped string
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        propname + "=" + propvalueNew,
+                                        propname + "=" + LDAPUtils.escapeSearchString(propvalue),
                                         counter(size)));
         return size.get();
     }

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
@@ -170,10 +170,13 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public SortedSet<GeoServerUser> getUsers() {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
+        // Replace "\" with "\5C" for search.
+        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
+        
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(userSearchBase, allUsersSearchFilter, addToUsers(users)));
+                                .search(userSearchBase, allUsersSearchFilterNew, addToUsers(users)));
 
         return Collections.unmodifiableSortedSet(users);
     }
@@ -430,10 +433,14 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     @Override
     public int getUserCount() {
         AtomicInteger size = new AtomicInteger(0);
+
+        // Replace "\" with "\5C" for search.
+        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
+                
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(userSearchBase, allUsersSearchFilter, counter(size)));
+                                .search(userSearchBase, allUsersSearchFilterNew, counter(size)));
 
         return size.get();
     }
@@ -441,10 +448,14 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     @Override
     public int getGroupCount() {
         AtomicInteger size = new AtomicInteger(0);
+
+        // Replace "\" with "\5C" for search.
+        String allGroupsSearchFilterNew = allGroupsSearchFilter.replace("\\", "\\5C");
+
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(groupSearchBase, allGroupsSearchFilter, counter(size)));
+                                .search(groupSearchBase, allGroupsSearchFilterNew, counter(size)));
         return size.get();
     }
 
@@ -474,12 +485,15 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public SortedSet<GeoServerUser> getUsersNotHavingProperty(String propname) {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
+        // Replace "\" with "\5C" for search.
+        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
+
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        "(&(!(" + propname + "=*))(" + allUsersSearchFilter + "))",
+                                        "(&(!(" + propname + "=*))(" + allUsersSearchFilterNew + "))",
                                         addToUsers(users)));
 
         return users;
@@ -488,12 +502,16 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     @Override
     public int getUserCountNotHavingProperty(String propname) {
         AtomicInteger size = new AtomicInteger(0);
+
+        // Replace "\" with "\5C" for search.
+        String allUsersSearchFilterNew = allUsersSearchFilter.replace("\\", "\\5C");
+
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        "(&(!(" + propname + "=*))(" + allUsersSearchFilter + "))",
+                                        "(&(!(" + propname + "=*))(" + allUsersSearchFilterNew + "))",
                                         counter(size)));
         return size.get();
     }
@@ -503,12 +521,15 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
             throws IOException {
         final SortedSet<GeoServerUser> users = new TreeSet<>();
 
+        // Replace "\" with "\5C" for search.
+        String propvalueNew = propvalue.replace("\\", "\\5C");
+
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
                                 .search(
                                         userSearchBase,
-                                        propname + "=" + propvalue,
+                                        propname + "=" + propvalueNew,
                                         addToUsers(users)));
 
         return users;
@@ -518,10 +539,14 @@ public class LDAPUserGroupService extends LDAPBaseSecurityService
     public int getUserCountHavingPropertyValue(String propname, String propvalue)
             throws IOException {
         AtomicInteger size = new AtomicInteger(0);
+
+        // Replace "\" with "\5C" for search.
+        String propvalueNew = propvalue.replace("\\", "\\5C");
+
         authenticateIfNeeded(
                 (ctx, ldapEntryIdentification) ->
                         LDAPUtils.getLdapTemplateInContext(ctx, template)
-                                .search(userSearchBase, propname + "=" + propvalue, counter(size)));
+                                .search(userSearchBase, propname + "=" + propvalueNew, counter(size)));
         return size.get();
     }
 }

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUtils.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUtils.java
@@ -109,4 +109,20 @@ public class LDAPUtils {
         }
         return authTemplate;
     }
+    /**
+     * Escapes the "\" token in search strings for the Spring method template.search().
+     *
+     * <p>For the Spring method template.search(...) several characters are escaped with a "\". For
+     * example, if you have user CNs with a comma such as "Smith, John", this comma is escaped with
+     * a "\". This results in "Smith\, John". Characters other than commas are also escaped (see
+     * https://ldap.com/ldap-dns-and-rdns).
+     *
+     * <p>In the new Spring version, the escape token must be "\\" or "\5C" to get correct results
+     * when searching for users etc. For example the search string "Smith\, John" is escaped to
+     * "Smith\\, John". Actually, there is a double escape.
+     */
+    public static String escapeSearchString(String searchString) {
+        // Replace the escape token "\\" with "\\\\" to search.
+        return searchString.replace("\\", "\\\\");
+    }
 }

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUtils.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUtils.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2023 Open Source Geospatial Foundation - all rights reserved
  * (c) 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPUtilsTest.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPUtilsTest.java
@@ -1,4 +1,4 @@
-/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPUtilsTest.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPUtilsTest.java
@@ -1,0 +1,19 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security.ldap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** @author Eddy Scheper */
+public class LDAPUtilsTest {
+    @Test
+    public void testSearchString() {
+        Assert.assertEquals("", LDAPUtils.escapeSearchString(""));
+        Assert.assertEquals("Smith", LDAPUtils.escapeSearchString("Smith"));
+        Assert.assertEquals("Smith\\\\, John", LDAPUtils.escapeSearchString("Smith\\, John"));
+    }
+}


### PR DESCRIPTION
[![GEOS-10452](https://badgen.net/badge/JIRA/GEOS-10452/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10452)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fixes a Role Services for LDAP/Active Directory issue [GEOS-10452].

After release 2.15.x in some cases using a LDAP Active Directory "Role Service" does not work anymore.

Tests shows when using an user defined with a CN with comma's (for example: <surname>, <firstname>), getting roles went well until release 2.15.x but after release 2.15.x getting roles results to none.

Getting roles for users etc. of a "Role Service" the GeoServer code uses a lowlevel Spring method: <ldap template>.search(...). In releases until 2.15.x when an user CN is used, the comma is "escaped" with "\". While debugging the currently master (20220619) tests shows that instead of "\" the token "\5C" or "\\" should be used when using the Spring search method. After changing the code roles of all Active Directory users are correctly retrieved.

For this fix this issue the method "escapeSearchString(...)" is added to "LDAPUtils.java".

Also an UnitTest is added.

**Testcase for the PR** 

To test the LDAP Active Directory functionality we have a public AD server available with some users defined. See below some information.

CAUSION: The Azure LDAP server IP address is not static and may be change in the future.

<pre>
LDAP Server:
  ldap://40.113.110.42/dc=geoad,dc=local
Users:
  geouser1
    CN=geouser1,CN=Users,DC=geoad,DC=local
    memberOf:
      CN=Algemeen,CN=Users,DC=geoad,DC=local
    sAMAccountName=geouser1
  geouser3
    CN=geouser3,OU=Users,OU=Accounts,OU=Aris,DC=geoad,DC=local
    memberOf:
      CN=Kadaster,CN=Users,DC=geoad,DC=local
    sAMAccountName=geouser3
  geouser9
    CN=User9, Geo,CN=Users,DC=geoad,DC=local
    memberOf:
      CN=Kadaster,CN=Users,DC=geoad,DC=local
      CN=Algemeen,CN=Users,DC=geoad,DC=local
    sAMAccountName=geouser9
</pre>

Follow the steps below to test this PR.

CAUSION: The specified ip-address may be ch

1) Start GeoServer and login as Admin

2) Add an Authentication Provider
<pre>
Security | Authentication
	Authentication Providers
		Add new
			Click "LDAP"

Name:                                  ad-ldap-test
Server URL:                            ldap://40.113.110.42/dc=geoad,dc=local
TLS:                                   OFF
User lookup pattern:            
Filter used to lookup user:            (sAMAccountName={1})
Format used for user login name:       {0}@geoad.local
Use LDAP groups for authorization:     ON
Bind user before searching for groups: ON
Group search base:                     CN=Users
Group search filter:                   member={0}
Group to use as ADMIN:
Group to use as GROUP_ADMIN:
Enable Hierarchical groups search:     OFF

Save
</pre>

3) Test the Authentication Provider connection

<pre>
Security | Authentication
	Authentication Providers
		Click "ad-ldap-test"

Username:     geouser3
Password:      geoww123
Click "Test Connection"
The message "Connection Successful" will be shown.

Username:     geouser9
Password:     geoww123
Click "Test Connection"
The message "Connection Successful" will be shown.
</pre>

4) Activate Authentication Provider
<pre>
Security | Authentication
	Provider Chain
		Set selected providers to:
			default
			ad-ldap-test
Save
</pre>

5) Add Role Provider
<pre>
Security | Users, Groups, Roles
	Role Services
		Add new
			Click "LDAP"
Name:                                  ldaprs-test
Server URL:                            ldap://40.113.110.42/dc=geoad,dc=local
TLS:                                   OFF
Group search base:                     CN=Users
Group user membership search filter:  
All groups search filter:             
Filter used to lookup user:           
Authenticate to extract roles:         ON
Username:                              geouser1@geoad.local
Password:                              geoww123
Enable Hierarchical groups search:     OFF

Save
</pre>

6) Check Roles
<pre>
Security | Users, Groups, Roles
	Roles
		Click "ldaprs-test"
A list of roles will be shown containing the role "ROLE_KADASTER".
</pre>

7) Protect data layer
<pre>
Security | Data
	Data Security
		Add new rule
Workspace:           sf
Layer and groups:    roads
Acsess mode:         Read

Set Selected Roles to:
	ROLE_KADASTER

Save
</pre>

8) Set Catalog Mode
<pre>
Security | Data
	Catalog Mode
		CHALLENGE

Save
</pre>

9) Copy the OpenLayers URL of the Spearfish roads layer
<pre>
Data | Layer Preview
	Spearfish roads
Copy the OpenLayers URL.
</pre>

10) Test Roads with an unauthorized user
<pre>
Open a new Private Window (use Shft+Ctrl+P in FireFox) and paste:
http://192.168.0.57:8080/geoserver/sf/wms?service=WMS&version=1.1.0&request=GetMap&layers=sf%3Aroads&bbox=589434.8564686741%2C4914006.337837095%2C609527.2102150217%2C4928063.398014731&width=768&height=537&srs=EPSG%3A26713&styles=&format=application/openlayers
Login:
	geouser1
	geoww123
You will be get the message "HTTP ERROR 403 Forbidden".
</pre>

11) Test Roads with an authorized user
<pre>
Open a new Private Window (use Shft+Ctrl+P in FireFox) and paste:
http://192.168.0.57:8080/geoserver/sf/wms?service=WMS&version=1.1.0&request=GetMap&layers=sf%3Aroads&bbox=589434.8564686741%2C4914006.337837095%2C609527.2102150217%2C4928063.398014731&width=768&height=537&srs=EPSG%3A26713&styles=&format=application/openlayers
Login:
	geouser9
	geoww123
A map will be shown.
</pre>



<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
