### PR TITLE
[GEOS-10725] : [WFS] : GetFeature Performance with jdbc plugin

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/CatalogNamespaceSupport.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/CatalogNamespaceSupport.java
@@ -6,10 +6,9 @@
 package org.geoserver.wfs;
 
 import java.util.Enumeration;
+import java.util.Iterator;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.NamespaceInfo;
-import org.geoserver.catalog.Predicates;
-import org.geoserver.catalog.util.CloseableIterator;
 import org.xml.sax.helpers.NamespaceSupport;
 
 /** NamespaceContext based on GeoServer catalog. */
@@ -30,16 +29,13 @@ public class CatalogNamespaceSupport extends NamespaceSupport {
 
     @Override
     public Enumeration getPrefixes() {
-        @SuppressWarnings("PMD.CloseResource") // best effort closing
-        final CloseableIterator<NamespaceInfo> it =
-                catalog.list(NamespaceInfo.class, Predicates.acceptAll());
+        final Iterator<NamespaceInfo> it = catalog.getNamespaces().iterator();
         return new Enumeration() {
             @Override
             public boolean hasMoreElements() {
                 if (it.hasNext()) {
                     return true;
                 } else {
-                    it.close();
                     return false;
                 }
             }


### PR DESCRIPTION
[![GEOS-10725](https://badgen.net/badge/JIRA/GEOS-10725/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10725)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->