### PR TITLE
[GEOS-10694] Suppress stacktrace on startup when logging.xml is missing.

### DIFF
--- a/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
@@ -112,7 +112,7 @@ public class LoggingStartupContextListener implements ServletContextListener {
         // the "change" between logging.xml and the versions stored in JDBC. KS
         // TODO find a better solution than re-initializing on JDBCCOnfig startup.
         Resource f = store.get("logging.xml");
-        if (f != null) {
+        if (f != null && f.getType() == Resource.Type.RESOURCE) {
             XStreamPersister xp = new XStreamPersisterFactory().createXMLPersister();
             try (BufferedInputStream in = new BufferedInputStream(f.in())) {
                 LoggingInfo loginfo = xp.load(in, LoggingInfo.class);

--- a/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
+++ b/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
@@ -142,10 +142,17 @@ public class LoggingStartupContextListenerTest {
         context.setInitParameter(
                 "GEOSERVER_LOG_LOCATION", new File(tmp, "foo.log").getAbsolutePath());
 
-        ServletContextListener listener = new LoggingStartupContextListener();
+        try (TestAppender appender = TestAppender.createAppender("quite", null)) {
+            appender.startRecording("org.geoserver.logging");
 
-        listener.contextInitialized(new ServletContextEvent(context));
-        listener.contextDestroyed(new ServletContextEvent(context));
+            appender.trigger("Could not reconfigure LOG4J loggers");
+
+            ServletContextListener listener = new LoggingStartupContextListener();
+            listener.contextInitialized(new ServletContextEvent(context));
+            listener.contextDestroyed(new ServletContextEvent(context));
+
+            appender.stopRecording("org.geoserver.logging");
+        }
     }
 
     @Test

--- a/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
+++ b/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
@@ -125,6 +126,26 @@ public class LoggingStartupContextListenerTest {
                         fileAppender.getFileName());
             }
         }
+    }
+
+    @Test
+    public void testLogLocationFromEmptyContext() throws Exception {
+        File tmp = File.createTempFile("log", "tmp", new File("target"));
+        tmp.delete();
+        tmp.mkdirs();
+
+        File logs = new File(tmp, "logs");
+        assertTrue(logs.mkdirs());
+
+        MockServletContext context = new MockServletContext();
+        context.setInitParameter("GEOSERVER_DATA_DIR", tmp.getPath());
+        context.setInitParameter(
+                "GEOSERVER_LOG_LOCATION", new File(tmp, "foo.log").getAbsolutePath());
+
+        ServletContextListener listener = new LoggingStartupContextListener();
+
+        listener.contextInitialized(new ServletContextEvent(context));
+        listener.contextDestroyed(new ServletContextEvent(context));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10685](https://badgen.net/badge/JIRA/GEOS-10685/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10685)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10694](https://osgeo-org.atlassian.net/browse/GEOS-10694)
[GEOS-10693](https://osgeo-org.atlassian.net/browse/GEOS-10693)

Starting on an empty context without any logging.xml generates an error. 
Even worse: an empty logging.xml file is generated instead. This raises future future errors.
(The possibly deeper problem here is, that `Resource.in()` creates an empty new file.)

Expected behavior: silently ignore the empty logging.xml and don't create an empty one.

Committed a unit test to demonstrate the error an a fix to resolve it.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).