### PR TITLE
[GEOS-10837] geopackage output fails when java.io.tmpdir on network share

### DIFF
--- a/doc/en/user/source/extensions/geopkg-output/install.rst
+++ b/doc/en/user/source/extensions/geopkg-output/install.rst
@@ -24,20 +24,19 @@ To verify that the extension was installed successfully:
 
    .. code-block:: XML
 
-    <GetFeature>
-        <ResultFormat>
-            <GML2/>
-            <GML3/>
-            <SHAPE-ZIP/>
-            <CSV/>
-            <JSON/>
-            <KML/>
-            <geopackage/>
-            <geopkg/>
-            <gpkg/>
-        </ResultFormat>
-    </GetFeature>
-
+      <GetFeature>
+          <ResultFormat>
+              <GML2/>
+              <GML3/>
+              <SHAPE-ZIP/>
+              <CSV/>
+              <JSON/>
+              <KML/>
+              <geopackage/>
+              <geopkg/>
+              <gpkg/>
+          </ResultFormat>
+      </GetFeature>
 
 .. note::
 

--- a/doc/en/user/source/extensions/geopkg-output/usage.rst
+++ b/doc/en/user/source/extensions/geopkg-output/usage.rst
@@ -22,6 +22,27 @@ You can use `geopkg`, `geopackage`, or `gpkg` as the output format in the reques
 
     GeoPackages always have the ordinates in X,Y (``EAST_NORTH``) format.
 
+WFS Output Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+GeoPackage output format configuration properties are available. For information on use of configuration properties see :ref:`running in a production environment <production_config>` instructions.
+
+geopackage.wfs.indexed
+''''''''''''''''''''''
+
+By default a spatial index is generated when generating GeoPackage output.
+
+Use java system property ``-Dgeopackage.wfs.indexed=false`` to suppress the generation of a spatial index in generated geopackage output. 
+
+geopackage.wfs.tempdir
+''''''''''''''''''''''
+
+The GeoPackage file format is an SQLite database which can only be managed as a file locally.  To produce a GeoPackage GeoServer makes use of a temporary file created in ``java.io.tmpdir`` location. This temporary file is removed once the response is completed.
+
+Some container environments recommend use of a network share for their ``java.io.tmpdir`` location. This approach is not compatible with SQLite database driver which requires a local disk location and file lock.
+
+To override the temporary file location used for GeoPackage output format file generation use property ``-Dgeopackage.wfs.tempdir=<path location>`` to provide an alternate path.
+
 WMS
 ^^^
 
@@ -46,8 +67,8 @@ You can use ``format=geopkg``, ``format=geopackage``, or ``format=gpkg`` as the 
 .. note::
     Regardless of WMS axis order used for ``bbox`` the resulting GeoPackages always have the ordinates in X,Y (``EAST_NORTH``) order as required by the specification.
 
-Format options
-~~~~~~~~~~~~~~
+WMS Format options
+''''''''''''''''''
 
 You can also add format options (``format_options=param1:value1;param2:value2;...``) to the request.   With all default values, you will get a GeoPackage with PNG tiles of multiple resolutions.  There will be a little more than 255 total tiles - all occupying the area in the request's bbox.
 
@@ -101,4 +122,3 @@ You can also add format options (``format_options=param1:value1;param2:value2;..
      - Do NOT set.
 
        default: TRUE (required for GeoPackage - `The tile coordinate (0,0) always refers to the tile in the upper left corner of the tile matrix...`)
-

--- a/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/wfs/GeoPackageGetFeatureOutputFormat.java
+++ b/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/wfs/GeoPackageGetFeatureOutputFormat.java
@@ -47,7 +47,7 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
     protected static Logger LOGGER = Logging.getLogger(GeoPackageGetFeatureOutputFormat.class);
 
     public static final String PROPERTY_INDEXED = "geopackage.wfs.indexed";
-    public static final String CUSTOM_TEMP_DIR_PROPERTY = "geopackage.getfeatureoutput.tempdir";
+    public static final String CUSTOM_TEMP_DIR_PROPERTY = "geopackage.wfs.tempdir";
 
     public GeoPackageGetFeatureOutputFormat(GeoServer gs) {
         super(gs, Sets.union(Sets.newHashSet(MIME_TYPES), Sets.newHashSet(NAMES)));

--- a/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/wfs/GeoPackageGetFeatureOutputFormat.java
+++ b/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/wfs/GeoPackageGetFeatureOutputFormat.java
@@ -87,9 +87,9 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
      * <p>If the CUSTOM_TEMP_DIR_PROPERTY directory doesn't exist (or isnt a directory), then an
      * exception is thrown
      *
-     * @param prefix
-     * @param suffix
-     * @return
+     * @param prefix filename prefix, must be three characters or more
+     * @param suffix filename suffix, or if null {@code null} suffix {@code ".tmp") used
+     * @return path to newly created temporary file
      */
     File createTempFile(String prefix, String suffix) throws IOException {
         String customTempDir = GeoServerExtensions.getProperty(CUSTOM_TEMP_DIR_PROPERTY);


### PR DESCRIPTION
[![GEOS-10837](https://badgen.net/badge/JIRA/GEOS-10837/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10837)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This allows the user to set a property (i.e. `-Dgeopackage.getfeatureoutput.tempdir=/path/to/temp`) that uses an alternative temp dir for the geopackage.  For people with the standard java temp dir being a mounted network drive, they should use this (pointing to a local drive).

GeoPKG (SQL Lite) has a lot of problems locking when writing to cloud (or network-mounted) file systems.

NOTE: I moved the test cases into the "proper" package (to match the class-under-test `GeoPackageGetFeatureOutputFormat`).
  

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [n/a] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [n/a] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->