### PR TITLE
[GEOS-10880] OGC API Features cannot handle crs-bbox with uri "http://www.opengis.net/def/crs/OGC/1.3/CRS84"

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
@@ -194,6 +194,26 @@ public class FeatureTest extends FeaturesTestSupport {
     }
 
     @Test
+    public void testBBOXOGCAuthority() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/v1/collections/"
+                                + roadSegments
+                                + "/items?"
+                                + "bbox=35,0,60,3"
+                                + "&bbox-crs=http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                        200);
+        assertEquals("FeatureCollection", json.read("type", String.class));
+        // should return those two features only
+        assertEquals(2, (int) json.read("features.length()", Integer.class));
+        assertEquals(
+                1, json.read("features[?(@.id == 'PrimitiveGeoFeature.f001')]", List.class).size());
+        assertEquals(
+                1, json.read("features[?(@.id == 'PrimitiveGeoFeature.f002')]", List.class).size());
+    }
+
+    @Test
     public void testBBoxDatelineCrossingFilter() throws Exception {
         String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =


### PR DESCRIPTION
[![GEOS-10880](https://badgen.net/badge/JIRA/GEOS-10880/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10880)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Needs https://github.com/geotools/geotools/pull/4206 for the test to actually pass (but no build will run it, so I expect to get a green anyways)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->