### PR TITLE
[GEOS-10792] acceptVersions negotiation isn't working with WCS

### DIFF
--- a/src/extension/wcs2_0-eo/core/src/test/resources/describeEOCoverageSetTrims.xml
+++ b/src/extension/wcs2_0-eo/core/src/test/resources/describeEOCoverageSetTrims.xml
@@ -4,7 +4,7 @@
     xmlns:wcs="http://www.opengis.net/wcs/2.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.opengis.net/wcseo/1.0 http://schemas.opengis.net/wcseo/1.0/wcsEOAll.xsd"
-    service="WCS" version="2.0.0" count="100">
+    service="WCS" version="2.0.1" count="100">
     <wcseo:eoId>sf__spatio-temporal_dss</wcseo:eoId>
     <wcseo:containment>OVERLAPS</wcseo:containment>
     <wcseo:Sections>

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -47,7 +48,6 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import net.opengis.ows11.AcceptVersionsType;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
@@ -513,16 +513,15 @@ public class Dispatcher extends AbstractController {
         if (req.getService().isEmpty() || !req.getRequest().equalsIgnoreCase("getCapabilities")) {
             return;
         }
-        AcceptVersionsType acceptVersions = (AcceptVersionsType) req.getKvp().get("AcceptVersions");
+        String acceptVersions = (String) req.getRawKvp().get("AcceptVersions");
         if (acceptVersions == null) {
             return;
         }
-        @SuppressWarnings(value = "unchecked")
+
         List<Version> acceptVersionsList =
-                ((List<String>) acceptVersions.getVersion())
-                        .stream()
-                                .map(x -> new Version(normalizeVersion(x)))
-                                .collect(Collectors.toList());
+                Arrays.asList(acceptVersions.split(",")).stream()
+                        .map(x -> new Version(normalizeVersion(x)))
+                        .collect(Collectors.toList());
 
         req.setAcceptVersions(acceptVersionsList);
     }

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -598,9 +598,12 @@ public class Dispatcher extends AbstractController {
                 throw new ServiceException(msg, "InvalidParameterValue", "service");
             }
         }
-        req.setVersion(serviceDescriptor.getVersion().toString());
         req.setServiceDescriptor(serviceDescriptor);
