### PR TITLE
[GEOS-10669] The STAC API does not declare suppport for the search fields extension

### DIFF
--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
@@ -124,6 +124,10 @@ public class STACService {
     public static final String STAC_SEARCH = "https://api.stacspec.org/v1.0.0-beta.5/item-search";
     public static final String STAC_SEARCH_SORT =
             "https://api.stacspec.org/v1.0.0-beta.5/item-search#sort";
+
+    public static final String STAC_SEARCH_FIELDS =
+            "https://api.stacspec.org/v1.0.0-beta.5/item-search#fields";
+
     public static final String STAC_SEARCH_FILTER =
             "https://api.stacspec.org/v1.0.0-beta.5/item-search#filter";
     public static final String STAC_FEATURES =
@@ -195,6 +199,7 @@ public class STACService {
                         STAC_SEARCH,
                         STAC_SEARCH_FILTER,
                         STAC_SEARCH_SORT,
+                        STAC_SEARCH_FIELDS,
                         FEATURES_FILTER,
                         FILTER,
                         ECQL,

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ConformanceTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ConformanceTest.java
@@ -48,6 +48,7 @@ public class ConformanceTest extends STACTestSupport {
             STACService.STAC_SEARCH,
             STACService.STAC_SEARCH_FILTER,
             STACService.STAC_SEARCH_SORT,
+            STACService.STAC_SEARCH_FIELDS,
             FEATURES_FILTER,
             FILTER,
             ECQL,

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/SearchTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/SearchTest.java
@@ -703,6 +703,18 @@ public class SearchTest extends STACTestSupport {
         }
     }
 
+    @Test
+    public void testSearchPropertySelectionTopLevel() throws Exception {
+        DocumentContext doc =
+                getAsJSONPath(
+                        "ogc/stac/search?collections=SENTINEL2&fields=-links,-assets&filter=datetime > DATE('2017-02-25') and datetime < DATE('2017-03-31')&sortby=id",
+                        200);
+
+        String featurePath = "features[?(@.id != 'GS_TEST_PRODUCT.01')]";
+        assertEquals(0, doc.read(featurePath + ".assets", List.class).size());
+        assertEquals(0, doc.read(featurePath + ".links", List.class).size());
+    }
+
     public void testIndexOptimizerVisitorConvertsDouble() throws Exception {
         List<String> collections = Arrays.asList("SAS1");
         Filter filter = getStacService().parseFilter(collections, "s1:ipf_version>2", null);


### PR DESCRIPTION
[![GEOS-10669](https://badgen.net/badge/JIRA/GEOS-10669/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10669)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->