### PR TITLE
[2.20.x backport][GEOS-10821] OpenID - Allow configuration of post_login_redirect_uri

### DIFF
--- a/doc/en/user/source/community/oauth2/index.rst
+++ b/doc/en/user/source/community/oauth2/index.rst
@@ -293,6 +293,8 @@ and the GUI will auto-fill itself based on the document contents:
    .. figure:: images/discovery.png
       :align: center
 
+The UI allow to set also the ``Post Logout Redirect URI`` which will be used to populate the  ``post_logout_redirect_uri`` request param, when doing the global logout from the GeoServer UI. The OpenId provider will use the URI to redirect to the desired app page.
+
 In addition, the OpenID connect authentication is able to extract the user roles from
 either the ID token or the Access Token:
 

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
@@ -7,6 +7,7 @@
 package org.geoserver.security.oauth2;
 
 import org.geoserver.security.config.RoleSource;
+import org.springframework.util.StringUtils;
 
 /**
  * Filter configuration for OpenId Connect. This is completely freeform, so adding only the basic
@@ -18,6 +19,7 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
     String jwkURI;
     String tokenRolesClaim;
     String responseMode;
+    String postLogoutRedirectUri;
     boolean sendClientSecret = false;
 
     /** Supports extraction of roles among the token claims */
@@ -81,6 +83,14 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
         this.sendClientSecret = sendClientSecret;
     }
 
