### PR TITLE
GEOS-6313 Lifecycle handlers during shutdown

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -1109,7 +1109,7 @@ public abstract class GeoServerLoader {
         }
     }
 
-    public void destroy() throws Exception {
+    public void destroy() {
         // dispose
         if (geoserver != null) {
             geoserver.dispose();

--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoaderProxy.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoaderProxy.java
@@ -8,10 +8,11 @@ package org.geoserver.config;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
 
 /**
  * A proxy for {@link GeoServerLoader} that loads the actual loader instance based on the spring
@@ -24,7 +25,7 @@ import org.springframework.context.ApplicationContextAware;
  */
 public class GeoServerLoaderProxy
         implements BeanPostProcessor,
-                DisposableBean,
+                ApplicationListener<ContextClosedEvent>,
                 ApplicationContextAware,
                 GeoServerReinitializer {
 
@@ -69,7 +70,7 @@ public class GeoServerLoaderProxy
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void onApplicationEvent(ContextClosedEvent event) {
         if (loader != null) {
             loader.destroy();
         }

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
@@ -559,11 +559,9 @@ public class GeoServerImpl implements GeoServer, ApplicationContextAware {
             try {
                 callback.accept(handler);
             } catch (Throwable t) {
-                LOGGER.logp(
+                LOGGER.log(
                         Level.SEVERE,
-                        handler.getClass().getName(),
-                        name,
-                        "A GeoServer lifecycle handler threw an exception",
+                        "A GeoServer lifecycle handler threw an exception during " + name,
                         t);
             }
         }

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleShutdownTest.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleShutdownTest.java
@@ -1,0 +1,29 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * If any lifecycle call happens before the shutdown, the required lifecycle beans are already
+ * cached and can be used to call onDispose() on each. There was a problem however, that if no such
+ * call happened until the final shutdown, the beans could not be created anymore [GEOS-6313]. So,
+ * this unit test just starts and stops the geoserver without further actions. The base class
+ * verifies, if onDispose() was finally called. To get it run, at least a single dummy test method
+ * must be defined.
+ */
+public class GeoServerLifecycleShutdownTest extends GeoServerLifecycleTestSupport {
+
+    /**
+     * This test is just a dummy to turn this class into a unit test. The relevant test happens on
+     * destroyGeoServer().
+     */
+    @Test
+    public synchronized void testRunning() {
+        assertTrue(applicationContext.isRunning());
+    }
+}

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleTest.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleTest.java
@@ -1,0 +1,79 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver;
+
+import static org.junit.Assert.assertTrue;
+
+import org.geoserver.config.impl.GeoServerLifecycleHandler;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+public class GeoServerLifecycleTest extends GeoServerSystemTestSupport {
+
+    @Override
+    protected void onSetUp(SystemTestData data) throws Exception {
+        super.onSetUp(data);
+        ConfigurableListableBeanFactory beanFactory = applicationContext.getBeanFactory();
+        beanFactory.registerSingleton("lifecycleWatcher", new LifecycleWatcher());
+    }
+
+    protected LifecycleWatcher getLifecycleWatcher() {
+        return applicationContext.getBean(LifecycleWatcher.class);
+    }
+
+    @Test
+    public synchronized void testRunning() {
+        assertTrue(applicationContext.isRunning());
+    }
+
+    @Override
+    protected void destroyGeoServer() {
+        LifecycleWatcher watcher = getLifecycleWatcher().reset();
+        super.destroyGeoServer();
+        assertTrue(watcher.didDispose);
+    }
+
+    protected static class LifecycleWatcher implements GeoServerLifecycleHandler {
+
+        boolean didReload = false;
+
+        boolean didBeforeReload = false;
+
+        boolean didReset = false;
+
+        boolean didDispose = false;
+
+        public LifecycleWatcher reset() {
+            didBeforeReload = false;
+            didReload = false;
+            didReset = false;
+            didDispose = false;
+
+            return this;
+        }
+
+        @Override
+        public void onReset() {
+            didReset = true;
+        }
+
+        @Override
+        public void onReload() {
+            didReload = true;
+        }
+
+        @Override
+        public void onDispose() {
+            didDispose = true;
+        }
+
+        @Override
+        public void beforeReload() {
+            didBeforeReload = true;
+        }
+    }
+}

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleTest.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleTest.java
@@ -1,4 +1,4 @@
-/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleTestSupport.java
@@ -9,10 +9,19 @@ import static org.junit.Assert.assertTrue;
 import org.geoserver.config.impl.GeoServerLifecycleHandler;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.test.GeoServerSystemTestSupport;
-import org.junit.Test;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
-public class GeoServerLifecycleTest extends GeoServerSystemTestSupport {
+/**
+ * Base test class for GeoServer lifecycle tests to verify different {@link
+ * GeoServerLifecycleHandler} calls.
+ *
+ * <p>Subclasses may ask the internal {@link LifecycleWatcher} if the expected call took place. A
+ * special case is the onDispose() call, which can not be addressed by a unit test. Therefor an
+ * assertion was placed in the destroyGeoServer() hook.
+ *
+ * @author d.stueken (con terra)
+ */
+public class GeoServerLifecycleTestSupport extends GeoServerSystemTestSupport {
 
     @Override
     protected void onSetUp(SystemTestData data) throws Exception {
@@ -25,15 +34,11 @@ public class GeoServerLifecycleTest extends GeoServerSystemTestSupport {
         return applicationContext.getBean(LifecycleWatcher.class);
     }
 
-    @Test
-    public synchronized void testRunning() {
-        assertTrue(applicationContext.isRunning());
-    }
-
     @Override
     protected void destroyGeoServer() {
         LifecycleWatcher watcher = getLifecycleWatcher().reset();
         super.destroyGeoServer();
+        // verify if onDispose() was finally called.
         assertTrue(watcher.didDispose);
     }
 

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
@@ -8,7 +8,12 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-public class GeoServerLifecycleTests extends GeoServerLifecycleTest {
+/**
+ * Test if all callbacks on {@link LifecycleWatcher} took place
+ *
+ * @author d.stueken (con terra)
+ */
+public class GeoServerLifecycleTests extends GeoServerLifecycleTestSupport {
 
     @Test
     public void testReset() {

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
@@ -1,4 +1,4 @@
-/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
@@ -4,7 +4,7 @@
  */
 package org.geoserver;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 

--- a/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerLifecycleTests.java
@@ -1,0 +1,27 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class GeoServerLifecycleTests extends GeoServerLifecycleTest {
+
+    @Test
+    public void testReset() {
+        LifecycleWatcher watcher = getLifecycleWatcher().reset();
+        getGeoServer().reset();
+        assertTrue(watcher.didReset);
+    }
+
+    @Test
+    public void testReload() throws Exception {
+        LifecycleWatcher watcher = getLifecycleWatcher().reset();
+        getGeoServer().reload();
+        assertTrue(watcher.didBeforeReload);
+        assertTrue(watcher.didReload);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -358,7 +358,7 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
         if (applicationContext == null) {
             return;
         }
-        getGeoServer().dispose();
+
         try {
             // dispose WFS XSD schema's - they will otherwise keep geoserver instance alive
             // forever!!


### PR DESCRIPTION
[![GEOS-6313](https://badgen.net/badge/JIRA/GEOS-6313/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-6313)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is another attempt to resolve the shutdown problems of GEOS-6313 which are around since 2014. 

Similar problems are also described by [GEOS-8122]. Those are fixed by manually calling [getGeoServer().dispose()](https://github.com/geoserver/geoserver/commit/849bced5b29c2919310372af42b8d591c17e984f).

This fixed the unit tests but not the source of the problem: Calling `Geoserver.dispose()` from `applicationContext.close()` was too late to acquire the necessary `GeoServerLifecycleHandler` beans and throws an exception. This inhibits calling `catalog.dispose()` due to a missing finally block. This can be fixed easily.

A unit test `GeoServerLifecycleTests` verifies calling the various `GeoServerLifecycleHandler` callbacks.
However there is still a problem with `Geoserver.dispose()`  if it is called _without_ a previous call to `Geoserver.reset()`.
This is exposed by the base `GeoServerLifecycleTest`.

To resolve this, the shutdown procedure is triggered by `ApplicationListener<ContextClosedEvent>` instead of  `DisposableBean` now, to allow to acquire the beans.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).