### PR TITLE
[GEOS-10884] OGC API features should return a 400 when bbox-crs contains invalid content

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBBoxParser.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBBoxParser.java
@@ -38,7 +38,7 @@ public class APIBBoxParser {
      * null or empty.
      */
     public static Filter toFilter(String bbox) throws FactoryException {
-        return toFilter(bbox, null);
+        return toFilter(bbox, (CoordinateReferenceSystem) null);
     }
 
     /**
@@ -66,6 +66,21 @@ public class APIBBoxParser {
                     "Bounding box array must have either 4 or 6 ordinates",
                     HttpStatus.BAD_REQUEST);
         }
+        return toFilter(parsed);
+    }
+
+    /**
+     * Turns a bbox specification into a OGC filter, using the given CRS, or {@link
+     * DefaultGeographicCRS#WGS84} if null is passed. Will return {@link Filter#INCLUDE} if the bbox
+     * spec itself is null or empty.
+     */
+    public static Filter toFilter(String bbox, String crs) throws FactoryException {
+        if (bbox == null || bbox.trim().isEmpty()) {
+            return Filter.INCLUDE;
+        }
+
+        // to envelopes first, build filter around them then
+        ReferencedEnvelope[] parsed = parse(bbox, crs);
         return toFilter(parsed);
     }
 
@@ -107,7 +122,16 @@ public class APIBBoxParser {
 
     /** Parses a BBOX with the given CRS, if null {@link DefaultGeographicCRS#WGS84} will be used */
     public static ReferencedEnvelope[] parse(String value, String crs) throws FactoryException {
-        return parse(value, crs != null ? CRS.decode(crs, true) : null);
+        return parse(value, parseCRS(crs));
+    }
+
+    private static CoordinateReferenceSystem parseCRS(String crs) throws FactoryException {
+        try {
+            return crs != null ? CRS.decode(crs, true) : null;
+        } catch (NoSuchAuthorityCodeException e) {
+            throw new APIException(
+                    INVALID_PARAMETER_VALUE, "Invalid CRS: " + crs, HttpStatus.BAD_REQUEST);
+        }
     }
 
     /** Parses a BBOX with the given CRS, if null {@link DefaultGeographicCRS#WGS84} will be used */

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
@@ -352,11 +352,7 @@ public class FeatureService {
         query.setTypeNames(Arrays.asList(new QName(ft.getNamespace().getURI(), ft.getName())));
         List<Filter> filters = new ArrayList<>();
         if (bbox != null) {
-            CoordinateReferenceSystem queryCRS = DefaultGeographicCRS.WGS84;
-            if (bboxCRS != null) {
-                queryCRS = CRS.decode(bboxCRS);
-            }
-            filters.add(APIBBoxParser.toFilter(bbox, queryCRS));
+            filters.add(APIBBoxParser.toFilter(bbox, bboxCRS));
         }
         if (datetime != null) {
             filters.add(buildTimeFilter(ft, datetime));
@@ -398,6 +394,10 @@ public class FeatureService {
         // build a response tracking both results and request to allow reusing the existing WFS
         // output formats
         return new FeaturesResponse(request.getAdaptee(), response);
+    }
+
+    private static CoordinateReferenceSystem parseCRS(String bboxCRS) throws FactoryException {
+        return CRS.decode(bboxCRS);
     }
 
     /** TODO: use DimensionInfo instead? It's used to return the time range in the collection */

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import net.minidev.json.JSONArray;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
+import org.geoserver.ogcapi.APIException;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -211,6 +212,23 @@ public class FeatureTest extends FeaturesTestSupport {
                 1, json.read("features[?(@.id == 'PrimitiveGeoFeature.f001')]", List.class).size());
         assertEquals(
                 1, json.read("features[?(@.id == 'PrimitiveGeoFeature.f002')]", List.class).size());
+    }
+
+    @Test
+    public void testInvalidBBOXCRS() throws Exception {
+        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/v1/collections/"
+                                + roadSegments
+                                + "/items?"
+                                + "bbox=35,0,60,3"
+                                + "&bbox-crs=http://www.opengis.net/def/crs/OGC/1.3/INVALID",
+                        400);
+        assertEquals(APIException.INVALID_PARAMETER_VALUE, json.read("code", String.class));
+        assertEquals(
+                "Invalid CRS: http://www.opengis.net/def/crs/OGC/1.3/INVALID",
+                json.read("description"));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10884](https://badgen.net/badge/JIRA/GEOS-10884/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10884)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently returns a 500 instead.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->