### PR TITLE
Slim GeoJSON WFS output format

### DIFF
--- a/src/community/slimgeojson/README.md
+++ b/src/community/slimgeojson/README.md
@@ -1,0 +1,109 @@
+# Slim GeoJSON WFS output format extension
+
+This module adds the Slim GeoJSON WFS output format. That format is a more compact and memory-friendly variant of traditional GeoJSON, which saves space by removing redundant schema information for simple feature results. For complex features there are no differences compared to traditional GeoJSON output.
+
+This module adds these additional WFS output formats for requesting simple features in Slim GeoJSON format:
+
+- `application/json; subtype=geojson/slim`  
+   for Slim GeoJSON
+- `text/javascript; subtype=geojson/slim`  
+   for Slim GeoJSON in JSONP requests
+
+In traditional GeoJSON, every feature in a (simple feature) feature collection has its own schema information. That is, every feature contains all its (not necessarily short) attribute names. Except the geometry name, these are used as the keys in the `"properties"` map:
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "areas.1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590529, 4914625]
+      },
+      "geometry_name": "the_geom",
+      "properties": {
+        "area_no": 12,
+        "area_name": "Mainland",
+        "area_description": "grassland",
+        "area_cost_center": "0815"
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "areas.2",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590215, 4913987]
+      },
+      "geometry_name": "the_geom",
+      "properties": {
+        "area_no": 17,
+        "area_name": "South region",
+        "area_description" : "meadow, pasture",
+        "area_cost_center": "0812"
+      }
+    }
+  ],
+  "totalFeatures": 2,
+  "numberMatched": 2,
+  "numberReturned": 2,
+  "timeStamp": "2022-10-03T08:44:45.118Z",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "urn:ogc:def:crs:EPSG::26713"
+    }
+  }
+}
+```
+
+Since all features have the same schema information, we do not have to write the attribute names for every feature. Instead, we add a single `"schema"` property to the end of the top-level `"FeatureCollection"` object:
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "areas.1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590529, 4914625]
+      },
+      "geometry_name": "the_geom",
+      "properties": [12, "Mainland", "grassland", "0815"]
+    },
+    {
+      "type": "Feature",
+      "id": "areas.2",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590215, 4913987]
+      },
+      "properties": [17, "South region", "meadow, pasture", "0812"]
+    }
+  ],
+  "totalFeatures": 2,
+  "numberMatched": 2,
+  "numberReturned": 2,
+  "timeStamp": "2022-10-03T08:44:45.118Z",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "urn:ogc:def:crs:EPSG::26713"
+    }
+  },
+  "schema": {
+    "properties": ["area_no", "area_name", "area_description", "area_cost_center"],
+    "geometry_name": "the_geom"
+  }
+}
+```
+
+With Slim GeoJSON, each feature's `"properties"` map becomes an _ordered list_ (array) whose index corresponds to the `"properties"` array that holds the attribute names in the new `"schema"` object. The `"geometry_name"` becomes an additional property of the new schema object.
+
+In the above example, without whitespaces and line breaks, savings are only about 5%. With much more features savings could reach almost 27% (the ratio of the sizes of two feature objects), that is, the size of the Slim GeoJSON is only 73% of the size of traditional GeoJSON. More savings are possible with more attributes per feature. Savings basically depend on the ratio between schema information size and data size. In tests requesting several thousands of simple features with 200+ columns/attributes savings up to 70% have been achieved.
+
+These savings drop to between \~50% and \~97% when a compressing content encoding method (like gzip, deflate or brotli) is used on the wire. However, it's not all about transfer size. The smaller the uncompressed JSON response, the lesser the client's JSON parser has to process. Smaller uncompressed responses are also much more memory-friendly on both the server and the client side.

--- a/src/community/slimgeojson/pom.xml
+++ b/src/community/slimgeojson/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (C) 2016 - Open Source Geospatial Foundation. All rights reserved.
+ Copyright (C) 2022 - Open Source Geospatial Foundation. All rights reserved.
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->

