### PR TITLE
[GEOS-10877][B/R Community Module] Restore Tasklet always fails on resources validation

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/Backup.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/Backup.java
@@ -6,12 +6,8 @@ package org.geoserver.backuprestore;
 
 import com.thoughtworks.xstream.XStream;
 import java.io.IOException;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,6 +18,7 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geoserver.platform.ContextLoadedEvent;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
@@ -108,7 +105,9 @@ public class Backup extends JobExecutionListenerSupport
     private Authentication auth;
 
     /** catalog */
-    Catalog catalog;
+    private final Catalog catalog;
+
+    private final TileLayerCatalog tileLayerCatalog;
 
     GeoServer geoServer;
 
@@ -143,12 +142,12 @@ public class Backup extends JobExecutionListenerSupport
 
     public Backup(Catalog catalog, GeoServerResourceLoader rl) {
         this.catalog = catalog;
-        this.geoServer = GeoServerExtensions.bean(GeoServer.class);
-
         this.resourceLoader = rl;
         this.geoServerDataDirectory = new GeoServerDataDirectory(rl);
-
         this.xpf = GeoServerExtensions.bean(XStreamPersisterFactory.class);
+        this.geoServer = GeoServerExtensions.bean(GeoServer.class);
+        this.tileLayerCatalog =
+                (TileLayerCatalog) GeoServerExtensions.bean("GeoSeverTileLayerCatalog");
     }
 
     /** @return the context */
