### PR TITLE
[GEOS-10723] params.extractor Resource

### DIFF
--- a/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
+++ b/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/Filter.java
@@ -65,8 +65,8 @@ public final class Filter implements GeoServerFilter, ExtensionPriority {
         if (dataDirectory != null) {
             Utils.info(LOGGER, "Initiating parameters extractor rules.");
             Resource resource = dataDirectory.get(RulesDao.getRulesPath());
-            rules = RulesDao.getRules(() -> resource.in());
-            resource.addListener(notify -> rules = RulesDao.getRules(() -> resource.in()));
+            rules = RulesDao.getRules(resource);
+            resource.addListener(notify -> rules = RulesDao.getRules(resource));
         } else {
             // no rules were loaded
             Utils.info(
@@ -85,7 +85,7 @@ public final class Filter implements GeoServerFilter, ExtensionPriority {
      * this happens the related instance will be used instead of the one initialized by Spring.
      */
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
+    public void init(FilterConfig filterConfig) {
         GeoServerDataDirectory dataDirectory =
                 GeoServerExtensions.bean(GeoServerDataDirectory.class);
         Utils.info(LOGGER, "Initiating parameters extractor as a standard web container filter.");

--- a/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
+++ b/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/RulesDao.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.geoserver.config.GeoServerDataDirectory;
@@ -43,40 +42,50 @@ public final class RulesDao {
 
     public static List<Rule> getRules() {
         Resource rules = getDataDirectory().get(getRulesPath());
-        return getRules(() -> rules.in());
+        return getRules(rules);
     }
 
     private static GeoServerDataDirectory getDataDirectory() {
         return (GeoServerDataDirectory) GeoServerExtensions.bean("dataDirectory");
     }
 
-    public static List<Rule> getRules(Supplier<InputStream> iss) {
-        try (InputStream inputStream = iss.get()) {
-            if (inputStream.available() == 0) {
-                Utils.info(LOGGER, "Parameters extractor rules file seems to be empty.");
-                return new ArrayList<>();
+    /**
+     * Read a list of Rule from a resource. Return an empty list if the resource does not exist.
+     *
+     * @param resource to read.
+     * @return a list of Rule or an empty list if the resource does not exist.
+     */
+    public static List<Rule> getRules(Resource resource) {
+        // This prevents Resource.in() from creating the file or throwing an exception.
+        if (resource.getType() == Resource.Type.RESOURCE) {
+            try (InputStream inputStream = resource.in()) {
+                if (inputStream.available() == 0) {
+                    Utils.info(LOGGER, "Parameters extractor rules file seems to be empty.");
+                } else {
+                    RuleList list = (RuleList) xStream.fromXML(inputStream);
+                    List<Rule> rules = list.rules == null ? new ArrayList<>() : list.rules;
+                    Utils.info(LOGGER, "Parameters extractor loaded %d rules.", rules.size());
+                    return rules;
+                }
+            } catch (Exception exception) {
+                throw Utils.exception(exception, "Error parsing rules files.");
             }
-
-            RuleList list = (RuleList) xStream.fromXML(inputStream);
-            List<Rule> rules = list.rules == null ? new ArrayList<>() : list.rules;
-            Utils.info(LOGGER, "Parameters extractor loaded %d rules.", rules.size());
-            return rules;
-        } catch (Exception exception) {
-            throw Utils.exception(exception, "Error parsing rules files.");
+        } else {
+            Utils.info(LOGGER, "Rule file does not exist.");
         }
+        return new ArrayList<>();
     }
 
     public static void saveOrUpdateRule(Rule rule) {
         Resource rules = getDataDirectory().get(getRulesPath());
         Resource tmpRules = getDataDirectory().get(getTempRulesPath());
-        saveOrUpdateRule(rule, () -> rules.in(), () -> tmpRules.out());
+        saveOrUpdateRule(rule, rules, tmpRules);
         rules.delete();
         tmpRules.renameTo(rules);
     }
 
-    public static void saveOrUpdateRule(
-            Rule rule, Supplier<InputStream> iss, Supplier<OutputStream> oss) {
-        List<Rule> rules = getRules(iss);
+    public static void saveOrUpdateRule(Rule rule, Resource in, Resource out) {
+        List<Rule> rules = getRules(in);
         boolean exists = false;
         for (int i = 0; i < rules.size() && !exists; i++) {
             if (rules.get(i).getId().equals(rule.getId())) {
@@ -87,27 +96,24 @@ public final class RulesDao {
         if (!exists) {
             rules.add(rule);
         }
-        writeRules(rules, oss);
+        writeRules(rules, out);
         Utils.info(LOGGER, "Parameters extractor rules updated.");
     }
 
     public static void deleteRules(String... rulesIds) {
         Resource rules = getDataDirectory().get(getRulesPath());
         Resource tmpRules = getDataDirectory().get(getTempRulesPath());
-        deleteRules(() -> rules.in(), () -> tmpRules.out(), rulesIds);
+        deleteRules(rules, tmpRules, rulesIds);
         rules.delete();
         tmpRules.renameTo(rules);
     }
 
-    public static void deleteRules(
-            Supplier<InputStream> inputStream,
-            Supplier<OutputStream> outputStream,
-            String... ruleIds) {
+    public static void deleteRules(Resource input, Resource output, String... ruleIds) {
         List<Rule> rules =
-                getRules(inputStream).stream()
+                getRules(input).stream()
                         .filter(rule -> !matchesAnyRuleId(rule, ruleIds))
                         .collect(Collectors.toList());
-        writeRules(rules, outputStream);
+        writeRules(rules, output);
         Utils.info(LOGGER, "Deleted one or more parameters extractor rules.");
     }
 
@@ -115,8 +121,8 @@ public final class RulesDao {
         return Arrays.stream(ruleIds).anyMatch(ruleId -> ruleId.equals(rule.getId()));
     }
 
-    private static void writeRules(List<Rule> rules, Supplier<OutputStream> oss) {
-        try (OutputStream outputStream = oss.get()) {
+    private static void writeRules(List<Rule> rules, Resource resource) {
+        try (OutputStream outputStream = resource.out()) {
             xStream.toXML(new RuleList(rules), outputStream);
         } catch (Exception exception) {
             throw Utils.exception(exception, "Something bad happen when writing rules.");

--- a/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
+++ b/src/extension/params-extractor/src/main/java/org/geoserver/params/extractor/UrlMangler.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.params.extractor;
 
+import static org.geoserver.params.extractor.EchoParametersDao.getEchoParameters;
+import static org.geoserver.params.extractor.EchoParametersDao.getEchoParametersPath;
+
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -26,10 +29,9 @@ public class UrlMangler implements URLMangler {
     private List<EchoParameter> echoParameters;
 
     public UrlMangler(GeoServerDataDirectory dataDirectory) {
-        Resource resource = dataDirectory.get(EchoParametersDao.getEchoParametersPath());
-        echoParameters = EchoParametersDao.getEchoParameters(resource.in());
-        resource.addListener(
-                notify -> echoParameters = EchoParametersDao.getEchoParameters(resource.in()));
+        Resource resource = dataDirectory.get(getEchoParametersPath());
+        echoParameters = getEchoParameters(resource);
+        resource.addListener(notify -> echoParameters = getEchoParameters(resource));
     }
 
     private HttpServletRequest getHttpRequest(Request request) {

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/EchoParametersDaoTest.java
@@ -7,75 +7,62 @@ package org.geoserver.params.extractor;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.InputStream;
 import java.util.List;
 import org.junit.Test;
 
 public final class EchoParametersDaoTest extends TestSupport {
 
-    @Test
-    public void testParsingEmptyFile() throws Exception {
-        doWork(
-                "data/echoParameters1.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
-                    assertThat(echoParameters.size(), is(0));
-                });
+    static List<EchoParameter> getEchoParameters() {
+        return EchoParametersDao.getEchoParameters();
+    }
+
+    static List<EchoParameter> getEchoParameters(String path) {
+        return EchoParametersDao.getEchoParameters(getResource(path));
     }
 
     @Test
-    public void testParsingEmptyEchoParameters() throws Exception {
-        doWork(
-                "data/echoParameters2.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
-                    assertThat(echoParameters.size(), is(0));
-                });
+    public void testParsingEmptyFile() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters1.xml");
+        assertThat(echoParameters.size(), is(0));
     }
 
     @Test
-    public void testParsingEchoParameter() throws Exception {
-        doWork(
-                "data/echoParameters3.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
-                    assertThat(echoParameters.size(), is(1));
-                    checkEchoParameter(
-                            echoParameters.get(0),
-                            new EchoParameterBuilder()
-                                    .withId("1")
-                                    .withParameter("CQL_FILTER")
-                                    .withActivated(true)
-                                    .build());
-                });
+    public void testParsingEmptyEchoParameters() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters2.xml");
+        assertThat(echoParameters.size(), is(0));
     }
 
     @Test
-    public void testParsingMultipleEchoParameters() throws Exception {
-        doWork(
-                "data/echoParameters4.xml",
-                (InputStream inputStream) -> {
-                    List<EchoParameter> echoParameters =
-                            EchoParametersDao.getEchoParameters(inputStream);
-                    assertThat(echoParameters.size(), is(2));
-                    checkEchoParameter(
-                            findEchoParameter("0", echoParameters),
-                            new EchoParameterBuilder()
-                                    .withId("0")
-                                    .withParameter("CQL_FILTER")
-                                    .withActivated(true)
-                                    .build());
-                    checkEchoParameter(
-                            findEchoParameter("1", echoParameters),
-                            new EchoParameterBuilder()
-                                    .withId("1")
-                                    .withParameter("BBOX")
-                                    .withActivated(false)
-                                    .build());
-                });
+    public void testParsingEchoParameter() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters3.xml");
+        assertThat(echoParameters.size(), is(1));
+        checkEchoParameter(
+                echoParameters.get(0),
+                new EchoParameterBuilder()
+                        .withId("1")
+                        .withParameter("CQL_FILTER")
+                        .withActivated(true)
+                        .build());
+    }
+
+    @Test
+    public void testParsingMultipleEchoParameters() {
+        List<EchoParameter> echoParameters = getEchoParameters("data/echoParameters4.xml");
+        assertThat(echoParameters.size(), is(2));
+        checkEchoParameter(
+                findEchoParameter("0", echoParameters),
+                new EchoParameterBuilder()
+                        .withId("0")
+                        .withParameter("CQL_FILTER")
+                        .withActivated(true)
+                        .build());
+        checkEchoParameter(
+                findEchoParameter("1", echoParameters),
+                new EchoParameterBuilder()
+                        .withId("1")
+                        .withParameter("BBOX")
+                        .withActivated(false)
+                        .build());
     }
 
     @Test
@@ -101,24 +88,24 @@ public final class EchoParametersDaoTest extends TestSupport {
                         .withParameter("bbox")
                         .build();
         // get the existing echo parameters, this should return an empty list
-        List<EchoParameter> echoParameters = EchoParametersDao.getEchoParameters();
+        List<EchoParameter> echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(0));
         // we save echo parameters A and B
         EchoParametersDao.saveOrUpdateEchoParameter(echoParameterA);
         EchoParametersDao.saveOrUpdateEchoParameter(echoParameterB);
-        echoParameters = EchoParametersDao.getEchoParameters();
+        echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(2));
         checkEchoParameter(echoParameterA, findEchoParameter("0", echoParameters));
         checkEchoParameter(echoParameterB, findEchoParameter("1", echoParameters));
         // we update echo parameter B using rule C
         EchoParametersDao.saveOrUpdateEchoParameter(echoParameterC);
-        echoParameters = EchoParametersDao.getEchoParameters();
+        echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(2));
         checkEchoParameter(echoParameterA, findEchoParameter("0", echoParameters));
         checkEchoParameter(echoParameterC, findEchoParameter("1", echoParameters));
         // we delete echo parameter A
         EchoParametersDao.deleteEchoParameters("0");
-        echoParameters = EchoParametersDao.getEchoParameters();
+        echoParameters = getEchoParameters();
         assertThat(echoParameters.size(), is(1));
     }
 }

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/RulesDaoTest.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/RulesDaoTest.java
@@ -4,129 +4,113 @@
  */
 package org.geoserver.params.extractor;
 
+import static org.geoserver.params.extractor.RulesDao.getRules;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.InputStream;
 import java.util.List;
 import org.junit.Test;
 
 public final class RulesDaoTest extends TestSupport {
 
-    @Test
-    public void testParsingEmptyFile() throws Exception {
-        doWork(
-                "data/rules1.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
-                    assertThat(rules.size(), is(0));
-                });
+    static List<Rule> getRules() {
+        return RulesDao.getRules();
+    }
+
+    static List<Rule> getRules(String path) {
+        return RulesDao.getRules(getResource(path));
     }
 
     @Test
-    public void testParsingEmptyRules() throws Exception {
-        doWork(
-                "data/rules2.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
-                    assertThat(rules.size(), is(0));
-                });
+    public void testParsingEmptyFile() {
+        List<Rule> rules = getRules("data/rules1.xml");
+        assertThat(rules.size(), is(0));
     }
 
     @Test
-    public void testParsingPositionRule() throws Exception {
-        doWork(
-                "data/rules3.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
-                    assertThat(rules.size(), is(1));
-                    checkRule(
-                            rules.get(0),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withPosition(3)
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                });
+    public void testParsingEmptyRules() {
+        List<Rule> rules = getRules("data/rules2.xml");
+        assertThat(rules.size(), is(0));
     }
 
     @Test
-    public void testParsingMatchRule() throws Exception {
-        doWork(
-                "data/rules4.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
-                    assertThat(rules.size(), is(1));
-                    checkRule(
-                            rules.get(0),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withMatch("^.*?(/([^/]+?))/[^/]+$")
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                });
+    public void testParsingPositionRule() {
+        List<Rule> rules = getRules("data/rules3.xml");
+        assertThat(rules.size(), is(1));
+        checkRule(
+                rules.get(0),
+                new RuleBuilder()
+                        .withId("0")
+                        .withPosition(3)
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .build());
     }
 
     @Test
-    public void testParsingMultipleRules() throws Exception {
-        doWork(
-                "data/rules5.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
-                    assertThat(rules.size(), is(3));
-                    checkRule(
-                            findRule("0", rules),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withPosition(3)
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                    checkRule(
-                            findRule("1", rules),
-                            new RuleBuilder()
-                                    .withId("1")
-                                    .withMatch("^.*?(/([^/]+?))/[^/]+$")
-                                    .withParameter("cql_filter")
-                                    .withRemove(2)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                    checkRule(
-                            findRule("2", rules),
-                            new RuleBuilder()
-                                    .withId("2")
-                                    .withPosition(4)
-                                    .withParameter("cql_filter")
-                                    .withRemove(null)
-                                    .withTransform("seq='$2'")
-                                    .build());
-                });
+    public void testParsingMatchRule() {
+        List<Rule> rules = getRules("data/rules4.xml");
+        assertThat(rules.size(), is(1));
+        checkRule(
+                rules.get(0),
+                new RuleBuilder()
+                        .withId("0")
+                        .withMatch("^.*?(/([^/]+?))/[^/]+$")
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .build());
     }
 
     @Test
-    public void testParsingCombineRepeatRule() throws Exception {
-        doWork(
-                "data/rules6.xml",
-                (InputStream inputStream) -> {
-                    List<Rule> rules = RulesDao.getRules(() -> inputStream);
-                    assertThat(rules.size(), is(1));
-                    checkRule(
-                            rules.get(0),
-                            new RuleBuilder()
-                                    .withId("0")
-                                    .withMatch("^.*?(/([^/]+?))/[^/]+$")
-                                    .withParameter("cql_filter")
-                                    .withRemove(1)
-                                    .withTransform("seq='$2'")
-                                    .withCombine("$1;$2")
-                                    .withRepeat(true)
-                                    .build());
-                });
+    public void testParsingMultipleRules() {
+        List<Rule> rules = getRules("data/rules5.xml");
+        assertThat(rules.size(), is(3));
+        checkRule(
+                findRule("0", rules),
+                new RuleBuilder()
+                        .withId("0")
+                        .withPosition(3)
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .build());
+        checkRule(
+                findRule("1", rules),
+                new RuleBuilder()
+                        .withId("1")
+                        .withMatch("^.*?(/([^/]+?))/[^/]+$")
+                        .withParameter("cql_filter")
+                        .withRemove(2)
+                        .withTransform("seq='$2'")
+                        .build());
+        checkRule(
+                findRule("2", rules),
+                new RuleBuilder()
+                        .withId("2")
+                        .withPosition(4)
+                        .withParameter("cql_filter")
+                        .withRemove(null)
+                        .withTransform("seq='$2'")
+                        .build());
+    }
+
+    @Test
+    public void testParsingCombineRepeatRule() {
+        List<Rule> rules = getRules("data/rules6.xml");
+        assertThat(rules.size(), is(1));
+        checkRule(
+                rules.get(0),
+                new RuleBuilder()
+                        .withId("0")
+                        .withMatch("^.*?(/([^/]+?))/[^/]+$")
+                        .withParameter("cql_filter")
+                        .withRemove(1)
+                        .withTransform("seq='$2'")
+                        .withCombine("$1;$2")
+                        .withRepeat(true)
+                        .build());
     }
 
     @Test
@@ -163,24 +147,24 @@ public final class RulesDaoTest extends TestSupport {
                         .withCombine("$1 OR $2")
                         .build();
         // get the existing rules, this should return an empty list
-        List<Rule> rules = RulesDao.getRules();
+        List<Rule> rules = getRules();
         assertThat(rules.size(), is(0));
         // we save rules A and B
         RulesDao.saveOrUpdateRule(ruleA);
         RulesDao.saveOrUpdateRule(ruleB);
-        rules = RulesDao.getRules();
+        rules = getRules();
         assertThat(rules.size(), is(2));
         checkRule(ruleA, findRule("0", rules));
         checkRule(ruleB, findRule("1", rules));
         // we update rule B using rule C
         RulesDao.saveOrUpdateRule(ruleC);
-        rules = RulesDao.getRules();
+        rules = getRules();
         assertThat(rules.size(), is(2));
         checkRule(ruleA, findRule("0", rules));
         checkRule(ruleC, findRule("1", rules));
         // we delete rule A
         RulesDao.deleteRules("0");
-        rules = RulesDao.getRules();
+        rules = getRules();
         assertThat(rules.size(), is(1));
         checkRule(ruleC, findRule("1", rules));
     }

--- a/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
+++ b/src/extension/params-extractor/src/test/java/org/geoserver/params/extractor/TestSupport.java
@@ -10,14 +10,13 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.ResourceStore;
 import org.geoserver.util.IOUtils;
 import org.junit.After;
@@ -41,7 +40,7 @@ public abstract class TestSupport {
     protected ResourceStore resourceStore;
 
     @Before
-    public void voidSetup() throws IOException {
+    public void voidSetup() {
         deleteTestDirectoryQuietly();
         TEST_DIRECTORY.mkdir();
         resourceStore = new FileSystemResourceStore(TEST_DIRECTORY);
@@ -59,18 +58,12 @@ public abstract class TestSupport {
         }
     }
 
-    protected static void doWork(String resourcePath, Consumer<InputStream> consumer)
-            throws Exception {
+    protected static Resource getResource(String resourcePath) {
         URL resource = EchoParametersDaoTest.class.getClassLoader().getResource(resourcePath);
         assertThat(resource, notNullValue());
         File file = new File(resource.getFile());
         assertThat(file.exists(), is(true));
-        try (InputStream inputStream = new FileInputStream(file)) {
-            if (inputStream.available() == 0) {
-                return;
-            }
-            consumer.accept(inputStream);
-        }
+        return Files.asResource(file);
     }
 
     protected void checkRule(Rule ruleA, Rule ruleB) {
@@ -106,8 +99,8 @@ public abstract class TestSupport {
         }
     }
 
-    protected EchoParameter findEchoParameter(String id, List<EchoParameter> rules) {
-        return rules.stream()
+    protected EchoParameter findEchoParameter(String id, List<EchoParameter> echoParameters) {
+        return echoParameters.stream()
                 .filter(echoParameter -> echoParameter.getId().equals(id))
                 .findFirst()
                 .orElse(null);


### PR DESCRIPTION
GEOS-10723

This is a revised pull request replacing [PR #6304](https://github.com/geoserver/geoserver/pull/6304). 
This one focus on the primary problem of using `Resource.in()` and verifies `resource.getType() == Resource.Type.RESOURCE`.
Some confirmed simplifications of the test classes are picked up, too.
Additional aspects of #6304 will be done in a separate issue/PR.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).
