### PR TITLE
jdbcconfig - fixed incorrect logging for queries with complex filters

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbUtils.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbUtils.java
@@ -5,13 +5,16 @@
  */
 package org.geoserver.jdbcconfig.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.geotools.util.logging.Logging;
 
 public class DbUtils {
@@ -19,6 +22,9 @@ public class DbUtils {
     static final Logger LOGGER = Logging.getLogger(DbUtils.class.getPackage().getName());
 
     public static Map<String, ?> params(Object... kv) {
+        if (kv.length == 0) {
+            return Collections.emptyMap();
+        }
         Map<String, Object> params = new LinkedHashMap<>();
         String paramName;
         Object paramValue;
@@ -32,44 +38,54 @@ public class DbUtils {
 
     public static void logStatement(CharSequence sql, Map<String, ?> namedParameters) {
         if (LOGGER.isLoggable(Level.FINER)) {
-            StringBuilder sb = new StringBuilder(sql);
-            for (Entry<String, ?> e : namedParameters.entrySet()) {
-                Object value = e.getValue();
-                String sval;
-                if (value instanceof Collection) {
-                    Collection<?> c = (Collection<?>) value;
-                    StringBuilder cv = new StringBuilder();
-                    for (Iterator<?> it = c.iterator(); it.hasNext(); ) {
-                        Object v = it.next();
-                        if (v == null) {
-                            cv.append("null");
-                        } else if (v instanceof Number) {
-                            cv.append(v);
-                        } else {
-                            cv.append("'").append(String.valueOf(v)).append("'");
-                        }
-                        if (it.hasNext()) {
-                            cv.append(", ");
-                        }
-                    }
-                    sval = cv.toString();
-                } else {
-                    sval =
-                            value == null
-                                    ? "null"
-                                    : (value instanceof Number
-                                            ? String.valueOf(value)
-                                            : "'" + String.valueOf(value) + "'");
-                }
-                String paramName = ":" + e.getKey();
-                int idx;
-                while ((idx = sb.indexOf(paramName)) > -1) {
-                    sb.replace(idx, idx + paramName.length(), sval);
-                }
-            }
-            LOGGER.finer(sb.toString());
+            LOGGER.finer("Querying: " + getLogStatement(sql, namedParameters));
         } else if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine("querying " + sql + "\n with values: " + namedParameters);
+            if (namedParameters == null || namedParameters.isEmpty()) {
+                LOGGER.fine("Querying: " + sql);
+            } else {
+                LOGGER.fine("Querying: " + sql + "\n with values: " + namedParameters);
+            }
         }
+    }
+
+    public static String getLogStatement(CharSequence sql, Map<String, ?> namedParameters) {
+        if (namedParameters == null || namedParameters.isEmpty()) {
+            return sql.toString();
+        }
+        StringBuilder sb = new StringBuilder(sql);
+        if (namedParameters.size() >= 10) {
+            // replace the parameters in reverse order to correctly handle complex queries
+            // with 10+ of a certain type of parameter
+            List<Entry<String, ?>> list = new ArrayList<>(namedParameters.entrySet());
+            Collections.reverse(list);
+            list.forEach(parameter -> replaceParameter(sb, parameter));
+        } else {
+            namedParameters.entrySet().forEach(parameter -> replaceParameter(sb, parameter));
+        }
+        return sb.toString();
+    }
+
+    private static void replaceParameter(StringBuilder sb, Entry<String, ?> parameter) {
+        Object value = parameter.getValue();
+        String paramValue;
+        if (value instanceof Collection) {
+            Collection<?> c = (Collection<?>) value;
+            paramValue = c.stream().map(DbUtils::toString).collect(Collectors.joining(", "));
+        } else {
+            paramValue = toString(value);
+        }
+        String paramName = ":" + parameter.getKey();
+        for (int index; (index = sb.indexOf(paramName)) > -1; ) {
+            sb.replace(index, index + paramName.length(), paramValue);
+        }
+    }
+
+    private static String toString(Object value) {
+        if (value == null) {
+            return "null";
+        } else if (value instanceof Number) {
+            return value.toString();
+        }
+        return "'" + value.toString().replace("'", "''") + "'";
     }
 }

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/DbUtilsTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/DbUtilsTest.java
@@ -1,0 +1,43 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.jdbcconfig.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.Test;
+
+public class DbUtilsTest {
+
+    @Test
+    public void testReplacingNullParameters() {
+        assertEquals("foo", DbUtils.getLogStatement("foo", null));
+    }
+
+    @Test
+    public void testReplacingEmptyParameters() {
+        assertEquals("foo", DbUtils.getLogStatement("foo", DbUtils.params()));
+    }
+
+    @Test
+    public void testReplacingOneParameter() {
+        Map<String, ?> params = DbUtils.params("v0", Arrays.asList(0, 1));
+        String actual = DbUtils.getLogStatement("(:v0), (:v0)", params);
+        assertEquals("(0, 1), (0, 1)", actual);
+    }
+
+    @Test
+    public void testReplacingTenParameters() {
+        Map<String, ?> params =
+                DbUtils.params(
+                        "v0", null, "v1", 95, "v2", 85, "v3", 75, "v4", 65, "v5", 55, "v6", 45,
+                        "v7", 35, "v8", 25, "v9", "'", "v10", "100");
+        String sql = ":v0, :v1, :v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9, :v10, :v10, :v10";
+        String actual = DbUtils.getLogStatement(sql, params);
+        String expected = "null, 95, 95, 85, 75, 65, 55, 45, 35, 25, '''', '100', '100', '100'";
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
This PR breaks up the jdbcconfig debug logging code into smaller methods and fixes logging incorrect statements for complex filters where a numbered parameters gets up to 10+ (e.g., ptype10).  I didn't create a ticket since this is a debug logging change.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->