### PR TITLE
[GEOS-10517] jms-cluster classes missing from XStream security configuration

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/JMSXStreamFactory.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/JMSXStreamFactory.java
@@ -1,0 +1,68 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.cluster.impl;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.mapper.SecurityMapper;
+import com.thoughtworks.xstream.security.NoTypePermission;
+import com.thoughtworks.xstream.security.TypePermission;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.geoserver.catalog.event.CatalogEvent;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.config.util.XStreamServiceLoader;
+import org.geoserver.platform.GeoServerExtensions;
+
+public class JMSXStreamFactory {
+
+    private final XStream xs;
+
+    public JMSXStreamFactory(XStreamPersisterFactory factory, GeoServer gs)
+            throws InvocationTargetException, IllegalAccessException, NoSuchMethodException,
+                    NoSuchFieldException {
+        XStreamPersister persister = factory.createXMLPersister();
+        // add XStream configuration from the service loaders
+        Method method =
+                XStreamServiceLoader.class.getDeclaredMethod(
+                        "initXStreamPersister", XStreamPersister.class, GeoServer.class);
+        method.setAccessible(true);
+        for (XStreamServiceLoader loader :
+                GeoServerExtensions.extensions(XStreamServiceLoader.class)) {
+            method.invoke(loader, persister, gs);
+        }
+        // copy over the security configuration using reflection, there are no openings to get it,
+        // but we need that and not the converter configuration, aliases and the like, as
+        // the event handlers should get full objects for references, not just ids
+        XStream persisterXStream = persister.getXStream();
+        this.xs = new XStream();
+        Field securityMapperField = XStream.class.getDeclaredField("securityMapper");
+        securityMapperField.setAccessible(true);
+        SecurityMapper smPersister = (SecurityMapper) securityMapperField.get(persisterXStream);
+        Field permissionsField = SecurityMapper.class.getDeclaredField("permissions");
+        permissionsField.setAccessible(true);
+        List<TypePermission> permissions = (List<TypePermission>) permissionsField.get(smPersister);
+        permissions.stream()
+                .filter(p -> !(p instanceof NoTypePermission))
+                .forEach(p -> xs.addPermission(p));
+
+        // Now add bits that are unique to the cluster module
+        // add events from this module
+        this.xs.allowTypesByWildcard(new String[] {"org.geoserver.cluster.**"});
+        // add internal catalog events
+        this.xs.allowTypeHierarchy(CatalogEvent.class);
+        // add these converters to avoid the need to handle a large number of allows just
+        // for the tree of objects that make up a CRS
+        this.xs.registerConverter(new XStreamPersister.CRSConverter());
+    }
+
+    public XStream createXStream() {
+        return xs;
+    }
+}

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/DocumentFile.java
@@ -68,6 +68,7 @@ public class DocumentFile {
     public void writeTo(Resource file) throws JDOMException, IOException {
         try (OutputStream out = file.out()) {
             IOUtils.write(body, out);
+            out.flush();
         }
     }
 }

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/CatalogUtils.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/CatalogUtils.java
@@ -250,7 +250,10 @@ public abstract class CatalogUtils {
         }
 
         // localize layers
-        info.getStyles().addAll(localizeStyles(new HashSet<StyleInfo>(info.getStyles()), catalog));
+        Set<StyleInfo> localizeStyles =
+                localizeStyles(new HashSet<StyleInfo>(info.getStyles()), catalog);
+        info.getStyles().clear();
+        info.getStyles().addAll(localizeStyles);
 
         // attach to the catalog
         final CatalogBuilder builder = new CatalogBuilder(catalog);

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogEventHandler.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogEventHandler.java
@@ -18,6 +18,7 @@ import org.geoserver.catalog.event.impl.CatalogModifyEventImpl;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.cluster.JMSEventHandler;
 import org.geoserver.cluster.JMSEventHandlerSPI;
