### PR TITLE
[Backport 2.23.x] [GEOS-10889] OGC API info section should report the spec version, not the server version

### DIFF
--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/v1/dggs/DGGSAPIBuilder.java
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/java/org/geoserver/ogcapi/v1/dggs/DGGSAPIBuilder.java
@@ -18,7 +18,7 @@ import org.geoserver.ogcapi.v1.features.FeaturesResponse;
 public class DGGSAPIBuilder extends OpenAPIBuilder<DGGSInfo> {
 
     public DGGSAPIBuilder() {
-        super(DGGSAPIBuilder.class, "openapi.yaml", "DGGS 1.0 server", "ogc/dggs");
+        super(DGGSAPIBuilder.class, "openapi.yaml", "DGGS 1.0 server", DGGSService.class);
     }
 
     @Override

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CoveragesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CoveragesAPIBuilder.java
@@ -23,7 +23,7 @@ public class CoveragesAPIBuilder extends org.geoserver.ogcapi.OpenAPIBuilder<WCS
                 CoveragesAPIBuilder.class,
                 "openapi.yaml",
                 "Coverages 1.0 server",
-                "ogc/coverages/v1");
+                CoveragesService.class);
     }
 
     /**

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CoveragesService.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CoveragesService.java
@@ -63,7 +63,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /** Implementation of OGC Coverages API service */
 @APIService(
         service = "Coverages",
-        version = "1.0.1",
+        version = "1.0.0",
         landingPage = "ogc/coverages/v1",
         serviceClass = WCSInfo.class)
 @RequestMapping(path = APIDispatcher.ROOT_PATH + "/coverages/v1")

--- a/src/community/ogcapi/ogcapi-coverages/src/main/resources/applicationContext.xml
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/resources/applicationContext.xml
@@ -25,7 +25,7 @@
     <!-- Bridges to have OGC services show up as OWS services too -->
     <bean id="coveragesServiceFactory" class="org.geoserver.ogcapi.APIServiceFactoryBean">
         <constructor-arg index="0" value="Coverages"/>
-        <constructor-arg index="1" value="1.0.1"/>
+        <constructor-arg index="1" value="1.0.0"/>
     </bean>
 
 </beans>

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/ApiTest.java
@@ -117,6 +117,9 @@ public class ApiTest extends CoveragesTestSupport {
                 servers.get(0).getUrl(),
                 equalTo("http://localhost:8080/geoserver/ogc/coverages/v1"));
 
