### PR TITLE
[Backport 2.21.x] [GEOS-10700] Restore ability to customize built-in logging profiles along with profile update procedure

### DIFF
--- a/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
@@ -59,6 +59,12 @@ public class LoggingStartupContextListener implements ServletContextListener {
             return;
         }
 
+        String updateBuiltInLoggingProfiles =
+                GeoServerExtensions.getProperty(
+                        LoggingUtils.UPDATE_BUILT_IN_LOGGING_PROFILES, context);
+
+        LoggingUtils.updateBuiltInLoggingProfiles = Boolean.valueOf(updateBuiltInLoggingProfiles);
+
         try {
             File baseDir = new File(GeoServerResourceLoader.lookupGeoServerDataDirectory(context));
 

--- a/src/main/src/main/java/org/geoserver/logging/LoggingUtils.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingUtils.java
@@ -32,7 +32,7 @@ import org.vfny.geoserver.global.ConfigurationException;
  * bridge).
  *
  * <p>To troubleshoot use {@code org.apache.logging.log4j.simplelog.StatusLogger.level=DEBUG}, or
- * adjust {@code log4j2.xml} file &lt;Configuration status=&quote;trace&quote;&gt;.
+ * adjust {@code log4j2.xml} file {@code <Configuration status="trace">}.
  *
  * @see org.geoserver.config.LoggingInfo
  */
