### PR TITLE
[GEOS-10885] Remove Axis Order from OGC API Header

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureResponseMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureResponseMessageConverter.java
@@ -6,9 +6,7 @@ package org.geoserver.ogcapi.v1.features;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.ogcapi.MessageConverterResponseAdapter;
 import org.geoserver.ows.Request;
@@ -16,12 +14,8 @@ import org.geoserver.ows.Response;
 import org.geoserver.platform.Operation;
 import org.geoserver.wfs.WFSGetFeatureOutputFormat;
 import org.geoserver.wfs.request.FeatureCollectionResponse;
-import org.geotools.referencing.CRS;
 import org.geotools.util.Version;
 import org.geotools.util.logging.Logging;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.cs.CoordinateSystemAxis;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -38,11 +32,6 @@ public class FeatureResponseMessageConverter
 
     static final Logger LOGGER = Logging.getLogger(FeatureResponseMessageConverter.class);
     private static final Version V2 = new Version("2.0");
-    /**
-     * Name of the header stating the CRS of the response see
-     * https://docs.ogc.org/is/18-058/18-058.html#_coordinate_reference_system_information_independent_of_the_feature_encoding
-     */
-    public static final String CRS_RESPONSE_HEADER = "Content-Crs";
 
     List<Response> responses;
 
@@ -59,49 +48,6 @@ public class FeatureResponseMessageConverter
             throws IOException {
         setHeaders(value.getResponse(), operation, response, httpOutputMessage);
         response.write(value.getResponse(), httpOutputMessage.getBody(), operation);
-    }
-
-    @Override
-    protected void setHeaders(
-            Object result, Operation operation, Response response, HttpOutputMessage message) {
-        super.setHeaders(result, operation, response, message);
-        // CRS extension, set CRS and axis order
-        CoordinateReferenceSystem crs =
-                Optional.ofNullable((FeatureCollectionResponse) result)
-                        .map(fct -> fct.getFeatures().get(0))
-                        .map(fc -> fc.getSchema())
-                        .map(ft -> ft.getCoordinateReferenceSystem())
-                        .orElse(null);
-        if (crs != null) {
-            try {
-                String crsURI = FeatureService.getCRSURI(crs);
-                String orderSpec = getOrderSpecification(crs);
-                if (crsURI != null && orderSpec != null) {
-                    message.getHeaders()
-                            .set(CRS_RESPONSE_HEADER, crsURI + "; axisOrder=" + orderSpec);
-                }
-            } catch (FactoryException e) {
-                LOGGER.log(
-                        Level.INFO,
-                        "Failed to lookup EPSG code of CRS, won't set the OGC-CRS header." + crs,
-                        e);
-            }
-        }
-    }
-
-    private String getOrderSpecification(CoordinateReferenceSystem crs) {
-        CRS.AxisOrder order = CRS.getAxisOrder(crs);
-        CoordinateSystemAxis a0 = crs.getCoordinateSystem().getAxis(0);
-        CoordinateSystemAxis a1 = crs.getCoordinateSystem().getAxis(1);
-        String orderSpec;
-        if (order == CRS.AxisOrder.EAST_NORTH) {
-            orderSpec = a0.getAbbreviation() + "," + a1.getAbbreviation();
-        } else if (order == CRS.AxisOrder.NORTH_EAST) {
-            orderSpec = a1.getAbbreviation() + "," + a0.getAbbreviation();
-        } else {
-            orderSpec = null;
-        }
-        return orderSpec;
     }
 
     @Override

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/HttpHeaderContentCrsAppender.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/HttpHeaderContentCrsAppender.java
@@ -1,0 +1,63 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.features;
+
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.http.HttpServletResponse;
+import org.geoserver.ows.AbstractDispatcherCallback;
+import org.geoserver.ows.Request;
+import org.geoserver.ows.Response;
+import org.geoserver.platform.Operation;
+import org.geoserver.wfs.request.FeatureCollectionResponse;
+import org.geotools.util.logging.Logging;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * Sets the Content-Crs header on the response, if the response is a feature collection response.
+ */
+public class HttpHeaderContentCrsAppender extends AbstractDispatcherCallback {
+    static final Logger LOGGER = Logging.getLogger(HttpHeaderContentCrsAppender.class);
+    /**
+     * Name of the header stating the CRS of the response see
+     * https://docs.ogc.org/is/18-058/18-058.html#_coordinate_reference_system_information_independent_of_the_feature_encoding
+     */
+    public static final String CRS_RESPONSE_HEADER = "Content-Crs";
+
+    @Override
+    public Response responseDispatched(
+            Request request, Operation operation, Object result, Response response) {
+
+        // is this a feature response we are about to encode?
+        if (result instanceof FeaturesResponse) {
+            HttpServletResponse httpResponse = request.getHttpResponse();
+            FeatureCollectionResponse fcr = ((FeaturesResponse) result).getResponse();
+            CoordinateReferenceSystem crs =
+                    Optional.ofNullable(fcr)
+                            .map(fct -> fct.getFeatures().get(0))
+                            .map(fc -> fc.getSchema())
+                            .map(ft -> ft.getCoordinateReferenceSystem())
+                            .orElse(null);
+            if (crs != null) {
+                try {
+                    String crsURI = FeatureService.getCRSURI(crs);
+                    if (crsURI != null) {
+                        httpResponse.addHeader(CRS_RESPONSE_HEADER, crsURI);
+                    }
+                } catch (FactoryException e) {
+                    LOGGER.log(
+                            Level.INFO,
+                            "Failed to lookup EPSG code of CRS, won't set the Content-Crs header."
+                                    + crs,
+                            e);
+                }
+            }
+        }
+
+        return response;
+    }
+}

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/applicationContext.xml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/applicationContext.xml
@@ -19,6 +19,7 @@
 >
 
     <bean id="headerLinksAppender" class="org.geoserver.ogcapi.v1.features.HttpHeaderLinksAppender"/>
