### PR TITLE
[Backport 2.22.x] [GEOS-10833] GeoServerHomePage unresponsive against large catalogs - fix regression on layer dropdown

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -138,7 +138,6 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
 
     private void homeInit() {
         GeoServer gs = getGeoServer();
-        initFromPageParameters(getPageParameters());
 
         boolean admin = getSession().isAdmin();
 

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerHomePage.java
@@ -252,8 +252,12 @@ public class GeoServerHomePage extends GeoServerBasePage implements GeoServerUnl
         String layerSelection = toLayer(workspaceName, layerName);
 
         PageParameters pageParams = new PageParameters();
-        pageParams.add("workspace", workspaceSelection, 0, INamedParameters.Type.QUERY_STRING);
-        pageParams.add("layer", layerSelection, 1, INamedParameters.Type.QUERY_STRING);
+        if (!Strings.isEmpty(workspaceSelection)) {
+            pageParams.add("workspace", workspaceSelection, 0, INamedParameters.Type.QUERY_STRING);
+        }
+        if (!Strings.isEmpty(layerSelection)) {
+            pageParams.add("layer", layerSelection, 1, INamedParameters.Type.QUERY_STRING);
+        }
         setResponsePage(GeoServerHomePage.class, pageParams);
     }
 

--- a/src/web/core/src/main/java/org/geoserver/web/HomePageSelection.java
+++ b/src/web/core/src/main/java/org/geoserver/web/HomePageSelection.java
@@ -218,6 +218,9 @@ abstract class HomePageSelection implements Serializable {
                             } else {
                                 page.selectHomePage(null, prefixed);
                             }
+                        } else {
+                            String workspaceName = page.getWorkspaceFieldText();
+                            page.selectHomePage(workspaceName, null);
                         }
                     }
                 };

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerHomePageTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,6 +160,41 @@ public class GeoServerHomePageTest extends GeoServerWicketTestSupport {
         assertEquals(page3.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
         assertEquals(
                 page3.getPublishedInfo(), getCatalog().getLayerByName(getLayerId(BASIC_POLYGONS)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDropDownLayerSelection() throws Exception {
+        tester.startPage(GeoServerHomePage.class);
+        tester.assertNoErrorMessage();
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        Page page1 = tester.getLastRenderedPage();
+
+        // select a layer directly
+        FormTester form = tester.newFormTester("form");
+        form.setValue("layer:select", getLayerId(BASIC_POLYGONS));
+        tester.executeAjaxEvent("form:layer:select", "change");
+
+        // it switched to a new page with a single layer
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page2 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page2);
+        assertEquals(page2.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+        assertEquals(
+                page2.getPublishedInfo(), getCatalog().getLayerByName(getLayerId(BASIC_POLYGONS)));
+
+        // now un-select the layer
+        form = tester.newFormTester("form");
+        form.setValue("layer:select", null);
+        tester.executeAjaxEvent("form:layer:select", "change");
+
+        // it switched to a new page with a single layer
+        tester.assertRenderedPage(GeoServerHomePage.class);
+        GeoServerHomePage page3 = (GeoServerHomePage) tester.getLastRenderedPage();
+        assertNotSame(page1, page3);
+        assertNotSame(page2, page3);
+        assertEquals(page2.getWorkspaceInfo(), getCatalog().getWorkspaceByName(CITE_PREFIX));
+        assertNull(page2.getPublishedInfo());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10833](https://badgen.net/badge/JIRA/GEOS-10833/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10833)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6561
 **Authored by:** @aaime