### PR TITLE
GEOS-10802 OGC API: queryables page crashed on complex features

### DIFF
--- a/src/community/ogcapi/ogcapi-core/pom.xml
+++ b/src/community/ogcapi/ogcapi-core/pom.xml
@@ -147,6 +147,26 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-app-schema</artifactId>
+      <version>${gt.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-app-schema</artifactId>
+      <version>${gt.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-app-schema-test</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
       <version>${project.version}</version>

--- a/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/QueryablesBuilderComplexFeaturesTest.java
+++ b/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/QueryablesBuilderComplexFeaturesTest.java
@@ -1,0 +1,27 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi;
+
+import static org.junit.Assert.assertTrue;
+
+import org.geoserver.test.AbstractAppSchemaMockData;
+import org.geoserver.test.AbstractAppSchemaTestSupport;
+import org.geoserver.test.FeatureChainingMockData;
+import org.junit.Test;
+
+public class QueryablesBuilderComplexFeaturesTest extends AbstractAppSchemaTestSupport {
+    @Override
+    protected AbstractAppSchemaMockData createTestData() {
+        return new FeatureChainingMockData();
+    }
+
+    @Test
+    public void testQueryablesBuilder() throws Exception {
+        QueryablesBuilder qb =
+                new QueryablesBuilder("id")
+                        .forType(getCatalog().getFeatureTypeByName("MappedFeature"));
+        assertTrue(qb.queryables.getProperties().containsKey("observationMethod"));
+    }
+}


### PR DESCRIPTION
[![GEOS-10802](https://badgen.net/badge/JIRA/GEOS-10802/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10802)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->