### PR TITLE
[Backport 2.23.x] [Community] security oauth2 release collects the wrong spring-security-oauth2 version of the JARs

### DIFF
--- a/src/community/security/oauth2-geonode/pom.xml
+++ b/src/community/security/oauth2-geonode/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2-geonode/pom.xml
+++ b/src/community/security/oauth2-geonode/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.0.16.RELEASE</version>
+      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2-github/pom.xml
+++ b/src/community/security/oauth2-github/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2-github/pom.xml
+++ b/src/community/security/oauth2-github/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.0.16.RELEASE</version>
+      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2-google/pom.xml
+++ b/src/community/security/oauth2-google/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2-google/pom.xml
+++ b/src/community/security/oauth2-google/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.0.16.RELEASE</version>
+      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
@@ -47,7 +47,6 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/community/security/oauth2/oauth2-core/pom.xml
+++ b/src/community/security/oauth2/oauth2-core/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>org.springframework.security.oauth</groupId>
       <artifactId>spring-security-oauth2</artifactId>
-      <version>2.5.2.RELEASE</version>
     </dependency>
 
     <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -94,6 +94,7 @@
     <jts.version>1.19.0</jts.version>
     <spring.version>5.3.25</spring.version>
     <spring.security.version>5.7.6</spring.security.version>
+    <spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
     <servlet-api.version>3.1.0</servlet-api.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>
@@ -1049,6 +1050,11 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-cas</artifactId>
         <version>${spring.security.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security.oauth</groupId>
+        <artifactId>spring-security-oauth2</artifactId>
+        <version>${spring.security.oauth2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jasypt</groupId>


### PR DESCRIPTION
Backport #6694
 **Authored by:** @afabiani