### PR TITLE
fix(docs): correct restructuredtext links

### DIFF
--- a/doc/en/docguide/source/background.rst
+++ b/doc/en/docguide/source/background.rst
@@ -8,7 +8,7 @@ Welcome!  From all of the GeoServer users and developers, we are happy to see th
 Writing Documentation
 ---------------------
 
-GeoServer documentation written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`_, a lightweight markup syntax, and built into HTML and PDF content using `Sphinx <http://sphinx.pocoo.org>`_, a documentation framework written by the developers of Python.  In this way, the documentation could be merged with the source code of GeoServer itself, and exist in the `same repository <https://github.com/geoserver/geoserver>`_.  With this merge, version control follows naturally, so documentation can now be version specific.  
+GeoServer documentation written in `reStructuredText <https://docutils.sourceforge.io/rst.html>`_, a lightweight markup syntax, and built into HTML and PDF content using `Sphinx <http://sphinx.pocoo.org>`_, a documentation framework written by the developers of Python.  In this way, the documentation could be merged with the source code of GeoServer itself, and exist in the `same repository <https://github.com/geoserver/geoserver>`_.  With this merge, version control follows naturally, so documentation can now be version specific.  
 
 We handle changes to the documentation in the same way as we do changes to the code base, so you need to make a branch for your change and submit it as a "pull request" to the main repository, this is all explained in the :ref:`workflow` section later.
 

--- a/doc/en/docguide/source/sphinx.rst
+++ b/doc/en/docguide/source/sphinx.rst
@@ -3,7 +3,7 @@
 Sphinx Syntax
 =============
 
-This page contains syntax rules, tips, and tricks for using Sphinx and reStructuredText.  For more information, please see this  `comprehensive guide to reStructuredText <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html>`_, as well as the `Sphinx reStructuredText Primer <http://sphinx.pocoo.org/rest.html>`_.
+This page contains syntax rules, tips, and tricks for using Sphinx and reStructuredText.  For more information, please see this  `comprehensive guide to reStructuredText <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html>`_, as well as the `Sphinx reStructuredText Primer <http://sphinx.pocoo.org/rest.html>`_.
 
 Basic markup
 ------------

--- a/doc/en/docguide/source/workflow.rst
+++ b/doc/en/docguide/source/workflow.rst
@@ -75,7 +75,7 @@ Inside this directory, there are four directories::
 Make changes
 ------------
 
-Documentation in Sphinx is written in `reStructuredText <http://docutils.sourceforge.net/rst.htm>`_, a lightweight markup syntax.  For suggestions on writing reStructuredText for use with Sphinx, please see the section on :ref:`sphinx`.  For suggestions about writing style, please see the :ref:`style_guidelines`.
+Documentation in Sphinx is written in `reStructuredText <https://docutils.sourceforge.io/rst.html>`_, a lightweight markup syntax.  For suggestions on writing reStructuredText for use with Sphinx, please see the section on :ref:`sphinx`.  For suggestions about writing style, please see the :ref:`style_guidelines`.
 
 
 Build and test locally


### PR DESCRIPTION
This PR fixes the broken reStructuredText links and makes sure all the reStructuredText links use the same URL.

The reStructuredText link using `.htm` no longer worked, and were not redirected. I replaced all reStructuredText links with the current directed link, which is `https://docutils.sourceforge.io`.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] ~~I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).~~
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).