### PR TITLE
[GEOS-10846] Enable auto-escaping for REST HTML templates

### DIFF
--- a/src/rest/src/main/java/org/geoserver/rest/RestBaseController.java
+++ b/src/rest/src/main/java/org/geoserver/rest/RestBaseController.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.rest;
 
+import freemarker.core.HTMLOutputFormat;
 import freemarker.core.ParseException;
 import freemarker.template.Configuration;
 import freemarker.template.ObjectWrapper;
@@ -83,6 +84,7 @@ public abstract class RestBaseController implements RequestBodyAdvice {
         if (encoding != null) {
             cfg.setDefaultEncoding(encoding);
         }
+        cfg.setOutputFormat(HTMLOutputFormat.INSTANCE);
         return cfg;
     }
 

--- a/src/restconfig/src/test/java/org/geoserver/rest/SettingsControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/SettingsControllerTest.java
@@ -5,6 +5,9 @@
 package org.geoserver.rest;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -103,6 +106,18 @@ public class SettingsControllerTest extends CatalogRESTTestSupport {
     @Test
     public void testGetContactAsHTML() throws Exception {
         getAsDOM(RestBaseController.ROOT_PATH + "/settings/contact.html", 200);
+    }
+
+    @Test
+    public void testGetContactAsHTMLXSS() throws Exception {
+        String decoded = "<foo>bar</foo>";
+        String encoded = "&lt;foo&gt;bar&lt;/foo&gt;";
+        GeoServerInfo geoServerInfo = geoServer.getGlobal();
+        geoServerInfo.getSettings().getContact().setAddress(decoded);
+        geoServer.save(geoServerInfo);
+        String html = getAsString(RestBaseController.ROOT_PATH + "/settings/contact.html");
+        assertThat(html, not(containsString(decoded)));
+        assertThat(html, containsString(encoded));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10846](https://badgen.net/badge/JIRA/GEOS-10846/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10846)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR enables FreeMarker's built-in auto-escaping functionality for REST HTML templates.  A setting to enable/disable this doesn't seem necessary since all of the REST templates are included in the JAR files and I looked at the templates in every ftl-templates directory I could find and didn't see any obvious conflicts with enabling this.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->