### PR TITLE
[GEOS-10729] Concurrent access on data access rules (authorization) can lead to loss of configured catalog mode, and lost rules

### DIFF
--- a/src/main/src/test/java/org/geoserver/security/impl/MemoryDataAccessRuleDAO.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/MemoryDataAccessRuleDAO.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.security.impl;
 
+import java.io.IOException;
 import java.util.Properties;
 import org.geoserver.catalog.Catalog;
 import org.vfny.geoserver.global.ConfigurationException;
@@ -22,5 +23,10 @@ class MemoryDataAccessRuleDAO extends DataAccessRuleDAO {
     protected void checkPropertyFile(boolean force) {
         // skip checking
         lastModified = Long.MAX_VALUE;
+    }
+
+    @Override
+    public synchronized void storeRules() throws IOException {
+        // nothing to do, not resource based
     }
 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/AbstractAccesRuleDAOConcurrencyTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/AbstractAccesRuleDAOConcurrencyTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.security.impl;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -17,7 +18,7 @@ import org.junit.Test;
 
 public abstract class AbstractAccesRuleDAOConcurrencyTest<D extends AbstractAccessRuleDAO> {
 
-    private static final int LOOPS = 10000;
+    protected static final int DEFAULT_LOOPS = 10000;
     private static final int THREADS = 4;
     D dao;
     private ExecutorService executors;
@@ -45,7 +46,7 @@ public abstract class AbstractAccesRuleDAOConcurrencyTest<D extends AbstractAcce
     public void testConcurrentModifications() throws Exception {
         // REST operations change the contents of the DAO by using
         List<Callable<Void>> manipulators =
-                IntStream.range(1, LOOPS)
+                IntStream.range(1, getLoops())
                         .mapToObj(c -> (Callable<Void>) () -> manipulate(c))
                         .collect(Collectors.toList());
 
@@ -56,11 +57,16 @@ public abstract class AbstractAccesRuleDAOConcurrencyTest<D extends AbstractAcce
         }
     }
 
+    protected int getLoops() {
+        // go a little easier, this is writing on the file system
+        return DEFAULT_LOOPS;
+    }
+
     /**
      * Performs a read/write manipulation on the DAO contents
      *
      * @param c
      * @return
      */
-    protected abstract Void manipulate(int c);
+    protected abstract Void manipulate(int c) throws IOException;
 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/DataAccesRuleDAOFileConcurrencyTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/DataAccesRuleDAOFileConcurrencyTest.java
@@ -1,0 +1,58 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Properties;
+import org.apache.commons.io.FileUtils;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.impl.LayerInfoImpl;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+
+/** Same as {@link DataAccessRuleDAOTest} but using an actual property file */
+public class DataAccesRuleDAOFileConcurrencyTest extends DataAccesRuleDAOConcurrencyTest {
+
+    @Override
+    protected DataAccessRuleDAO buildDAO() throws Exception {
+        // make a nice little catalog that does always tell us stuff is there
+        Catalog catalog = createNiceMock(Catalog.class);
+        expect(catalog.getWorkspaceByName(anyObject()))
+                .andReturn(new WorkspaceInfoImpl())
+                .anyTimes();
+        expect(catalog.getLayerByName((String) anyObject()))
+                .andReturn(new LayerInfoImpl())
+                .anyTimes();
+        replay(catalog);
+
+        // base rules
+        Properties props = new Properties();
+        props.put("mode", "CHALLENGE");
+        props.put("*.*.r", "*");
+
+        File dir = new File("target/layers-concurrency");
+        FileUtils.deleteQuietly(dir);
+        dir.mkdir();
+
+        try (FileOutputStream fos = new FileOutputStream(new File(dir, "layers.properties"))) {
+            props.store(fos, null);
+        }
+
+        FileSystemResourceStore store = new FileSystemResourceStore(dir);
+        return new DataAccessRuleDAO(catalog, store.get("/"));
+    }
+
+    @Override
+    protected int getLoops() {
+        // less loops, this is hitting the file system
+        return DEFAULT_LOOPS * 5;
+    }
+}


### PR DESCRIPTION
[![GEOS-10729](https://badgen.net/badge/JIRA/GEOS-10729/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10729)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->