### PR TITLE
[2.18.x][GEOS-10842] Escape user inputs in SQL queries 

### DIFF
--- a/doc/en/developer/source/conf.py
+++ b/doc/en/developer/source/conf.py
@@ -100,15 +100,15 @@ pygments_style = 'sphinx'
 # -----------------------------------
 
 extlinks = { 
-    'wiki': ('https://github.com/geoserver/geoserver/wiki/%s',''),
-    'website': ('http://geoserver.org/%s',''),
-    'user': ('http://docs.geoserver.org/'+branch+'/en/user/%s',''),
-    'developer': ('http://docs.geoserver.org/latest/en/developer/%s',''),
-    'docguide': ('http://docs.geoserver.org/latest/en/docguide/%s',''),
-    'geotools': ('https://docs.geotools.org/stable/userguide/%s',''),
-    'geos': ('https://osgeo-org.atlassian.net/browse/GEOS-%s','GEOS-'),
-    'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-'),
-    'api': ('http://docs.geoserver.org/stable/en/api/#1.0.0/%s','')
+    'wiki': ('https://github.com/geoserver/geoserver/wiki/%s',None),
+    'website': ('http://geoserver.org/%s',None),
+    'user': ('http://docs.geoserver.org/'+branch+'/en/user/%s',None),
+    'developer': ('http://docs.geoserver.org/latest/en/developer/%s',None),
+    'docguide': ('http://docs.geoserver.org/latest/en/docguide/%s',None),
+    'geotools': ('https://docs.geotools.org/stable/userguide/%s',None),
+    'geos': ('https://osgeo-org.atlassian.net/browse/GEOS-%s','GEOS-%'),
+    'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-%'),
+    'api': ('http://docs.geoserver.org/stable/en/api/#1.0.0/%s',None)
 }
 
 # Options for HTML output

--- a/doc/en/developer/source/programming-guide/wps-services/design-guide.rst
+++ b/doc/en/developer/source/programming-guide/wps-services/design-guide.rst
@@ -99,7 +99,7 @@ Once the ProcessFilter is coded it can be activated by declaring it in the Sprin
 for example the ``ProcessSelector`` subclass that controls which processes can be exposed based on
 the WPS admin panel configuration is registered in ``applicationContext.xml`` as follows:
 
-.. code-block:: java
+.. code-block:: xml
 
     <!-- The default process filters -->
     <bean id="unsupportedParameterTypeProcessFilter" class="org.geoserver.wps.UnsupportedParameterTypeProcessFilter"/>

--- a/doc/en/user/source/conf.py
+++ b/doc/en/user/source/conf.py
@@ -57,6 +57,7 @@ release = '2.18-SNAPSHOT'
 branch = '2.18.x'
 
 # Users don't need to see the "SNAPSHOT" notation when it's there
+download = release
 if release.find('SNAPSHOT') != -1:
    release = '2.18.x'
    download_release = 'https://build.geoserver.org/geoserver/'+branch+'/geoserver-'+version+'.x-latest-%s.zip'
@@ -105,18 +106,18 @@ pygments_style = 'sphinx'
 # -----------------------------------
 
 extlinks = { 
-    'wiki': ('https://github.com/geoserver/geoserver/wiki/%s',''),
-    'website': ('http://geoserver.org/%s',''),
-    'user': ('http://docs.geoserver.org/'+branch+'/en/user/%s',''),
-    'developer': ('http://docs.geoserver.org/latest/en/developer/%s',''),
-    'docguide': ('http://docs.geoserver.org/latest/en/docguide/%s',''),
-    'geos': ('https://osgeo-org.atlassian.net/browse/GEOS-%s','GEOS-'),
-    'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-'),
-    'api': ('http://docs.geoserver.org/stable/en/api/#1.0.0/%s',''),
-    'geotools': ('https://docs.geotools.org/stable/userguide/%s',''),
-    'download_release': (download_release,None),
-    'download_extension': (download_extension,None),
-    'download_community': (download_community,None)
+    'wiki': ('https://github.com/geoserver/geoserver/wiki/%s',None),
+    'website': ('http://geoserver.org/%s',None),
+    'user': ('http://docs.geoserver.org/'+branch+'/en/user/%s',None),
+    'developer': ('http://docs.geoserver.org/latest/en/developer/%s',None),
+    'docguide': ('http://docs.geoserver.org/latest/en/docguide/%s',None),
+    'geos': ('https://osgeo-org.atlassian.net/browse/GEOS-%s','GEOS-%s'),
+    'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-%s'),
+    'api': ('http://docs.geoserver.org/stable/en/api/#1.0.0/%s',None),
+    'geotools': ('https://docs.geotools.org/stable/userguide/%s',None),
+    'download_release': (download_release,'geoserver-'+download+'-%s.zip'),
+    'download_extension': (download_extension,'geoserver-'+download+'-%s-plugin.zip'),
+    'download_community': (download_community,'geoserver-'+download+'-%s-plugin.zip')
 }
 
 # Common substitutions

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -103,6 +103,7 @@ import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.impl.CoverageAccessInfoImpl;
 import org.geoserver.config.impl.GeoServerInfoImpl;
 import org.geoserver.config.impl.JAIInfoImpl;
+import org.geoserver.jdbcloader.JDBCLoaderProperties;
 import org.geoserver.ows.util.OwsUtils;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.util.CacheProvider;
