### PR TITLE
[Backport 2.23.x] GEOS-10802 OGC API: queryables page crashed on complex features

### DIFF
--- a/src/community/ogcapi/ogcapi-core/pom.xml
+++ b/src/community/ogcapi/ogcapi-core/pom.xml
@@ -147,6 +147,26 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-app-schema</artifactId>
+      <version>${gt.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-app-schema</artifactId>
+      <version>${gt.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-app-schema-test</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
       <version>${project.version}</version>

--- a/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/QueryablesBuilderComplexFeaturesTest.java
+++ b/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/QueryablesBuilderComplexFeaturesTest.java
@@ -1,0 +1,27 @@
+/* (c) 2021 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi;
+
+import static org.junit.Assert.assertTrue;
+
+import org.geoserver.test.AbstractAppSchemaMockData;
+import org.geoserver.test.AbstractAppSchemaTestSupport;
+import org.geoserver.test.FeatureChainingMockData;
+import org.junit.Test;
+
+public class QueryablesBuilderComplexFeaturesTest extends AbstractAppSchemaTestSupport {
+    @Override
+    protected AbstractAppSchemaMockData createTestData() {
+        return new FeatureChainingMockData();
+    }
+
+    @Test
+    public void testQueryablesBuilder() throws Exception {
+        QueryablesBuilder qb =
+                new QueryablesBuilder("id")
+                        .forType(getCatalog().getFeatureTypeByName("MappedFeature"));
+        assertTrue(qb.queryables.getProperties().containsKey("observationMethod"));
+    }
+}


### PR DESCRIPTION
[![GEOS-10802](https://badgen.net/badge/JIRA/GEOS-10802/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10802)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6565
 **Authored by:** @NielsCharlier