### PR TITLE
[GEOS-10709] Schemaless Features - Simplified property access might return values for wrong property names

### DIFF
--- a/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
+++ b/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.schemalessfeatures.mongodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -15,6 +16,7 @@ import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geotools.data.FeatureSource;
+import org.geotools.data.Query;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
@@ -126,6 +128,24 @@ public class SchemalessCollectionTest extends AbstractMongoDBOnlineTestSupport {
             Object result = pn.evaluate(f);
             List<Number> values = (List<Number>) result;
             assertAvg(values);
+        }
+    }
+
+    @Test
+    public void testWrongPropertyName() throws Exception {
+        FeatureTypeInfo fti =
+                getCatalog().getFeatureTypeByName("gs:" + StationsTestSetup.COLLECTION_NAME);
+        @SuppressWarnings("unchecked")
+        FeatureSource<FeatureType, Feature> source =
+                (FeatureSource<FeatureType, Feature>) fti.getFeatureSource(null, null);
+        FeatureCollection<FeatureType, Feature> collection = source.getFeatures(Query.ALL);
+
+        FeatureIterator<Feature> it = collection.features();
+        PropertyName pn = FF.property("some_wrong_heading.measurements.values.value");
+        while (it.hasNext()) {
+            Feature f = it.next();
+            Object result = pn.evaluate(f);
+            assertNull(result);
         }
     }
 

--- a/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
+++ b/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
@@ -98,14 +98,17 @@ public class SchemalessPropertyAccessorFactory implements PropertyAccessorFactor
             for (int i = 0; i < path.length; i++) {
                 String pathPart = path[i];
                 result = walkComplexAttribute(complexAttribute, pathPart);
-                if (result instanceof ComplexAttribute)
+                if (result instanceof ComplexAttribute) {
                     complexAttribute = (ComplexAttribute) result;
-                else if (result instanceof List) {
+                } else if (result instanceof List) {
                     @SuppressWarnings("unchecked")
                     List<Object> attributes = List.class.cast(result);
                     List<Object> results = walkList(attributes, path, i);
-                    if (results.size() == 1) return results.get(0);
-                    else return results;
+                    if (results.size() == 1) result = results.get(0);
+                    else result = results;
+                    break;
+                } else if (result == null) {
+                    break;
                 }
             }
             return result;


### PR DESCRIPTION
[![GEOS-10709](https://badgen.net/badge/JIRA/GEOS-10709/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10709)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->