### PR TITLE
[Backport 2.22.x] [GEOS-10647] Welcome page links to GetCapabilities do not follow the OGC standards

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/GWCServiceDescriptionProvider.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/GWCServiceDescriptionProvider.java
@@ -76,46 +76,46 @@ public class GWCServiceDescriptionProvider extends ServiceDescriptionProvider {
 
     private String createLinkWMSC(WorkspaceInfo workspaceInfo, PublishedInfo layerInfo) {
         if ((workspaceInfo == null) && (layerInfo == null)) {
-            return "../gwc/service/wms?services=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
+            return "../gwc/service/wms?service=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
         }
         if ((workspaceInfo != null) && (layerInfo != null)) {
             return "../"
                     + workspaceInfo.getName()
                     + "/"
                     + layerInfo.getName()
-                    + "/gwc/service/wms?services=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
+                    + "/gwc/service/wms?service=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
         }
         if ((workspaceInfo != null)) {
             return "../"
                     + workspaceInfo.getName()
-                    + "/gwc/service/wms?services=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
+                    + "/gwc/service/wms?service=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
         }
 
         // workspaceInfo will be null
         return "../"
                 + layerInfo.getName()
-                + "/gwc/service/wms?services=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
+                + "/gwc/service/wms?service=WMS&version=1.1.1&request=GetCapabilities&tiled=true";
     }
 
     private String createLinkWMTS(WorkspaceInfo workspaceInfo, PublishedInfo layerInfo) {
         if ((workspaceInfo == null) && (layerInfo == null)) {
-            return "../gwc/service/wmts?services=WMTS&version=1.1.1&request=GetCapabilities";
+            return "../gwc/service/wmts?service=WMTS&version=1.1.1&request=GetCapabilities";
         }
         if ((workspaceInfo != null) && (layerInfo != null)) {
             return "../"
                     + workspaceInfo.getName()
                     + "/"
                     + layerInfo.getName()
-                    + "/gwc/service/wmts?services=WMTS&version=1.1.1&request=GetCapabilities";
+                    + "/gwc/service/wmts?service=WMTS&version=1.1.1&request=GetCapabilities";
         }
         if ((workspaceInfo != null)) {
             return "../"
                     + workspaceInfo.getName()
-                    + "/gwc/service/wmts?services=WMTS&version=1.1.1&request=GetCapabilities";
+                    + "/gwc/service/wmts?service=WMTS&version=1.1.1&request=GetCapabilities";
         }
         return "../"
                 + layerInfo.getName()
-                + "/gwc/service/wmts?services=WMTS&version=1.1.1&request=GetCapabilities";
+                + "/gwc/service/wmts?service=WMTS&version=1.1.1&request=GetCapabilities";
     }
 
     private String createLinkTMS(WorkspaceInfo workspaceInfo, PublishedInfo layerInfo) {

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCServiceLinksTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/GWCServiceLinksTest.java
@@ -83,8 +83,10 @@ public class GWCServiceLinksTest extends GeoServerWicketTestSupport {
 
             if (link.getProtocol().equals("wms")) {
                 assertTrue("version", link.getLink().contains("&version="));
+                assertTrue("service", link.getLink().contains("&service=WMS"));
             } else if (link.getProtocol().equals("wmts")) {
                 assertTrue("version", link.getLink().contains("&version="));
+                assertTrue("service", link.getLink().contains("&service=WMTS"));
             }
         }
     }


### PR DESCRIPTION
[![GEOS-10647](https://badgen.net/badge/JIRA/GEOS-10647/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10647)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport of https://github.com/geoserver/geoserver/pull/6282