### PR TITLE
STAC extension: fix item.json path

### DIFF
--- a/doc/en/user/source/community/opensearch-eo/STAC.rst
+++ b/doc/en/user/source/community/opensearch-eo/STAC.rst
@@ -47,7 +47,7 @@ in the ``$GEOSERER_DATA_DIR/templates/ogc/stac`` folder:
 Specifically for the JSON output:
 
 * `$GEOSERER_DATA_DIR/templates/ogc/stac/collections.json` is the `collections template <https://raw.githubusercontent.com/geoserver/geoserver/main/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/stac/collections.json>`_
-* `$GEOSERER_DATA_DIR/templates/os-eo/items.json` is the `items template <https://raw.githubusercontent.com/geoserver/geoserver/main/src/community/oseo/oseo-service/src/main/resources/org/geoserver/opensearch/eo/items.json>`_
+* `$GEOSERER_DATA_DIR/templates/ogc/stac/items.json` is the `items template <https://raw.githubusercontent.com/geoserver/geoserver/main/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/stac/items.json>`_
 
 The JSON templates in the case of STAC also drive database querying, the exposed STAC properties
 are back-mapped into database properties by interpreting the template. It is advised to keep 


### PR DESCRIPTION
I believe the template for item.json path was wrong in documentation, it gave 404.