### PR TITLE
[Backport 2.21.x][GEOS-10812] Update Jettison to 1.5.3 (#6469)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -750,7 +750,7 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.5.2</version>
+        <version>1.5.3</version>
       </dependency>
       <dependency>
         <groupId>lucene</groupId>


### PR DESCRIPTION
[![GEOS-10812](https://badgen.net/badge/JIRA/GEOS-10812/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10812)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

backports https://github.com/geoserver/geoserver/pull/6469

Co-authored-by: Mark Prins <1165786+mprins@users.noreply.github.com>