### PR TITLE
[Backport 2.22.x] [GEOS-10890] Wrong path for the license file in the Windows installer script

### DIFF
--- a/src/release/installer/win/build/geoserver_winsetup.nsi
+++ b/src/release/installer/win/build/geoserver_winsetup.nsi
@@ -187,7 +187,7 @@ Var GSPassHWND
 ; ----------------------------------------------------------------------------
 ; Convert NOTICE.txt markdown into an RTF file using Pandoc
 
-  !system 'pandoc -s -f markdown -t rtf "..\source\licences\NOTICE.txt" -o license.rtf'
+  !system 'pandoc -s -f markdown -t rtf "..\source\license\NOTICE.txt" -o license.rtf'
 
 ; ----------------------------------------------------------------------------
 ; Installer pages


### PR DESCRIPTION
[![GEOS-10890](https://badgen.net/badge/JIRA/GEOS-10890/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10890)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6669
 **Authored by:** @juanluisrp