### PR TITLE
[GEOS-10756] Add support for manual configuration of start and end value in WMS Layer Dimensions

### DIFF
--- a/doc/en/api/1.0.0/coverages.yaml
+++ b/doc/en/api/1.0.0/coverages.yaml
@@ -577,7 +577,8 @@ paths:
               featureType:              
                 $ref: "#/definitions/CoverageInfo"
           examples:
-            application/json: {
+            application/json: |
+                          {
                               "coverage": {
                                   "abstract": "Digital elevation model for the Spearfish region.\r\n\r\nsfdem is a Tagged Image File Format with Geographic information",
                                   "defaultInterpolationMethod": "nearest neighbor",
@@ -633,10 +634,25 @@ paths:
                                       "miny": 44.370187074132616
                                   },
                                   "metadata": {
-                                      "entry": {
-                                          "$": "sfdem_sfdem",
-                                          "@key": "dirName"
-                                      }
+                                      "entry": [
+                                        {
+                                            "$": "sfdem_sfdem",
+                                            "@key": "dirName"
+                                        },
+                                        {
+                                            "@key": "time",
+                                            "dimensionInfo": {
+                                                "enabled": true,
+                                                "presentation": "CONTINUOUS_INTERVAL",
+                                                "units": "ISO8601",
+                                                "defaultValue": "",
+                                                "nearestMatchEnabled": false,
+                                                "rawNearestMatchEnabled": false,
+                                                "startValue": 2001,
+                                                "endValue": "2017-09-01"
+                                            }
+                                        }
+                                      ]
                                   },
                                   "name": "sfdem",
                                   "namespace": {
@@ -756,8 +772,14 @@ paths:
                   <entry key="cacheAgeMax">10</entry>
                   <entry key="time">
                     <dimensionInfo>
-                      <enabled>false</enabled>
+                      <enabled>true</enabled>
+                      <presentation>CONTINUOUS_INTERVAL</presentation>
+                      <units>ISO8601</units>
                       <defaultValue/>
+                      <nearestMatchEnabled>false</nearestMatchEnabled>
+                      <rawNearestMatchEnabled>false</rawNearestMatchEnabled>
+                      <startValue>2001</startValue>
+                      <endValue>2017-09-01</endValue>
                     </dimensionInfo>
                   </entry>
                   <entry key="cachingEnabled">true</entry>

--- a/doc/en/api/1.0.0/featuretypes.yaml
+++ b/doc/en/api/1.0.0/featuretypes.yaml
@@ -421,6 +421,16 @@ paths:
                       {
                         "@key": "dirName",
                         "$": "DS_poi_poi"
+                      },
+                      {
+                        "@key": "time",
+                        "dimensionInfo": {
+                          "enabled": true,
+                          "attribute": "time",
+                          "presentation": "DISCRETE_INTERVAL",
+                          "startValue": "2020-05-01T00:00:00Z",
+                          "endValue": "2021-06-01T00:00:00Z"
+                        }
                       }
                     ]
                   },
@@ -538,8 +548,11 @@ paths:
                             <entry key="cacheAgeMax">3000</entry>
                             <entry key="time">
                                   <dimensionInfo>
-                                          <enabled>false</enabled>
-                                          <defaultValue/>
+                                          <enabled>true</enabled>
+                                          <attribute>time</attribute>
+                                          <presentation>DISCRETE_INTERVAL</presentation>
+                                          <startValue>2020-05-01T00:00:00Z</startValue>
+                                          <endValue>2021-06-01T00:00:00Z</endValue>
                                   </dimensionInfo>
                             </entry>
                             <entry key="cachingEnabled">true</entry>

--- a/doc/en/user/source/data/webadmin/layers.rst
+++ b/doc/en/user/source/data/webadmin/layers.rst
@@ -389,6 +389,16 @@ For each enabled dimension the following configuration options are available:
   Can be empty (no limit), a single value (symmetric search) or using a ``before/after`` syntax to
   specify an asymmetric search range. Time distances should specified using the ISO period syntax. For example, ``PT1H/PT0H`` allows to search up to one hour before the user specified value,
   but not after.
+* **Begin of data range**—A manually declared start value for the data range. When specified, the ``End of data range`` has to be specified also.
+  Has to be either numeric, an ISO 8601 DateTime format or the string ``PRESENT``. If left blank GeoServer will determine the value automatically
+  based on the data. When using 'PRESENT' the current DateTime of the server will be used when the capabilities document is generated.
+  Setting this value manually may be desired when working with layers consisting of huge amounts of data where the automatic determination can get slow.
+  This parameter is only handled for WMS Layers in their capabilities document.
+* **End of data range**—A manually declared end value for the data range. When specified, the ``Begin of data range`` has to be specified also.
+  Has to be either numeric, an ISO 8601 DateTime format or the string ``PRESENT``. If left blank GeoServer will determine the value automatically
+  based on the data. When using 'PRESENT' the current DateTime of the server will be used when the capabilities document is generated.
+  Setting this value manually may be desired when working with layers consisting of huge amounts of data where the automatic determination can get slow.
+  This parameter is only handled for WMS Layers in their capabilities document.
 
 For time dimension the value must be in ISO 8601 DateTime format ``yyyy-MM-ddThh:mm:ss.SSSZ`` For elevation dimension, the value must be and integer of floating point number.
 
@@ -424,6 +434,16 @@ For each enabled dimension the following configuration options are available:
 * **Acceptable interval**—A maximum search distance from the specified value (available only when nearest match is enabled).
   Can be empty (no limit), a single value (symmetric search) or using a ``before/after`` syntax to
   specify an asymmetric search range.
+* **Begin of data range**—A manually declared start value for the data range. When specified, the ``End of data range`` has to be specified also.
+  Has to be either numeric, an ISO 8601 DateTime format or the string ``PRESENT``. If left blank GeoServer will determine the value automatically
+  based on the data. When using 'PRESENT' the current DateTime of the server will be used when the capabilities document is generated.
+  Setting this value manually may be desired when working with layers consisting of huge amounts of data where the automatic determination can get slow.
+  This parameter is only handled for WMS Layers in their capabilities document.
+* **End of data range**—A manually declared end value for the data range. When specified, the ``Begin of data range`` has to be specified also.
+  Has to be either numeric, an ISO 8601 DateTime format or the string ``PRESENT``. If left blank GeoServer will determine the value automatically
+  based on the data. When using 'PRESENT' the current DateTime of the server will be used when the capabilities document is generated.
+  Setting this value manually may be desired when working with layers consisting of huge amounts of data where the automatic determination can get slow.
+  This parameter is only handled for WMS Layers in their capabilities document.
 
 Edit Layer: Security
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/restput.xml
+++ b/restput.xml
@@ -1,0 +1,9 @@
+<featureType>
+  <metadata>
+    <entry key="time">
+        <dimensionInfo>
+            <enabled>false</enabled>
+        </dimensionInfo>
+    </entry>
+  </metadata>
+</featureType>

--- a/src/main/src/main/java/org/geoserver/catalog/DimensionInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/DimensionInfo.java
@@ -122,4 +122,28 @@ public interface DimensionInfo extends Serializable {
      * #getAcceptableInterval()}.
      */
     public void setAcceptableInterval(String acceptableInterval);
+
+    /**
+     * Returns the start value for the data range, which will be used in capabilities documents. Has
+     * to be either numeric, of type ISO8601 DateTime or the string "PRESENT" which will use the
+     * current DateTime when the capabilities document is generated.
+     *
+     * @return the value for startValue
+     */
+    public String getStartValue();
+
+    /** Sets the startValue for the data range */
+    public void setStartValue(String startValue);
+
+    /**
+     * Returns the end value for the data range, which will be used in capabilities documents. Has
+     * to be either numeric, of type ISO8601 DateTime or the string "PRESENT" which will use the
+     * current DateTime when the capabilities document is generated.
+     *
+     * @return the value for endValue
+     */
+    public String getEndValue();
+
+    /** Sets the endValue for the data range */
+    public void setEndValue(String endValue);
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/DimensionInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/DimensionInfoImpl.java
@@ -44,6 +44,10 @@ public class DimensionInfoImpl implements DimensionInfo {
 
     String acceptableInterval;
 
+    String startValue;
+
+    String endValue;
+
     /** The default constructor */
     public DimensionInfoImpl() {
         super();
@@ -62,6 +66,8 @@ public class DimensionInfoImpl implements DimensionInfo {
         this.defaultValue = info.getDefaultValue();
         this.nearestMatchEnabled = info.isNearestMatchEnabled();
         this.rawNearestMatchEnabled = info.isRawNearestMatchEnabled();
+        this.startValue = info.getStartValue();
+        this.endValue = info.getEndValue();
     }
 
     @Override
@@ -167,6 +173,26 @@ public class DimensionInfoImpl implements DimensionInfo {
     }
 
     @Override
+    public String getStartValue() {
+        return startValue;
+    }
+
+    @Override
+    public void setStartValue(String startValue) {
+        this.startValue = startValue;
+    }
+
+    @Override
+    public String getEndValue() {
+        return endValue;
+    }
+
+    @Override
+    public void setEndValue(String endValue) {
+        this.endValue = endValue;
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("DimensionInfoImpl [attribute=").append(attribute);
@@ -179,6 +205,8 @@ public class DimensionInfoImpl implements DimensionInfo {
         sb.append(", nearest=").append(nearestMatchEnabled);
         sb.append(", rawNearestMatch=").append(rawNearestMatchEnabled);
         sb.append(", acceptableInterval=").append(acceptableInterval);
+        sb.append(", startValue=").append(startValue);
+        sb.append(", endValue=").append(endValue);
         sb.append("]");
         return sb.toString();
     }
@@ -204,6 +232,8 @@ public class DimensionInfoImpl implements DimensionInfo {
                                 : rawNearestMatchEnabled.hashCode());
         result =
                 prime * result + ((acceptableInterval == null) ? 0 : acceptableInterval.hashCode());
+        result = prime * result + ((startValue == null) ? 0 : startValue.hashCode());
+        result = prime * result + ((endValue == null) ? 0 : endValue.hashCode());
         return result;
     }
 
@@ -222,7 +252,9 @@ public class DimensionInfoImpl implements DimensionInfo {
                 && Objects.equals(defaultValue, that.defaultValue)
                 && Objects.equals(nearestMatchEnabled, that.nearestMatchEnabled)
                 && Objects.equals(rawNearestMatchEnabled, that.rawNearestMatchEnabled)
-                && Objects.equals(acceptableInterval, that.acceptableInterval);
+                && Objects.equals(acceptableInterval, that.acceptableInterval)
+                && Objects.equals(startValue, that.startValue)
+                && Objects.equals(endValue, that.endValue);
     }
 
     @Override

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -1922,6 +1922,40 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
     }
 
     /**
+     * Adds static start and end data range values to the specified layer.
+     *
+     * @param layer The layer name
+     * @param dimensionName The dimension name (key in the resource metadata map)
+     * @param startValue The startValue
+     * @param endValue The endValue
+     */
+    protected void setupVectorStartAndEndValues(
+            QName layer, String dimensionName, String startValue, String endValue) {
+        ResourceInfo info = getCatalog().getResourceByName(getLayerId(layer), ResourceInfo.class);
+        DimensionInfo di = info.getMetadata().get(dimensionName, DimensionInfo.class);
+        di.setStartValue(startValue);
+        di.setEndValue(endValue);
+        getCatalog().save(info);
+    }
+
+    /**
+     * Adds static start and end data range values to the specified layer.
+     *
+     * @param layer The layer name
+     * @param dimensionName The dimension name (key in the resource metadata map)
+     * @param startValue The startValue
+     * @param endValue The endValue
+     */
+    protected void setupRasterStartAndEndValues(
+            QName layer, String dimensionName, String startValue, String endValue) {
+        CoverageInfo info = getCatalog().getCoverageByName(layer.getLocalPart());
+        DimensionInfo di = info.getMetadata().get(dimensionName, DimensionInfo.class);
+        di.setStartValue(startValue);
+        di.setEndValue(endValue);
+        getCatalog().save(info);
+    }
+
+    /**
      * Asserts that the image is not blank, in the sense that there must be pixels different from
      * the passed background color.
      *

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/DimensionEditor.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/DimensionEditor.html
@@ -61,6 +61,14 @@
               <input type="text" wicket:id="acceptableInterval" class="field text" />
             </div>
           </li>
+          <li wicket:id="startEndContainer">
+            <label><wicket:message key="startValue">startValue</wicket:message></label>
+            <input type="text" wicket:id="startValue" class="field text" />
+            &nbsp;<em><span class="error" wicket:id="startValueValidationMsg"></span></em>
+            <label><wicket:message key="endValue">endValue</wicket:message></label>
+            <input type="text" wicket:id="endValue" class="field text" />
+            &nbsp;<em><span class="error" wicket:id="endValueValidationMsg"></span></em>
+          </li>
         </ul>
       </li>
     </ul>

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/VectorCustomDimensionEditor.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/VectorCustomDimensionEditor.html
@@ -64,6 +64,14 @@
               <input type="text" wicket:id="acceptableInterval" class="field text" />
             </div>
           </li>
+          <li wicket:id="startEndContainer">
+            <label><wicket:message key="startValue">startValue</wicket:message></label>
+            <input type="text" wicket:id="startValue" class="field text" />
+            &nbsp;<em><span class="error" wicket:id="startValueValidationMsg"></span></em>
+            <label><wicket:message key="endValue">endValue</wicket:message></label>
+            <input type="text" wicket:id="endValue" class="field text" />
+            &nbsp;<em><span class="error" wicket:id="endValueValidationMsg"></span></em>
+          </li>
         </ul>
       </li>
     </ul>

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/VectorCustomDimensionEntry.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/VectorCustomDimensionEntry.java
@@ -148,6 +148,26 @@ public class VectorCustomDimensionEntry implements DimensionInfo {
     }
 
     @Override
+    public String getStartValue() {
+        return dimensionInfo.getStartValue();
+    }
+
+    @Override
+    public void setStartValue(String startValue) {
+        dimensionInfo.setStartValue(startValue);
+    }
+
+    @Override
+    public String getEndValue() {
+        return dimensionInfo.getEndValue();
+    }
+
+    @Override
+    public void setEndValue(String endValue) {
+        dimensionInfo.setEndValue(endValue);
+    }
+
+    @Override
     public boolean isRawNearestMatchEnabled() {
         // raw nearest match isn't implemented on vectors, yet.
         return false;

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -1107,11 +1107,15 @@ DimensionEditor.referenceValue.invalidTimeReferenceValue = Reference time value 
 DimensionEditor.referenceValue.invalidElevationReferenceValue = Reference elevation value must be numeric
 DimensionEditor.referenceValue.emptyReferenceValue = Reference value cannot not be empty
 DimensionEditor.invalidAcceptableInterval = Invalid syntax for acceptable interval: '${actual}'. Must be empty, a single value, or two values separated by slash. Time values must use the ISO period syntax (e.g., PT1H)
+DimensionEditor.invalidStartOrEndDate = ${valuePrefix} data range value must be an ISO8601 DateTime or a construct like 'PRESENT'
+DimensionEditor.invalidStartOrEndElevation = ${valuePrefix} data range value must be numeric
 
 DimensionEditor.nearestMatch = Nearest Match
 # Update this text if we implement nearest match for WFS too, in the future
 DimensionEditor.rawNearestMatch = Nearest Match On raw data (WCS)
 DimensionEditor.acceptableInterval = Acceptable Interval
+DimensionEditor.startValue = Begin of data range
+DimensionEditor.endValue = End of data range
 
 VectorCustomDimensionEditor.customDimName = Dimension Name
 VectorCustomDimensionEditor.enabled                          = Enabled
@@ -1141,6 +1145,10 @@ VectorCustomDimensionEditor.invalidAcceptableInterval = Invalid syntax for accep
 
 VectorCustomDimensionEditor.nearestMatch = Nearest Match
 VectorCustomDimensionEditor.acceptableInterval = Acceptable Interval
+
+VectorCustomDimensionEditor.startValue = Begin of data range
+VectorCustomDimensionEditor.endValue = End of data range
+VectorCustomDimensionEditor.invalidStartOrEndCustom = ${valuePrefix} data range value must be numeric, an ISO8601 DateTime or a construct like 'PRESENT'
 
 VectorCustomDimensionEditor.removeButton = Remove
 

--- a/src/wms/src/test/java/org/geoserver/wms/dimension/DimensionInfoSerializationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/dimension/DimensionInfoSerializationTest.java
@@ -53,6 +53,32 @@ public class DimensionInfoSerializationTest extends WMSTestSupport {
         assertBackAndForthSerialization(Strategy.NEAREST, "2014-01-24T13:25:00.000Z");
     }
 
+    @Test
+    public void testDimensionRangeXMLSerialization() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+        DimensionInfo di = new DimensionInfoImpl();
+        di.setStartValue(startValue);
+        di.setEndValue(endValue);
+        Document doc = marshallToXML(di);
+
+        assertXpathExists("//startValue", doc);
+        assertXpathEvaluatesTo(startValue, "//startValue", doc);
+        assertXpathExists("//endValue", doc);
+        assertXpathEvaluatesTo(endValue, "//endValue", doc);
+
+        DimensionInfo di2 = unmarshallFromXML(doc);
+        assertEquals(
+                "Unmarshalled startValue does not match the original one",
+                di2.getStartValue(),
+                startValue);
+
+        assertEquals(
+                "Unmarshalled endValue does not match the original one",
+                di2.getEndValue(),
+                endValue);
+    }
+
     protected void assertBackAndForthSerialization(Strategy used) throws Exception {
         assertBackAndForthSerialization(used, null);
     }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsRasterCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsRasterCapabilitiesTest.java
@@ -374,4 +374,96 @@ public class DimensionsRasterCapabilitiesTest extends WMSDimensionsTestSupport {
         assertXpathEvaluatesTo("20.0", "//Layer/Extent/@default", dom);
         assertXpathEvaluatesTo("20.0/150.0/0", "//Layer/Extent", dom);
     }
+
+    @Test
+    public void testStaticTimeRange() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.TIME,
+                DimensionPresentation.DISCRETE_INTERVAL,
+                Double.valueOf(1000 * 60 * 60 * 12),
+                null,
+                null);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT12H", "//Layer/Extent", dom);
+    }
+
+    @Test
+    public void testStaticTimeRangeContinuous() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.TIME,
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                null,
+                null);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT1S",
+                "//Layer[Name='sf:timeranges']/Extent",
+                dom);
+    }
+
+    @Test
+    public void testStaticElevationRange() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.ELEVATION,
+                DimensionPresentation.DISCRETE_INTERVAL,
+                1.1,
+                UNITS,
+                UNIT_SYMBOL);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo("-11034.0/8848.86/1.1", "//Layer[Name='sf:timeranges']/Extent", dom);
+    }
+
+    @Test
+    public void testStaticElevationRangeContinuous() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.ELEVATION,
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                UNITS,
+                UNIT_SYMBOL);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo("-11034.0/8848.86/0", "//Layer[Name='sf:timeranges']/Extent", dom);
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorCapabilitiesTest.java
@@ -690,6 +690,161 @@ public class DimensionsVectorCapabilitiesTest extends WMSDimensionsTestSupport {
         assertXpathEvaluatesTo("0.0/3.0/0", "//Layer/Extent", dom);
     }
 
+    @Test
+    public void testStaticTimeRange() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupVectorDimension(
+                ResourceInfo.TIME,
+                "time",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                Double.valueOf(1000 * 60 * 60 * 12),
+                null,
+                null);
+
+        setupVectorStartAndEndValues(V_TIME_ELEVATION, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT12H",
+                "//Layer[Name='sf:TimeElevation']/Extent",
+                dom);
+    }
+
+    @Test
+    public void testStaticTimeRangeContinuous() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupVectorDimension(
+                ResourceInfo.TIME,
+                "time",
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                null,
+                null);
+
+        setupVectorStartAndEndValues(V_TIME_ELEVATION, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT1S",
+                "//Layer[Name='sf:TimeElevation']/Extent",
+                dom);
+    }
+
+    @Test
+    public void testStaticElevationRange() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupVectorDimension(
+                ResourceInfo.ELEVATION,
+                "time",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                1.0,
+                null,
+                null);
+
+        setupVectorStartAndEndValues(
+                V_TIME_ELEVATION, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "-11034.0/8848.86/1.0", "//Layer[Name='sf:TimeElevation']/Extent", dom);
+    }
+
+    @Test
+    public void testStaticElevationRangeContinuous() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupVectorDimension(
+                ResourceInfo.ELEVATION,
+                "time",
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                null,
+                null);
+
+        setupVectorStartAndEndValues(
+                V_TIME_ELEVATION, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "-11034.0/8848.86/0", "//Layer[Name='sf:TimeElevation']/Extent", dom);
+    }
+
+    @Test
+    public void testStaticCustomRange() throws Exception {
+        String startValue = "-3";
+        String endValue = "8848.86";
+
+        setupVectorDimension(
+                "dim_custom",
+                "custom",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                1.0,
+                UNITS,
+                UNIT_SYMBOL);
+
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName("TimeElevation");
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setStartValue(startValue);
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setEndValue(endValue);
+        getCatalog().save(info);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("custom", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(UNITS, "//Layer/Dimension/@units", dom);
+        assertXpathEvaluatesTo(UNIT_SYMBOL, "//Layer/Dimension/@unitSymbol", dom);
+        assertXpathEvaluatesTo("-3.0/8848.86/1.0", "//Layer[Name='sf:TimeElevation']/Extent", dom);
+    }
+
+    @Test
+    public void testStaticCustomDateRange() throws Exception {
+        String startValue = "2021-01";
+        String endValue = "2022-04-05T01:20:00Z";
+
+        setupVectorDimension(
+                "dim_custom",
+                "custom",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                Double.valueOf(1000 * 60 * 60 * 24),
+                UNITS,
+                UNIT_SYMBOL);
+
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName("TimeElevation");
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setStartValue(startValue);
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setEndValue(endValue);
+        getCatalog().save(info);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.1.1"), false);
+
+        assertXpathEvaluatesTo("1", "count(//Layer/Dimension)", dom);
+        assertXpathEvaluatesTo("custom", "//Layer/Dimension/@name", dom);
+        assertXpathEvaluatesTo(UNITS, "//Layer/Dimension/@units", dom);
+        assertXpathEvaluatesTo(UNIT_SYMBOL, "//Layer/Dimension/@unitSymbol", dom);
+        assertXpathEvaluatesTo(
+                "2021-01-01T00:00:00.000Z/2022-04-05T01:20:00.000Z/P1D",
+                "//Layer[Name='sf:TimeElevation']/Extent",
+                dom);
+    }
+
     protected TestResourceAccessManager getResourceAccessManager() {
         return (TestResourceAccessManager) applicationContext.getBean("testResourceAccessManager");
     }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/DimensionsRasterCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/DimensionsRasterCapabilitiesTest.java
@@ -249,4 +249,98 @@ public class DimensionsRasterCapabilitiesTest extends WMSDimensionsTestSupport {
         assertXpathEvaluatesTo("time", "//wms:Layer/wms:Dimension/@name", dom);
         assertXpathEvaluatesTo("P1M/PRESENT", "//wms:Layer/wms:Dimension/@default", dom);
     }
+
+    @Test
+    public void testStaticTimeRange() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.TIME,
+                DimensionPresentation.DISCRETE_INTERVAL,
+                Double.valueOf(1000 * 60 * 60 * 12),
+                null,
+                null);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT12H",
+                "//wms:Layer/wms:Dimension",
+                dom);
+    }
+
+    @Test
+    public void testStaticTimeRangeContinuous() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.TIME,
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                null,
+                null);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT1S",
+                "//wms:Layer/wms:Dimension",
+                dom);
+    }
+
+    @Test
+    public void testStaticElevationRange() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.ELEVATION,
+                DimensionPresentation.DISCRETE_INTERVAL,
+                1.1,
+                UNITS,
+                UNIT_SYMBOL);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo("-11034.0/8848.86/1.1", "//wms:Layer/wms:Dimension", dom);
+    }
+
+    @Test
+    public void testStaticElevationRangeContinuous() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupRasterDimension(
+                TIMERANGES,
+                ResourceInfo.ELEVATION,
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                UNITS,
+                UNIT_SYMBOL);
+
+        setupRasterStartAndEndValues(TIMERANGES, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo("-11034.0/8848.86/0", "//wms:Layer/wms:Dimension", dom);
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/DimensionsVectorCapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/DimensionsVectorCapabilitiesTest.java
@@ -733,6 +733,159 @@ public class DimensionsVectorCapabilitiesTest extends WMSDimensionsTestSupport {
         assertXpathEvaluatesTo("0.0,1.0,2.0,3.0", "//wms:Layer/wms:Dimension", dom);
     }
 
+    @Test
+    public void testStaticTimeRange() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupVectorDimension(
+                ResourceInfo.TIME,
+                "time",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                Double.valueOf(1000 * 60 * 60 * 12),
+                null,
+                null);
+
+        setupVectorStartAndEndValues(V_TIME_ELEVATION, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT12H",
+                "//wms:Layer/wms:Dimension",
+                dom);
+    }
+
+    @Test
+    public void testStaticTimeRangeContinuous() throws Exception {
+        String startValue = "2014-01-24T13:25:00.000Z";
+        String endValue = "2021";
+
+        setupVectorDimension(
+                ResourceInfo.TIME,
+                "time",
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                null,
+                null);
+
+        setupVectorStartAndEndValues(V_TIME_ELEVATION, ResourceInfo.TIME, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("time", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo(
+                "2014-01-24T13:25:00.000Z/2021-01-01T00:00:00.000Z/PT1S",
+                "//wms:Layer/wms:Dimension",
+                dom);
+    }
+
+    @Test
+    public void testStaticElevationRange() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupVectorDimension(
+                ResourceInfo.ELEVATION,
+                "time",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                1.0,
+                null,
+                null);
+
+        setupVectorStartAndEndValues(
+                V_TIME_ELEVATION, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo("-11034.0/8848.86/1.0", "//wms:Layer/wms:Dimension", dom);
+    }
+
+    @Test
+    public void testStaticElevationRangeContinuous() throws Exception {
+        String startValue = "-11034.0";
+        String endValue = "8848.86";
+
+        setupVectorDimension(
+                ResourceInfo.ELEVATION,
+                "time",
+                DimensionPresentation.CONTINUOUS_INTERVAL,
+                null,
+                null,
+                null);
+
+        setupVectorStartAndEndValues(
+                V_TIME_ELEVATION, ResourceInfo.ELEVATION, startValue, endValue);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("elevation", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo("-11034.0/8848.86/0", "//wms:Layer/wms:Dimension", dom);
+    }
+
+    @Test
+    public void testStaticCustomRange() throws Exception {
+        String startValue = "-3";
+        String endValue = "8848.86";
+
+        setupVectorDimension(
+                "dim_custom",
+                "custom",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                1.0,
+                UNITS,
+                UNIT_SYMBOL);
+
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName("TimeElevation");
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setStartValue(startValue);
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setEndValue(endValue);
+        getCatalog().save(info);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("custom", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo(UNITS, "//wms:Layer/wms:Dimension/@units", dom);
+        assertXpathEvaluatesTo(UNIT_SYMBOL, "//wms:Layer/wms:Dimension/@unitSymbol", dom);
+        assertXpathEvaluatesTo("-3.0/8848.86/1.0", "//wms:Layer/wms:Dimension", dom);
+    }
+
+    @Test
+    public void testStaticCustomDateRange() throws Exception {
+        String startValue = "2021-01";
+        String endValue = "2022-04-05T01:20:00Z";
+
+        setupVectorDimension(
+                "dim_custom",
+                "custom",
+                DimensionPresentation.DISCRETE_INTERVAL,
+                Double.valueOf(1000 * 60 * 60 * 24),
+                UNITS,
+                UNIT_SYMBOL);
+
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName("TimeElevation");
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setStartValue(startValue);
+        info.getMetadata().get("dim_custom", DimensionInfo.class).setEndValue(endValue);
+        getCatalog().save(info);
+
+        Document dom = dom(get("wms?request=getCapabilities&version=1.3.0"), false);
+
+        assertXpathEvaluatesTo("1", "count(//wms:Layer/wms:Dimension)", dom);
+        assertXpathEvaluatesTo("custom", "//wms:Layer/wms:Dimension/@name", dom);
+        assertXpathEvaluatesTo(UNITS, "//wms:Layer/wms:Dimension/@units", dom);
+        assertXpathEvaluatesTo(UNIT_SYMBOL, "//wms:Layer/wms:Dimension/@unitSymbol", dom);
+        assertXpathEvaluatesTo(
+                "2021-01-01T00:00:00.000Z/2022-04-05T01:20:00.000Z/P1D",
+                "//wms:Layer/wms:Dimension",
+                dom);
+    }
+
     protected TestResourceAccessManager getResourceAccessManager() {
         return (TestResourceAccessManager) applicationContext.getBean("testResourceAccessManager");
     }


### PR DESCRIPTION
[![GEOS-10756](https://badgen.net/badge/JIRA/GEOS-10756/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10756)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This adds two new input fields in the Dimensions Tab of a layer.
The fields allow to manually specify the start and end datetime GeoServer should use when generating the capabilities for this layer:

![image](https://user-images.githubusercontent.com/1381363/196456249-8bc0cbba-b7c1-4b6e-a31b-01bc82e08d26.png)


Values have to be ISO8601 or the string `PRESENT` to reflect the current DateTime in the Capabilities.
The settings from the screenshot above lead to the following capabilities for that layer:

![image](https://user-images.githubusercontent.com/1381363/196454863-ed7972d2-ebad-47fb-87db-e629717305d6.png)

When specifying start and end times, the automatic detection of those which GeoServer usually does is skipped and the given values are used.

This is especially useful when working with layers that are based on very large datasets, as the auto detection may become very slow / unresponding leading to slow / unresponsive capabilities responses.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->