### PR TITLE
[GEOS-10847] WFSResourceVoter should only vote on WFS content

### DIFF
--- a/src/web/wfs/src/test/java/org/geoserver/wfs/web/WFSServiceDescriptionProviderTest.java
+++ b/src/web/wfs/src/test/java/org/geoserver/wfs/web/WFSServiceDescriptionProviderTest.java
@@ -8,13 +8,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.data.test.SystemTestData;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.web.ServiceDescription;
 import org.geoserver.web.ServiceLinkDescription;
+import org.geoserver.wfs.WFSResourceVoter;
 import org.junit.Test;
 
 public class WFSServiceDescriptionProviderTest extends GeoServerSystemTestSupport {
+
+    @Override
+    protected void setUpTestData(SystemTestData testData) throws Exception {
+        testData.setUpDefault();
+        testData.setUpDefaultRasterLayers();
+    }
 
     @Test
     public void serviceDescriptorAndLinks() {
@@ -37,5 +48,20 @@ public class WFSServiceDescriptionProviderTest extends GeoServerSystemTestSuppor
                 assertTrue("version", link.getLink().contains("&version="));
             }
         }
+    }
+
+    @Test
+    public void ignoreCoverage() {
+        WFSServiceDescriptionProvider provider =
+                GeoServerExtensions.bean(WFSServiceDescriptionProvider.class);
+        Catalog catalog = getCatalog();
+        WorkspaceInfo gs = catalog.getWorkspaceByName("gs");
+        LayerInfo world = catalog.getLayerByName("World");
+
+        WFSResourceVoter voter = new WFSResourceVoter();
+        assertTrue(voter.hideService("WFS", world.getResource()));
+
+        List<ServiceDescription> services = provider.getServices(gs, world);
+        assertEquals(1, services.size());
     }
 }

--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSResourceVoter.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSResourceVoter.java
@@ -12,7 +12,7 @@ public class WFSResourceVoter implements ServiceResourceVoter {
 
     @Override
     public boolean hideService(String serviceType, ResourceInfo resource) {
-        if ("WFS".equalsIgnoreCase(serviceType)) return false;
+        if (!"WFS".equalsIgnoreCase(serviceType)) return false;
         return !(resource instanceof FeatureTypeInfo);
     }
 }


### PR DESCRIPTION
[![GEOS-1084](https://badgen.net/badge/JIRA/GEOS-1084/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-1084)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->