### PR TITLE
[GEOS-10837] GeoPackage output locking mode normal

### DIFF
--- a/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/GeoPkg.java
+++ b/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/GeoPkg.java
@@ -43,12 +43,15 @@ public class GeoPkg {
      */
     public static GeoPackage getGeoPackage(File file) throws IOException {
         SQLiteConfig config = new SQLiteConfig();
-        config.setSharedCache(true);
+        config.setSharedCache(false);
         config.setJournalMode(SQLiteConfig.JournalMode.OFF);
-        config.setPragma(SQLiteConfig.Pragma.SYNCHRONOUS, "OFF");
-        config.setLockingMode(SQLiteConfig.LockingMode.EXCLUSIVE);
+        config.setSynchronous(SQLiteConfig.SynchronousMode.OFF);
+        config.setLockingMode(SQLiteConfig.LockingMode.NORMAL);
+        config.setTempStore(SQLiteConfig.TempStore.MEMORY);
+
         Map<String, Object> params = new HashMap<>();
         params.put(JDBCDataStoreFactory.BATCH_INSERT_SIZE.key, 10000);
+
         return new GeoPackage(file, config, params);
     }
 }


### PR DESCRIPTION
[![GEOS-10837](https://badgen.net/badge/JIRA/GEOS-10837/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10837)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->