### PR TITLE
New community module: SpatialJSON WFS Output Format

### DIFF
--- a/doc/en/user/source/community/index.rst
+++ b/doc/en/user/source/community/index.rst
@@ -61,6 +61,7 @@ officially part of the GeoServer releases. They are however built along with the
    saml/index
    schemaless-features/index
    smart-data-loader/index
+   spatialjson/index
    stac-datastore/index
    solr/index
    taskmanager/index

--- a/doc/en/user/source/community/spatialjson/development.rst
+++ b/doc/en/user/source/community/spatialjson/development.rst
@@ -1,0 +1,26 @@
+.. _spatialjson_development:
+
+Development Status
+==================
+
+The SpatialJSON format is still a playground for implementing several optimizations to transfer
+even huge amounts of spatial data from the server to the client efficiently:
+
+#. **Opt. 1: Removing redundant schema information**, see :doc:`topic <schema>`
+#. Opt. 2: Removing redundant attribute values (e. g. shared string table)
+#. Opt. 3: Handling sparse rows (most values are NULL) more efficiently
+#. Opt. 4: Reducing space required for geometries (e. g. differential coordinates)
+
+Bold items have already been implemented.
+
+The shown optimizations are ordered from *simple to implement* to *hard to implement* (not *really*
+hard, however). That's also the intended order of implementation. Although some
+optimizations are optional, all optimizations could be in effect at the same time. Then, each
+optimization contributes his part to lower the space required for encoding a certain set of
+features.
+
+In some cases, however, it may be useful to specify which optimizations shall be used for a
+request. Several techniques are available to give a client the ability to specify the set of
+SpatialJSON optimizations it is able or willing to use (e. g. parameter ``format_options``,
+additional ``outputFormat`` parameters). It's still not clear how this will be implemented and how
+fine grained that will be.

--- a/doc/en/user/source/community/spatialjson/index.rst
+++ b/doc/en/user/source/community/spatialjson/index.rst
@@ -1,0 +1,29 @@
+.. _spatialjson:
+
+SpatialJSON WFS Output Format Extension
+=======================================
+
+This module adds the SpatialJSON WFS output format. The SpatialJSON format is a more compact and
+memory-friendly variant of GeoServer's GeoJSON format. It aims to save space by applying several
+optimizations to traditional GeoJSON format for simple feature results. Most of these optimizations
+work by removing redundand information from the JSON-encoded features.
+
+A service exception is thrown if the result contains complex features as the SpatialJSON format
+does not handle those.
+
+.. note:: The SpatialJSON format is **not compatible** with GeoJSON. A SpatialJSON enabled reader is required to decode features transferred in SpatialJSON format.
+
+This module adds two additional WFS output formats for requesting simple features in SpatialJSON
+format:
+
+-  ``application/json; subtype=json/spatial`` for requesting SpatialJSON
+-  ``text/javascript; subtype=json/spatial`` for requesting SpatialJSON as a JSONP request
+
+.. warning:: At the time of writing, this format is still *work in progress* and changes may be applied in the future.
+
+.. toctree::
+    :maxdepth: 1
+
+    installation
+    development
+    schema

--- a/doc/en/user/source/community/spatialjson/installation.rst
+++ b/doc/en/user/source/community/spatialjson/installation.rst
@@ -1,0 +1,28 @@
+.. _spatialjson_installation:
+
+Installation
+============
+
+Manual Installation
+-------------------
+
+To download and install the required extensions by hand:
+
+#. Download the geoserver-|release|-spatialjson-plugin.zip from:
+
+   * `Community Builds <https://build.geoserver.org/geoserver/main/community-latest/>`_ (GeoServer WebSite)
+   
+   It is important to download the version that matches the GeoServer you are running.
+
+#. Stop the GeoServer application.
+
+#. Navigate into the :file:`webapps/geoserver/WEB-INF/lib` folder.
+
+   These files make up the running GeoServer application.
+
+#. Unzip the contents of the zip file into the :file:`lib` folder.
+
+#. Restart the Application Server.
+
+After restarting the Application Server the SpatialJSON WFS output format is available and ready to
+use.

