### PR TITLE
[GEOS-10578] OGCAPI - Features - Add `storageCrs` property for Collections

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureResponseMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureResponseMessageConverter.java
@@ -17,7 +17,6 @@ import org.geoserver.platform.Operation;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
 import org.geotools.referencing.CRS;
-import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.util.Version;
 import org.geotools.util.logging.Logging;
 import org.opengis.referencing.FactoryException;
@@ -72,7 +71,7 @@ public class FeatureResponseMessageConverter
                         .orElse(null);
         if (crs != null) {
             try {
-                String crsURI = getCRSURI(crs);
+                String crsURI = FeatureService.getCRSURI(crs);
                 String orderSpec = getOrderSpecification(crs);
                 if (crsURI != null && orderSpec != null) {
                     message.getHeaders()
@@ -85,14 +84,6 @@ public class FeatureResponseMessageConverter
                         e);
             }
         }
-    }
-
-    private String getCRSURI(CoordinateReferenceSystem crs) throws FactoryException {
-        if (CRS.equalsIgnoreMetadata(crs, DefaultGeographicCRS.WGS84)) {
-            return FeatureService.DEFAULT_CRS;
-        }
-        Integer code = CRS.lookupEpsgCode(crs, false);
-        return FeatureService.CRS_PREFIX + code;
     }
 
     private String getOrderSpecification(CoordinateReferenceSystem crs) {

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -69,6 +69,7 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.sort.SortBy;
+import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -134,6 +135,21 @@ public class FeatureService {
             return result;
         }
         return defaultCRS;
+    }
+
+    /**
+     * Returns the CRS-URI for a given CRS.
+     *
+     * @param crs the CRS
+     * @return
+     * @throws FactoryException
+     */
+    public static String getCRSURI(CoordinateReferenceSystem crs) throws FactoryException {
+        if (CRS.equalsIgnoreMetadata(crs, DefaultGeographicCRS.WGS84)) {
+            return FeatureService.DEFAULT_CRS;
+        }
+        Integer code = CRS.lookupEpsgCode(crs, false);
+        return FeatureService.CRS_PREFIX + code;
     }
 
     protected List<String> getServiceCRSList() {

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/collection_include.ftl
@@ -1,10 +1,13 @@
 <div class="card-body">
   <ul>
-    <#if collection.title??> 
+    <#if collection.title??>
       <li><b>Title</b>: <span id="${collection.htmlId}_title">${collection.title}</span><br/></li>
       </#if>
       <#if collection.description??>
       <li><b>Description</b>: <span id="${collection.htmlId}_description">${collection.description!}</span><br/></li>
+      </#if>
+      <#if collection.storageCrs??>
+      <li><b>Storage CRS</b>: <span id="${collection.htmlId}_storageCrs">${collection.storageCrs!}</span><br/></li>
       </#if>
       <#assign spatial = collection.extent.spatial>
       <li><b>Geographic extents</b>:
@@ -14,20 +17,20 @@
       </#list>
       </ul>
       </li>
-      
+
       <li>Queryables as <a id="html_${collection.htmlId}_queryables" href="${collection.getLinkUrl('queryables', 'text/html')!}">HTML</a>.
       </li>
       <#if collection.mapPreviewURL??>
       <li>The layer can also be explored in this <a href="${collection.mapPreviewURL}">map preview</a></li>
       </#if>
-      <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping --> 
+      <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping -->
       ${htmlExtensions(collection)}
   </ul>
 </div>
 <div class="card-footer">
   <div class="row">
     <div class="col-auto pe-0 py-1">
-      Data as <a id="html_${collection.htmlId}_link" class="btn btn-outline-primary btn-sm" href="${collection.getLinkUrl('items', 'text/html')!}&limit=${service.maxNumberOfFeaturesForPreview}">HTML</a>    
+      Data as <a id="html_${collection.htmlId}_link" class="btn btn-outline-primary btn-sm" href="${collection.getLinkUrl('items', 'text/html')!}&limit=${service.maxNumberOfFeaturesForPreview}">HTML</a>
       or choose another format:
     </div>
     <div class="col-auto py-1">
@@ -40,4 +43,4 @@
     </div>
   </div>
 </div>
-      
+

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
@@ -427,6 +427,10 @@ components:
           example:
             - http://www.opengis.net/def/crs/OGC/1.3/CRS84
             - http://www.opengis.net/def/crs/EPSG/0/4326
+        storageCrs:
+          description: the CRS identifier, from the list of supported CRS identifiers, that may be used to retrieve features from a collection without the need to apply a CRS transformation
+          type: string
+          format: uri
     collections:
       type: object
       required:

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/CollectionTest.java
@@ -103,6 +103,10 @@ public class CollectionTest extends FeaturesTestSupport {
                     c + " is not using a numeric code",
                     c.substring("http://www.opengis.net/def/crs/EPSG/0/".length()).matches("\\d+"));
         }
+
+        // check the storage CRS
+        String storageCrs = json.read("storageCrs");
+        assertEquals("http://www.opengis.net/def/crs/OGC/1.3/CRS84", storageCrs);
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/CollectionsTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/CollectionsTest.java
@@ -70,7 +70,8 @@ public class CollectionsTest extends FeaturesTestSupport {
         int expected = getCatalog().getFeatureTypes().size();
         assertEquals(expected, (int) json.read("collections.length()", Integer.class));
 
-        // check we have the expected number of links and they all use the right "rel" relation
+        // check we have the expected number of links and they all use the right "rel"
+        // relation
         Collection<MediaType> formats =
                 GeoServerExtensions.bean(
                                 APIDispatcher.class, GeoServerSystemTestSupport.applicationContext)
@@ -179,6 +180,9 @@ public class CollectionsTest extends FeaturesTestSupport {
         assertEquals(
                 BASIC_POLYGONS_DESCRIPTION,
                 document.select("#" + basicPolygonsHtmlId + "_description").text());
+        assertEquals(
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                document.select("#" + basicPolygonsHtmlId + "_storageCrs").text());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10758](https://badgen.net/badge/JIRA/GEOS-10758/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10758)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->