+    public String getPostLogoutRedirectUri() {
+        return postLogoutRedirectUri;
+    }
+
+    public void setPostLogoutRedirectUri(String postLogoutRedirectUri) {
+        this.postLogoutRedirectUri = postLogoutRedirectUri;
+    }
+
     @Override
     protected StringBuilder buildAuthorizationUrl() {
         StringBuilder sb = super.buildAuthorizationUrl();
@@ -92,9 +102,15 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
 
     protected StringBuilder buildEndSessionUrl(final String idToken) {
         final StringBuilder logoutUri = new StringBuilder(getLogoutUri());
-        if (idToken != null) {
-            logoutUri.append("?").append("id_token_hint=").append(idToken);
-        }
+        boolean first = true;
+        if (idToken != null) first = appendParam(first, "id_token_hint", idToken, logoutUri);
+        if (StringUtils.hasText(getPostLogoutRedirectUri()))
+            appendParam(first, "post_logout_redirect_uri", getPostLogoutRedirectUri(), logoutUri);
         return logoutUri;
+    }
+
+    private boolean appendParam(boolean first, String name, String value, StringBuilder sb) {
+        sb.append(first ? "?" : "&").append(name).append("=").append(value);
+        return false;
     }
 }

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
@@ -247,6 +247,7 @@ public class OpenIdConnectIntegrationTest extends GeoServerSystemTestSupport {
         OpenIdConnectFilterConfig config =
                 (OpenIdConnectFilterConfig) manager.loadFilterConfig("openidconnect");
         config.setSendClientSecret(true);
+        config.setPostLogoutRedirectUri(null);
         manager.saveFilter(config);
 
         // make believe we authenticated and got the redirect back, with the code

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdFilterConfigTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdFilterConfigTest.java
@@ -10,10 +10,9 @@ import org.junit.Test;
 
 public class OpenIdFilterConfigTest {
 
-    @Test
-    public void testResponseModeInAuthorizationUrl() {
-        String baseUrl = "http://localhost:8080";
+    private OpenIdConnectFilterConfig getFilterConfig() {
         OpenIdConnectFilterConfig filterConfig = new OpenIdConnectFilterConfig();
+        String baseUrl = "http://localhost:8080";
         filterConfig.setName("openidconnect");
         filterConfig.setClassName(OpenIdConnectAuthenticationFilter.class.getName());
         filterConfig.setCliendId("efhrufuu3uhu3uhu");
@@ -26,6 +25,13 @@ public class OpenIdFilterConfigTest {
         filterConfig.setScopes("openid profile email phone address");
         filterConfig.setEnableRedirectAuthenticationEntryPoint(true);
         filterConfig.setPrincipalKey("email");
+        filterConfig.setLogoutUri("http://localhost:8181/global-logout-uri");
+        return filterConfig;
+    }
+
+    @Test
+    public void testResponseModeInAuthorizationUrl() {
+        OpenIdConnectFilterConfig filterConfig = getFilterConfig();
         filterConfig.setRoleSource(OpenIdConnectFilterConfig.OpenIdRoleSource.IdToken);
         filterConfig.setTokenRolesClaim("roles");
         // for ease of testing, do not use HTTPS
@@ -35,5 +41,25 @@ public class OpenIdFilterConfigTest {
 
         String authUrl = filterConfig.buildAuthorizationUrl().toString();
         assertTrue(authUrl.contains("response_mode=query"));
+    }
+
+    @Test
+    public void testEndSessionUrl() {
+        OpenIdConnectFilterConfig filterConfig = getFilterConfig();
+        filterConfig.setPostLogoutRedirectUri("http://localhost:8080/post-redirect");
+        String logouturl = filterConfig.buildEndSessionUrl("aToken").toString();
+        assertTrue(
+                logouturl.contains(
+                        "?id_token_hint=aToken&post_logout_redirect_uri=http://localhost:8080/post-redirect"));
+    }
+
+    @Test
+    public void testEndSessionUrlNullToken() {
+        OpenIdConnectFilterConfig filterConfig = getFilterConfig();
+        filterConfig.setPostLogoutRedirectUri("http://localhost:8080/post-redirect");
+        String logouturl = filterConfig.buildEndSessionUrl(null).toString();
+        assertTrue(
+                logouturl.contains(
+                        "?post_logout_redirect_uri=http://localhost:8080/post-redirect"));
     }
 }

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.html
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.html
@@ -23,6 +23,13 @@
                 <a href="#" wicket:id="responseModeHelp" class="help-link"></a>
             </li>
             <li>
+                <label for="postLogoutRedirectUri"><span><wicket:message
+                        key="postLogoutRedirectUri"></wicket:message></span></label>
+                <input id="postLogoutRedirectUri" wicket:id="postLogoutRedirectUri" type="text"
+                       class="field text"/>
+                <a href="#" wicket:id="postLogoutRedirectUriHelp" class="help-link"></a>
+            </li>
+            <li>
                 <label for="sendClientSecret"><span><wicket:message
                         key="sendClientSecret"></wicket:message></span></label>
             </li>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanel.java
@@ -58,6 +58,9 @@ public class OpenIdConnectAuthProviderPanel
         add(new HelpLink("jwkURIHelp", this).setDialog(dialog));
         add(new TextField<String>("jwkURI"));
 
+        add(new HelpLink("postLogoutRedirectUriHelp", this).setDialog(dialog));
+        add(new TextField<String>("postLogoutRedirectUri"));
+
         add(new HelpLink("responseModeHelp", this).setDialog(dialog));
         add(new TextField<String>("responseMode"));
         add(new HelpLink("sendClientSecretHelp", this).setDialog(dialog));

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication.properties
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/main/resources/GeoServerApplication.properties
@@ -89,6 +89,10 @@ OpenIdConnectAuthProviderPanel.sendClientSecretHelp.title=Send Client Secret in 
 OpenIdConnectAuthProviderPanel.sendClientSecretHelp= Check this option if the OpenId server requires a confidential client \
   to send the client_secret in the token response (eg. ADFS and Azure AD).
 
+OpenIdConnectAuthProviderPanel.postLogoutRedirectUri=Post Logout Redirect URI
+OpenIdConnectAuthProviderPanel.postLogoutRedirectUriHelp.title=Post Logout Redirect URI
+OpenIdConnectAuthProviderPanel.postLogoutRedirectUriHelp=<p>The URI to which the user should be redirected from the OpenId provider once a global logout has been completed</p>
+
 RoleSource.IdToken=ID Token
 RoleSource.AccessToken=Access Token
 

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/test/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanelTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-web/src/test/java/org/geoserver/web/security/oauth2/OpenIdConnectAuthProviderPanelTest.java
@@ -70,6 +70,31 @@ public class OpenIdConnectAuthProviderPanelTest extends AbstractSecurityNamedSer
         tester.assertModelValue("panel:panel:form:panel:sendClientSecret", true);
     }
 
+    @Test
+    public void testPostRedirectUri() throws Exception {
+        String baseUrl = "https://localhost:8080";
+        navigateToOpenIdPanel("OpenIdFilter3");
+        formTester.setValue("panel:content:name", "OpenIdFilter3");
+        formTester.setValue("panel:content:userAuthorizationUri", baseUrl + "/authorize");
+        formTester.setValue("panel:content:accessTokenUri", baseUrl + "/token");
+        formTester.setValue("panel:content:checkTokenEndpointUrl", baseUrl + "/checkToken");
+        formTester.setValue("panel:content:logoutUri", baseUrl + "/logout");
+        formTester.setValue("panel:content:scopes", "open_id");
+        formTester.setValue("panel:content:cliendId", "fnruurnu4unu4");
+        formTester.setValue("panel:content:clientSecret", "fnruurnu4unu4");
+        formTester.setValue("panel:content:jwkURI", baseUrl + "/jwk");
+
+        formTester.setValue(
+                "panel:content:postLogoutRedirectUri", "http://localhost:8080/post/redirect");
+
+        clickSave();
+        tester.assertNoErrorMessage();
+        clickNamedServiceConfig("OpenIdFilter3");
+        tester.assertModelValue(
+                "panel:panel:form:panel:postLogoutRedirectUri",
+                "http://localhost:8080/post/redirect");
+    }
+
     @Override
     protected AbstractSecurityPage getBasePage() {
         return new AuthenticationPage();


### PR DESCRIPTION
[![GEOS-10821](https://badgen.net/badge/JIRA/GEOS-10821/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10821)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->