### PR TITLE
[GEOS-10678]: NPE if <settings> element is missing

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -1111,6 +1111,8 @@ public abstract class GeoServerLoader {
 
     public void destroy() throws Exception {
         // dispose
-        geoserver.dispose();
+        if (geoserver != null) {
+            geoserver.dispose();
+        }
     }
 }

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -2565,7 +2565,7 @@ public class XStreamPersister {
                 Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
             GeoServerInfo geoServerInfo = (GeoServerInfo) source;
             SettingsInfo settings = geoServerInfo.getSettings();
-            if (settings.isUseHeadersProxyURL() == null) {
+            if (settings != null && settings.isUseHeadersProxyURL() == null) {
                 settings.setUseHeadersProxyURL(geoServerInfo.isUseHeadersProxyURL());
                 if (geoServerInfo instanceof GeoServerInfoImpl)
                     ((GeoServerInfoImpl) geoServerInfo).setUseHeadersProxyURLRaw(null);
@@ -2579,9 +2579,11 @@ public class XStreamPersister {
                 Object result, HierarchicalStreamReader reader, UnmarshallingContext context) {
             // migrate proxy headers to settings if needed
             GeoServerInfoImpl info = (GeoServerInfoImpl) super.doUnmarshal(result, reader, context);
-            if (info.getSettings().isUseHeadersProxyURL() == null
+            SettingsInfo settings = info.getSettings();
+            if (settings != null
+                    && settings.isUseHeadersProxyURL() == null
                     && info.isUseHeadersProxyURL() != null) {
-                info.getSettings().setUseHeadersProxyURL(info.isUseHeadersProxyURL());
+                settings.setUseHeadersProxyURL(info.isUseHeadersProxyURL());
                 info.setUseHeadersProxyURLRaw(null);
             }
             return info;

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -77,6 +77,7 @@ import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.impl.GeoServerImpl;
 import org.geoserver.config.impl.ServiceInfoImpl;
+import org.geoserver.config.impl.SettingsInfoImpl;
 import org.geoserver.config.util.XStreamPersister.CRSConverter;
 import org.geoserver.config.util.XStreamPersister.SRSConverter;
 import org.geoserver.platform.GeoServerExtensionsHelper;
@@ -1472,6 +1473,15 @@ public class XStreamPersisterTest {
         XMLAssert.assertXpathEvaluatesTo("key2", "//settings/metadata/map/entry[2]/string[1]", doc);
         XMLAssert.assertXpathEvaluatesTo(
                 "value2", "//settings/metadata/map/entry[2]/string[2]", doc);
+    }
+
+    @Test
+    public void readSettingsMetadataMissingElement() throws Exception {
+        String xml = "<global/>";
+        GeoServerInfo gs =
+                persister.load(new ByteArrayInputStream(xml.getBytes()), GeoServerInfo.class);
+
+        XMLAssert.assertEquals(gs.getSettings(), new SettingsInfoImpl());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10678](https://badgen.net/badge/JIRA/GEOS-10678/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10678)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10678](https://osgeo-org.atlassian.net/browse/GEOS-10678)

When using `data/minimal/global.xml` no `<settings>` element is defined.
This causes a NPE on `XStreamPersister.doUnmarshal()`.
`XStreamPersister.doMarshal()` looks similar, so I also added a precaution null check here.

If the initialization fails, spring destroys its singleton beans again. 
This causes an other NPE on`GeoServerLoader.destroy()` since it was not fully initialized. 
So I added an other NP check here.

# Checklist

- [x]  I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).