### PR TITLE
[GEOS-10870] Allow importer AttributesToPointGeometryTransform to preserve original geometries, and to configure the name of the target geometry

### DIFF
--- a/doc/en/user/source/extensions/importer/rest_reference.rst
+++ b/doc/en/user/source/extensions/importer/rest_reference.rst
@@ -948,7 +948,7 @@ Computes a new field based on an expression that can use the other field values
 AttributesToPointGeometryTransform
 """"""""""""""""""""""""""""""""""
 
-Transforms two numeric fields ``latField`` and ``lngField`` into a point geometry representation ``POINT(lngField,latField)``, the source fields will be removed.
+Transforms two numeric fields ``latField`` and ``lngField`` into a point geometry representation with ``pointFieldName`` setting name of the point ``POINT(lngField,latField)``, the source fields will be removed if ``preserveGeometry`` is false.
 
 .. list-table::
    :header-rows: 1
@@ -962,6 +962,12 @@ Transforms two numeric fields ``latField`` and ``lngField`` into a point geometr
    * - lngField
      - N
      - The "longitude" field
+   * - pointFieldName
+     - Y
+     - The name of the point
+   * - preserveGeometry
+     - Y
+     - Setting this flag will prevent source fields from removal (false by default)
 
 CreateIndexTransform
 """"""""""""""""""""

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/transform/AttributesToPointGeometryTransform.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/transform/AttributesToPointGeometryTransform.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.importer.transform;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.geoserver.importer.ImportTask;
 import org.geotools.data.DataStore;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -21,13 +22,15 @@ public class AttributesToPointGeometryTransform extends AbstractTransform
     /** serialVersionUID */
     private static final long serialVersionUID = 1L;
 
-    private static final String POINT_NAME = "location";
+    static final String POINT_NAME = "location";
 
     private final String latField;
 
     private final String lngField;
 
     private final String pointFieldName;
+
+    private final Boolean preserveGeometry;
 
     private static GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
@@ -37,9 +40,17 @@ public class AttributesToPointGeometryTransform extends AbstractTransform
 
     public AttributesToPointGeometryTransform(
             String latField, String lngField, String pointFieldName) {
+        this(latField, lngField, pointFieldName, false);
+    }
+
+    public AttributesToPointGeometryTransform(
+            String latField, String lngField, String pointFieldName, Boolean preserveGeometry) {
         this.latField = latField;
         this.lngField = lngField;
-        this.pointFieldName = pointFieldName;
+        this.pointFieldName =
+                ObjectUtils.defaultIfNull(
+                        pointFieldName, AttributesToPointGeometryTransform.POINT_NAME);
+        this.preserveGeometry = preserveGeometry;
     }
 
     @Override
@@ -64,11 +75,13 @@ public class AttributesToPointGeometryTransform extends AbstractTransform
         }
 
         GeometryDescriptor geometryDescriptor = featureType.getGeometryDescriptor();
-        if (geometryDescriptor != null) {
+
+        if (!preserveGeometry && geometryDescriptor != null) {
             builder.remove(geometryDescriptor.getLocalName());
         }
         builder.remove(latField);
         builder.remove(lngField);
+
         builder.add(pointFieldName, Point.class);
 
         return builder.buildFeatureType();
@@ -114,6 +127,14 @@ public class AttributesToPointGeometryTransform extends AbstractTransform
         return lngField;
     }
 
+    public String getPointFieldName() {
+        return pointFieldName;
+    }
+
+    public boolean isPreserveGeometry() {
+        return preserveGeometry;
+    }
+
     @Override
     public String toString() {
         return "AttributesToPointGeometryTransform{"
@@ -125,6 +146,9 @@ public class AttributesToPointGeometryTransform extends AbstractTransform
                 + '\''
                 + ", pointFieldName='"
                 + pointFieldName
+                + '\''
+                + ", preserveGeometry='"
+                + preserveGeometry
                 + '\''
                 + '}';
     }

--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/converters/ImportJSONReader.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/converters/ImportJSONReader.java
@@ -346,7 +346,15 @@ public class ImportJSONReader {
         } else if ("AttributesToPointGeometryTransform".equalsIgnoreCase(type)) {
             String latField = json.getString("latField");
             String lngField = json.getString("lngField");
-            transform = new AttributesToPointGeometryTransform(latField, lngField);
+            String pointFieldName = (String) json.get("pointFieldName");
+            String preserveGeometry = (String) json.get("preserveGeometry");
+
+            transform =
+                    new AttributesToPointGeometryTransform(
+                            latField,
+                            lngField,
+                            pointFieldName,
+                            Boolean.parseBoolean(preserveGeometry));
         } else if ("ReprojectTransform".equalsIgnoreCase(type)) {
             CoordinateReferenceSystem source =
                     json.has("source") ? crs(json.getString("source")) : null;

--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/converters/ImportJSONWriter.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/converters/ImportJSONWriter.java
@@ -467,6 +467,8 @@ public class ImportJSONWriter {
                         (AttributesToPointGeometryTransform) transform;
                 json.key("latField").value(atpgt.getLatField());
                 json.key("lngField").value(atpgt.getLngField());
+                json.key("pointFieldName").value(atpgt.getPointFieldName());
+                json.key("preserveGeometry").value(atpgt.isPreserveGeometry());
             } else if (transform.getClass() == ReprojectTransform.class) {
                 ReprojectTransform rt = (ReprojectTransform) transform;
                 json.key("source").value(srs(rt.getSource()));

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/AttributesToPointGeometryTransformTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/AttributesToPointGeometryTransformTest.java
@@ -1,0 +1,63 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.importer.rest;
+
+import static org.geoserver.importer.rest.ImportTransformTest.BASEPATH;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.importer.ImportContext;
+import org.geoserver.importer.ImportTask;
+import org.geoserver.importer.ImporterTestSupport;
+import org.geoserver.importer.SpatialFile;
+import org.geoserver.importer.transform.AttributesToPointGeometryTransform;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AttributesToPointGeometryTransformTest extends ImporterTestSupport {
+
+    DataStoreInfo store;
+
+    @Before
+    public void setupTransformContext() throws Exception {
+        File dir = unpack("shape/archsites_epsg_prj.zip");
+
+        SpatialFile file = new SpatialFile(new File(dir, "archsites.shp"));
+        file.prepare();
+
+        ImportContext context = importer.createContext(file, store);
+        ImportTask importTask = context.getTasks().get(0);
+
+        AttributesToPointGeometryTransform transform =
+                new AttributesToPointGeometryTransform("LAT", "LON", "point", true);
+
+        importTask.addTransform(transform);
+        importer.changed(importTask);
+    }
+
+    /**
+     * Tests if all fields processed correctly by writer
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetTransform() throws Exception {
+        int id = lastId();
+        JSON json = getAsJSON(BASEPATH + "/imports/" + id + "/tasks/0/transforms/0");
+
+        assertTrue(json instanceof JSONObject);
+
+        JSONObject jsonObject = (JSONObject) json;
+
+        assertEquals("LAT", jsonObject.get("latField"));
+        assertEquals("LON", jsonObject.get("lngField"));
+        assertEquals("point", jsonObject.get("pointFieldName"));
+        assertTrue(jsonObject.getBoolean("preserveGeometry"));
+    }
+}

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportTransformTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImportTransformTest.java
@@ -32,7 +32,7 @@ public class ImportTransformTest extends ImporterTestSupport {
 
     DataStoreInfo store;
 
-    private static String BASEPATH = RestBaseController.ROOT_PATH;
+    static String BASEPATH = RestBaseController.ROOT_PATH;
 
     /**
      * Create a test transform context: one import task with two transforms:

--- a/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImporterIntegrationTest.java
+++ b/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImporterIntegrationTest.java
@@ -259,7 +259,7 @@ public class ImporterIntegrationTest extends ImporterTestSupport {
         // print(json);
         int importId = json.getJSONObject("import").getInt("id");
 
-        checkLatLonTransformedImport(importId);
+        checkLatLonTransformedImport(importId, "location");
     }
 
     @Test
@@ -300,6 +300,65 @@ public class ImporterIntegrationTest extends ImporterTestSupport {
                 (JSONObject)
                         json(
                                 postAsServletResponse(
+                                        "/rest/imports?expand=1",
+                                        contextDefinition,
+                                        "application/json"));
+        // print(json);
+        int importId = json.getJSONObject("import").getInt("id");
+
+        // upload the data
+        String body =
+                "--AaB03x\r\nContent-Disposition: form-data; name=filedata; filename=data.csv\r\n"
+                        + "Content-Type: text/plain\n"
+                        + "\r\n\r\n"
+                        + FileUtils.readFileToString(locations, "UTF-8")
+                        + "\r\n--AaB03x--";
+
+        post("/rest/imports/" + importId + "/tasks", body, "multipart/form-data; boundary=AaB03x");
+
+        checkLatLonTransformedImport(importId, "location");
+    }
+
+    @Test
+    public void testTransformationsUploadWithOptionalFields() throws Exception {
+        File dir = unpack("csv/locations.zip");
+        String wsName = getCatalog().getDefaultWorkspace().getName();
+
+        File locations = new File(dir, "locations.csv");
+
+        // @formatter:off
+        String contextDefinition =
+                "{\n"
+                        + "   \"import\": {\n"
+                        + "      \"targetWorkspace\": {\n"
+                        + "         \"workspace\": {\n"
+                        + "            \"name\": \""
+                        + wsName
+                        + "\"\n"
+                        + "         }\n"
+                        + "      },\n"
+                        + "      targetStore: {\n"
+                        + "        dataStore: {\n"
+                        + "        name: \"h2\",\n"
+                        + "        }\n"
+                        + "      },\n"
+                        + "      \"transforms\": [\n"
+                        + "        {\n"
+                        + "          \"type\": \"AttributesToPointGeometryTransform\",\n"
+                        + "          \"latField\": \"LAT\","
+                        + "          \"lngField\": \"LON\","
+                        + "          \"pointFieldName\": \"point\","
+                        + "          \"preserveGeometry\": \"true\""
+                        + "        }\n"
+                        + "      ]"
+                        + "   }\n"
+                        + "}";
+        // @formatter:on
+
+        JSONObject json =
+                (JSONObject)
+                        json(
+                                postAsServletResponse(
                                         "/rest/imports", contextDefinition, "application/json"));
         // print(json);
         int importId = json.getJSONObject("import").getInt("id");
@@ -314,10 +373,11 @@ public class ImporterIntegrationTest extends ImporterTestSupport {
 
         post("/rest/imports/" + importId + "/tasks", body, "multipart/form-data; boundary=AaB03x");
 
-        checkLatLonTransformedImport(importId);
+        checkLatLonTransformedImport(importId, "point");
     }
 
-    private void checkLatLonTransformedImport(int importId) throws IOException {
+    private void checkLatLonTransformedImport(int importId, String expectedPoint)
+            throws IOException {
         ImportContext context = importer.getContext(importId);
         assertEquals(1, context.getTasks().size());
         ImportTask task = context.getTasks().get(0);
@@ -344,7 +404,7 @@ public class ImporterIntegrationTest extends ImporterTestSupport {
         SimpleFeatureType featureType = (SimpleFeatureType) fti.getFeatureType();
         GeometryDescriptor geometryDescriptor = featureType.getGeometryDescriptor();
         assertNotNull("Expecting geometry", geometryDescriptor);
-        assertEquals("Invalid geometry name", "location", geometryDescriptor.getLocalName());
+        assertEquals("Invalid geometry name", expectedPoint, geometryDescriptor.getLocalName());
         assertEquals(3, featureType.getAttributeCount());
         FeatureSource<? extends FeatureType, ? extends Feature> featureSource =
                 fti.getFeatureSource(null, null);
@@ -359,7 +419,7 @@ public class ImporterIntegrationTest extends ImporterTestSupport {
             assertNotNull(feature);
             assertEquals("Invalid city attribute", "Trento", feature.getAttribute("CITY"));
             assertEquals("Invalid number attribute", 140, feature.getAttribute("NUMBER"));
-            Object geomAttribute = feature.getAttribute("location");
+            Object geomAttribute = feature.getAttribute(expectedPoint);
             assertNotNull("Expected geometry", geomAttribute);
             Point point = (Point) geomAttribute;
             Coordinate coordinate = point.getCoordinate();


### PR DESCRIPTION
[![GEOS-10870](https://badgen.net/badge/JIRA/GEOS-10870/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10870)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See https://osgeo-org.atlassian.net/browse/GEOS-10870

Added support of pointFieldName to [ImportJSONReader](https://github.com/Judge73/geoserver/blob/37ccb262b1fa13741a412309273ad3597a93f332/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/converters/ImportJSONReader.java#L350)/[Writer](https://github.com/Judge73/geoserver/blob/37ccb262b1fa13741a412309273ad3597a93f332/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/converters/ImportJSONWriter.java#L470) to set if from REST API calls. 
Also added preserveGeometry flag to prevent [AttributesToPointGeometryTransform](https://github.com/Judge73/geoserver/blob/37ccb262b1fa13741a412309273ad3597a93f332/src/extension/importer/core/src/main/java/org/geoserver/importer/transform/AttributesToPointGeometryTransform.java#L67) deletion of geometry when needed.
Added tests that check if transform request with new fields behaves correctly to [ImporterIntegrationTest](https://github.com/Judge73/geoserver/blob/37ccb262b1fa13741a412309273ad3597a93f332/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/ImporterIntegrationTest.java#L321) and that new fields are represented correctly when requesting info about transform to [AttributesToPointGeometryTransformTest](https://github.com/Judge73/geoserver/blob/37ccb262b1fa13741a412309273ad3597a93f332/src/extension/importer/rest/src/test/java/org/geoserver/importer/rest/AttributesToPointGeometryTransformTest.java#L24)
Updated user documentation accordingly.
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->