### PR TITLE
[Backport 2.21.x] [GEOS-10863] Update Oracle JDBC driver to 19.18.0.0

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -140,7 +140,7 @@
     <marlin.version>0.9.3</marlin.version>
     <postgresql.jdbc.version>42.4.3</postgresql.jdbc.version>
     <postgis.jdbc.version>1.3.3</postgis.jdbc.version>
-    <oracle.jdbc.version>19.10.0.0</oracle.jdbc.version>
+    <oracle.jdbc.version>19.18.0.0</oracle.jdbc.version>
     <mysql.jdbc.version>8.0.28</mysql.jdbc.version>
     <solrj.version>7.2.1</solrj.version>
     <mockito.version>3.12.4</mockito.version>


### PR DESCRIPTION
[![GEOS-10863](https://badgen.net/badge/JIRA/GEOS-10863/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10863)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6611
 **Authored by:** @mprins