### PR TITLE
[GEOS-10817] Features Templating - XML HTML output doesn't escape all html and xml symbols

### DIFF
--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XHTMLTemplateWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XHTMLTemplateWriter.java
@@ -23,6 +23,7 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.stream.events.Attribute;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.geoserver.featurestemplating.builders.EncodingHints;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -131,6 +132,11 @@ public class XHTMLTemplateWriter extends XMLTemplateWriter {
         } catch (XMLStreamException e) {
             throw new IOException(e);
         }
+    }
+
+    @Override
+    protected String escape(String value) {
+        return StringEscapeUtils.escapeHtml(value);
     }
 
     @Override

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLMappedFeature.xhtml
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLMappedFeature.xhtml
@@ -64,6 +64,12 @@ ul, #myUL {
                         <li>${gml:name}</li>
                     </ul>
                 </li>
+                <li>
+                    <span class="caret">Degrees</span>
+                    <ul class="nested">
+                        <li>60°</li>
+                    </ul>
+                </li>
                 <li gft:isCollection="true" gft:source="gsml:specification/gsml:GeologicUnit">
                     <span class="caret">Specifications</span>
                     <ul class="nested">

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/TemplateGetFeatureResponseHelper.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/TemplateGetFeatureResponseHelper.java
@@ -40,6 +40,8 @@ public class TemplateGetFeatureResponseHelper {
 
     private TemplateIdentifier format;
 
+    private static final String ESCAPE_CHARS = "escapeCharacters";
+
     TemplateGetFeatureResponseHelper(Catalog catalog, TemplateIdentifier format) {
         this.catalog = catalog;
         this.format = format;
@@ -69,9 +71,15 @@ public class TemplateGetFeatureResponseHelper {
             case GML32:
             case HTML:
                 XMLOutputFactory xMLOutputFactory = XMLOutputFactory.newInstance();
+                // we do ourselves the escaping in the template writer since the one provided in the
+                // XMLStreamWriter implementation
+                // doesn't handle all the characters.
+                if (xMLOutputFactory.isPropertySupported(ESCAPE_CHARS))
+                    xMLOutputFactory.setProperty(ESCAPE_CHARS, false);
                 try {
                     XMLStreamWriter xMLStreamWriter =
-                            xMLOutputFactory.createXMLStreamWriter(output);
+                            xMLOutputFactory.createXMLStreamWriter(output, "UTF-8");
+
                     if (format.equals(TemplateIdentifier.HTML))
                         outputWriter = new XHTMLTemplateWriter(xMLStreamWriter, output);
                     else outputWriter = new GMLTemplateWriter(xMLStreamWriter, version);

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetComplexFeatureResponseTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetComplexFeatureResponseTest.java
@@ -117,6 +117,20 @@ public class HTMLGetComplexFeatureResponseTest extends TemplateComplexTestSuppor
         assertTrue(resp.getContentAsString().contains("Unable to find a JSON-LD template"));
     }
 
+    @Test
+    public void testEscaping() {
+        Document doc =
+                getAsDOM(
+                        "wfs?request=GetFeature&version=1.1.0&typename=gsml:MappedFeature"
+                                + "&outputFormat=text/html"
+                                + MF_HTML_PARAM);
+        assertXpathMatches(
+                "60&deg;",
+                "//html/body/ul/li[./span = 'MappedFeature']/ul/li[./span = 'Degrees']/ul/li",
+                doc);
+        assertHTMLResult(doc);
+    }
+
     private void assertHTMLResult(Document doc) {
         assertXpathCount(1, "//html/head/style", doc);
         assertXpathCount(5, "//html/body/ul/li[./span = 'MappedFeature']", doc);


### PR DESCRIPTION
[![GEOS-10817](https://badgen.net/badge/JIRA/GEOS-10817/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10817)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->