### PR TITLE
Update Ubuntu 18.04 workflows to 20.04

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Backport
     steps:
       - name: Backport Bot

--- a/.github/workflows/linux_jdk8.yml
+++ b/.github/workflows/linux_jdk8.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             jdk: 8
             dist: 'temurin'
     steps:


### PR DESCRIPTION
Backport bot is failing with this message:

 ```
This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see https://github.com/actions/runner-images/issues/6002
 ```

So trying to update the builds still using 18.04 to 20.04