+import org.geoserver.ows.util.OwsUtils;
 
 /**
  * Abstract class which use Xstream as message serializer/de-serializer. We extend this class to
@@ -57,6 +58,7 @@ public abstract class JMSCatalogEventHandler extends JMSEventHandler<String, Cat
         final Object source = xstream.fromXML(s);
         if (source instanceof CatalogEvent) {
             final CatalogEvent ev = (CatalogEvent) source;
+            if (ev.getSource() != null) OwsUtils.resolveCollections(ev.getSource());
             if (LOGGER.isLoggable(Level.FINE)) {
                 final CatalogInfo info = ev.getSource();
                 LOGGER.fine("Incoming message event of type CatalogEvent: " + info.getId());

--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/rest/ClusterController.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/impl/rest/ClusterController.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.cluster.impl.rest;
 
+import com.thoughtworks.xstream.converters.collections.PropertiesConverter;
 import freemarker.template.SimpleHash;
 import freemarker.template.Template;
 import java.io.IOException;
@@ -136,5 +137,6 @@ public class ClusterController extends AbstractCatalogController {
     @Override
     public void configurePersister(XStreamPersister persister, XStreamMessageConverter converter) {
         persister.getXStream().allowTypes(new Class[] {Properties.class});
+        persister.getXStream().registerConverter(new PropertiesConverter());
     }
 }

--- a/src/community/jms-cluster/jms-geoserver/src/main/resources/applicationContext.xml
+++ b/src/community/jms-cluster/jms-geoserver/src/main/resources/applicationContext.xml
@@ -87,7 +87,12 @@
 	<bean id="RestDispatcherCallback"
 		class="org.geoserver.cluster.impl.events.RestDispatcherCallback" />
 
-	<bean id="JMSXstream" class="com.thoughtworks.xstream.XStream" />
+	<bean id="JMSXstreamFactory" class="org.geoserver.cluster.impl.JMSXStreamFactory" depends-on="geoServerLoader,catalog">
+		<constructor-arg ref="xstreamPersisterFactory"/>
+		<constructor-arg ref="geoServer"/>
+	</bean>
+	
+	<bean id="JMSXstream" factory-bean ="JMSXstreamFactory" factory-method="createXStream"/>
 
 	<!-- Producers -->
 

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/DocumentFileTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/DocumentFileTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import com.thoughtworks.xstream.XStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -17,6 +16,9 @@ import java.nio.file.Files;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLUnit;
+import org.geoserver.cluster.impl.JMSXStreamFactory;
+import org.geoserver.config.impl.GeoServerImpl;
+import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.Resource;
 import org.junit.After;
@@ -46,7 +48,11 @@ public class DocumentFileTest {
         // instantiating a document file representing the style file
         DocumentFile documentFile = new DocumentFile(resource);
         // serialising the file document
-        DocumentFileHandlerSPI handler = new DocumentFileHandlerSPI(0, new XStream());
+        DocumentFileHandlerSPI handler =
+                new DocumentFileHandlerSPI(
+                        0,
+                        new JMSXStreamFactory(new XStreamPersisterFactory(), new GeoServerImpl())
+                                .createXStream());
         String result = handler.createHandler().serialize(documentFile);
         // checking the serialization result
         assertThat(result, notNullValue());

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogModifyEventHandlerTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/impl/handlers/catalog/JMSCatalogModifyEventHandlerTest.java
@@ -9,12 +9,14 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
-import com.thoughtworks.xstream.XStream;
 import java.util.Arrays;
 import org.geoserver.catalog.event.CatalogEvent;
 import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.impl.CatalogModifyEventImpl;
 import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.cluster.impl.JMSXStreamFactory;
+import org.geoserver.config.impl.GeoServerImpl;
+import org.geoserver.config.util.XStreamPersisterFactory;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
@@ -31,7 +33,12 @@ public final class JMSCatalogModifyEventHandlerTest {
                 Arrays.asList("new_value", new CatalogImpl(), null, new CatalogImpl()));
         // serialise the event and deserialize it
         JMSCatalogModifyEventHandlerSPI handler =
-                new JMSCatalogModifyEventHandlerSPI(0, null, new XStream(), null);
+                new JMSCatalogModifyEventHandlerSPI(
+                        0,
+                        null,
+                        new JMSXStreamFactory(new XStreamPersisterFactory(), new GeoServerImpl())
+                                .createXStream(),
+                        null);
         String serializedEvent = handler.createHandler().serialize(catalogModifyEvent);
         CatalogEvent newEvent = handler.createHandler().deserialize(serializedEvent);
         // check the deserialized event

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/CatalogDiffVisitor.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/CatalogDiffVisitor.java
@@ -206,6 +206,10 @@ public final class CatalogDiffVisitor implements CatalogVisitor {
         StyleInfo otherStyle = otherCatalog.getStyle(style.getId());
         if (!(Objects.equals(style, otherStyle)
                 && getStyleFile(style, dataDir).equals(getStyleFile(otherStyle, otherDataDir)))) {
+            if (Objects.equals(style, otherStyle)) {
+                System.out.println(getStyleFile(style, dataDir));
+                System.out.println(getStyleFile(otherStyle, otherDataDir));
+            }
             differences.add(new InfoDiff(style, otherStyle));
         }
     }

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/InfoDiff.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/InfoDiff.java
@@ -33,4 +33,9 @@ public final class InfoDiff {
     public Info getInfoB() {
         return infoB;
     }
+
+    @Override
+    public String toString() {
+        return "InfoDiff{" + "infoA=" + infoA + ", infoB=" + infoB + '}';
+    }
 }

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTestsUtils.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTestsUtils.java
@@ -16,6 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.lang3.SerializationUtils;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -293,29 +294,31 @@ public final class IntegrationTestsUtils {
     }
 
     /** Remove info object from the provided GeoServer instance. */
