### PR TITLE
GEOS-10500 WFS-T unable to delete more than 30 features in a single t…

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/request/Delete.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/request/Delete.java
@@ -16,6 +16,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.xsd.EMFUtils;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
+import org.opengis.filter.Or;
 
 /**
  * Delete element in a Transaction request.
@@ -80,12 +81,9 @@ public abstract class Delete extends TransactionElement {
         Filter currentFilter = (Filter) EMFUtils.get(obj, property);
 
         List<Filter> filters = new ArrayList<>();
-        if (newFilter != null) {
-            filters.add(newFilter);
-        }
-        if (currentFilter != null) {
-            filters.add(currentFilter);
-        }
+
+        flattenFilter(newFilter, filters);
+        flattenFilter(currentFilter, filters);
 
         Filter result;
         if (filters.isEmpty()) {
@@ -100,6 +98,16 @@ public abstract class Delete extends TransactionElement {
             ((DeleteElementTypeImpl) obj).setFilter(result);
         } else if (obj instanceof DeleteTypeImpl) {
             ((DeleteTypeImpl) obj).setFilter(result);
+        }
+    }
+
+    private void flattenFilter(Filter filter, List<Filter> filters) {
+        if (filter != null) {
+            if (filter instanceof Or) {
+                filters.addAll(((Or) filter).getChildren());
+            } else {
+                filters.add(filter);
+            }
         }
     }
 }


### PR DESCRIPTION
[![GEOS-10500](https://badgen.net/badge/JIRA/GEOS-10500/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10500)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10500 WFS-T unable to delete more than 30 features in a single transaction when the data source is PostGIS]

Deleting reasonably large batch of features (in this case 30) took enormous amounts of time
due to the way filters are aggregated on deletion. A new filter is added each time, and if added filter has nested filters (children) such process creates filters with deeply nested structure.
Example:
[[ 30 ] OR [[ 29 ] OR [[ 28 ] OR [[ 27 ] OR [[ 26 ] OR [[ 25 ] OR [[ 24 ] OR [[ 23 ] OR [[ 22 ] OR [[ 21 ] OR [[ 20 ] OR [[ 19 ] OR [[ 18 ] OR [[ 17 ] OR [[ 16 ] OR [[ 15 ] OR [[ 14 ] OR [[ 13 ] OR [[ 12 ] OR [[ 11 ] OR [[ 10 ] OR [[ 9 ] OR [[ 8 ] OR [[ 7 ] OR [[ 6 ] OR [[ 5 ] OR [[ 4 ] OR [[ 3 ] OR [[ 2 ] OR [ 1 ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]

Changes were added to join all "children" on one layer instead of creating nested structure.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->