### PR TITLE
[GEOS-10809] : Keycloak : add support for usernames with spaces

### DIFF
--- a/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/KeycloakUrlBuilder.java
+++ b/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/KeycloakUrlBuilder.java
@@ -5,8 +5,9 @@
 
 package org.geoserver.security.keycloak;
 
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 /** A builder for a keycloak rest endpoint. */
 class KeycloakUrlBuilder {
@@ -46,8 +47,11 @@ class KeycloakUrlBuilder {
      */
     KeycloakUrlBuilder userByName(String userName) {
         users();
-        sb.append("?exact=true&username=")
-                .append(URLEncoder.encode(userName, StandardCharsets.UTF_8));
+        try {
+            sb.append("?exact=true&username=").append(URLEncoder.encode(userName, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new UncheckedIOException(e);
+        }
         return this;
     }
 

--- a/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/KeycloakUrlBuilder.java
+++ b/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/KeycloakUrlBuilder.java
@@ -5,9 +5,8 @@
 
 package org.geoserver.security.keycloak;
 
-import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /** A builder for a keycloak rest endpoint. */
 class KeycloakUrlBuilder {
@@ -47,11 +46,8 @@ class KeycloakUrlBuilder {
      */
     KeycloakUrlBuilder userByName(String userName) {
         users();
-        try {
-            sb.append("?exact=true&username=").append(URLEncoder.encode(userName, "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new UncheckedIOException(e);
-        }
+        sb.append("?exact=true&username=")
+                .append(URLEncoder.encode(userName, StandardCharsets.UTF_8));
         return this;
     }
 

--- a/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/KeycloakUrlBuilder.java
+++ b/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/KeycloakUrlBuilder.java
@@ -5,6 +5,10 @@
 
 package org.geoserver.security.keycloak;
 
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 /** A builder for a keycloak rest endpoint. */
 class KeycloakUrlBuilder {
 
@@ -43,7 +47,11 @@ class KeycloakUrlBuilder {
      */
     KeycloakUrlBuilder userByName(String userName) {
         users();
-        sb.append("?exact=true&username=").append(userName);
+        try {
+            sb.append("?exact=true&username=").append(URLEncoder.encode(userName, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new UncheckedIOException(e);
+        }
         return this;
     }
 

--- a/src/community/security/keycloak/src/test/java/org/geoserver/security/keycloak/KeycloakUrlBuilderTest.java
+++ b/src/community/security/keycloak/src/test/java/org/geoserver/security/keycloak/KeycloakUrlBuilderTest.java
@@ -1,0 +1,21 @@
+/* (c) 2022 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.keycloak;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KeycloakUrlBuilderTest extends TestCase {
+
+    @Test
+    public void testUserByName() {
+        KeycloakUrlBuilder builder = new KeycloakUrlBuilder("testRealm", "http://keycloak/auth");
+        String result = builder.userByName("test username").build();
+        Assert.assertFalse(result.contains(" "));
+        Assert.assertTrue(result.endsWith("username"));
+    }
+}


### PR DESCRIPTION
[![GEOS-10809](https://badgen.net/badge/JIRA/GEOS-10809/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10809)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When using geoserver secured via keycloak, an error is thrown if the user has a username containing at least one space.
This PR should fix this.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->