### PR TITLE
[GEOS-10723] params.extractor Resource

### DIFF
--- a/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
+++ b/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
@@ -65,8 +65,8 @@ public final class Filter implements GeoServerFilter, ExtensionPriority {
         if (dataDirectory != null) {
             Utils.info(LOGGER, "Initiating parameters extractor rules.");
             Resource resource = dataDirectory.get(RulesDao.getRulesPath());
-            rules = RulesDao.getRules(() -> resource.in());
-            resource.addListener(notify -> rules = RulesDao.getRules(() -> resource.in()));
+            rules = RulesDao.getRules(resource);
+            resource.addListener(notify -> rules = RulesDao.getRules(resource));
         } else {
             // no rules were loaded
             Utils.info(

--- a/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
+++ b/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
@@ -52,12 +52,12 @@ public final class RulesDao {
 
     /**
      * Read a list of Rule from a resource. Return an empty list if the resource does not exist.
-     * This prevents Resource.in() from creating the file or throwing an exception.
      *
      * @param resource to read.
      * @return a list of Rule or an empty list if the resource does not exist.
      */
     public static List<Rule> getRules(Resource resource) {
+        // This prevents Resource.in() from creating the file or throwing an exception.
         return resource.optionalRead(RulesDao::read).orElseGet(ArrayList::new);
     }
 

--- a/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
+++ b/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.geoserver.config.GeoServerDataDirectory;
@@ -43,40 +42,50 @@ public final class RulesDao {
 
     public static List<Rule> getRules() {
         Resource rules = getDataDirectory().get(getRulesPath());
-        return getRules(() -> rules.in());
+        return getRules(rules);
     }
 
     private static GeoServerDataDirectory getDataDirectory() {
         return (GeoServerDataDirectory) GeoServerExtensions.bean("dataDirectory");
     }
 
-    public static List<Rule> getRules(Supplier<InputStream> iss) {
-        try (InputStream inputStream = iss.get()) {
-            if (inputStream.available() == 0) {
-                Utils.info(LOGGER, "Parameters extractor rules file seems to be empty.");
-                return new ArrayList<>();
+    /**
+     * Read a list of Rule from a resource. Return an empty list if the resource does not exist.
+     * This prevents Resource.in() from creating the file or throwing an exception.
+     *
+     * @param resource to read.
+     * @return a list of Rule or an empty list if the resource does not exist.
+     */
+    public static List<Rule> getRules(Resource resource) {
+        if (resource.getType() == Resource.Type.RESOURCE) {
+            try (InputStream inputStream = resource.in()) {
+                if (inputStream.available() == 0) {
+                    Utils.info(LOGGER, "Parameters extractor rules file seems to be empty.");
+                } else {
+                    RuleList list = (RuleList) xStream.fromXML(inputStream);
+                    List<Rule> rules = list.rules == null ? new ArrayList<>() : list.rules;
+                    Utils.info(LOGGER, "Parameters extractor loaded %d rules.", rules.size());
+                    return rules;
+                }
+            } catch (Exception exception) {
+                throw Utils.exception(exception, "Error parsing rules files.");
             }
-
-            RuleList list = (RuleList) xStream.fromXML(inputStream);
-            List<Rule> rules = list.rules == null ? new ArrayList<>() : list.rules;
-            Utils.info(LOGGER, "Parameters extractor loaded %d rules.", rules.size());
-            return rules;
-        } catch (Exception exception) {
-            throw Utils.exception(exception, "Error parsing rules files.");
+        } else {
+            Utils.info(LOGGER, "Rule file does not exist.");
         }
+        return new ArrayList<>();
     }
 
     public static void saveOrUpdateRule(Rule rule) {
         Resource rules = getDataDirectory().get(getRulesPath());
         Resource tmpRules = getDataDirectory().get(getTempRulesPath());
-        saveOrUpdateRule(rule, () -> rules.in(), () -> tmpRules.out());
+        saveOrUpdateRule(rule, rules, tmpRules);
         rules.delete();
         tmpRules.renameTo(rules);
     }
 
-    public static void saveOrUpdateRule(
-            Rule rule, Supplier<InputStream> iss, Supplier<OutputStream> oss) {
-        List<Rule> rules = getRules(iss);
+    public static void saveOrUpdateRule(Rule rule, Resource in, Resource out) {
+        List<Rule> rules = getRules(in);
         boolean exists = false;
         for (int i = 0; i < rules.size() && !exists; i++) {
             if (rules.get(i).getId().equals(rule.getId())) {
@@ -87,27 +96,24 @@ public final class RulesDao {
         if (!exists) {
             rules.add(rule);
         }
-        writeRules(rules, oss);
+        writeRules(rules, out);
         Utils.info(LOGGER, "Parameters extractor rules updated.");
     }
 
     public static void deleteRules(String... rulesIds) {
         Resource rules = getDataDirectory().get(getRulesPath());
         Resource tmpRules = getDataDirectory().get(getTempRulesPath());
-        deleteRules(() -> rules.in(), () -> tmpRules.out(), rulesIds);
+        deleteRules(rules, tmpRules, rulesIds);
         rules.delete();
         tmpRules.renameTo(rules);
     }
 
-    public static void deleteRules(
-            Supplier<InputStream> inputStream,
-            Supplier<OutputStream> outputStream,
-            String... ruleIds) {
+    public static void deleteRules(Resource input, Resource output, String... ruleIds) {
         List<Rule> rules =
-                getRules(inputStream).stream()
+                getRules(input).stream()
                         .filter(rule -> !matchesAnyRuleId(rule, ruleIds))
                         .collect(Collectors.toList());
-        writeRules(rules, outputStream);
+        writeRules(rules, output);
         Utils.info(LOGGER, "Deleted one or more parameters extractor rules.");
     }
 
@@ -115,8 +121,8 @@ public final class RulesDao {
         return Arrays.stream(ruleIds).anyMatch(ruleId -> ruleId.equals(rule.getId()));
     }
 
-    private static void writeRules(List<Rule> rules, Supplier<OutputStream> oss) {
-        try (OutputStream outputStream = oss.get()) {
+    private static void writeRules(List<Rule> rules, Resource resource) {
+        try (OutputStream outputStream = resource.out()) {
             xStream.toXML(new RuleList(rules), outputStream);
         } catch (Exception exception) {
             throw Utils.exception(exception, "Something bad happen when writing rules.");

--- a/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
+++ b/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.params.extractor;
 
+import static org.geoserver.params.extractor.EchoParametersDao.getEchoParameters;
+import static org.geoserver.params.extractor.EchoParametersDao.getEchoParametersPath;
+
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -26,10 +29,9 @@ public class UrlMangler implements URLMangler {
     private List<EchoParameter> echoParameters;
 
     public UrlMangler(GeoServerDataDirectory dataDirectory) {
-        Resource resource = dataDirectory.get(EchoParametersDao.getEchoParametersPath());
-        echoParameters = EchoParametersDao.getEchoParameters(resource.in());
-        resource.addListener(
-                notify -> echoParameters = EchoParametersDao.getEchoParameters(resource.in()));
+        Resource resource = dataDirectory.get(getEchoParametersPath());
+        echoParameters = getEchoParameters(resource);
+        resource.addListener(notify -> echoParameters = getEchoParameters(resource));
     }
 
     private HttpServletRequest getHttpRequest(Request request) {

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
@@ -43,7 +43,6 @@ public final class EchoParametersDaoTest extends TestSupport {
                         .withParameter("CQL_FILTER")
                         .withActivated(true)
                         .build());
-        ;
     }
 
     @Test

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
@@ -4,11 +4,12 @@
  */
 package org.geoserver.params.extractor;
 
+import static org.geoserver.params.extractor.EchoParametersDao.getEchoParameters;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.InputStream;
 import java.util.List;
+import org.geoserver.platform.resource.Resource;
 import org.junit.Test;
 
 public final class EchoParametersDaoTest extends TestSupport {
@@ -17,9 +18,8 @@ public final class EchoParametersDaoTest extends TestSupport {
     public void testParsingEmptyFile() throws Exception {
         doWork(
                 "data/echoParameters1.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
+                (Resource input) -> {
+                    List<EchoParameter> echoParameters = getEchoParameters(input);
                     assertThat(echoParameters.size(), is(0));
                 });
     }
@@ -28,9 +28,8 @@ public final class EchoParametersDaoTest extends TestSupport {
     public void testParsingEmptyEchoParameters() throws Exception {
         doWork(
                 "data/echoParameters2.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
+                (Resource input) -> {
+                    List<EchoParameter> echoParameters = getEchoParameters(input);
                     assertThat(echoParameters.size(), is(0));
                 });
     }
@@ -39,9 +38,8 @@ public final class EchoParametersDaoTest extends TestSupport {
     public void testParsingEchoParameter() throws Exception {
         doWork(
                 "data/echoParameters3.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
+                (Resource input) -> {
+                    List<EchoParameter> echoParameters = getEchoParameters(input);
                     assertThat(echoParameters.size(), is(1));
                     checkEchoParameter(
                             echoParameters.get(0),
@@ -57,9 +55,8 @@ public final class EchoParametersDaoTest extends TestSupport {
     public void testParsingMultipleEchoParameters() throws Exception {
         doWork(
                 "data/echoParameters4.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
+                (Resource input) -> {
+                    List<EchoParameter> echoParameters = getEchoParameters(input);
                     assertThat(echoParameters.size(), is(2));
                     checkEchoParameter(
                             findEchoParameter("0", echoParameters),
@@ -101,24 +98,24 @@ public final class EchoParametersDaoTest extends TestSupport {
                         .withParameter("bbox")
                         .build();
         // get the existing echo parameters, this should return an empty list
-        List<EchoParameter> echoParameters = EchoParametersDao.getEchoParameters();
+        List<EchoParameter> echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(0));
         // we save echo parameters A and B
         EchoParametersDao.saveOrUpdateEchoParameter(echoParameterA);
         EchoParametersDao.saveOrUpdateEchoParameter(echoParameterB);
-        echoParameters = EchoParametersDao.getEchoParameters();
+        echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(2));
         checkEchoParameter(echoParameterA, findEchoParameter("0", echoParameters));
         checkEchoParameter(echoParameterB, findEchoParameter("1", echoParameters));
         // we update echo parameter B using rule C
         EchoParametersDao.saveOrUpdateEchoParameter(echoParameterC);
-        echoParameters = EchoParametersDao.getEchoParameters();
+        echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(2));
         checkEchoParameter(echoParameterA, findEchoParameter("0", echoParameters));
         checkEchoParameter(echoParameterC, findEchoParameter("1", echoParameters));
         // we delete echo parameter A
         EchoParametersDao.deleteEchoParameters("0");
-        echoParameters = EchoParametersDao.getEchoParameters();
+        echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(1));
     }
 }

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
@@ -4,75 +4,66 @@
  */
 package org.geoserver.params.extractor;
 
-import static org.geoserver.params.extractor.EchoParametersDao.getEchoParameters;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
-import org.geoserver.platform.resource.Resource;
 import org.junit.Test;
 
 public final class EchoParametersDaoTest extends TestSupport {
 
-    @Test
-    public void testParsingEmptyFile() throws Exception {
-        doWork(
-                "data/echoParameters1.xml",
-                (Resource input) -> {
-                    List<EchoParameter> echoParameters = getEchoParameters(input);
-                    assertThat(echoParameters.size(), is(0));
-                });
+    static List<EchoParameter> getEchoParameters() {
+        return EchoParametersDao.getEchoParameters();
+    }
+
+    static List<EchoParameter> getEchoParameters(String path) {
+        return EchoParametersDao.getEchoParameters(getResource(path));
     }
 
     @Test
-    public void testParsingEmptyEchoParameters() throws Exception {
-        doWork(
-                "data/echoParameters2.xml",
-                (Resource input) -> {
-                    List<EchoParameter> echoParameters = getEchoParameters(input);
-                    assertThat(echoParameters.size(), is(0));
-                });
+    public void testParsingEmptyFile() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters1.xml");
+        assertThat(echoParameters.size(), is(0));
     }
 
     @Test
-    public void testParsingEchoParameter() throws Exception {
-        doWork(
-                "data/echoParameters3.xml",
-                (Resource input) -> {
-                    List<EchoParameter> echoParameters = getEchoParameters(input);
-                    assertThat(echoParameters.size(), is(1));
-                    checkEchoParameter(
-                            echoParameters.get(0),
-                            new EchoParameterBuilder()
-                                    .withId("1")
-                                    .withParameter("CQL_FILTER")
-                                    .withActivated(true)
-                                    .build());
-                });
+    public void testParsingEmptyEchoParameters() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters2.xml");
+        assertThat(echoParameters.size(), is(0));
     }
 
     @Test
-    public void testParsingMultipleEchoParameters() throws Exception {
-        doWork(
-                "data/echoParameters4.xml",
-                (Resource input) -> {
-                    List<EchoParameter> echoParameters = getEchoParameters(input);
-                    assertThat(echoParameters.size(), is(2));
-                    checkEchoParameter(
-                            findEchoParameter("0", echoParameters),
-                            new EchoParameterBuilder()
-                                    .withId("0")
-                                    .withParameter("CQL_FILTER")
-                                    .withActivated(true)
-                                    .build());
-                    checkEchoParameter(
-                            findEchoParameter("1", echoParameters),
-                            new EchoParameterBuilder()
-                                    .withId("1")
-                                    .withParameter("BBOX")
-                                    .withActivated(false)
-                                    .build());
-                });
+    public void testParsingEchoParameter() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters3.xml");
+        assertThat(echoParameters.size(), is(1));
+        checkEchoParameter(
+                echoParameters.get(0),
+                new EchoParameterBuilder()
+                        .withId("1")
+                        .withParameter("CQL_FILTER")
+                        .withActivated(true)
+                        .build());
+        ;
+    }
+
+    @Test
+    public void testParsingMultipleEchoParameters() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters4.xml");
+        assertThat(echoParameters.size(), is(2));
+        checkEchoParameter(
+                findEchoParameter("0", echoParameters),
+                new EchoParameterBuilder()
+                        .withId("0")
+                        .withParameter("CQL_FILTER")
+                        .withActivated(true)
+                        .build());
+        checkEchoParameter(
+                findEchoParameter("1", echoParameters),
+                new EchoParameterBuilder()
+                        .withId("1")
+                        .withParameter("BBOX")
+                        .withActivated(false)
+                        .build());
     }
 
     @Test

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/RulesDaoTest.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/RulesDaoTest.java
@@ -4,11 +4,12 @@
  */
 package org.geoserver.params.extractor;
 
+import static org.geoserver.params.extractor.RulesDao.getRules;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.InputStream;
 import java.util.List;
+import org.geoserver.platform.resource.Resource;
 import org.junit.Test;
 
 public final class RulesDaoTest extends TestSupport {
@@ -17,8 +18,8 @@ public final class RulesDaoTest extends TestSupport {
     public void testParsingEmptyFile() throws Exception {
         doWork(
                 "data/rules1.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
+                (Resource input) -> {
+                    List<Rule> rules = getRules(input);
                     assertThat(rules.size(), is(0));
                 });
     }
@@ -27,8 +28,8 @@ public final class RulesDaoTest extends TestSupport {
     public void testParsingEmptyRules() throws Exception {
         doWork(
                 "data/rules2.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
+                (Resource input) -> {
+                    List<Rule> rules = getRules(input);
                     assertThat(rules.size(), is(0));
                 });
     }
@@ -37,8 +38,8 @@ public final class RulesDaoTest extends TestSupport {
     public void testParsingPositionRule() throws Exception {
         doWork(
                 "data/rules3.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
+                (Resource input) -> {
+                    List<Rule> rules = getRules(input);
                     assertThat(rules.size(), is(1));
                     checkRule(
                             rules.get(0),
@@ -56,8 +57,8 @@ public final class RulesDaoTest extends TestSupport {
     public void testParsingMatchRule() throws Exception {
         doWork(
                 "data/rules4.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
+                (Resource input) -> {
+                    List<Rule> rules = getRules(input);
                     assertThat(rules.size(), is(1));
                     checkRule(
                             rules.get(0),
@@ -75,8 +76,8 @@ public final class RulesDaoTest extends TestSupport {
     public void testParsingMultipleRules() throws Exception {
         doWork(
                 "data/rules5.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
+                (Resource input) -> {
+                    List<Rule> rules = getRules(input);
                     assertThat(rules.size(), is(3));
                     checkRule(
                             findRule("0", rules),
@@ -112,8 +113,8 @@ public final class RulesDaoTest extends TestSupport {
     public void testParsingCombineRepeatRule() throws Exception {
         doWork(
                 "data/rules6.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
+                (Resource input) -> {
+                    List<Rule> rules = getRules(input);
                     assertThat(rules.size(), is(1));
                     checkRule(
                             rules.get(0),
@@ -163,24 +164,24 @@ public final class RulesDaoTest extends TestSupport {
                         .withCombine("$1 OR $2")
                         .build();
         // get the existing rules, this should return an empty list
-        List<Rule> rules = RulesDao.getRules();
+        List<Rule> rules = getRules();
         assertThat(rules.size(), is(0));
         // we save rules A and B
         RulesDao.saveOrUpdateRule(ruleA);
         RulesDao.saveOrUpdateRule(ruleB);
-        rules = RulesDao.getRules();
+        rules = getRules();
         assertThat(rules.size(), is(2));
         checkRule(ruleA, findRule("0", rules));
         checkRule(ruleB, findRule("1", rules));
         // we update rule B using rule C
         RulesDao.saveOrUpdateRule(ruleC);
-        rules = RulesDao.getRules();
+        rules = getRules();
         assertThat(rules.size(), is(2));
         checkRule(ruleA, findRule("0", rules));
         checkRule(ruleC, findRule("1", rules));
         // we delete rule A
         RulesDao.deleteRules("0");
-        rules = RulesDao.getRules();
+        rules = getRules();
         assertThat(rules.size(), is(1));
         checkRule(ruleC, findRule("1", rules));
     }

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/RulesDaoTest.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/RulesDaoTest.java
@@ -9,125 +9,108 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
-import org.geoserver.platform.resource.Resource;
 import org.junit.Test;
 
 public final class RulesDaoTest extends TestSupport {
 
-    @Test
-    public void testParsingEmptyFile() throws Exception {
-        doWork(
-                "data/rules1.xml",
-                (Resource input) -> {
-                    List<Rule> rules = getRules(input);
-                    assertThat(rules.size(), is(0));
-                });
+    static List<Rule> getRules() {
+        return RulesDao.getRules();
+    }
+
+    static List<Rule> getRules(String path) {
+        return RulesDao.getRules(getResource(path));
     }
 
     @Test
-    public void testParsingEmptyRules() throws Exception {
-        doWork(
-                "data/rules2.xml",
-                (Resource input) -> {
-                    List<Rule> rules = getRules(input);
-                    assertThat(rules.size(), is(0));
-                });
+    public void testParsingEmptyFile() {
+        List<Rule> rules = getRules("data/rules1.xml");
+        assertThat(rules.size(), is(0));
     }
 
     @Test
-    public void testParsingPositionRule() throws Exception {
-        doWork(
-                "data/rules3.xml",
-                (Resource input) -> {
-                    List<Rule> rules = getRules(input);
-                    assertThat(rules.size(), is(1));
-                    checkRule(
-                            rules.get(0),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withPosition(3)
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                });
+    public void testParsingEmptyRules() {
+        List<Rule> rules = getRules("data/rules2.xml");
+        assertThat(rules.size(), is(0));
     }
 
     @Test
-    public void testParsingMatchRule() throws Exception {
-        doWork(
-                "data/rules4.xml",
-                (Resource input) -> {
-                    List<Rule> rules = getRules(input);
-                    assertThat(rules.size(), is(1));
-                    checkRule(
-                            rules.get(0),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withMatch("^.*?(/([^/]+?))/[^/]+$")
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                });
+    public void testParsingPositionRule() {
+        List<Rule> rules = getRules("data/rules3.xml");
+        assertThat(rules.size(), is(1));
+        checkRule(
+                rules.get(0),
+                new RuleBuilder()
+                        .withId("0")
+                        .withPosition(3)
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .build());
     }
 
     @Test
-    public void testParsingMultipleRules() throws Exception {
-        doWork(
-                "data/rules5.xml",
-                (Resource input) -> {
-                    List<Rule> rules = getRules(input);
-                    assertThat(rules.size(), is(3));
-                    checkRule(
-                            findRule("0", rules),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withPosition(3)
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                    checkRule(
-                            findRule("1", rules),
-                            new RuleBuilder()
-                                    .withId("1")
-                                    .withMatch("^.*?(/([^/]+?))/[^/]+$")
-                                    .withParameter("cql_filter")
-                                    .withRemove(2)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                    checkRule(
-                            findRule("2", rules),
-                            new RuleBuilder()
-                                    .withId("2")
-                                    .withPosition(4)
-                                    .withParameter("cql_filter")
-                                    .withRemove(null)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                });
+    public void testParsingMatchRule() {
+        List<Rule> rules = getRules("data/rules4.xml");
+        assertThat(rules.size(), is(1));
+        checkRule(
+                rules.get(0),
+                new RuleBuilder()
+                        .withId("0")
+                        .withMatch("^.*?(/([^/]+?))/[^/]+$")
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .build());
     }
 
     @Test
-    public void testParsingCombineRepeatRule() throws Exception {
-        doWork(
-                "data/rules6.xml",
-                (Resource input) -> {
-                    List<Rule> rules = getRules(input);
-                    assertThat(rules.size(), is(1));
-                    checkRule(
-                            rules.get(0),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withMatch("^.*?(/([^/]+?))/[^/]+$")
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .withCombine("$1;$2")
-                                    .withRepeat(true)
-                                    .build());
-                });
+    public void testParsingMultipleRules() {
+        List<Rule> rules = getRules("data/rules5.xml");
+        assertThat(rules.size(), is(3));
+        checkRule(
+                findRule("0", rules),
+                new RuleBuilder()
+                        .withId("0")
+                        .withPosition(3)
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .build());
+        checkRule(
+                findRule("1", rules),
+                new RuleBuilder()
+                        .withId("1")
+                        .withMatch("^.*?(/([^/]+?))/[^/]+$")
+                        .withParameter("cql_filter")
+                        .withRemove(2)
+                        .withTransform("seq='$2'")
+                        .build());
+        checkRule(
+                findRule("2", rules),
+                new RuleBuilder()
+                        .withId("2")
+                        .withPosition(4)
+                        .withParameter("cql_filter")
+                        .withRemove(null)
+                        .withTransform("seq='$2'")
+                        .build());
+    }
+
+    @Test
+    public void testParsingCombineRepeatRule() {
+        List<Rule> rules = getRules("data/rules6.xml");
+        assertThat(rules.size(), is(1));
+        checkRule(
+                rules.get(0),
+                new RuleBuilder()
+                        .withId("0")
+                        .withMatch("^.*?(/([^/]+?))/[^/]+$")
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .withCombine("$1;$2")
+                        .withRepeat(true)
+                        .build());
     }
 
     @Test

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.Files;
@@ -41,7 +40,7 @@ public abstract class TestSupport {
     protected ResourceStore resourceStore;
 
     @Before
-    public void voidSetup() throws IOException {
+    public void voidSetup() {
         deleteTestDirectoryQuietly();
         TEST_DIRECTORY.mkdir();
         resourceStore = new FileSystemResourceStore(TEST_DIRECTORY);
@@ -59,13 +58,12 @@ public abstract class TestSupport {
         }
     }
 
-    protected static void doWork(String resourcePath, Consumer<Resource> consumer)
-            throws Exception {
+    protected static Resource getResource(String resourcePath) {
         URL resource = EchoParametersDaoTest.class.getClassLoader().getResource(resourcePath);
         assertThat(resource, notNullValue());
         File file = new File(resource.getFile());
         assertThat(file.exists(), is(true));
-        consumer.accept(Files.asResource(file));
+        return Files.asResource(file);
     }
 
     protected void checkRule(Rule ruleA, Rule ruleB) {
@@ -101,8 +99,8 @@ public abstract class TestSupport {
         }
     }
 
-    protected EchoParameter findEchoParameter(String id, List<EchoParameter> rules) {
-        return rules.stream()
+    protected EchoParameter findEchoParameter(String id, List<EchoParameter> echoParameters) {
+        return echoParameters.stream()
                 .filter(echoParameter -> echoParameter.getId().equals(id))
                 .findFirst()
                 .orElse(null);

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
@@ -10,14 +10,14 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.util.IOUtils;
 import org.junit.After;
@@ -59,18 +59,13 @@ public abstract class TestSupport {
         }
     }
 
-    protected static void doWork(String resourcePath, Consumer<InputStream> consumer)
+    protected static void doWork(String resourcePath, Consumer<Resource> consumer)
             throws Exception {
         URL resource = EchoParametersDaoTest.class.getClassLoader().getResource(resourcePath);
         assertThat(resource, notNullValue());
         File file = new File(resource.getFile());
         assertThat(file.exists(), is(true));
-        try (InputStream inputStream = new FileInputStream(file)) {
-            if (inputStream.available() == 0) {
-                return;
-            }
-            consumer.accept(inputStream);
-        }
+        consumer.accept(Files.asResource(file));
     }
 
     protected void checkRule(Rule ruleA, Rule ruleB) {

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
@@ -13,6 +13,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.function.IOConsumer;
 import org.apache.commons.io.function.IOFunction;
 
 /**
@@ -237,12 +238,22 @@ public interface Resource {
     }
 
     /**
+     * Write data to a resource using an output stream to write to and close it hereafter.
+     *
+     * @param consumer to perform the writing.
+     * @throws IOException thrown if something went wrong.
+     */
+    default void write(IOConsumer<OutputStream> consumer) throws IOException {
+        try (OutputStream out = this.out()) {
+            consumer.accept(out);
+        }
+    }
+
+    /**
      * Writes a resource contents as a byte array. Usage is suggested only if the resource is known
      * to be small (e.g. a configuration file).
      */
     default void setContents(byte[] byteArray) throws IOException {
-        try (OutputStream os = out()) {
-            IOUtils.write(byteArray, os);
-        }
+        write(out -> IOUtils.write(byteArray, out));
     }
 }

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
@@ -5,7 +5,11 @@
  */
 package org.geoserver.platform.resource;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
@@ -191,9 +195,7 @@ public interface Resource {
      * known to be small (e.g. a configuration file).
      */
     default byte[] getContents() throws IOException {
-        try (InputStream in = in()) {
-            return org.apache.commons.io.IOUtils.toByteArray(in);
-        }
+        return read(org.apache.commons.io.IOUtils::toByteArray);
     }
 
     /**


### PR DESCRIPTION
[![GEOS-10723](https://badgen.net/badge/JIRA/GEOS-10723/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10723)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Classes from `org.geoserver.params.extractor` frequently use `InputStreams` and `OutputStreams`. Doing so, it is not clear if the producer or the consumer has to close the stream. Using `Supplier<*Stream>` does not help either. This also leads to additional catch/try/resource blocks spread all over the code. This approach uses `org.geoserver.platform.resource.Resource` instead.

This way the catch/try/resource blocks can be kept small and consistent.
This also enables to consider `Type.UNDEFINED` concerning [GEOS-10705].

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).