### PR TITLE
[GEOS-10770] support list of audiences in access token

### DIFF
--- a/doc/en/user/source/community/oauth2/index.rst
+++ b/doc/en/user/source/community/oauth2/index.rst
@@ -327,7 +327,7 @@ To Use:
 The Access Token (JWT) is validated;
 
 #. The Access Token is used to get the "userinfo" endpoint.  The underlying IDP will verify the token (i.e. signature and expiry)
-#. The Audience of the Token is checked that it is the same as the GeoServer configured Client Id.  This make sure an Access Token for another application is not being inappropriately reused in GeoServer (cf. `AudienceAccessTokenValidator.java`).
+#. The Audience of the Token is checked that it contains the GeoServer configured Client Id.  This make sure an Access Token for another application is not being inappropriately reused in GeoServer (cf. `AudienceAccessTokenValidator.java`).
 #. The Subject of the `userinfo` and Access Token are verified to be about the same person.  The OpenID specification recommends checking this (cf. `SubjectTokenValidator.java`).
 
 

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
@@ -43,10 +43,10 @@ public class AudienceAccessTokenValidator implements TokenValidator {
             throws Exception {
         String clientId = config.getCliendId();
         if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null)) {
-            if(claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
+            if (claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
                 return;
-            } else if(claimsJWT.get(AUDIENCE_CLAIM_NAME) instanceof Collection
-                && ((Collection)claimsJWT.get(AUDIENCE_CLAIM_NAME)).contains(clientId)) {
+            } else if (claimsJWT.get(AUDIENCE_CLAIM_NAME) instanceof Collection
+                    && ((Collection) claimsJWT.get(AUDIENCE_CLAIM_NAME)).contains(clientId)) {
                 return;
             }
         }

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidator.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.security.oauth2.bearer;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
@@ -41,9 +42,13 @@ public class AudienceAccessTokenValidator implements TokenValidator {
     public void verifyToken(OpenIdConnectFilterConfig config, Map claimsJWT, Map userInfoClaims)
             throws Exception {
         String clientId = config.getCliendId();
-        if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null)
-                && claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
-            return;
+        if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null)) {
+            if(claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
+                return;
+            } else if(claimsJWT.get(AUDIENCE_CLAIM_NAME) instanceof Collection
+                && ((Collection)claimsJWT.get(AUDIENCE_CLAIM_NAME)).contains(clientId)) {
+                return;
+            }
         }
 
         if ((claimsJWT.get(APPID_CLAIM_NAME) != null)

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidatorTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidatorTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.security.oauth2.bearer;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
@@ -50,6 +51,17 @@ public class AudienceAccessTokenValidatorTest {
     public void testSelfCreatedGood() throws Exception {
         Map claims = new HashMap();
         claims.put("aud", clientId);
+
+        AudienceAccessTokenValidator validator = getValidator();
+        OpenIdConnectFilterConfig config = getConfig();
+
+        validator.verifyToken(config, claims, null);
+    }
+    
+    @Test
+    public void testAudListGood() throws Exception {
+        Map claims = new HashMap();
+        claims.put("aud", Arrays.asList(clientId,"other-client"));
 
         AudienceAccessTokenValidator validator = getValidator();
         OpenIdConnectFilterConfig config = getConfig();

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidatorTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/bearer/AudienceAccessTokenValidatorTest.java
@@ -57,11 +57,11 @@ public class AudienceAccessTokenValidatorTest {
 
         validator.verifyToken(config, claims, null);
     }
-    
+
     @Test
     public void testAudListGood() throws Exception {
         Map claims = new HashMap();
-        claims.put("aud", Arrays.asList(clientId,"other-client"));
+        claims.put("aud", Arrays.asList(clientId, "other-client"));
 
         AudienceAccessTokenValidator validator = getValidator();
         OpenIdConnectFilterConfig config = getConfig();


### PR DESCRIPTION
[![GEOS-10770](https://badgen.net/badge/JIRA/GEOS-10770/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10770)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

According to [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750) Bearer Tokens are allowed to contain a list of audience claims. This PR extends gs-sec-oauth2-openid-connect-core validation of Bearer Tokens introduced in [PR 6167](https://github.com/geoserver/geoserver/pull/6167) to also support a list in JWT attribute "aud".

see also: https://osgeo-org.atlassian.net/browse/GEOS-10770
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way): GEOS-10770
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->