### PR TITLE
GEOS-10717: XStreamServiceLoader performance improvement with XstreamPersister caching

### DIFF
--- a/src/main/src/test/java/org/geoserver/config/util/XStreamServiceLoaderTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamServiceLoaderTest.java
@@ -1,0 +1,66 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.impl.GeoServerImpl;
+import org.geoserver.config.impl.ServiceInfoImpl;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.Resource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class XStreamServiceLoaderTest {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testXstreamPersisterReusedIfCalledWithSameGeoServerInstance() throws Exception {
+        GeoServerResourceLoader rl = new GeoServerResourceLoader(folder.getRoot());
+
+        XStreamServiceLoader<ServiceInfo> loader =
+                new XStreamServiceLoader<ServiceInfo>(rl, "test") {
+
+                    @Override
+                    public Class<ServiceInfo> getServiceClass() {
+                        return ServiceInfo.class;
+                    }
+
+                    @Override
+                    protected ServiceInfo createServiceFromScratch(GeoServer gs) {
+                        return new ServiceInfoImpl();
+                    }
+                };
+        loader = spy(loader);
+
+        GeoServerImpl gs1 = new GeoServerImpl();
+        GeoServerImpl gs2 = new GeoServerImpl();
+
+        ServiceInfo service = loader.createServiceFromScratch(gs1);
+        Resource datadirRoot = rl.get("");
+
+        // initXStreamPersister first called on save for gs1
+        loader.save(service, gs1, datadirRoot);
+        verify(loader, times(1)).initXStreamPersister(any(XStreamPersister.class), same(gs1));
+
+        // then called again when getting gs2 as argument, but only once
+        loader.load(gs2);
+        loader.load(gs2);
+        verify(loader, times(1)).initXStreamPersister(any(XStreamPersister.class), same(gs2));
+
+        // and called only once again when getting gs1 as argument
+        loader.load(gs1);
+        loader.load(gs1);
+        verify(loader, times(2)).initXStreamPersister(any(XStreamPersister.class), same(gs1));
+    }
+}


### PR DESCRIPTION
[![GEOS-10717](https://badgen.net/badge/JIRA/GEOS-10717/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10717)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`XStreamServiceLoader` creates and initializes a new `XStreamPersister` every time it has to save or load a ServiceInfo, which comes with considerable overhead when depersisting thousands of service files.

Since `load()` receives a `GeoServer` argument, which has to be set to the `XStreamPersiter`, a new `XStreamPersister` instance will be created if `load()` is called with a different `GeoServer` reference.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->