-        return fireServiceDispatchedCallback(req, serviceDescriptor);
+        Service result = fireServiceDispatchedCallback(req, serviceDescriptor);
+        if (req.getVersion() == null) {
+            req.setVersion(serviceDescriptor.getVersion().toString());
+        }
+        return result;
     }
 
     Service fireServiceDispatchedCallback(Request req, Service service) {

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -1236,10 +1236,16 @@ public class Dispatcher extends AbstractController {
         if ((version == null) && (acceptsVersions != null)) {
             if (namespace != null) {
                 // need to match based on the XML request namespace.
-                matches =
+                List<Service> filteredMatches =
                         matches.stream()
-                                .filter(x -> x.getNamespace().equals(namespace))
+                                .filter(
+                                        x ->
+                                                (x.getNamespace() != null)
+                                                        && x.getNamespace().equals(namespace))
                                 .collect(Collectors.toList());
+                if (filteredMatches.size() > 0) {
+                    matches = filteredMatches;
+                }
             } else {
                 for (Version acceptVersion : acceptsVersions) {
                     boolean match =

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -1243,7 +1243,7 @@ public class Dispatcher extends AbstractController {
                                                 (x.getNamespace() != null)
                                                         && x.getNamespace().equals(namespace))
                                 .collect(Collectors.toList());
-                if (filteredMatches.size() > 0) {
+                if (!filteredMatches.isEmpty()) {
                     matches = filteredMatches;
                 }
             } else {

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -313,7 +313,13 @@ public class Dispatcher extends AbstractController {
                     (net.opengis.ows11.AcceptVersionsType) request.getKvp().get("ACCEPTVERSIONS");
 
             AcceptVersionsType newValue = Ows10Factory.eINSTANCE.createAcceptVersionsType();
-            current.getVersion().stream().forEach(x -> newValue.getVersion().add((String) x));
+            @SuppressWarnings("unchecked")
+            List<String> values =
+                    (List<String>)
+                            current.getVersion().stream()
+                                    .map(x -> x.toString())
+                                    .collect(Collectors.toList());
+            values.stream().forEach(x -> newValue.getVersion().add(x));
 
             request.getKvp().put("ACCEPTVERSIONS", newValue);
         }
@@ -537,12 +543,10 @@ public class Dispatcher extends AbstractController {
 
     /** parses the AcceptVersions from the request KVP and puts it in the request */
     void handleAcceptVersionsKVP(Request req) {
-        if ((req.getVersion() != null)
-                || (req.getService() == null)
-                || (req.getRequest() == null)) {
+        if ((req.getVersion() != null) || (req.getRequest() == null)) {
             return;
         }
-        if (req.getService().isEmpty() || !req.getRequest().equalsIgnoreCase("getCapabilities")) {
+        if (!req.getRequest().equalsIgnoreCase("GetCapabilities")) {
             return;
         }
         String acceptVersions = (String) req.getRawKvp().get("AcceptVersions");

--- a/src/ows/src/main/java/org/geoserver/ows/Request.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Request.java
@@ -7,12 +7,14 @@ package org.geoserver.ows;
 
 import java.io.BufferedReader;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.Service;
+import org.geotools.util.Version;
 
 /**
  * A collection of the informations collected and parsed by the {@link Dispatcher} while doing its
@@ -53,6 +55,9 @@ public class Request {
 
     /** OWS protocol version (combined with service and request) */
     protected String version;
+
+    /** For GetCapabilities Requests, the versions the client says it can handle */
+    private List<Version> acceptVersions;
 
     /**
      * xml namespace used in request body, only relevant for post requests and when request body
@@ -111,6 +116,7 @@ public class Request {
         this.service = other.service;
         this.request = other.request;
         this.version = other.version;
+        this.acceptVersions = other.acceptVersions;
         this.namespace = other.namespace;
         this.serviceDescriptor = other.serviceDescriptor;
         this.context = other.context;
@@ -173,6 +179,11 @@ public class Request {
     /** The service version */
     public String getVersion() {
         return version;
+    }
+
+    /** The service versions the client can handle (for GetCapabilities Negotiation) */
+    public List<Version> getAcceptVersions() {
+        return acceptVersions;
     }
 
     /** The request namespace */
@@ -330,6 +341,11 @@ public class Request {
      */
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    /** @param versions Versions the client can accept (GetCapabilities Negotiation) */
+    public void setAcceptVersions(List<Version> versions) {
+        this.acceptVersions = versions;
     }
 
     /** Sets the request namespace */

--- a/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
@@ -63,7 +63,7 @@ public class RequestUtils {
         if (acceptedList == null || acceptedList.isEmpty()) return provided.last().toString();
 
         // next figure out what the client accepts (and check they are good version numbers)
-        TreeSet<Version> accepted = new TreeSet<>();
+        List<Version> accepted = new ArrayList<>();
         for (String v : acceptedList) {
             checkVersionNumber(v, null);
 
@@ -83,19 +83,19 @@ public class RequestUtils {
         String version = null;
         if (!accepted.isEmpty()) {
             // return the highest version provided
-            version = accepted.last().toString();
+            version = accepted.get(0).toString();
         } else {
             for (String v : acceptedList) {
                 accepted.add(new Version(v));
             }
 
             // if highest accepted less then lowest provided, send lowest
-            if ((accepted.last()).compareTo(provided.first()) < 0) {
+            if ((accepted.get(accepted.size() - 1)).compareTo(provided.first()) < 0) {
                 version = (provided.first()).toString();
             }
 
             // if lowest accepted is greater then highest provided, send highest
-            if ((accepted.first()).compareTo(provided.last()) > 0) {
+            if ((accepted.get(0)).compareTo(provided.last()) > 0) {
                 version = (provided.last()).toString();
             }
 
@@ -108,7 +108,7 @@ public class RequestUtils {
                 while (v.hasNext()) {
                     Version current = v.next();
 
-                    if (current.compareTo(accepted.last()) > 0) {
+                    if (current.compareTo(accepted.get(accepted.size() - 1)) > 0) {
                         break;
                     }
 

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/GetCapabilitiesResponse.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/GetCapabilitiesResponse.java
@@ -31,7 +31,7 @@ public class GetCapabilitiesResponse extends Response {
     public boolean canHandle(Operation operation) {
         // is this a wcs 1.1.1 or 1.1.0 one?
         return "GetCapabilities".equalsIgnoreCase(operation.getId())
-                && operation.getService().getId().equals("wcs")
+                && operation.getService().getId().equalsIgnoreCase("wcs")
                 && (operation.getService().getVersion().toString().equals("1.1.0")
                         || operation.getService().getVersion().toString().equals("1.1.1"));
     }

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/ResourceAccessManagerWCSTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/ResourceAccessManagerWCSTest.java
@@ -113,7 +113,7 @@ public class ResourceAccessManagerWCSTest extends WCSTestSupport {
         setRequestAuth("cite", "cite");
         Document dom =
                 getAsDOM(
-                        "wcs?request=DescribeCoverage&service=WCS&version=2.0.0&coverageId=sf__watertemp");
+                        "wcs?request=DescribeCoverage&service=WCS&version=2.0.1&coverageId=sf__watertemp");
         print(dom);
 
         // print(dom);

--- a/src/wcs2_0/src/test/resources/requestGetFullCoverage.xml
+++ b/src/wcs2_0/src/test/resources/requestGetFullCoverage.xml
@@ -2,7 +2,7 @@
 <wcs:GetCoverage xmlns:wcs="http://www.opengis.net/wcs/2.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.opengis.net/wcs/2.0 ../../wcsAll.xsd"
-    service="WCS" version="2.0.0">
+    service="WCS" version="2.0.1">
   <wcs:CoverageId>wcs__BlueMarble</wcs:CoverageId>
   <wcs:format>image/tiff</wcs:format>
 </wcs:GetCoverage>

--- a/src/web/app/src/test/java/org/geoserver/integration/VersionNegotiationKVPIntegrationTest.java
+++ b/src/web/app/src/test/java/org/geoserver/integration/VersionNegotiationKVPIntegrationTest.java
@@ -1,0 +1,267 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/** Tests version negotiation for GetCapabilities Requests (KVP). */
+public class VersionNegotiationKVPIntegrationTest extends GeoServerSystemTestSupport {
+
+    /**
+     * Executes a GetCapabilities request with the given version and acceptsVersion. this goes to
+     * the "ows" endpoint
+     */
+    public Document doGetCapOWS(String version, String acceptVersions, String service)
+            throws Exception {
+        String url = "ows?service=" + service + "&request=getCapabilities";
+        if (version != null) url += "&version=" + version;
+        if (acceptVersions != null) url += "&acceptVersions=" + acceptVersions;
+
+        Document doc = getAsDOM(url);
+        return doc;
+    }
+
+    public Document doGetCapURL(String url) throws Exception {
+        Document doc = getAsDOM(url);
+        return doc;
+    }
+
+    /**
+     * Executes a GetCapabilities request with the given version and acceptsVersion. this goes to
+     * the service specific endpoint (.../wfs?...)
+     */
+    public Document doGetCapService(String version, String acceptVersions, String service)
+            throws Exception {
+        String url = service.toLowerCase() + "?service=" + service + "&request=getCapabilities";
+        if (version != null) url += "&version=" + version;
+        if (acceptVersions != null) url += "&acceptVersions=" + acceptVersions;
+
+        Document doc = getAsDOM(url);
+        return doc;
+    }
+
+    /**
+     * checks that the capabilities document has an attribute called "version" with the correct
+     * version number.
+     */
+    public static void assertVersion(Document doc, String version) {
+        assertEquals(version, doc.getDocumentElement().getAttribute("version"));
+    }
+
+    /**
+     * Tests that setting an exact `version=...` in the GetCapabilities requests works. OGC 1.1.0
+     * spec - "If the server implements the requested version number, the server must send that
+     * version. "
+     */
+    @Test
+    public void testExactVersionOWS() throws Exception {
+        Document doc;
+
+        // --wfs
+        doc = doGetCapOWS("1.0.0", null, "wfs");
+        assertVersion(doc, "1.0.0");
+
+        doc = doGetCapOWS("1.1.0", null, "wfs");
+        assertVersion(doc, "1.1.0");
+
+        doc = doGetCapOWS("2.0.0", null, "wfs");
+        assertVersion(doc, "2.0.0");
+
+        // wcs
+        doc = doGetCapOWS("2.0.1", null, "WCS");
+        assertVersion(doc, "2.0.1");
+
+        doc = doGetCapOWS("1.1.0", null, "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapOWS("1.1.1", null, "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapOWS("1.0.0", null, "WCS");
+        assertVersion(doc, "1.0.0");
+
+        // wms
+        doc = doGetCapOWS("1.3.0", null, "wms");
+        assertVersion(doc, "1.3.0");
+
+        doc = doGetCapOWS("1.1.1", null, "wms");
+        assertVersion(doc, "1.1.1");
+
+        // wmts
+        doc = doGetCapURL("gwc/service/wmts?service=WMTS&request=GetCapabilities");
+        assertVersion(doc, "1.0.0");
+
+        // tms
+        doc = doGetCapURL("gwc/service/tms/1.0.0");
+        assertVersion(doc, "1.0.0");
+
+        // wmts-c
+        doc = doGetCapURL("gwc/service/wms?request=GetCapabilities&version=1.1.1&tiled=true");
+        assertVersion(doc, "1.1.1");
+    }
+
+    /**
+     * Tests that setting an exact `version=...` in the GetCapabilities requests works. OGC 1.1.0
+     * spec - "If the server implements the requested version number, the server must send that
+     * version. "
+     */
+    @Test
+    public void testExactVersionService() throws Exception {
+        Document doc;
+
+        // --wfs
+        doc = doGetCapService("1.0.0", null, "wfs");
+        assertVersion(doc, "1.0.0");
+
+        doc = doGetCapService("1.1.0", null, "wfs");
+        assertVersion(doc, "1.1.0");
+
+        doc = doGetCapService("2.0.0", null, "wfs");
+        assertVersion(doc, "2.0.0");
+
+        // wcs
+        doc = doGetCapService("2.0.1", null, "WCS");
+        assertVersion(doc, "2.0.1");
+
+        doc = doGetCapService("1.1.0", null, "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapService("1.1.1", null, "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapService("1.0.0", null, "WCS");
+        assertVersion(doc, "1.0.0");
+
+        // wms
+        doc = doGetCapService("1.3.0", null, "wms");
+        assertVersion(doc, "1.3.0");
+
+        doc = doGetCapService("1.1.1", null, "wms");
+        assertVersion(doc, "1.1.1");
+    }
+
+    /**
+     * Tests that setting a single `AcceptVersions=...` in the GetCapabilities requests works (to
+     * OWS endpoint)
+     */
+    @Test
+    public void testSingleAcceptVersionsOWS() throws Exception {
+        Document doc;
+
+        // --wfs
+        doc = doGetCapOWS(null, "1.0.0", "wfs");
+        assertVersion(doc, "1.0.0");
+
+        doc = doGetCapOWS(null, "1.1.0", "wfs");
+        assertVersion(doc, "1.1.0");
+
+        doc = doGetCapOWS(null, "2.0.0", "wfs");
+        assertVersion(doc, "2.0.0");
+
+        // wcs
+        doc = doGetCapOWS(null, "2.0.1", "WCS");
+        assertVersion(doc, "2.0.1");
+
+        doc = doGetCapOWS(null, "1.1.0", "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapOWS(null, "1.1.1", "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapOWS(null, "1.0.0", "WCS");
+        assertVersion(doc, "1.0.0");
+
+        // wms
+        doc = doGetCapOWS(null, "1.3.0", "wms");
+        assertVersion(doc, "1.3.0");
+
+        doc = doGetCapOWS(null, "1.1.1", "wms");
+        assertVersion(doc, "1.1.1");
+    }
+
+    @Test
+    public void delme() throws Exception {
+        Document doc = doGetCapService(null, "2.0.1", "WCS");
+        assertVersion(doc, "2.0.1");
+    }
+    /**
+     * Tests that setting a single `AcceptVersions=...` in the GetCapabilities requests works (to
+     * service endpoint)
+     */
+    @Test
+    public void testSingleAcceptVersionsService() throws Exception {
+        Document doc;
+
+        // --wfs
+        doc = doGetCapService(null, "1.0.0", "wfs");
+        assertVersion(doc, "1.0.0");
+
+        doc = doGetCapService(null, "1.1.0", "wfs");
+        assertVersion(doc, "1.1.0");
+
+        doc = doGetCapService(null, "2.0.0", "wfs");
+        assertVersion(doc, "2.0.0");
+
+        // wcs
+        doc = doGetCapService(null, "2.0.1", "WCS");
+        assertVersion(doc, "2.0.1");
+
+        doc = doGetCapService(null, "1.1.0", "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapService(null, "1.1.1", "WCS");
+        assertVersion(doc, "1.1.1");
+
+        doc = doGetCapService(null, "1.0.0", "WCS");
+        assertVersion(doc, "1.0.0");
+
+        // wms
+        doc = doGetCapService(null, "1.3.0", "wms");
+        assertVersion(doc, "1.3.0");
+
+        doc = doGetCapService(null, "1.1.1", "wms");
+        assertVersion(doc, "1.1.1");
+    }
+
+    @Test
+    public void testAcceptVersions() throws Exception {
+        Document doc;
+
+        // --wfs with non-known (choose the one that exists)
+        doc = doGetCapService(null, "1.0.0,6.6.6", "wfs");
+        assertVersion(doc, "1.0.0");
+        doc = doGetCapService(null, "6.6.6,1.0.0", "wfs");
+        assertVersion(doc, "1.0.0");
+        doc = doGetCapService(null, "6.6.6,1.0.0,6.6.6", "wfs");
+        assertVersion(doc, "1.0.0");
+
+        // choose first
+        doc = doGetCapService(null, "1.0.0,2.0.0", "wfs");
+        assertVersion(doc, "1.0.0");
+
+        // choose first
+        doc = doGetCapService(null, "2.0.0,1.0.0", "wfs");
+        assertVersion(doc, "2.0.0");
+
+        // choose best one below requested
+        doc = doGetCapService(null, "1.5.0", "wfs");
+        assertVersion(doc, "1.1.0");
+    }
+
+    @Test
+    public void testVersion() throws Exception {
+        Document doc;
+
+        doc = doGetCapService("0.9.0", null, "wfs");
+        assertVersion(doc, "1.0.0");
+
+        doc = doGetCapService(null, null, "wfs");
+        assertVersion(doc, "2.0.0");
+    }
+}

--- a/src/web/app/src/test/java/org/geoserver/integration/VersionNegotiationKVPIntegrationTest.java
+++ b/src/web/app/src/test/java/org/geoserver/integration/VersionNegotiationKVPIntegrationTest.java
@@ -19,7 +19,7 @@ public class VersionNegotiationKVPIntegrationTest extends GeoServerSystemTestSup
      */
     public Document doGetCapOWS(String version, String acceptVersions, String service)
             throws Exception {
-        String url = "ows?service=" + service + "&request=getCapabilities";
+        String url = "ows?service=" + service + "&request=GetCapabilities";
         if (version != null) url += "&version=" + version;
         if (acceptVersions != null) url += "&acceptVersions=" + acceptVersions;
 
@@ -38,12 +38,47 @@ public class VersionNegotiationKVPIntegrationTest extends GeoServerSystemTestSup
      */
     public Document doGetCapService(String version, String acceptVersions, String service)
             throws Exception {
-        String url = service.toLowerCase() + "?service=" + service + "&request=getCapabilities";
+        String url = service.toLowerCase() + "?service=" + service + "&request=GetCapabilities";
         if (version != null) url += "&version=" + version;
         if (acceptVersions != null) url += "&acceptVersions=" + acceptVersions;
 
         Document doc = getAsDOM(url);
         return doc;
+    }
+
+    /**
+     * test when they don't put a service=... in the request (but use the "service" endpoint)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testServiceNoService() throws Exception {
+        // wfs
+        String url = "wfs?request=GetCapabilities&version=1.0.0";
+        Document doc = doGetCapURL(url);
+        assertVersion(doc, "1.0.0");
+
+        url = "wfs?request=GetCapabilities&acceptVersions=2.0.0";
+        doc = doGetCapURL(url);
+        assertVersion(doc, "2.0.0");
+
+        // wms
+        url = "wms?request=GetCapabilities&version=1.3.0";
+        doc = doGetCapURL(url);
+        assertVersion(doc, "1.3.0");
+
+        url = "wms?request=GetCapabilities&acceptVersions=1.1.1";
+        doc = doGetCapURL(url);
+        assertVersion(doc, "1.1.1");
+
+        // wcs
+        url = "wcs?request=GetCapabilities&version=1.1.1";
+        doc = doGetCapURL(url);
+        assertVersion(doc, "1.1.1");
+
+        url = "wcs?request=GetCapabilities&acceptVersions=1.1.1";
+        doc = doGetCapURL(url);
+        assertVersion(doc, "1.1.1");
     }
 
     /**
@@ -185,11 +220,6 @@ public class VersionNegotiationKVPIntegrationTest extends GeoServerSystemTestSup
         assertVersion(doc, "1.1.1");
     }
 
-    @Test
-    public void delme() throws Exception {
-        Document doc = doGetCapService(null, "2.0.1", "WCS");
-        assertVersion(doc, "2.0.1");
-    }
     /**
      * Tests that setting a single `AcceptVersions=...` in the GetCapabilities requests works (to
      * service endpoint)

--- a/src/web/app/src/test/java/org/geoserver/integration/VersionNegotiationXMLIntegrationTest.java
+++ b/src/web/app/src/test/java/org/geoserver/integration/VersionNegotiationXMLIntegrationTest.java
@@ -1,0 +1,226 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.integration;
+
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/** Tests version negotiation for GetCapabilities Requests (XML post). */
+public class VersionNegotiationXMLIntegrationTest extends GeoServerSystemTestSupport {
+
+    /** */
+    public Document doPOSTService(String service, String xml) throws Exception {
+        String url = service.toLowerCase();
+        Document doc = postAsDOM(url, xml);
+        return doc;
+    }
+
+    public Document doPOSTOWS(String xml) throws Exception {
+        String url = "ows";
+        Document doc = postAsDOM(url, xml);
+        return doc;
+    }
+
+    /**
+     * NOTE: cf testWFS111 CITE tests use these two xml documents to get 1.1.0 and 1.0.0
+     * capabilities documents. The only difference is the version=1.0.0. However, this is an
+     * optional element. This is the CITE expectation.
+     */
+    @Test
+    public void testWFS110() throws Exception {
+        String xml =
+                "<GetCapabilities\n"
+                        + "         service=\"WFS\"\n"
+                        + "         xmlns=\"http://www.opengis.net/wfs\"\n"
+                        + "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "/>";
+        Document doc = doPOSTService("wfs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.0");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.0");
+    }
+
+    /**
+     * NOTE: cf testWFS110 CITE tests use these two xml documents to get 1.1.0 and 1.0.0
+     * capabilities documents. The only difference is the version=1.0.0. However, this is an
+     * optional element. This is the CITE expectation.
+     */
+    @Test
+    public void testWFS100() throws Exception {
+        String xml =
+                "<GetCapabilities\n"
+                        + "         service=\"WFS\"\n"
+                        + "         version=\"1.0.0\"\n"
+                        + "         xmlns=\"http://www.opengis.net/wfs\"\n"
+                        + "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "/>";
+        Document doc = doPOSTService("wfs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.0.0");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.0.0");
+    }
+
+    /**
+     * note - this has a different schema namespace than the 1.0.0/1.1.1 requests
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWFS200() throws Exception {
+        String xml =
+                "<GetCapabilities service=\"WFS\" \n"
+                        + "   xmlns=\"http://www.opengis.net/wfs/2.0\"\n"
+                        + "   xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n";
+        Document doc = doPOSTService("wfs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "2.0.0");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "2.0.0");
+    }
+    /** taken from cite wfs20 */
+    @Test
+    public void testWFSAcceptVersion() throws Exception {
+        String xml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<wfs:GetCapabilities  service=\"WFS\" "
+                        + "    xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" "
+                        + "    xmlns:ows=\"http://www.opengis.net/ows\" "
+                        + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                        + ">\n"
+                        + "<ows:AcceptVersions>\n"
+                        + "    <ows:Version>1.1.0</ows:Version>\n"
+                        + "    <ows:Version>2.0.0</ows:Version>\n"
+                        + "  </ows:AcceptVersions>\n"
+                        + "</wfs:GetCapabilities>";
+        Document doc = doPOSTService("wfs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.0");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.0");
+
+        xml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<wfs:GetCapabilities  service=\"WFS\" xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" xmlns:ows=\"http://www.opengis.net/ows\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" >\n"
+                        + "<ows:AcceptVersions>\n"
+                        + "    <ows:Version>10.0.0</ows:Version>\n"
+                        + "    <ows:Version>2.0.0</ows:Version>\n"
+                        + "    <ows:Version>1.1.0</ows:Version>\n"
+                        + "  </ows:AcceptVersions>\n"
+                        + "</wfs:GetCapabilities>";
+
+        doc = doPOSTService("wfs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "2.0.0");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "2.0.0");
+
+        xml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<wfs:GetCapabilities  service=\"WFS\" xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" xmlns:ows=\"http://www.opengis.net/ows\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" >\n"
+                        + "<ows:AcceptVersions>\n"
+                        + "    <ows:Version>1.0.0</ows:Version>\n"
+                        + "    <ows:Version>1.1.0</ows:Version>\n"
+                        + "  </ows:AcceptVersions>\n"
+                        + "</wfs:GetCapabilities>";
+
+        doc = doPOSTService("wfs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.0.0");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.0.0");
+    }
+
+    @Test
+    public void testWCS201() throws Exception {
+        String xml =
+                "<wcs:GetCapabilities  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "  xmlns:ows=\"http://www.opengis.net/ows/2.0\"\n"
+                        + "  xmlns:wcs=\"http://www.opengis.net/wcs/2.0\"\n"
+                        + "  service=\"WCS\">\n"
+                        + "  <ows:AcceptVersions>\n"
+                        + "  <ows:Version>2.0.1</ows:Version>\n"
+                        + "  </ows:AcceptVersions>\n"
+                        + "</wcs:GetCapabilities>";
+        Document doc = doPOSTService("wcs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "2.0.1");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "2.0.1");
+    }
+
+    @Test
+    public void testWCS111() throws Exception {
+        String xml =
+                " <GetCapabilities xmlns=\"http://www.opengis.net/wcs/1.1.1\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/wcs/1.1.1 http://schemas.opengis.net/wcs/1.1.1/wcsAll.xsd\" service = \"WCS\">\n"
+                        + "                  <ows:AcceptVersions>\n"
+                        + "                    <ows:Version>1.1.1</ows:Version>\n"
+                        + "                  </ows:AcceptVersions>\n"
+                        + "                </GetCapabilities>";
+        Document doc = doPOSTService("wcs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+
+        xml =
+                " <GetCapabilities xmlns=\"http://www.opengis.net/wcs/1.1.1\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/wcs/1.1.1 http://schemas.opengis.net/wcs/1.1.1/wcsAll.xsd\" service = \"WCS\">\n"
+                        + "                  <ows:AcceptVersions>\n"
+                        + "                    <ows:Version>0.0.0</ows:Version>\n"
+                        + "                    <ows:Version>1.1.1</ows:Version>\n"
+                        + "                  </ows:AcceptVersions>\n"
+                        + "                </GetCapabilities>";
+        doc = doPOSTService("wcs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+    }
+
+    // note - GS returns a 1.1.1 document for a 1.1.0 request
+    @Test
+    public void testWCS110() throws Exception {
+        String xml =
+                " <GetCapabilities xmlns=\"http://www.opengis.net/wcs/1.1.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"   service = \"WCS\">\n"
+                        + "                  <ows:AcceptVersions>\n"
+                        + "                    <ows:Version>1.1.0</ows:Version>\n"
+                        + "                  </ows:AcceptVersions>\n"
+                        + "                </GetCapabilities>";
+        Document doc = doPOSTService("wcs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+
+        xml =
+                "<GetCapabilities xmlns=\"http://www.opengis.net/wcs/1.1.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/wcs/1.1.1 http://schemas.opengis.net/wcs/1.1.1/wcsAll.xsd\" service = \"WCS\">\n"
+                        + "                  <ows:AcceptVersions>\n"
+                        + "                    <ows:Version>0.0.0</ows:Version>\n"
+                        + "                    <ows:Version>1.1.0</ows:Version>\n"
+                        + "                  </ows:AcceptVersions>\n"
+                        + "                </GetCapabilities>";
+
+        doc = doPOSTService("wcs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.1.1");
+    }
+
+    // from cite - no acceptVersions testing (old spec)
+    @Test
+    public void testWCS100() throws Exception {
+        String xml =
+                "<GetCapabilities xmlns=\"http://www.opengis.net/wcs\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/wcs http://schemas.opengis.net/wcs/1.0.0/wcsCapabilities.xsd\" version=\"1.0.0\" service=\"WCS\">\n"
+                        + "</GetCapabilities>";
+        Document doc = doPOSTService("wcs", xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.0.0");
+
+        doc = doPOSTOWS(xml);
+        VersionNegotiationKVPIntegrationTest.assertVersion(doc, "1.0.0");
+    }
+}

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/VersionNegotiationTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/VersionNegotiationTest.java
@@ -45,7 +45,7 @@ public class VersionNegotiationTest extends WFSTestSupport {
         request.getAcceptVersions().getVersion().add("1.1.0");
 
         TransformerBase tx = getCaps.run(GetCapabilitiesRequest.adapt(request));
-        assertTrue(tx instanceof CapabilitiesTransformer.WFS1_1);
+        assertTrue(tx instanceof CapabilitiesTransformer.WFS1_0); //choose first appropriate AcceptVersions
     }
 
     @Test

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/VersionNegotiationTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/VersionNegotiationTest.java
@@ -45,7 +45,10 @@ public class VersionNegotiationTest extends WFSTestSupport {
         request.getAcceptVersions().getVersion().add("1.1.0");
 
         TransformerBase tx = getCaps.run(GetCapabilitiesRequest.adapt(request));
-        assertTrue(tx instanceof CapabilitiesTransformer.WFS1_0); //choose first appropriate AcceptVersions
+        assertTrue(
+                tx
+                        instanceof
+                        CapabilitiesTransformer.WFS1_0); // choose first appropriate AcceptVersions
     }
 
     @Test

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesAllowedMimeTypesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesAllowedMimeTypesTest.java
@@ -70,7 +70,7 @@ public class CapabilitiesAllowedMimeTypesTest extends WMSTestSupport {
 
         doc =
                 getAsDOM(
-                        "sf/PrimitiveGeoFeature/wms?service=WMS&request=getCapabilities&version==1.1.1",
+                        "sf/PrimitiveGeoFeature/wms?service=WMS&request=getCapabilities&version=1.1.1",
                         true);
         formatNodes =
                 xpath.getMatchingNodes(
@@ -89,7 +89,7 @@ public class CapabilitiesAllowedMimeTypesTest extends WMSTestSupport {
 
         doc =
                 getAsDOM(
-                        "sf/PrimitiveGeoFeature/wms?service=WMS&request=getCapabilities&version==1.1.1",
+                        "sf/PrimitiveGeoFeature/wms?service=WMS&request=getCapabilities&version=1.1.1",
                         true);
         formatNodes =
                 xpath.getMatchingNodes(


### PR DESCRIPTION
[![GEOS-10792](https://badgen.net/badge/JIRA/GEOS-10792/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10792)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

When using the acceptVersions negotiation with WCS (not sure about other systems), the system gets into a “half-2.0.2” and “half-1.1.1” situation.   You get an error.

For example,

https://how2map.geocat.live/geoserver/ows?service=WCS&request=getcapabilities&acceptVersions=1.1.1

JIRA: https://osgeo-org.atlassian.net/browse/GEOS-10792


Looking here;

[geoserver/GetCapabilities.java at main · geoserver/geoserver](https://github.com/geoserver/geoserver/blob/main/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/GetCapabilities.java#L49)

You can see it trying to “re-dispatch” a 1.1.1 result in the 2.0.2 service.  This causes issues during output.

This PR does parsing of the acceptVersion (KVP and XML) and puts them in the Request object.
It then does version negotiation.  

# TO DO

1. feedback to make sure this is ok
2. Test case
3. remove this old code.  Is there anywhere else that needs removing?
 [geoserver/GetCapabilities.java at main · geoserver/geoserver](https://github.com/geoserver/geoserver/blob/main/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/GetCapabilities.java#L49)

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->