### PR TITLE
Make all OGC API modules pass QA checks, update test dependencies to work on Java 11, fix a few tests

### DIFF
--- a/src/community/ogcapi/dggs/dggs-clickhouse/src/test/java/org/geotools/dggs/clickhouse/ClickHouseOnlineTestCase.java
+++ b/src/community/ogcapi/dggs/dggs-clickhouse/src/test/java/org/geotools/dggs/clickhouse/ClickHouseOnlineTestCase.java
@@ -18,12 +18,17 @@ package org.geotools.dggs.clickhouse;
 
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.geootols.dggs.clickhouse.ClickHouseDGGSDataStore;
 import org.geootols.dggs.clickhouse.ClickHouseDGGStoreFactory;
 import org.geotools.dggs.DGGSFactoryFinder;
 import org.geotools.test.OnlineTestCase;
+import org.geotools.util.logging.Logging;
 
 public abstract class ClickHouseOnlineTestCase extends OnlineTestCase {
+
+    static final Logger LOGGER = Logging.getLogger(ClickHouseOnlineTestCase.class);
 
     protected ClickHouseDGGSDataStore dataStore;
 
@@ -38,6 +43,16 @@ public abstract class ClickHouseOnlineTestCase extends OnlineTestCase {
         @SuppressWarnings("unchecked")
         Map<String, ?> params = (Map) fixture;
         this.dataStore = (ClickHouseDGGSDataStore) factory.createDataStore(params);
+    }
+
+    @Override
+    protected boolean isOnline() {
+        String dggsId = getDGGSId();
+        boolean present = DGGSFactoryFinder.getFactory(dggsId).isPresent();
+        if (!present) {
+            LOGGER.log(Level.WARNING, dggsId + " is not present, skipping the test");
+        }
+        return present;
     }
 
     /**

--- a/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/PolygonFunction.java
+++ b/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/PolygonFunction.java
@@ -50,7 +50,7 @@ public class PolygonFunction extends DGGSSetFunctionBase {
                     Polygon polygon = (Polygon) getParameterValue(object, 1);
                     Integer resolution = (Integer) getParameterValue(object, 2);
                     Boolean compact =
-                            Optional.of((Boolean) getParameterValue(null, 3)).orElse(false);
+                            Optional.ofNullable((Boolean) getParameterValue(null, 3)).orElse(false);
                     DGGSInstance dggs = (DGGSInstance) getParameterValue(object, 4);
                     if (polygon == null || resolution == null || dggs == null)
                         return Collections.emptyIterator();
@@ -80,7 +80,7 @@ public class PolygonFunction extends DGGSSetFunctionBase {
         if (!isStable()) throw new IllegalStateException("Source parameters are not stable");
         Polygon polygon = (Polygon) getParameterValue(null, 1);
         Integer resolution = (Integer) getParameterValue(null, 2);
-        Boolean compact = Optional.of((Boolean) getParameterValue(null, 3)).orElse(false);
+        Boolean compact = Optional.ofNullable((Boolean) getParameterValue(null, 3)).orElse(false);
         DGGSInstance dggs = (DGGSInstance) getParameterValue(null, 4);
 
         return dggs.polygon(polygon, resolution, compact);

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIFilterParser.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIFilterParser.java
@@ -86,9 +86,9 @@ public class APIFilterParser {
 
         try {
             Filter parsedFilter = null;
-            if (filterLang.equals(ECQL_TEXT)) {
+            if (ECQL_TEXT.equals(filterLang)) {
                 parsedFilter = ECQL.toFilter(filter);
-            } else if (filterLang.equals(CQL2_JSON)) {
+            } else if (CQL2_JSON.equals(filterLang)) {
                 CQLJsonCompiler cqlJsonCompiler =
                         new CQLJsonCompiler(filter, new FilterFactoryImpl());
                 cqlJsonCompiler.compileFilter();

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
@@ -53,7 +53,7 @@ public class QueryablesBuilder {
 
     public QueryablesBuilder forType(FeatureTypeInfo ft) throws IOException {
         this.queryables.setCollectionId(ft.prefixedName());
-        this.queryables.setTitle(Optional.of(ft.getTitle()).orElse(ft.prefixedName()));
+        this.queryables.setTitle(Optional.ofNullable(ft.getTitle()).orElse(ft.prefixedName()));
         this.queryables.setDescription(ft.getDescription());
         return forType((SimpleFeatureType) ft.getFeatureType());
     }

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/CollectionsTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/CollectionsTest.java
@@ -192,7 +192,7 @@ public class CollectionsTest extends CoveragesTestSupport {
         GeoServerInfo info = gs.getGlobal();
         SettingsInfo settings = info.getSettings();
         settings.setProxyBaseUrl("${X-Forwarded-Proto}://test-headers/geoserver/");
-        info.setUseHeadersProxyURL(true);
+        info.getSettings().setUseHeadersProxyURL(true);
         gs.save(info);
         try {
             MockHttpServletRequest request = createRequest("ogc/coverages/collections?f=html");
@@ -222,7 +222,7 @@ public class CollectionsTest extends CoveragesTestSupport {
             info = gs.getGlobal();
             settings = info.getSettings();
             settings.setProxyBaseUrl(null);
-            info.setUseHeadersProxyURL(null);
+            info.getSettings().setUseHeadersProxyURL(null);
             gs.save(info);
         }
     }

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
@@ -169,7 +169,7 @@ public class ApiTest extends FeaturesTestSupport {
         // filter languages
         Parameter langs = api.getComponents().getParameters().get("filter-lang");
         assertEquals(
-                langs.getSchema().getEnum(), new ArrayList(APIFilterParser.SUPPORTED_ENCODINGS));
+                langs.getSchema().getEnum(), new ArrayList<>(APIFilterParser.SUPPORTED_ENCODINGS));
 
         // ... feature
         PathItem item = paths.get("/collections/{collectionId}/items/{featureId}");

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/CollectionsTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/CollectionsTest.java
@@ -220,7 +220,7 @@ public class CollectionsTest extends FeaturesTestSupport {
         GeoServerInfo info = gs.getGlobal();
         SettingsInfo settings = info.getSettings();
         settings.setProxyBaseUrl("${X-Forwarded-Proto}://test-headers/geoserver/");
-        info.setUseHeadersProxyURL(true);
+        info.getSettings().setUseHeadersProxyURL(true);
         gs.save(info);
         try {
             MockHttpServletRequest request = createRequest("ogc/features/collections?f=html");
@@ -250,7 +250,7 @@ public class CollectionsTest extends FeaturesTestSupport {
             info = gs.getGlobal();
             settings = info.getSettings();
             settings.setProxyBaseUrl(null);
-            info.setUseHeadersProxyURL(null);
+            info.getSettings().setUseHeadersProxyURL(null);
             gs.save(info);
         }
     }

--- a/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/styles/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/styles/openapi.yaml
@@ -988,7 +988,7 @@ components:
         (part of conformance class 'style-validation') \
         'yes' creates a new style after successful validation
         and returns 400, if validation fails,
-        ’no' creates the style without validation and 
+        'no' creates the style without validation and 
         'only' just validates the style without creating a
         new style and returns 400, if validation fails,
         otherwise 204.

--- a/src/community/ogcapi/ogcapi-styles/src/test/resources/org/geoserver/ogcapi/styles/tasmania.sld
+++ b/src/community/ogcapi/ogcapi-styles/src/test/resources/org/geoserver/ogcapi/styles/tasmania.sld
@@ -534,7 +534,7 @@
                     <sld:PointSymbolizer>
                         <sld:Graphic>
                             <sld:ExternalGraphic>
-                                <sld:OnlineResource xlink:href="../img/marker.png" />
+                                <sld:OnlineResource xlink:href="img/marker.png" />
                                 <sld:Format>image/png</sld:Format>
                             </sld:ExternalGraphic>
                             <sld:Opacity>0.7</sld:Opacity>

--- a/src/community/ogcapi/ogcapi-tiles/pom.xml
+++ b/src/community/ogcapi/ogcapi-tiles/pom.xml
@@ -101,18 +101,6 @@
       <version>1.20-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-easymock</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesSampleDataProvider.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesSampleDataProvider.java
@@ -40,26 +40,21 @@ public class TilesSampleDataProvider implements SampleDataProvider {
                 // is there any vector format, that is, actual "data"?
                 return mimeTypes.stream()
                         .filter(m -> m.isVector())
-                        .map(
-                                m -> {
-                                    String href =
-                                            ResponseUtils.buildURL(
-                                                    APIRequestInfo.get().getBaseURL(),
-                                                    "ogc/tiles/collections/"
-                                                            + ResponseUtils.urlEncode(
-                                                                    layer.prefixedName()
-                                                                            + "/tiles"),
-                                                    Collections.singletonMap("f", m.getFormat()),
-                                                    URLMangler.URLType.SERVICE);
-                                    return new Link(
-                                            href,
-                                            "tiles",
-                                            m.getFormat(),
-                                            "Tiles as " + m.getFormat());
-                                })
+                        .map(m -> buildSampleDataLink(layer, m))
                         .collect(Collectors.toList());
             }
         }
         return Collections.emptyList();
+    }
+
+    private Link buildSampleDataLink(LayerInfo layer, MimeType m) {
+        String href =
+                ResponseUtils.buildURL(
+                        APIRequestInfo.get().getBaseURL(),
+                        "ogc/tiles/collections/"
+                                + ResponseUtils.urlEncode(layer.prefixedName() + "/tiles"),
+                        Collections.singletonMap("f", m.getFormat()),
+                        URLMangler.URLType.SERVICE);
+        return new Link(href, "tiles", m.getFormat(), "Tiles as " + m.getFormat());
     }
 }

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/TileJSONBuilderTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/TileJSONBuilderTest.java
@@ -1,11 +1,9 @@
 package org.geoserver.ogcapi.tiles;
 
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.geoserver.ogcapi.APIRequestInfo;
 import org.geowebcache.grid.GridSubset;
@@ -13,63 +11,57 @@ import org.geowebcache.layer.meta.LayerMetaInformation;
 import org.geowebcache.layer.meta.TileJSON;
 import org.geowebcache.mbtiles.layer.MBTilesLayer;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(APIRequestInfo.class)
-@PowerMockIgnore({"jdk.internal.reflect.*"})
 public class TileJSONBuilderTest {
 
     @Test
     public void testMBTiles() throws Exception {
+        try (MockedStatic<APIRequestInfo> staticRequestInfos =
+                Mockito.mockStatic(APIRequestInfo.class)) {
+            APIRequestInfo requestInfo = mock(APIRequestInfo.class);
+            when(APIRequestInfo.get()).thenReturn(requestInfo);
+            staticRequestInfos.when(APIRequestInfo::get).thenReturn(requestInfo);
 
-        PowerMock.mockStatic(APIRequestInfo.class);
-        APIRequestInfo requestInfo = createNiceMock(APIRequestInfo.class);
-        expect(APIRequestInfo.get()).andReturn(requestInfo).anyTimes();
-        PowerMock.replay(APIRequestInfo.class);
+            when(requestInfo.getBaseURL()).thenReturn("http://localhost:8081/geoserver");
 
-        expect(requestInfo.getBaseURL()).andReturn("http://localhost:8081/geoserver");
-        replay(requestInfo);
+            MBTilesLayer mbTilesLayer = mock(MBTilesLayer.class);
+            LayerMetaInformation metaInformation = mock(LayerMetaInformation.class);
+            GridSubset subset = mock(GridSubset.class);
 
-        MBTilesLayer mbTilesLayer = mock(MBTilesLayer.class);
-        LayerMetaInformation metaInformation = mock(LayerMetaInformation.class);
-        GridSubset subset = mock(GridSubset.class);
+            when(mbTilesLayer.getName()).thenReturn("countries");
+            when(mbTilesLayer.getGridSubset(anyString())).thenReturn(subset);
+            when(mbTilesLayer.getMetaInformation()).thenReturn(metaInformation);
+            when(mbTilesLayer.supportsTileJSON()).thenReturn(true);
+            TileJSON tileJSON = new TileJSON();
+            tileJSON.setName("countries");
+            tileJSON.setDescription("Natural Earth Data with .shp data from  TileMill");
+            tileJSON.setAttribution("Natural Earth Data");
+            tileJSON.setMinZoom(0);
+            tileJSON.setMaxZoom(6);
+            tileJSON.setScheme("xyz");
+            when(mbTilesLayer.getTileJSON()).thenReturn(tileJSON);
 
-        expect(mbTilesLayer.getName()).andReturn("countries").anyTimes();
-        expect(mbTilesLayer.getGridSubset(anyString())).andReturn(subset).anyTimes();
-        expect(mbTilesLayer.getMetaInformation()).andReturn(metaInformation).anyTimes();
-        expect(mbTilesLayer.supportsTileJSON()).andReturn(true).anyTimes();
-        TileJSON tileJSON = new TileJSON();
-        tileJSON.setName("countries");
-        tileJSON.setDescription("Natural Earth Data with .shp data from  TileMill");
-        tileJSON.setAttribution("Natural Earth Data");
-        tileJSON.setMinZoom(0);
-        tileJSON.setMaxZoom(6);
-        tileJSON.setScheme("xyz");
-        expect(mbTilesLayer.getTileJSON()).andReturn(tileJSON);
-        replay(mbTilesLayer);
+            TileJSONBuilder tileJSONBuilder =
+                    new TileJSONBuilder(
+                            "countries",
+                            "application/vnd.mapbox-vector-tile",
+                            "EPSG:900913",
+                            mbTilesLayer);
+            TileJSON actualJson = tileJSONBuilder.build();
 
-        TileJSONBuilder tileJSONBuilder =
-                new TileJSONBuilder(
-                        "countries",
-                        "application/vnd.mapbox-vector-tile",
-                        "EPSG:900913",
-                        mbTilesLayer);
-        TileJSON actualJson = tileJSONBuilder.build();
-
-        assertEquals("countries", actualJson.getName());
-        assertEquals(
-                "http://localhost:8081/geoserver/ogc/tiles/collections/countries/tiles/EPSG:900913/{z}/{y}/{x}?f=application%2Fvnd.mapbox-vector-tile",
-                actualJson.getTiles()[0]);
-        assertEquals(
-                "Natural Earth Data with .shp data from  TileMill", actualJson.getDescription());
-        assertEquals("Natural Earth Data", tileJSON.getAttribution());
-        assertEquals(0, tileJSON.getMinZoom().longValue());
-        assertEquals(6, tileJSON.getMaxZoom().longValue());
-        assertEquals("xyz", tileJSON.getScheme());
+            assertEquals("countries", actualJson.getName());
+            assertEquals(
+                    "http://localhost:8081/geoserver/ogc/tiles/collections/countries/tiles/EPSG:900913/{z}/{y}/{x}?f=application%2Fvnd.mapbox-vector-tile",
+                    actualJson.getTiles()[0]);
+            assertEquals(
+                    "Natural Earth Data with .shp data from  TileMill",
+                    actualJson.getDescription());
+            assertEquals("Natural Earth Data", tileJSON.getAttribution());
+            assertEquals(0, tileJSON.getMinZoom().longValue());
+            assertEquals(6, tileJSON.getMaxZoom().longValue());
+            assertEquals("xyz", tileJSON.getScheme());
+        }
     }
 }

--- a/src/community/ogcapi/ogcapi-tiles/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Just a set of clean ups to make a build of ``ogcapi`` fully pass even with ``-Dqa`` enabled.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->