### PR TITLE
[GEOS-10726] ogc-api: add encoding tag with charset taken from geoserver settings

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractHTMLMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractHTMLMessageConverter.java
@@ -12,6 +12,7 @@ import freemarker.template.TemplateModelException;
 import freemarker.template.utility.DeepUnwrap;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -195,6 +196,15 @@ public abstract class AbstractHTMLMessageConverter<T> extends AbstractHttpMessag
         return v;
     }
 
+    @Override
+    public Charset getDefaultCharset() {
+        Charset defaultCharset = super.getDefaultCharset();
+        if (defaultCharset == null) {
+            defaultCharset = Charset.forName(geoServer.getSettings().getCharset());
+        }
+        return defaultCharset;
+    }
+
     private String processHtmlExtensions(Map<String, Object> model, List arguments) {
         try {
             List<HTMLExtensionCallback> callbacks =
@@ -202,7 +212,7 @@ public abstract class AbstractHTMLMessageConverter<T> extends AbstractHttpMessag
             StringBuilder sb = new StringBuilder();
             Request dr = Dispatcher.REQUEST.get();
             for (HTMLExtensionCallback callback : callbacks) {
-                String html = callback.getExtension(dr, model, arguments);
+                String html = callback.getExtension(dr, model, getDefaultCharset(), arguments);
                 if (html != null) {
                     // add a separation just for output readability
                     if (sb.length() > 0) {

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FreemarkerTemplateSupport.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FreemarkerTemplateSupport.java
@@ -5,12 +5,14 @@
 package org.geoserver.ogcapi;
 
 import freemarker.cache.ClassTemplateLoader;
+import freemarker.core.Environment;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.geoserver.catalog.ResourceInfo;
@@ -124,19 +126,36 @@ public class FreemarkerTemplateSupport {
      * @param writer The writer receiving the template output
      */
     public void processTemplate(
+            Template template, Map<String, Object> model, Writer writer, Charset charset)
+            throws IOException {
+        try {
+            Environment env = template.createProcessingEnvironment(model, writer, null);
+            env.setOutputEncoding(charset.name());
+            env.process();
+        } catch (TemplateException e) {
+            throw new IOException("Error occured processing template " + template.getName(), e);
+        }
+    }
+
+    /**
+     * Processes a template and returns the result as a string
+     *
+     * @param resource The resource reference used to lookup templates in the data dir
+     * @param templateName The template name
+     * @param referenceClass The reference class for classpath template loading
+     * @param model The model to be applied
+     * @param writer The writer receiving the template output
+     */
+    public void processTemplate(
             ResourceInfo resource,
             String templateName,
             Class<?> referenceClass,
             Map<String, Object> model,
-            Writer writer)
+            Writer writer,
+            Charset charset)
             throws IOException {
         Template template = getTemplate(resource, templateName, referenceClass);
-
-        try {
-            template.process(model, writer);
-        } catch (TemplateException e) {
-            throw new IOException("Error occured processing template " + templateName, e);
-        }
+        processTemplate(template, model, writer, charset);
     }
 
     /**
@@ -151,10 +170,11 @@ public class FreemarkerTemplateSupport {
             ResourceInfo resource,
             String templateName,
             Class<?> referenceClass,
-            Map<String, Object> model)
+            Map<String, Object> model,
+            Charset charset)
             throws IOException {
         StringWriter sw = new StringWriter();
-        processTemplate(resource, templateName, referenceClass, model, sw);
+        processTemplate(resource, templateName, referenceClass, model, sw, charset);
         return sw.toString();
     }
 }

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/HTMLExtensionCallback.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/HTMLExtensionCallback.java
@@ -5,6 +5,7 @@
 package org.geoserver.ogcapi;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import org.geoserver.ows.Request;
@@ -30,6 +31,7 @@ public interface HTMLExtensionCallback {
      * @param model The model value that will be used by the template
      * @param htmlExtensionArguments the arguments provided to the htmlExtension function
      */
-    public String getExtension(Request dr, Map<String, Object> model, List htmlExtensionArguments)
+    public String getExtension(
+            Request dr, Map<String, Object> model, Charset charset, List htmlExtensionArguments)
             throws IOException;
 }

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/SimpleHTMLMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/SimpleHTMLMessageConverter.java
@@ -56,7 +56,8 @@ public class SimpleHTMLMessageConverter<T> extends AbstractHTMLMessageConverter<
                     templateName,
                     serviceClass,
                     model,
-                    new OutputStreamWriter(outputMessage.getBody()));
+                    new OutputStreamWriter(outputMessage.getBody(), getDefaultCharset()),
+                    getDefaultCharset());
         } finally {
             // the model can be working over feature collections, make sure they are cleaned up
             purgeIterators();

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/common-header.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/common-header.ftl
@@ -7,7 +7,7 @@
       <#elseif model?? && model.htmlTitle?has_content>
         <title>${model.htmlTitle}</title>
       </#if>
-      <meta charset="UTF-8">
+      <meta http-equiv="content-type" content="text/html; charset=${.output_encoding}">
       <link rel="stylesheet" href="${resourceLink("apicss/bootstrap.min.css")}" type="text/css" media="all" />
       <link rel="stylesheet" href="${resourceLink("apicss/geoserver.css")}" type="text/css" media="all" />
       <link rel="stylesheet" href="${resourceLink("apicss/treeview.css")}" type="text/css" media="all" />

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
@@ -57,6 +57,19 @@ public class ApiTest extends FeaturesTestSupport {
     }
 
     @Test
+    public void testHTMLEncoding() throws Exception {
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse("ogc/features?f=text/html", 200);
+        assertEquals("text/html", response.getContentType());
+        String html = response.getContentAsString();
+        GeoServerBaseTestSupport.LOGGER.info(html);
+        assertThat(
+                html,
+                containsString(
+                        "<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\">"));
+    }
+
+    @Test
     public void testApiHTML() throws Exception {
         MockHttpServletResponse response =
                 getAsMockHttpServletResponse("ogc/features/api?f=text/html", 200);

--- a/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/maps/HTMLMapMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/maps/HTMLMapMessageConverter.java
@@ -63,7 +63,8 @@ public class HTMLMapMessageConverter extends AbstractHTMLMessageConverter<HTMLMa
                 "htmlmap.ftl",
                 MapsService.class,
                 model,
-                new OutputStreamWriter(outputMessage.getBody()));
+                new OutputStreamWriter(outputMessage.getBody(), getDefaultCharset()),
+                getDefaultCharset());
     }
 
     /**

--- a/src/community/ogcapi/ogcapi-tiled-features/src/main/java/org/geoserver/ogcapi/features/tiled/TiledFeaturesExtension.java
+++ b/src/community/ogcapi/ogcapi-tiled-features/src/main/java/org/geoserver/ogcapi/features/tiled/TiledFeaturesExtension.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,12 +60,13 @@ public class TiledFeaturesExtension
     }
 
     @Override
-    public String getExtension(Request dr, Map<String, Object> model, List htmlExtensionArguments)
+    public String getExtension(
+            Request dr, Map<String, Object> model, Charset charset, List htmlExtensionArguments)
             throws IOException {
         if (dr.getService().equals(FEATURES)) {
             if (dr.getRequest().equals(REQ_LANDING)) {
                 return templateSupport.processTemplate(
-                        null, "landingPageTileMatrixExtension.ftl", getClass(), model);
+                        null, "landingPageTileMatrixExtension.ftl", getClass(), model, charset);
             } else if (dr.getRequest().equals(REQ_COLLECTION)) {
                 // get the collection provided by the function call and replace the model
                 Map<String, Object> clonedModel = new HashMap<>(model);
@@ -72,7 +74,7 @@ public class TiledFeaturesExtension
                 if (tiledFeatures.isTiledVectorLayer(collection.getId())) {
                     clonedModel.put("collection", collection);
                     return templateSupport.processTemplate(
-                            null, "collectionExtension.ftl", getClass(), clonedModel);
+                            null, "collectionExtension.ftl", getClass(), clonedModel, charset);
                 }
             } else if (dr.getRequest().equals(REQ_COLLECTIONS)) {
                 // get the collection provided by the function call and replace the model
@@ -81,7 +83,7 @@ public class TiledFeaturesExtension
                 if (tiledFeatures.isTiledVectorLayer(collection.getId())) {
                     clonedModel.put("collection", collection);
                     return templateSupport.processTemplate(
-                            null, "collectionExtension.ftl", getClass(), clonedModel);
+                            null, "collectionExtension.ftl", getClass(), clonedModel, charset);
                 }
             }
         }


### PR DESCRIPTION
[![GEOS-10726](https://badgen.net/badge/JIRA/GEOS-10726/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10726)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->