### PR TITLE
[GEOS-10737] GeoCSS misses support for labelInFeatureInfo and labelAttributeName vendor options

### DIFF
--- a/doc/en/user/source/styling/css/properties.rst
+++ b/doc/en/user/source/styling/css/properties.rst
@@ -532,6 +532,15 @@ Raster symbology
       * string
       * Controls how the color map entries are interpreted, the possible values are "ramp", "intervals" and "values", with ramp being the default if no "raster-color-map-type" is provided. The default "ramp" behavior is to linearly interpolate color between the provided values, and assign the lowest color to all values below the lowest value, and the highest color to all values above the highest value. The "intervals" behavior instead assigns solid colors between values, whilst "values" only assigns colors to the specified values, every other value in the raster is not painted at all
       * no
+    - * ``raster-label-fi``
+      * string
+      * Controls if and how color map entry labels are included, as attributes, in the GetFeatureInfo output. Valid values are ``add``, adding the labels as extra attributes, ``replace``, using the labels in place of the actual value, or ``none`` (the default) which does not include the labels in the output.
+      * no
+    - * ``raster-label-name``
+      * string
+      * If color map entry labels are included in the GetFeatureInfo output, this property controls then name of the attribute that will contain them.
+      * no
+
  
 .. _css_properties_shared:
 


### PR DESCRIPTION
[![GEOS-10737](https://badgen.net/badge/JIRA/GEOS-10737/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10737)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Documentation update, actual fix done in GeoTools.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->