### PR TITLE
[GEOS-4727] Editing SQL views seems to be leaking connections (2.20.x backport)

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/SQLViewAbstractPage.java
@@ -464,7 +464,7 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
         // if so, try to build an override feature type
         Connection cx = null;
         try {
-            store.getConnection(Transaction.AUTO_COMMIT);
+            cx = store.getConnection(Transaction.AUTO_COMMIT);
             SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
             tb.setName(base.getName());
             for (AttributeDescriptor ad : base.getAttributeDescriptors()) {
@@ -494,7 +494,7 @@ public abstract class SQLViewAbstractPage extends GeoServerSecuredPage {
             }
             return tb.buildFeatureType();
         } catch (SQLException e) {
-            throw (IOException) new IOException(e.getMessage()).initCause(e);
+            throw new IOException(e.getMessage(), e);
         } finally {
             store.closeSafe(cx);
         }


### PR DESCRIPTION
[![GEOS-4727](https://badgen.net/badge/JIRA/GEOS-4727/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-4727)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main. Removed test as it cannot be written in this branch, lacks a support method in SQLDialect not available in the GeoTools 2.20.x depends onto.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->