### PR TITLE
[Backport 2.22.x] [GEOS-10899] Features template escapes twice HTML produced outputs

### DIFF
--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
@@ -68,8 +68,7 @@ public abstract class XMLTemplateWriter extends TemplateOutputWriter {
             else {
                 streamWriter.writeStartElement(name);
                 evaluateChildren(encodingHints);
-                streamWriter.writeCharacters(
-                        StringEscapeUtils.escapeHtml(staticContent.toString()));
+                streamWriter.writeCharacters(staticContent.toString());
                 streamWriter.writeEndElement();
             }
         } catch (XMLStreamException e) {

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLHtmlFeature.xhtml
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLHtmlFeature.xhtml
@@ -1,0 +1,76 @@
+<gft:Template>
+    <gft:Options>
+        <style>
+            <![CDATA[
+ul, #myUL {
+  list-style-type: none;
+}
+
+#myUL {
+  margin: 0;
+  padding: 0;
+}
+
+.caret {
+  cursor: pointer;
+  -webkit-user-select: none; /* Safari 3.1+ */
+  -moz-user-select: none; /* Firefox 2+ */
+  -ms-user-select: none; /* IE 10+ */
+  user-select: none;
+}
+
+.caret::before {
+  content: "\25B6";
+  color: black;
+  display: inline-block;
+  margin-right: 6px;
+}
+
+.caret-down::before {
+  -ms-transform: rotate(90deg); /* IE 9 */
+  -webkit-transform: rotate(90deg); /* Safari */'
+  transform: rotate(90deg);
+}
+
+.nested {
+  display: none;
+}
+
+.active {
+  display: block;
+}
+]]>
+        </style>
+        <script>
+            <![CDATA[
+  window.onload = function() {
+  var toggler = document.getElementsByClassName("caret");
+  for (let item of toggler){
+    item.addEventListener("click", function() {
+    this.parentElement.querySelector(".nested").classList.toggle("active");
+    this.classList.toggle("caret-down");
+  });
+  }
+  }
+]]>
+        </script>
+    </gft:Options>
+    <ul id="myUL">
+        <li><span class="caret">HTML Features</span>
+            <ul class="nested">
+                <li>${FID}</li>
+                <li><span class="caret">Name</span>
+                    <ul class="nested">
+                        <li>${NAME}</li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="caret">Degrees</span>
+                    <ul class="nested">
+                        <li>${DEGREES}</li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</gft:Template>

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLMappedFeature.xhtml
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLMappedFeature.xhtml
@@ -67,7 +67,7 @@ ul, #myUL {
                 <li>
                     <span class="caret">Degrees</span>
                     <ul class="nested">
-                        <li>60°</li>
+                        <li>60&amp;deg;</li>
                     </ul>
                 </li>
                 <li gft:isCollection="true" gft:source="gsml:specification/gsml:GeologicUnit">

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetSimpleFeaturesResponseWFSTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetSimpleFeaturesResponseWFSTest.java
@@ -1,0 +1,57 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.featurestemplating.response;
+
+import java.util.Collections;
+import javax.xml.namespace.QName;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.data.test.CiteTestData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.featurestemplating.configuration.SupportedFormat;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+public class HTMLGetSimpleFeaturesResponseWFSTest extends TemplateComplexTestSupport {
+
+    static final QName HTML_FEATURES =
+            new QName(CiteTestData.CITE_URI, "HtmlFeatures", CiteTestData.CITE_PREFIX);
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        testData.addVectorLayer(
+                HTML_FEATURES,
+                Collections.emptyMap(),
+                "HtmlFeatures.properties",
+                getClass(),
+                getCatalog());
+        Catalog catalog = getCatalog();
+        FeatureTypeInfo htmlFeatures =
+                catalog.getFeatureTypeByName(
+                        HTML_FEATURES.getPrefix(), HTML_FEATURES.getLocalPart());
+        String htmlTemplate = "HTMLHtmlFeature.xhtml";
+        setUpTemplate(
+                "requestParam('html')='true'",
+                SupportedFormat.HTML,
+                htmlTemplate,
+                "html-html-features",
+                ".xhtml",
+                HTML_FEATURES.getPrefix(),
+                htmlFeatures);
+    }
+
+    @Test
+    public void testHtmlResponse() throws Exception {
+        StringBuilder sb = new StringBuilder("wfs?request=GetFeature&version=2.0");
+        sb.append("&TYPENAME=cite:HtmlFeatures&outputFormat=");
+        sb.append("text/html&cql_filter=NAME='Features1'&html=true");
+        String t = getAsString(sb.toString());
+        Document doc = getAsDOM(sb.toString());
+        assertXpathMatches(
+                "60&deg;",
+                "//html/body/ul/li[./span = 'HTML Features']/ul/li[./span = 'Degrees']/ul/li",
+                doc);
+    }
+}

--- a/src/community/features-templating/features-templating-ows/src/test/resources/org/geoserver/featurestemplating/response/HtmlFeatures.properties
+++ b/src/community/features-templating/features-templating-ows/src/test/resources/org/geoserver/featurestemplating/response/HtmlFeatures.properties
@@ -1,0 +1,3 @@
+_=the_geom:Point:srid=4326,FID:String,NAME:String,DEGREES:String
+HtmlFeatures.1=POINT(-23.5 45.0)|1|Features1|60°
+HtmlFeatures.2=POINT(33.5 -15.0)|2|Features2|23°


### PR DESCRIPTION
[![GEOS-10899](https://badgen.net/badge/JIRA/GEOS-10899/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10899)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6693
 **Authored by:** @nmco