### PR TITLE
[GEOS-10677] Improve cleanup of multi part form upload to the dispatcher

### DIFF
--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -320,6 +320,8 @@
     <constructor-arg ref="geoServer"/>
   </bean>
   
+  <bean id="fileItemCleanupCallback" class="org.geoserver.ows.FileItemCleanupCallback"/>
+
   <bean id="serviceResourceProvider" class="org.geoserver.catalog.ServiceResourceProvider">
   	<constructor-arg ref="geoServer"/>
   </bean>

--- a/src/ows/src/main/java/org/geoserver/ows/FileItemCleanupCallback.java
+++ b/src/ows/src/main/java/org/geoserver/ows/FileItemCleanupCallback.java
@@ -1,0 +1,45 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows;
+
+import java.io.Reader;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.fileupload.FileItem;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Dispatcher callback to ensure that all uploaded files are deleted at the end of a
+ * multipart/form-data request instead of relying on the garbage collector to delete the files
+ * through the {@link org.apache.commons.fileupload.disk.DiskFileItem#finalize()} method.
+ */
+public class FileItemCleanupCallback extends AbstractDispatcherCallback {
+
+    private static final Logger LOGGER = Logging.getLogger(FileItemCleanupCallback.class);
+
+    private static final ThreadLocal<List<FileItem>> FILE_ITEMS =
+            ThreadLocal.withInitial(Collections::emptyList);
+
+    public static void setFileItems(List<FileItem> fileItems) {
+        FILE_ITEMS.set(fileItems);
+    }
+
+    @Override
+    public void finished(Request request) {
+        List<FileItem> items = FILE_ITEMS.get();
+        FILE_ITEMS.remove();
+        if (!items.isEmpty()) {
+            try (Reader r = request.getInput()) {
+                // just closing the input which may be pointing to a temp file
+            } catch (Exception e) {
+                LOGGER.log(Level.FINEST, "Unable to close request input", e);
+            }
+            // delete all of the temp file uploads for this request
+            items.forEach(FileItem::delete);
+        }
+    }
+}

--- a/src/ows/src/test/java/org/geoserver/ows/FileItemCleanupCallbackTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/FileItemCleanupCallbackTest.java
@@ -1,0 +1,122 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+import com.google.common.base.Strings;
+import java.io.File;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.context.support.FileSystemXmlApplicationContext;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class FileItemCleanupCallbackTest {
+
+    private static final String BOUNDARY = "----1234";
+
+    // temp files are only created for fields that exceed a certain content length
+    private static final String FILE_CONTENTS =
+            Strings.repeat("1", DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD + 1);
+
+    private static String oldTmpDir;
+
+    @Rule public TemporaryFolder tmpFolder = new TemporaryFolder(new File("target"));
+
+    @BeforeClass
+    public static void saveTempDir() {
+        oldTmpDir = System.getProperty("java.io.tmpdir");
+    }
+
+    @AfterClass
+    public static void clearTempDir() {
+        if (oldTmpDir == null) {
+            System.clearProperty("java.io.tmpdir");
+        } else {
+            System.setProperty("java.io.tmpdir", oldTmpDir);
+        }
+    }
+
+    @Before
+    public void initTempDir() throws Exception {
+        System.setProperty("java.io.tmpdir", tmpFolder.getRoot().getCanonicalPath());
+    }
+
+    @Test
+    public void testFormDataEmpty() throws Exception {
+        assertEmptyDirectory(null, null);
+    }
+
+    @Test
+    public void testFormDataUsingFile() throws Exception {
+        assertEmptyDirectory("\"file1\"; filename=\"foo.txt\"", "\"file2\"; filename=\"bar.txt\"");
+    }
+
+    @Test
+    public void testFormDataUsingBody() throws Exception {
+        assertEmptyDirectory("\"junk\"", "\"body\"");
+    }
+
+    @Test
+    public void testFormDataWithoutFileOrBody() throws Exception {
+        assertEmptyDirectory("\"junk\"", "\"junk\"");
+    }
+
+    private void assertEmptyDirectory(String field1, String field2) throws Exception {
+        // create the mock HTTP request
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/geoserver/ows");
+        request.setContentType("multipart/form-data; boundary=" + BOUNDARY);
+        String content = "";
+        if (field1 != null) {
+            content =
+                    "--"
+                            + BOUNDARY
+                            + "\r\nContent-Disposition: form-data; name="
+                            + field1
+                            + "\r\n\r\n"
+                            + FILE_CONTENTS
+                            + "\r\n--"
+                            + BOUNDARY
+                            + "\r\nContent-Disposition: form-data; name="
+                            + field2
+                            + "\r\n\r\n"
+                            + FILE_CONTENTS
+                            + "\r\n--"
+                            + BOUNDARY
+                            + "--\r\n";
+        }
+        request.setContent(content.getBytes());
+
+        // init a new dispatcher and dispatch the request
+        URL url = getClass().getResource("applicationContext.xml");
+        try (FileSystemXmlApplicationContext context =
+                new FileSystemXmlApplicationContext(url.toString())) {
+            Dispatcher dispatcher = (Dispatcher) context.getBean("dispatcher");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            dispatcher.handleRequest(request, response);
+        }
+
+        // verify that all upload temp files were deleted
+        List<Path> files = new ArrayList<>();
+        try (DirectoryStream<Path> stream =
+                Files.newDirectoryStream(tmpFolder.getRoot().toPath(), "upload_*.tmp")) {
+            stream.forEach(files::add);
+        }
+        assertThat("Uploaded files were not deleted", files, empty());
+    }
+}

--- a/src/ows/src/test/java/org/geoserver/ows/applicationContext.xml
+++ b/src/ows/src/test/java/org/geoserver/ows/applicationContext.xml
@@ -44,4 +44,5 @@
 		</constructor-arg>
 	</bean>
 	
+    <bean id="fileItemCleanupCallback" class="org.geoserver.ows.FileItemCleanupCallback"/>
 </beans>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -795,7 +795,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3.3</version>
+        <version>1.4</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
[![GEOS-10677](https://badgen.net/badge/JIRA/GEOS-10677/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10677)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR updates the OWS dispatcher to close streams and remove temp files for multipart/form-data requests without relying on the garbage collector.  Unnecessary input streams are no longer opened for requests that contain multiple file uploads and an NPE is fixed if the dispatcher couldn't find a field to read the input from.  This PR also fixes a race condition where the GC could try to delete a file while the stream is still open which would fail on Windows or could delete the file before GeoServer finished parsing it on Linux. The commons-fileupload upgrade fixes some edge cases where invalid input could leave streams open so it is relevant to this PR.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->