### PR TITLE
Fix --mount option

### DIFF
--- a/doc/en/user/source/installation/docker.rst
+++ b/doc/en/user/source/installation/docker.rst
@@ -48,7 +48,7 @@ This will run the container with a local data directory.  The data directory wil
 
 #. Run the container
 
-      docker run \-\-mount type=bind,src=/MY/DATADIRECTORY,target=/opt/geoserver_data -it -p8080:8080 docker.osgeo.org/geoserver:|release|
+      docker run --mount type=bind,src=/MY/DATADIRECTORY,target=/opt/geoserver_data -it -p8080:8080 docker.osgeo.org/geoserver:|release|
 
 
 #. In a web browser, navigate to ``http://localhost:8080/geoserver``.


### PR DESCRIPTION
In the docker documentation, the mount option was incorrectly -mount instead of --mount.

Also, the release name of docker container is incorrect :
`docker.osgeo.org/geoserver:2.22-SNAPSHOT` does not exist and should be replaced by `docker.osgeo.org/geoserver:2.22-RC` but I did not find where to change this.