--- a/src/community/slimgeojson/pom.xml
+++ b/src/community/slimgeojson/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2016 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.geoserver</groupId>
+    <artifactId>community</artifactId>
+    <version>2.22-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver.community</groupId>
+  <artifactId>gs-slimgeojson</artifactId>
+  <packaging>jar</packaging>
+  <name>GeoServer Slim GeoJSON WFS output format</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-wfs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/community/slimgeojson/src/main/java/org/geoserver/wfs/json/SlimGeoJSONGetFeatureResponse.java
+++ b/src/community/slimgeojson/src/main/java/org/geoserver/wfs/json/SlimGeoJSONGetFeatureResponse.java
@@ -1,0 +1,227 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import java.util.Date;
+import java.util.List;
+import org.geoserver.config.GeoServer;
+import org.geoserver.data.util.TemporalUtils;
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.ServiceException;
+import org.geoserver.wfs.request.FeatureCollectionResponse;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * A GetFeatureInfo response handler specialized in producing JSON and JSONP data in <em>Slim
+ * GeoJSON</em> format for a GetFeature request.
+ *
+ * @author Carsten Klein, DataGis
+ */
+public class SlimGeoJSONGetFeatureResponse extends GeoJSONGetFeatureResponse {
+
+    // currently no logger required
+    // private final Logger LOGGER = org.geotools.util.logging.Logging.getLogger(this.getClass());
+
+    private static String parseMimeType(String format) {
+        int pos = format.indexOf(';');
+        return pos != -1 ? format.substring(0, pos).trim() : format;
+    }
+
+    public SlimGeoJSONGetFeatureResponse(GeoServer gs, String format) {
+        super(gs, format, JSONType.isJsonpMimeType(parseMimeType(format)));
+    }
+
+    /** capabilities output format string. */
+    @Override
+    public String getCapabilitiesElementName() {
+        return getOutputFormats().isEmpty() ? null : getOutputFormats().iterator().next();
+    }
+
+    /** Returns the mime type */
+    @Override
+    public String getMimeType(Object value, Operation operation) throws ServiceException {
+        return getOutputFormats().isEmpty() ? null : getOutputFormats().iterator().next();
+    }
+
+    /**
+     * Modified version of {@link GeoJSONGetFeatureResponse#encodeSimpleFeatures} writing a
+     * feature's property values only as an array.
+     */
+    @Override
+    protected FeaturesInfo encodeSimpleFeatures(GeoJSONBuilder jsonWriter,
+            List<FeatureCollection> resultsList, boolean featureBounding, Operation operation) {
+        String id_option = getIdOption();
+
+        CoordinateReferenceSystem crs = null;
+        boolean hasGeom = false;
+        long featureCount = 0;
+        for (FeatureCollection collection : resultsList) {
+            try (FeatureIterator iterator = collection.features()) {
+                SimpleFeatureType fType;
+                List<AttributeDescriptor> types = null;
+                GeometryDescriptor defaultGeomType = null;
+                // encode each simple feature
+                while (iterator.hasNext()) {
+                    // get next simple feature
+                    SimpleFeature simpleFeature = (SimpleFeature) iterator.next();
+                    featureCount++;
+                    // start writing the JSON feature object
+                    jsonWriter.object();
+                    jsonWriter.key("type").value("Feature");
+                    fType = simpleFeature.getFeatureType();
+                    types = fType.getAttributeDescriptors();
+                    // write the simple feature id
+                    if (id_option == null) {
+                        // no specific attribute nominated, use the simple feature id
+                        jsonWriter.key("id").value(simpleFeature.getID());
+                    } else if (id_option.length() != 0) {
+                        // a specific attribute was nominated to be used as id
+                        Object value = simpleFeature.getAttribute(id_option);
+                        jsonWriter.key("id").value(value);
+                    }
+                    // set that axis order that should be used to write geometries
+                    defaultGeomType = fType.getGeometryDescriptor();
+                    if (defaultGeomType != null) {
+                        CoordinateReferenceSystem featureCrs =
+                                defaultGeomType.getCoordinateReferenceSystem();
+                        jsonWriter.setAxisOrder(CRS.getAxisOrder(featureCrs));
+                        if (crs == null) {
+                            crs = featureCrs;
+                        }
+                    } else {
+                        // If we don't know, assume EAST_NORTH so that no swapping occurs
+                        jsonWriter.setAxisOrder(CRS.AxisOrder.EAST_NORTH);
+                    }
+                    // start writing the simple feature geometry JSON object
+                    Geometry aGeom = (Geometry) simpleFeature.getDefaultGeometry();
+                    if (aGeom != null || writeNullGeometries()) {
+                        jsonWriter.key("geometry");
+                        // Write the geometry, whether it is a null or not
+                        if (aGeom != null) {
+                            jsonWriter.writeGeom(aGeom);
+                            hasGeom = true;
+                        } else {
+                            jsonWriter.value(null);
+                        }
+                    }
+                    // start writing feature properties JSON object
+                    jsonWriter.key("properties");
+                    jsonWriter.array();
+                    for (int j = 0; j < types.size(); j++) {
+                        Object value = simpleFeature.getAttribute(j);
+                        AttributeDescriptor ad = types.get(j);
+                        if (id_option != null && id_option.equals(ad.getLocalName())) {
+                            continue; // skip this value as it is used as the id
+                        }
+                        if (ad instanceof GeometryDescriptor) {
+                            // This is an area of the spec where they
+                            // decided to 'let convention evolve',
+                            // that is how to handle multiple
+                            // geometries. My take is to print the
+                            // geometry here if it's not the default.
+                            // If it's the default that you already
+                            // printed above, so you don't need it here.
+                            if (!ad.equals(defaultGeomType)) {
+                                if (value == null) {
+                                    jsonWriter.value(null);
+                                } else {
+                                    // if it was the default geometry, it has been written above
+                                    // already
+                                    jsonWriter.writeGeom((Geometry) value);
+                                }
+                            }
+                        } else if (Date.class.isAssignableFrom(ad.getType().getBinding())
+                                && TemporalUtils.isDateTimeFormatEnabled()) {
+                            // Temporal types print handling
+                            jsonWriter.value(TemporalUtils.printDate((Date) value));
+                        } else {
+                            if ((value instanceof Double && Double.isNaN((Double) value))
+                                    || value instanceof Float && Float.isNaN((Float) value)) {
+                                jsonWriter.value(null);
+                            } else if ((value instanceof Double
+                                    && ((Double) value) == Double.POSITIVE_INFINITY)
+                                    || value instanceof Float
+                                            && ((Float) value) == Float.POSITIVE_INFINITY) {
+                                jsonWriter.value("Infinity");
+                            } else if ((value instanceof Double
+                                    && ((Double) value) == Double.NEGATIVE_INFINITY)
+                                    || value instanceof Float
+                                            && ((Float) value) == Float.NEGATIVE_INFINITY) {
+                                jsonWriter.value("-Infinity");
+                            } else {
+                                jsonWriter.value(value);
+                            }
+                        }
+                    }
+                    jsonWriter.endArray(); // end the properties
+
+                    // Bounding box for feature in properties
+                    ReferencedEnvelope refenv =
+                            ReferencedEnvelope.reference(simpleFeature.getBounds());
+                    if (featureBounding && !refenv.isEmpty()) {
+                        jsonWriter.writeBoundingBox(refenv);
+                    }
+
+                    writeExtraFeatureProperties(simpleFeature, operation, jsonWriter);
+
+                    jsonWriter.endObject(); // end the feature
+                }
+            }
+        }
+        return new FeaturesInfo(crs, hasGeom, featureCount);
+    }
+
+    /** Writes schema information */
+    @Override
+    protected void writeExtraCollectionProperties(FeatureCollectionResponse response,
+            Operation operation, GeoJSONBuilder jw) {
+        String id_option = getIdOption();
+
+        String geometryName = null;
+        List<FeatureCollection> resultsList = response.getFeature();
+        FeatureCollection collection = resultsList.get(0);
+        try (FeatureIterator iterator = collection.features()) {
+
+            if (iterator.hasNext()) {
+                jw.key("schema").object();
+                jw.key("properties").array();
+
+                SimpleFeature simpleFeature = (SimpleFeature) iterator.next();
+                SimpleFeatureType fType = simpleFeature.getFeatureType();
+                GeometryDescriptor defaultGeomType = fType.getGeometryDescriptor();
+                List<AttributeDescriptor> types = fType.getAttributeDescriptors();
+
+                for (int j = 0; j < types.size(); j++) {
+                    AttributeDescriptor ad = types.get(j);
+                    if (id_option != null && id_option.equals(ad.getLocalName())) {
+                        continue; // skip this attribute as it it used as the id
+                    }
+                    if (ad.equals(defaultGeomType)) {
+                        geometryName = defaultGeomType.getLocalName();
+                        continue; // skip this attribute as it is used as default geometry
+                    }
+                    jw.value(ad.getLocalName());
+                }
+                jw.endArray();
+
+                if (geometryName != null) {
+                    jw.key("geometry_name").value(geometryName);
+                }
+                jw.endObject();
+            }
+        }
+
+        super.writeExtraCollectionProperties(response, operation, jw);
+    }
+}

