### PR TITLE
[GEOS-10700] Restore ability to customize built-in logging profiles along with profile update procedure

### DIFF
--- a/doc/en/user/source/configuration/logging.rst
+++ b/doc/en/user/source/configuration/logging.rst
@@ -18,8 +18,27 @@ The GeoServer logging profiles assign logging levels to specific server operatio
   * Operational (``INFO``, ``CONFIG``) levels
   * Verbose (``DEBUG``, ``TRACE``, ``FINEST``) levels
 
-
 In addition to the built-in profiles you may setup a custom logging profile, or override the logging configuration completely (even to use another logging library altogether).
+
+Built-in logging profiles
+-------------------------
+
+GeoServer includes several built-in logging profiles:
+
+* :download:`DEFAULT_LOGGING </../../../../src/main/src/main/resources/DEFAULT_LOGGING.xml>`
+* :download:`GEOSERVER_DEVELOPER_LOGGING </../../../../src/main/src/main/resources/GEOSERVER_DEVELOPER_LOGGING.xml>`
+* :download:`GEOTOOLS_DEVELOPER_LOGGING </../../../../src/main/src/main/resources/GEOTOOLS_DEVELOPER_LOGGING.xml>`
+* :download:`PRODUCTION_LOGGING </../../../../src/main/src/main/resources/PRODUCTION_LOGGING.xml>`
+* :download:`QUIET_LOGGING </../../../../src/main/src/main/resources/QUIET_LOGGING.xml>`
+* :download:`VERBOSE_LOGGING </../../../../src/main/src/main/resources/VERBOSE_LOGGING.xml>`
+
+The built-in logging profiles are installed into your data directory the first time the application is run. If you have customized (see the next section) these files and wish to restore the original contents:
+
+* Use the startup parameter ``-DUPDATE_BUILT_IN_LOGGING_PROFILES=true``, the built-in logging profiles will be checked and updated if required; or
+* Delete the file and restart GeoServer, the missing file will be restored; or
+* Copy the contents from the download links above
+
+For a description of these logging profiles see :ref:`config_globalsettings_log_profile`. Additional built-in logging profiles are supplied by installed extensions (example :download:`IMPORTER_LOGGING </../../../../src/extension/importer/core/src/main/resources/IMPORTER_LOGGING.xml>` profile is built into the importer extension).
 
 Custom logging profiles
 -----------------------
@@ -109,13 +128,15 @@ There are however a few rules to follow:
 
   * Use ``additivity="false"`` to prevent a message collected from one logger from being passed to the next.
   
-  If you end up with double log messages chances check for this common misconfiguration.
+    If you end up with double log messages chances check for this common misconfiguration.
   
   * The ``Root`` logger is last in the list and should collect everything.
 
 
 Example of console only logging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Copy built-in logging profile and customize:
 
 1. Copy an example such as :download:`QUIET_LOGGING.xml </../../../../src/main/src/main/resources/QUIET_LOGGING.xml>` to :file:`CONSOLE_LOGGING.xml`:
 
@@ -201,7 +222,7 @@ If you wish GeoServer not to override the normal Log4J behavior you can set the 
 
   RELINQUISH_LOG4J_CONTROL=true
   
-This can be combined with ``log4j2.configurationFile`` system property to `configure Log4J externally <https://logging.apache.org/log4j/2.x/manual/configuration.html#AutomaticConfiguration>`__ :
+This can be combined with ``log4j2.configurationFile`` system property to `configure Log4J externally <https://logging.apache.org/log4j/2.x/manual/configuration.html#AutomaticConfiguration>`__ ::
 
   -DRELINQUISH_LOG4J_CONTROL=true -Dlog4j2.configurationFile=logging_configuration.xml
   

--- a/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
@@ -59,6 +59,12 @@ public class LoggingStartupContextListener implements ServletContextListener {
             return;
         }
 
+        String updateBuiltInLoggingProfiles =
+                GeoServerExtensions.getProperty(
+                        LoggingUtils.UPDATE_BUILT_IN_LOGGING_PROFILES, context);
+
+        LoggingUtils.updateBuiltInLoggingProfiles = Boolean.valueOf(updateBuiltInLoggingProfiles);
+
         try {
             File baseDir = new File(GeoServerResourceLoader.lookupGeoServerDataDirectory(context));
 

--- a/src/main/src/main/java/org/geoserver/logging/LoggingUtils.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingUtils.java
@@ -32,7 +32,7 @@ import org.vfny.geoserver.global.ConfigurationException;
  * bridge).
  *
  * <p>To troubleshoot use {@code org.apache.logging.log4j.simplelog.StatusLogger.level=DEBUG}, or
- * adjust {@code log4j2.xml} file &lt;Configuration status=&quote;trace&quote;&gt;.
+ * adjust {@code log4j2.xml} file {@code <Configuration status="trace">}.
  *
  * @see org.geoserver.config.LoggingInfo
  */
@@ -47,10 +47,20 @@ public class LoggingUtils {
      */
     public static final String RELINQUISH_LOG4J_CONTROL = "RELINQUISH_LOG4J_CONTROL";
 
-    // public static String loggingLocation;
-
-    /** Value of loggingRedirection established by {@link LoggingStartupContextListener}. */
+    /** Logging redirection value established by {@link LoggingStartupContextListener}. */
     static boolean relinquishLog4jControl = false;
+
+    /**
+     * Property used to enable update of built-in logging profiles on startup.
+     *
+     * <p>Use {@code -DUPDATE_BUILT_IN_LOGGING_PROFILES=true} to allow GeoServer to update built-in
+     * logging profiles during startup.
+     */
+    public static final String UPDATE_BUILT_IN_LOGGING_PROFILES =
+            "UPDATE_BUILT_IN_LOGGING_PROFILES";
+
+    /** Logging profile update policy established by {@link LoggingStartupContextListener}. */
+    static boolean updateBuiltInLoggingProfiles = false;
 
     /**
      * Property used override Log4J default, and force use of another logging framework.


### PR DESCRIPTION
[![GEOS-10700](https://badgen.net/badge/JIRA/GEOS-10700/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10700)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This restores the default functionality of allowing customization of built-in logging profiles. In addition the documentation is updated with a manual procedure for updating built-in profiles and an optional flag ``UPDATE_BUILT_IN_LOGGING_PROFILES`` to allow the automatic management of built-in logging profiles.

This replaces:
- https://github.com/geoserver/geoserver/pull/6234
- https://github.com/geoserver/geoserver/pull/6242

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->