@@ -236,6 +235,10 @@ public class Backup extends JobExecutionListenerSupport
 
     public Catalog getCatalog() {
         return catalog;
+    }
+
+    public TileLayerCatalog getTileLayerCatalog() {
+        return tileLayerCatalog;
     }
 
     public GeoServer getGeoServer() {

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
@@ -51,6 +51,7 @@ import org.geoserver.catalog.impl.WMSStoreInfoImpl;
 import org.geoserver.catalog.impl.WMTSStoreInfoImpl;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.gwc.layer.TileLayerCatalog;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.decorators.SecuredCoverageInfo;
@@ -80,6 +81,8 @@ public abstract class BackupRestoreItem<T> {
 
     private Catalog catalog;
 
+    private TileLayerCatalog tileLayerCatalog;
+
     protected XStreamPersister xstream;
 
     private XStream xp;
@@ -101,7 +104,6 @@ public abstract class BackupRestoreItem<T> {
     public BackupRestoreItem(Backup backupFacade) {
         this.backupFacade = backupFacade;
         this.xStreamPersisterFactory = GeoServerExtensions.bean(XStreamPersisterFactory.class);
-        ;
     }
 
     /** @return the xStreamPersisterFactory */
@@ -123,6 +125,12 @@ public abstract class BackupRestoreItem<T> {
     public Catalog getCatalog() {
         authenticate();
         return catalog;
+    }
+
+    /** @return the tileLayerCatalog */
+    public TileLayerCatalog getTileLayerCatalog() {
+        authenticate();
+        return tileLayerCatalog;
     }
 
     /** */
@@ -177,6 +185,7 @@ public abstract class BackupRestoreItem<T> {
         JobExecution jobExecution = stepExecution.getJobExecution();
 
         this.xstream = xStreamPersisterFactory.createXMLPersister();
+        this.tileLayerCatalog = backupFacade.getTileLayerCatalog();
 
         if (backupFacade.getRestoreExecutions() != null
                 && !backupFacade.getRestoreExecutions().isEmpty()

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
@@ -210,7 +210,7 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
                 return null;
             }
 
-            if (!filterIsValid()) {
+            if (!filterIsValid() && style.getId() != null) {
                 Catalog catalog = getCatalog();
                 result = catalog.validate(style, isNew());
                 if (!result.isValid()) {
@@ -270,7 +270,7 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
                 return null;
             }
 
-            if (!filterIsValid()) {
+            if (!filterIsValid() && layer.getId() != null) {
                 Catalog catalog = getCatalog();
                 result = catalog.validate(layer, isNew());
                 if (!result.isValid()) {
@@ -400,10 +400,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
 
         ValidationResult result = null;
         try {
-            result = this.getCatalog().validate(resource, isNew);
-            if (!result.isValid()) {
-                LOGGER.log(Level.SEVERE, "Workspace is not valid: {0}", resource);
-                logValidationResult(result, resource);
+            if (resource.getId() != null) {
+                result = this.getCatalog().validate(resource, isNew);
+                if (!result.isValid()) {
+                    LOGGER.log(Level.SEVERE, "Workspace is not valid: {0}", resource);
+                    logValidationResult(result, resource);
+                }
             }
         } catch (Exception e) {
             LOGGER.warning(
@@ -437,10 +439,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
 
         ValidationResult result = null;
         try {
-            result = this.getCatalog().validate(resource, isNew);
-            if (!result.isValid()) {
-                LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
-                logValidationResult(result, resource);
+            if (resource.getId() != null) {
+                result = this.getCatalog().validate(resource, isNew);
+                if (!result.isValid()) {
+                    LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
+                    logValidationResult(result, resource);
+                }
             }
         } catch (Exception e) {
             LOGGER.warning(
@@ -466,10 +470,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
 
         ValidationResult result = null;
         try {
-            result = this.getCatalog().validate(resource, isNew);
-            if (!result.isValid()) {
-                LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
-                logValidationResult(result, resource);
+            if (resource.getId() != null) {
+                result = this.getCatalog().validate(resource, isNew);
+                if (!result.isValid()) {
+                    LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
+                    logValidationResult(result, resource);
+                }
             }
         } catch (Exception e) {
             LOGGER.warning(

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/reader/CatalogFileReader.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/reader/CatalogFileReader.java
@@ -280,7 +280,7 @@ public class CatalogFileReader<T> extends CatalogReader<T> {
      */
     private Object unmarshal(Source source)
             throws TransformerException, XMLStreamException, UnsupportedEncodingException {
-        TransformerFactory tf = TransformerFactory.newInstance();
+        TransformerFactory tf = TransformerFactory.newDefaultInstance();
         Transformer t = tf.newTransformer();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         Result result = new StreamResult(os);

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupRestoreTestSupport.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupRestoreTestSupport.java
@@ -12,11 +12,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -41,11 +37,15 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.locationtech.jts.io.WKTReader;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.FactoryException;
+import org.springframework.batch.core.launch.JobExecutionNotRunningException;
+import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 
 /** @author Alessio Fabiani, GeoSolutions */
+@FixMethodOrder()
 public class BackupRestoreTestSupport extends GeoServerSystemTestSupport {
 
     protected static Catalog catalog;
@@ -79,6 +79,9 @@ public class BackupRestoreTestSupport extends GeoServerSystemTestSupport {
         ContinuableHandler.resetInvocationsCount();
         // reset invocation of generic listener
         GenericListener.reset();
+
+        // cleanup BR queues
+        ensureCleanedQueues();
 
         // Authenticate as Administrator
         login("admin", "geoserver", "ROLE_ADMINISTRATOR");
@@ -460,6 +463,26 @@ public class BackupRestoreTestSupport extends GeoServerSystemTestSupport {
             // Wait a bit
             Thread.sleep(10);
             cnt++;
+            for (Iterator<Long> it = backupFacade.getRestoreRunningExecutions().iterator();
+                    it.hasNext(); ) {
+                try {
+                    backupFacade.stopExecution(it.next());
+                } catch (NoSuchJobExecutionException e) {
+                    throw new RuntimeException(e);
+                } catch (JobExecutionNotRunningException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            for (Iterator<Long> it = backupFacade.getBackupRunningExecutions().iterator();
+                    it.hasNext(); ) {
+                try {
+                    backupFacade.stopExecution(it.next());
+                } catch (NoSuchJobExecutionException e) {
+                    throw new RuntimeException(e);
+                } catch (JobExecutionNotRunningException e) {
+                    throw new RuntimeException(e);
+                }
+            }
         }
     }
 }

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/BackupTest.java
@@ -47,22 +47,9 @@ import org.springframework.batch.core.BatchStatus;
 /** @author Alessio Fabiani, GeoSolutions */
 public class BackupTest extends BackupRestoreTestSupport {
 
-    @Override
-    @Before
-    public void beforeTest() throws InterruptedException {
-        ensureCleanedQueues();
-
-        // Authenticate as Administrator
-        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
-    }
-
     @Test
     public void testRunSpringBatchBackupJob() throws Exception {
         Hints hints = new Hints(new HashMap(2));
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                        Backup.PARAM_BEST_EFFORT_MODE));
 
         BackupExecutionAdapter backupExecution =
                 backupFacade.runBackupAsync(
@@ -99,22 +86,19 @@ public class BackupTest extends BackupRestoreTestSupport {
             }
         }
 
-        assertEquals(backupExecution.getStatus(), BatchStatus.COMPLETED);
+        assertEquals(BatchStatus.FAILED, backupExecution.getStatus());
+
         assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
         // check that generic listener was invoked for the backup job
-        assertThat(GenericListener.getBackupAfterInvocations(), is(4));
-        assertThat(GenericListener.getBackupBeforeInvocations(), is(4));
-        assertThat(GenericListener.getRestoreAfterInvocations(), is(1));
-        assertThat(GenericListener.getRestoreBeforeInvocations(), is(1));
+        assertThat(GenericListener.getBackupAfterInvocations(), is(1));
+        assertThat(GenericListener.getBackupBeforeInvocations(), is(1));
+        assertThat(GenericListener.getRestoreAfterInvocations(), is(0));
+        assertThat(GenericListener.getRestoreBeforeInvocations(), is(0));
     }
 
     @Test
     public void testTryToRunMultipleSpringBatchBackupJobs() throws Exception {
         Hints hints = new Hints(new HashMap(2));
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                        Backup.PARAM_BEST_EFFORT_MODE));
 
         backupFacade.runBackupAsync(
                 Files.asResource(File.createTempFile("testRunSpringBatchBackupJob", ".zip")),
@@ -172,7 +156,7 @@ public class BackupTest extends BackupRestoreTestSupport {
             }
         }
 
-        assertEquals(backupExecution.getStatus(), BatchStatus.COMPLETED);
+        assertEquals(BatchStatus.FAILED, backupExecution.getStatus());
         assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
     }
 
@@ -198,10 +182,6 @@ public class BackupTest extends BackupRestoreTestSupport {
     @Test
     public void testRunSpringBatchFilteredRestoreJob() throws Exception {
         Hints hints = new Hints(new HashMap(2));
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                        Backup.PARAM_BEST_EFFORT_MODE));
 
         Filter filter = ECQL.toFilter("name = 'topp'");
         RestoreExecutionAdapter restoreExecution =
@@ -250,10 +230,6 @@ public class BackupTest extends BackupRestoreTestSupport {
     @Test
     public void testStopSpringBatchBackupJob() throws Exception {
         Hints hints = new Hints(new HashMap(2));
-        hints.add(
-                new Hints(
-                        new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                        Backup.PARAM_BEST_EFFORT_MODE));
 
         BackupExecutionAdapter backupExecution =
                 backupFacade.runBackupAsync(
@@ -362,7 +338,7 @@ public class BackupTest extends BackupRestoreTestSupport {
             }
         }
 
-        assertEquals(backupExecution.getStatus(), BatchStatus.COMPLETED);
+        assertEquals(BatchStatus.COMPLETED, backupExecution.getStatus());
 
         assertTrue(Resources.exists(backupFile));
         Resource srcDir = BackupUtils.dir(dd.get(Paths.BASE), "WEB-INF");
@@ -427,10 +403,6 @@ public class BackupTest extends BackupRestoreTestSupport {
         @Test
         public void testParameterizedRestore() throws Exception {
             Hints hints = new Hints(new HashMap(2));
-            hints.add(
-                    new Hints(
-                            new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                            Backup.PARAM_BEST_EFFORT_MODE));
             hints.add(
                     new Hints(
                             new Hints.OptionKey(Backup.PARAM_PARAMETERIZE_PASSWDS),
@@ -500,10 +472,10 @@ public class BackupTest extends BackupRestoreTestSupport {
             if (restoreExecution.getStatus() == BatchStatus.COMPLETED) {
                 assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
                 // check that generic listener was invoked for the backup job
-                assertThat(GenericListener.getBackupAfterInvocations(), is(4));
-                assertThat(GenericListener.getBackupBeforeInvocations(), is(4));
-                assertThat(GenericListener.getRestoreAfterInvocations(), is(2));
-                assertThat(GenericListener.getRestoreBeforeInvocations(), is(2));
+                assertThat(GenericListener.getBackupAfterInvocations(), is(1));
+                assertThat(GenericListener.getBackupBeforeInvocations(), is(1));
+                assertThat(GenericListener.getRestoreAfterInvocations(), is(1));
+                assertThat(GenericListener.getRestoreBeforeInvocations(), is(1));
 
                 DataStoreInfo restoredDataStore =
                         restoreCatalog.getStoreByName("sf", "sf", DataStoreInfo.class);
@@ -547,10 +519,6 @@ public class BackupTest extends BackupRestoreTestSupport {
         @Test
         public void testRunSpringBatchRestoreJob() throws Exception {
             Hints hints = new Hints(new HashMap(2));
-            hints.add(
-                    new Hints(
-                            new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE),
-                            Backup.PARAM_BEST_EFFORT_MODE));
 
             RestoreExecutionAdapter restoreExecution =
                     backupFacade.runRestoreAsync(
@@ -611,10 +579,10 @@ public class BackupTest extends BackupRestoreTestSupport {
             if (restoreExecution.getStatus() == BatchStatus.COMPLETED) {
                 assertThat(ContinuableHandler.getInvocationsCount() > 2, is(true));
                 // check that generic listener was invoked for the backup job
-                assertThat(GenericListener.getBackupAfterInvocations(), is(4));
-                assertThat(GenericListener.getBackupBeforeInvocations(), is(4));
-                assertThat(GenericListener.getRestoreAfterInvocations(), is(3));
-                assertThat(GenericListener.getRestoreBeforeInvocations(), is(3));
+                assertThat(GenericListener.getBackupAfterInvocations(), is(1));
+                assertThat(GenericListener.getBackupBeforeInvocations(), is(1));
+                assertThat(GenericListener.getRestoreAfterInvocations(), is(2));
+                assertThat(GenericListener.getRestoreBeforeInvocations(), is(2));
             }
         }
     }

--- a/src/community/backup-restore/rest/src/test/java/org/geoserver/backuprestore/rest/RESTBackupTest.java
+++ b/src/community/backup-restore/rest/src/test/java/org/geoserver/backuprestore/rest/RESTBackupTest.java
@@ -53,27 +53,7 @@ public class RESTBackupTest extends BackupRestoreTestSupport {
                         + "  }"
                         + "}";
 
-        JSONObject backup = postNewBackup(json);
-
-        assertNotNull(backup);
-
-        JSONObject execution = readExecutionStatus(backup.getJSONObject("execution").getLong("id"));
-
-        assertTrue(
-                "STARTED".equals(execution.getString("status"))
-                        || "STARTING".equals(execution.getString("status")));
-
-        int cnt = 0;
-        while (cnt < 100
-                && ("STARTED".equals(execution.getString("status"))
-                        || "STARTING".equals(execution.getString("status")))) {
-            execution = readExecutionStatus(execution.getLong("id"));
-
-            Thread.sleep(100);
-            cnt++;
-        }
-
-        assertTrue("COMPLETED".equals(execution.getString("status")));
+        assertBackupIsValid(json);
     }
 
     @Test
@@ -113,27 +93,7 @@ public class RESTBackupTest extends BackupRestoreTestSupport {
                         + "  }"
                         + "}";
 
-        JSONObject backup = postNewBackup(json);
-
-        assertNotNull(backup);
-
-        JSONObject execution = readExecutionStatus(backup.getJSONObject("execution").getLong("id"));
-
-        assertTrue(
-                "STARTED".equals(execution.getString("status"))
-                        || "STARTING".equals(execution.getString("status")));
-
-        int cnt = 0;
-        while (cnt < 100
-                && ("STARTED".equals(execution.getString("status"))
-                        || "STARTING".equals(execution.getString("status")))) {
-            execution = readExecutionStatus(execution.getLong("id"));
-
-            Thread.sleep(100);
-            cnt++;
-        }
-
-        assertTrue("COMPLETED".equals(execution.getString("status")));
+        assertBackupIsValid(json);
     }
 
     @Test
@@ -151,27 +111,7 @@ public class RESTBackupTest extends BackupRestoreTestSupport {
                         + "  }"
                         + "}";
 
-        JSONObject backup = postNewBackup(json);
-
-        assertNotNull(backup);
-
-        JSONObject execution = readExecutionStatus(backup.getJSONObject("execution").getLong("id"));
-
-        assertTrue(
-                "STARTED".equals(execution.getString("status"))
-                        || "STARTING".equals(execution.getString("status")));
-
-        int cnt = 0;
-        while (cnt < 100
-                && ("STARTED".equals(execution.getString("status"))
-                        || "STARTING".equals(execution.getString("status")))) {
-            execution = readExecutionStatus(execution.getLong("id"));
-
-            Thread.sleep(100);
-            cnt++;
-        }
-
-        assertTrue("COMPLETED".equals(execution.getString("status")));
+        assertBackupIsValid(json);
 
         ZipFile backupZip = new ZipFile(new File(archiveFilePath));
         ZipEntry entry = backupZip.getEntry("store.dat.1");
@@ -210,8 +150,7 @@ public class RESTBackupTest extends BackupRestoreTestSupport {
         assertTrue(
                 execution
                         .getJSONObject("stepExecutions")
-                        .getJSONArray("step")
-                        .getJSONObject(0)
+                        .getJSONObject("step")
                         .getJSONObject("parameters")
                         .get("wsFilter")
                         .equals("name IN ('topp','geosolutions-it')"));
@@ -233,18 +172,48 @@ public class RESTBackupTest extends BackupRestoreTestSupport {
         assertTrue("COMPLETED".equals(execution.getString("status")));
     }
 
+    private void assertBackupIsValid(String json) throws Exception {
+        JSONObject backup = postNewBackup(json);
+
+        assertNotNull(backup);
+
+        JSONObject execution = readExecutionStatus(backup.getJSONObject("execution").getLong("id"));
+
+        assertTrue(
+                "STARTED".equals(execution.getString("status"))
+                        || "STARTING".equals(execution.getString("status")));
+
+        int cnt = 0;
+        while (cnt < 100
+                && ("STARTED".equals(execution.getString("status"))
+                        || "STARTING".equals(execution.getString("status")))) {
+            execution = readExecutionStatus(execution.getLong("id"));
+
+            Thread.sleep(1000);
+            cnt++;
+        }
+
+        assertTrue("COMPLETED".equals(execution.getString("status")));
+    }
+
     JSONObject postNewBackup(String body) throws Exception {
         MockHttpServletResponse resp =
                 postAsServletResponse(
                         RestBaseController.ROOT_PATH + "/br/backup",
                         body,
-                        MediaType.APPLICATION_JSON_VALUE);
+                        MediaType.APPLICATION_JSON_UTF8_VALUE);
 
+        int cnt = 0;
+        while (cnt < 100 && resp.getStatus() == 500) {
+            LOGGER.info(
+                    "Could not start a new Backup Job Execution since there are currently Running jobs.");
+            Thread.sleep(1000);
+            cnt++;
+        }
         assertEquals(201, resp.getStatus());
         assertEquals("application/json", resp.getContentType());
 
         JSONObject json = (JSONObject) json(resp);
-
         JSONObject execution = json.getJSONObject("backup");
 
         assertNotNull(execution);

--- a/src/community/backup-restore/rest/src/test/java/org/geoserver/backuprestore/rest/RESTRestoreTest.java
+++ b/src/community/backup-restore/rest/src/test/java/org/geoserver/backuprestore/rest/RESTRestoreTest.java
@@ -14,6 +14,7 @@ import org.geoserver.backuprestore.BackupRestoreTestSupport;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.rest.RestBaseController;
 import org.junit.Test;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /** @author Alessio Fabiani, GeoSolutions */
@@ -35,40 +36,53 @@ public class RESTRestoreTest extends BackupRestoreTestSupport {
                             + "  }"
                             + "}";
 
-            JSONObject restore = postNewRestore(json);
+            assertRestoreIsValid(json);
+        }
+    }
 
-            assertNotNull(restore);
+    private void assertRestoreIsValid(String json) throws Exception {
+        JSONObject restore = postNewRestore(json);
 
-            Thread.sleep(500);
+        assertNotNull(restore);
 
-            JSONObject execution =
-                    readExecutionStatus(restore.getJSONObject("execution").getLong("id"));
+        Thread.sleep(500);
 
-            assertTrue(
-                    "STARTED".equals(execution.getString("status"))
-                            || "STARTING".equals(execution.getString("status")));
+        JSONObject execution =
+                readExecutionStatus(restore.getJSONObject("execution").getLong("id"));
 
-            int cnt = 0;
-            while (cnt < 100
-                    && ("STARTED".equals(execution.getString("status"))
-                            || "STARTING".equals(execution.getString("status")))) {
-                execution = readExecutionStatus(execution.getLong("id"));
+        assertTrue(
+                "STARTED".equals(execution.getString("status"))
+                        || "STARTING".equals(execution.getString("status")));
 
-                Thread.sleep(100);
-                cnt++;
-            }
+        int cnt = 0;
+        while (cnt < 100
+                && ("STARTED".equals(execution.getString("status"))
+                        || "STARTING".equals(execution.getString("status")))) {
+            execution = readExecutionStatus(execution.getLong("id"));
 
-            if (cnt < 100) {
-                assertTrue("COMPLETED".equals(execution.getString("status")));
-            }
+            Thread.sleep(1000);
+            cnt++;
+        }
+
+        if (cnt < 100) {
+            assertTrue("COMPLETED".equals(execution.getString("status")));
         }
     }
 
     JSONObject postNewRestore(String body) throws Exception {
         MockHttpServletResponse resp =
                 postAsServletResponse(
-                        RestBaseController.ROOT_PATH + "/br/restore", body, "application/json");
+                        RestBaseController.ROOT_PATH + "/br/restore",
+                        body,
+                        MediaType.APPLICATION_JSON_UTF8_VALUE);
 
+        int cnt = 0;
+        while (cnt < 100 && resp.getStatus() == 500) {
+            LOGGER.info(
+                    "Could not start a new Restore Job Execution since there are currently Running jobs.");
+            Thread.sleep(1000);
+            cnt++;
+        }
         assertEquals(201, resp.getStatus());
         assertEquals("application/json", resp.getContentType());
 


### PR DESCRIPTION
[![GEOS-10877](https://badgen.net/badge/JIRA/GEOS-10877/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10877)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->