### PR TITLE
Shutdown.bat: support java path with spaces

### DIFF
--- a/src/release/bin/shutdown.bat
+++ b/src/release/bin/shutdown.bat
@@ -32,7 +32,7 @@ goto shutdown
 
 :trySystemJava
   echo The JAVA_HOME environment variable is not defined, trying to use System Java
-for /f %%i in ('where java') do set RUN_JAVA=%%i
+for /f "tokens=*" %%i in ('where java') do set RUN_JAVA=%%i
 rem --- we might be on amd64 having only x86 jre installed ---
 if "%RUN_JAVA%"=="" if DEFINED ProgramFiles(x86) if NOT "%PROCESSOR_ARCHITECTURE%"=="x86" (
     rem --- restart the batch in x86 mode---


### PR DESCRIPTION
The original `for /f %f in ('where java')` truncates "Program Files" into "Program". PR adds "tokens=*"
Fixes https://osgeo-org.atlassian.net/browse/GEOS-7506