### PR TITLE
[GEOS-10700] Avoid automaticly updating logging profiles from built-in template

### DIFF
--- a/src/main/src/main/java/org/geoserver/logging/LoggingUtilsDelegate.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingUtilsDelegate.java
@@ -5,7 +5,6 @@
 package org.geoserver.logging;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,7 +16,6 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -598,11 +596,8 @@ class LoggingUtilsDelegate {
     }
 
     /**
-     * Used by modules to register additional built-in logging profiles during startup, confirming
-     * logConfigFile is available.
-     *
-     * <p>This method will check resource loader logConfigFile profile and create from internal
-     * template if needed.
+     * Restores the given built-in logging configuration, if it's no longer found in the GeoServer
+     * data directory.
      *
      * @param resourceLoader GeoServer resource access
      * @param logConfigFile Logging profile matching a built-in template on the classpath
@@ -619,18 +614,18 @@ class LoggingUtilsDelegate {
                 resourceLoader.copyFromClassPath(logConfigXml, target);
             } catch (IOException e) {
                 LoggingStartupContextListener.getLogger()
-                        .config(
-                                "Check '"
-                                        + logConfigXml
-                                        + "' logging configuration - unable to create. Is your data dir writeable?");
+                        .log(
+                                Level.CONFIG,
+                                "Unable to create '{0}'. Is your data directory writeable?",
+                                target.getAbsolutePath());
             }
         }
     }
     /**
      * Upgrade standard logging configurations to match built-in class resources.
      *
-     * <p>This method will check against the internal templates and unpack any xml
-     * configurations that are missing, and remove any log4j properties configurations.
+     * <p>This method will check against the internal templates and unpack any xml configurations
+     * that are missing, and remove any log4j properties configurations.
      *
      * @param resourceLoader GeoServer resource access
      */
@@ -665,26 +660,5 @@ class LoggingUtilsDelegate {
             }
             checkBuiltInLoggingConfiguration(resourceLoader, logConfigFile);
         }
-    }
-
-    /**
-     * Used to access internal logging template contents.
-     *
-     * @param classpathResource Example "DEFAULT_LOGGING.xml"
-     * @return inputstream for resource contents
-     * @throws IOException If the resource could not be found.
-     */
-    private static InputStream getStreamFromResource(String classpathResource) throws IOException {
-        InputStream is = null;
-        is = Thread.currentThread().getContextClassLoader().getResourceAsStream(classpathResource);
-        if (is == null) {
-            throw new IOException(
-                    "Could not obtain "
-                            + classpathResource
-                            + " from scope "
-                            + Thread.currentThread().getContextClassLoader().toString()
-                            + ".");
-        }
-        return is;
     }
 }

--- a/src/main/src/main/java/org/geoserver/logging/LoggingUtilsDelegate.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingUtilsDelegate.java
@@ -599,11 +599,10 @@ class LoggingUtilsDelegate {
 
     /**
      * Used by modules to register additional built-in logging profiles during startup, confirming
-     * logConfigFile is available (and updating if needed).
+     * logConfigFile is available.
      *
-     * <p>This method will check resource loader logConfigFile profile against the internal
-     * templates and only update the xml file if needed. If the file is updated the previous
-     * definition is available as a {@code xml.bak} file allowing.
+     * <p>This method will check resource loader logConfigFile profile and create from internal
+     * template if needed.
      *
      * @param resourceLoader GeoServer resource access
      * @param logConfigFile Logging profile matching a built-in template on the classpath
@@ -615,36 +614,7 @@ class LoggingUtilsDelegate {
         String logConfigXml = logConfigFile + ".xml";
 
         File target = new File(logsDirectory.getAbsolutePath(), logConfigXml);
-        if (target.exists()) {
-            try (FileInputStream targetContents = new FileInputStream(target);
-                    InputStream template = getStreamFromResource(logConfigXml)) {
-                if (!IOUtils.contentEquals(targetContents, template)) {
-                    String logConfigBackup = logConfigFile + ".xml.bak";
-                    File backup = new File(logsDirectory.getAbsolutePath(), logConfigBackup);
-                    boolean renamed = target.renameTo(backup);
-                    if (renamed) {
-                        LoggingStartupContextListener.getLogger()
-                                .finer(
-                                        "Check '"
-                                                + logConfigXml
-                                                + "' logging configuration - outdated and renamed to '"
-                                                + logConfigBackup
-                                                + "'");
-                    }
-                    LoggingStartupContextListener.getLogger()
-                            .finer("Check '" + logConfigXml + "' logging configuration, outdated");
-                    resourceLoader.copyFromClassPath(logConfigXml, target);
-                }
-            } catch (IOException e) {
-                LoggingStartupContextListener.getLogger()
-                        .log(
-                                Level.WARNING,
-                                "Check '"
-                                        + logConfigXml
-                                        + "' logging configuration - unable to check against template",
-                                e);
-            }
-        } else {
+        if (!target.exists()) {
             try {
                 resourceLoader.copyFromClassPath(logConfigXml, target);
             } catch (IOException e) {
@@ -659,8 +629,8 @@ class LoggingUtilsDelegate {
     /**
      * Upgrade standard logging configurations to match built-in class resources.
      *
-     * <p>This method will check each LOGGING profile against the internal templates and unpack any
-     * xml configurations that are missing, and remove any log4j properties configurations.
+     * <p>This method will check against the internal templates and unpack any xml
+     * configurations that are missing, and remove any log4j properties configurations.
      *
      * @param resourceLoader GeoServer resource access
      */


### PR DESCRIPTION
[![GEOS-10700](https://badgen.net/badge/JIRA/GEOS-10700/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10700)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket. 
Replaces https://github.com/geoserver/geoserver/pull/6234
Needs squash-merge to go back being a single commit.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->