### PR TITLE
[GEOS-10476] STAC Sortables should be the same as the configured queryables

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
@@ -33,6 +33,17 @@ public class QueryablesBuilder {
             "https://geojson.org/schema/MultiPolygon.json";
     public static final String GEOMETRY_SCHEMA_REF = "https://geojson.org/schema/Geometry.json";
 
+    public static final String POINT = "Point";
+    public static final String MULTIPOINT = "MultiPoint";
+    public static final String LINESTRING = "LineString";
+    public static final String MULTILINESTRING = "MultiLineString";
+    public static final String POLYGON = "Polygon";
+    public static final String MULTIPOLYGON = "MultiPolygon";
+    public static final String GENERIC_GEOMETRY = "Generic geometry";
+    public static final String DATE = "Date";
+    public static final String DATE_TIME = "DateTime";
+    public static final String TIME = "Time";
+
     Queryables queryables;
 
     public QueryablesBuilder(String id) {
@@ -80,25 +91,25 @@ public class QueryablesBuilder {
         String description;
         if (Point.class.isAssignableFrom(binding)) {
             ref = POINT_SCHEMA_REF;
-            description = "Point";
+            description = POINT;
         } else if (MultiPoint.class.isAssignableFrom(binding)) {
             ref = MULTIPOINT_SCHEMA_REF;
-            description = "MultiPoint";
+            description = MULTIPOINT;
         } else if (LineString.class.isAssignableFrom(binding)) {
             ref = LINESTRING_SCHEMA_REF;
-            description = "LineString";
+            description = LINESTRING;
         } else if (MultiLineString.class.isAssignableFrom(binding)) {
             ref = MULTILINESTRING_SCHEMA_REF;
-            description = "MultiLineString";
+            description = MULTILINESTRING;
         } else if (Polygon.class.isAssignableFrom(binding)) {
             ref = POLYGON_SCHEMA_REF;
-            description = "Polygon";
+            description = POLYGON;
         } else if (MultiPolygon.class.isAssignableFrom(binding)) {
             ref = MULTIPOLYGON_SCHEMA_REF;
-            description = "MultiPolygon";
+            description = MULTIPOLYGON;
         } else {
             ref = GEOMETRY_SCHEMA_REF;
-            description = "Generic geometry";
+            description = GENERIC_GEOMETRY;
         }
 
         schema.set$ref(ref);
@@ -113,13 +124,13 @@ public class QueryablesBuilder {
         schema.setDescription(schema.getType());
         if (java.sql.Date.class.isAssignableFrom(binding)) {
             schema.setFormat("date");
-            schema.setDescription("Date");
+            schema.setDescription(DATE);
         } else if (java.sql.Time.class.isAssignableFrom(binding)) {
             schema.setFormat("time");
-            schema.setDescription("Time");
+            schema.setDescription(TIME);
         } else if (java.util.Date.class.isAssignableFrom(binding)) {
             schema.setFormat("date-time");
-            schema.setDescription("DateTime");
+            schema.setDescription(DATE_TIME);
         }
         return schema;
     }

--- a/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCOpenSearchAccess.java
+++ b/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCOpenSearchAccess.java
@@ -476,6 +476,7 @@ public class JDBCOpenSearchAccess implements org.geoserver.opensearch.eo.store.O
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public FeatureSource<FeatureType, Feature> getFeatureSource(Name typeName) throws IOException {
         if (collectionFeatureType.getName().equals(typeName)) {

--- a/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCOpenSearchAccessFactory.java
+++ b/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCOpenSearchAccessFactory.java
@@ -86,6 +86,7 @@ public class JDBCOpenSearchAccessFactory implements DataAccessFactory {
         return new Param[] {DBTYPE, REPOSITORY_PARAM, STORE_PARAM, NAMESPACE};
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean canProcess(Map<String, ?> params) {
         // copied from AbstractDataStoreFactory... really, this code should be somewhere

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/QueryResultBuilder.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/QueryResultBuilder.java
@@ -434,14 +434,23 @@ class QueryResultBuilder {
         FeatureType itemsSchema =
                 accessProvider.getOpenSearchAccess().getProductSource().getSchema();
         TemplateBuilder builder;
-        if (collectionIds == null || collectionIds.size() > 1) {
+        STACSortablesMapper mapper = null;
+        STACQueryablesBuilder stacQueryablesBuilder = null;
+        String collectionId = null;
+        if (collectionIds != null && !collectionIds.isEmpty()) {
             // right now assuming multiple collections means using search, where the
             // sortables are generic
-            builder = templates.getItemTemplate(null);
-        } else {
-            builder = templates.getItemTemplate(collectionIds.get(0));
+            collectionId = collectionIds.get(0);
         }
-        STACSortablesMapper mapper = new STACSortablesMapper(builder, itemsSchema);
+        mapper =
+                STACSortablesMapper.getSortablesMapper(
+                        collectionId,
+                        templates,
+                        sampleFeatures,
+                        collectionsCache,
+                        itemsSchema,
+                        geoServer);
+
         return mapper.map(sortby);
     }
 

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACQueryablesBuilder.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACQueryablesBuilder.java
@@ -48,6 +48,10 @@ public class STACQueryablesBuilder {
     private static Set<String> SKIP_PROPERTIES = new HashSet<>();
 
     private static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
+    public static final String ID = "ID";
+    public static final String COLLECTION = "Collection";
+    public static final String GEOMETRY = "Geometry";
+    public static final String DATETIME = "Datetime";
 
     static final Map<String, String> WELL_KNOWN_PROPERTIES;
 
@@ -125,10 +129,10 @@ public class STACQueryablesBuilder {
             }
         }
         // force in the extra properties not found under properties
-        properties.put("id", getSchema("ID", ID_SCHEMA_REF));
-        properties.put("collection", getSchema("Collection", COLLECTION_SCHEMA_REF));
-        properties.put("geometry", getSchema("Geometry", GEOMETRY_SCHEMA_REF));
-        properties.put("datetime", getSchema("Datetime", DATETIME_SCHEMA_REF));
+        properties.put("id", getSchema(ID, ID_SCHEMA_REF));
+        properties.put("collection", getSchema(COLLECTION, COLLECTION_SCHEMA_REF));
+        properties.put("geometry", getSchema(GEOMETRY, GEOMETRY_SCHEMA_REF));
+        properties.put("datetime", getSchema(DATETIME, DATETIME_SCHEMA_REF));
 
         return this.queryables;
     }

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
@@ -597,14 +597,22 @@ public class STACService {
         FeatureType itemsSchema =
                 accessProvider.getOpenSearchAccess().getProductSource().getSchema();
         TemplateBuilder builder;
-        if (collectionIds == null || collectionIds.size() > 1) {
+        STACSortablesMapper mapper = null;
+        STACQueryablesBuilder stacQueryablesBuilder = null;
+        String collectionId = null;
+        if (collectionIds != null && !collectionIds.isEmpty()) {
             // right now assuming multiple collections means using search, where the
             // sortables are generic
-            builder = templates.getItemTemplate(null);
-        } else {
-            builder = templates.getItemTemplate(collectionIds.get(0));
+            collectionId = collectionIds.get(0);
         }
-        STACSortablesMapper mapper = new STACSortablesMapper(builder, itemsSchema);
+        mapper =
+                STACSortablesMapper.getSortablesMapper(
+                        collectionId,
+                        templates,
+                        sampleFeatures,
+                        collectionsCache,
+                        itemsSchema,
+                        geoServer);
         return mapper.map(sortby);
     }
 
@@ -746,7 +754,17 @@ public class STACService {
         FeatureType itemsSchema =
                 accessProvider.getOpenSearchAccess().getProductSource().getSchema();
         RootBuilder template = this.templates.getItemTemplate(collectionId);
-        Sortables sortables = new STACSortablesMapper(template, itemsSchema, id).getSortables();
+        STACSortablesMapper sortablesMapper =
+                STACSortablesMapper.getSortablesMapper(
+                        collectionId,
+                        templates,
+                        sampleFeatures,
+                        collectionsCache,
+                        itemsSchema,
+                        geoServer,
+                        template,
+                        id);
+        Sortables sortables = sortablesMapper.getSortables();
         sortables.setCollectionId(collectionId);
         return sortables;
     }
@@ -788,8 +806,17 @@ public class STACService {
         FeatureType itemsSchema =
                 accessProvider.getOpenSearchAccess().getProductSource().getSchema();
         RootBuilder template = this.templates.getItemTemplate(null);
-        Sortables sortables = new STACSortablesMapper(template, itemsSchema, id).getSortables();
-        return sortables;
+        STACSortablesMapper sortablesMapper =
+                STACSortablesMapper.getSortablesMapper(
+                        null,
+                        templates,
+                        sampleFeatures,
+                        collectionsCache,
+                        itemsSchema,
+                        geoServer,
+                        template,
+                        id);
+        return sortablesMapper.getSortables();
     }
 
     private boolean supportsFieldsSelection(HttpServletRequest request)

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACSortablesMapperTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACSortablesMapperTest.java
@@ -6,26 +6,35 @@ package org.geoserver.ogcapi.stac;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
 
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Map;
 import org.geoserver.featurestemplating.configuration.Template;
 import org.geoserver.featurestemplating.readers.TemplateReaderConfiguration;
+import org.geoserver.opensearch.eo.OSEOInfo;
+import org.geoserver.opensearch.eo.OSEOInfoImpl;
 import org.geoserver.opensearch.eo.store.JDBCOpenSearchAccessTest;
 import org.geoserver.opensearch.eo.store.OpenSearchAccess;
 import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.Resource;
+import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureSource;
+import org.geotools.factory.CommonFactoryFinder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
 
 public class STACSortablesMapperTest {
+    private static final String FAKE_ID = "foobar";
 
     static OpenSearchAccess data;
 
@@ -48,8 +57,17 @@ public class STACSortablesMapperTest {
         TemplateReaderConfiguration config =
                 new TemplateReaderConfiguration(STACTemplates.getNamespaces(products));
         Template template = new Template(templateDefinition, config);
+        OSEOInfo service = new OSEOInfoImpl();
+        STACQueryablesBuilder qbuilder =
+                new STACQueryablesBuilder(
+                        FAKE_ID,
+                        template.getRootBuilder(),
+                        products.getSchema(),
+                        null,
+                        null,
+                        service);
         STACSortablesMapper builder =
-                new STACSortablesMapper(template.getRootBuilder(), products.getSchema());
+                new STACSortablesMapper(template.getRootBuilder(), products.getSchema(), qbuilder);
         Map<String, String> sortables = builder.getSortablesMap();
 
         // common sortables from spec
@@ -66,6 +84,97 @@ public class STACSortablesMapperTest {
     }
 
     @Test
+    public void testGetSortableLimitedByGlobalConfiguration() throws Exception {
+        FileSystemResourceStore resourceStore =
+                new FileSystemResourceStore(new File("./src/test/resources"));
+        Resource templateDefinition = resourceStore.get("items-test.json");
+        FeatureSource<FeatureType, Feature> products = data.getProductSource();
+        TemplateReaderConfiguration config =
+                new TemplateReaderConfiguration(STACTemplates.getNamespaces(products));
+        Template template = new Template(templateDefinition, config);
+        OSEOInfoImpl service = new OSEOInfoImpl();
+        service.setGlobalQueryables(
+                Collections.singletonList(
+                        "one.two.three")); // limits sortables to standard set + one.two.three
+        STACQueryablesBuilder qbuilder =
+                new STACQueryablesBuilder(
+                        FAKE_ID,
+                        template.getRootBuilder(),
+                        products.getSchema(),
+                        null,
+                        null,
+                        service);
+        STACSortablesMapper builder =
+                new STACSortablesMapper(template.getRootBuilder(), products.getSchema(), qbuilder);
+        Map<String, String> sortables = builder.getSortablesMap();
+
+        // common sortables from spec
+        assertThat(sortables, hasEntry("collection", "parentIdentifier"));
+        assertThat(sortables, hasEntry("datetime", "timeStart"));
+        assertThat(sortables, hasEntry("id", "identifier"));
+
+        assertThat(
+                sortables,
+                // missing because not in the global queryables
+                not(hasEntry("created", "eop:creationDate")));
+        assertThat(sortables, not(hasEntry("view:sun_azimuth", "eop:illuminationAzimuthAngle")));
+
+        // one custom, and nested, property
+        assertThat(
+                sortables,
+                hasEntry(
+                        "one.two.three",
+                        // present because it is in the global queryables
+                        "eop:illuminationAzimuthAngle"));
+    }
+
+    @Test
+    public void testGetSortableLimitedByCollectionConfiguration() throws Exception {
+        FileSystemResourceStore resourceStore =
+                new FileSystemResourceStore(new File("./src/test/resources"));
+        Resource templateDefinition = resourceStore.get("items-test.json");
+        FeatureSource<FeatureType, Feature> products = data.getProductSource();
+        TemplateReaderConfiguration config =
+                new TemplateReaderConfiguration(STACTemplates.getNamespaces(products));
+        Template template = new Template(templateDefinition, config);
+        OSEOInfoImpl service = new OSEOInfoImpl();
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        Filter collectionSampleFilter = ff.equals(ff.property("name"), ff.literal("LANDSAT8"));
+        Feature sampleCollectionFeature =
+                DataUtilities.first(data.getCollectionSource().getFeatures(collectionSampleFilter));
+        STACQueryablesBuilder qbuilder =
+                new STACQueryablesBuilder(
+                        FAKE_ID,
+                        template.getRootBuilder(),
+                        products.getSchema(),
+                        null,
+                        sampleCollectionFeature,
+                        service);
+        STACSortablesMapper builder =
+                new STACSortablesMapper(template.getRootBuilder(), products.getSchema(), qbuilder);
+        Map<String, String> sortables = builder.getSortablesMap();
+
+        // common sortables from spec, always available to sortables
+        assertThat(sortables, hasEntry("collection", "parentIdentifier"));
+        assertThat(sortables, hasEntry("datetime", "timeStart"));
+        assertThat(sortables, hasEntry("id", "identifier"));
+
+        assertThat(
+                sortables,
+                // missing because not in the global or collection queryables
+                not(hasEntry("missing", "eo:wavelength")));
+        assertThat(sortables, not(hasEntry("missing", "eo:wavelength")));
+
+        assertThat(
+                sortables,
+                hasEntry(
+                        "view:sun_azimuth",
+                        // present because it eop:illuminationAzimuthAngle is in the collection
+                        // queryables
+                        "eop:illuminationAzimuthAngle"));
+    }
+
+    @Test
     public void testSortablesIncludeFlat() throws Exception {
         FileSystemResourceStore resourceStore =
                 new FileSystemResourceStore(new File("./src/test/resources"));
@@ -74,8 +183,17 @@ public class STACSortablesMapperTest {
         TemplateReaderConfiguration config =
                 new TemplateReaderConfiguration(STACTemplates.getNamespaces(products));
         Template template = new Template(templateDefinition, config);
+        OSEOInfo service = new OSEOInfoImpl();
+        STACQueryablesBuilder qbuilder =
+                new STACQueryablesBuilder(
+                        FAKE_ID,
+                        template.getRootBuilder(),
+                        products.getSchema(),
+                        null,
+                        null,
+                        service);
         STACSortablesMapper builder =
-                new STACSortablesMapper(template.getRootBuilder(), products.getSchema());
+                new STACSortablesMapper(template.getRootBuilder(), products.getSchema(), qbuilder);
         Map<String, String> sortables = builder.getSortablesMap();
 
         // common sortables from spec

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACTestSupport.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/STACTestSupport.java
@@ -63,7 +63,8 @@ public class STACTestSupport extends OGCApiTestSupport {
         GeoServer gs = getGeoServer();
         OSEOInfo service = gs.getService(OSEOInfo.class);
         service.setTitle(STAC_TITLE);
-        service.getGlobalQueryables().addAll(Arrays.asList("id", "geometry", "collection"));
+        service.getGlobalQueryables()
+                .addAll(Arrays.asList("id", "geometry", "collection", "eo:cloud_cover"));
         gs.save(service);
 
         setupBasicOpenSearch(testData, getCatalog(), gs, false);

--- a/src/community/oseo/oseo-stac/src/test/resources/items-test.json
+++ b/src/community/oseo/oseo-stac/src/test/resources/items-test.json
@@ -20,6 +20,7 @@
         "start_datetime": "$filter{timeStart is not null and timeEnd is not null and timeStart <> timeEnd},${timeStart}",
         "end_datetime": "$filter{timeStart is not null and timeEnd is not null and timeStart <> timeEnd},${timeEnd}",
         "datetime": "$filter{timeStart is not null and (timeEnd is null or timeStart = timeEnd)},${timeStart}",
+        "missing": "${eo:wavelength}",
         "created": "${eop:creationDate}",
         "updated": "${eop:modificationDate}",
         "platform": "${eop:productPlatform}",

--- a/src/community/oseo/web-oseo/src/main/java/org/geoserver/opensearch/eo/web/OSEOAdminPage.java
+++ b/src/community/oseo/web-oseo/src/main/java/org/geoserver/opensearch/eo/web/OSEOAdminPage.java
@@ -96,9 +96,10 @@ public class OSEOAdminPage extends BaseServiceAdminPage<OSEOInfo> {
                         "globalQueryables",
                         LiveCollectionModel.list(new PropertyModel(info, "globalQueryables"))) {
                     @Override
-                    protected IConverter<?> createConverter(Class<?> type) {
-                        if (List.class.equals(type)) return new QueryablesConverter();
-                        return super.createConverter(type);
+                    public <C> IConverter<C> getConverter(Class<C> type) {
+                        if (type.isAssignableFrom(ArrayList.class))
+                            return (IConverter<C>) new QueryablesConverter();
+                        return super.getConverter(type);
                     }
                 };
         globalQueryables.setType(List.class);


### PR DESCRIPTION
[![GEOS-10746](https://badgen.net/badge/JIRA/GEOS-10746/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10746)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->