### PR TITLE
[GEOS-10894] Random control-flow errors on Mac builds

### DIFF
--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/AbstractFlowControllerTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/AbstractFlowControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
  */
 public abstract class AbstractFlowControllerTest {
 
-    protected static final long MAX_WAIT = 20000;
+    protected static final long MAX_WAIT = 60000;
 
     /**
      * Waits until the thread enters in WAITING or TIMED_WAITING state

--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/PriorityFlowControllerTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/PriorityFlowControllerTest.java
@@ -119,8 +119,9 @@ public class PriorityFlowControllerTest extends AbstractFlowControllerTest {
             assertEquals(ThreadState.COMPLETE, t2.state);
             waitState(ThreadState.PROCESSING, t3, MAX_WAIT);
 
-            // unlock t2 as well
+            // unlock t2 and t3 as well
             t2.interrupt();
+            t3.interrupt();
         } finally {
             waitAndKill(t1, MAX_WAIT);
             waitAndKill(t2, MAX_WAIT);


### PR DESCRIPTION
[![GEOS-10894](https://badgen.net/badge/JIRA/GEOS-10894/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10894)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->