### PR TITLE
[GEOS-10731] GWC variable Parameterization does not work with geoserver-environmen…

### DIFF
--- a/src/extension/gwc-s3/src/main/resources/applicationContext.xml
+++ b/src/extension/gwc-s3/src/main/resources/applicationContext.xml
@@ -11,7 +11,7 @@
    Bean configuration file for the gwc-aws-s3 module
   </description>
   
-  <bean id="S3BlobStoreConfigProvider" class="org.geowebcache.s3.S3BlobStoreConfigProvider" depends-on="geoWebCacheExtensions">
+  <bean id="S3BlobStoreConfigProvider" class="org.geowebcache.s3.S3BlobStoreConfigProvider" depends-on="gwcSynchEnv">
     <description>
       Contributes XStream configuration settings to org.geowebcache.config.XMLConfiguration to encode S3BlobStoreInfo instances
     </description>

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -191,6 +191,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
 
     private final GridSetBroker gridSetBroker;
 
+    private GWCSynchEnv gwcSynchEnv;
+
     private DiskQuotaMonitor monitor;
 
     private CatalogLayerEventListener catalogLayerEventListener;
@@ -233,6 +235,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
      * @param jdbcConfigurationStorage GeoServer integrator for GeoWebCache DiskQuota {@link
      *     JDBCConfiguration}
      * @param blobStoreAggregator GeoWebCache BlobStore Aggregator
+     * @param gwcSynchEnv GeoServer integrator for GeoWebCache environment synchronization
      */
     public GWC(
             final GWCConfigPersister gwcConfigPersister,
@@ -246,7 +249,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             final Catalog rawCatalog,
             final DefaultStorageFinder storageFinder,
             final JDBCConfigurationStorage jdbcConfigurationStorage,
-            final BlobStoreAggregator blobStoreAggregator) {
+            final BlobStoreAggregator blobStoreAggregator,
+            final GWCSynchEnv gwcSynchEnv) {
 
         this.gwcConfigPersister = gwcConfigPersister;
         this.tld = tld;
@@ -268,6 +272,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
 
         this.jdbcConfigurationStorage = jdbcConfigurationStorage;
         this.blobStoreAggregator = blobStoreAggregator;
+        this.gwcSynchEnv = gwcSynchEnv;
     }
 
     /** Updates the configurable lock provider to use the specified bean */
@@ -296,30 +301,44 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     }
 
     /**
+     * Gets the singleton instance of the GeoServer GWC environment synchronizer
+     *
+     * @return the singleton instance of the GeoServer GWC environment synchronizer
+     */
+    public GWCSynchEnv getGwcSynchEnv() {
+        return gwcSynchEnv;
+    }
+
+    /**
      * Retrieves the GWC mediator bean, if registered in the spring context or set via {@link
-     * #set(GWC)}.
+     * #set(GWC,GWCSynchEnv)}.
      *
      * @return The {@link GWC} mediator bean
      * @throws IllegalStateException if no {@link GWC} instance was found.
      */
     public static GWC get() {
-        GWC.INSTANCE.syncEnv();
+        GWC.INSTANCE.gwcSynchEnv.syncEnv();
         return GWC.INSTANCE;
     }
 
     /**
-     * Only to aid in unit testing for the places where a mock GWC mediator is needed and {@link
-     * GWC#get()} is used; set it to {@code null} at each {@code tearDown} methed for each test that
-     * sets it through {@link GWC#set(GWC)} at its {@code setUp} method
+     * Only to aid in unit testing for the places where a mock GWC mediator and GeoServer
+     * environment synchhronizer are needed
+     *
+     * @param instance the GWC mediator instance
+     * @param gwcSynchEnv the GeoServer environment synchronizer instance
      */
