### PR TITLE
[10705] Loading missing resources creates unsolicited empty files

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
@@ -201,7 +201,8 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public InputStream in() {
-            File actualFile = file();
+            // just take the File as is, don't create it.
+            File actualFile = this.file;
             if (!actualFile.exists()) {
                 throw new IllegalStateException("File not found " + actualFile);
             }

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -77,7 +77,8 @@ public final class Files {
 
         @Override
         public InputStream in() {
-            final File actualFile = file();
+            // just take the File as is, don't create it.
+            final File actualFile = this.file;
             if (!actualFile.exists()) {
                 throw new IllegalStateException("Cannot access " + actualFile);
             }

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -126,15 +126,15 @@ public abstract class ResourceTheoryTest {
     }
 
     @Theory
-    public void theoryUndefinedHaveIstreamAndBecomeResource(String path) throws Exception {
+    public void theoryUndefinedHaveNoIstreams(String path) throws Exception {
         Resource res = getResource(path);
 
         assumeThat(res, is(undefined()));
 
-        try (InputStream result = res.in()) {
-            assertThat(result, notNullValue());
-            assertThat(res, is(resource()));
-        }
+        assertThrows(IllegalStateException.class, () -> res.in().close());
+
+        // must not be created unintentionally.
+        assertThat(res, is(undefined()));
     }
 
     @Theory


### PR DESCRIPTION
[![GEOS-10705](https://badgen.net/badge/JIRA/GEOS-10705/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10705)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

After merging [GEOS-10723] [GEOS-10724] and [GEOS-10743], we now can realize the idea to throw an `Exception` in `Resource.in()` if the file does not exist. 

Finally `XStreamPersister.load(InputStream)` is affected by this change, too. All usages already have some error handling block. But they are sensitive on `IOException` but not on `IllegalStateException`. So I introduced a new `XStreamPersister.load(Resource)` method which throws an `FileNotFoundException` if the resource is not of `Type.RESOURCE`.
This replaces the boilerplate try/resource blocks and integrates smoothly, since an `IOException` is already expected.

I noticed some cases where the `InputStream` was wrapped by an `BufferedInputStream`, so I used it in general (to be discussed, see also [GSIP 155](https://github.com/geoserver/geoserver/pull/2060#pullrequestreview-18679072)).

I don't have a unit test for the new load method yet, since I was not sure where to place it. But I can provide some easily I think.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).