+        // info version is spec version
+        assertEquals("1.0.0", api.getInfo().getVersion());
+
         // paths
         Paths paths = api.getPaths();
 

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/CoverageTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/CoverageTest.java
@@ -103,7 +103,7 @@ public class CoverageTest extends CoveragesTestSupport {
     public void testVersionHeader() throws Exception {
         MockHttpServletResponse response =
                 getAsServletResponse("ogc/coverages/v1/collections/rs:DEM/coverage");
-        assertTrue(headerHasValue(response, "API-Version", "1.0.1"));
+        assertTrue(headerHasValue(response, "API-Version", "1.0.0"));
     }
 
     private void assertBBOXDEM(

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/LandingPageTest.java
@@ -21,10 +21,10 @@ public class LandingPageTest extends CoveragesTestSupport {
 
     @Test
     public void testServiceDescriptor() {
-        Service service = getService("Coverages", new Version("1.0.1"));
+        Service service = getService("Coverages", new Version("1.0.0"));
         assertNotNull(service);
         assertEquals("Coverages", service.getId());
-        assertEquals(new Version("1.0.1"), service.getVersion());
+        assertEquals(new Version("1.0.0"), service.getVersion());
         assertThat(service.getService(), CoreMatchers.instanceOf(CoveragesService.class));
         assertThat(
                 service.getOperations(),

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
@@ -396,10 +396,6 @@ public class FeatureService {
         return new FeaturesResponse(request.getAdaptee(), response);
     }
 
-    private static CoordinateReferenceSystem parseCRS(String bboxCRS) throws FactoryException {
-        return CRS.decode(bboxCRS);
-    }
-
     /** TODO: use DimensionInfo instead? It's used to return the time range in the collection */
     private Filter buildTimeFilter(FeatureTypeInfo ft, String time)
             throws ParseException, IOException {

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesAPIBuilder.java
@@ -22,7 +22,11 @@ import org.geoserver.wfs.WFSInfo;
 public class FeaturesAPIBuilder extends org.geoserver.ogcapi.OpenAPIBuilder<WFSInfo> {
 
     public FeaturesAPIBuilder() {
-        super(FeaturesAPIBuilder.class, "openapi.yaml", "Features 1.0 server", "ogc/features/v1");
+        super(
+                FeaturesAPIBuilder.class,
+                "openapi.yaml",
+                "Features 1.0 server",
+                FeatureService.class);
     }
 
     /**

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
@@ -159,6 +159,9 @@ public class ApiTest extends FeaturesTestSupport {
                 servers.get(0).getUrl(),
                 equalTo("http://localhost:8080/geoserver/ogc/features/v1"));
 
+        // info version is spec version
+        assertEquals("1.0.1", api.getInfo().getVersion());
+
         // paths
         Paths paths = api.getPaths();
 

--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/v1/images/ImagesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/v1/images/ImagesAPIBuilder.java
@@ -30,7 +30,7 @@ public class ImagesAPIBuilder extends OpenAPIBuilder<ImagesServiceInfo> {
     private final GeoServer geoServer;
 
     public ImagesAPIBuilder(GeoServer geoServer) {
-        super(ImagesServiceInfo.class, "openapi.yaml", "Images API", "ogc/images/v1");
+        super(ImagesServiceInfo.class, "openapi.yaml", "Images API", ImagesService.class);
         this.geoServer = geoServer;
     }
 

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesAPIBuilder.java
@@ -17,7 +17,7 @@ import org.geoserver.ogcapi.OpenAPIBuilder;
 public class StylesAPIBuilder extends OpenAPIBuilder<StylesServiceInfo> {
 
     public StylesAPIBuilder() {
-        super(StylesAPIBuilder.class, "openapi.yaml", "Style API", "ogc/styles/v1");
+        super(StylesAPIBuilder.class, "openapi.yaml", "Style API", StylesService.class);
     }
 
     @Override

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/v1/tiles/TilesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/v1/tiles/TilesAPIBuilder.java
@@ -22,7 +22,7 @@ public class TilesAPIBuilder extends OpenAPIBuilder<TilesServiceInfo> {
     private final GWC gwc;
 
     public TilesAPIBuilder(GWC gwc) {
-        super(TilesServiceInfo.class, "openapi.yaml", "Tiles API", "ogc/tiles/v1");
+        super(TilesServiceInfo.class, "openapi.yaml", "Tiles API", TilesService.class);
         this.gwc = gwc;
     }
 

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/v1/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/v1/tiles/TilesService.java
@@ -75,7 +75,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @APIService(
         service = "Tiles",
-        version = "1.0.1",
+        version = "1.0.0",
         landingPage = "ogc/tiles/v1",
         serviceClass = TilesServiceInfo.class)
 @RequestMapping(path = APIDispatcher.ROOT_PATH + "/tiles/v1")

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/applicationContext.xml
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/applicationContext.xml
@@ -23,7 +23,7 @@
 
   <bean id="tilesServiceFactory" class="org.geoserver.ogcapi.APIServiceFactoryBean">
     <constructor-arg index="0" value="Tiles"/>
-    <constructor-arg index="1" value="1.0.1"/>
+    <constructor-arg index="1" value="1.0.0"/>
   </bean>
   
 </beans>

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/ApiTest.java
@@ -115,6 +115,9 @@ public class ApiTest extends TilesTestSupport {
         assertThat(
                 servers.get(0).getUrl(), equalTo("http://localhost:8080/geoserver/ogc/tiles/v1"));
 
+        // info version is spec version
+        assertEquals("1.0.0", api.getInfo().getVersion());
+
         // paths
         Paths paths = api.getPaths();
 

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/CollectionsTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/CollectionsTest.java
@@ -142,6 +142,6 @@ public class CollectionsTest extends TilesTestSupport {
     public void testVersionHeader() throws Exception {
         MockHttpServletResponse response =
                 getAsServletResponse("ogc/tiles/v1/collections/?f=application/x-yaml");
-        assertTrue(headerHasValue(response, "API-Version", "1.0.1"));
+        assertTrue(headerHasValue(response, "API-Version", "1.0.0"));
     }
 }

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/LandingPageTest.java
@@ -22,10 +22,10 @@ public class LandingPageTest extends TilesTestSupport {
 
     @Test
     public void testServiceDescriptor() {
-        Service service = getService("Tiles", new Version("1.0.1"));
+        Service service = getService("Tiles", new Version("1.0.0"));
         assertNotNull(service);
         assertEquals("Tiles", service.getId());
-        assertEquals(new Version("1.0.1"), service.getVersion());
+        assertEquals(new Version("1.0.0"), service.getVersion());
         assertThat(service.getService(), CoreMatchers.instanceOf(TilesService.class));
         assertThat(
                 service.getOperations(),

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACAPIBuilder.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACAPIBuilder.java
@@ -37,7 +37,7 @@ public class STACAPIBuilder extends org.geoserver.ogcapi.OpenAPIBuilder<OSEOInfo
     private final OpenSearchAccessProvider accessProvider;
 
     public STACAPIBuilder(OpenSearchAccessProvider accessProvider) {
-        super(STACAPIBuilder.class, "openapi.yaml", "STAC server", "ogc/stac/v1");
+        super(STACAPIBuilder.class, "openapi.yaml", "STAC server", STACService.class);
         this.accessProvider = accessProvider;
     }
 

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACService.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACService.java
@@ -103,7 +103,7 @@ import org.springframework.web.context.request.ServletWebRequest;
 /** Implementation of OGC Features API service */
 @APIService(
         service = "STAC",
-        version = "1.0.1",
+        version = "1.0.0",
         landingPage = "ogc/stac/v1",
         serviceClass = OSEOInfo.class)
 @RequestMapping(path = APIDispatcher.ROOT_PATH + "/stac/v1")

--- a/src/community/oseo/oseo-stac/src/main/resources/applicationContext.xml
+++ b/src/community/oseo/oseo-stac/src/main/resources/applicationContext.xml
@@ -20,7 +20,7 @@
     <!-- Bridges to have OGC services show up as OWS services too -->
     <bean id="stacServiceFactory" class="org.geoserver.ogcapi.APIServiceFactoryBean">
         <constructor-arg index="0" value="STAC"/>
-        <constructor-arg index="1" value="1.0.1"/>
+        <constructor-arg index="1" value="1.0.0"/>
     </bean>
 
 </beans>

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/ApiTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/ApiTest.java
@@ -117,6 +117,9 @@ public class ApiTest extends STACTestSupport {
         assertThat(servers, hasSize(1));
         assertThat(servers.get(0).getUrl(), equalTo("http://localhost:8080/geoserver/ogc/stac/v1"));
 
+        // info version is spec version
+        assertEquals("1.0.0", api.getInfo().getVersion());
+
         // paths
         Paths paths = api.getPaths();
 

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/CollectionsTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/CollectionsTest.java
@@ -188,6 +188,6 @@ public class CollectionsTest extends STACTestSupport {
     public void testVersionHeader() throws Exception {
         MockHttpServletResponse response =
                 getAsServletResponse("ogc/stac/v1/collections/SENTINEL2?f=json");
-        assertTrue(headerHasValue(response, "API-Version", "1.0.1"));
+        assertTrue(headerHasValue(response, "API-Version", "1.0.0"));
     }
 }

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/LandingPageTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/LandingPageTest.java
@@ -28,10 +28,10 @@ public class LandingPageTest extends STACTestSupport {
 
     @Test
     public void testServiceDescriptor() {
-        Service service = getService("STAC", new Version("1.0.1"));
+        Service service = getService("STAC", new Version("1.0.0"));
         assertNotNull(service);
         assertEquals("STAC", service.getId());
-        assertEquals(new Version("1.0.1"), service.getVersion());
+        assertEquals(new Version("1.0.0"), service.getVersion());
         assertThat(service.getService(), CoreMatchers.instanceOf(STACService.class));
         assertThat(
                 service.getOperations(),


### PR DESCRIPTION
Backport #6667
 **Authored by:** @aaime