@@ -47,10 +47,20 @@ public class LoggingUtils {
      */
     public static final String RELINQUISH_LOG4J_CONTROL = "RELINQUISH_LOG4J_CONTROL";
 
-    // public static String loggingLocation;
-
-    /** Value of loggingRedirection established by {@link LoggingStartupContextListener}. */
+    /** Logging redirection value established by {@link LoggingStartupContextListener}. */
     static boolean relinquishLog4jControl = false;
+
+    /**
+     * Property used to enable update of built-in logging profiles on startup.
+     *
+     * <p>Use {@code -DUPDATE_BUILT_IN_LOGGING_PROFILES=true} to allow GeoServer to update built-in
+     * logging profiles during startup.
+     */
+    public static final String UPDATE_BUILT_IN_LOGGING_PROFILES =
+            "UPDATE_BUILT_IN_LOGGING_PROFILES";
+
+    /** Logging profile update policy established by {@link LoggingStartupContextListener}. */
+    static boolean updateBuiltInLoggingProfiles = false;
 
     /**
      * Property used override Log4J default, and force use of another logging framework.

--- a/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
+++ b/src/main/src/test/java/org/geoserver/logging/LoggingStartupContextListenerTest.java
@@ -9,13 +9,21 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.regex.Pattern.DOTALL;
 import static org.geoserver.logging.GeoServerXMLConfiguration.attributeGet;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.servlet.ServletContextEvent;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -56,6 +64,87 @@ public class LoggingStartupContextListenerTest {
     @AfterClass
     public static void reset() {
         Locale.setDefault(systemLocale);
+    }
+
+    @Test
+    public void testUpdateBuiltInLoggingProfile() throws Exception {
+
+        final File TARGET_DIR = new File("./target");
+        final File LOGS_DIR = new File(TARGET_DIR, "logs");
+        final File DEFAULT_LOGGING_FILE = new File(LOGS_DIR, "DEFAULT_LOGGING.xml");
+
+        FileUtils.deleteQuietly(LOGS_DIR);
+        GeoServerResourceLoader loader = new GeoServerResourceLoader(TARGET_DIR);
+
+        // make it copy the log files
+        LoggingUtils.initLogging(loader, "DEFAULT_LOGGING.xml", false, true, null);
+        assertTrue("DEFAULT_LOGGING.xml created", DEFAULT_LOGGING_FILE.exists());
+
+        // customize with a comment
+        try (FileWriter fileWriter = new FileWriter(DEFAULT_LOGGING_FILE, true);
+                BufferedWriter buffered = new BufferedWriter(fileWriter);
+                PrintWriter writer = new PrintWriter(buffered)) {
+            writer.println("# Hello World");
+        }
+        try (Stream<String> stream = Files.lines(Paths.get(DEFAULT_LOGGING_FILE.getPath()))) {
+            boolean found = stream.anyMatch(lines -> lines.contains("# Hello World"));
+            assertTrue("default logging customized", found);
+        }
+
+        // Use UPDATE_BUILT_IN_LOGGING_PROFILES policy to restore built-in definition
+        try {
+            LoggingUtils.updateBuiltInLoggingProfiles = true;
+
+            // update built-in DEFAULT_LOGGING.xml
+            LoggingUtils.initLogging(loader, "DEFAULT_LOGGING.xml", false, true, null);
+        } finally {
+            LoggingUtils.updateBuiltInLoggingProfiles = false;
+        }
+
+        try (Stream<String> stream = Files.lines(Paths.get(DEFAULT_LOGGING_FILE.getPath()))) {
+            boolean found = stream.anyMatch(lines -> lines.contains("# Hello World"));
+            assertFalse("default logging customized", found);
+        }
+    }
+
+    @Test
+    public void testAvoidCustomizationOverwrite() throws Exception {
+        final File target = new File("./target/logs-customize");
+        File logs = new File(target, "logs");
+        FileUtils.deleteQuietly(logs);
+        GeoServerResourceLoader loader = new GeoServerResourceLoader(target);
+        FileSystemResourceStore store = (FileSystemResourceStore) loader.getResourceStore();
+        store.setLockProvider(new MemoryLockProvider());
+
+        // make it copy the log files
+        LoggingUtils.initLogging(loader, "VERBOSE_LOGGING.xml", false, false, null);
+
+        // customize the verbose logging profile
+        File verbose = new File(logs, "VERBOSE_LOGGING.xml");
+        String xml = FileUtils.readFileToString(verbose, StandardCharsets.UTF_8);
+        String xmlUpdated = xml.replace("trace", "debug");
+        FileUtils.writeStringToFile(verbose, xmlUpdated, StandardCharsets.UTF_8);
+        long lastModified = verbose.lastModified();
+
+        // switch to that logging profile, this will generate some logs
+        LoggingUtils.initLogging(loader, "VERBOSE_LOGGING.xml", false, false, null);
+        try (TestAppender appender = TestAppender.createAppender("override-test", null)) {
+            appender.startRecording("org.geoserver.logging");
+
+            // file was not modified
+            assertEquals(lastModified, verbose.lastModified());
+
+            // two log messages, one above, one below threshold
+            Logger logger = LogManager.getLogger("org.geoserver.logging");
+            logger.debug("Should appear");
+            logger.trace("Should not appear");
+
+            appender.stopRecording("org.geoserver.logging");
+
+            // check the messages have been filtered by level as expected
+            appender.assertTrue("Should appear");
+            appender.assertFalse("Should not appear");
+        }
     }
 
     @Test
@@ -153,18 +242,41 @@ public class LoggingStartupContextListenerTest {
     @Test
     public void testInitLoggingLock() throws Exception {
 
-        final File target = new File("./target");
-        FileUtils.deleteQuietly(new File(target, "logs"));
-        GeoServerResourceLoader loader = new GeoServerResourceLoader(target);
+        final File TARGET_DIR = new File("./target");
+        final File LOGS_DIR = new File(TARGET_DIR, "logs");
+        final File DEFAULT_LOGGING_FILE = new File(LOGS_DIR, "DEFAULT_LOGGING.xml");
+
+        FileUtils.deleteQuietly(LOGS_DIR);
+        GeoServerResourceLoader loader = new GeoServerResourceLoader(TARGET_DIR);
         FileSystemResourceStore store = (FileSystemResourceStore) loader.getResourceStore();
         store.setLockProvider(new MemoryLockProvider());
 
         // make it copy the log files
         LoggingUtils.initLogging(loader, "DEFAULT_LOGGING.xml", false, true, null);
+        assertTrue("DEFAULT_LOGGING.xml created", DEFAULT_LOGGING_FILE.exists());
+
         // init once from default logging
         LoggingUtils.initLogging(loader, "DEFAULT_LOGGING.xml", false, true, null);
         // init twice, here it used to lock up
         LoggingUtils.initLogging(loader, "DEFAULT_LOGGING.xml", false, true, null);
+
+        try (FileWriter fileWriter = new FileWriter(DEFAULT_LOGGING_FILE, true);
+                BufferedWriter buffered = new BufferedWriter(fileWriter);
+                PrintWriter writer = new PrintWriter(buffered)) {
+            writer.println("# Hello World");
+        }
+        try (Stream<String> stream = Files.lines(Paths.get(DEFAULT_LOGGING_FILE.getPath()))) {
+            boolean found = stream.anyMatch(lines -> lines.contains("# Hello World"));
+            assertTrue("default logging customized", found);
+        }
+        try {
+            System.getProperties().put("UPDATE_BUILT_IN_LOGGING_PROFILES", "true");
+
+            // update built-in DEFAULT_LOGGING.xml
+            LoggingUtils.initLogging(loader, "DEFAULT_LOGGING.xml", false, true, null);
+        } finally {
+            System.getProperties().remove("UPDATE_BUILT_IN_LOGGING_PROFILES");
+        }
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10700](https://badgen.net/badge/JIRA/GEOS-10700/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10700)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport of https://github.com/geoserver/geoserver/pull/6254