@@ -159,6 +160,8 @@ public class ConfigDatabase implements ApplicationContextAware {
 
     private Dialect dialect;
 
+    private JDBCLoaderProperties properties;
+
     private DataSource dataSource;
 
     private DbMappings dbMappings;
@@ -193,15 +196,19 @@ public class ConfigDatabase implements ApplicationContextAware {
         //
     }
 
-    public ConfigDatabase(final DataSource dataSource, final XStreamInfoSerialBinding binding) {
-        this(dataSource, binding, null);
+    public ConfigDatabase(
+            JDBCLoaderProperties properties,
+            DataSource dataSource,
+            XStreamInfoSerialBinding binding) {
+        this(properties, dataSource, binding, null);
     }
 
     public ConfigDatabase(
+            JDBCLoaderProperties properties,
             final DataSource dataSource,
             final XStreamInfoSerialBinding binding,
             CacheProvider cacheProvider) {
-
+        this.properties = properties;
         this.binding = binding;
         this.template = new NamedParameterJdbcTemplate(dataSource);
         // cannot use dataSource at this point due to spring context config hack
@@ -222,7 +229,7 @@ public class ConfigDatabase implements ApplicationContextAware {
 
     private Dialect dialect() {
         if (dialect == null) {
-            this.dialect = Dialect.detect(dataSource);
+            this.dialect = Dialect.detect(dataSource, properties.isDebugMode());
         }
         return dialect;
     }
@@ -286,7 +293,7 @@ public class ConfigDatabase implements ApplicationContextAware {
 
         QueryBuilder<T> sqlBuilder = QueryBuilder.forCount(dialect, of, dbMappings).filter(filter);
 
-        final StringBuilder sql = sqlBuilder.build();
+        final String sql = sqlBuilder.build();
         final Filter unsupportedFilter = sqlBuilder.getUnsupportedFilter();
         final boolean fullySupported = Filter.INCLUDE.equals(unsupportedFilter);
         if (LOGGER.isLoggable(Level.FINER)) {
@@ -299,7 +306,7 @@ public class ConfigDatabase implements ApplicationContextAware {
             final Map<String, Object> namedParameters = sqlBuilder.getNamedParameters();
             logStatement(sql, namedParameters);
 
-            count = template.queryForObject(sql.toString(), namedParameters, Integer.class);
+            count = template.queryForObject(sql, namedParameters, Integer.class);
         } else {
             LOGGER.fine(
                     "Filter is not fully supported, doing scan of supported part to return the number of matches");
@@ -355,7 +362,7 @@ public class ConfigDatabase implements ApplicationContextAware {
                         .offset(offset)
                         .limit(limit)
                         .sortOrder(sortOrder);
-        final StringBuilder sql = sqlBuilder.build();
+        final String sql = sqlBuilder.build();
 
         List<String> ids = null;
 
@@ -398,7 +405,7 @@ public class ConfigDatabase implements ApplicationContextAware {
             // with rownum in the 2nd - queryForList will throw an exception
             ids =
                     template.query(
-                            sql.toString(),
+                            sql,
                             namedParameters,
                             new RowMapper<String>() {
                                 @Override
@@ -465,7 +472,7 @@ public class ConfigDatabase implements ApplicationContextAware {
 
         QueryBuilder<T> sqlBuilder = QueryBuilder.forIds(dialect, of, dbMappings).filter(filter);
 
-        final StringBuilder sql = sqlBuilder.build();
+        final String sql = sqlBuilder.build();
         final Map<String, Object> namedParameters = sqlBuilder.getNamedParameters();
         final Filter unsupportedFilter = sqlBuilder.getUnsupportedFilter();
         final boolean fullySupported = Filter.INCLUDE.equals(unsupportedFilter);
@@ -482,7 +489,7 @@ public class ConfigDatabase implements ApplicationContextAware {
         // with rownum in the 2nd - queryForList will throw an exception
         List<String> ids =
                 template.query(
-                        sql.toString(),
+                        sql,
                         namedParameters,
                         new RowMapper<String>() {
                             @Override

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/Dialect.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/Dialect.java
@@ -8,12 +8,20 @@ package org.geoserver.jdbcconfig.internal;
 import com.google.common.base.Joiner;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
 public class Dialect {
 
-    public static Dialect detect(DataSource dataSource) {
+    // see
+    // https://github.com/hibernate/hibernate-orm/commit/59fede7acaaa1579b561407aefa582311f7ebe78
+    private static final Pattern ESCAPE_CLOSING_COMMENT_PATTERN = Pattern.compile("\\*/");
+    private static final Pattern ESCAPE_OPENING_COMMENT_PATTERN = Pattern.compile("/\\*");
+
+    private boolean debugMode;
+
+    public static Dialect detect(DataSource dataSource, boolean debugMode) {
         Dialect dialect;
         try {
             Connection conn = dataSource.getConnection();
@@ -27,7 +35,44 @@ public class Dialect {
         } catch (SQLException ex) {
             throw new RuntimeException(ex);
         }
+        dialect.setDebugMode(debugMode);
         return dialect;
+    }
+
+    public boolean isDebugMode() {
+        return debugMode;
+    }
+
+    public void setDebugMode(boolean debugMode) {
+        this.debugMode = debugMode;
+    }
+
+    /** Escapes the contents of the SQL comment to prevent SQL injection. */
+    public String escapeComment(String comment) {
+        String escaped = ESCAPE_CLOSING_COMMENT_PATTERN.matcher(comment).replaceAll("*\\\\/");
+        return ESCAPE_OPENING_COMMENT_PATTERN.matcher(escaped).replaceAll("/\\\\*");
+    }
+
+    /** Appends the objects to the SQL in a comment if debug mode is enabled. */
+    public StringBuilder appendComment(StringBuilder sql, Object... objects) {
+        if (!debugMode) {
+            return sql;
+        }
+        sql.append(" /* ");
+        for (Object object : objects) {
+            sql.append(escapeComment(String.valueOf(object)));
+        }
+        return sql.append(" */\n");
+    }
+
+    /** Appends the objects to the SQL in an comment if debug mode is enabled. */
+    public StringBuilder appendComment(Object sql, Object... objects) {
+        return appendComment((StringBuilder) sql, objects);
+    }
+
+    /** Appends one of the strings to the SQL depending on whether debug mode is enabled. */
+    public StringBuilder appendIfDebug(StringBuilder sql, String ifEnabled, String ifDisabled) {
+        return sql.append(debugMode ? ifEnabled : ifDisabled);
     }
 
     public void applyOffsetLimit(

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/FilterToCatalogSQL.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/FilterToCatalogSQL.java
@@ -19,6 +19,7 @@ import org.geoserver.function.IsInstanceOf;
 import org.geotools.filter.Capabilities;
 import org.geotools.filter.LikeFilterImpl;
 import org.opengis.filter.And;
+import org.opengis.filter.BinaryLogicOperator;
 import org.opengis.filter.ExcludeFilter;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
@@ -94,13 +95,16 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
         CAPABILITIES = builder.getContents();
     }
 
+    private final Dialect dialect;
+
     private final Class<?> queryType;
 
     private final DbMappings dbMappings;
 
     private Map<String, Object> namedParams;
 
-    public FilterToCatalogSQL(Class<?> queryType, DbMappings dbMappings) {
+    public FilterToCatalogSQL(Dialect dialect, Class<?> queryType, DbMappings dbMappings) {
+        this.dialect = dialect;
         this.queryType = queryType;
         this.dbMappings = dbMappings;
         namedParams = Maps.newHashMap();
@@ -133,8 +137,7 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
      */
     @Override
     public Object visit(ExcludeFilter filter, Object extraData) {
-        append(extraData, "(1=0) /* EXCLUDE */\n");
-        return extraData;
+        return dialect.appendComment(append(extraData, "0 = 1"), "EXCLUDE");
     }
 
     /**
@@ -143,8 +146,7 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
      */
     @Override
     public Object visit(IncludeFilter filter, Object extraData) {
-        append(extraData, "(1=1) /* INCLUDE */\n");
-        return extraData;
+        return dialect.appendComment(append(extraData, "1 = 1"), "INCLUDE");
     }
 
     /**
@@ -172,81 +174,57 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
             String valueCol1 = matchingCase ? "o1.value" : "UPPER(o1.value)";
             String valueCol2 = matchingCase ? "o2.value" : "UPPER(o2.value)";
 
-            StringBuilder builder;
-
             switch (matchAction) {
                     // respect matchaction
                 case ALL: // all = another value for the property may not occur
-                    builder =
-                            append(
-                                    extraData,
-                                    "oid NOT IN (SELECT o1.oid FROM object_property o1, object_property o2 WHERE(o1.oid=o2.oid)  ",
-                                    "AND o1.property_type IN (:",
-                                    propertyTypesParam1,
-                                    ") ",
-                                    "AND o2.property_type IN (:",
-                                    propertyTypesParam2,
-                                    ") ",
-                                    "AND ",
-                                    valueCol1,
-                                    " != ",
-                                    valueCol2,
-                                    " ) /* ",
-                                    filter.toString(),
-                                    " */ \n");
+                    append(
+                            extraData,
+                            "oid NOT IN (SELECT o1.oid FROM object_property o1, object_property o2 WHERE o1.oid = o2.oid ",
+                            "AND o1.property_type IN (:",
+                            propertyTypesParam1,
+                            ") AND o2.property_type IN (:",
+                            propertyTypesParam2,
+                            ") AND ",
+                            valueCol1,
+                            " != ",
+                            valueCol2,
+                            ")");
                     break;
                 case ANY: // any = the value for the property must occur at least once
-                    builder =
-                            append(
-                                    extraData,
-                                    "oid IN (SELECT o1.oid FROM object_property o1, object_property o2 WHERE(o1.oid=o2.oid)  ",
-                                    "AND o1.property_type IN (:",
-                                    propertyTypesParam1,
-                                    ") ",
-                                    "AND o2.property_type IN (:",
-                                    propertyTypesParam2,
-                                    ") ",
-                                    "AND ",
-                                    valueCol1,
-                                    " = ",
-                                    valueCol2,
-                                    " ) /* ",
-                                    filter.toString(),
-                                    " */ \n");
+                    append(
+                            extraData,
+                            "oid IN (SELECT o1.oid FROM object_property o1, object_property o2 WHERE o1.oid = o2.oid ",
+                            "AND o1.property_type IN (:",
+                            propertyTypesParam1,
+                            ") AND o2.property_type IN (:",
+                            propertyTypesParam2,
+                            ") AND ",
+                            valueCol1,
+                            " = ",
+                            valueCol2,
+                            ")");
                     break;
                 case ONE: // one = the value for the property must occur exactly once
-                    builder =
-                            append(
-                                    extraData,
-                                    "oid IN (SELECT o1.oid FROM object_property o1, object_property o2 WHERE(o1.oid=o2.oid) ",
-                                    "AND o1.property_type IN (:",
-                                    propertyTypesParam1,
-                                    ") ",
-                                    "AND o2.property_type IN (:",
-                                    propertyTypesParam2,
-                                    ") ",
-                                    "AND ",
-                                    valueCol1,
-                                    " = ",
-                                    valueCol2,
-                                    " GROUP BY (oid) HAVING COUNT(oid)=1) /* ",
-                                    filter.toString(),
-                                    "/* ",
-                                    filter.toString(),
-                                    " */ \n");
+                    append(
+                            extraData,
+                            "oid IN (SELECT o1.oid FROM object_property o1, object_property o2 WHERE o1.oid = o2.oid ",
+                            "AND o1.property_type IN (:",
+                            propertyTypesParam1,
+                            ") AND o2.property_type IN (:",
+                            propertyTypesParam2,
+                            ") AND ",
+                            valueCol1,
+                            " = ",
+                            valueCol2,
+                            " GROUP BY (oid) HAVING COUNT(oid) = 1)");
                     break;
                 default:
                     throw new IllegalArgumentException("MatchAction: " + matchAction);
             }
-
-            return builder;
-
         } else {
 
             if (filter.getExpression1() instanceof IsInstanceOf) {
-                StringBuilder builder =
-                        append(extraData, handleInstanceOf((IsInstanceOf) filter.getExpression1()));
-                return builder;
+                return handleInstanceOf((IsInstanceOf) filter.getExpression1(), extraData);
             }
 
             // comparing a literal with a field
@@ -272,74 +250,60 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
                 expectedValue = expectedValue.toUpperCase();
             }
             String valueParam = newParam("value", expectedValue);
-
-            StringBuilder builder;
             String valueCol = matchingCase ? "value" : "UPPER(value)";
 
             switch (matchAction) {
                     // respect match action
                 case ALL: // all = another value for the property may not occur
-                    builder =
-                            append(
-                                    extraData,
-                                    "oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:",
-                                    propertyTypesParam,
-                                    ") AND ",
-                                    valueCol,
-                                    " != :",
-                                    valueParam,
-                                    ") /* ",
-                                    filter.toString(),
-                                    " */ \n");
+                    append(
+                            extraData,
+                            "oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                            propertyTypesParam,
+                            ") AND ",
+                            valueCol,
+                            " != :",
+                            valueParam,
+                            ")");
                     break;
                 case ANY: // any = the value for the property must occur at least once
-                    builder =
-                            append(
-                                    extraData,
-                                    "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
-                                    propertyTypesParam,
-                                    ") AND ",
-                                    valueCol,
-                                    " = :",
-                                    valueParam,
-                                    ") /* ",
-                                    filter.toString(),
-                                    " */ \n");
+                    append(
+                            extraData,
+                            "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                            propertyTypesParam,
+                            ") AND ",
+                            valueCol,
+                            " = :",
+                            valueParam,
+                            ")");
                     break;
                 case ONE: // one = the value for the property must occur exactly once
-                    builder =
-                            append(
-                                    extraData,
-                                    "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
-                                    propertyTypesParam,
-                                    ") AND ",
-                                    valueCol,
-                                    " = :",
-                                    valueParam,
-                                    " GROUP BY (oid) HAVING COUNT(oid)=1) /* ",
-                                    filter.toString(),
-                                    " */ \n");
+                    append(
+                            extraData,
+                            "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                            propertyTypesParam,
+                            ") AND ",
+                            valueCol,
+                            " = :",
+                            valueParam,
+                            " GROUP BY (oid) HAVING COUNT(oid) = 1)");
                     break;
                 default:
                     throw new IllegalArgumentException("MatchAction: " + matchAction);
             }
-
-            return builder;
         }
+        return dialect.appendComment(extraData, filter);
     }
 
-    private String handleInstanceOf(IsInstanceOf instanceOf) {
+    private Object handleInstanceOf(IsInstanceOf instanceOf, Object extraData) {
         Expression expression1 = instanceOf.getParameters().get(0);
 
-        Class clazz = expression1.evaluate(null, Class.class);
-
-        if (clazz == null || dbMappings.getTypeId(clazz) == null) {
-            return "(1=0) /* EXCLUDE */\n";
-        }
-
+        Class<?> clazz = expression1.evaluate(null, Class.class);
         Integer typeId = dbMappings.getTypeId(clazz);
-
-        return "type_id = " + typeId + "/* isInstanceOf " + clazz.toString() + " */ \n";
+        if (typeId == null) {
+            return visit(Filter.EXCLUDE, extraData);
+        }
+        append(extraData, "type_id = ", typeId.toString());
+        return dialect.appendComment(extraData, "isInstanceOf ", clazz.getName());
     }
 
     /**
@@ -349,7 +313,6 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
     @Override
     public Object visit(PropertyIsLike filter, Object extraData) {
         final PropertyName expression1 = (PropertyName) filter.getExpression();
-        // TODO: check for indexed property name
 
         final String propertyTypesParam = propertyTypesParam(expression1);
 
@@ -361,63 +324,52 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
         final boolean matchCase = filter.isMatchingCase();
 
         final String pattern =
-                LikeFilterImpl.convertToSQL92(esc, multi, single, matchCase, literal);
+                LikeFilterImpl.convertToSQL92(esc, multi, single, matchCase, literal, false);
 
         // respect match case
+        String valueParam = newParam("value", pattern);
         String valueCol = matchCase ? "value" : "UPPER(value)";
-
-        StringBuilder builder;
 
         switch (matchAction) {
                 // respect match action
             case ALL: // all = another value for the property may not occur
-                builder =
-                        append(
-                                extraData,
-                                "oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:",
-                                propertyTypesParam,
-                                ") AND NOT(",
-                                valueCol,
-                                " LIKE '",
-                                pattern,
-                                "')) /* ",
-                                filter.toString(),
-                                " */ \n");
+                append(
+                        extraData,
+                        "oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                        propertyTypesParam,
+                        ") AND ",
+                        valueCol,
+                        " NOT LIKE :",
+                        valueParam,
+                        ")");
                 break;
             case ANY: // any = the value for the property must occur at least once
-                builder =
-                        append(
-                                extraData,
-                                "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
-                                propertyTypesParam,
-                                ") AND ",
-                                valueCol,
-                                " LIKE '",
-                                pattern,
-                                "') /* ",
-                                filter.toString(),
-                                " */ \n");
+                append(
+                        extraData,
+                        "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                        propertyTypesParam,
+                        ") AND ",
+                        valueCol,
+                        " LIKE :",
+                        valueParam,
+                        ")");
                 break;
             case ONE: // one = the value for the property must occur exactly once
-                builder =
-                        append(
-                                extraData,
-                                "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
-                                propertyTypesParam,
-                                ") AND ",
-                                valueCol,
-                                " LIKE '",
-                                pattern,
-                                "' ",
-                                "GROUP BY (oid) HAVING COUNT(oid)=1 ) /* ",
-                                filter.toString(),
-                                " */ \n");
+                append(
+                        extraData,
+                        "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                        propertyTypesParam,
+                        ") AND ",
+                        valueCol,
+                        " LIKE :",
+                        valueParam,
+                        " GROUP BY (oid) HAVING COUNT(oid) = 1)");
+
                 break;
             default:
                 throw new IllegalArgumentException("MatchAction: " + matchAction);
         }
-
-        return builder;
+        return dialect.appendComment(extraData, filter);
     }
 
     private String propertyTypesParam(final PropertyName property) {
@@ -478,40 +430,30 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
     /** @see org.opengis.filter.FilterVisitor#visit(org.opengis.filter.And, java.lang.Object) */
     @Override
     public Object visit(And filter, Object extraData) {
-        StringBuilder sql = (StringBuilder) extraData;
-
-        List<Filter> children = filter.getChildren();
-        checkArgument(children.size() > 0);
-        sql.append("(\n\t");
-
-        for (Iterator<Filter> it = children.iterator(); it.hasNext(); ) {
-            Filter child = it.next();
-            sql = (StringBuilder) child.accept(this, sql);
-            if (it.hasNext()) {
-                sql = append(extraData, "\tAND\n\t");
-            }
-        }
-        sql.append(")");
-        return sql;
+        return visit(filter, "AND", extraData);
     }
 
     /** @see org.opengis.filter.FilterVisitor#visit(org.opengis.filter.Or, java.lang.Object) */
     @Override
     public Object visit(Or filter, Object extraData) {
-        StringBuilder sql = (StringBuilder) extraData;
+        return visit(filter, "OR", extraData);
+    }
 
+    protected Object visit(BinaryLogicOperator filter, String type, Object extraData) {
+        StringBuilder sql = (StringBuilder) extraData;
         List<Filter> children = filter.getChildren();
         checkArgument(children.size() > 0);
-        sql.append("(");
+        sql.append('(');
+        dialect.appendIfDebug(sql, "\n    ", "");
         for (Iterator<Filter> it = children.iterator(); it.hasNext(); ) {
-            Filter child = it.next();
-            sql = (StringBuilder) child.accept(this, sql);
+            it.next().accept(this, sql);
             if (it.hasNext()) {
-                sql = append(extraData, "\tOR\n\t");
+                dialect.appendIfDebug(sql, "    ", " ");
+                sql.append(type);
+                dialect.appendIfDebug(sql, "\n    ", " ");
             }
         }
-        sql.append(")");
-        return sql;
+        return sql.append(')');
     }
 
     /** @see org.opengis.filter.FilterVisitor#visit(org.opengis.filter.Id, java.lang.Object) */
@@ -524,8 +466,13 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
     /** @see org.opengis.filter.FilterVisitor#visit(org.opengis.filter.Not, java.lang.Object) */
     @Override
     public Object visit(Not filter, Object extraData) {
-
-        return filter.getFilter().accept(this, append(extraData, " NOT "));
+        Filter child = filter.getFilter();
+        // these filter types are already enclosed in parentheses
+        boolean extraParens =
+                !(child instanceof And || child instanceof Or || child instanceof PropertyIsNull);
+        append(extraData, "NOT ", extraParens ? "(" : "");
+        child.accept(this, extraData);
+        return append(extraData, extraParens ? ")" : "");
     }
 
     /**
@@ -588,17 +535,14 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
         final PropertyName propertyName = (PropertyName) filter.getExpression();
         final String propertyTypesParam = propertyTypesParam(propertyName);
 
-        StringBuilder builder =
-                append(
-                        extraData,
-                        "(oid IN (select oid from object_property where property_type in (:",
-                        propertyTypesParam,
-                        ") and value IS NULL) OR oid NOT  in (select oid from object_property where property_type in (:"
-                                + propertyTypesParam
-                                + "))) /* ",
-                        filter.toString(),
-                        " */ \n");
-        return builder;
+        append(
+                extraData,
+                "(oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                propertyTypesParam,
+                ") AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                propertyTypesParam,
+                ")))");
+        return dialect.appendComment(extraData, filter);
     }
 
     /**
@@ -610,15 +554,12 @@ public class FilterToCatalogSQL implements FilterVisitor, ExpressionVisitor {
         final PropertyName propertyName = (PropertyName) filter.getExpression();
         final String propertyTypesParam = propertyTypesParam(propertyName);
 
-        StringBuilder builder =
-                append(
-                        extraData,
-                        "oid IN (select oid from object_property where property_type in (:",
-                        propertyTypesParam,
-                        ") and value IS NULL) /* ",
-                        filter.toString(),
-                        " */ \n");
-        return builder;
+        append(
+                extraData,
+                "oid IN (SELECT oid FROM object_property WHERE property_type IN (:",
+                propertyTypesParam,
+                ") AND value IS NULL)");
+        return dialect.appendComment(extraData, filter);
     }
 
     /**

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/OracleDialect.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/OracleDialect.java
@@ -21,13 +21,18 @@ public class OracleDialect extends Dialect {
             limit += 1; // not zero-based
         }
         if (offset != null && limit != null) {
-            sql.insert(0, "select * from ( select query.*, rownum rnum from (\n");
-            sql.append(") query\n");
+            sql.insert(
+                    0,
+                    "SELECT * FROM (SELECT query.*, rownum rnum FROM ("
+                            + (isDebugMode() ? "\n" : ""));
+            sql.append(") query");
+            appendIfDebug(sql, "\n", " ");
             if (limit != Integer.MAX_VALUE) {
                 limit = offset + limit;
             }
-            sql.append("where rownum <= ").append(limit).append(")\n");
-            sql.append("where rnum > ").append(offset);
+            sql.append("WHERE rownum <= ").append(limit).append(")");
+            appendIfDebug(sql, "\n", " ");
+            sql.append("WHERE rnum > ").append(offset);
         }
     }
 

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/QueryBuilder.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/QueryBuilder.java
@@ -123,7 +123,7 @@ class QueryBuilder<T extends Info> {
         return this;
     }
 
-    private void querySortBy(StringBuilder query, StringBuilder whereClause, SortBy[] orders) {
+    private void querySortBy(StringBuilder query, String whereClause, SortBy[] orders) {
 
         /*
          * Start with the oid and id from the object table selecting for type and the filter.
@@ -139,15 +139,15 @@ class QueryBuilder<T extends Info> {
 
         int i = 0;
 
-        query.append("SELECT id FROM ");
-
-        query.append("\n    (SELECT oid, id FROM object WHERE ");
-        if (queryType != null) {
-            query.append("type_id in (:types) /* ")
-                    .append(queryType.getCanonicalName())
-                    .append(" */\n      AND ");
+        query.append("SELECT id FROM");
+        dialect.appendIfDebug(query, "\n    ", " ");
+        query.append("(SELECT oid, id FROM object WHERE type_id IN (:types)");
+        dialect.appendComment(query, queryType.getName());
+        if (whereClause != null) {
+            dialect.appendIfDebug(query, "      ", " ");
+            query.append("AND ").append(whereClause);
         }
-        query.append(whereClause).append(") object");
+        query.append(") object");
 
         for (SortBy order : orders) {
             final String sortProperty = order.getPropertyName().getPropertyName();
@@ -162,35 +162,36 @@ class QueryBuilder<T extends Info> {
             Map<String, Object> namedParameters = getNamedParameters();
             namedParameters.put(propertyParamName, sortPropertyTypeIds);
 
-            query.append("\n  LEFT JOIN");
-            query.append("\n    (SELECT oid, value ")
-                    .append(attributeName)
-                    .append(" FROM \n      object_property WHERE property_type IN (:")
+            dialect.appendIfDebug(query, "\n  ", " ");
+            query.append("LEFT JOIN");
+            dialect.appendIfDebug(query, "\n    ", " ");
+            query.append("(SELECT oid, value ").append(attributeName).append(" FROM");
+            dialect.appendIfDebug(query, "\n      ", " ");
+            query.append("object_property WHERE property_type IN (:")
                     .append(propertyParamName)
                     .append(")) ")
                     .append(subSelectName);
-
-            query.append("  /* ")
-                    .append(order.getPropertyName().getPropertyName())
-                    .append(" ")
-                    .append(ascDesc(order))
-                    .append(" */");
-
-            query.append("\n  ON object.oid = ").append(subSelectName).append(".oid");
+            dialect.appendComment(
+                    query, order.getPropertyName().getPropertyName(), " ", ascDesc(order));
+            dialect.appendIfDebug(query, "  ", " ");
+            query.append("ON object.oid = ").append(subSelectName).append(".oid");
             // Update the ORDER BY clause to be added later
             if (i > 0) orderBy.append(", ");
             orderBy.append(attributeName).append(" ").append(ascDesc(order));
 
             i++;
         }
-
-        query.append("\n  ").append(orderBy);
+        dialect.appendIfDebug(query, "\n  ", " ");
+        query.append(orderBy);
     }
 
-    private StringBuilder buildWhereClause() {
+    private String buildWhereClause() {
+        this.predicateBuilder =
+                new FilterToCatalogSQL(this.dialect, this.queryType, this.dbMappings);
+        if (Filter.INCLUDE.equals(this.originalFilter)) {
+            return null;
+        }
         final SimplifyingFilterVisitor filterSimplifier = new SimplifyingFilterVisitor();
-
-        this.predicateBuilder = new FilterToCatalogSQL(this.queryType, this.dbMappings);
         Capabilities fcs = new Capabilities(FilterToCatalogSQL.CAPABILITIES);
         FeatureType parent = null;
         // use this to instruct the filter splitter which filters can be encoded depending on
@@ -231,36 +232,42 @@ class QueryBuilder<T extends Info> {
                 (Filter) supported.accept(new LiteralDemultiplyingFilterVisitor(), null);
         this.supportedFilter = (Filter) demultipliedFilter.accept(filterSimplifier, null);
         this.unsupportedFilter = (Filter) unsupported.accept(filterSimplifier, null);
-
+        if (Filter.INCLUDE.equals(this.supportedFilter)) {
+            return null;
+        }
         StringBuilder whereClause = new StringBuilder();
-        return (StringBuilder) this.supportedFilter.accept(predicateBuilder, whereClause);
+        return this.supportedFilter.accept(predicateBuilder, whereClause).toString();
     }
 
-    public StringBuilder build() {
+    public String build() {
 
-        StringBuilder whereClause = buildWhereClause();
+        String whereClause = buildWhereClause();
 
         StringBuilder query = new StringBuilder();
         if (isCountQuery) {
-            if (Filter.INCLUDE.equals(this.originalFilter)) {
-                query.append("select count(oid) from object where type_id in (:types)");
-            } else {
-                query.append("select count(oid) from object where type_id in (:types) AND (\n");
-                query.append(whereClause).append("\n)");
+            query.append("SELECT COUNT(oid) FROM object WHERE type_id IN (:types)");
+            dialect.appendComment(query, queryType.getName());
+            if (whereClause != null) {
+                dialect.appendIfDebug(query, "", " ");
+                query.append("AND ").append(whereClause);
             }
         } else {
-            SortBy[] orders = this.sortOrder;
-            if (orders == null) {
-                query.append("select id from object where type_id in (:types) AND (\n");
-                query.append(whereClause).append(")\n");
-                query.append(" ORDER BY oid");
+            if (sortOrder != null) {
+                querySortBy(query, whereClause, sortOrder);
             } else {
-                querySortBy(query, whereClause, orders);
+                query.append("SELECT id FROM object WHERE type_id IN (:types)");
+                dialect.appendComment(query, queryType.getName());
+                dialect.appendIfDebug(query, "", " ");
+                if (whereClause != null) {
+                    query.append("AND ").append(whereClause);
+                    dialect.appendIfDebug(query, whereClause.endsWith("\n") ? "" : " ", " ");
+                }
+                query.append("ORDER BY oid");
             }
             applyOffsetLimit(query);
         }
 
-        return query;
+        return query.toString().trim();
     }
 
     /** When the query was built, were the offset and limit included. */

--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/JDBCLoaderProperties.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcloader/JDBCLoaderProperties.java
@@ -107,4 +107,12 @@ public class JDBCLoaderProperties extends Properties {
     public void setDatasourceId(String datasourceId) {
         this.datasourceId = datasourceId;
     }
+
+    public boolean isDebugMode() {
+        return Boolean.parseBoolean(getProperty("debugMode", "false"));
+    }
+
+    public void setDebugMode(boolean debugMode) {
+        setProperty("debugMode", String.valueOf(debugMode));
+    }
 }

--- a/src/community/jdbcconfig/src/main/resources/applicationContext.xml
+++ b/src/community/jdbcconfig/src/main/resources/applicationContext.xml
@@ -33,6 +33,7 @@
   </bean>
 
   <bean id="JDBCConfigDB" class="org.geoserver.jdbcconfig.internal.ConfigDatabase">
+    <constructor-arg ref="jdbcConfigProperties" />
     <constructor-arg ref="jdbcConfigDataSource" />
     <constructor-arg ref="jdbcPersistenceBinding" />
   </bean>

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties
@@ -10,6 +10,11 @@ initScript=jdbcconfig/scripts/initdb.postgres.sql
 # flag controlling whether the existing (non-db) catalog should be imported
 import=true
 
+# Flag controlling whether to add comments and some pretty-printing to SQL queries to
+# assist with debugging.  Setting this to false may allow the module to better take
+# advantage of prepared statement caching.
+debugMode=false
+
 # database connection info
 jdbcUrl=jdbc:postgresql://localhost:5432/gscatalog
 driverClassName=org.postgresql.Driver

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.h2
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.h2
@@ -14,6 +14,11 @@ initdb=true
 initScript=jdbcconfig/scripts/initdb.h2.sql
 import=true
 
+# Flag controlling whether to add comments and some pretty-printing to SQL queries to
+# assist with debugging.  Setting this to false may allow the module to better take
+# advantage of prepared statement caching.
+debugMode=false
+
 jdbcUrl=jdbc:h2:file:${GEOSERVER_DATA_DIR}/jdbcconfig/catalog;AUTO_SERVER=TRUE
 driverClassName=org.h2.Driver
 username=sa

--- a/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.postgres
+++ b/src/community/jdbcconfig/src/main/resources/jdbcconfig.properties.postgres
@@ -31,6 +31,11 @@ initScript=jdbcconfig/scripts/initdb.postgres.sql
 #
 import=true
 
+# Flag controlling whether to add comments and some pretty-printing to SQL queries to
+# assist with debugging.  Setting this to false may allow the module to better take
+# advantage of prepared statement caching.
+debugMode=false
+
 #
 # The JNDI name for the data source.  Uncomment to use JNDI.
 #

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/JDBCConfigTestSupport.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/JDBCConfigTestSupport.java
@@ -32,6 +32,7 @@ import org.geoserver.jdbcconfig.internal.JDBCConfigProperties;
 import org.geoserver.jdbcconfig.internal.JDBCConfigXStreamPersisterInitializer;
 import org.geoserver.jdbcconfig.internal.Util;
 import org.geoserver.jdbcconfig.internal.XStreamInfoSerialBinding;
+import org.geoserver.jdbcloader.JDBCLoaderProperties;
 import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -414,7 +415,9 @@ public class JDBCConfigTestSupport {
         @Bean
         public ConfigDatabase configDatabase() {
             return new ConfigDatabase(
-                    dataSource(), new XStreamInfoSerialBinding(new XStreamPersisterFactory()));
+                    new JDBCLoaderProperties(null),
+                    dataSource(),
+                    new XStreamInfoSerialBinding(new XStreamPersisterFactory()));
         }
 
         @Bean

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/QueryBuilderTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/QueryBuilderTest.java
@@ -16,6 +16,11 @@
  */
 package org.geoserver.jdbcconfig.internal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import junit.framework.TestCase;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.Predicates;
@@ -23,12 +28,16 @@ import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.jdbcconfig.JDBCConfigTestSupport;
 import org.junit.Test;
 import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.sort.SortBy;
 
 /**
  * @author groldan
  * @author Kevin Smith, OpenGeo
  */
 public class QueryBuilderTest extends TestCase {
+
+    private static final FilterFactory FACTORY = Predicates.factory;
 
     private JDBCConfigTestSupport testSupport;
 
@@ -38,7 +47,6 @@ public class QueryBuilderTest extends TestCase {
 
     public void setUp() throws Exception {
         dialect = new Dialect();
-        dbMappings = new DbMappings(dialect);
         testSupport =
                 new JDBCConfigTestSupport(
                         (JDBCConfigTestSupport.DBConfig)
@@ -53,118 +61,956 @@ public class QueryBuilderTest extends TestCase {
 
     public void testQueryAll() {
         Filter filter = Predicates.equal("name", "ws1");
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .build();
+
+        QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings).filter(filter).build();
     }
 
     public void testSort1() {
         Filter filter = Predicates.acceptAll();
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .sortOrder(Predicates.asc("foo"))
-                        .build();
+
+        QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
+                .filter(filter)
+                .sortOrder(Predicates.asc("foo"))
+                .build();
     }
 
     public void testSort2() {
         Filter filter = Predicates.acceptAll();
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .sortOrder(Predicates.asc("foo"), Predicates.desc("bar"))
-                        .build();
+
+        QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
+                .filter(filter)
+                .sortOrder(Predicates.asc("foo"), Predicates.desc("bar"))
+                .build();
     }
 
     public void testSort3() {
         Filter filter = Predicates.acceptAll();
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .sortOrder(
-                                Predicates.asc("foo"),
-                                Predicates.desc("bar"),
-                                Predicates.asc("baz"))
-                        .build();
-    }
-
-    public void testSort3WithFilter() {
-        Filter filter = Predicates.equal("name", "quux");
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .sortOrder(
-                                Predicates.asc("foo"),
-                                Predicates.desc("bar"),
-                                Predicates.asc("baz"))
-                        .build();
+        QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
+                .filter(filter)
+                .sortOrder(Predicates.asc("foo"), Predicates.desc("bar"), Predicates.asc("baz"))
+                .build();
     }
 
     @Test
-    public void testNotEquals() {
-        // Create the filter
-        Filter filter = Predicates.notEqual("name", "quux");
-        // Build it
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .build();
-        String sql = build.toString();
-        // Ensure the following sql is present
-        assertTrue(
-                sql.contains(
-                        "NOT oid IN (SELECT oid FROM object_property WHERE property_type IN (:ptype0) AND UPPER(value) = :value0)"));
+    public void testForIdsSort1DebugDisabled() {
+        String expected =
+                "SELECT id FROM (SELECT oid, id FROM object WHERE type_id IN (:types)) object "
+                        + "LEFT JOIN (SELECT oid, value prop0 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty0)) subSelect0 ON object.oid = subSelect0.oid "
+                        + "ORDER BY prop0 ASC";
+        verifyForIds(expected, false, Predicates.acceptAll(), Predicates.asc("foo"));
     }
 
     @Test
-    public void testIsInstanceOf() {
-        // Create the filter
-        Filter filter = Predicates.isInstanceOf(LayerInfo.class);
-        // Build it
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .build();
-        String sql = build.toString();
-        // Ensure the following sql is present
-        assertTrue(sql.contains("type_id = " + dbMappings.getTypeId(LayerInfo.class)));
+    public void testForIdsSort1DebugEnabled() {
+        String expected =
+                "SELECT id FROM"
+                        + "\n    (SELECT oid, id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\n) object"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop0 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty0)) subSelect0 /* foo ASC */"
+                        + "\n  ON object.oid = subSelect0.oid"
+                        + "\n  ORDER BY prop0 ASC";
+        verifyForIds(expected, true, Predicates.acceptAll(), Predicates.asc("foo"));
     }
 
     @Test
-    public void testIsNull() {
-        // Create the filter
-        Filter filter = Predicates.isNull("name");
-        // Build it
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .build();
-        String sql = build.toString();
-
-        String sqlNull =
-                "oid IN (select oid from object_property where property_type in (:"
-                        + "ptype0) and value IS NULL) OR oid NOT  in (select oid from object_property where property_type in (:"
-                        + "ptype0))";
-        // Ensure the following sql is present
-        assertTrue(sql.contains(sqlNull));
+    public void testForIdsSort2DebugDisabled() {
+        String expected =
+                "SELECT id FROM (SELECT oid, id FROM object WHERE type_id IN (:types)) object "
+                        + "LEFT JOIN (SELECT oid, value prop0 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty0)) subSelect0 ON object.oid = subSelect0.oid "
+                        + "LEFT JOIN (SELECT oid, value prop1 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty1)) subSelect1 ON object.oid = subSelect1.oid "
+                        + "ORDER BY prop0 ASC, prop1 DESC";
+        verifyForIds(
+                expected,
+                false,
+                Predicates.acceptAll(),
+                Predicates.asc("foo"),
+                Predicates.desc("bar"));
     }
 
     @Test
-    public void testIsNil() {
-        // Create the filter
-        Filter filter = Predicates.isNull("name");
-        // Build it
-        StringBuilder build =
-                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
-                        .filter(filter)
-                        .build();
-        String sql = build.toString();
+    public void testForIdsSort2DebugEnabled() {
+        String expected =
+                "SELECT id FROM"
+                        + "\n    (SELECT oid, id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\n) object"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop0 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty0)) subSelect0 /* foo ASC */"
+                        + "\n  ON object.oid = subSelect0.oid"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop1 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty1)) subSelect1 /* bar DESC */"
+                        + "\n  ON object.oid = subSelect1.oid"
+                        + "\n  ORDER BY prop0 ASC, prop1 DESC";
+        verifyForIds(
+                expected,
+                true,
+                Predicates.acceptAll(),
+                Predicates.asc("foo"),
+                Predicates.desc("bar"));
+    }
 
-        String sqlNil =
-                "oid IN (select oid from object_property where property_type in (:"
-                        + "ptype0) and value IS NULL)";
-        // Ensure the following sql is present
-        assertTrue(sql.contains(sqlNil));
+    @Test
+    public void testForIdsSort3DebugDisabled() {
+        String expected =
+                "SELECT id FROM (SELECT oid, id FROM object WHERE type_id IN (:types)) object "
+                        + "LEFT JOIN (SELECT oid, value prop0 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty0)) subSelect0 ON object.oid = subSelect0.oid "
+                        + "LEFT JOIN (SELECT oid, value prop1 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty1)) subSelect1 ON object.oid = subSelect1.oid "
+                        + "LEFT JOIN (SELECT oid, value prop2 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty2)) subSelect2 ON object.oid = subSelect2.oid "
+                        + "ORDER BY prop0 ASC, prop1 DESC, prop2 ASC";
+        verifyForIds(
+                expected,
+                false,
+                Predicates.acceptAll(),
+                Predicates.asc("foo"),
+                Predicates.desc("bar"),
+                Predicates.asc("baz"));
+    }
+
+    public void testForIdsSort3DebugEnabled() {
+        String expected =
+                "SELECT id FROM"
+                        + "\n    (SELECT oid, id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\n) object"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop0 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty0)) subSelect0 /* foo ASC */"
+                        + "\n  ON object.oid = subSelect0.oid"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop1 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty1)) subSelect1 /* bar DESC */"
+                        + "\n  ON object.oid = subSelect1.oid"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop2 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty2)) subSelect2 /* baz ASC */"
+                        + "\n  ON object.oid = subSelect2.oid"
+                        + "\n  ORDER BY prop0 ASC, prop1 DESC, prop2 ASC";
+        verifyForIds(
+                expected,
+                true,
+                Predicates.acceptAll(),
+                Predicates.asc("foo"),
+                Predicates.desc("bar"),
+                Predicates.asc("baz"));
+    }
+
+    @Test
+    public void testForIdsSort3WithFilterDebugDisabled() {
+        String expected =
+                "SELECT id FROM (SELECT oid, id FROM object WHERE type_id IN (:types) AND oid IN "
+                        + "(SELECT oid FROM object_property WHERE property_type IN (:ptype0) AND value = :value0)) object "
+                        + "LEFT JOIN (SELECT oid, value prop0 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty0)) subSelect0 ON object.oid = subSelect0.oid "
+                        + "LEFT JOIN (SELECT oid, value prop1 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty1)) subSelect1 ON object.oid = subSelect1.oid "
+                        + "LEFT JOIN (SELECT oid, value prop2 FROM object_property "
+                        + "WHERE property_type IN (:sortProperty2)) subSelect2 ON object.oid = subSelect2.oid "
+                        + "ORDER BY prop0 ASC, prop1 DESC, prop2 ASC";
+        verifyForIds(
+                expected,
+                false,
+                Predicates.equal("name", "quux"),
+                Predicates.asc("foo"),
+                Predicates.desc("bar"),
+                Predicates.asc("baz"));
+    }
+
+    @Test
+    public void testForIdsSort3WithFilterDebugEnabled() {
+        String expected =
+                "SELECT id FROM"
+                        + "\n    (SELECT oid, id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\n      AND oid IN (SELECT oid FROM object_property WHERE property_type IN (:ptype0) AND value = :value0) /* [ name = quux ] */"
+                        + "\n) object"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop0 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty0)) subSelect0 /* foo ASC */"
+                        + "\n  ON object.oid = subSelect0.oid"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop1 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty1)) subSelect1 /* bar DESC */"
+                        + "\n  ON object.oid = subSelect1.oid"
+                        + "\n  LEFT JOIN"
+                        + "\n    (SELECT oid, value prop2 FROM"
+                        + "\n      object_property WHERE property_type IN (:sortProperty2)) subSelect2 /* baz ASC */"
+                        + "\n  ON object.oid = subSelect2.oid"
+                        + "\n  ORDER BY prop0 ASC, prop1 DESC, prop2 ASC";
+        verifyForIds(
+                expected,
+                true,
+                Predicates.equal("name", "quux"),
+                Predicates.asc("foo"),
+                Predicates.desc("bar"),
+                Predicates.asc("baz"));
+    }
+
+    @Test
+    public void testForCountUnknownProperty() {
+        dialect.setDebugMode(false);
+        String expected = "SELECT COUNT(oid) FROM object WHERE type_id IN (:types)";
+        Filter filter = Predicates.equal("foo.bar.baz", "quux");
+        QueryBuilder<?> builder =
+                QueryBuilder.forCount(dialect, WorkspaceInfo.class, dbMappings).filter(filter);
+        String actual = builder.build();
+        assertEquals(expected, actual);
+        assertEquals(Filter.INCLUDE, builder.getSupportedFilter());
+        assertEquals(filter, builder.getUnsupportedFilter());
+        assertFalse(builder.isOffsetLimitApplied());
+        assertEquals(1, builder.getNamedParameters().size());
+    }
+
+    @Test
+    public void testForIdsUnknownProperty() {
+        dialect.setDebugMode(false);
+        String expected = "SELECT id FROM object WHERE type_id IN (:types) ORDER BY oid";
+        Filter filter = Predicates.equal("foo.bar.baz", "quux");
+        QueryBuilder<?> builder =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings).filter(filter);
+        String actual = builder.build();
+        assertEquals(expected, actual);
+        assertEquals(Filter.INCLUDE, builder.getSupportedFilter());
+        assertEquals(filter, builder.getUnsupportedFilter());
+        assertFalse(builder.isOffsetLimitApplied());
+        assertEquals(1, builder.getNamedParameters().size());
+    }
+
+    @Test
+    public void testForCountSimplifiedInclude() {
+        dialect.setDebugMode(false);
+        String expected = "SELECT COUNT(oid) FROM object WHERE type_id IN (:types)";
+        Filter filter = Predicates.and(Predicates.acceptAll(), Predicates.acceptAll());
+        QueryBuilder<?> builder =
+                QueryBuilder.forCount(dialect, WorkspaceInfo.class, dbMappings).filter(filter);
+        String actual = builder.build();
+        assertEquals(expected, actual);
+        assertEquals(Filter.INCLUDE, builder.getSupportedFilter());
+        assertEquals(Filter.INCLUDE, builder.getUnsupportedFilter());
+        assertFalse(builder.isOffsetLimitApplied());
+        assertEquals(1, builder.getNamedParameters().size());
+    }
+
+    @Test
+    public void testForIdsSimplifiedInclude() {
+        dialect.setDebugMode(false);
+        String expected = "SELECT id FROM object WHERE type_id IN (:types) ORDER BY oid";
+        Filter filter = Predicates.and(Predicates.acceptAll(), Predicates.acceptAll());
+        QueryBuilder<?> builder =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings).filter(filter);
+        String actual = builder.build();
+        assertEquals(expected, actual);
+        assertEquals(Filter.INCLUDE, builder.getSupportedFilter());
+        assertEquals(Filter.INCLUDE, builder.getUnsupportedFilter());
+        assertTrue(builder.isOffsetLimitApplied());
+        assertEquals(1, builder.getNamedParameters().size());
+    }
+
+    @Test
+    public void testForIdsIncludeWithOffSetDebugDisabled() {
+        dialect.setDebugMode(false);
+        String expected =
+                "SELECT id FROM object WHERE type_id IN (:types) ORDER BY oid limit 2147483647 offset 5";
+        String actual =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings).offset(5).build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testForIdsIncludeWithLimitDebugDisabled() {
+        dialect.setDebugMode(false);
+        String expected = "SELECT id FROM object WHERE type_id IN (:types) ORDER BY oid limit 10";
+        String actual =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings).limit(10).build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testForIdsIncludeWithOffSetAndLimitDebugDisabled() {
+        dialect.setDebugMode(false);
+        String expected =
+                "SELECT id FROM object WHERE type_id IN (:types) ORDER BY oid limit 10 offset 5";
+        String actual =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
+                        .offset(5)
+                        .limit(10)
+                        .build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testForIdsIncludeWithOffSetDebugEnabled() {
+        dialect.setDebugMode(true);
+        String expected =
+                "SELECT id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\nORDER BY oid limit 2147483647 offset 5";
+        String actual =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings).offset(5).build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testForIdsIncludeWithLimitDebugEnabled() {
+        dialect.setDebugMode(true);
+        String expected =
+                "SELECT id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\nORDER BY oid limit 10";
+        String actual =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings).limit(10).build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testForIdsIncludeWithOffSetAndLimitDebugEnabled() {
+        dialect.setDebugMode(true);
+        String expected =
+                "SELECT id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\nORDER BY oid limit 10 offset 5";
+        String actual =
+                QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings)
+                        .offset(5)
+                        .limit(10)
+                        .build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testForCountIncludeDebugDisabled() {
+        String expected = "SELECT COUNT(oid) FROM object WHERE type_id IN (:types)";
+        verifyForCount(expected, false, Predicates.acceptAll());
+    }
+
+    @Test
+    public void testForCountIncludeDebugEnabled() {
+        String expected =
+                "SELECT COUNT(oid) FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */";
+        verifyForCount(expected, true, Predicates.acceptAll());
+    }
+
+    @Test
+    public void testForIdsIncludeDebugDisabled() {
+        String expected = "SELECT id FROM object WHERE type_id IN (:types) ORDER BY oid";
+        verifyForIds(expected, false, Predicates.acceptAll());
+    }
+
+    @Test
+    public void testForIdsIncludeDebugEnabled() {
+        String expected =
+                "SELECT id FROM object WHERE type_id IN (:types) /* org.geoserver.catalog.WorkspaceInfo */"
+                        + "\nORDER BY oid";
+        verifyForIds(expected, true, Predicates.acceptAll());
+    }
+
+    @Test
+    public void testForCountAndIsInstanceofDebugDisabled() {
+        String expected = "(type_id = 14 AND 0 = 1)";
+        Filter filter =
+                Predicates.and(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountAndIsInstanceofDebugEnabled() {
+        String expected =
+                "(\n    type_id = 14 /* isInstanceOf org.geoserver.catalog.LayerInfo */"
+                        + "\n    AND\n    0 = 1 /* EXCLUDE */\n)";
+        Filter filter =
+                Predicates.and(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsAndIsInstanceofDebugDisabled() {
+        String expected = "(type_id = 14 AND 0 = 1) ";
+        Filter filter =
+                Predicates.and(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsAndIsInstanceofDebugEnabled() {
+        String expected =
+                "(\n    type_id = 14 /* isInstanceOf org.geoserver.catalog.LayerInfo */"
+                        + "\n    AND\n    0 = 1 /* EXCLUDE */\n) ";
+        Filter filter =
+                Predicates.and(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountOrIsInstanceofDebugDisabled() {
+        String expected = "(type_id = 14 OR 0 = 1)";
+        Filter filter =
+                Predicates.or(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountOrIsInstanceofDebugEnabled() {
+        String expected =
+                "(\n    type_id = 14 /* isInstanceOf org.geoserver.catalog.LayerInfo */"
+                        + "\n    OR\n    0 = 1 /* EXCLUDE */\n)";
+        Filter filter =
+                Predicates.or(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsOrIsInstanceofDebugDisabled() {
+        String expected = "(type_id = 14 OR 0 = 1) ";
+        Filter filter =
+                Predicates.or(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsOrIsInstanceofDebugEnabled() {
+        String expected =
+                "(\n    type_id = 14 /* isInstanceOf org.geoserver.catalog.LayerInfo */"
+                        + "\n    OR\n    0 = 1 /* EXCLUDE */\n) ";
+        Filter filter =
+                Predicates.or(
+                        Predicates.isInstanceOf(LayerInfo.class),
+                        Predicates.isInstanceOf(String.class));
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsEqualToSensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0)";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsEqualToSensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = quux ] */";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsEqualToSensitiveDebugEnabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = FOO*\\/BAR ] */";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), true);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsEqualToSensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) ";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsEqualToSensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = quux ] */\n";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsEqualToSensitiveDebugEnabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = FOO*\\/BAR ] */\n";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), true);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsEqualToInsensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0)";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsEqualToInsensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = quux ] */";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsEqualToInsensitiveDebugEnabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = FOO*\\/BAR ] */";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), false);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsEqualToInsensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) ";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsEqualToInsensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = quux ] */\n";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsEqualToInsensitiveDebugEnabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = FOO*\\/BAR ] */\n";
+        Filter filter = FACTORY.equal(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), false);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsNotEqualToSensitiveDebugDisabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0))";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsNotEqualToSensitiveDebugEnabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = quux ] */\n)";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsNotEqualToSensitiveDebugEnabledEscaping() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = FOO*\\/BAR ] */\n)";
+        Filter filter =
+                FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), true);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsNotEqualToSensitiveDebugDisabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0)) ";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsNotEqualToSensitiveDebugEnabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = quux ] */\n) ";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), true);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsNotEqualToSensitiveDebugEnabledEscaping() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value = :value0) /* [ name = FOO*\\/BAR ] */\n) ";
+        Filter filter =
+                FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), true);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsNotEqualToInsensitiveDebugDisabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0))";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsNotEqualToInsensitiveDebugEnabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = quux ] */\n)";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsNotEqualToInsensitiveDebugEnabledEscaping() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = FOO*\\/BAR ] */\n)";
+        Filter filter =
+                FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), false);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsNotEqualToInsensitiveDebugDisabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0)) ";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsNotEqualToInsensitiveDebugEnabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = quux ] */\n) ";
+        Filter filter = FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("quux"), false);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsNotEqualToInsensitiveDebugEnabledEscaping() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) = :value0) /* [ name = FOO*\\/BAR ] */\n) ";
+        Filter filter =
+                FACTORY.notEqual(FACTORY.property("name"), FACTORY.literal("FOO*/BAR"), false);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeSensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0)";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", true);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeSensitiveDebugDisabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0)";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", true);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeSensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) /* [ name is like %quux% ] */";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", true);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeSensitiveDebugEnabledEscaping1() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) /* [ name is like %\\'FOO% ] */";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", true);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeSensitiveDebugEnabledEscaping2() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) /* [ name is like %FOO*\\/BAR% ] */";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%FOO*/BAR%", "%", "_", "\\", true);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeSensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) ";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", true);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeSensitiveDebugDisabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) ";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", true);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeSensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) /* [ name is like %quux% ] */\n";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", true);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeSensitiveDebugEnabledEscaping1() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) /* [ name is like %\\'FOO% ] */\n";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", true);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeSensitiveDebugEnabledEscaping2() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND value LIKE :value0) /* [ name is like %FOO*\\/BAR% ] */\n";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%FOO*/BAR%", "%", "_", "\\", true);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeInsensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0)";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", false);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeInsensitiveDebugDisabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0)";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", false);
+        verifyForCount(expected, false, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeInsensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) /* [ name is like %quux% ] */";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", false);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeInsensitiveDebugEnabledEscaping1() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) /* [ name is like %\\'FOO% ] */";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", false);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsLikeInsensitiveDebugEnabledEscaping2() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) /* [ name is like %FOO*\\/BAR% ] */";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%FOO*/BAR%", "%", "_", "\\", false);
+        verifyForCount(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeInsensitiveDebugDisabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) ";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", false);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeInsensitiveDebugDisabledEscaping() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) ";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", false);
+        verifyForIds(expected, false, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeInsensitiveDebugEnabled() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) /* [ name is like %quux% ] */\n";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%quux%", "%", "_", "\\", false);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeInsensitiveDebugEnabledEscaping1() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) /* [ name is like %\\'FOO% ] */\n";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%\\'FOO%", "%", "_", "\\", false);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForIdsIsLikeInsensitiveDebugEnabledEscaping2() {
+        String expected =
+                "oid IN (SELECT oid FROM object_property WHERE property_type "
+                        + "IN (:ptype0) AND UPPER(value) LIKE :value0) /* [ name is like %FOO*\\/BAR% ] */\n";
+        Filter filter = FACTORY.like(FACTORY.property("name"), "%FOO*/BAR%", "%", "_", "\\", false);
+        verifyForIds(expected, true, filter);
+    }
+
+    @Test
+    public void testForCountIsNullDebugDisabled() {
+        String expected =
+                "(oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0)))";
+        verifyForCount(expected, false, Predicates.isNull("name"));
+    }
+
+    @Test
+    public void testForCountIsNullDebugEnabled() {
+        String expected =
+                "(oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0))) /* [ name IS NULL ] */";
+        verifyForCount(expected, true, Predicates.isNull("name"));
+    }
+
+    @Test
+    public void testForIdsIsNullDebugDisabled() {
+        String expected =
+                "(oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0))) ";
+        verifyForIds(expected, false, Predicates.isNull("name"));
+    }
+
+    @Test
+    public void testForIdsIsNullDebugEnabled() {
+        String expected =
+                "(oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0))) /* [ name IS NULL ] */\n";
+        verifyForIds(expected, true, Predicates.isNull("name"));
+    }
+
+    @Test
+    public void testForCountIsNotNullDebugDisabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0)))";
+        verifyForCount(expected, false, Predicates.not(Predicates.isNull("name")));
+    }
+
+    @Test
+    public void testForCountIsNotNullDebugEnabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0))) /* [ name IS NULL ] */";
+        verifyForCount(expected, true, Predicates.not(Predicates.isNull("name")));
+    }
+
+    @Test
+    public void testForIdsIsNotNullDebugDisabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0))) ";
+        verifyForIds(expected, false, Predicates.not(Predicates.isNull("name")));
+    }
+
+    @Test
+    public void testForIdsIsNotNullDebugEnabled() {
+        String expected =
+                "NOT (oid IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0) AND value IS NULL) OR oid NOT IN (SELECT oid FROM object_property WHERE property_type IN (:"
+                        + "ptype0))) /* [ name IS NULL ] */\n";
+        verifyForIds(expected, true, Predicates.not(Predicates.isNull("name")));
+    }
+
+    private void verifyForCount(String expectedSQL, boolean debugMode, Filter filter) {
+        String expected = expectedSQL;
+        if (!expected.startsWith("SELECT")) {
+            expected =
+                    "SELECT COUNT(oid) FROM object WHERE type_id IN (:types) "
+                            + (debugMode ? "/* org.geoserver.catalog.WorkspaceInfo */\n" : "")
+                            + "AND "
+                            + expectedSQL;
+        }
+        QueryBuilder<?> builder = QueryBuilder.forCount(dialect, WorkspaceInfo.class, dbMappings);
+        verifyQuery(builder, expected, debugMode, filter);
+    }
+
+    private void verifyForIds(
+            String expectedSQL, boolean debugMode, Filter filter, SortBy... order) {
+        String expected = expectedSQL;
+        if (!expected.startsWith("SELECT")) {
+            expected =
+                    "SELECT id FROM object WHERE type_id IN (:types) "
+                            + (debugMode ? "/* org.geoserver.catalog.WorkspaceInfo */\n" : "")
+                            + "AND "
+                            + expectedSQL
+                            + "ORDER BY oid";
+        }
+        QueryBuilder<?> builder = QueryBuilder.forIds(dialect, WorkspaceInfo.class, dbMappings);
+        verifyQuery(builder, expected, debugMode, filter, order);
+    }
+
+    private void verifyQuery(
+            QueryBuilder<?> builder,
+            String expected,
+            boolean debugMode,
+            Filter filter,
+            SortBy... order) {
+        dialect.setDebugMode(debugMode);
+        String actual = builder.filter(filter).sortOrder(order).build();
+        assertEquals(expected, actual);
+        if (Filter.INCLUDE.equals(filter)) {
+            assertEquals(Filter.INCLUDE, builder.getSupportedFilter());
+        } else {
+            assertNotEquals(Filter.INCLUDE, builder.getSupportedFilter());
+        }
+        assertEquals(Filter.INCLUDE, builder.getUnsupportedFilter());
+        assertEquals(!actual.startsWith("SELECT COUNT"), builder.isOffsetLimitApplied());
+        assertFalse(builder.getNamedParameters().isEmpty());
     }
 }


### PR DESCRIPTION
[![GEOS-10842](https://badgen.net/badge/JIRA/GEOS-10842/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10842)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-10839] Add JDBC Configuration parameter to disable SQL comments and pretty-printing

Backport from main

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->