-    private static void remove(GeoServer geoServer, Catalog catalog, Info info) {
+    private static void remove(GeoServer geoServer, Catalog cat, Info info) {
+        // go low level, bypass the catalog checks
+        CatalogFacade cf = cat.getFacade();
         if (info instanceof WorkspaceInfo) {
-            catalog.remove((WorkspaceInfo) info);
+            cf.remove((WorkspaceInfo) info);
         } else if (info instanceof NamespaceInfo) {
-            catalog.remove((NamespaceInfo) info);
+            cf.remove((NamespaceInfo) info);
         } else if (info instanceof DataStoreInfo) {
-            catalog.remove((DataStoreInfo) info);
+            cf.remove((DataStoreInfo) info);
         } else if (info instanceof CoverageStoreInfo) {
-            catalog.remove((CoverageStoreInfo) info);
+            cf.remove((CoverageStoreInfo) info);
         } else if (info instanceof WMSStoreInfo) {
-            catalog.remove((WMSStoreInfo) info);
+            cf.remove((WMSStoreInfo) info);
         } else if (info instanceof FeatureTypeInfo) {
-            catalog.remove((FeatureTypeInfo) info);
+            cf.remove((FeatureTypeInfo) info);
         } else if (info instanceof CoverageInfo) {
-            catalog.remove((CoverageInfo) info);
+            cf.remove((CoverageInfo) info);
         } else if (info instanceof LayerInfo) {
-            catalog.remove((LayerInfo) info);
+            cf.remove((LayerInfo) info);
         } else if (info instanceof StyleInfo) {
-            catalog.remove((StyleInfo) info);
+            cf.remove((StyleInfo) info);
         } else if (info instanceof LayerGroupInfo) {
-            catalog.remove((LayerGroupInfo) info);
+            cf.remove((LayerGroupInfo) info);
         } else if (info instanceof WMSLayerInfo) {
-            catalog.remove((WMSLayerInfo) info);
+            cf.remove((WMSLayerInfo) info);
         } else if (info instanceof SettingsInfo) {
             geoServer.remove((SettingsInfo) info);
         } else if (info instanceof ServiceInfo) {

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/rest/ClusterControllerTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/rest/ClusterControllerTest.java
@@ -46,6 +46,7 @@ public class ClusterControllerTest extends GeoServerSystemTestSupport {
     public void testGetConfigurationJSON() throws Exception {
         // get JSON properties
         JSON json = getAsJSON("rest/cluster.json");
+        print(json);
         assertThat(json, notNullValue());
         assertThat(json, instanceOf(JSONObject.class));
         JSONObject jsonObject = (JSONObject) json;

--- a/src/main/src/main/java/org/geoserver/config/util/SecureXStream.java
+++ b/src/main/src/main/java/org/geoserver/config/util/SecureXStream.java
@@ -58,6 +58,7 @@ import java.lang.reflect.Constructor;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -188,7 +189,11 @@ public class SecureXStream extends XStream {
                     Map.class,
                     HashMap.class,
                     TreeMap.class,
-                    ConcurrentHashMap.class
+                    ConcurrentHashMap.class,
+                    java.util.Collections.emptyList().getClass(),
+                    java.util.Collections.emptyMap().getClass(),
+                    java.util.Collections.emptySet().getClass(),
+                    Arrays.asList("foo").getClass()
                 });
 
         // Allow classes from user defined whitelist

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -595,6 +595,8 @@ public class XStreamPersister {
         xs.allowTypeHierarchy(Info.class);
         xs.allowTypeHierarchy(Multimap.class);
         xs.allowTypeHierarchy(JAIInfo.class);
+        xs.allowTypeHierarchy(JAIEXTInfo.class);
+        xs.allowTypeHierarchy(CoverageAccessInfo.class);
         xs.allowTypes(new Class[] {DynamicProxyMapper.DynamicProxy.class});
         xs.allowTypes(new String[] {"java.util.Collections$SingletonList"});
         xs.allowTypesByWildcard(new String[] {"org.geoserver.catalog.**"});


### PR DESCRIPTION
[![GEOS-10517](https://badgen.net/badge/JIRA/GEOS-10517/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10517)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details. While I was at it, made all tests pass again, fixing a few more things (the JMS module was completely non functional due to the XStream white list issue, don't think other tickets are useful).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->