### PR TITLE
Add example of using FlatGeobuf granules to the Vector Mosaic documentation

### DIFF
--- a/doc/en/user/source/community/vector-mosaic/delegate.rst
+++ b/doc/en/user/source/community/vector-mosaic/delegate.rst
@@ -61,3 +61,29 @@ in a single map:
 .. figure:: images/places-mosaic.png
    :align: center
 
+Creating FlatGeobuf Granules with ogr2ogr and ogrtindex
+======================================================================
+
+`FlatGeobuf <https://flatgeobuf.org>`_ files make for an excellent option for cloud storage of granule data due the built in support for R-Tree indices and the use of `HTTP Range requests <https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests>`_ to limit the amount of data streamed over the network.
+
+``ogr2ogr`` can be used to convert a directory of shapefiles into a directory of indexed Flatgeobufs using a simple bash script like below
+
+.. code-block:: bash
+
+   #!/bin/bash
+   shopt -s nullglob
+   FILES="/data/tiger/*.shp"
+   for f in $FILES
+   do
+     fgbfilename="$(basename $f .shp).fgb"
+     ogr2ogr -f FlatGeobuf $fgbfilename $f -nlt PROMOTE_TO_MULTI -lco SPATIAL_INDEX=YES
+   done
+
+Here is an example that generates a delegate shapefile from the directory of FlatGeobufs.  The third step below uses ``ogr2ogr`` commandline to trim a comma and number that ``ogrtindex`` appends to the end of the granule reference, and to turn the file location into a valid URL.  Note the exclusion of the ``write_absolute_path``.  Instead we append the AWS S3 bucket URL to the generated filename.  
+
+#. Switch to directory with the FlatGeoBufs.
+#. ogrtindex -tileindex "params" delegate_raw.shp \*.fgb
+#. ogr2ogr delegate.shp delegate_raw.shp -dialect SQLite -sql "SELECT Geometry,'https://mybucketname.s3.amazonaws.com/'||SUBSTR(params,1,LENGTH(params)-2) AS params from delegate_raw"
+#. Upload FlatGeobuf granule files to the S3 bucket referenced in the earlier step (and confirm that the bucket contents are publicly available).
+
+At this point you can publish the ``delegate.shp`` shapefile as a store in GeoServer as described in the previous example or you can load it into PostGIS before publication (see `Smart Data Loader <../smart-data-loader/data-store.html>`_ for a tool for creating the PostGIS store).  A PostGIS delegate is especially useful mosaics that might change over time due to support for concurrent edits, high rate loading and transactions.  Note that because the granule references in the index are HTTPS URLs the index FlatgeoBuf can be hosted anywhere that your GeoServer installation can access.


### PR DESCRIPTION
[![GEOS-10673](https://badgen.net/badge/JIRA/GEOS-10673/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10673)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->