### PR TITLE
[Backport 2.22.x] [GEOS-10853] Adjust the OGC API Features conformance classes

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -102,6 +102,9 @@ public class FeatureService {
     public static final String OAS30 =
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30";
 
+    public static final String CRS_BY_REFERENCE =
+            "http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs";
+
     public static final String CRS_PREFIX = "http://www.opengis.net/def/crs/EPSG/0/";
     public static final String DEFAULT_CRS = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
 
@@ -270,7 +273,8 @@ public class FeatureService {
                         OAS30,
                         HTML,
                         GEOJSON,
-                        GMLSF0,
+                        /* GMLSF0, GS does not use the gmlsf namespace */
+                        CRS_BY_REFERENCE,
                         FEATURES_FILTER,
                         FILTER,
                         ECQL,

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ConformanceTest.java
@@ -47,7 +47,7 @@ public class ConformanceTest extends FeaturesTestSupport {
             FeatureService.OAS30,
             FeatureService.HTML,
             FeatureService.GEOJSON,
-            FeatureService.GMLSF0,
+            FeatureService.CRS_BY_REFERENCE,
             FEATURES_FILTER,
             FILTER,
             ECQL,


### PR DESCRIPTION
[![GEOS-10853](https://badgen.net/badge/JIRA/GEOS-10853/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10853)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6564
 **Authored by:** @aaime