### PR TITLE
[GEOS-10784] CITE WFS 1.1 - don't do illegal geometry conversions

### DIFF
--- a/src/wfs/src/test/java/org/geoserver/wfs/TransactionTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/TransactionTest.java
@@ -1131,4 +1131,40 @@ public class TransactionTest extends WFSTestSupport {
                         .getAttribute("exceptionCode");
         assertEquals("InvalidParameterValue", code);
     }
+
+    /**
+     * This tests the situation where a Polygon-based FeatureType is updated with a LineString value.
+     * Since these are different dimensions, this should be disallowed.  This test is based on
+     * CITE test "wfs:wfs-1.1.0-Transaction-tc10.1".
+     */
+    @Test
+    public void testBadGeometryTypeUpdate() throws Exception {
+        // perform an update to the_geom property (type is Polygon) with a LineString value
+        String update =
+                "<wfs:Transaction service=\"WFS\" version=\"1.1.0\" "
+                        + "xmlns:cgf=\"cite\" "
+                        + "xmlns:ogc=\"http://www.opengis.net/ogc\" "
+                        + "xmlns:wfs=\"http://www.opengis.net/wfs\" "
+                        + "xmlns:gml=\"http://www.opengis.net/gml\"> "
+                        + "<wfs:Update typeName=\"cgf:BasicPolygons\" > "
+                        + "<wfs:Property>"
+                        + "<wfs:Name>the_geom</wfs:Name>"
+                        + "<wfs:Value>"
+                        + "<gml:LineString>"
+                        + "<gml:coordinates decimal=\".\" cs=\",\" ts=\" \">"
+                        + "494475.71056415,5433016.8189323 494982.70115662,5435041.95096618"
+                        + "</gml:coordinates>"
+                        + "</gml:LineString>"
+                        + "</wfs:Value>"
+                        + "</wfs:Property>"
+                        + "</wfs:Update>"
+                        + "</wfs:Transaction>";
+        Document resp = postAsDOM("wfs", update);
+        //response is an OWS Exception of type "InvalidValue", with locator "the_geom"
+        // ie.   <ows:Exception exceptionCode="InvalidValue" locator="the_geom">
+        checkOws10Exception(resp);
+        Node exceptionNode = resp.getElementsByTagName("ows:Exception").item(0);
+        assertEquals("InvalidValue",exceptionNode.getAttributes().getNamedItem("exceptionCode").getTextContent());
+        assertEquals("the_geom",exceptionNode.getAttributes().getNamedItem("locator").getTextContent());
+    }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/TransactionTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/TransactionTest.java
@@ -1133,8 +1133,8 @@ public class TransactionTest extends WFSTestSupport {
     }
 
     /**
-     * This tests the situation where a Polygon-based FeatureType is updated with a LineString value.
-     * Since these are different dimensions, this should be disallowed.  This test is based on
+     * This tests the situation where a Polygon-based FeatureType is updated with a LineString
+     * value. Since these are different dimensions, this should be disallowed. This test is based on
      * CITE test "wfs:wfs-1.1.0-Transaction-tc10.1".
      */
     @Test
@@ -1160,11 +1160,14 @@ public class TransactionTest extends WFSTestSupport {
                         + "</wfs:Update>"
                         + "</wfs:Transaction>";
         Document resp = postAsDOM("wfs", update);
-        //response is an OWS Exception of type "InvalidValue", with locator "the_geom"
+        // response is an OWS Exception of type "InvalidValue", with locator "the_geom"
         // ie.   <ows:Exception exceptionCode="InvalidValue" locator="the_geom">
         checkOws10Exception(resp);
         Node exceptionNode = resp.getElementsByTagName("ows:Exception").item(0);
-        assertEquals("InvalidValue",exceptionNode.getAttributes().getNamedItem("exceptionCode").getTextContent());
-        assertEquals("the_geom",exceptionNode.getAttributes().getNamedItem("locator").getTextContent());
+        assertEquals(
+                "InvalidValue",
+                exceptionNode.getAttributes().getNamedItem("exceptionCode").getTextContent());
+        assertEquals(
+                "the_geom", exceptionNode.getAttributes().getNamedItem("locator").getTextContent());
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/UpdateElementHandlerTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/UpdateElementHandlerTest.java
@@ -1,0 +1,40 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.geotools.geometry.jts.WKTReader2;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+public class UpdateElementHandlerTest {
+
+    @Test
+    public void testCheckConsistentGeometryDimensions() throws Exception {
+        WKTReader2 wktReader = new WKTReader2();
+
+        Geometry g = wktReader.read("POINT(0 0)");
+        assertTrue(UpdateElementHandler.checkConsistentGeometryDimensions(g, Point.class));
+        assertTrue(UpdateElementHandler.checkConsistentGeometryDimensions(g, MultiPoint.class));
+        assertFalse(UpdateElementHandler.checkConsistentGeometryDimensions(g, LineString.class));
+        assertFalse(UpdateElementHandler.checkConsistentGeometryDimensions(g, Polygon.class));
+
+        g = wktReader.read("LINESTRING(0 0, 1 1)");
+        assertFalse(UpdateElementHandler.checkConsistentGeometryDimensions(g, Point.class));
+        assertTrue(UpdateElementHandler.checkConsistentGeometryDimensions(g, LineString.class));
+        assertFalse(UpdateElementHandler.checkConsistentGeometryDimensions(g, Polygon.class));
+
+        g = wktReader.read("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))");
+        assertFalse(UpdateElementHandler.checkConsistentGeometryDimensions(g, Point.class));
+        assertFalse(UpdateElementHandler.checkConsistentGeometryDimensions(g, LineString.class));
+        assertTrue(UpdateElementHandler.checkConsistentGeometryDimensions(g, Polygon.class));
+    }
+}


### PR DESCRIPTION
[![GEOS-10784](https://badgen.net/badge/JIRA/GEOS-10784/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10784)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

One of the CITE tests attempts to put the wrong geometry type (multicurve (linestring) into a polygon).

JIRA: https://osgeo-org.atlassian.net/browse/GEOS-10784

Geoserver would convert this linestring to a polygon and do the insert.

The Polygon that it created just appended all the line's coordinates together, so it wasnt a very good conversion.

CITE test explicitly check that this situation throws an exception. 

This change allows for most geometry xforms, but doesn't allow dimensional changes (i.e. 2d to 1d).

Here is the CITE test:

https://github.com/opengeospatial/ets-wfs11/blob/master/src/main/scripts/ctl/wfs-transaction/Transaction/Transaction-XML.xml#L815

 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->