### PR TITLE
[GEOS-10813] -- jdbcconfig cache bug,changed the workspace name

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -104,6 +104,7 @@ import org.geoserver.config.impl.CoverageAccessInfoImpl;
 import org.geoserver.config.impl.GeoServerInfoImpl;
 import org.geoserver.config.impl.JAIInfoImpl;
 import org.geoserver.ows.util.OwsUtils;
+import org.geoserver.platform.ExtensionPriority;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.util.CacheProvider;
 import org.geoserver.util.DefaultCacheProvider;
@@ -1744,9 +1745,14 @@ public class ConfigDatabase implements ApplicationContextAware {
         releaseWriteLock(id);
     }
 
-    /** Listens to catalog events clearing cache entires when resources are modified. */
-    // Copied from org.geoserver.catalog.ResourcePool
-    public class CatalogClearingListener implements CatalogListener {
+    /**
+     * Listens to catalog events clearing cache entires when resources are modified. Copied from
+     * org.geoserver.catalog.ResourcePool upgrade CatalogClearingListener clear old source default
+     * priority is 100
+     *
+     * @see CatalogImpl#addListener(CatalogListener)
+     */
+    public class CatalogClearingListener implements CatalogListener, ExtensionPriority {
 
         @Override
         public void handleAddEvent(CatalogAddEvent event) {
@@ -1784,6 +1790,11 @@ public class ConfigDatabase implements ApplicationContextAware {
 
         @Override
         public void reloaded() {}
+
+        @Override
+        public int getPriority() {
+            return 999;
+        }
     }
     /** Listens to configuration events clearing cache entires when resources are modified. */
     public class ConfigClearingListener extends ConfigurationListenerAdapter {

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -262,6 +262,12 @@ public class ConfigDatabase implements ApplicationContextAware {
         return dbMappings;
     }
 
+    /**
+     * CatalogClearingListener listener will be added to CatalogImpl when CatalogImpl is set, and
+     * CatalogImpl's addListener method will sort the listener
+     *
+     * @param catalog
+     */
     public void setCatalog(CatalogImpl catalog) {
         this.catalog = catalog;
         this.binding.setCatalog(catalog);

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -262,12 +262,6 @@ public class ConfigDatabase implements ApplicationContextAware {
         return dbMappings;
     }
 
-    /**
-     * CatalogClearingListener listener will be added to CatalogImpl when CatalogImpl is set, and
-     * CatalogImpl's addListener method will sort the listener
-     *
-     * @param catalog
-     */
     public void setCatalog(CatalogImpl catalog) {
         this.catalog = catalog;
         this.binding.setCatalog(catalog);

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1788,11 +1788,6 @@ public class CatalogImpl implements Catalog {
         return Collections.unmodifiableCollection(listeners);
     }
 
-    /**
-     * Add sorted listeners that implement ExtensionPriority interface to get priority through getPriority (), otherwise the default priority is 100. You can have the listener implementation ExtensionPriority specify the priority that determines the order in which the listener executes
-     *
-     * @param listener
-     */
     @Override
     public void addListener(CatalogListener listener) {
         listeners.add(listener);

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -1788,6 +1788,11 @@ public class CatalogImpl implements Catalog {
         return Collections.unmodifiableCollection(listeners);
     }
 
+    /**
+     * Add sorted listeners that implement ExtensionPriority interface to get priority through getPriority (), otherwise the default priority is 100. You can have the listener implementation ExtensionPriority specify the priority that determines the order in which the listener executes
+     *
+     * @param listener
+     */
     @Override
     public void addListener(CatalogListener listener) {
         listeners.add(listener);


### PR DESCRIPTION
[![GEOS-10813](https://badgen.net/badge/JIRA/GEOS-10813/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10813)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->


See jira ticket for details.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->