--- a/doc/en/user/source/community/spatialjson/schema.rst
+++ b/doc/en/user/source/community/spatialjson/schema.rst
@@ -1,0 +1,121 @@
+ .. _spatialjson_schema:
+ 
+Opt. 1: Removing Redundant Schema Information
+=============================================
+
+In traditional GeoJSON, every feature in a (simple feature) feature collection has its own schema
+information. That is, every feature contains all its (not necessarily short) attribute names. Except
+the geometry name, these names are used as the keys in the ``"properties"`` map:
+
+.. code:: json
+
+   {
+     "type": "FeatureCollection",
+     "features": [
+       {
+         "type": "Feature",
+         "id": "areas.1",
+         "geometry": {
+           "type": "Point",
+           "coordinates": [590529, 4914625]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+           "area_no": 12,
+           "area_name": "Mainland",
+           "area_description": "grassland",
+           "area_cost_center": "0815"
+         }
+       },
+       {
+         "type": "Feature",
+         "id": "areas.2",
+         "geometry": {
+           "type": "Point",
+           "coordinates": [590215, 4913987]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+           "area_no": 17,
+           "area_name": "South region",
+           "area_description" : "meadow, pasture",
+           "area_cost_center": "0812"
+         }
+       }
+     ],
+     "totalFeatures": 2,
+     "numberMatched": 2,
+     "numberReturned": 2,
+     "timeStamp": "2022-10-17T08:12:45.248Z",
+     "crs": {
+       "type": "name",
+       "properties": {
+         "name": "urn:ogc:def:crs:EPSG::26713"
+       }
+     }
+   }
+
+Since all features have the same schema information, SpatialJSON does not write attribute names for
+every feature. Instead, a single ``"schemaInformation"`` property is added to the end of the
+top-level ``"FeatureCollection"`` object:
+
+.. code:: json
+
+   {
+     "type": "FeatureCollection",
+     "features": [
+       {
+         "type": "Feature",
+         "id": "areas.1",
+         "geometry": {
+           "type": "Point",
+           "coordinates": [590529, 4914625]
+         },
+         "properties": [12, "Mainland", "grassland", "0815"]
+       },
+       {
+         "type": "Feature",
+         "id": "areas.2",
+         "geometry": {
+           "type": "Point",
+           "coordinates": [590215, 4913987]
+         },
+         "properties": [17, "South region", "meadow, pasture", "0812"]
+       }
+     ],
+     "totalFeatures": 2,
+     "numberMatched": 2,
+     "numberReturned": 2,
+     "timeStamp": "2022-10-17T08:14:36.521Z",
+     "crs": {
+       "type": "name",
+       "properties": {
+         "name": "urn:ogc:def:crs:EPSG::26713"
+       }
+     },
+     "schemaInformation": {
+       "propertyNames": ["area_no", "area_name", "area_description", "area_cost_center"],
+       "geometryName": "the_geom"
+     }
+   }
+
+With SpatialJSON, each feature’s ``"properties"`` map becomes an *ordered list* (array) whose index
+corresponds to the ``"propertyNames"`` array that holds the attribute names in the new 
+``"schemaInformation"`` object. Additionally, the repeated property ``"geometry_name"`` is replaced
+by a single property named ``"geometryName"`` in the new schema information object.
+
+Evaluation
+----------
+
+In the above example, without whitespaces and line breaks, savings in space are only about 5%. With
+much more features savings could reach almost 27% (the ratio of the sizes of a GeoJSON and a
+SpatialJSON feature object), that is, the size of the SpatialJSON response is only 73% of the size
+of a traditional GeoJSON response. More savings are possible with more attributes per feature.
+Savings basically depend on the ratio between schema information size and data size. In tests
+requesting several thousands of simple features with 200+ columns/attributes savings up to 70% have
+been achieved.
+
+These savings drop to between ~50% and ~3% when a compressing content encoding method (like gzip,
+deflate or brotli) is used on the wire. However, it’s not all about transfer size. The smaller the
+uncompressed JSON response, the lesser characters the client has to parse. Smaller uncompressed
+responses are also much more memory-friendly on both the server and the client side.

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -42,6 +42,7 @@
             <descriptor>release/ext-pgraster.xml</descriptor>
             <descriptor>release/ext-dyndimension.xml</descriptor>
             <descriptor>release/ext-flatgeobuf.xml</descriptor>
