### PR TITLE
[GEOS-10787] CITE WCS 1.1.1 - Throw exception on bad 'store' parameter

### DIFF
--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/GetCoverageRequestReader.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/GetCoverageRequestReader.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.wcs.kvp;
 
+import static org.vfny.geoserver.wcs.WcsException.WcsExceptionCode.InvalidParameterValue;
 import static org.vfny.geoserver.wcs.WcsException.WcsExceptionCode.MissingParameterValue;
 
 import java.util.Map;
@@ -17,6 +18,7 @@ import net.opengis.wcs11.TimeSequenceType;
 import net.opengis.wcs11.Wcs111Factory;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.ows.kvp.EMFKvpRequestReader;
+import org.geoserver.ows.util.KvpUtils;
 import org.vfny.geoserver.wcs.WcsException;
 import org.vfny.geoserver.wcs.WcsException.WcsExceptionCode;
 
@@ -44,6 +46,17 @@ public class GetCoverageRequestReader extends EMFKvpRequestReader {
 
         // build output element
         getCoverage.setOutput(parseOutputElement(kvp));
+
+        String store = KvpUtils.caseInsensitiveParam(rawKvp, "store", null);
+        if (store != null) {
+            if (!store.equalsIgnoreCase("TRUE") && !store.equalsIgnoreCase("FALSE")) {
+                // OGC Specification says that STORE must be either True or False
+                throw new WcsException(
+                        "store parameter has an invalid value - must be True or False",
+                        InvalidParameterValue,
+                        "store");
+            }
+        }
 
         return getCoverage;
     }

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/kvp/GetCoverageReaderTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/kvp/GetCoverageReaderTest.java
@@ -100,6 +100,30 @@ public class GetCoverageReaderTest extends WCSTestSupport {
         }
     }
 
+    /**
+     * According to WFS 1.1 spec, the store parameter must be "True" or "False". CITE test
+     * "GetCoverage_Store_Bogus" tests that an exception is thrown. This test does the same - makes
+     * a request with a bad "store" parameter and expects a WcsException.
+     */
+    @Test
+    public void testWrongStoreParameter() throws Exception {
+        Map<String, Object> raw = baseMap();
+        final String layerId = getLayerId(TASMANIA_BM);
+        raw.put("identifier", layerId);
+        raw.put("format", "image/tiff");
+        raw.put("BoundingBox", "-45,146,-42,147");
+        raw.put("store", "BAD_BAD_BAD");
+        raw.put("GridBaseCRS", "urn:ogc:def:crs:EPSG:6.6:4326");
+        try {
+            GetCoverageType getCoverage =
+                    (GetCoverageType) reader.read(reader.createRequest(), parseKvp(raw), raw);
+            fail("GetCoverage worked with a bad 'store' parameter");
+        } catch (WcsException e) {
+            assertEquals(InvalidParameterValue.toString(), e.getCode());
+            assertEquals("store", e.getLocator());
+        }
+    }
+
     @Test
     public void testBasic() throws Exception {
         Map<String, Object> raw = baseMap();

--- a/src/wcs1_1/src/test/java/org/geoserver/wcs/kvp/GetCoverageReaderTest.java
+++ b/src/wcs1_1/src/test/java/org/geoserver/wcs/kvp/GetCoverageReaderTest.java
@@ -115,8 +115,7 @@ public class GetCoverageReaderTest extends WCSTestSupport {
         raw.put("store", "BAD_BAD_BAD");
         raw.put("GridBaseCRS", "urn:ogc:def:crs:EPSG:6.6:4326");
         try {
-            GetCoverageType getCoverage =
-                    (GetCoverageType) reader.read(reader.createRequest(), parseKvp(raw), raw);
+            reader.read(reader.createRequest(), parseKvp(raw), raw);
             fail("GetCoverage worked with a bad 'store' parameter");
         } catch (WcsException e) {
             assertEquals(InvalidParameterValue.toString(), e.getCode());


### PR DESCRIPTION
[![GEOS-10787](https://badgen.net/badge/JIRA/GEOS-10787/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10787)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

According to WFS 1.1 spec, the “store” parameter must be "True" or "False". 

CITE test "GetCoverage_Store_Bogus" tests that an exception is thrown when its set to something else.

Geoserver treats an unknown value (ie. “bogus”) as false.

JIRA: https://osgeo-org.atlassian.net/browse/GEOS-10787  


NOTE: an alternative place to fix this would be in `BooleanKvpParser`. However, I think this would cause some side-effects.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->