### PR TITLE
[Backport 2.21.x] [GEOS-10878] wps-multidimensional and wps-jdbc are not being deployed on maven repo

### DIFF
--- a/src/extension/pom.xml
+++ b/src/extension/pom.xml
@@ -449,7 +449,9 @@
         <module>web-resource</module>
         <module>params-extractor</module>
         <module>gwc-s3</module>
+        <module>wmts-multi-dimensional</module>
         <module>wps-download</module>
+        <module>wps-jdbc</module>
         <module>mapml</module>
         <module>geopkg-output</module>
       </modules>


### PR DESCRIPTION
[![GEOS-10878](https://badgen.net/badge/JIRA/GEOS-10878/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10878)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6649
 **Authored by:** @aaime