+    <bean id="contentCrsAppender" class="org.geoserver.ogcapi.v1.features.HttpHeaderContentCrsAppender"/>
 
     <!-- <mvc:annotation-driven/> -->
     <context:component-scan base-package="org.geoserver.ogcapi.v1.features"/>

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
@@ -56,8 +56,8 @@ public class FeatureTest extends FeaturesTestSupport {
                 getAsMockHttpServletResponse(
                         "ogc/features/v1/collections/" + roadSegments + "/items", 200);
         assertEquals(
-                "http://www.opengis.net/def/crs/OGC/1.3/CRS84; axisOrder=Lon,Lat",
-                response.getHeader(FeatureResponseMessageConverter.CRS_RESPONSE_HEADER));
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("FeatureCollection", json.read("type", String.class));
         assertEquals(5, (int) json.read("features.length()", Integer.class));
@@ -94,8 +94,8 @@ public class FeatureTest extends FeaturesTestSupport {
                                 + "3857",
                         200);
         assertEquals(
-                "http://www.opengis.net/def/crs/EPSG/0/3857; axisOrder=X,Y",
-                response.getHeader(FeatureResponseMessageConverter.CRS_RESPONSE_HEADER));
+                "http://www.opengis.net/def/crs/EPSG/0/3857",
+                response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("FeatureCollection", json.read("type", String.class));
         assertEquals(5, (int) json.read("features.length()", Integer.class));
@@ -647,6 +647,16 @@ public class FeatureTest extends FeaturesTestSupport {
     }
 
     @Test
+    public void testGetLayerAsHTMLHeader() throws Exception {
+        String roadSegments = getLayerId(MockData.ROAD_SEGMENTS);
+        String url = "ogc/features/v1/collections/" + roadSegments + "/items?f=html";
+        MockHttpServletResponse response = getAsMockHttpServletResponse(url, 200);
+        assertEquals(
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
+    }
+
+    @Test
     public void testGetLayerAsHTMLPagingLinks() throws Exception {
         String roadSegments = ResponseUtils.urlEncode(getLayerId(MockData.ROAD_SEGMENTS));
         String urlBase = "ogc/features/v1/collections/" + roadSegments + "/items?f=html";
@@ -742,8 +752,8 @@ public class FeatureTest extends FeaturesTestSupport {
                                 + "/items/PrimitiveGeoFeature.f002",
                         200);
         assertEquals(
-                "http://www.opengis.net/def/crs/OGC/1.3/CRS84; axisOrder=Lon,Lat",
-                response.getHeader(FeatureResponseMessageConverter.CRS_RESPONSE_HEADER));
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("Feature", json.read("type", String.class));
         assertEquals("PrimitiveGeoFeature.f002", json.read("id", String.class));
@@ -779,8 +789,8 @@ public class FeatureTest extends FeaturesTestSupport {
                                 + "?crs=CRS:84",
                         200);
         assertEquals(
-                "http://www.opengis.net/def/crs/OGC/1.3/CRS84; axisOrder=Lon,Lat",
-                response.getHeader(FeatureResponseMessageConverter.CRS_RESPONSE_HEADER));
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("Feature", json.read("type", String.class));
         assertEquals("PrimitiveGeoFeature.f002", json.read("id", String.class));


### PR DESCRIPTION
[![GEOS-10885](https://badgen.net/badge/JIRA/GEOS-10885/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10885)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

added test


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->