### PR TITLE
Fix GeoServerDataDirectoryTest clean up after running tests

### DIFF
--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
@@ -45,6 +45,7 @@ public class GeoServerDataDirectoryTest {
 
     @AfterClass
     public static void afterClass() {
+        GeoServerExtensionsHelper.init(null);
         factory = null;
     }
 


### PR DESCRIPTION
GeoServerDataDirectoryTest doesn't properly clean up the application context after it is finished.  This causes more than 2,000 stack traces in the logs about "BeanFactory not initialized or already closed" when running the gs-main unit tests.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->