-    public static void set(GWC instance) {
+    public static void set(GWC instance, GWCSynchEnv gwcSynchEnv) {
+        if (instance != null) {
+            instance.gwcSynchEnv = gwcSynchEnv;
+        }
         GWC.INSTANCE = instance;
     }
 
     /** @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet() */
     @Override
     public void afterPropertiesSet() throws Exception {
-        GWC.set(this);
+        GWC.set(this, gwcSynchEnv);
     }
 
     /** @see org.springframework.beans.factory.DisposableBean#destroy() */
@@ -332,7 +351,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         if (this.catalogStyleChangeListener != null) {
             catalog.removeListener(this.catalogStyleChangeListener);
         }
-        GWC.set(null);
+        GWC.set(null, null);
     }
 
     public Catalog getCatalog() {
@@ -2377,36 +2396,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         this.gwcEnvironment = GeoServerExtensions.bean(GeoWebCacheEnvironment.class);
         GWC.INSTANCE = GeoServerExtensions.bean(GWC.class);
 
-        syncEnv();
-    }
-
-    /**
-     * Synchronizes environment properties between the {@link GeoServerEnvironment} and the {@link
-     * GeoWebCacheEnvironment}. (GeoServer properties will override GeoWebCache properties)
-     */
-    public void syncEnv() throws IllegalArgumentException {
-        if (needsSynchronization()) {
-            synchronized (this) {
-                if (needsSynchronization()) {
-                    Properties gwcProps = gwcEnvironment.getProps();
-
-                    if (gwcProps == null) {
-                        gwcProps = new Properties();
-                    }
-                    gwcProps.putAll(gsEnvironment.getProps());
-
-                    gwcEnvironment.setProps(gwcProps);
-                }
-            }
-        }
-    }
-
-    private boolean needsSynchronization() {
-        return GeoServerEnvironment.allowEnvParametrization()
-                && gsEnvironment != null
-                && gsEnvironment.getProps() != null
-                && gwcEnvironment != null
-                && (gsEnvironment.isStale() || gwcEnvironment.getProps() == null);
+        GWC.INSTANCE.gwcSynchEnv.syncEnv();
     }
 
     /**

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWCSynchEnv.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWCSynchEnv.java
@@ -1,0 +1,94 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import java.util.Properties;
+import org.geoserver.platform.GeoServerEnvironment;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geowebcache.GeoWebCacheEnvironment;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/** This class is responsible for synchronizing the GeoServer environment for GWC. */
+public class GWCSynchEnv implements ApplicationContextAware {
+    private GeoWebCacheEnvironment gwcEnvironment;
+
+    GeoServerEnvironment gsEnvironment;
+
+    private boolean forceSync = false;
+
+    /**
+     * Constructor to inject the GeoServerEnvironment.
+     *
+     * @param gsEnvironment the GeoServerEnvironment
+     */
+    public GWCSynchEnv(GeoServerEnvironment gsEnvironment) {
+        this.gsEnvironment = gsEnvironment;
+    }
+
+    /**
+     * Only for unit tests, this inserts a GeoServerEnvironment instance that is not a bean.
+     *
+     * @param gsEnvironment the GeoServerEnvironment instance to use
+     */
+    protected void setGsEnvironment(GeoServerEnvironment gsEnvironment) {
+        this.gsEnvironment = gsEnvironment;
+    }
+
+    /**
+     * Only for unit tests, this inserts a GeoWebCacheEnvironment instance that is not a bean.
+     *
+     * @param gwcEnvironment the GeoWebCacheEnvironment instance to use
+     */
+    protected void setGwcEnvironment(GeoWebCacheEnvironment gwcEnvironment) {
+        this.gwcEnvironment = gwcEnvironment;
+    }
+
+    /**
+     * Only for unit tests, this forces the synchronization of the GeoServer and GeoWebCache while
+     * avoiding setting system properties.
+     *
+     * @param forceSync
+     */
+    protected void setForceSync(boolean forceSync) {
+        this.forceSync = forceSync;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.gwcEnvironment = GeoServerExtensions.bean(GeoWebCacheEnvironment.class);
+        syncEnv();
+    }
+    /**
+     * Synchronizes environment properties between the {@link GeoServerEnvironment} and the {@link
+     * GeoWebCacheEnvironment}. (GeoServer properties will override GeoWebCache properties)
+     */
+    public void syncEnv() throws IllegalArgumentException {
+        if (needsSynchronization()) {
+            synchronized (this) {
+                if (needsSynchronization()) {
+                    Properties gwcProps = gwcEnvironment.getProps();
+
+                    if (gwcProps == null) {
+                        gwcProps = new Properties();
+                    }
+                    gwcProps.putAll(gsEnvironment.getProps());
+
+                    gwcEnvironment.setProps(gwcProps);
+                }
+            }
+        }
+    }
+
+    private boolean needsSynchronization() {
+        return (GeoServerEnvironment.allowEnvParametrization() || forceSync)
+                && gsEnvironment != null
+                && gsEnvironment.getProps() != null
+                && gwcEnvironment != null
+                && (gsEnvironment.isStale() || gwcEnvironment.getProps() == null);
+    }
+}

