### PR TITLE
[GEOS-10871] Force use of AntRun plugin 3.1.0

### DIFF
--- a/src/community/netcdf-ghrsst/pom.xml
+++ b/src/community/netcdf-ghrsst/pom.xml
@@ -72,6 +72,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>process-resources</id>

--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -443,6 +443,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>install</phase>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -2280,7 +2280,7 @@
 
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.7</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>read-manifest</id>

--- a/src/release/pom.xml
+++ b/src/release/pom.xml
@@ -493,6 +493,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>remove-dependencies</id>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -240,7 +240,7 @@
       <!-- Builds a valid data directory into the web app -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>configPackage</id>
@@ -269,9 +269,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <delete dir="${webappSourceDirectory}/data"></delete>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -153,6 +153,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>process-resources</id>


### PR DESCRIPTION
[![GEOS-10871](https://badgen.net/badge/JIRA/GEOS-10871/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10871)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR force the use of the 3.1.0 version of AntRun plugin.

As in last version <tasks> were replaced with <task>, if we don't force the version it use the old 1.3 that doesn't support <tasks>. 

It results for example in @project.version@ not replaced in some web/core properties files.

Solve : https://osgeo-org.atlassian.net/browse/GEOS-10871