### PR TITLE
jdbcconfig - log parameter values in order they appear in query

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -656,7 +656,6 @@ public class ConfigDatabase implements ApplicationContextAware {
             final String storedValue,
             Integer relatedOid,
             Integer relatedPropertyType) {
-        Map<String, ?> params = params("value", storedValue);
 
         final String insertPropertySQL =
                 "insert into object_property " //
@@ -665,22 +664,22 @@ public class ConfigDatabase implements ApplicationContextAware {
         final Number propertyType = prop.getPropertyType().getOid();
         final String id = info.getId();
 
-        params =
+        Map<String, ?> params =
                 params(
                         "object_id",
-                        infoPk, //
+                        infoPk,
                         "property_type",
-                        propertyType, //
-                        "id",
-                        id, //
+                        propertyType,
                         "related_oid",
-                        relatedOid, //
+                        relatedOid,
                         "related_property_type",
-                        relatedPropertyType, //
+                        relatedPropertyType,
                         "colindex",
-                        colIndex, //
+                        colIndex,
                         "value",
-                        storedValue);
+                        storedValue,
+                        "id",
+                        id);
 
         logStatement(insertPropertySQL, params);
         template.update(insertPropertySQL, params);
@@ -1040,14 +1039,14 @@ public class ConfigDatabase implements ApplicationContextAware {
                                     + "where related_oid = :oid and related_property_type = :property_type and colindex = :colindex";
                     params =
                             params(
+                                    "value",
+                                    storedValue,
                                     "oid",
                                     oid,
                                     "property_type",
                                     propertyType,
                                     "colindex",
-                                    colIndex,
-                                    "value",
-                                    storedValue);
+                                    colIndex);
                     logStatement(updateRelated, params);
                     int relatedUpdateCnt = template.update(updateRelated, params);
                     if (LOGGER.isLoggable(Level.FINER)) {

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbUtils.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbUtils.java
@@ -5,9 +5,9 @@
  */
 package org.geoserver.jdbcconfig.internal;
 
-import com.google.common.collect.Maps;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -19,7 +19,7 @@ public class DbUtils {
     static final Logger LOGGER = Logging.getLogger(DbUtils.class.getPackage().getName());
 
     public static Map<String, ?> params(Object... kv) {
-        Map<String, Object> params = Maps.newHashMap();
+        Map<String, Object> params = new LinkedHashMap<>();
         String paramName;
         Object paramValue;
         for (int i = 0; i < kv.length; i += 2) {

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/FilterToCatalogSQL.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/FilterToCatalogSQL.java
@@ -8,9 +8,9 @@ package org.geoserver.jdbcconfig.internal;
 import static com.google.common.base.Preconditions.*;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -98,12 +98,11 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
 
     private final DbMappings dbMappings;
 
-    private Map<String, Object> namedParams;
+    private final Map<String, Object> namedParams = new LinkedHashMap<>();
 
     public FilterToCatalogSQL(Class<?> queryType, DbMappings dbMappings) {
         this.queryType = queryType;
         this.dbMappings = dbMappings;
-        namedParams = Maps.newHashMap();
         List<Integer> concreteQueryTypes = dbMappings.getConcreteQueryTypes(queryType);
         namedParams.put("types", concreteQueryTypes);
     }


### PR DESCRIPTION
This PR updates the jdbcconfig debug logging to log the parameter values in the same order that they appear in the SQL query.  I didn't create a JIRA ticket for this.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->