### PR TITLE
[GEOS-10854] Follow up Spring upgrade, make tests pass again

### DIFF
--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/DGGSService.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/dggs/DGGSService.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.ogcapi.dggs;
 
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
+import static org.geoserver.ogcapi.OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE;
 import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import static org.geotools.dggs.gstore.DGGSStore.RESOLUTION;
 
@@ -38,7 +40,6 @@ import org.geoserver.ogcapi.DefaultContentType;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.ogcapi.Link;
 import org.geoserver.ogcapi.OGCAPIMediaTypes;
-import org.geoserver.ogcapi.OpenAPIMessageConverter;
 import org.geoserver.ogcapi.PropertiesParser;
 import org.geoserver.ogcapi.features.FeaturesGetFeature;
 import org.geoserver.ogcapi.features.FeaturesResponse;
@@ -134,11 +135,11 @@ public class DGGSService {
     }
 
     @GetMapping(
-            path = "api",
+            path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",
             produces = {
-                OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
-                "application/x-yaml",
+                OPEN_API_MEDIA_TYPE_VALUE,
+                APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })
     @ResponseBody

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIContentNegotiationManager.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIContentNegotiationManager.java
@@ -19,6 +19,7 @@ import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.accept.ContentNegotiationStrategy;
 import org.springframework.web.accept.HeaderContentNegotiationStrategy;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
 
 /**
  * A ContentNegotiationManager using the "f" query parameter as a way to request a few well known
@@ -61,10 +62,16 @@ public class APIContentNegotiationManager extends ContentNegotiationManager {
     private class OpenAPIContentNegotiationStrategy implements ContentNegotiationStrategy {
         @Override
         public List<MediaType> resolveMediaTypes(NativeWebRequest nativeWebRequest) {
-            if (nativeWebRequest.getContextPath().endsWith("/openapi.json")) {
-                return Arrays.asList(OPEN_API_MEDIA_TYPE);
-            } else if (nativeWebRequest.getContextPath().endsWith("/openapi.yaml")) {
-                return Arrays.asList(APPLICATION_YAML);
+            if (nativeWebRequest instanceof ServletWebRequest) {
+                ServletWebRequest servletWebRequest = (ServletWebRequest) nativeWebRequest;
+                if (servletWebRequest.getRequest().getRequestURI().endsWith("/openapi.json")) {
+                    return Arrays.asList(OPEN_API_MEDIA_TYPE);
+                } else if (servletWebRequest
+                        .getRequest()
+                        .getRequestURI()
+                        .endsWith("/openapi.yaml")) {
+                    return Arrays.asList(APPLICATION_YAML);
+                }
             }
             return MEDIA_TYPE_ALL_LIST;
         }

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/CoveragesService.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/coverages/CoveragesService.java
@@ -6,6 +6,8 @@ package org.geoserver.ogcapi.coverages;
 
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.geoserver.ogcapi.APIException.INVALID_PARAMETER_VALUE;
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
+import static org.geoserver.ogcapi.OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.IOException;
@@ -35,7 +37,6 @@ import org.geoserver.ogcapi.ConformanceClass;
 import org.geoserver.ogcapi.ConformanceDocument;
 import org.geoserver.ogcapi.DefaultContentType;
 import org.geoserver.ogcapi.HTMLResponseBody;
-import org.geoserver.ogcapi.OpenAPIMessageConverter;
 import org.geoserver.ogcapi.coverages.cis.DomainSet;
 import org.geoserver.ows.kvp.TimeParser;
 import org.geoserver.platform.ServiceException;
@@ -144,11 +145,11 @@ public class CoveragesService {
     }
 
     @GetMapping(
-            path = "openapi",
+            path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",
             produces = {
-                OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
-                "application/x-yaml",
+                OPEN_API_MEDIA_TYPE_VALUE,
+                APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })
     @ResponseBody

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/features/FeatureService.java
@@ -191,7 +191,7 @@ public class FeatureService {
     }
 
     @GetMapping(
-            path = "openapi",
+            path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",
             produces = {
                 OPEN_API_MEDIA_TYPE_VALUE,

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/images/ImagesService.java
@@ -6,6 +6,7 @@ package org.geoserver.ogcapi.images;
 
 import static java.util.stream.Collectors.toList;
 import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
+import static org.geoserver.ogcapi.OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE;
 import static org.geotools.gce.imagemosaic.Utils.FF;
 
 import io.swagger.v3.oas.models.OpenAPI;
@@ -41,7 +42,6 @@ import org.geoserver.ogcapi.APIService;
 import org.geoserver.ogcapi.ConformanceClass;
 import org.geoserver.ogcapi.ConformanceDocument;
 import org.geoserver.ogcapi.HTMLResponseBody;
-import org.geoserver.ogcapi.OpenAPIMessageConverter;
 import org.geoserver.ogcapi.ResourceNotFoundException;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.kvp.TimeParser;
@@ -155,10 +155,10 @@ public class ImagesService implements ApplicationContextAware {
     }
 
     @GetMapping(
-            path = "openapi",
+            path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",
             produces = {
-                OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
+                OPEN_API_MEDIA_TYPE_VALUE,
                 APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/styles/StylesService.java
@@ -5,6 +5,7 @@
 package org.geoserver.ogcapi.styles;
 
 import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
+import static org.geoserver.ogcapi.OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE;
 import static org.geoserver.ogcapi.styles.StylesService.ValidationMode.only;
 import static org.geoserver.ogcapi.styles.StylesService.ValidationMode.yes;
 
@@ -38,7 +39,6 @@ import org.geoserver.ogcapi.APIRequestInfo;
 import org.geoserver.ogcapi.APIService;
 import org.geoserver.ogcapi.ConformanceDocument;
 import org.geoserver.ogcapi.HTMLResponseBody;
-import org.geoserver.ogcapi.OpenAPIMessageConverter;
 import org.geoserver.ogcapi.ResourceNotFoundException;
 import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.ows.URLMangler;
@@ -160,10 +160,10 @@ public class StylesService {
     }
 
     @GetMapping(
-            path = "openapi",
+            path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",
             produces = {
-                OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
+                OPEN_API_MEDIA_TYPE_VALUE,
                 APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/tiles/TilesService.java
@@ -135,7 +135,7 @@ public class TilesService {
     }
 
     @GetMapping(
-            path = "openapi",
+            path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",
             produces = {
                 OPEN_API_MEDIA_TYPE_VALUE,


### PR DESCRIPTION
[![GEOS-10854](https://badgen.net/badge/JIRA/GEOS-10854/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10854)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The resource at "openapi.json" would not work anymore after the Spring upgrade. Fixes included.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->