### PR TITLE
[GEOS-10724] SpringResourceAdaptor should throw a FileNotFoundException instead of creating any missing file

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/SpringResourceAdaptor.java
+++ b/src/main/src/main/java/org/geoserver/config/SpringResourceAdaptor.java
@@ -1,4 +1,4 @@
-/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
@@ -107,9 +107,16 @@ public class SpringResourceAdaptor implements org.springframework.core.io.Resour
         return file;
     }
 
+    /**
+     * {@link org.springframework.core.io.Resource#contentLength()} suggests to throw an IOException
+     * while {@link java.io.File#length()} suggests to return 0L instead, which is used here to
+     * kinder the client code. Directory resources also return 0L.
+     *
+     * @return the content length for this resource or 0L if it is not a file.
+     */
     @Override
-    public long contentLength() throws IOException {
-        return getFile().length();
+    public long contentLength() {
+        return resource.getType() == RESOURCE ? resource.file().length() : 0;
     }
 
     @Override
@@ -118,8 +125,7 @@ public class SpringResourceAdaptor implements org.springframework.core.io.Resour
     }
 
     @Override
-    public org.springframework.core.io.Resource createRelative(String relativePath)
-            throws IOException {
+    public org.springframework.core.io.Resource createRelative(String relativePath) {
         return new SpringResourceAdaptor(resource.get(relativePath));
     }
 

--- a/src/main/src/test/java/org/geoserver/config/GeoServerPropertyConfigurerTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerPropertyConfigurerTest.java
@@ -8,7 +8,9 @@ package org.geoserver.config;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Properties;
 import org.junit.After;
 import org.junit.Before;
@@ -33,6 +35,17 @@ public class GeoServerPropertyConfigurerTest {
     @After
     public void tearDown() throws Exception {
         ctx.close();
+    }
+
+    @Test
+    public void testConfigFileCreated() throws IOException {
+        Properties p = new Properties();
+        try (FileInputStream is = new FileInputStream("target/foo.properties")) {
+            p.load(is);
+        }
+        assertEquals(p.size(), 2);
+        assertEquals(p.get("prop1"), "value1");
+        assertEquals(p.get("prop2"), "value2");
     }
 
     @Test

--- a/src/main/src/test/java/org/geoserver/config/SpringResourceAdaptorTest.java
+++ b/src/main/src/test/java/org/geoserver/config/SpringResourceAdaptorTest.java
@@ -1,0 +1,95 @@
+/* (c) 2015 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.config;
+
+import static org.geoserver.platform.resource.Resource.Type.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SpringResourceAdaptorTest {
+
+    Resource directoryResource;
+    Resource missingResource;
+    Resource existingResource;
+
+    @Before
+    public void setUp() throws Exception {
+
+        FileSystemResourceStore target = new FileSystemResourceStore(new File("target"));
+
+        missingResource = target.get("missingFile");
+        assertFalse(Resources.exists(missingResource));
+
+        existingResource = target.get("existingFile");
+        Resources.createNewFile(existingResource);
+        assertTrue(Resources.exists(existingResource));
+
+        directoryResource = existingResource.parent();
+        assertTrue(Resources.exists(directoryResource));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        existingResource.delete();
+        missingResource.delete();
+    }
+
+    @Test
+    public void testExistingResource() throws IOException {
+
+        assertEquals(RESOURCE, existingResource.getType());
+        assertTrue(Resources.exists(existingResource));
+
+        SpringResourceAdaptor springResource = new SpringResourceAdaptor(existingResource);
+
+        assertTrue(springResource.isReadable());
+        assertNotNull(springResource.getFile());
+
+        try (InputStream is = springResource.getInputStream()) {
+            assertNotNull(is);
+        }
+    }
+
+    @Test
+    public void testDirectoryResource() throws IOException {
+
+        assertEquals(DIRECTORY, directoryResource.getType());
+        assertTrue(Resources.exists(directoryResource));
+
+        SpringResourceAdaptor springResource = new SpringResourceAdaptor(directoryResource);
+
+        assertFalse(springResource.isReadable());
+        assertNotNull(springResource.getFile());
+
+        assertThrows(FileNotFoundException.class, () -> springResource.getInputStream().close());
+    }
+
+    @Test
+    public void testMissingResource() {
+
+        assertEquals(UNDEFINED, missingResource.getType());
+        assertFalse(Resources.exists(missingResource));
+
+        SpringResourceAdaptor springResource = new SpringResourceAdaptor(missingResource);
+
+        assertFalse(springResource.isReadable());
+        assertThrows(FileNotFoundException.class, springResource::getFile);
+        assertThrows(FileNotFoundException.class, () -> springResource.getInputStream().close());
+
+        // must not be created unintentionally.
+        assertFalse(Resources.exists(missingResource));
+    }
+}

--- a/src/main/src/test/java/org/geoserver/config/SpringResourceAdaptorTest.java
+++ b/src/main/src/test/java/org/geoserver/config/SpringResourceAdaptorTest.java
@@ -5,8 +5,14 @@
 
 package org.geoserver.config;
 
-import static org.geoserver.platform.resource.Resource.Type.*;
-import static org.junit.Assert.*;
+import static org.geoserver.platform.resource.Resource.Type.DIRECTORY;
+import static org.geoserver.platform.resource.Resource.Type.RESOURCE;
+import static org.geoserver.platform.resource.Resource.Type.UNDEFINED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;


### PR DESCRIPTION
[![GEOS-10724](https://badgen.net/badge/JIRA/GEOS-10724/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10724)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The `SpringResourceAdaptor` wraps an `org.geoserver.platform.resource.Resource` into a `org.springframework.core.io.Resource`.

Both are quite similar, but while the geoserver Resource wraps any `IOException` into an `IllegalStateException`  
(which is fine to use it in λ-expressions), the spring Resource however can and should throw the `IOException` itself.

Looking at [GeoServerPropertyConfigurer:104](https://github.com/geoserver/geoserver/blob/190f8849b9a2da54f709f227f3ad3e93a1194f41/src/main/src/main/java/org/geoserver/config/GeoServerPropertyConfigurer.java#L104) it seems, the missing config file shall be created and filled.
However, `super.loadProperties` indirectly creates some empty config file instead. 

Since this situation was not covered before, the first commit adds some unit test to show up the problem.

The second commit modifies `SpringResourceAdaptor`  to throw `FileNotFoundException` for `Resource.Type.UNDEFINED`.

Remaining question: what about `Resource.Type.DIRECTORY`?

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary)
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).