+            <descriptor>release/ext-spatialjson.xml</descriptor>
             <descriptor>release/ext-gpx.xml</descriptor>
             <descriptor>release/ext-jms-cluster.xml</descriptor>
             <descriptor>release/ext-hz-cluster.xml</descriptor>
@@ -204,6 +205,7 @@
         <module>pgraster</module>
         <module>dyndimension</module>
         <module>flatgeobuf</module>
+        <module>spatialjson</module>
         <module>gpxppio</module>
         <module>jms-cluster</module>
         <module>hz-cluster</module>
@@ -319,6 +321,12 @@
       <id>flatgeobuf</id>
       <modules>
         <module>flatgeobuf</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>spatialjson</id>
+      <modules>
+        <module>spatialjson</module>
       </modules>
     </profile>
     <profile>

--- a/src/community/release/ext-spatialjson.xml
+++ b/src/community/release/ext-spatialjson.xml
@@ -1,0 +1,16 @@
+<assembly>
+    <id>spatialjson-plugin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>release/target/dependency</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>gs-spatialjson*.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-spatialjson</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
       <artifactId>gs-pgraster</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/src/community/spatialjson/README.md
+++ b/src/community/spatialjson/README.md
@@ -1,0 +1,162 @@
+# SpatialJSON WFS Output Format Extension
+
+This module adds the SpatialJSON WFS output format. The SpatialJSON format is a more compact and
+memory-friendly variant of GeoServer's GeoJSON format. It aims to save space by applying several
+optimizations to traditional GeoJSON format for simple feature results. Most of these optimizations
+work by removing redundand information from the JSON-encoded features.
+
+A service exception is thrown if the result contains complex features as the SpatialJSON format
+does not handle those.
+
+> **Note**: The SpatialJSON format is **not compatible** with GeoJSON. A SpatialJSON enabled reader
+> is required to decode features transferred in SpatialJSON format.
+
+This module adds two additional WFS output formats for requesting simple features in SpatialJSON
+format:
+
+- `application/json; subtype=json/spatial` for requesting SpatialJSON
+- `text/javascript; subtype=json/spatial` for requesting SpatialJSON as a JSONP request
+
+> **Warning**: At the time of writing, this format is still _work in progress_ and changes may be
+> applied in the future.
+
+### Development Status
+
+The SpatialJSON format is still a playground for implementing several optimizations to transfer
+even huge amounts of spatial data from the server to the client efficiently:
+
+1. **Opt. 1: Removing redundant schema information**, see [topic](#opt-1-removing-redundant-schema-information)
+2. Opt. 2: Removing redundant attribute values (e. g. shared string table)
+3. Opt. 3: Handling sparse rows (most values are NULL) more efficiently
+4. Opt. 4: Reducing space required for geometries (e. g. coordinates
+
+Bold items have already been implemented.
+
+The shown optimizations are ordered from *simple to implement* to *hard to implement* (not *really*
+hard, however). That's also the intended order of implementation. Although some optimizations are
+optional, all optimizations could be in effect at the same time. Then, each optimization
+contributes his part to lower the space required for encoding a certain set of features.
+
+In some cases, however, it may be useful to specify which optimizations shall be used for a
+request. Several techniques are available to give a client the ability to specify the set of
+SpatialJSON optimizations it is able or willing to use (e. g. parameter `format_options`,
+additional `outputFormat` parameters). It's still not clear how this will be implemented and how
+fine grained that will be.
+
+## Opt. 1: Removing Redundant Schema Information
+
+In traditional GeoJSON, every feature in a (simple feature) feature collection has its own schema
+information. That is, every feature contains all its (not necessarily short) attribute names.
+Except the geometry name, these names are used as the keys in the `"properties"` map:
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "areas.1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590529, 4914625]
+      },
+      "geometry_name": "the_geom",
+      "properties": {
+        "area_no": 12,
+        "area_name": "Mainland",
+        "area_description": "grassland",
+        "area_cost_center": "0815"
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "areas.2",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590215, 4913987]
+      },
+      "geometry_name": "the_geom",
+      "properties": {
+        "area_no": 17,
+        "area_name": "South region",
+        "area_description" : "meadow, pasture",
+        "area_cost_center": "0812"
+      }
+    }
+  ],
+  "totalFeatures": 2,
+  "numberMatched": 2,
+  "numberReturned": 2,
+  "timeStamp": "2022-10-17T08:12:45.248Z",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "urn:ogc:def:crs:EPSG::26713"
+    }
+  }
+}
+```
+
+Since all features have the same schema information, SpatialJSON does not write attribute names for
+every feature. Instead, a single `"schemaInformation"` property is added to the end of the
+top-level `"FeatureCollection"` object:
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "areas.1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590529, 4914625]
+      },
+      "properties": [12, "Mainland", "grassland", "0815"]
+    },
+    {
+      "type": "Feature",
+      "id": "areas.2",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [590215, 4913987]
+      },
+      "properties": [17, "South region", "meadow, pasture", "0812"]
+    }
+  ],
+  "totalFeatures": 2,
+  "numberMatched": 2,
+  "numberReturned": 2,
+  "timeStamp": "2022-10-17T08:14:36.521Z",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "urn:ogc:def:crs:EPSG::26713"
+    }
+  },
+  "schemaInformation": {
+    "propertyNames": ["area_no", "area_name", "area_description", "area_cost_center"],
+    "geometryName": "the_geom"
+  }
+}
+```
+
+With SpatialJSON, each feature's `"properties"` map becomes an *ordered list* (array) whose index
+corresponds to the `"propertyNames"` array that holds the attribute names in the new
+`"schemaInformation"` object. Additionally, the repeated property `"geometry_name"` is replaced by
+a single property named `"geometryName"` in the new schema information object.
+
+### Evaluation
+
+In the above example, without whitespaces and line breaks, savings in space are only about 5%. With
+much more features savings could reach almost 27% (the ratio of the sizes of a GeoJSON and a
+SpatialJSON feature object), that is, the size of the SpatialJSON response is only 73% of the size
+of a traditional GeoJSON response. More savings are possible with more attributes per feature.
+Savings basically depend on the ratio between schema information size and data size. In tests
+requesting several thousands of simple features with 200+ columns/attributes savings up to 70% have
+been achieved.
+
+These savings drop to between \~50% and \~3% when a compressing content encoding method (like gzip,
+deflate or brotli) is used on the wire. However, it's not all about transfer size. The smaller the
+uncompressed JSON response, the lesser characters the client has to parse. Smaller uncompressed
+responses are also much more memory-friendly on both the server and the client side.

