### PR TITLE
Restore OpenSearch build after changes in OGC API, GeoTools XML encoding and the Spring upgrade

### DIFF
--- a/src/community/oseo/oseo-service/src/main/java/org/geoserver/opensearch/eo/response/DescriptionTransformer.java
+++ b/src/community/oseo/oseo-service/src/main/java/org/geoserver/opensearch/eo/response/DescriptionTransformer.java
@@ -61,7 +61,7 @@ public class DescriptionTransformer extends LambdaTransformerBase {
             namespaces.put("xmlns:geo", "http://a9.com/-/opensearch/extensions/geo/1.0/");
             namespaces.put("xmlns:time", "http://a9.com/-/opensearch/extensions/time/1.0/");
             namespaces.put("xmlns:eo", "http://a9.com/-/opensearch/extensions/eo/1.0/");
-            namespaces.put("xmlns:atom  ", "http://www.w3.org/2005/Atom");
+            namespaces.put("xmlns:atom", "http://www.w3.org/2005/Atom");
             element(
                     "OpenSearchDescription",
                     () -> describeOpenSearch(description),

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/AbstractItemsHTMLMessageConverter.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/AbstractItemsHTMLMessageConverter.java
@@ -4,8 +4,9 @@
  */
 package org.geoserver.ogcapi.stac;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import freemarker.template.Template;
-import freemarker.template.TemplateException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.HashMap;
@@ -43,12 +44,7 @@ public abstract class AbstractItemsHTMLMessageConverter<T extends AbstractItemsR
         addLinkFunctions(APIRequestInfo.get().getBaseURL(), model);
 
         try (OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody())) {
-            try {
-                header.process(model, osw);
-            } catch (TemplateException e) {
-                String msg = "Error occurred processing header template.";
-                throw new IOException(msg, e);
-            }
+            templateSupport.processTemplate(header, model, osw, UTF_8);
 
             // process content template for all feature collections found
             model.put("featureInfo", value.getItems().getSchema());
@@ -57,25 +53,12 @@ public abstract class AbstractItemsHTMLMessageConverter<T extends AbstractItemsR
             model.put("next", value.getNext());
 
             if (!value.getItems().isEmpty()) {
-                try {
-                    content.process(model, osw);
-                } catch (TemplateException e) {
-                    throw new IOException("Error occurred processing content template", e);
-                }
+                templateSupport.processTemplate(content, model, osw, UTF_8);
             } else {
-                try {
-                    empty.process(model, osw);
-                } catch (TemplateException e) {
-                    throw new IOException("Error occurred processing empty template", e);
-                }
+                templateSupport.processTemplate(empty, model, osw, UTF_8);
             }
 
-            try {
-                footer.process(model, osw);
-            } catch (TemplateException e) {
-                String msg = "Error occurred processing footer template.";
-                throw new IOException(msg, e);
-            }
+            templateSupport.processTemplate(footer, model, osw, UTF_8);
             osw.flush();
         } finally {
             purgeIterators();

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/stac/STACService.java
@@ -16,6 +16,7 @@ import static org.geoserver.ogcapi.ConformanceClass.ECQL;
 import static org.geoserver.ogcapi.ConformanceClass.ECQL_TEXT;
 import static org.geoserver.ogcapi.ConformanceClass.FEATURES_FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.FILTER;
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
 import static org.geoserver.opensearch.eo.store.OpenSearchAccess.EO_IDENTIFIER;
 import static org.geoserver.opensearch.eo.store.OpenSearchQueries.getProductProperties;
 import static org.geoserver.ows.URLMangler.URLType.RESOURCE;
@@ -219,11 +220,11 @@ public class STACService {
     }
 
     @GetMapping(
-            path = "api",
+            path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",
             produces = {
                 OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE,
-                "application/x-yaml",
+                APPLICATION_YAML_VALUE,
                 MediaType.TEXT_XML_VALUE
             })
     @ResponseBody

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ApiTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/ApiTest.java
@@ -43,7 +43,7 @@ public class ApiTest extends STACTestSupport {
 
     @Test
     public void testApiJson() throws Exception {
-        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/stac/api", 200);
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/stac/openapi", 200);
         assertThat(
                 response.getContentType(),
                 CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));
@@ -58,7 +58,7 @@ public class ApiTest extends STACTestSupport {
     @Test
     public void testApiHTML() throws Exception {
         MockHttpServletResponse response =
-                getAsMockHttpServletResponse("ogc/stac/api?f=text/html", 200);
+                getAsMockHttpServletResponse("ogc/stac/openapi?f=text/html", 200);
         assertEquals("text/html", response.getContentType());
         String html = response.getContentAsString();
         GeoServerBaseTestSupport.LOGGER.info(html);
@@ -83,12 +83,12 @@ public class ApiTest extends STACTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/stac/api?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
+                        "url: \"http://localhost:8080/geoserver/ogc/stac/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
     }
 
     @Test
     public void testApiYaml() throws Exception {
-        String yaml = getAsString("ogc/stac/api?f=application/x-yaml");
+        String yaml = getAsString("ogc/stac/openapi?f=application/x-yaml");
         GeoServerBaseTestSupport.LOGGER.log(Level.INFO, yaml);
 
         ObjectMapper mapper = Yaml.mapper();
@@ -98,7 +98,7 @@ public class ApiTest extends STACTestSupport {
 
     @Test
     public void testYamlAsAcceptsHeader() throws Exception {
-        MockHttpServletRequest request = createRequest("ogc/stac/api");
+        MockHttpServletRequest request = createRequest("ogc/stac/openapi");
         request.setMethod("GET");
         request.setContent(new byte[] {});
         request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/x-yaml, text/html");

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/LandingPageTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/stac/LandingPageTest.java
@@ -116,7 +116,7 @@ public class LandingPageTest extends STACTestSupport {
         // check API links
         assertJSONList(
                 json,
-                "links[?(@.href =~ /.*ogc\\/stac\\/api.*/)].rel",
+                "links[?(@.href =~ /.*ogc\\/stac\\/openapi.*/)].rel",
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DESC,
                 Link.REL_SERVICE_DOC);


### PR DESCRIPTION
Tests in this community module have accumulated failures due to various changes all landing in a short amount of time in GeoTools and GeoServer. This PR makes the tests pass again.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->