### PR TITLE
Improve homepage performance, fall back on simpler selection modes for large catalogs

### DIFF
--- a/doc/en/user/source/webadmin/welcome.rst
+++ b/doc/en/user/source/webadmin/welcome.rst
@@ -7,6 +7,13 @@ The :guilabel:`Welcome Page` lists the web services published by GeoServer for m
 
 .. _welcome_webservices:
 
+.. note:: The workspace and layer selectors migth take a lot of time to fill up against large catalogs. Because of this, GeoServer tries to limit the time taken to fill them (by default, 5 seconds), and the amount of items in them (by default, 1000), and will fall back on simple text fields if the time limit is reached. 
+  In some situations, that won't be enough and the page might get stuck anyways. The following variables can be used to tweak the behavior:
+
+  *  ``GeoServerHomePage.selectionMode`` : can be set to ``text`` to always use simple text fields, ``dropdown`` to always use dropdowns, or ``auto`` to use the default automatic behavior.
+  * ``GeoServerHomePage.selectionTimeout`` : the time limit in milliseconds, defaults to 5000.
+  * ``GeoServerHomePage.selectionMaxItems`` : the maximum number of items to show in the dropdowns, defaults to 1000.
+
 Web Services
 ------------
 

--- a/src/main/src/main/java/org/geoserver/catalog/Predicates.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Predicates.java
@@ -18,6 +18,8 @@ import org.opengis.filter.MultiValuedFilter.MatchAction;
 import org.opengis.filter.Not;
 import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
@@ -341,5 +343,14 @@ public class Predicates {
      */
     public static Filter notEqual(final String property, final Object expected) {
         return factory.notEqual(factory.property(property), factory.literal(expected));
+    }
+
+    /** Encodes a Filter checking that the given property is equal to one of the provided values. */
+    public static Filter in(String propertyName, List<? extends Object> values) {
+        List<Expression> arguments = new ArrayList<>();
+        arguments.add(factory.property(propertyName));
+        values.stream().map(v -> factory.literal(v)).forEach(l -> arguments.add(l));
+        Function in = factory.function("in", arguments.toArray(new Expression[arguments.size()]));
+        return factory.equals(in, factory.literal(true));
     }
 }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogPropertyAccessor.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogPropertyAccessor.java
@@ -85,6 +85,10 @@ public class CatalogPropertyAccessor implements PropertyAccessor {
         if (input instanceof Info && Predicates.ANY_TEXT.getPropertyName().equals(propertyName)) {
             return getAnyText((Info) input);
         }
+        if (input instanceof Info && "id".equals(propertyName)) {
+            return ((Info) input).getId();
+        }
+
         String[] propertyNames = propertyName.split("\\.");
         return getProperty(input, propertyNames, 0);
     }