--- a/src/community/spatialjson/pom.xml
+++ b/src/community/spatialjson/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2022 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.geoserver</groupId>
+    <artifactId>community</artifactId>
+    <version>2.23-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver.community</groupId>
+  <artifactId>gs-spatialjson</artifactId>
+  <packaging>jar</packaging>
+  <name>SpatialJSON WFS Output Format</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-wfs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/community/spatialjson/src/main/java/org/geoserver/wfs/json/SpatialJSONGetFeatureResponse.java
+++ b/src/community/spatialjson/src/main/java/org/geoserver/wfs/json/SpatialJSONGetFeatureResponse.java
@@ -35,8 +35,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  */
 public class SpatialJSONGetFeatureResponse extends GeoJSONGetFeatureResponse {
 
-    // currently no logger required
-    // private final Logger LOGGER = org.geotools.util.logging.Logging.getLogger(this.getClass());
 
     private static String parseMimeType(String format) {
         int pos = format.indexOf(';');

--- a/src/community/spatialjson/src/main/java/org/geoserver/wfs/json/SpatialJSONGetFeatureResponse.java
+++ b/src/community/spatialjson/src/main/java/org/geoserver/wfs/json/SpatialJSONGetFeatureResponse.java
@@ -35,7 +35,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  */
 public class SpatialJSONGetFeatureResponse extends GeoJSONGetFeatureResponse {
 
-
     private static String parseMimeType(String format) {
         int pos = format.indexOf(';');
         return pos != -1 ? format.substring(0, pos).trim() : format;
@@ -239,8 +238,7 @@ public class SpatialJSONGetFeatureResponse extends GeoJSONGetFeatureResponse {
                 GeometryDescriptor defaultGeomType = fType.getGeometryDescriptor();
                 List<AttributeDescriptor> types = fType.getAttributeDescriptors();
 
-                for (int j = 0; j < types.size(); j++) {
-                    AttributeDescriptor ad = types.get(j);
+                for (AttributeDescriptor ad : types) {
                     if (id_option != null && id_option.equals(ad.getLocalName())) {
                         continue; // skip this attribute as it it used as the id
                     }

--- a/src/community/spatialjson/src/main/java/org/geoserver/wfs/json/SpatialJSONGetFeatureResponse.java
+++ b/src/community/spatialjson/src/main/java/org/geoserver/wfs/json/SpatialJSONGetFeatureResponse.java
@@ -1,0 +1,266 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.json;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.List;
+import org.geoserver.config.GeoServer;
+import org.geoserver.data.util.TemporalUtils;
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.ServiceException;
+import org.geoserver.wfs.WFSException;
+import org.geoserver.wfs.request.FeatureCollectionResponse;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.Name;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * A GetFeatureInfo response handler specialized in producing JSON and JSONP data in
+ * <em>SpatialJSON</em> format for a GetFeature request.
+ *
+ * @author Carsten Klein, DataGis
+ */
+public class SpatialJSONGetFeatureResponse extends GeoJSONGetFeatureResponse {
+
+    // currently no logger required
+    // private final Logger LOGGER = org.geotools.util.logging.Logging.getLogger(this.getClass());
+
+    private static String parseMimeType(String format) {
+        int pos = format.indexOf(';');
+        return pos != -1 ? format.substring(0, pos).trim() : format;
+    }
+
+    public SpatialJSONGetFeatureResponse(GeoServer gs, String format) {
+        super(gs, format, JSONType.isJsonpMimeType(parseMimeType(format)));
+    }
+
+    /** capabilities output format string. */
+    @Override
+    public String getCapabilitiesElementName() {
+        return getOutputFormats().isEmpty() ? null : getOutputFormats().iterator().next();
+    }
+
+    /** Returns the mime type */
+    @Override
+    public String getMimeType(Object value, Operation operation) throws ServiceException {
+        return getOutputFormats().isEmpty() ? null : getOutputFormats().iterator().next();
+    }
+
+    @Override
+    protected void write(
+            FeatureCollectionResponse featureCollection, OutputStream output, Operation operation)
+            throws IOException {
+        Name typeName = null;
+        for (FeatureCollection fc : featureCollection.getFeatures()) {
+            FeatureType schema = fc.getSchema();
+            if (typeName == null) {
+                typeName = schema.getName();
+            } else if (!typeName.equals(schema.getName())) {
+                throw new WFSException(
+                                "Query returned an inhomogenous list of feature types but "
+                                        + "output format SpatialJSON supports encoding a single "
+                                        + "feature type per request only",
+                                "InvalidParameterValue")
+                        .locator("outputFormat");
+            }
+            if (!(schema instanceof SimpleFeatureType)) {
+                // this feature collection contains complex features
+                throw new WFSException(
+                                "Feature type "
+                                        + typeName.toString()
+                                        + " contains complex features but output format "
+                                        + "SpatialJSON supports encoding simple features only",
+                                "InvalidParameterValue")
+                        .locator("outputFormat");
+            }
+        }
+        super.write(featureCollection, output, operation);
+    }
+
+    /**
+     * Modified version of {@link GeoJSONGetFeatureResponse#encodeSimpleFeatures} writing simple
+     * features in SpatialJSON format.
+     */
+    @Override
+    protected FeaturesInfo encodeSimpleFeatures(
+            GeoJSONBuilder jsonWriter,
+            List<FeatureCollection> resultsList,
+            boolean featureBounding,
+            Operation operation) {
+        String id_option = getIdOption();
+
+        CoordinateReferenceSystem crs = null;
+        boolean hasGeom = false;
+        long featureCount = 0;
+        for (FeatureCollection collection : resultsList) {
+            try (FeatureIterator iterator = collection.features()) {
+                SimpleFeatureType fType;
+                List<AttributeDescriptor> types = null;
+                GeometryDescriptor defaultGeomType = null;
+                // encode each simple feature
+                while (iterator.hasNext()) {
+                    // get next simple feature
+                    SimpleFeature simpleFeature = (SimpleFeature) iterator.next();
+                    featureCount++;
+                    // start writing the JSON feature object
+                    jsonWriter.object();
+                    jsonWriter.key("type").value("Feature");
+                    fType = simpleFeature.getFeatureType();
+                    types = fType.getAttributeDescriptors();
+                    // write the simple feature id
+                    if (id_option == null) {
+                        // no specific attribute nominated, use the simple feature id
+                        jsonWriter.key("id").value(simpleFeature.getID());
+                    } else if (id_option.length() != 0) {
+                        // a specific attribute was nominated to be used as id
+                        Object value = simpleFeature.getAttribute(id_option);
+                        jsonWriter.key("id").value(value);
+                    }
+                    // set that axis order that should be used to write geometries
+                    defaultGeomType = fType.getGeometryDescriptor();
+                    if (defaultGeomType != null) {
+                        CoordinateReferenceSystem featureCrs =
+                                defaultGeomType.getCoordinateReferenceSystem();
+                        jsonWriter.setAxisOrder(CRS.getAxisOrder(featureCrs));
+                        if (crs == null) {
+                            crs = featureCrs;
+                        }
+                    } else {
+                        // If we don't know, assume EAST_NORTH so that no swapping occurs
+                        jsonWriter.setAxisOrder(CRS.AxisOrder.EAST_NORTH);
+                    }
+                    // start writing the simple feature geometry JSON object
+                    Geometry aGeom = (Geometry) simpleFeature.getDefaultGeometry();
+                    if (aGeom != null || writeNullGeometries()) {
+                        jsonWriter.key("geometry");
+                        // Write the geometry, whether it is a null or not
+                        if (aGeom != null) {
+                            jsonWriter.writeGeom(aGeom);
+                            hasGeom = true;
+                        } else {
+                            jsonWriter.value(null);
+                        }
+                    }
+                    // start writing feature properties JSON object
+                    jsonWriter.key("properties");
+                    jsonWriter.array();
+                    for (int j = 0; j < types.size(); j++) {
+                        Object value = simpleFeature.getAttribute(j);
+                        AttributeDescriptor ad = types.get(j);
+                        if (id_option != null && id_option.equals(ad.getLocalName())) {
+                            continue; // skip this value as it is used as the id
+                        }
+                        if (ad instanceof GeometryDescriptor) {
+                            // This is an area of the spec where they
+                            // decided to 'let convention evolve',
+                            // that is how to handle multiple
+                            // geometries. My take is to print the
+                            // geometry here if it's not the default.
+                            // If it's the default that you already
+                            // printed above, so you don't need it here.
+                            if (!ad.equals(defaultGeomType)) {
+                                if (value == null) {
+                                    jsonWriter.value(null);
+                                } else {
+                                    // if it was the default geometry, it has been written above
+                                    // already
+                                    jsonWriter.writeGeom((Geometry) value);
+                                }
+                            }
+                        } else if (Date.class.isAssignableFrom(ad.getType().getBinding())
+                                && TemporalUtils.isDateTimeFormatEnabled()) {
+                            // Temporal types print handling
+                            jsonWriter.value(TemporalUtils.printDate((Date) value));
+                        } else {
+                            if ((value instanceof Double && Double.isNaN((Double) value))
+                                    || value instanceof Float && Float.isNaN((Float) value)) {
+                                jsonWriter.value(null);
+                            } else if ((value instanceof Double
+                                            && ((Double) value) == Double.POSITIVE_INFINITY)
+                                    || value instanceof Float
+                                            && ((Float) value) == Float.POSITIVE_INFINITY) {
+                                jsonWriter.value("Infinity");
+                            } else if ((value instanceof Double
+                                            && ((Double) value) == Double.NEGATIVE_INFINITY)
+                                    || value instanceof Float
+                                            && ((Float) value) == Float.NEGATIVE_INFINITY) {
+                                jsonWriter.value("-Infinity");
+                            } else {
+                                jsonWriter.value(value);
+                            }
+                        }
+                    }
+                    jsonWriter.endArray(); // end the properties
+
+                    // Bounding box for feature in properties
+                    ReferencedEnvelope refenv =
+                            ReferencedEnvelope.reference(simpleFeature.getBounds());
+                    if (featureBounding && !refenv.isEmpty()) {
+                        jsonWriter.writeBoundingBox(refenv);
+                    }
+
+                    writeExtraFeatureProperties(simpleFeature, operation, jsonWriter);
+
+                    jsonWriter.endObject(); // end the feature
+                }
+            }
+        }
+        return new FeaturesInfo(crs, hasGeom, featureCount);
+    }
+
+    /** Writes schema information */
+    @Override
+    protected void writeExtraCollectionProperties(
+            FeatureCollectionResponse response, Operation operation, GeoJSONBuilder jw) {
+        String id_option = getIdOption();
+
+        String geometryName = null;
+        List<FeatureCollection> resultsList = response.getFeature();
+        FeatureCollection collection = resultsList.get(0);
+        try (FeatureIterator iterator = collection.features()) {
+
+            if (iterator.hasNext()) {
+                jw.key("schemaInformation").object();
+                jw.key("propertyNames").array();
+
+                SimpleFeature simpleFeature = (SimpleFeature) iterator.next();
+                SimpleFeatureType fType = simpleFeature.getFeatureType();
+                GeometryDescriptor defaultGeomType = fType.getGeometryDescriptor();
+                List<AttributeDescriptor> types = fType.getAttributeDescriptors();
+
+                for (int j = 0; j < types.size(); j++) {
+                    AttributeDescriptor ad = types.get(j);
+                    if (id_option != null && id_option.equals(ad.getLocalName())) {
+                        continue; // skip this attribute as it it used as the id
+                    }
+                    if (ad.equals(defaultGeomType)) {
+                        geometryName = defaultGeomType.getLocalName();
+                        continue; // skip this attribute as it is used as default geometry
+                    }
+                    jw.value(ad.getLocalName());
+                }
+                jw.endArray();
+
+                if (geometryName != null) {
+                    jw.key("geometryName").value(geometryName);
+                }
+                jw.endObject();
+            }
+        }
+
+        super.writeExtraCollectionProperties(response, operation, jw);
+    }
+}

--- a/src/community/spatialjson/src/main/resources/GeoServerApplication.properties
+++ b/src/community/spatialjson/src/main/resources/GeoServerApplication.properties
@@ -1,0 +1,2 @@
+format.wfs.application/json;\ subtype\=json/spatial=SpatialJSON
+format.wfs.text/javascript;\ subtype\=json/spatial=SpatialJSON (JSONP)

--- a/src/community/spatialjson/src/main/resources/applicationContext.xml
+++ b/src/community/spatialjson/src/main/resources/applicationContext.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2022 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<beans>
+    <!-- GetFeature SpatialJSON -->
+    <bean id="spatialJSONGetFeatureResponse" class="org.geoserver.wfs.json.SpatialJSONGetFeatureResponse">
+        <constructor-arg ref="geoServer" />
+        <constructor-arg value="application/json; subtype=json/spatial" />
+    </bean>
+    
+    <!-- GetFeature SpatialJSON (JSONP) -->
+    <bean id="spatialJSONPGetFeatureResponse" class="org.geoserver.wfs.json.SpatialJSONGetFeatureResponse">
+        <constructor-arg ref="geoServer" />
+        <constructor-arg value="text/javascript; subtype=json/spatial" />
+    </bean>
+    
+    <!-- ModuleStatus SpatialJSON -->
+    <bean id="spatialJSONExtension" class="org.geoserver.platform.ModuleStatusImpl">
+        <property name="module" value="gs-spatialjson" />
+        <property name="name" value="SpatialJSON Format Output Extension"/>
+        <property name="component" value="SpatialJSON Format Output Extension"/>
+        <property name="available" value="true"/>
+        <property name="enabled" value="true"/>
+  </bean>
+</beans>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -1731,6 +1731,16 @@
       </dependencies>
     </profile>
     <profile>
+      <id>spatialjson</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-spatialjson</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>smart-data-loader</id>
       <dependencies>
         <dependency>

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -69,7 +69,7 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
     /**
      * Constructor to be used by subclasses.
      *
-     * @param outputFormat The well-known name of the format, not {@code null}
+     * @param format The well-known name of the format, not {@code null}
      * @param jsonp {@code true} if specified format uses JSONP
      */
     protected GeoJSONGetFeatureResponse(GeoServer gs, String format, boolean jsonp) {

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -52,6 +52,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  *
  * @author Simone Giannecchini, GeoSolutions
  * @author Carlo Cancellieri - GeoSolutions
+ * @author Carsten Klein, DataGis
  */
 public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
         implements ComplexFeatureAwareFormat {
@@ -63,6 +64,17 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
     public GeoJSONGetFeatureResponse(GeoServer gs, String format) {
         super(gs, format);
         jsonp = JSONType.isJsonpMimeType(format);
+    }
+
+    /**
+     * Constructor to be used by subclasses.
+     *
+     * @param outputFormat The well-known name of the format, not <code>null</code>
+     * @param jsonp <code>true</code> if specified format uses JSONP
+     */
+    protected GeoJSONGetFeatureResponse(GeoServer gs, String format, boolean jsonp) {
+        super(gs, format);
+        this.jsonp = jsonp;
     }
 
     /** capabilities output format string. */
@@ -334,13 +346,13 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
             FeatureCollectionResponse response, Operation operation, GeoJSONBuilder jw) {}
 
     /** Container class for information related with a group of features. */
-    private class FeaturesInfo {
+    protected class FeaturesInfo {
 
         final CoordinateReferenceSystem crs;
         final boolean hasGeometry;
         public long featureCount;
 
-        private FeaturesInfo(
+        protected FeaturesInfo(
                 CoordinateReferenceSystem crs, boolean hasGeometry, long featureCount) {
             this.crs = crs;
             this.hasGeometry = hasGeometry;

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONGetFeatureResponse.java
@@ -69,8 +69,8 @@ public class GeoJSONGetFeatureResponse extends WFSGetFeatureOutputFormat
     /**
      * Constructor to be used by subclasses.
      *
-     * @param outputFormat The well-known name of the format, not <code>null</code>
-     * @param jsonp <code>true</code> if specified format uses JSONP
+     * @param outputFormat The well-known name of the format, not {@code null}
+     * @param jsonp {@code true} if specified format uses JSONP
      */
     protected GeoJSONGetFeatureResponse(GeoServer gs, String format, boolean jsonp) {
         super(gs, format);


### PR DESCRIPTION
This module adds the SpatialJSON WFS output format. The SpatialJSON format is a more compact and memory-friendly variant of GeoServer's GeoJSON format. It aims to save space by applying several optimizations to traditional GeoJSON format for  simple feature results. Most of these optimizations work by removing redundand information from the JSON-encoded features.

A service exception is thrown if the result contains complex features as the SpatialJSON format does not handle those.

See the [README.md](https://github.com/cklein05/geoserver/tree/spatialjson/src/community/spatialjson) for a more detailed description of the format.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).