### PR TITLE
[GEOS-10818] Schemaless Property Accessor returns emptylist instead of null for null/not existing properties

### DIFF
--- a/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
+++ b/src/community/schemaless-features/mongodb-schemaless/src/test/java/org/geoserver/schemalessfeatures/mongodb/SchemalessCollectionTest.java
@@ -161,4 +161,23 @@ public class SchemalessCollectionTest extends AbstractMongoDBOnlineTestSupport {
         }
         assertEquals(30, sum / denom);
     }
+
+    @Test
+    public void testNotExistingPropUnderUnboundedFeatures() throws Exception {
+        // test that when evaluating a property name traversing nested features
+        // with cardinality > 1 and not existing or null property for all the nested features
+        // the return value is null and not empty list.
+        FeatureTypeInfo fti =
+                getCatalog().getFeatureTypeByName("gs:" + StationsTestSetup.COLLECTION_NAME);
+        @SuppressWarnings("unchecked")
+        FeatureSource<FeatureType, Feature> source =
+                (FeatureSource<FeatureType, Feature>) fti.getFeatureSource(null, null);
+        FeatureCollection<FeatureType, Feature> collection =
+                source.getFeatures(FF.equals(FF.property("name"), FF.literal("station 1")));
+
+        FeatureIterator<Feature> it = collection.features();
+        PropertyName pn = FF.property("measurements.notExisting");
+        Feature f = it.next();
+        assertNull(pn.evaluate(f));
+    }
 }

--- a/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
+++ b/src/community/schemaless-features/schemaless-core/src/main/java/org/geoserver/schemalessfeatures/filter/SchemalessPropertyAccessorFactory.java
@@ -105,6 +105,7 @@ public class SchemalessPropertyAccessorFactory implements PropertyAccessorFactor
                     List<Object> attributes = List.class.cast(result);
                     List<Object> results = walkList(attributes, path, i);
                     if (results.size() == 1) result = results.get(0);
+                    else if (results.isEmpty()) result = null;
                     else result = results;
                     break;
                 } else if (result == null) {


### PR DESCRIPTION
[![GEOS-10818](https://badgen.net/badge/JIRA/GEOS-10818/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10818)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->