--- a/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.geoserver.catalog.Catalog;
@@ -152,7 +153,8 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         if (layerName != null) {
             if (!ANY.equals(root) && rawCatalog.getWorkspaceByName(root) == null)
                 LOGGER.warning("Namespace/Workspace " + root + " is unknown in rule " + rule);
-            if (!ANY.equals(layerName)
+            if (LOGGER.isLoggable(Level.FINE)
+                    && !ANY.equals(layerName)
                     && rawCatalog.getLayerByName(new NameImpl(root, layerName)) == null
                     && rawCatalog.getLayerGroupByName(root, layerName) == null)
                 LOGGER.fine("Layer " + root + ":" + layerName + " is unknown in rule: " + rule);

--- a/src/web/core/src/main/java/org/geoserver/web/AdminRequestWicketCallback.java
+++ b/src/web/core/src/main/java/org/geoserver/web/AdminRequestWicketCallback.java
@@ -5,9 +5,11 @@
  */
 package org.geoserver.web;
 
+import org.apache.wicket.Session;
 import org.apache.wicket.request.component.IRequestablePage;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.geoserver.security.AdminRequest;
+import org.geoserver.web.spring.security.GeoServerSession;
 
 /**
  * Wicket callback that sets the {@link AdminRequest} thread local.
@@ -35,10 +37,18 @@ public class AdminRequestWicketCallback implements WicketCallback {
         // for non secured page requests we abort the admin request since they are meant to be
         // accessible anonymously, so we don't consider this an admin request
         if (requestTarget == null
-                || !(GeoServerSecuredPage.class.isAssignableFrom(requestTarget)
-                        || GeoServerHomePage.class.isAssignableFrom(requestTarget))) {
+                || !GeoServerSecuredPage.class.isAssignableFrom(requestTarget)
+                || (GeoServerHomePage.class.isAssignableFrom(requestTarget) && !isAdmin())) {
             AdminRequest.abort();
         }
+    }
+
+    private boolean isAdmin() {
+        Session session = Session.get();
+        if (session instanceof GeoServerSession) {
+            return ((GeoServerSession) session).isAdmin();
+        }
+        return false;
     }
 
     @Override

--- a/src/web/core/src/main/java/org/geoserver/web/BoundedCatalogLoader.java
+++ b/src/web/core/src/main/java/org/geoserver/web/BoundedCatalogLoader.java
@@ -1,0 +1,67 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.util.CloseableIterator;
+import org.opengis.filter.Filter;
+
+/**
+ * Loads {@link org.geoserver.catalog.CatalogInfo} objects from the catalog, with a timeout and a
+ * maximum number of objects to load.
+ */
+class BoundedCatalogLoader<T extends CatalogInfo> implements Serializable {
+
+    List<T> result = new ArrayList<>();
+    boolean boundExceeded = false;
+    long residualTime;
+
+    public BoundedCatalogLoader(T item) {
+        this.result.add(item);
+        this.boundExceeded = false;
+    }
+
+    public BoundedCatalogLoader(
+            Catalog catalog, Filter filter, Class<T> target, long timeout, int max) {
+        // perform a bounded load of the catalog
+        // (single call, doing count + list is slower and count cannot be stopped mid-way)
+        long limit = System.currentTimeMillis() + timeout;
+        try (CloseableIterator<T> search = catalog.list(target, filter, 0, max + 1, null)) {
+            while (System.currentTimeMillis() < limit && search.hasNext()) {
+                result.add(search.next());
+            }
+        }
+        // check if bounds have been exceeded
+        this.residualTime = limit - System.currentTimeMillis();
+        boundExceeded = residualTime <= 0 || result.size() > max;
+        // if went beyond the limit, remove the last elements
+        if (result.size() > max) {
+            // creating new list because sublist is not serializable
+            result = new ArrayList<>(result.subList(0, max));
+        }
+    }
+
+    /** Returns the list of elements loaded from the catalog */
+    public List<T> getResult() {
+        return result;
+    }
+
+    /**
+     * Returns true if the bounds were exceeded (either timed out, or went beyond maximum count),
+     * false otherwise
+     */
+    public boolean isBoundExceeded() {
+        return boundExceeded;
+    }
+
+    /** Returns the residual time, that is the time left after the load operation was completed. */
+    public long getResidualTime() {
+        return residualTime;
+    }
+}

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
@@ -106,7 +106,7 @@ public class GeoServerBasePage extends WebPage implements IAjaxIndicatorAware {
         commonBaseInit();
     }
 
-    private void commonBaseInit() {
+    protected void commonBaseInit() {
         // lookup for a pluggable favicon
         PackageResourceReference faviconReference = null;
         List<HeaderContribution> cssContribs =

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.html
@@ -5,11 +5,11 @@
   <form wicket:id="form">
     <div class="select">
 			<img class="icon" src="#" wicket:id="workspace.icon" wicket:message="title:workspace"/>
-			<select wicket:id="workspace"/>
+			<span wicket:id="workspace"/>
 	  </div>
     <div class="select">
-			<img class="icon" src="#" wicket:id="layer.icon" wicket:message="title:layer"/>
-		  <select wicket:id="layer"/>
+		  <img class="icon" src="#" wicket:id="layer.icon" wicket:message="title:layer"/>
+		  <span wicket:id="layer"/>
 	  </div>
     <div id="refresh">
 		  <a href="#" wicket:id="refresh">refresh</a>
@@ -82,9 +82,15 @@
 <p>
 	<span wicket:id="footerMessage"></span> <span wicket:id="footerContact"></span>
 </p>
+
+	<wicket:fragment wicket:id="text">
+		<input type="text" wicket:id="text"/>
+	</wicket:fragment>
+
+	<wicket:fragment wicket:id="select">
+		<select wicket:id="select"/>
+	</wicket:fragment>
+	
 </wicket:extend>
-
-
-
 </body>
 </html>

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -252,12 +252,8 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
         String layerSelection = toLayer(workspaceName, layerName);
 
         PageParameters pageParams = new PageParameters();
-        if (workspaceSelection != null) {
-            pageParams.add("workspace", workspaceSelection, 0, INamedParameters.Type.QUERY_STRING);
-        }
-        if (layerSelection != null) {
-            pageParams.add("layer", layerSelection, 1, INamedParameters.Type.QUERY_STRING);
-        }
+        pageParams.add("workspace", workspaceSelection, 0, INamedParameters.Type.QUERY_STRING);
+        pageParams.add("layer", layerSelection, 1, INamedParameters.Type.QUERY_STRING);
         setResponsePage(GeoServerHomePage.class, pageParams);
     }
 
@@ -763,7 +759,11 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
                 return layerName.substring(0, layerName.indexOf(":"));
             }
         }
-        return workspaceName;
+        if (!Strings.isEmpty(workspaceName)) {
+            return workspaceName;
+        } else {
+            return "";
+        }
     }
 
     /**
@@ -781,7 +781,7 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
                 return layerName;
             }
         } else {
-            return null;
+            return "";
         }
     }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/HomePageSelection.java
+++ b/src/web/core/src/main/java/org/geoserver/web/HomePageSelection.java
@@ -1,0 +1,495 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web;
+
+import static org.geoserver.catalog.Predicates.acceptAll;
+
+import java.io.Serializable;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.FormComponent;
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.panel.Fragment;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.util.convert.ConversionException;
+import org.apache.wicket.util.convert.IConverter;
+import org.apache.wicket.util.string.Strings;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.Predicates;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.web.data.layer.PublishedChoiceRenderer;
+import org.geoserver.web.data.layer.PublishedInfosModel;
+import org.geoserver.web.data.workspace.WorkspaceChoiceNameRenderer;
+import org.geoserver.web.data.workspace.WorkspacesModel;
+import org.geoserver.web.spring.security.GeoServerSession;
+import org.geoserver.web.wicket.ParamResourceModel;
+import org.geoserver.web.wicket.Select2DropDownChoice;
+import org.geotools.util.logging.Logging;
+import org.opengis.filter.Filter;
+
+/**
+ * Strategy to manage selection of {@link WorkspaceInfo} and {@link PublishedInfo}, as well as
+ * describing the selection results.
+ */
+abstract class HomePageSelection implements Serializable {
+
+    static final Logger LOGGER = Logging.getLogger(HomePageSelection.class);
+
+    /** Maximum time to load workspaces and layers, in milliseconds */
+
+    /**
+     * System property used to externally define {@link #HomePageSelection}.
+     *
+     * <p>If provided this setting will override any configuration option.
+     */
+    public static String SELECTION_MODE = "GeoServerHomePage.selectionMode";
+
+    enum SelectionMode {
+
+        /** Automatically choose between dropdowns and simple text based on catalog size */
+        AUTOMATIC,
+        /**
+         * Layer autocomplete is only available when workspace prefix provided. Suitable for large
+         * catalogues with many workspaces
+         */
+        DROPDOWN,
+
+        /** Disable autocomplete, use plain text-field for workspace and layer selection */
+        TEXT;
+
+        static SelectionMode get() {
+            try {
+                String mode = GeoServerExtensions.getProperty(SELECTION_MODE);
+                if (!Strings.isEmpty(mode)) {
+                    return SelectionMode.valueOf(mode.toUpperCase());
+                }
+            } catch (IllegalArgumentException ignore) {
+                LOGGER.fine("Unrecognized GeoServer home page selection mode: " + ignore);
+            }
+            return SelectionMode.AUTOMATIC;
+        }
+    }
+
+    /** The chosen selection mode */
+    static SelectionMode MODE = SelectionMode.get();
+
+    static long HOME_PAGE_TIMEOUT = Long.getLong("GeoServerHomePage.selectionTimeout", 5000);
+
+    /** Maximum number of workspaces and layers to load */
+    static int HOME_PAGE_MAX_ITEMS =
+            Integer.getInteger("GeoServerHomePage.selectionMaxItems", 1000);
+
+    public static HomePageSelection getHomePageSelection(GeoServerHomePage page) {
+        if (MODE == SelectionMode.DROPDOWN) {
+            return new DropDown(page);
+        } else if (MODE == SelectionMode.TEXT) {
+            return new Text(page);
+        } else {
+            return new Auto(page);
+        }
+    }
+
+    protected final GeoServerHomePage page;
+
+    HomePageSelection(GeoServerHomePage page) {
+        this.page = page;
+    }
+
+    abstract String getDescription();
+
+    abstract FormComponent<WorkspaceInfo> getWorkspaceField(Form form, String componentId);
+
+    static FormComponent<WorkspaceInfo> getWorkspaceSelect2Choice(
+            GeoServerHomePage page, Form form, String componentId) {
+        Select2DropDownChoice<WorkspaceInfo> component =
+                new Select2DropDownChoice<>(
+                        "select",
+                        new PropertyModel<>(page, "workspaceInfo"),
+                        new WorkspacesModel(),
+                        new WorkspaceChoiceNameRenderer()) {
+
+                    @Override
+                    protected boolean wantOnSelectionChangedNotifications() {
+                        return true;
+                    }
+
+                    @Override
+                    protected void onSelectionChanged(WorkspaceInfo newSelection) {
+                        super.onSelectionChanged(newSelection);
+                        if (newSelection != null) {
+                            page.selectHomePage(newSelection.getName(), null);
+                        } else {
+                            String workspaceName = page.getWorkspaceFieldText();
+                            page.selectHomePage(workspaceName, null);
+                        }
+                    }
+                };
+        component.setNullValid(true);
+
+        Fragment fragment = new Fragment(componentId, "select", page);
+        fragment.add(component);
+        form.add(fragment);
+
+        return component;
+    }
+
+    protected TextField<WorkspaceInfo> getWorkspaceTextField(Form form, String componentId) {
+        TextField<WorkspaceInfo> component =
+                new TextField<>("text", new PropertyModel<>(page, "workspaceInfo")) {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    public <C> IConverter<C> getConverter(Class<C> type) {
+                        if (WorkspaceInfo.class.isAssignableFrom(type)) {
+                            return (IConverter<C>) new WorkspaceInfoConverter();
+                        }
+                        return null;
+                    }
+                };
+        component.setOutputMarkupId(true);
+
+        Fragment fragment = new Fragment(componentId, "text", page);
+        fragment.add(component);
+        form.add(fragment);
+
+        return component;
+    }
+
+    /**
+     * Returns the editor for the GeoServerHomePage.publishedInfo property
+     *
+     * @param componentId The identifier of the component
+     */
+    abstract FormComponent<PublishedInfo> getPublishedField(Form form, String componentId);
+
+    static Select2DropDownChoice<PublishedInfo> getPublishedSelect2Choice(
+            GeoServerHomePage page, Form form, String componentId) {
+        PublishedInfosModel layersModel =
+                new PublishedInfosModel() {
+                    @Override
+                    protected Filter getFilter() {
+                        return getLayerFilter(page, page.getWorkspaceInfo());
+                    }
+                };
+        IChoiceRenderer<PublishedInfo> layersRenderer =
+                new PublishedChoiceRenderer() {
+                    @Override
+                    public Object getDisplayValue(PublishedInfo layer) {
+                        return page.getWorkspaceInfo() != null
+                                ? layer.getName()
+                                : layer.prefixedName();
+                    }
+                };
+
+        Select2DropDownChoice<PublishedInfo> component =
+                new Select2DropDownChoice<>(
+                        "select",
+                        new PropertyModel<>(page, "publishedInfo"),
+                        layersModel,
+                        layersRenderer) {
+
+                    @Override
+                    protected boolean wantOnSelectionChangedNotifications() {
+                        return true;
+                    }
+
+                    @Override
+                    protected void onSelectionChanged(PublishedInfo newSelection) {
+                        super.onSelectionChanged(newSelection);
+                        if (newSelection != null) {
+                            String prefixed = newSelection.prefixedName();
+                            if (prefixed.contains(":")) {
+                                String workspaceName = prefixed.substring(0, prefixed.indexOf(":"));
+                                String layerName = prefixed.substring(prefixed.indexOf(":") + 1);
+
+                                page.selectHomePage(workspaceName, layerName);
+                            } else {
+                                page.selectHomePage(null, prefixed);
+                            }
+                        }
+                    }
+                };
+        component.setNullValid(true);
+
+        Fragment fragment = new Fragment(componentId, "select", page);
+        fragment.add(component);
+        form.add(fragment);
+
+        return component;
+    }
+
+    protected TextField<PublishedInfo> getPublishedTextField(Form form, String componentId) {
+        TextField<PublishedInfo> component =
+                new TextField<>("text", new PropertyModel<>(page, "publishedInfo")) {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    public <C> IConverter<C> getConverter(Class<C> type) {
+                        if (PublishedInfo.class.isAssignableFrom(type)) {
+                            return (IConverter<C>) new PublishedInfoConverter();
+                        }
+                        return null;
+                    }
+                };
+        component.setOutputMarkupId(true);
+
+        Fragment fragment = new Fragment(componentId, "text", page);
+        fragment.add(component);
+        form.add(fragment);
+
+        return component;
+    }
+
+    /**
+     * Predicate construct to efficiently query catalog for PublishedInfo suitable for interaction.
+     *
+     * @param workspace Optional workspace to limit search to a single workspace
+     * @return Filter for use with catalog.
+     */
+    private static Filter getLayerFilter(GeoServerHomePage page, WorkspaceInfo workspace) {
+
+        // need to get only advertised and enabled layers
+        Filter isLayerInfo = Predicates.isInstanceOf(LayerInfo.class);
+        Filter isLayerGroupInfo = Predicates.isInstanceOf(LayerGroupInfo.class);
+
+        Filter enabledFilter = Predicates.equal("resource.enabled", true);
+        Filter storeEnabledFilter = Predicates.equal("resource.store.enabled", true);
+        Filter advertisedFilter = Predicates.equal("resource.advertised", true);
+        Filter enabledLayerGroup = Predicates.equal("enabled", true);
+        Filter advertisedLayerGroup = Predicates.equal("advertised", true);
+
+        // Filter for the Layers
+        List<Filter> layerFilters = new ArrayList<>();
+        layerFilters.add(isLayerInfo);
+        if (workspace != null) {
+            layerFilters.add(Predicates.equal("resource.namespace.prefix", workspace.getName()));
+        }
+        layerFilters.add(enabledFilter);
+        layerFilters.add(storeEnabledFilter);
+        layerFilters.add(advertisedFilter);
+
+        Filter layerFilter = Predicates.and(layerFilters);
+
+        // Filter for the LayerGroups
+        List<Filter> groupFilters = new ArrayList<>();
+        groupFilters.add(isLayerGroupInfo);
+        if (workspace != null) {
+            groupFilters.add(Predicates.equal("workspace.name", workspace.getName()));
+        }
+        if (!page.getGeoServer().getGlobal().isGlobalServices()) {
+            // skip global layer groups if global services are disabled
+            groupFilters.add(Predicates.not(Predicates.isNull("workspace.name")));
+        }
+        groupFilters.add(enabledLayerGroup);
+        groupFilters.add(advertisedLayerGroup);
+
+        Filter layerGroupFilter = Predicates.and(groupFilters);
+
+        // Or filter for merging them
+        return Predicates.or(layerFilter, layerGroupFilter);
+    }
+
+    protected StringResourceModel getFullDescription(int workspaceCount, int layerCount) {
+        Locale locale = page.getLocale();
+        PublishedInfo publishedInfo = page.getPublishedInfo();
+        WorkspaceInfo workspaceInfo = page.getWorkspaceInfo();
+
+        NumberFormat numberFormat = NumberFormat.getIntegerInstance(locale);
+        numberFormat.setGroupingUsed(true);
+
+        String userName = GeoServerSession.get().getUsername();
+
+        HashMap<String, String> params = new HashMap<>();
+        params.put("workspaceCount", numberFormat.format(workspaceCount));
+        params.put("layerCount", numberFormat.format(layerCount));
+        params.put("user", escapeMarkup(userName));
+
+        boolean isGlobal = page.getGeoServer().getGlobal().isGlobalServices();
+
+        if (publishedInfo != null && publishedInfo instanceof LayerInfo) {
+            params.put("layerName", escapeMarkup(publishedInfo.prefixedName()));
+            return new StringResourceModel(
+                    "GeoServerHomePage.descriptionLayer", page, new Model<>(params));
+        } else if (publishedInfo != null && publishedInfo instanceof LayerGroupInfo) {
+            params.put("layerName", escapeMarkup(publishedInfo.prefixedName()));
+            return new StringResourceModel(
+                    "GeoServerHomePage.descriptionLayerGroup", page, new Model<>(params));
+        } else if (workspaceInfo != null) {
+            params.put("workspaceName", escapeMarkup(workspaceInfo.getName()));
+            return new StringResourceModel(
+                    "GeoServerHomePage.descriptionWorkspace", page, new Model<>(params));
+        } else if (isGlobal) {
+            return new StringResourceModel(
+                    "GeoServerHomePage.descriptionGlobal", page, new Model<>(params));
+        } else {
+            return new StringResourceModel(
+                    "GeoServerHomePage.descriptionGlobalOff", page, new Model<>(params));
+        }
+    }
+
+    /**
+     * Count of PublishedInfo (ie layer or layergroup) taking the current workspace and global
+     * services into account.
+     *
+     * @return Count of addressable layers
+     */
+    private static int countLayerNames(GeoServerHomePage page, WorkspaceInfo workspaceInfo) {
+        return page.getCatalog().count(PublishedInfo.class, getLayerFilter(page, workspaceInfo));
+    }
+
+    /**
+     * Escape text before being used in formatting (to prevent any raw html being displayed).
+     *
+     * @param text Text to escape
+     * @return escaped text
+     */
+    private String escapeMarkup(String text) {
+        return new StringBuilder(Strings.escapeMarkup(text)).toString();
+    }
+
+    /** Forces drop down selection */
+    static class DropDown extends HomePageSelection {
+        public DropDown(GeoServerHomePage page) {
+            super(page);
+        }
+
+        @Override
+        String getDescription() {
+            int workspaceCount = page.getCatalog().count(WorkspaceInfo.class, acceptAll());
+            int layerCount = countLayerNames(page, page.getWorkspaceInfo());
+            return getFullDescription(workspaceCount, layerCount).getString();
+        }
+
+        @Override
+        FormComponent<WorkspaceInfo> getWorkspaceField(Form form, String componentId) {
+            return getWorkspaceSelect2Choice(page, form, componentId);
+        }
+
+        @Override
+        FormComponent<PublishedInfo> getPublishedField(Form form, String componentId) {
+            return getPublishedSelect2Choice(page, form, componentId);
+        }
+    }
+
+    static class Text extends HomePageSelection {
+        public Text(GeoServerHomePage page) {
+            super(page);
+        }
+
+        @Override
+        String getDescription() {
+            return new ParamResourceModel("GeoServerHomePage.description", page).getString();
+        }
+
+        @Override
+        FormComponent<WorkspaceInfo> getWorkspaceField(Form form, String componentId) {
+            return getWorkspaceTextField(form, componentId);
+        }
+
+        @Override
+        FormComponent<PublishedInfo> getPublishedField(Form form, String componentId) {
+            return getPublishedTextField(form, componentId);
+        }
+    }
+
+    static class Auto extends HomePageSelection {
+
+        private final BoundedCatalogLoader<WorkspaceInfo> workspaceLoader;
+        private BoundedCatalogLoader<PublishedInfo> publishedLoader;
+
+        public Auto(GeoServerHomePage page) {
+            super(page);
+            // load workspaces and layers honoring max total time
+            this.workspaceLoader =
+                    new BoundedCatalogLoader<>(
+                            page.getCatalog(),
+                            Predicates.acceptAll(),
+                            WorkspaceInfo.class,
+                            HOME_PAGE_TIMEOUT,
+                            HOME_PAGE_MAX_ITEMS);
+            this.publishedLoader =
+                    new BoundedCatalogLoader<>(
+                            page.getCatalog(),
+                            getLayerFilter(page, page.getWorkspaceInfo()),
+                            PublishedInfo.class,
+                            workspaceLoader.getResidualTime(),
+                            HOME_PAGE_MAX_ITEMS);
+        }
+
+        @Override
+        String getDescription() {
+            // if it was too expensive to compute counts, go with
+            if (workspaceLoader.isBoundExceeded() || publishedLoader.isBoundExceeded())
+                return new ParamResourceModel("GeoServerHomePage.description", page).getString();
+            else
+                return getFullDescription(
+                                workspaceLoader.getResult().size(),
+                                publishedLoader.getResult().size())
+                        .getString();
+        }
+
+        @Override
+        FormComponent<WorkspaceInfo> getWorkspaceField(Form form, String componentId) {
+            if (workspaceLoader.isBoundExceeded()) return getWorkspaceTextField(form, componentId);
+            return getWorkspaceSelect2Choice(page, form, componentId);
+        }
+
+        @Override
+        FormComponent<PublishedInfo> getPublishedField(Form form, String componentId) {
+            if (publishedLoader.isBoundExceeded()) return getPublishedTextField(form, componentId);
+            return getPublishedSelect2Choice(page, form, componentId);
+        }
+    }
+
+    private class WorkspaceInfoConverter implements IConverter<WorkspaceInfo> {
+        @Override
+        public WorkspaceInfo convertToObject(String s, Locale locale) throws ConversionException {
+            return page.getCatalog().getWorkspaceByName(s);
+        }
+
+        @Override
+        public String convertToString(WorkspaceInfo workspaceInfo, Locale locale) {
+            return workspaceInfo.getName();
+        }
+    }
+
+    private class PublishedInfoConverter implements IConverter<PublishedInfo> {
+        @Override
+        public PublishedInfo convertToObject(String s, Locale locale) throws ConversionException {
+            WorkspaceInfo ws = page.getWorkspaceInfo();
+            if (ws != null) {
+                PublishedInfo result = page.getCatalog().getLayerGroupByName(ws, s);
+                if (result == null && !s.contains(":")) {
+                    result = page.getCatalog().getLayerByName(ws.getName() + ":" + s);
+                } else {
+                    result = page.getCatalog().getLayerByName(s);
+                }
+                return result;
+
+            } else {
+                PublishedInfo result = page.getCatalog().getLayerGroupByName(s);
+                if (result == null) {
+                    result = page.getCatalog().getLayerByName(s);
+                }
+                return result;
+            }
+        }
+
+        @Override
+        public String convertToString(PublishedInfo published, Locale locale) {
+            if (page.getWorkspaceInfo() != null) return published.getName();
+            else return published.prefixedName();
+        }
+    }
+}

