### PR TITLE
[GEOS-10760] GeoFence XML REST API broken: wrong element names

### DIFF
--- a/src/extension/geofence/geofence-server/src/main/java/org/geoserver/geofence/server/rest/GeofenceJaxbRestConfiguration.java
+++ b/src/extension/geofence/geofence-server/src/main/java/org/geoserver/geofence/server/rest/GeofenceJaxbRestConfiguration.java
@@ -1,0 +1,46 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.geofence.server.rest;
+
+import java.util.List;
+import java.util.logging.Logger;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.geotools.util.logging.Logging;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * {@link WebMvcConfigurer} that makes sure {@link Jaxb2RootElementHttpMessageConverter} is present
+ * in order to handle JAXB annotated classes.
+ *
+ * <p>{@link WebMvcConfigurationSupport#addDefaultHttpMessageConverters()} will not add a {@link
+ * Jaxb2RootElementHttpMessageConverter} if Jackson2 is in the classpath, and will add a {@code
+ * MappingJackson2XmlHttpMessageConverter} instead, rendering the JAXB2 annotations in Geofence's
+ * REST object model useless. On the other hand, {@link Jaxb2RootElementHttpMessageConverter} will
+ * only engage for {@link XmlRootElement @XmlRootElement} annotated message payloads.
+ *
+ * @since 2.22.1
+ */
+@Component
+public class GeofenceJaxbRestConfiguration implements WebMvcConfigurer {
+
+    private static final Logger LOGGER =
+            Logging.getLogger(Jaxb2RootElementHttpMessageConverter.class);
+
+    /**
+     * Makes sure {@link Jaxb2RootElementHttpMessageConverter} is available and has higher priority
+     * than {@code MappingJackson2XmlHttpMessageConverter}, otherwise it'll be picked up and the
+     * JAXB annotations won't be respected.
+     */
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.removeIf(Jaxb2RootElementHttpMessageConverter.class::isInstance);
+        converters.add(0, new Jaxb2RootElementHttpMessageConverter());
+        LOGGER.info("JAXB message converter added to handle Geofence message payloads");
+    }
+}

--- a/src/extension/geofence/geofence-server/src/test/java/org/geoserver/geofence/server/rest/RulesRestControllerTest.java
+++ b/src/extension/geofence/geofence-server/src/test/java/org/geoserver/geofence/server/rest/RulesRestControllerTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.UUID;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.custommonkey.xmlunit.XMLAssert;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.geofence.GeofenceBaseTest;
@@ -779,6 +780,44 @@ public class RulesRestControllerTest extends GeofenceBaseTest {
                 rule.getLimits().getAllowedArea());
 
         assertEquals("HIDDEN", rule.getLimits().getCatalogMode());
+    }
+
+    @Test
+    public void testRulesXMLPayload() throws Exception {
+
+        this.adminService.getAll().stream()
+                .mapToLong(ShortRule::getId)
+                .peek(id -> LOGGER.warning("deleting " + id))
+                .forEach(adminService::delete);
+
+        JaxbRule rule = new JaxbRule();
+        rule.setPriority(7L);
+        rule.setWorkspace("workspace");
+        rule.setLayer("layer");
+        rule.setAccess("ALLOW");
+        rule.setRoleName("ROLE_EDITOR");
+        rule.setLayerDetails(new JaxbRule.LayerDetails());
+        final long id = prepareGeoFenceTestRules(rule);
+
+        final String expected =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" //
+                        + "<Rules count=\"1\">" //
+                        + "<Rule id=\""
+                        + id
+                        + "\">" //
+                        + "<access>ALLOW</access>" //
+                        + "<layer>layer</layer>" //
+                        + "<layerDetails>" //
+                        + "<spatialFilterType>INTERSECT</spatialFilterType>" //
+                        + "</layerDetails>" //
+                        + "<priority>7</priority>" //
+                        + "<roleName>ROLE_EDITOR</roleName>" //
+                        + "<workspace>workspace</workspace>" //
+                        + "</Rule>" //
+                        + "</Rules>";
+
+        String response = super.getAsString("/rest/geofence/rules");
+        XMLAssert.assertXMLEqual(expected, response);
     }
 
     /**


### PR DESCRIPTION
[![GEOS-10760](https://badgen.net/badge/JIRA/GEOS-10760/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10760)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix a regression in encoding GeoFence JAXB message payloads introduced by [GEOS-10591](https://osgeo-org.atlassian.net/browse/GEOS-10591) at commit cf57b56edcfc22080fe73c3951b01b3408088a10 (`2.22.x` series), which adds the `jackson-dataformat-xml` dependency to `gs-ows`.

As a result, `WebMvcConfigurationSupport.addDefaultHttpMessageConverters()` will not add a Jaxb2RootElementHttpMessageConverter`, but a `MappingJackson2XmlHttpMessageConverter` instead, rendering the JAXB2 annotations in Geofence's REST object model useless.

This patch makes `org.geoserver.rest.RestConfiguration` extend `DelegatingWebMvcConfiguration` instead of WebMvcConfigurationSupport`, which is a subclass itself, to detect and delegate to all beansof type `WebMvcConfigurer`, allowing them to customize the configuration provided by `WebMvcConfigurationSupport`.

A `WebMvcConfigurer` (`GeofenceJaxbRestConfiguration`) is then contributed by the `geofence-server` module, to implement `configureMessageConverters()` making sure a `Jaxb2RootElementHttpMessageConverter` is provided with higher precedence than `MappingJackson2XmlHttpMessageConverter`.

This is safe, since the Jaxb converter will only engage for message payloads annotated with JAXB's `@XmlRootElement`.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->