### PR TITLE
[GEOS-10705] Exception on missing input files

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
@@ -201,7 +201,7 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public InputStream in() {
-            File actualFile = file();
+            File actualFile = file(false);
             if (!actualFile.exists()) {
                 throw new IllegalStateException("File not found " + actualFile);
             }
@@ -232,7 +232,7 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public OutputStream out() {
-            final File actualFile = file();
+            final File actualFile = file(true);
             if (!actualFile.exists()) {
                 throw new IllegalStateException("Cannot access " + actualFile);
             }
@@ -297,8 +297,8 @@ public class FileSystemResourceStore implements ResourceStore {
         }
 
         @Override
-        public File file() {
-            if (!file.exists()) {
+        public File file(boolean create) {
+            if (create && !file.exists()) {
                 try {
                     File parent = file.getParentFile();
                     if (!parent.exists()) {
@@ -513,7 +513,7 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public void setContents(byte[] byteArray) throws IOException {
-            final File actualFile = file();
+            final File actualFile = file(true);
             if (!actualFile.exists()) {
                 throw new IllegalStateException("Cannot access " + actualFile);
             }

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -77,7 +77,7 @@ public final class Files {
 
         @Override
         public InputStream in() {
-            final File actualFile = file();
+            final File actualFile = file(false);
             if (!actualFile.exists()) {
                 throw new IllegalStateException("Cannot access " + actualFile);
             }
@@ -90,7 +90,7 @@ public final class Files {
 
         @Override
         public OutputStream out() {
-            final File actualFile = file();
+            final File actualFile = file(true);
             if (!actualFile.exists()) {
                 throw new IllegalStateException("Cannot access " + actualFile);
             }
@@ -157,12 +157,13 @@ public final class Files {
         }
 
         @Override
-        public File file() {
+        public File file(boolean create) {
             if (file.isDirectory()) {
                 throw new IllegalStateException("Cannot create file: is already a directory.");
             }
             try {
-                if (!file.exists()
+                if (create
+                        && !file.exists()
                         && !((file.getParentFile() == null
                                         || file.getParentFile().exists()
                                         || file.getParentFile().mkdirs())

--- a/src/platform/src/main/java/org/geoserver/platform/resource/NullResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/NullResourceStore.java
@@ -63,7 +63,7 @@ final class NullResourceStore implements ResourceStore {
             }
 
             @Override
-            public File file() {
+            public File file(boolean create) {
                 throw new IllegalStateException("No file access to ResourceStore.EMPTY");
             }
 

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
@@ -108,9 +108,20 @@ public interface Resource {
      * <p>The resource may need to be unpacked into the GeoServer data directory prior to use. Do
      * not assume the file exists before calling this method.
      *
+     * @param create if true, the file must exist or is created.
      * @return file access to resource contents.
      */
-    File file();
+    File file(boolean create);
+
+    /**
+     * File access to resource contents. This does not create any missing file. The file may be
+     * created by calling out().
+     *
+     * @return the File path.
+     */
+    default File file() {
+        return file(false);
+    }
 
     /**
      * Directory access to resource contents.

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Resources.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Resources.java
@@ -797,8 +797,8 @@ public class Resources {
         }
 
         @Override
-        public File file() {
-            return delegate.file();
+        public File file(boolean create) {
+            return delegate.file(create);
         }
 
         @Override

--- a/src/platform/src/main/java/org/geoserver/platform/resource/URIs.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/URIs.java
@@ -76,7 +76,7 @@ public final class URIs {
         }
 
         @Override
-        public File file() {
+        public File file(boolean create) {
             return URLs.urlToFile(url);
         }
 

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -126,15 +126,15 @@ public abstract class ResourceTheoryTest {
     }
 
     @Theory
-    public void theoryUndefinedHaveIstreamAndBecomeResource(String path) throws Exception {
+    public void theoryUndefinedHaveNoIstreams(String path) throws Exception {
         Resource res = getResource(path);
 
         assumeThat(res, is(undefined()));
 
-        try (InputStream result = res.in()) {
-            assertThat(result, notNullValue());
-            assertThat(res, is(resource()));
-        }
+        assertThrows(IllegalStateException.class, () -> res.in().close());
+
+        // must not be created unintentionally.
+        assertThat(res, is(undefined()));
     }
 
     @Theory


### PR DESCRIPTION
[![GEOS-10705](https://badgen.net/badge/JIRA/GEOS-10705/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10705)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Introduced an `IllegalStateException` when opening non existing input files.
Also Resource.file() does not create the file by default any more.

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).