### PR TITLE
[GEOS-10833] GeoServerHomePage unresponsive against large catalogs - fix regression on layer dropdown

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -138,7 +138,6 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
 
     private void homeInit() {
         GeoServer gs = getGeoServer();
-        initFromPageParameters(getPageParameters());
 
         boolean admin = getSession().isAdmin();
 

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -252,8 +252,12 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
         String layerSelection = toLayer(workspaceName, layerName);
 
         PageParameters pageParams = new PageParameters();
-        pageParams.add("workspace", workspaceSelection, 0, INamedParameters.Type.QUERY_STRING);
-        pageParams.add("layer", layerSelection, 1, INamedParameters.Type.QUERY_STRING);
+        if (!Strings.isEmpty(workspaceSelection)) {
+            pageParams.add("workspace", workspaceSelection, 0, INamedParameters.Type.QUERY_STRING);
+        }
+        if (!Strings.isEmpty(layerSelection)) {
+            pageParams.add("layer", layerSelection, 1, INamedParameters.Type.QUERY_STRING);
+        }
         setResponsePage(GeoServerHomePage.class, pageParams);
     }
 

--- a/src/web/core/src/main/java/org/geoserver/web/HomePageSelection.java
+++ b/src/web/core/src/main/java/org/geoserver/web/HomePageSelection.java
@@ -218,6 +218,9 @@ abstract class HomePageSelection implements Serializable {
                             } else {
                                 page.selectHomePage(null, prefixed);
                             }
+                        } else {
+                            String workspaceName = page.getWorkspaceFieldText();
+                            page.selectHomePage(workspaceName, null);
                         }
                     }
                 };

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,6 +160,41 @@ public class GeoServerHomePageTest extends GeoServerWicketTestSupport {
         assertEquals(page3.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
         assertEquals(
                 page3.getPublishedInfo(), getCatalog().getLayerByName(getLayerId(BASIC_POLYGONS)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDropDownLayerSelection() throws Exception {
+        tester.startPage(GeoServerHomePage.class);
+        tester.assertNoErrorMessage();
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        Page page1 = tester.getLastRenderedPage();
+
+        // select a layer directly
+        FormTester form = tester.newFormTester("form");
+        form.setValue("layer:select", getLayerId(BASIC_POLYGONS));
+        tester.executeAjaxEvent("form:layer:select", "change");
+
+        // it switched to a new page with a single layer
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page2 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page2);
+        assertEquals(page2.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+        assertEquals(
+                page2.getPublishedInfo(), getCatalog().getLayerByName(getLayerId(BASIC_POLYGONS)));
+
+        // now un-select the layer
+        form = tester.newFormTester("form");
+        form.setValue("layer:select", null);
+        tester.executeAjaxEvent("form:layer:select", "change");
+
+        // it switched to a new page with a single layer
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page3 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page3);
+        assertNotSame(page2, page3);
+        assertEquals(page2.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+        assertNull(page2.getPublishedInfo());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10833](https://badgen.net/badge/JIRA/GEOS-10833/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10833)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

@jodygarnett this should fix the layer selection clearing issue you saw. While I was at it, I've also made the URLs better looking (instead of an empty key, the key is removed altogether).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->