### PR TITLE
[GEOS-10666] Mosaic uses excess memory when mosaicking many small images (2.21.x backport)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -102,7 +102,7 @@
     <ant.version>1.10.11</ant.version>
     <httpclient.version>4.5.13</httpclient.version>
     <imageio-ext.version>1.4.5</imageio-ext.version>
-    <jaiext.version>1.1.23</jaiext.version>
+    <jaiext.version>1.1.24</jaiext.version>
     <java.awt.headless>true</java.awt.headless>
     <sun.java2d.d3d>true</sun.java2d.d3d>
     <jvm.opts></jvm.opts>


### PR DESCRIPTION
[![GEOS-10666](https://badgen.net/badge/JIRA/GEOS-10666/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10666)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->