### PR TITLE
[GEOS-10879] Dispatcher should not respond to non standard HTTP methods

### DIFF
--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -237,6 +237,11 @@
     <bean id="loggingFilter" class="org.geoserver.filters.LoggingFilter">
         <constructor-arg ref="geoServer"/>
     </bean>
+
+    <!-- This filter restricts the HTTP methods that can be used to access GeoServer
+        to: GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS -->
+    <bean id="methodFilter" class="org.geoserver.filters.HTTPMethodFilter" />
+
   
   <!-- the proxyfing URL mangler, along with machinery to support headers expansion usage in asynch requests -->
   <bean id="proxyfier" class="org.geoserver.ows.ProxifyingURLMangler">

--- a/src/main/src/main/java/org/geoserver/filters/HTTPMethodFilter.java
+++ b/src/main/src/main/java/org/geoserver/filters/HTTPMethodFilter.java
@@ -1,0 +1,47 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.filters;
+
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** A filter that restricts the HTTP methods that can be used to access GeoServer. */
+public class HTTPMethodFilter implements GeoServerFilter {
+    private static final List<String> HTTP_METHOD_OPTIONS =
+            List.of("GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS");
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // nothing to do
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            if (!HTTP_METHOD_OPTIONS.contains(httpRequest.getMethod())) {
+                httpResponse.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            } else {
+                chain.doFilter(request, response);
+            }
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // nothing to do
+    }
+}

--- a/src/main/src/test/java/org/geoserver/filters/HTTPMethodFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/HTTPMethodFilterTest.java
@@ -1,0 +1,104 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.filters;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Tests of a filter that restricts the HTTP methods that can be used to access GeoServer. */
+public class HTTPMethodFilterTest {
+    @Test
+    public void testGETRequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("GET");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testPOSTRequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("POST");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testPUTRequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("PUT");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testDELETERequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("DELETE");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testHEADRequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("HEAD");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testOPTIONSRequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("OPTIONS");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testPATCHRequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("PATCH");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testInvalidRequest() throws Exception {
+        MockHttpServletResponse response = getResponseByMethod("PROPFIND");
+        assertEquals(405, response.getStatus());
+        response = getResponseByMethod("ACL");
+        assertEquals(405, response.getStatus());
+        response = getResponseByMethod("MKCALENDAR");
+        assertEquals(405, response.getStatus());
+        response = getResponseByMethod("LINK");
+        assertEquals(405, response.getStatus());
+        response = getResponseByMethod("BREW");
+        assertEquals(405, response.getStatus());
+        response = getResponseByMethod("WHEN");
+        assertEquals(405, response.getStatus());
+    }
+
+    private MockHttpServletResponse getResponseByMethod(String method)
+            throws ServletException, IOException {
+        MockHttpServletRequest request =
+                new MockHttpServletRequest(method, "http://www.geoserver.org");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setContentType("text/plain");
+
+        // run the filter
+        HTTPMethodFilter filter = new HTTPMethodFilter();
+        MockFilterChain chain =
+                new MockFilterChain() {
+                    @Override
+                    @SuppressWarnings("PMD.CloseResource")
+                    public void doFilter(ServletRequest request, ServletResponse response)
+                            throws IOException, ServletException {
+                        ServletOutputStream os = response.getOutputStream();
+                        os.print("Some random text");
+                        os.close();
+                        // ka-blam! (or not?)
+                        os.flush();
+                    }
+                };
+        filter.doFilter(request, response, chain);
+        return response;
+    }
+}


### PR DESCRIPTION
[![GEOS-10879](https://badgen.net/badge/JIRA/GEOS-10879/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10879)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

added tests


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->