### PR TITLE
[GEOS-10783] CITE WFS 1.1 - unable to lock features

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -1307,7 +1307,9 @@ public class ResourcePool {
         SimpleFeatureSource fs = dataStore.getFeatureSource(nativeName);
 
         // if feature type customization is there, apply it first
-        if (info.getAttributes() != null && !info.getAttributes().isEmpty()) {
+        if (info.getAttributes() != null
+                && !info.getAttributes().isEmpty()
+                && !info.getFeatureType().equals(fs.getSchema())) {
             fs = (SimpleFeatureSource) transformer.wrapFeatureSource(info, fs);
         }
         // then check name, and other customizations (e.g., projection policy)

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -80,8 +80,10 @@ import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
 import org.geotools.coverage.util.CoverageUtilities;
 import org.geotools.data.DataAccess;
 import org.geotools.data.DataStore;
+import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
 import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureLocking;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.data.wfs.WFSDataStoreFactory;
@@ -728,6 +730,22 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
                                         .toASCIIString());
                     }
                 });
+    }
+
+    /**
+     * This checks that the resource pool does NOT wrap the FeatureSource so that it prevents
+     * locking
+     */
+    @Test
+    public void testSourceIsNotIncorrectlyWrappedAndCanLock() throws IOException {
+        Catalog cat = getCatalog();
+        ResourcePool resourcePool = cat.getResourcePool();
+
+        FeatureTypeInfo featureTypeInfo = cat.getFeatureTypeByName("Lines");
+        featureTypeInfo.getAttributes().addAll(featureTypeInfo.attributes());
+        FeatureSource source = resourcePool.getFeatureSource(featureTypeInfo, null);
+
+        assertTrue(source instanceof SimpleFeatureLocking);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10783](https://badgen.net/badge/JIRA/GEOS-10783/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10783)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

While running CITE tests, i was unable to lock any features.

JIRA: https://osgeo-org.atlassian.net/browse/GEOS-10783

Tracking this down, what was happening is that this was being called:

` fs = (SimpleFeatureSource) transformer.wrapFeatureSource(info, fs);`

This was returning a non-locking SimpleFeatureSource.  This was then wrapped in another non-lock SimpleFeatureSource.

This was because the Feature Info had a list of attributes in it.  I'm not sure if this is particular to the CITE configuration or if GS locking is completely broken for everyone.

Test cases have getAttributes() returning an empty list, while the actual catalog returns a full list of attributes.

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->