--- a/src/web/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/core/src/main/resources/GeoServerApplication.properties
@@ -280,6 +280,7 @@ GeoServerHomePage.footer                = This GeoServer instance is running ver
 GeoServerHomePage.footerContact         = Contact <a href="mailto:${contactEmail}">administrator</a>.
 GeoServerHomePage.serviceCapabilities   = Service Capabilities
 GeoServerHomePage.title                 = Welcome
+GeoServerHomePage.description     = GeoServer - Geospatial Web Services
 GeoServerHomePage.descriptionGlobal     = GeoServer Web Service, ${user} access to ${workspaceCount} workspaces, with ${layerCount} layers.
 GeoServerHomePage.descriptionGlobalOff  = GeoServer, ${user} access. Select a workspace or layer, above, to change to a virtual web service.
 GeoServerHomePage.descriptionWorkspace  = GeoServer Virtual Web Service, ${user} access to <strong>${workspaceName}</strong> workspace, with ${layerCount} layers.

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
@@ -5,22 +5,38 @@
  */
 package org.geoserver.web;
 
+import static org.geoserver.data.test.MockData.BASIC_POLYGONS;
+import static org.geoserver.data.test.MockData.CITE_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.wicket.Component;
+import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.util.tester.FormTester;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.SettingsInfo;
+import org.geoserver.web.wicket.Select2DropDownChoice;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
 public class GeoServerHomePageTest extends GeoServerWicketTestSupport {
+
+    @Before
+    public void setupMode() {
+        // avoid flip-flops due to timeouts in the testing environment
+        HomePageSelection.MODE = HomePageSelection.SelectionMode.DROPDOWN;
+    }
 
     @Override
     protected void setUpSpring(List<String> springContextLocations) {
@@ -92,6 +108,120 @@ public class GeoServerHomePageTest extends GeoServerWicketTestSupport {
                 html,
                 CoreMatchers.containsString(
                         " <a href=\"mailto:&lt;b&gt;hello&lt;/b&gt;test@mail.com\">administrator</a>"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDropDownSelection() throws Exception {
+        tester.startPage(GeoServerHomePage.class);
+        tester.assertNoErrorMessage();
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        Page page1 = tester.getLastRenderedPage();
+
+        // check workspaces use a drop-down with suitable content
+        Select2DropDownChoice<WorkspaceInfo> workspaceSelector =
+                (Select2DropDownChoice<WorkspaceInfo>)
+                        tester.getComponentFromLastRenderedPage("form:workspace:select");
+        List<WorkspaceInfo> workspaces = getCatalog().getWorkspaces();
+        List<? extends WorkspaceInfo> workspaceChoices = workspaceSelector.getChoices();
+        assertEquals(workspaces.size(), workspaceChoices.size());
+
+        // and same goes for the layers case
+        Select2DropDownChoice<PublishedInfo> publishedSelector =
+                (Select2DropDownChoice<PublishedInfo>)
+                        tester.getComponentFromLastRenderedPage("form:layer:select");
+        List<PublishedInfo> publisheds = new ArrayList<>(getCatalog().getLayers());
+        publisheds.addAll(getCatalog().getLayerGroups());
+        List<? extends PublishedInfo> publishedChoices = publishedSelector.getChoices();
+        assertEquals(publisheds.size(), publishedChoices.size());
+
+        // select a workspace
+        FormTester form = tester.newFormTester("form");
+        form.setValue("workspace:select", CITE_PREFIX);
+        tester.executeAjaxEvent("form:workspace:select", "change");
+
+        // it switched to a new page with a single workspace
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page2 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page2);
+        assertEquals(page2.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+
+        // switch layer as well
+        form = tester.newFormTester("form");
+        form.setValue("layer:select", BASIC_POLYGONS.getLocalPart());
+        tester.executeAjaxEvent("form:layer:select", "change");
+
+        // it switched to a new page with a single layer
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page3 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page3);
+        assertNotSame(page2, page3);
+        assertEquals(page3.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+        assertEquals(
+                page3.getPublishedInfo(), getCatalog().getLayerByName(getLayerId(BASIC_POLYGONS)));
+    }
+
+    @Test
+    public void testTextSelection() throws Exception {
+        HomePageSelection.MODE = HomePageSelection.SelectionMode.TEXT;
+        tester.startPage(GeoServerHomePage.class);
+        tester.assertNoErrorMessage();
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page1 = (GeoServerHomePage) tester.getLastRenderedPage();
+
+        // check workspaces and layers use a simple text field
+        tester.assertComponent("form:workspace:text", TextField.class);
+        tester.assertComponent("form:layer:text", TextField.class);
+
+        // select a workspace
+        FormTester form = tester.newFormTester("form");
+        form.setValue("workspace:text", CITE_PREFIX);
+        tester.executeAjaxEvent("form:workspace:text", "change");
+
+        // it switched to a new page with a single workspace
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page2 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page2);
+        assertEquals(page2.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+
+        // switch layer as well
+        form = tester.newFormTester("form");
+        form.setValue("layer:text", BASIC_POLYGONS.getLocalPart());
+        tester.executeAjaxEvent("form:layer:text", "change");
+
+        // it switched to a new page with a single layer
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page3 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page3);
+        assertNotSame(page2, page3);
+        assertEquals(page3.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+        assertEquals(
+                page3.getPublishedInfo(), getCatalog().getLayerByName(getLayerId(BASIC_POLYGONS)));
+    }
+
+    @Test
+    public void testAutoSelection() throws Exception {
+        // go automatic
+        HomePageSelection.MODE = HomePageSelection.SelectionMode.AUTOMATIC;
+        HomePageSelection.HOME_PAGE_TIMEOUT = 1000 * 60 * 60 * 24; // basically no time limit
+
+        // force it to go text by means of the items
+        HomePageSelection.HOME_PAGE_MAX_ITEMS = 1;
+        tester.startPage(GeoServerHomePage.class);
+        tester.assertComponent("form:workspace:text", TextField.class);
+        tester.assertComponent("form:layer:text", TextField.class);
+
+        // now give it just enough to fill the workspaces but not the layers
+        HomePageSelection.HOME_PAGE_MAX_ITEMS = getCatalog().getWorkspaces().size();
+        tester.startPage(GeoServerHomePage.class);
+        tester.assertComponent("form:workspace:select", Select2DropDownChoice.class);
+        tester.assertComponent("form:layer:text", TextField.class);
+
+        // and now so much it can do dropdowns for both
+        HomePageSelection.HOME_PAGE_MAX_ITEMS = Integer.MAX_VALUE;
+        tester.startPage(GeoServerHomePage.class);
+        tester.assertComponent("form:workspace:select", Select2DropDownChoice.class);
+        tester.assertComponent("form:layer:select", Select2DropDownChoice.class);
     }
 
     public static class MockHomePageContentProvider implements GeoServerHomePageContentProvider {

--- a/src/web/demo/src/main/java/org/geoserver/web/catalogstresstool/CatalogStressTester.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/catalogstresstool/CatalogStressTester.java
@@ -414,7 +414,10 @@ public class CatalogStressTester extends GeoServerSecuredPage {
                 ((ResourceInfo) prototype).setNativeName(((ResourceInfo) original).getNativeName());
                 ((ResourceInfo) prototype).setName(newName);
                 if (parent != null) {
-                    ((ResourceInfo) prototype).setStore((StoreInfo) parent);
+                    ResourceInfo ri = (ResourceInfo) prototype;
+                    StoreInfo store = (StoreInfo) parent;
+                    ri.setStore(store);
+                    ri.setNamespace(catalog.getNamespaceByPrefix((store).getWorkspace().getName()));
                 }
                 sw.start();
                 catalog.add((ResourceInfo) prototype);


### PR DESCRIPTION
Based on two separate items:
* Allow the home page controls and description to fall back on [simpler, cheaper to initialize GUI controls](https://osgeo-org.atlassian.net/browse/GEOS-10833)
* [Speed up DefaultResourceAccessManager filters](https://osgeo-org.atlassian.net/browse/GEOS-10838) to speed up the above counts/fills (and along with it, layer preview and capabilities document generation)

[GEOS-10838](https://osgeo-org.atlassian.net/browse/GEOS-10838) makes the current GUI viable when relatively few items are available out of a large set of layers due to security rules. 

[GEOS-10833](https://osgeo-org.atlassian.net/browse/GEOS-10833) instead makes sure that if too many items are available, we can still have a working homepage, getting an acceptable response time (max 5 seconds by default) in exchange for a very simple user experience (plain text boxes, no autofill). 

I did not go for auto-complete text because a full kill-switch was needed anyways, due to the pluggability of both Catalog and ResourceAccessManager there was no way to guarantee that even getting the first item for an autocomplete with timeout would have happened in a suitable time. 

Adding the middle ground UI is still possible extending the enumeration in HomeSelection, if someone wants to go there. The "auto" mode is still implemented in such a way that if the current filter picks a small enough number of items, a dropdown will appear for them. Here is an example from a setup with 1000 workspaces and 40k layers.
The workspace is still a drop-down (matches the maximum in terms of items, still works decently), and when a specific workspace is chosen, then the layer chooser also becomes a drop-down and the description provides counts:


https://user-images.githubusercontent.com/325433/214547915-5e2520c4-ab45-4ec9-b22d-06e1e1e362c0.mp4

About the DefaultResourceAccessManager speed up, it's almost 2 orders of magnitude for complex data directories with many layers and many rules. Tests with a setup having around 20k layers and 40k security rules shows the following for a WMS 1.3 GetCapabilities request:
* 188 seconds with the baseline GeoServer
* 6 seconds with the changes in GeoServer, but without the In function static lookup
* 2.5 seconds with [GEOT-7301: Static lookup for In function](https://osgeo-org.atlassian.net/browse/GEOT-7301)

However, the change might come with a slowdown in some JDBCConfig installations, as the SQL generator for it cannot handle the "in" function (cases with many layers, and most not visible due to security rules). 
As a community module, there is no requirement to care for it, but I still left a system variable to get back the old filter building just in case. @sikeoka @NielsCharlier if you have a large set of layers and restrictive rules that limit access to them, implementing support for encoding the "in" function could prove quite beneficial, in terms of SQL time execution, compared to the current verbose and convoluted security filter. I had a look at doing it, but don't have enough experience with JDBCConfig, nor a good use case to test it against.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->