### PR TITLE
[Backport 2.22.x] [GEOS-10854] Move the OGC API OpenAPI definitions to the openapi resource

### DIFF
--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/test/java/org/geoserver/ogcapi/dggs/LandingPageTest.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/test/java/org/geoserver/ogcapi/dggs/LandingPageTest.java
@@ -110,7 +110,7 @@ public class LandingPageTest extends OGCApiTestSupport {
                 "http://localhost:8080/geoserver/ogc/dggs/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/dggs/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/ogc/dggs/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/dggs/conformance?f=text%2Fhtml",
@@ -125,7 +125,7 @@ public class LandingPageTest extends OGCApiTestSupport {
                 "http://localhost:8080/geoserver/sf/ogc/dggs/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/sf/ogc/dggs/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/sf/ogc/dggs/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/sf/ogc/dggs/conformance?f=text%2Fhtml",
@@ -151,13 +151,13 @@ public class LandingPageTest extends OGCApiTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/dggs\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/dggs\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);
         // check API with right API mime type
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/dggs/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0",
+                "http://localhost:8080/geoserver/ogc/dggs/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0",
                 readSingle(
                         json,
                         "links[?(@.type=='"

--- a/src/community/ogcapi/ogcapi-changeset/src/test/java/org/geoserver/ogcapi/changeset/TilesExtensionsTest.java
+++ b/src/community/ogcapi/ogcapi-changeset/src/test/java/org/geoserver/ogcapi/changeset/TilesExtensionsTest.java
@@ -33,7 +33,7 @@ public class TilesExtensionsTest extends OGCApiTestSupport {
 
     @Test
     public void testApiExtension() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/tiles/api", 200);
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/tiles/openapi", 200);
         assertThat(response.getContentType(), startsWith(OPEN_API_MEDIA_TYPE_VALUE));
         String json = response.getContentAsString();
         LOGGER.log(Level.INFO, json);

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractLandingPageDocumentNoConformance.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AbstractLandingPageDocumentNoConformance.java
@@ -25,7 +25,7 @@ public class AbstractLandingPageDocumentNoConformance extends AbstractDocument {
         addSelfLinks(serviceBase + "/");
         // api
         new LinksBuilder(OpenAPI.class, serviceBase)
-                .segment("/api")
+                .segment("/openapi")
                 .title("API definition for this endpoint as ")
                 .rel(Link.REL_SERVICE_DESC)
                 .classification("api")

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/GeoServerOpenAPI.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/GeoServerOpenAPI.java
@@ -30,7 +30,7 @@ public class GeoServerOpenAPI extends OpenAPI {
         String baseURL = APIRequestInfo.get().getBaseURL();
         return ResponseUtils.buildURL(
                 baseURL,
-                serviceBase + (serviceBase.endsWith("/") ? "api" : "/api"),
+                serviceBase + (serviceBase.endsWith("/") ? "openapi" : "/openapi"),
                 Collections.singletonMap("f", OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE),
                 URLMangler.URLType.SERVICE);
     }

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2YAMLMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2YAMLMessageConverter.java
@@ -14,8 +14,10 @@ import org.springframework.http.converter.json.AbstractJackson2HttpMessageConver
 /** Message converter encoding a Java bean into YAML using Jackson */
 public class MappingJackson2YAMLMessageConverter extends AbstractJackson2HttpMessageConverter {
 
-    public static final MediaType APPLICATION_YAML = MediaType.parseMediaType("application/x-yaml");
-    public static final String APPLICATION_YAML_VALUE = APPLICATION_YAML.toString();
+    public static final String APPLICATION_YAML_VALUE = "application/x-yaml";
+
+    public static final MediaType APPLICATION_YAML =
+            MediaType.parseMediaType(APPLICATION_YAML_VALUE);
 
     protected MappingJackson2YAMLMessageConverter() {
         super(Yaml.mapper(), APPLICATION_YAML);

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/CoveragesService.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/CoveragesService.java
@@ -144,7 +144,7 @@ public class CoveragesService {
     }
 
     @GetMapping(
-            path = "api",
+            path = "openapi",
             name = "getApi",
             produces = {
                 OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/ApiTest.java
@@ -38,7 +38,8 @@ public class ApiTest extends CoveragesTestSupport {
 
     @Test
     public void testApiJson() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/coverages/api", 200);
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse("ogc/coverages/openapi", 200);
         assertThat(
                 response.getContentType(),
                 CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));
@@ -53,7 +54,7 @@ public class ApiTest extends CoveragesTestSupport {
     @Test
     public void testApiHTML() throws Exception {
         MockHttpServletResponse response =
-                getAsMockHttpServletResponse("ogc/coverages/api?f=text/html", 200);
+                getAsMockHttpServletResponse("ogc/coverages/openapi?f=text/html", 200);
         assertEquals("text/html", response.getContentType());
         String html = response.getContentAsString();
         GeoServerBaseTestSupport.LOGGER.info(html);
@@ -78,12 +79,12 @@ public class ApiTest extends CoveragesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/coverages/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
+                        "url: \"http://localhost:8080/geoserver/ogc/coverages/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
     }
 
     @Test
     public void testApiYaml() throws Exception {
-        String yaml = getAsString("ogc/coverages/api?f=application/x-yaml");
+        String yaml = getAsString("ogc/coverages/openapi?f=application/x-yaml");
         GeoServerBaseTestSupport.LOGGER.log(Level.INFO, yaml);
 
         ObjectMapper mapper = Yaml.mapper();
@@ -93,7 +94,7 @@ public class ApiTest extends CoveragesTestSupport {
 
     @Test
     public void testYamlAsAcceptsHeader() throws Exception {
-        MockHttpServletRequest request = createRequest("ogc/coverages/api");
+        MockHttpServletRequest request = createRequest("ogc/coverages/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");
@@ -171,7 +172,7 @@ public class ApiTest extends CoveragesTestSupport {
     @Test
     @SuppressWarnings("unchecked") // getSchema not generified
     public void testWorkspaceQualifiedAPI() throws Exception {
-        MockHttpServletRequest request = createRequest("cdf/ogc/coverages/api");
+        MockHttpServletRequest request = createRequest("cdf/ogc/coverages/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/coverages/LandingPageTest.java
@@ -87,7 +87,7 @@ public class LandingPageTest extends CoveragesTestSupport {
                 "http://localhost:8080/geoserver/ogc/coverages/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/coverages/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/ogc/coverages/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/coverages/conformance?f=text%2Fhtml",
@@ -102,7 +102,7 @@ public class LandingPageTest extends CoveragesTestSupport {
                 "http://localhost:8080/geoserver/sf/ogc/coverages/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/sf/ogc/coverages/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/sf/ogc/coverages/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
     }
 
@@ -125,13 +125,13 @@ public class LandingPageTest extends CoveragesTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/coverages\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/coverages\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);
         // check API with right API mime type
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/coverages/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0",
+                "http://localhost:8080/geoserver/ogc/coverages/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0",
                 readSingle(
                         json,
                         "links[?(@.type=='"

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -17,6 +17,8 @@ import static org.geoserver.ogcapi.ConformanceClass.ECQL_TEXT;
 import static org.geoserver.ogcapi.ConformanceClass.FEATURES_FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.SORTBY;
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
+import static org.geoserver.ogcapi.OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE;
 
 import com.google.common.collect.ImmutableList;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -47,7 +49,6 @@ import org.geoserver.ogcapi.FunctionsDocument;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.ogcapi.JSONSchemaMessageConverter;
 import org.geoserver.ogcapi.OGCAPIMediaTypes;
-import org.geoserver.ogcapi.OpenAPIMessageConverter;
 import org.geoserver.ogcapi.Queryables;
 import org.geoserver.ogcapi.QueryablesBuilder;
 import org.geoserver.ows.URLMangler;
@@ -190,11 +191,11 @@ public class FeatureService {
     }
 
     @GetMapping(
-            path = "api",
+            path = "openapi",
             name = "getApi",
             produces = {
-                OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
-                "application/x-yaml",
+                OPEN_API_MEDIA_TYPE_VALUE,
+                APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })
     @ResponseBody

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/features/openapi.yaml
@@ -18,14 +18,14 @@ info:
   contact:
     name: Acme Corporation
     email: info@example.org
-    url: 'http://example.org/'
+    url: 'http://example.org'
   license:
     name: CC-BY 4.0 license
-    url: 'https://creativecommons.org/licenses/by/4.0/'
+    url: 'https://creativecommons.org/licenses/by/4.0'
 servers:
-  - url: 'https://data.example.org/'
+  - url: 'https://data.example.org'
     description: Production server
-  - url: 'https://dev.example.org/'
+  - url: 'https://dev.example.org'
     description: Development server
 tags:
   - name: Capabilities
@@ -49,6 +49,19 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/LandingPage'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  '/api':
+    get:
+      tags:
+        - Capabilities
+      summary: OpenAPI definition
+      description: |-
+        The OpenAPI document describing the API (this document)
+      operationId: getOpenApiDocument
+      responses:
+        '200':
+          $ref: '#/components/responses/ConformanceDeclaration'
         '500':
           $ref: '#/components/responses/ServerError'
   '/conformance':
@@ -900,7 +913,7 @@ components:
             title: Buildings in Bonn
             description: Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.
             links:
-              - href: 'http://data.example.org/'
+              - href: 'http://data.example.org'
                 rel: self
                 type: application/json
                 title: this document
@@ -1008,7 +1021,7 @@ components:
                     rel: items
                     type: text/html
                     title: Buildings
-                  - href: 'https://creativecommons.org/publicdomain/zero/1.0/'
+                  - href: 'https://creativecommons.org/publicdomain/zero/1.0'
                     rel: license
                     type: text/html
                     title: CC0-1.0
@@ -1068,7 +1081,7 @@ components:
                 rel: items
                 type: text/html
                 title: Buildings
-              - href: 'https://creativecommons.org/publicdomain/zero/1.0/'
+              - href: 'https://creativecommons.org/publicdomain/zero/1.0'
                 rel: license
                 type: text/html
                 title: CC0-1.0

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/ApiTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Yaml;
@@ -23,6 +24,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.servers.Server;
 import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +46,20 @@ public class ApiTest extends FeaturesTestSupport {
 
     @Test
     public void testApiJson() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/features/api", 200);
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse("ogc/features/openapi", 200);
+        validateJSONAPI(response);
+    }
+
+    @Test
+    public void testApiJsonExtension() throws Exception {
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse("ogc/features/openapi.json", 200);
+        validateJSONAPI(response);
+    }
+
+    private void validateJSONAPI(MockHttpServletResponse response)
+            throws UnsupportedEncodingException, JsonProcessingException {
         assertThat(
                 response.getContentType(),
                 CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));
@@ -59,7 +74,7 @@ public class ApiTest extends FeaturesTestSupport {
     @Test
     public void testApiHTML() throws Exception {
         MockHttpServletResponse response =
-                getAsMockHttpServletResponse("ogc/features/api?f=text/html", 200);
+                getAsMockHttpServletResponse("ogc/features/openapi?f=text/html", 200);
         assertEquals("text/html", response.getContentType());
         String html = response.getContentAsString();
         GeoServerBaseTestSupport.LOGGER.info(html);
@@ -84,12 +99,22 @@ public class ApiTest extends FeaturesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/features/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
+                        "url: \"http://localhost:8080/geoserver/ogc/features/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
     }
 
     @Test
     public void testApiYaml() throws Exception {
-        String yaml = getAsString("ogc/features/api?f=application/x-yaml");
+        String yaml = getAsString("ogc/features/openapi?f=application/x-yaml");
+        validateYAMLApi(yaml);
+    }
+
+    @Test
+    public void testApiYamlExtension() throws Exception {
+        String yaml = getAsString("ogc/features/openapi?f=application/x-yaml");
+        validateYAMLApi(yaml);
+    }
+
+    private void validateYAMLApi(String yaml) throws JsonProcessingException {
         GeoServerBaseTestSupport.LOGGER.log(Level.INFO, yaml);
 
         ObjectMapper mapper = Yaml.mapper();
@@ -99,7 +124,7 @@ public class ApiTest extends FeaturesTestSupport {
 
     @Test
     public void testYamlAsAcceptsHeader() throws Exception {
-        MockHttpServletRequest request = createRequest("ogc/features/api");
+        MockHttpServletRequest request = createRequest("ogc/features/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");
@@ -198,7 +223,7 @@ public class ApiTest extends FeaturesTestSupport {
 
     @Test
     public void testWorkspaceQualifiedAPI() throws Exception {
-        MockHttpServletRequest request = createRequest("cdf/ogc/features/api");
+        MockHttpServletRequest request = createRequest("cdf/ogc/features/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/features/LandingPageTest.java
@@ -102,7 +102,7 @@ public class LandingPageTest extends FeaturesTestSupport {
                 "http://localhost:8080/geoserver/ogc/features/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/features/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/ogc/features/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/features/conformance?f=text%2Fhtml",
@@ -117,7 +117,7 @@ public class LandingPageTest extends FeaturesTestSupport {
                 "http://localhost:8080/geoserver/sf/ogc/features/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/sf/ogc/features/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/sf/ogc/features/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
     }
 
@@ -140,13 +140,13 @@ public class LandingPageTest extends FeaturesTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/features\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/features\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);
         // check API with right API mime type
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/features/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0",
+                "http://localhost:8080/geoserver/ogc/features/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0",
                 readSingle(
                         json,
                         "links[?(@.type=='"

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
@@ -5,6 +5,7 @@
 package org.geoserver.ogcapi.images;
 
 import static java.util.stream.Collectors.toList;
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
 import static org.geotools.gce.imagemosaic.Utils.FF;
 
 import io.swagger.v3.oas.models.OpenAPI;
@@ -154,11 +155,11 @@ public class ImagesService implements ApplicationContextAware {
     }
 
     @GetMapping(
-            path = "api",
+            path = "openapi",
             name = "getApi",
             produces = {
                 OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
-                "application/x-yaml",
+                APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })
     @ResponseBody

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/ApiTest.java
@@ -35,7 +35,7 @@ public class ApiTest extends ImagesTestSupport {
 
     @Test
     public void testApiJson() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/images/api", 200);
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/images/openapi", 200);
         assertThat(
                 response.getContentType(),
                 CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));
@@ -50,7 +50,7 @@ public class ApiTest extends ImagesTestSupport {
     @Test
     public void testApiHTML() throws Exception {
         MockHttpServletResponse response =
-                getAsMockHttpServletResponse("ogc/images/api?f=text/html", 200);
+                getAsMockHttpServletResponse("ogc/images/openapi?f=text/html", 200);
         assertEquals("text/html", response.getContentType());
         String html = response.getContentAsString();
         LOGGER.info(html);
@@ -75,12 +75,12 @@ public class ApiTest extends ImagesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/images/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
+                        "url: \"http://localhost:8080/geoserver/ogc/images/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
     }
 
     @Test
     public void testApiYaml() throws Exception {
-        String yaml = getAsString("ogc/images/api?f=application/x-yaml");
+        String yaml = getAsString("ogc/images/openapi?f=application/x-yaml");
         LOGGER.log(Level.INFO, yaml);
 
         ObjectMapper mapper = Yaml.mapper();
@@ -90,7 +90,7 @@ public class ApiTest extends ImagesTestSupport {
 
     @Test
     public void testYamlAsAcceptsHeader() throws Exception {
-        MockHttpServletRequest request = createRequest("ogc/images/api");
+        MockHttpServletRequest request = createRequest("ogc/images/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");
@@ -142,7 +142,7 @@ public class ApiTest extends ImagesTestSupport {
 
     @Test
     public void testWorkspaceQualifiedAPI() throws Exception {
-        MockHttpServletRequest request = createRequest("gs/ogc/images/api");
+        MockHttpServletRequest request = createRequest("gs/ogc/images/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/images/LandingPageTest.java
@@ -91,7 +91,7 @@ public class LandingPageTest extends ImagesTestSupport {
                 "http://localhost:8080/geoserver/ogc/images/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/images/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/ogc/images/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/images/conformance?f=text%2Fhtml",
@@ -129,7 +129,7 @@ public class LandingPageTest extends ImagesTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/images\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/images\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);

--- a/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/maps/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/maps/LandingPageTest.java
@@ -104,7 +104,7 @@ public class LandingPageTest extends MapsTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/maps\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/maps\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.ogcapi.styles;
 
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
 import static org.geoserver.ogcapi.styles.StylesService.ValidationMode.only;
 import static org.geoserver.ogcapi.styles.StylesService.ValidationMode.yes;
 
@@ -159,11 +160,11 @@ public class StylesService {
     }
 
     @GetMapping(
-            path = "api",
+            path = "openapi",
             name = "getApi",
             produces = {
                 OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
-                "application/x-yaml",
+                APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })
     @ResponseBody

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/ApiTest.java
@@ -38,7 +38,7 @@ public class ApiTest extends StylesTestSupport {
 
     @Test
     public void testApiJson() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/styles/api", 200);
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/styles/openapi", 200);
         assertThat(
                 response.getContentType(),
                 CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));
@@ -53,7 +53,7 @@ public class ApiTest extends StylesTestSupport {
     @Test
     public void testApiHTML() throws Exception {
         MockHttpServletResponse response =
-                getAsMockHttpServletResponse("ogc/styles/api?f=text/html", 200);
+                getAsMockHttpServletResponse("ogc/styles/openapi?f=text/html", 200);
         assertEquals("text/html", response.getContentType());
         String html = response.getContentAsString();
         LOGGER.info(html);
@@ -78,12 +78,12 @@ public class ApiTest extends StylesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/styles/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
+                        "url: \"http://localhost:8080/geoserver/ogc/styles/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
     }
 
     @Test
     public void testApiYaml() throws Exception {
-        String yaml = getAsString("ogc/styles/api?f=application/x-yaml");
+        String yaml = getAsString("ogc/styles/openapi?f=application/x-yaml");
         LOGGER.log(Level.INFO, yaml);
 
         ObjectMapper mapper = Yaml.mapper();
@@ -93,7 +93,7 @@ public class ApiTest extends StylesTestSupport {
 
     @Test
     public void testYamlAsAcceptsHeader() throws Exception {
-        MockHttpServletRequest request = createRequest("ogc/styles/api");
+        MockHttpServletRequest request = createRequest("ogc/styles/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");
@@ -167,7 +167,7 @@ public class ApiTest extends StylesTestSupport {
 
     @Test
     public void testWorkspaceQualifiedAPI() throws Exception {
-        OpenAPI api = getOpenAPI("ws/ogc/styles/api");
+        OpenAPI api = getOpenAPI("ws/ogc/styles/openapi");
         Map<String, Parameter> params = api.getComponents().getParameters();
         Parameter styleId = params.get("styleId");
         @SuppressWarnings("unchecked")
@@ -191,7 +191,7 @@ public class ApiTest extends StylesTestSupport {
     @Test
     public void testWorkspaceQualifiedAPIGlobalOnly() throws Exception {
         // cdf has no local styles, only global ones
-        OpenAPI api = getOpenAPI("cdf/ogc/styles/api");
+        OpenAPI api = getOpenAPI("cdf/ogc/styles/openapi");
         Map<String, Parameter> params = api.getComponents().getParameters();
         Parameter collectionId = params.get("styleId");
         @SuppressWarnings("unchecked")

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/styles/LandingPageTest.java
@@ -101,7 +101,7 @@ public class LandingPageTest extends StylesTestSupport {
                 "http://localhost:8080/geoserver/ogc/styles/styles?f=text%2Fhtml",
                 document.select("#htmlStylesLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/styles/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/ogc/styles/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/styles/conformance?f=text%2Fhtml",
@@ -127,7 +127,7 @@ public class LandingPageTest extends StylesTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/styles\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/styles\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);

--- a/src/community/ogcapi/ogcapi-tiled-features/src/test/java/org/geoserver/ogcapi/features/tiled/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-tiled-features/src/test/java/org/geoserver/ogcapi/features/tiled/ApiTest.java
@@ -26,7 +26,8 @@ public class ApiTest extends TiledFeaturesTestSupport {
 
     @Test
     public void testApiJson() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/features/api", 200);
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse("ogc/features/openapi", 200);
         assertThat(
                 response.getContentType(),
                 CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.ogcapi.tiles;
 
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
+import static org.geoserver.ogcapi.OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE;
 import static org.geowebcache.conveyor.Conveyor.CacheResult.MISS;
 
 import io.swagger.v3.oas.models.OpenAPI;
@@ -36,7 +38,6 @@ import org.geoserver.ogcapi.ConformanceClass;
 import org.geoserver.ogcapi.ConformanceDocument;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.ogcapi.InvalidParameterValueException;
-import org.geoserver.ogcapi.OpenAPIMessageConverter;
 import org.geoserver.ogcapi.Queryables;
 import org.geoserver.ogcapi.QueryablesBuilder;
 import org.geoserver.ogcapi.ResourceNotFoundException;
@@ -134,11 +135,11 @@ public class TilesService {
     }
 
     @GetMapping(
-            path = "api",
+            path = "openapi",
             name = "getApi",
             produces = {
-                OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
-                "application/x-yaml",
+                OPEN_API_MEDIA_TYPE_VALUE,
+                APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })
     @ResponseBody

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/ApiTest.java
@@ -38,7 +38,7 @@ public class ApiTest extends TilesTestSupport {
 
     @Test
     public void testApiJson() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/tiles/api", 200);
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/tiles/openapi", 200);
         assertThat(
                 response.getContentType(),
                 CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));
@@ -53,7 +53,7 @@ public class ApiTest extends TilesTestSupport {
     @Test
     public void testApiHTML() throws Exception {
         MockHttpServletResponse response =
-                getAsMockHttpServletResponse("ogc/tiles/api?f=text/html", 200);
+                getAsMockHttpServletResponse("ogc/tiles/openapi?f=text/html", 200);
         assertEquals("text/html", response.getContentType());
         String html = response.getContentAsString();
         LOGGER.info(html);
@@ -78,12 +78,12 @@ public class ApiTest extends TilesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/tiles/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
+                        "url: \"http://localhost:8080/geoserver/ogc/tiles/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
     }
 
     @Test
     public void testApiYaml() throws Exception {
-        String yaml = getAsString("ogc/tiles/api?f=application/x-yaml");
+        String yaml = getAsString("ogc/tiles/openapi?f=application/x-yaml");
         LOGGER.log(Level.INFO, yaml);
 
         ObjectMapper mapper = Yaml.mapper();
@@ -93,7 +93,7 @@ public class ApiTest extends TilesTestSupport {
 
     @Test
     public void testYamlAsAcceptsHeader() throws Exception {
-        MockHttpServletRequest request = createRequest("ogc/tiles/api");
+        MockHttpServletRequest request = createRequest("ogc/tiles/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");
@@ -148,7 +148,7 @@ public class ApiTest extends TilesTestSupport {
     @Test
     @SuppressWarnings("unchecked") // getSchema().getEnum() not fully generified
     public void testWorkspaceQualifiedAPI() throws Exception {
-        MockHttpServletRequest request = createRequest("cdf/ogc/tiles/api");
+        MockHttpServletRequest request = createRequest("cdf/ogc/tiles/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/tiles/LandingPageTest.java
@@ -107,7 +107,7 @@ public class LandingPageTest extends TilesTestSupport {
                 "http://localhost:8080/geoserver/ogc/tiles/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/tiles/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/ogc/tiles/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/ogc/tiles/conformance?f=text%2Fhtml",
@@ -122,7 +122,7 @@ public class LandingPageTest extends TilesTestSupport {
                 "http://localhost:8080/geoserver/sf/ogc/tiles/collections?f=text%2Fhtml",
                 document.select("#htmlCollectionsLink").attr("href"));
         assertEquals(
-                "http://localhost:8080/geoserver/sf/ogc/tiles/api?f=text%2Fhtml",
+                "http://localhost:8080/geoserver/sf/ogc/tiles/openapi?f=text%2Fhtml",
                 document.select("#htmlApiLink").attr("href"));
         assertEquals(
                 "http://localhost:8080/geoserver/sf/ogc/tiles/conformance?f=text%2Fhtml",
@@ -148,7 +148,7 @@ public class LandingPageTest extends TilesTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/tiles\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/tiles\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);


### PR DESCRIPTION
[![GEOS-10854](https://badgen.net/badge/JIRA/GEOS-10854/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10854)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6567
 **Authored by:** @aaime