### PR TITLE
jdbcconfig - added debug logging to all database queries

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -936,8 +936,10 @@ public class ConfigDatabase implements ApplicationContextAware {
             rollbackFor = Exception.class)
     public void repopulateQueryableProperties() {
         InfoRowMapper<Info> mapper = new InfoRowMapper<Info>(Info.class, binding, 2);
+        String sql = "SELECT oid, blob FROM object";
+        logStatement(sql, null);
         template.query(
-                "SELECT oid, blob FROM object",
+                sql,
                 new ResultSetExtractor<Void>() {
 
                     @Override

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbMappings.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/DbMappings.java
@@ -309,11 +309,8 @@ public class DbMappings {
                     }
                 };
 
-        final List<PropertyType> propertyTypes;
-        {
-            final Map<String, ?> params = Collections.emptyMap();
-            propertyTypes = template.query(query, params, rowMapper);
-        }
+        logStatement(query, null);
+        List<PropertyType> propertyTypes = template.query(query, rowMapper);
 
         Map<Integer, Map<String, PropertyType>> perTypeProps = Maps.newHashMap();
         for (PropertyType pt : propertyTypes) {
@@ -330,7 +327,8 @@ public class DbMappings {
 
     private BiMap<Integer, Class<?>> loadTypes(NamedParameterJdbcOperations template) {
         String sql = "SELECT oid, typename FROM type";
-        SqlRowSet rowSet = template.queryForRowSet(sql, params("", ""));
+        logStatement(sql, null);
+        SqlRowSet rowSet = template.queryForRowSet(sql, params());
         BiMap<Integer, Class<?>> types = HashBiMap.create();
         if (rowSet.first()) {
             do {
@@ -356,7 +354,9 @@ public class DbMappings {
                 String.format(
                         "INSERT INTO type (typename, oid) VALUES (:typeName, %s)",
                         dialect.nextVal("seq_TYPE"));
-        int update = template.update(sql, params("typeName", typeName));
+        Map<String, ?> params = params("typeName", typeName);
+        logStatement(sql, params);
+        int update = template.update(sql, params);
         if (1 == update) {
             log("created type " + typeName);
         }


### PR DESCRIPTION
This PR adds debug logging to some jdbcconfig queries run during GeoServer startup or the jdbcconfig import that weren't being logged.  I didn't create a ticket since this is a debug logging change.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->