### PR TITLE
[GEOS-10782] CITE WFS 1.1 - HITS mimetype is incorrect

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/response/HitsOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/HitsOutputFormat.java
@@ -40,9 +40,15 @@ public class HitsOutputFormat extends WFSResponse {
         this.configuration = configuration;
     }
 
-    /** @return "text/xml"; */
+    /**
+     * for WFS 1.1.1 - returns "text/xml; subtype=gml/3.1.1" - as required by WFS 1.1.0 Spec
+     * otherwise "text/xml"
+     */
     @Override
     public String getMimeType(Object value, Operation operation) throws ServiceException {
+        if (operation.getService().getVersion().toString().equals("1.1.0")) {
+            return "text/xml; subtype=gml/3.1.1";
+        }
         return "text/xml";
     }
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/HitsOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/HitsOutputFormatTest.java
@@ -1,0 +1,28 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.response;
+
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.Service;
+import org.geotools.util.Version;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+
+public class HitsOutputFormatTest {
+
+    @Test
+    public void testMimeType() {
+        HitsOutputFormat hitsOutputFormat = new HitsOutputFormat(null,null);
+
+        //Operation and Service are final classes - difficult to mock
+        Service servicewfs11 = new Service("wfs11",null,null,new Version("1.1.0"),null);
+        Operation opwfs11 = new Operation("opwfs11",servicewfs11,null,null);
+
+        String mime = hitsOutputFormat.getMimeType(null,opwfs11);
+        assertEquals("text/xml; subtype=gml/3.1.1", mime);
+    }
+}

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/HitsOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/HitsOutputFormatTest.java
@@ -4,25 +4,24 @@
  */
 package org.geoserver.wfs.response;
 
+import static org.junit.Assert.assertEquals;
+
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.Service;
 import org.geotools.util.Version;
 import org.junit.Test;
 
-
-import static org.junit.Assert.assertEquals;
-
 public class HitsOutputFormatTest {
 
     @Test
     public void testMimeType() {
-        HitsOutputFormat hitsOutputFormat = new HitsOutputFormat(null,null);
+        HitsOutputFormat hitsOutputFormat = new HitsOutputFormat(null, null);
 
-        //Operation and Service are final classes - difficult to mock
-        Service servicewfs11 = new Service("wfs11",null,null,new Version("1.1.0"),null);
-        Operation opwfs11 = new Operation("opwfs11",servicewfs11,null,null);
+        // Operation and Service are final classes - difficult to mock
+        Service servicewfs11 = new Service("wfs11", null, null, new Version("1.1.0"), null);
+        Operation opwfs11 = new Operation("opwfs11", servicewfs11, null, null);
 
-        String mime = hitsOutputFormat.getMimeType(null,opwfs11);
+        String mime = hitsOutputFormat.getMimeType(null, opwfs11);
         assertEquals("text/xml; subtype=gml/3.1.1", mime);
     }
 }


### PR DESCRIPTION
[![GEOS-10782](https://badgen.net/badge/JIRA/GEOS-10782/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10782)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

For WFS 1.1.0 GetFeature (HITS) must return a mime type of  "text/xml; subtype=gml/3.1.1" according to the spec.

JIRA: https://osgeo-org.atlassian.net/browse/GEOS-10782

9.3 Response
The format of the response to a GetFeature request is controlled by the outputFormat
attribute. The default value for the outputFormat attribute shall be the MIME type
text/xml; subtype=gml/3.1.1.

The CITE tests check this;
https://github.com/opengeospatial/ets-wfs11/blob/master/src/main/scripts/ctl/basic/GetFeature/GetFeature-GET.xml#L193
(there are several checks)

Before Geoserver was always returning "text/xml" (without the subtype)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->