### PR TITLE
[Backport 2.22.x] [GEOS-10683] FileWrapperResourceTheoryTest fix for Java 11

### DIFF
--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
@@ -14,6 +14,12 @@ import org.junit.Rule;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.rules.TemporaryFolder;
 
+/**
+ * Test handling of file wrapper (Files.ResourceAdaptor) which works with absolute paths internally.
+ *
+ * <p>This ResourceAdaptor is intended to allow GeoServer to work with absolute paths outside of the
+ * data direct. As a result stores an absolute file internally.
+ */
 public class FileWrapperResourceTheoryTest extends ResourceTheoryTest {
 
     @Rule public TemporaryFolder folder = new TemporaryFolder();
@@ -25,21 +31,16 @@ public class FileWrapperResourceTheoryTest extends ResourceTheoryTest {
         };
     }
 
+    /**
+     * Resource, relative to temporary folder above.
+     *
+     * @param path resource path
+     * @return Resource
+     * @throws Exception
+     */
     @Override
     protected Resource getResource(String path) throws Exception {
-        File file = Paths.toFile(null, path);
-        if (!file.isAbsolute()) {
-            // in linux, an absolute path might appear relative if the root slash has been removed.
-            // This can also occur with the root path if java.io.tmpdir is relative.
-            String rootPath = folder.getRoot().getPath();
-            String rootPathWithoutSlash =
-                    rootPath.startsWith("/") ? rootPath.substring(1) : rootPath;
-            if (path.contains(rootPathWithoutSlash)) {
-                file = Paths.toFile(new File("/"), path);
-            } else {
-                file = Paths.toFile(folder.getRoot(), path);
-            }
-        }
+        File file = Paths.toFile(folder.getRoot(), path);
         return Files.asResource(file);
     }
 

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -408,9 +408,7 @@ public abstract class ResourceTheoryTest {
         assertThat(result, equalTo(testFile));
     }
 
-    // This is the behaviour of the file based implementation. Should this be required or left
-    // undefined with clear documentation indicating that it's implementation dependent?
-    // @Ignore
+    // This is the behaviour of the file based implementation is required
     @Theory
     public void theoryAddingFileToDirectoryAddsResource(String path) throws Exception {
         Resource res = getResource(path);
@@ -423,7 +421,7 @@ public abstract class ResourceTheoryTest {
 
         assumeTrue(file.createNewFile());
 
-        Resource child = getResource(Paths.path(res.path(), "newFileCreatedDirectly"));
+        Resource child = getResource(Paths.path(res.name(), "newFileCreatedDirectly"));
         Collection<Resource> children = res.list();
 
         assertThat(child, is(defined()));


### PR DESCRIPTION
[![GEOS-10683](https://badgen.net/badge/JIRA/GEOS-10683/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10683)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adjust test to use relative paths, to avoid complications with ResourceAdaptor use of absolute paths internally.

This is a backport of the test case fix from https://github.com/geoserver/geoserver/pull/6370 only allowing this java 8 branch to be built with Java 11 on a windows environment (by avoid some ill-advised relative path tests that are actually intended to be absolute paths).

See https://github.com/geoserver/geoserver/pull/6447 for a fix addressing the Resource API use of relative vs absolute paths.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->