### PR TITLE
[GEOS-10807] LayerGroup with nested group POST rest op fails with null styles attribute

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -58,6 +58,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.codehaus.jettison.json.JSONArray;
@@ -2227,11 +2228,12 @@ public class XStreamPersister {
             if (assignedInfos != null) {
                 for (int i = 0; i < assignedInfos.size(); i++) {
                     PublishedInfo publishedInfo = assignedInfos.get(i);
-                    if (publishedInfo instanceof LayerGroupInfo) {
+                    if (publishedInfo instanceof LayerGroupInfo
+                            && CollectionUtils.isNotEmpty(styles)) {
                         // if the styles is not null then this is
                         // a StyleInfo simply holding the style name
                         // of a LayerGroupStyle. We do not resolve it
-                        // as usual since is not present in the catalog but
+                        // as usual siWnce is not present in the catalog but
                         // get the ref and create a new StyleInfo object.
                         StyleInfo styleInfo = styles.get(i);
                         String ref = ResolvingProxy.getRef(styleInfo);

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerGroupControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/LayerGroupControllerTest.java
@@ -1045,4 +1045,87 @@ public class LayerGroupControllerTest extends CatalogRESTTestSupport {
             catalog.save(lg);
         }
     }
+
+    @Test
+    public void testPostJSONWithContainedGroupStyleNull() throws Exception {
+        LayerGroupInfo lg = null;
+        try {
+            String json =
+                    "{\n"
+                            + "  \"layerGroup\": {\n"
+                            + "    \"name\": \"layerGroupNullStyle\",\n"
+                            + "    \"publishables\": {\n"
+                            + "  \"published\": [\n"
+                            + "    {\n"
+                            + "      \"name\": \"sfLayerGroup\",\n"
+                            + "      \"@type\": \"layerGroup\"\n"
+                            + "    },"
+                            + "    {\n"
+                            + "      \"name\": \"citeLayerGroup\",\n"
+                            + "      \"@type\": \"layerGroup\"\n"
+                            + "    }"
+                            + "  ]\n"
+                            + "},\n"
+                            + "    \"styles\": null"
+                            + "  }\n"
+                            + "}";
+            MockHttpServletResponse response =
+                    postAsServletResponse(
+                            RestBaseController.ROOT_PATH + "/layergroups",
+                            json,
+                            "application/json");
+            assertEquals(201, response.getStatus());
+            assertEquals(MediaType.TEXT_PLAIN_VALUE, response.getContentType());
+
+            assertNotNull(response.getHeader("Location"));
+            assertTrue(response.getHeader("Location").endsWith("/layergroups/layerGroupNullStyle"));
+
+            lg = catalog.getLayerGroupByName("layerGroupNullStyle");
+            assertNotNull(lg);
+
+            assertEquals(2, lg.getLayers().size());
+            assertEquals("sfLayerGroup", lg.getLayers().get(0).getName());
+            assertNull(lg.getStyles().get(0));
+            assertEquals("citeLayerGroup", lg.getLayers().get(1).getName());
+            assertNull(lg.getStyles().get(0));
+        } finally {
+            if (lg != null) catalog.remove(lg);
+        }
+    }
+
+    @Test
+    public void testPostXMLWithContainedGroupStyleNull() throws Exception {
+        LayerGroupInfo lg = null;
+        try {
+            String xml =
+                    "<layerGroup>"
+                            + "<name>layerGroupNullStyle2</name>"
+                            + "<publishables>"
+                            + "<published type=\"layerGroup\">sfLayerGroup</published>"
+                            + "<published type=\"layerGroup\">citeLayerGroup</published>"
+                            + "</publishables>"
+                            + "<styles/>"
+                            + "</layerGroup>";
+            MockHttpServletResponse response =
+                    postAsServletResponse(
+                            RestBaseController.ROOT_PATH + "/layergroups", xml, "text/xml");
+            assertEquals(201, response.getStatus());
+            assertEquals(MediaType.TEXT_PLAIN_VALUE, response.getContentType());
+
+            assertNotNull(response.getHeader("Location"));
+            assertTrue(
+                    response.getHeader("Location").endsWith("/layergroups/layerGroupNullStyle2"));
+
+            lg = catalog.getLayerGroupByName("layerGroupNullStyle2");
+            assertNotNull(lg);
+
+            assertEquals(2, lg.getLayers().size());
+            assertEquals("sfLayerGroup", lg.getLayers().get(0).getName());
+            assertNull(lg.getStyles().get(0));
+            assertEquals("citeLayerGroup", lg.getLayers().get(1).getName());
+            assertNull(lg.getStyles().get(0));
+        } finally {
+            if (lg != null) catalog.remove(lg);
+        }
+    }
 }


### PR DESCRIPTION
[![GEOS-10807](https://badgen.net/badge/JIRA/GEOS-10807/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10807)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See jira ticket for details.
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->