### PR TITLE
[Backport 2.22.x] Bump commons-fileupload from 1.4 to 1.5 in /src

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -826,7 +826,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
Backport #6620
 **Authored by:** @dependabot[bot]