### PR TITLE
[Backport 2.21.x] [GEOS-10846] Enable auto-escaping for REST HTML templates

### DIFF
--- a/src/rest/src/main/java/org/geoserver/rest/RestBaseController.java
+++ b/src/rest/src/main/java/org/geoserver/rest/RestBaseController.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.rest;
 
+import freemarker.core.HTMLOutputFormat;
 import freemarker.core.ParseException;
 import freemarker.template.Configuration;
 import freemarker.template.ObjectWrapper;
@@ -83,6 +84,7 @@ public abstract class RestBaseController implements RequestBodyAdvice {
         if (encoding != null) {
             cfg.setDefaultEncoding(encoding);
         }
+        cfg.setOutputFormat(HTMLOutputFormat.INSTANCE);
         return cfg;
     }
 

--- a/src/restconfig/src/test/java/org/geoserver/rest/SettingsControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/SettingsControllerTest.java
@@ -5,6 +5,9 @@
 package org.geoserver.rest;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -103,6 +106,18 @@ public class SettingsControllerTest extends CatalogRESTTestSupport {
     @Test
     public void testGetContactAsHTML() throws Exception {
         getAsDOM(RestBaseController.ROOT_PATH + "/settings/contact.html", 200);
+    }
+
+    @Test
+    public void testGetContactAsHTMLXSS() throws Exception {
+        String decoded = "<foo>bar</foo>";
+        String encoded = "&lt;foo&gt;bar&lt;/foo&gt;";
+        GeoServerInfo geoServerInfo = geoServer.getGlobal();
+        geoServerInfo.getSettings().getContact().setAddress(decoded);
+        geoServer.save(geoServerInfo);
+        String html = getAsString(RestBaseController.ROOT_PATH + "/settings/contact.html");
+        assertThat(html, not(containsString(decoded)));
+        assertThat(html, containsString(encoded));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10846](https://badgen.net/badge/JIRA/GEOS-10846/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10846)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6555
 **Authored by:** @sikeoka