### PR TITLE
[GEOS-10743] read missing style files

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -2167,6 +2167,11 @@ public class ResourcePool {
         if (styleResource == null) {
             throw new IOException("No such resource: " + style.getFilename());
         }
+
+        // return an empty content if the file is missing.
+        if (styleResource.getType() == Resource.Type.UNDEFINED)
+            return new BufferedReader(new org.apache.commons.io.input.NullReader());
+
         return new BufferedReader(new InputStreamReader(styleResource.in()));
     }
 

--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -11,6 +11,7 @@ import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -2164,13 +2165,9 @@ public class ResourcePool {
      */
     public BufferedReader readStyle(StyleInfo style) throws IOException {
         Resource styleResource = dataDir().style(style);
-        if (styleResource == null) {
-            throw new IOException("No such resource: " + style.getFilename());
+        if (styleResource.getType() != Resource.Type.RESOURCE) {
+            throw new FileNotFoundException("No such resource: " + style.getFilename());
         }
-
-        // return an empty content if the file is missing.
-        if (styleResource.getType() == Resource.Type.UNDEFINED)
-            return new BufferedReader(new org.apache.commons.io.input.NullReader());
 
         return new BufferedReader(new InputStreamReader(styleResource.in()));
     }

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.awt.image.RenderedImage;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -709,6 +710,25 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
             // writeStyleFile throws an IOException
         }
         Assert.assertFalse("foo.sld should not exist on disk after a failure.", sldFile.exists());
+    }
+
+    /**
+     * Since GEOS-10743 readStyle() must throw a FileNotFoundException if the style file does not
+     * exist. (Before an empty file was returned.)
+     *
+     * @throws IOException
+     */
+    @Test(expected = FileNotFoundException.class)
+    public void testMissingStyleThrowsException() throws IOException {
+        Catalog catalog = getCatalog();
+        StyleInfo missing = catalog.getFactory().createStyle();
+        missing.setName("missing");
+        missing.setFilename("missing.sld");
+
+        ResourcePool pool = new ResourcePool(catalog);
+        try (BufferedReader reader = pool.readStyle(missing)) {
+            fail("FileNotFoundException expected for missing style files");
+        }
     }
 
     @Test

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleAdminPanel.java
@@ -232,7 +232,8 @@ public class StyleAdminPanel extends StyleEditTabPanel {
                 // ouch, the style file is gone! Register a generic error message
                 Session.get()
                         .error(
-                                new ParamResourceModel("styleNotFound", this, style.getFilename())
+                                new ParamResourceModel(
+                                                "styleNotFound", stylePage, style.getFilename())
                                         .getString());
             }
         }


### PR DESCRIPTION
[![GEOS-10743](https://badgen.net/badge/JIRA/GEOS-10743/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10743)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10743](https://osgeo-org.atlassian.net/browse/GEOS-10743)

[ResourcePool.readStyle](https://github.com/geoserver/geoserver/blob/main/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java#L2165) calls `Resource.in()` without any checking if the file exists.

The decision what to do, if the resource does not exist should be done at higher level. Unfortunately, it is directly turned into a character reader (even a BufferedReader) already. I think this not a good idea to do that at this level. For instance, the encoding is unclear at this point especially for SLD/XML files (same for writing). But I think this is again a refactoring going far beyond this issue.

To keep changes minimal and defensive, I simply returned an empty reader, which is compatible to the previous behavior, without opening (and thus creating) the file.

In general: ResourcePool seems to be a fat [god class](https://refactoring.guru/smells/large-class) which needs some slimming.
  
# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->