### PR TITLE
Remove "Post the Documentation" from Release guide

### DIFF
--- a/doc/en/developer/source/release-guide/index.rst
+++ b/doc/en/developer/source/release-guide/index.rst
@@ -300,50 +300,6 @@ Create the download page
 
 The `GeoServer website <http://geoserver.org/>`_ is managed as a `GitHub Pages repository <https://github.com/geoserver/geoserver.github.io>`_. Follow the `instructions <https://github.com/geoserver/geoserver.github.io#releases>`_ in the repository to create a download page for the release. This requires the url of the blog post announcing the release, so wait until after you have posted the announcement to do this.
 
-Post the Documentation
-----------------------
-
-.. note:: For now, this requires Boundless credentials; if you do not have them, please ask on the `GeoServer developer list <https://lists.sourceforge.net/lists/listinfo/geoserver-devel>`_ for someone to perform this step for you.
-
-.. note:: This content will likely move to GitHub in the near future.
-
-#. Log in to the server.
-
-#. Create the following new directories::
-
-     /var/www/docs.geoserver.org/htdocs/a.b.c
-     /var/www/docs.geoserver.org/htdocs/a.b.c/developer
-     /var/www/docs.geoserver.org/htdocs/a.b.c/user
-
-   where ``a.b.c`` is the full release number.
-
-#. Download the HTML documentation archive from the GeoServer download page, and extract the contents of both user manuals to the appropriate directory:
-    
-    .. code-block:: bash
-
-       cd /var/www/docs.geoserver.org/htdocs/a.b.c/
-       sudo wget http://downloads.sourceforge.net/geoserver/geoserver-a.b.c-htmldoc.zip
-       sudo unzip geoserver-a.b.c-htmldoc.zip
-       sudo rm geoserver-a.b.c-htmldoc.zip
-
-   .. note:: Steps 2 and 3 have now been automated by a bash script on the server, and can be completed by executing:
-      
-      .. code-block:: bash
-         
-         sudo /var/www/docs.geoserver.org/htdocs/postdocs.sh a.b.c
- 
-#. Open the file :file:`/var/www/docs.geoserver.org/htdocs/index.html` in a text editor.
-
-#. Add a new entry in the table for the most recent release::
-
-    <tr>
-      <td><strong><a href="http://geoserver.org/release/a.b.c/">a.b.c</a></strong></td>
-      <td><a href="a.b.c/user/">User Manual</a></td>
-      <td><a href="a.b.c/developer/">Developer Manual</a></td>
-    </tr>
-
-#. Save and close this file.
-
 Announce the Release
 --------------------
 


### PR DESCRIPTION
The "Post the Documentation" section no longer represents current practice, we just rely on maint/stable/main (see email list from Summer 2022)

Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).