### PR TITLE
[Backport 2.22.x] [GEOS-10869] Jayway JSON Path libraries not included anymore on GeoServer packages

### DIFF
--- a/src/community/cov-json/pom.xml
+++ b/src/community/cov-json/pom.xml
@@ -81,5 +81,10 @@
       <artifactId>gt-imagemosaic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/community/ogcapi/pom.xml
+++ b/src/community/ogcapi/pom.xml
@@ -30,4 +30,12 @@
     <module>ogcapi-coverages</module>
   </modules>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/src/community/oseo/pom.xml
+++ b/src/community/oseo/pom.xml
@@ -27,4 +27,13 @@
     <module>web-oseo</module>
     <module>oseo-integration-tests</module>
   </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/src/community/security/oauth2/oauth2-core/pom.xml
+++ b/src/community/security/oauth2/oauth2-core/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>2.6.3</version>

--- a/src/community/wmts-styles/pom.xml
+++ b/src/community/wmts-styles/pom.xml
@@ -49,5 +49,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/extension/vectortiles/pom.xml
+++ b/src/extension/vectortiles/pom.xml
@@ -60,6 +60,11 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1515,11 +1515,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
       <scope>test</scope>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -906,7 +906,7 @@
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
-        <version>2.4.0</version>
+        <version>2.7.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -755,6 +755,10 @@
       <id>authkey</id>
       <dependencies>
         <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-authkey</artifactId>
           <version>${project.version}</version>
@@ -1252,6 +1256,10 @@
       <id>backup-restore</id>
       <dependencies>
         <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.geoserver.community.backuprestore</groupId>
           <artifactId>gs-backup-restore-extension</artifactId>
           <version>${project.version}</version>
@@ -1307,6 +1315,10 @@
       <id>keycloak</id>
       <dependencies>
         <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-sec-keycloak</artifactId>
           <version>${project.version}</version>
@@ -1316,6 +1328,10 @@
     <profile>
       <id>oauth2-google</id>
       <dependencies>
+        <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
         <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>
@@ -1337,6 +1353,10 @@
       <id>oauth2-github</id>
       <dependencies>
         <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>
           <version>${project.version}</version>
@@ -1356,6 +1376,10 @@
     <profile>
       <id>oauth2-geonode</id>
       <dependencies>
+        <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
         <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>
@@ -1377,6 +1401,10 @@
       <id>oauth2-openid-connect</id>
       <dependencies>
         <dependency>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>
           <version>${project.version}</version>
@@ -1394,6 +1422,10 @@
       </dependencies>
     </profile>
     <profile>
+          <groupId>com.jayway.jsonpath</groupId>
+          <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
       <id>wmts-multi-dimensional</id>
       <dependencies>
         <dependency>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -755,10 +755,6 @@
       <id>authkey</id>
       <dependencies>
         <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
-        <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-authkey</artifactId>
           <version>${project.version}</version>
@@ -1256,10 +1252,6 @@
       <id>backup-restore</id>
       <dependencies>
         <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
-        <dependency>
           <groupId>org.geoserver.community.backuprestore</groupId>
           <artifactId>gs-backup-restore-extension</artifactId>
           <version>${project.version}</version>
@@ -1315,10 +1307,6 @@
       <id>keycloak</id>
       <dependencies>
         <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
-        <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-sec-keycloak</artifactId>
           <version>${project.version}</version>
@@ -1328,10 +1316,6 @@
     <profile>
       <id>oauth2-google</id>
       <dependencies>
-        <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
         <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>
@@ -1353,10 +1337,6 @@
       <id>oauth2-github</id>
       <dependencies>
         <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
-        <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>
           <version>${project.version}</version>
@@ -1377,10 +1357,6 @@
       <id>oauth2-geonode</id>
       <dependencies>
         <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
-        <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>
           <version>${project.version}</version>
@@ -1400,10 +1376,6 @@
     <profile>
       <id>oauth2-openid-connect</id>
       <dependencies>
-        <dependency>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
         <dependency>
           <groupId>org.geoserver.community.security</groupId>
           <artifactId>gs-sec-oauth2-core</artifactId>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -1422,10 +1422,6 @@
       </dependencies>
     </profile>
     <profile>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </dependency>
-        <dependency>
       <id>wmts-multi-dimensional</id>
       <dependencies>
         <dependency>


### PR DESCRIPTION
[![GEOS-10869](https://badgen.net/badge/JIRA/GEOS-10869/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10869)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6617
 **Authored by:** @afabiani