### PR TITLE
[GEOS-10848] Column remarks documentation should be updated to reflec…

### DIFF
--- a/doc/en/user/source/data/database/oracle.rst
+++ b/doc/en/user/source/data/database/oracle.rst
@@ -67,10 +67,8 @@ Configuring an Oracle datastore
    * - ``Metadata bbox``
      - 	Flag controlling the use of MDSYS.USER_SDO_GEOM_METADATA or MDSYS.ALL_SDO_GEOM_METADATA table for bounding box calculations, this brings a better performance if the views access is fast and the bounds are configured right in the tables default is false
    * -  ``Get remarks``
-     -  Boolean flag specifies whether REMARKS metadata will be returned. Note that this parameter is not available in the JNDI version of the DataStore. Instead you can set a Connection Property called remarksReporting as described in the Oracle `documentation`_.
-
-.. _documentation: https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/performance-extensions.html#GUID-15865071-39F2-430F-9EDA-EB34D0B2D560
-
+     -  Boolean flag specifies whether REMARKS metadata will be returned.
+     
 Connecting to an Oracle cluster
 -------------------------------
 


### PR DESCRIPTION
[![GEOS-10848](https://badgen.net/badge/JIRA/GEOS-10848/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10848)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…t that functionality is supported with JNDI


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->