### PR TITLE
[2.22.x][GEOS-10753] GeoServer can create GML output that is not valid XML

### DIFF
--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/GMLOutputFormatTest.java
@@ -5,12 +5,18 @@
  */
 package org.geoserver.wfs.xml;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathValuesEqual;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.util.Collections;
+import javax.xml.namespace.QName;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.WFSTestSupport;
 import org.geotools.feature.NameImpl;
 import org.geotools.wfs.v2_0.WFS;
@@ -20,6 +26,16 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 
 public class GMLOutputFormatTest extends WFSTestSupport {
+
+    private static final QName INVALID_CHARACTER =
+            new QName(MockData.DEFAULT_URI, "invalid_character", MockData.DEFAULT_PREFIX);
+
+    private static final QName INVALID_NAMESPACE =
+            new QName("http://www.w3.org/1999/xhtml", "invalid_namespace", "xhtml");
+
+    private static final QName INVALID_PREFIX =
+            new QName("http://invalid/prefix", "BasicPolygons", "'");
+
     private int defaultNumDecimals = -1;
     private boolean defaultForceDecimal = false;
     private boolean defaultPadWithZeros = false;
@@ -54,6 +70,21 @@ public class GMLOutputFormatTest extends WFSTestSupport {
         info.setNumDecimals(defaultNumDecimals);
         info.setForcedDecimal(defaultForceDecimal);
         info.setPadWithZeros(defaultPadWithZeros);
+    }
+
+    @Override
+    protected void setUpInternal(SystemTestData testData) throws Exception {
+        super.setUpInternal(testData);
+        testData.addVectorLayer(
+                INVALID_CHARACTER, Collections.emptyMap(), getClass(), getCatalog());
+        testData.addWorkspace(
+                INVALID_NAMESPACE.getPrefix(), INVALID_NAMESPACE.getNamespaceURI(), getCatalog());
+        testData.addVectorLayer(
+                INVALID_NAMESPACE, Collections.emptyMap(), getClass(), getCatalog());
+        testData.addWorkspace(
+                INVALID_PREFIX.getPrefix(), INVALID_PREFIX.getNamespaceURI(), getCatalog());
+        testData.addVectorLayer(
+                INVALID_PREFIX, Collections.emptyMap(), MockData.class, getCatalog());
     }
 
     @Test
@@ -225,5 +256,64 @@ public class GMLOutputFormatTest extends WFSTestSupport {
         assertEquals(
                 "0.0000 -1.0000 1.0000 0.0000 0.0000 1.0000 -1.0000 0.0000 0.0000 -1.0000",
                 dom.getElementsByTagName("gml:posList").item(0).getTextContent());
+    }
+
+    @Test
+    public void testGML2InvalidElementName() throws Exception {
+        testInvalidResponse(INVALID_CHARACTER, 2, "INVALID_CHARACTER_ERR");
+    }
+
+    @Test
+    public void testGML2InvalidNamespaceUri() throws Exception {
+        testInvalidResponse(INVALID_NAMESPACE, 2, "NAMESPACE_ERR");
+    }
+
+    @Test
+    public void testGML2InvalidNamespacePrefix() throws Exception {
+        testInvalidResponse(INVALID_PREFIX, 2, "INVALID_CHARACTER_ERR");
+    }
+
+    @Test
+    public void testGML3InvalidElementName() throws Exception {
+        testInvalidResponse(INVALID_CHARACTER, 3, "INVALID_CHARACTER_ERR");
+    }
+
+    @Test
+    public void testGML3InvalidNamespaceUri() throws Exception {
+        testInvalidResponse(INVALID_NAMESPACE, 3, "NAMESPACE_ERR");
+    }
+
+    @Test
+    public void testGML3InvalidNamespacePrefix() throws Exception {
+        testInvalidResponse(INVALID_PREFIX, 3, "INVALID_CHARACTER_ERR");
+    }
+
+    @Test
+    public void testGML32InvalidElementName() throws Exception {
+        testInvalidResponse(INVALID_CHARACTER, 32, "INVALID_CHARACTER_ERR");
+    }
+
+    @Test
+    public void testGML32InvalidNamespaceUri() throws Exception {
+        testInvalidResponse(INVALID_NAMESPACE, 32, "NAMESPACE_ERR");
+    }
+
+    @Test
+    public void testGML32InvalidNamespacePrefix() throws Exception {
+        testInvalidResponse(INVALID_PREFIX, 32, "INVALID_CHARACTER_ERR");
+    }
+
+    private void testInvalidResponse(QName layer, int version, String message) throws Exception {
+        Document dom =
+                getAsDOM(
+                        "wfs?request=getfeature&version=1.0.0&outputFormat=gml"
+                                + version
+                                + "&typename="
+                                + layer.getPrefix()
+                                + ":"
+                                + layer.getLocalPart());
+        assertXpathValuesEqual("1", "count(/ogc:ServiceExceptionReport/ogc:ServiceException)", dom);
+        String text = dom.getElementsByTagName("ServiceException").item(0).getTextContent();
+        assertThat(text, containsString(message));
     }
 }

--- a/src/wfs/src/test/resources/org/geoserver/wfs/xml/invalid_character.properties
+++ b/src/wfs/src/test/resources/org/geoserver/wfs/xml/invalid_character.properties
@@ -1,0 +1,2 @@
+_=the_geom:Point,foo><bar:int
+foo=POINT(0 0)|1

--- a/src/wfs/src/test/resources/org/geoserver/wfs/xml/invalid_namespace.properties
+++ b/src/wfs/src/test/resources/org/geoserver/wfs/xml/invalid_namespace.properties
@@ -1,0 +1,2 @@
+_=the_geom:Point,script:String
+foo=POINT(0 0)|foo


### PR DESCRIPTION
[![GEOS-10753](https://badgen.net/badge/JIRA/GEOS-10753/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10753)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

2.22.x backport for https://github.com/geoserver/geoserver/pull/6364
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->