--- a/src/community/slimgeojson/src/main/java/org/geoserver/wfs/json/SlimGeoJSONGetFeatureResponse.java
+++ b/src/community/slimgeojson/src/main/java/org/geoserver/wfs/json/SlimGeoJSONGetFeatureResponse.java
@@ -1,4 +1,4 @@
-/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/community/slimgeojson/src/main/resources/GeoServerApplication.properties
+++ b/src/community/slimgeojson/src/main/resources/GeoServerApplication.properties
@@ -1,0 +1,2 @@
+format.wfs.application/json;\ subtype\=geojson/slim=Slim GeoJSON
+format.wfs.text/javascript;\ subtype\=geojson/slim=Slim GeoJSON (JSONP)

--- a/src/community/slimgeojson/src/main/resources/applicationContext.xml
+++ b/src/community/slimgeojson/src/main/resources/applicationContext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (C) 2016 - Open Source Geospatial Foundation. All rights reserved.
+ Copyright (C) 2022 - Open Source Geospatial Foundation. All rights reserved.
  This code is licensed under the GPL 2.0 license, available at the root
  application directory.
  -->

--- a/src/community/slimgeojson/src/main/resources/applicationContext.xml
+++ b/src/community/slimgeojson/src/main/resources/applicationContext.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2016 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+    <!-- GetFeature SlimGeoJSON -->
+    <bean id="slimGeoJSONGetFeatureResponse" class="org.geoserver.wfs.json.SlimGeoJSONGetFeatureResponse">
+        <constructor-arg ref="geoServer" />
+        <constructor-arg value="application/json; subtype=geojson/slim" />
+    </bean>
+    
+    <!-- GetFeature SlimGeoJSON (JSONP) -->
+    <bean id="slimGeoJSONPGetFeatureResponse" class="org.geoserver.wfs.json.SlimGeoJSONGetFeatureResponse">
+        <constructor-arg ref="geoServer" />
+        <constructor-arg value="text/javascript; subtype=geojson/slim" />
+    </bean>
+    
+    <!-- ModuleStatus SlimGeoJSON -->
+    <bean id="slimGeoJSONExtension" class="org.geoserver.platform.ModuleStatusImpl">
+        <property name="module" value="gs-slimgeojson" />
+        <property name="name" value="Slim GeoJSON Format Output Extension"/>
+        <property name="component" value="Slim GeoJSON Format Output extension"/>
+        <property name="available" value="true"/>
+        <property name="enabled" value="true"/>
+  </bean>
+</beans>

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -52,6 +52,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  *
  * @author Simone Giannecchini, GeoSolutions
  * @author Carlo Cancellieri - GeoSolutions
