### PR TITLE
[GEOS-10680] FidTransformeVisitor misspelled

### DIFF
--- a/src/main/src/main/java/org/geoserver/feature/retype/FidTransformerVisitor.java
+++ b/src/main/src/main/java/org/geoserver/feature/retype/FidTransformerVisitor.java
@@ -20,10 +20,10 @@ import org.opengis.filter.identity.FeatureId;
  *
  * @author Andrea Aime
  */
-class FidTransformeVisitor extends DuplicatingFilterVisitor {
+class FidTransformerVisitor extends DuplicatingFilterVisitor {
     private FeatureTypeMap map;
 
-    public FidTransformeVisitor(FeatureTypeMap map) {
+    public FidTransformerVisitor(FeatureTypeMap map) {
         super(CommonFactoryFinder.getFilterFactory2(null));
         this.map = map;
     }

--- a/src/main/src/main/java/org/geoserver/feature/retype/RetypingDataStore.java
+++ b/src/main/src/main/java/org/geoserver/feature/retype/RetypingDataStore.java
@@ -288,7 +288,7 @@ public class RetypingDataStore extends DecoratingDataStore {
 
     /** Retypes a filter making sure the fids are using the internal typename prefix */
     Filter retypeFilter(Filter filter, FeatureTypeMap typeMap) {
-        FidTransformeVisitor visitor = new FidTransformeVisitor(typeMap);
+        FidTransformerVisitor visitor = new FidTransformerVisitor(typeMap);
         return (Filter) filter.accept(visitor, null);
     }
 


### PR DESCRIPTION
[![GEOS-10692](https://badgen.net/badge/JIRA/GEOS-10692/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10692)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10680](https://osgeo-org.atlassian.net/browse/GEOS-10692)

While the file reads as FidTransformerVisitor.java, the class itself  is misspelled as FidTransformeVisitor.

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).