### PR TITLE
[GEOS-10698] - OGCAPI and REST API coexistence issue

### DIFF
--- a/src/community/ogcapi/ogcapi-core/pom.xml
+++ b/src/community/ogcapi/ogcapi-core/pom.xml
@@ -80,6 +80,11 @@
       <version>${gt.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-rest</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-geojson-core</artifactId>
       <version>${gt.version}</version>

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIConfigurationSupport.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIConfigurationSupport.java
@@ -10,13 +10,10 @@ import java.util.logging.Logger;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.DispatcherCallback;
 import org.geoserver.ows.Request;
-import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.Operation;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.format.FormatterRegistry;
+import org.geoserver.rest.RestConfiguration;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.config.annotation.DelegatingWebMvcConfiguration;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod;
@@ -28,7 +25,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHan
 // Not @Configuration on purpose, or it will interfere with the REST API.
 // @Component is good enough to allow auto-wiring.
 @Component
-public class APIConfigurationSupport extends DelegatingWebMvcConfiguration {
+public class APIConfigurationSupport extends RestConfiguration {
 
     static final Logger LOGGER =
             org.geotools.util.logging.Logging.getLogger("org.geoserver.ogcapi");
@@ -52,6 +49,7 @@ public class APIConfigurationSupport extends DelegatingWebMvcConfiguration {
         @Override
         protected Object doInvoke(Object... args) throws Exception {
             Request request = Dispatcher.REQUEST.get();
+            if (request == null) return super.doInvoke(args);
             Operation operation =
                     new Operation(
                             request.getRequest(),
@@ -90,11 +88,6 @@ public class APIConfigurationSupport extends DelegatingWebMvcConfiguration {
 
     public void setCallbacks(List<DispatcherCallback> callbacks) {
         this.callbacks = callbacks;
-    }
-
-    @Override
-    protected void addFormatters(FormatterRegistry registry) {
-        GeoServerExtensions.extensions(Converter.class).forEach(c -> registry.addConverter(c));
     }
 
     // SHARE (or move to a callback handler/list class of sort?)

--- a/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/ApiConfigurationSupportTest.java
+++ b/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/ApiConfigurationSupportTest.java
@@ -1,0 +1,36 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.geoserver.rest.converters.FreemarkerHTMLMessageConverter;
+import org.junit.Test;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+public class ApiConfigurationSupportTest extends OGCApiTestSupport {
+
+    @Test
+    public void testUrlHelperType() {
+        RequestMappingHandlerMapping mappingHandler =
+                applicationContext.getBean(RequestMappingHandlerMapping.class);
+        assertEquals(
+                mappingHandler.getUrlPathHelper().getClass().getSimpleName(),
+                "GeoServerUrlPathHelper");
+    }
+
+    @Test
+    public void testConvertersContainsFreeMarker() {
+        RequestMappingHandlerAdapter mappingHandlerAdapter =
+                applicationContext.getBean(RequestMappingHandlerAdapter.class);
+        assertNotEquals(
+                0,
+                mappingHandlerAdapter.getMessageConverters().stream()
+                        .filter(c -> c instanceof FreemarkerHTMLMessageConverter)
+                        .count());
+    }
+}


### PR DESCRIPTION
[![GEOS-10698](https://badgen.net/badge/JIRA/GEOS-10698/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10698)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->