### PR TITLE
[GEOS-10699] WCS 2.0 latitude subsetting may fail if the source data has longitudes spanning both datelines

### DIFF
--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/WCSEnvelope.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/WCSEnvelope.java
@@ -75,8 +75,15 @@ public class WCSEnvelope extends AbstractEnvelope {
             ordinates[dimension + ordinates.length / 2] = maximum;
             ordinates[dimension] = minimum;
         } else if (dimension >= 0 && dimension < ordinates.length / 2) {
-            ordinates[dimension + ordinates.length / 2] = maximum;
-            ordinates[dimension] = minimum;
+            if (longitudeDimension != LONGIDUTE_NOT_FOUND
+                    && dimension == longitudeDimension
+                    && maximum - minimum > 360) {
+                ordinates[dimension + ordinates.length / 2] = 180;
+                ordinates[dimension] = -180;
+            } else {
+                ordinates[dimension + ordinates.length / 2] = maximum;
+                ordinates[dimension] = minimum;
+            }
         } else {
             throw indexOutOfBounds(dimension);
         }

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSEnvelopeTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSEnvelopeTest.java
@@ -1,0 +1,71 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wcs2_0;
+
+import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.geometry.GeneralEnvelope;
+import org.junit.Test;
+
+public class WCSEnvelopeTest {
+
+    @Test
+    public void testDatelineCrossing() {
+        WCSEnvelope env = new WCSEnvelope(WGS84);
+        env.setRange(0, 150, 210);
+        env.setRange(1, -10, 10);
+
+        // normalize, should split in two
+        GeneralEnvelope[] envelopes = env.getNormalizedEnvelopes();
+        assertEquals(2, envelopes.length);
+        assertEquals(newGeneralEnvelope(150, -10, 180, 10), envelopes[0]);
+        assertEquals(newGeneralEnvelope(-180, -10, -150, 10), envelopes[1]);
+
+        // intersection test
+        env.intersect(newGeneralEnvelope(160, -20, 180, 20));
+        assertEquals(newGeneralEnvelope(160, -10, 180, 10), new GeneralEnvelope(env));
+    }
+
+    @Test
+    public void testMoreThanWorldWest() {
+        WCSEnvelope env = new WCSEnvelope(WGS84);
+        env.setRange(0, -200, 165);
+        env.setRange(1, -10, 10);
+
+        // normalize should just give the whole world
+        GeneralEnvelope[] envelopes = env.getNormalizedEnvelopes();
+        assertEquals(1, envelopes.length);
+        assertEquals(newGeneralEnvelope(-180, -10, 180, 10), envelopes[0]);
+
+        // intersection test
+        env.intersect(newGeneralEnvelope(160, -20, 180, 20));
+        assertEquals(newGeneralEnvelope(160, -10, 180, 10), new GeneralEnvelope(env));
+    }
+
+    @Test
+    public void testMoreThanWorldEast() {
+        WCSEnvelope env = new WCSEnvelope(WGS84);
+        env.setRange(0, -160, 240);
+        env.setRange(1, -10, 10);
+
+        // normalize should just give the whole world
+        GeneralEnvelope[] envelopes = env.getNormalizedEnvelopes();
+        assertEquals(1, envelopes.length);
+        assertEquals(newGeneralEnvelope(-180, -10, 180, 10), envelopes[0]);
+
+        // intersection test
+        env.intersect(newGeneralEnvelope(160, -20, 180, 20));
+        assertEquals(newGeneralEnvelope(160, -10, 180, 10), new GeneralEnvelope(env));
+    }
+
+    private static GeneralEnvelope newGeneralEnvelope(
+            int minLon, int minLat, int maxLon, int maxLat) {
+        GeneralEnvelope expected =
+                new GeneralEnvelope(new double[] {minLon, minLat}, new double[] {maxLon, maxLat});
+        expected.setCoordinateReferenceSystem(WGS84);
+        return expected;
+    }
+}


### PR DESCRIPTION
[![GEOS-10699](https://badgen.net/badge/JIRA/GEOS-10699/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10699)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See tickets

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->