### PR TITLE
[Backport 2.21.x] [GEOS-10851] GWC S3 Blobstore Parameters Get Converted back to plain …

### DIFF
--- a/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStoreType.java
+++ b/src/extension/gwc-s3/src/main/java/org/geoserver/gwc/web/blob/S3BlobStoreType.java
@@ -20,7 +20,7 @@ public class S3BlobStoreType implements BlobStoreType<S3BlobStoreInfo> {
     public S3BlobStoreInfo newConfigObject() {
         S3BlobStoreInfo config = new S3BlobStoreInfo();
         config.setEnabled(true);
-        config.setMaxConnections(50);
+        config.setMaxConnections("50");
         return config;
     }
 

--- a/src/extension/gwc-s3/src/test/java/org/geoserver/gwc/web/blob/S3BlobStorePageTest.java
+++ b/src/extension/gwc-s3/src/test/java/org/geoserver/gwc/web/blob/S3BlobStorePageTest.java
@@ -105,7 +105,7 @@ public class S3BlobStorePageTest extends GeoServerWicketTestSupport {
                         .getForm()
                         .get("blobSpecificPanel:awsSecretKey")
                         .getDefaultModelObject()); // check if is stored as a fake in HTML
-        assertEquals(50, ((S3BlobStoreInfo) config).getMaxConnections().intValue());
+        assertEquals("50", ((S3BlobStoreInfo) config).getMaxConnections());
         assertEquals("PRIVATE", ((S3BlobStoreInfo) config).getAccess().toString());
 
         GWC.get().removeBlobStores(Collections.singleton("myblobstore"));
@@ -134,7 +134,7 @@ public class S3BlobStorePageTest extends GeoServerWicketTestSupport {
         assertEquals("mybucket", ((S3BlobStoreInfo) config).getBucket());
         assertEquals("myaccesskey", ((S3BlobStoreInfo) config).getAwsAccessKey());
         assertEquals("mysecretkey", ((S3BlobStoreInfo) config).getAwsSecretKey());
-        assertEquals(50, ((S3BlobStoreInfo) config).getMaxConnections().intValue());
+        assertEquals("50", ((S3BlobStoreInfo) config).getMaxConnections());
         assertEquals("PUBLIC", ((S3BlobStoreInfo) config).getAccess().toString());
 
         GWC.get().removeBlobStores(Collections.singleton("myblobstore"));
@@ -146,7 +146,7 @@ public class S3BlobStorePageTest extends GeoServerWicketTestSupport {
         Field id = BlobStoreInfo.class.getDeclaredField("name");
         id.setAccessible(true);
         id.set(sconfig, "myblobstore");
-        sconfig.setMaxConnections(50);
+        sconfig.setMaxConnections("50");
         sconfig.setBucket("mybucket");
         sconfig.setAwsAccessKey("myaccesskey");
         sconfig.setAwsSecretKey("mysecretkey");
@@ -211,7 +211,7 @@ public class S3BlobStorePageTest extends GeoServerWicketTestSupport {
         assertEquals("mybucket", ((S3BlobStoreInfo) config).getBucket());
         assertEquals(null, ((S3BlobStoreInfo) config).getAwsAccessKey());
         assertEquals(null, ((S3BlobStoreInfo) config).getAwsSecretKey());
-        assertEquals(50, ((S3BlobStoreInfo) config).getMaxConnections().intValue());
+        assertEquals("50", ((S3BlobStoreInfo) config).getMaxConnections());
         assertEquals("PRIVATE", ((S3BlobStoreInfo) config).getAccess().toString());
 
         GWC.get().removeBlobStores(Collections.singleton("myblobstore"));


### PR DESCRIPTION
Backport #6582
 **Authored by:** @turingtestfail