### PR TITLE
[GEOS-10757] CITE: WMS <Style> has elements in wrong order (DTD validation)

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -1150,6 +1150,7 @@ public class GetCapabilitiesTransformer extends TransformerBase {
         }
 
         private void handleCommonStyleElements(StyleInfo defaultStyle) {
+            element("Name", defaultStyle.prefixedName());
             Style ftStyle;
             try {
                 ftStyle = defaultStyle.getStyle();
@@ -1157,7 +1158,6 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            element("Name", defaultStyle.prefixedName());
         }
 
         private void handleStyleTitleAndAbstract(String prefixedName, Style ftStyle) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -1344,6 +1344,14 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             }
             handleMetadataList(metadataLinks);
 
+            if (CapabilityUtil.encodeGroupDefaultStyle(wmsConfig, layerGroup))
+                handleLayerGroupDefaultStyle(layerName);
+
+            if (isSingleOrOpaque(layerGroup))
+                handleLayerGroupStyles(layerName, layerGroup.getLayerGroupStyles());
+
+            handleScaleHint(layerGroup);
+
             // handle children layers and groups
             if (!LayerGroupInfo.Mode.OPAQUE_CONTAINER.equals(layerGroup.getMode())
                     && !LayerGroupInfo.Mode.SINGLE.equals(layerGroup.getMode())) {
@@ -1358,13 +1366,6 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                     }
                 }
             }
-            if (CapabilityUtil.encodeGroupDefaultStyle(wmsConfig, layerGroup))
-                handleLayerGroupDefaultStyle(layerName);
-
-            if (isSingleOrOpaque(layerGroup))
-                handleLayerGroupStyles(layerName, layerGroup.getLayerGroupStyles());
-
-            handleScaleHint(layerGroup);
 
             end("Layer");
         }

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
@@ -466,7 +466,7 @@ public class GetCapabilitiesTransformerTest extends WMSTestSupport {
         // get the wms 1.1.1 DTD
         URL dtdURL =
                 GetCapabilitiesTransformer.class.getResource(
-                        "/schemas/wms/1.1.1/wms_ms_capabilities.dtd");
+                        "/schemas/wms/1.1.1/WMS_MS_Capabilities.dtd");
         String dtd = Resources.toString(dtdURL, StandardCharsets.UTF_8);
 
         try (InputStream dtdInputStream = new ByteArrayInputStream(dtd.getBytes())) {

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
@@ -482,6 +482,7 @@ public class GetCapabilitiesTransformerTest extends WMSTestSupport {
             // we tell the parse to use our DTD instead of downloading it.
             builder.setEntityResolver(
                     new EntityResolver() {
+                        @Override
                         public InputSource resolveEntity(String publicId, String systemId)
                                 throws SAXException, IOException {
                             if (systemId.endsWith("WMS_MS_Capabilities.dtd")) {
@@ -509,7 +510,7 @@ public class GetCapabilitiesTransformerTest extends WMSTestSupport {
                     });
 
             // this will parse and validate - if there are parse issues the ErrorHandler will throw.
-            Document document = builder.parse(new ByteArrayInputStream(getCapXML.getBytes()));
+            builder.parse(new ByteArrayInputStream(getCapXML.getBytes()));
         }
     }
 


### PR DESCRIPTION
[![GEOS-10757](https://badgen.net/badge/JIRA/GEOS-10757/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10757)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The WMS DTD specifies that the order of tags inside the <Style> element must be Name, Title, ...
However, Geoserver was putting them in Title, Abstract, Name order.

<!ELEMENT Style ( Name, Title, Abstract?,
                  LegendURL*, StyleSheetURL?, StyleURL? ) >

This PR just puts the Name (correctly) first.

This is tested by CITE tests WMS 1.1.1.

I have added a test case that will validate the GetCapabilities against the DTD.

While doing this I noticed another problem - for nested Layers the nested Layer tag must be the last tag.

`Element Layer content does not follow the DTD, expecting (Name? , Title , Abstract? , KeywordList? , SRS* , LatLonBoundingBox? , BoundingBox* , Dimension* , Extent* , Attribution? , AuthorityURL* , Identifier* , MetadataURL* , DataURL* , FeatureListURL* , Style* , ScaleHint? , Layer*), got (Title Abstract KeywordList SRS LatLonBoundingBox BoundingBox Layer Style )`

In this, specific, example, the Style tag is AFTER the (nested layergroup) Layer tag.  It should be before.  Same for the ScaleHints.

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->