### PR TITLE
[GEOS-10881] Add Content-Crs header to OGC API

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureResponseMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureResponseMessageConverter.java
@@ -38,8 +38,11 @@ public class FeatureResponseMessageConverter
 
     static final Logger LOGGER = Logging.getLogger(FeatureResponseMessageConverter.class);
     private static final Version V2 = new Version("2.0");
-    /** Name of the header stating the CRS of the response */
-    public static final String CRS_RESPONSE_HEADER = "OGC-CRS";
+    /**
+     * Name of the header stating the CRS of the response see
+     * https://docs.ogc.org/is/18-058/18-058.html#_coordinate_reference_system_information_independent_of_the_feature_encoding
+     */
+    public static final String CRS_RESPONSE_HEADER = "Content-Crs";
 
     List<Response> responses;
 


### PR DESCRIPTION
[![GEOS-10881](https://badgen.net/badge/JIRA/GEOS-10881/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10881)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->