### PR TITLE
[GEOS-10887] Add angle brackets to OGC API CRS Header

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/HttpHeaderContentCrsAppender.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/HttpHeaderContentCrsAppender.java
@@ -46,7 +46,7 @@ public class HttpHeaderContentCrsAppender extends AbstractDispatcherCallback {
                 try {
                     String crsURI = FeatureService.getCRSURI(crs);
                     if (crsURI != null) {
-                        httpResponse.addHeader(CRS_RESPONSE_HEADER, crsURI);
+                        httpResponse.addHeader(CRS_RESPONSE_HEADER, "<" + crsURI + ">");
                     }
                 } catch (FactoryException e) {
                     LOGGER.log(

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
@@ -56,7 +56,7 @@ public class FeatureTest extends FeaturesTestSupport {
                 getAsMockHttpServletResponse(
                         "ogc/features/v1/collections/" + roadSegments + "/items", 200);
         assertEquals(
-                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>",
                 response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -94,7 +94,7 @@ public class FeatureTest extends FeaturesTestSupport {
                                 + "3857",
                         200);
         assertEquals(
-                "http://www.opengis.net/def/crs/EPSG/0/3857",
+                "<http://www.opengis.net/def/crs/EPSG/0/3857>",
                 response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -652,7 +652,7 @@ public class FeatureTest extends FeaturesTestSupport {
         String url = "ogc/features/v1/collections/" + roadSegments + "/items?f=html";
         MockHttpServletResponse response = getAsMockHttpServletResponse(url, 200);
         assertEquals(
-                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>",
                 response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
     }
 
@@ -752,7 +752,7 @@ public class FeatureTest extends FeaturesTestSupport {
                                 + "/items/PrimitiveGeoFeature.f002",
                         200);
         assertEquals(
-                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>",
                 response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("Feature", json.read("type", String.class));
@@ -789,7 +789,7 @@ public class FeatureTest extends FeaturesTestSupport {
                                 + "?crs=CRS:84",
                         200);
         assertEquals(
-                "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>",
                 response.getHeader(HttpHeaderContentCrsAppender.CRS_RESPONSE_HEADER));
         DocumentContext json = getAsJSONPath(response);
         assertEquals("Feature", json.read("type", String.class));


### PR DESCRIPTION
[![GEOS-10887](https://badgen.net/badge/JIRA/GEOS-10887/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10887)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->