+ * @author Carsten Klein, DataGis
  */
 public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
         implements ComplexFeatureAwareFormat {
@@ -63,6 +64,17 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
     public GeoJSONGetFeatureResponse(GeoServer gs, String format) {
         super(gs, format);
         jsonp = JSONType.isJsonpMimeType(format);
+    }
+
+    /**
+     * Constructor to be used by subclasses.
+     *
+     * @param outputFormat The well-known name of the format, not <code>null</code>
+     * @param jsonp <code>true</code> if specified format uses JSONP
+     */
+    protected GeoJSONGetFeatureResponse(GeoServer gs, String format, boolean jsonp) {
+        super(gs, format);
+        this.jsonp = jsonp;
     }
 
     /** capabilities output format string. */
@@ -334,14 +346,13 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
             FeatureCollectionResponse response, Operation operation, GeoJSONBuilder jw) {}
 
     /** Container class for information related with a group of features. */
-    private class FeaturesInfo {
+    protected class FeaturesInfo {
 
         final CoordinateReferenceSystem crs;
         final boolean hasGeometry;
         public long featureCount;
 
-        private FeaturesInfo(
-                CoordinateReferenceSystem crs, boolean hasGeometry, long featureCount) {
+        protected FeaturesInfo(CoordinateReferenceSystem crs, boolean hasGeometry, long featureCount) {
             this.crs = crs;
             this.hasGeometry = hasGeometry;
             this.featureCount = featureCount;


### PR DESCRIPTION
This community module adds the Slim GeoJSON WFS output format. That format is a more compact and memory-friendly variant of traditional GeoJSON, which saves space by removing redundant schema information for simple feature results. For complex features there are no differences compared to traditional GeoJSON output.

See the [README.md](https://github.com/cklein05/geoserver/tree/slimgeojson/src/community/slimgeojson) for a more detailed description of the format.

This community module and format was announced on the developer's mailing list as _Compact JSON Format_. I decided to rename it to _Slim GeoJSON_ as _Slim_ is shorter and easier to pronounce...

This PR contains the community module code as well as some changes in the already existing JSON provider, which this new format extends.

Still missing are the required entries in `.../src/community/pom.xml` as well as an XML file in directory
 `.../src/community/release` (if required). Also missing is the module's help content in directory (I guess) `.../doc/en/user/source/community/slimgeojson`. Maybe the linked README.md above is a good starting point for a module description. Are you going to add all these?

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

I guess that all the build checks are green. However, for a first time Maven user this was not so easy to get sorted. AFAIK, community modules are build only if profile `communityRelease` is specified on the command line. Also, the module needs to be added to file `.../src/community/pom.xml` (which I did not within this PR). So, after a successful build of the core, extensions and community modules, I've build the new module "by hand" from its own directory.

BTW, (how) do you invoke Maven from a standard Windows command line? Or are you all on Linux/Mac? It seems that there are problems with Windows paths containing backslashes. maven-compiler-plugin was complaining about an _invalid escape sequence_ in `C:\Users\...` near index 3. Also, some tests did not work correctly (I guess maven was unable to find and read the generated output files due to path name problems). So, I had to start Maven with the -f option in order to specify the path to the root pom.xml with slashes. Still tests did not work properly so I had to skipTests as well.