--- a/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
@@ -28,6 +28,11 @@
     <constructor-arg ref="rawCatalog" />
     <constructor-arg ref="gwcDefaultStorageFinder"/>
     <constructor-arg ref="gwcJdbcConfigurationStorage"/>
+    <constructor-arg ref="gwcSynchEnv"/>
+  </bean>
+
+  <bean id="gwcSynchEnv" class="org.geoserver.gwc.GWCSynchEnv" depends-on="geoWebCacheExtensions" lazy-init="false">
+    <constructor-arg ref="environments" />
   </bean>
 
   <bean id="gwcWMSExtendedCapabilitiesProvider" class="org.geoserver.gwc.wms.CachingExtendedCapabilitiesProvider">

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCSynchEnvTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCSynchEnvTest.java
@@ -1,0 +1,42 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.gwc;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+import org.geoserver.platform.GeoServerEnvironment;
+import org.geowebcache.GeoWebCacheEnvironment;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+/** Tests that the GWC Environment is synchronized with the GeoServer Environment. */
+public class GWCSynchEnvTest {
+
+    @AfterClass
+    public static void teardown() {
+        System.clearProperty("ENV_PROPERTIES");
+    }
+
+    @Test
+    public void testEnvParametrizationValues() throws Exception {
+        URL url = getClass().getResource("geoserver-environment.properties");
+        System.setProperty("ENV_PROPERTIES", url.getPath());
+        GeoServerEnvironment genv = new GeoServerEnvironment();
+
+        GWCSynchEnv gwcSynchEnv = new GWCSynchEnv(genv);
+
+        GeoWebCacheEnvironment gwcEnv = new GeoWebCacheEnvironment();
+        gwcSynchEnv.setGwcEnvironment(gwcEnv);
+
+        // force sync because system setting for allowing parametrization keeps getting reset
+        gwcSynchEnv.setForceSync(true);
+
+        gwcSynchEnv.syncEnv();
+
+        assertEquals(genv.resolveValue("${test.env}"), gwcEnv.resolveValue("${test.env}"));
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
@@ -198,6 +198,8 @@ public class GWCTest {
 
     private JDBCConfigurationStorage jdbcStorage;
 
+    private GWCSynchEnv synchEnv;
+
     static Resource tmpDir() throws IOException {
         Resource root = Files.asResource(new File(System.getProperty("java.io.tmpdir", ".")));
         Resource directory = Resources.createRandom("tmp", "", root);
@@ -247,6 +249,7 @@ public class GWCTest {
         jdbcStorage = createMock(JDBCConfigurationStorage.class);
         xmlConfig = mock(XMLConfiguration.class);
         blobStoreAggregator = mock(BlobStoreAggregator.class);
+        synchEnv = mock(GWCSynchEnv.class);
 
         gridSetBroker =
                 new GridSetBroker(Arrays.asList(new DefaultGridsets(true, true), xmlConfig));
@@ -323,7 +326,8 @@ public class GWCTest {
                                 catalog,
                                 storageFinder,
                                 jdbcStorage,
-                                blobStoreAggregator)
+                                blobStoreAggregator,
+                                synchEnv)
                         .createMock();
 
         expect(appContext.getBeanNamesForType(GWC.class))
@@ -400,18 +404,19 @@ public class GWCTest {
                         catalog,
                         storageFinder,
                         jdbcStorage,
-                        blobStoreAggregator);
+                        blobStoreAggregator,
+                        synchEnv);
         mediator.setApplicationContext(appContext);
 
         mediator = spy(mediator);
-        GWC.set(mediator);
+        GWC.set(mediator, synchEnv);
     }
 
     @After
     public void tearDown() {
         System.clearProperty("ALLOW_ENV_PARAMETRIZATION");
         System.clearProperty("TEST_ENV_PROPERTY");
-        GWC.set(null);
+        GWC.set(null, null);
     }
 
     private void mockCatalog() {

--- a/src/gwc/src/test/java/org/geoserver/gwc/function/IsCachedFunctionTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/function/IsCachedFunctionTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geotools.filter.FilterFactoryImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -22,12 +23,15 @@ public class IsCachedFunctionTest {
 
     private GWC mockGWC;
 
+    private GWCSynchEnv mockGWCSynchEnv;
+
     private LayerInfo layerInfo;
 
     @Before
     public void setUp() throws Exception {
         mockGWC = mock(GWC.class);
-        GWC.set(mockGWC);
+        mockGWCSynchEnv = mock(GWCSynchEnv.class);
+        GWC.set(mockGWC, mockGWCSynchEnv);
         layerInfo = mock(LayerInfo.class);
 
         when(mockGWC.hasTileLayer(eq(layerInfo))).thenReturn(true);
@@ -35,7 +39,7 @@ public class IsCachedFunctionTest {
 
     @After
     public void tearDown() throws Exception {
-        GWC.set(null);
+        GWC.set(null, null);
     }
 
     @Test

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogConfigurationLayerConformanceTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogConfigurationLayerConformanceTest.java
@@ -17,6 +17,7 @@ import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.MetadataMap;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geowebcache.GeoWebCacheException;
@@ -130,6 +131,8 @@ public class CatalogConfigurationLayerConformanceTest extends LayerConfiguration
 
     private GWC mediator;
 
+    private GWCSynchEnv synchEnv;
+
     private Catalog catalog;
 
     private File dataDir;
@@ -139,9 +142,12 @@ public class CatalogConfigurationLayerConformanceTest extends LayerConfiguration
         catalog = EasyMock.createMock("catalog", Catalog.class);
         gsBroker = EasyMock.createMock("gsBroker", GridSetBroker.class);
         mediator = EasyMock.createMock("mediator", GWC.class);
+        synchEnv = EasyMock.createMock("synchEnv", GWCSynchEnv.class);
 
-        mediator.syncEnv();
-        EasyMock.expectLastCall().anyTimes();
+        EasyMock.expect(mediator.getGwcSynchEnv()).andReturn(synchEnv).anyTimes();
+        synchEnv.syncEnv();
+        EasyMock.expectLastCall().andVoid().anyTimes();
+
         mediator.layerAdded(EasyMock.anyObject(String.class));
         EasyMock.expectLastCall().anyTimes();
         EasyMock.expect(mediator.layerRemoved(EasyMock.anyObject(String.class)))
@@ -149,9 +155,9 @@ public class CatalogConfigurationLayerConformanceTest extends LayerConfiguration
         mediator.layerRenamed(EasyMock.anyObject(String.class), EasyMock.anyObject(String.class));
         EasyMock.expectLastCall().anyTimes();
 
-        EasyMock.replay(catalog, gsBroker, mediator);
+        EasyMock.replay(catalog, gsBroker, mediator, synchEnv);
         context.addBean("mediator", mediator, GWC.class);
-        GWC.set(mediator);
+        GWC.set(mediator, synchEnv);
 
         gwcConfig = new GWCConfig();
         dataDir = temp.newFolder();
@@ -167,7 +173,7 @@ public class CatalogConfigurationLayerConformanceTest extends LayerConfiguration
 
     @After
     public void removeMediator() throws Exception {
-        GWC.set(null);
+        GWC.set(null, null);
     }
 
     @Override

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogConfigurationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/CatalogConfigurationTest.java
@@ -47,6 +47,7 @@ import org.geoserver.catalog.PublishedType;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.ows.LocalWorkspace;
 import org.geowebcache.config.DefaultGridsets;
@@ -76,6 +77,7 @@ public class CatalogConfigurationTest {
     private GeoServerTileLayerInfo layerInfo1, layerInfo2, groupInfo1, groupInfo2;
 
     private GWC mockMediator;
+    private GWCSynchEnv mockGWCSynchEnv;
 
     private GWCConfig defaults;
 
@@ -178,14 +180,15 @@ public class CatalogConfigurationTest {
         config = new CatalogConfiguration(catalog, tileLayerCatalog, gridSetBroker);
 
         mockMediator = mock(GWC.class);
-        GWC.set(mockMediator);
+        mockGWCSynchEnv = mock(GWCSynchEnv.class);
+        GWC.set(mockMediator, mockGWCSynchEnv);
         when(mockMediator.getConfig()).thenReturn(defaults);
         when(mockMediator.getCatalog()).thenReturn(catalog);
     }
 
     @After
     public void tearDown() {
-        GWC.set(null);
+        GWC.set(null, null);
     }
 
     @Test

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -89,6 +89,7 @@ import org.geoserver.catalog.impl.ResourceInfoImpl;
 import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.dispatch.GwcServiceDispatcherCallback;
 import org.geoserver.ows.Dispatcher;
@@ -161,22 +162,26 @@ public class GeoServerTileLayerTest {
 
     private GWC mockGWC;
 
+    private GWCSynchEnv mockGWCSynchEnv;
+
     private FeatureTypeInfoImpl resource;
 
     private NamespaceInfoImpl ns;
 
     @After
     public void tearDown() throws Exception {
-        GWC.set(null);
+        GWC.set(null, null);
         Dispatcher.REQUEST.remove();
     }
 
     @Before
     public void setUp() throws Exception {
         mockGWC = mock(GWC.class);
+        mockGWCSynchEnv = mock(GWCSynchEnv.class);
+
         MemoryLockProvider lockProvider = new MemoryLockProvider();
         when(mockGWC.getLockProvider()).thenReturn(lockProvider);
-        GWC.set(mockGWC);
+        GWC.set(mockGWC, mockGWCSynchEnv);
 
         final String layerInfoId = "mock-layer-info";
 

--- a/src/gwc/src/test/resources/org/geoserver/gwc/geoserver-environment.properties
+++ b/src/gwc/src/test/resources/org/geoserver/gwc/geoserver-environment.properties
@@ -1,0 +1,5 @@
+demo.wms.url = http://demo.geo-solutions.it/geoserver
+test.env = AF-TEST
+jdbc.host = localhost
+jdbc.port = 5432
+proxy.custom = http://custom.host/

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaSettingsPage.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaSettingsPage.java
@@ -176,7 +176,7 @@ public class DiskQuotaSettingsPage extends GeoServerSecuredPage {
 
     private GWC getGWC() {
         final GWC gwc = (GWC) getGeoServerApplication().getBean("gwcFacade");
-        gwc.syncEnv();
+        gwc.getGwcSynchEnv().syncEnv();
         return gwc;
     }
 

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayerProviderTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayerProviderTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.test.GeoServerTestSupport;
 import org.geowebcache.config.ConfigurationException;
@@ -83,8 +84,10 @@ public class CachedLayerProviderTest extends GeoServerTestSupport {
     @Test
     public void testAdvertised() {
         GWC oldGWC = GWC.get();
+        GWCSynchEnv oldGWCSynchEnv = GWC.get().getGwcSynchEnv();
         GWC gwc = mock(GWC.class);
-        GWC.set(gwc);
+        GWCSynchEnv synchEnv = mock(GWCSynchEnv.class);
+        GWC.set(gwc, synchEnv);
         // Adding a few Mocks for an Unadvertised Layer
         TileLayer l = mock(TileLayer.class);
         when(l.isAdvertised()).thenReturn(false);
@@ -106,7 +109,7 @@ public class CachedLayerProviderTest extends GeoServerTestSupport {
         // Ensure that the two numbers are equal
         assertEquals(gwcSize, providerSize);
 
-        // Set the old GWC
-        GWC.set(oldGWC);
+        // Set the old GWC and GWCSynchEnv
+        GWC.set(oldGWC, oldGWCSynchEnv);
     }
 }

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerEditCacheOptionsTabPanelInfoTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerEditCacheOptionsTabPanelInfoTest.java
@@ -18,6 +18,7 @@ import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MetadataMap;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.gwc.GWC;
+import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.gwc.layer.GeoServerTileLayerInfo;
@@ -35,6 +36,8 @@ public class LayerEditCacheOptionsTabPanelInfoTest {
 
     GWC gwc;
 
+    GWCSynchEnv synchEnv;
+
     IModel<? extends ResourceInfo> resourceModel;
 
     LayerInfo layer;
@@ -45,7 +48,8 @@ public class LayerEditCacheOptionsTabPanelInfoTest {
     public void setUpInternal() throws Exception {
         panelInfo = new LayerEditCacheOptionsTabPanelInfo();
         gwc = mock(GWC.class);
-        GWC.set(gwc);
+        synchEnv = mock(GWCSynchEnv.class);
+        GWC.set(gwc, synchEnv);
 
         defaults = GWCConfig.getOldDefaults();
         when(gwc.getConfig()).thenReturn(defaults);
@@ -63,7 +67,7 @@ public class LayerEditCacheOptionsTabPanelInfoTest {
 
     @After
     public void tearDown() {
-        GWC.set(null);
+        GWC.set(null, null);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10731](https://badgen.net/badge/JIRA/GEOS-10731/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10731)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…t.properties due to the bean initialization order

missed adds

cleanup

added test


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->