### PR TITLE
[Backport 2.21.x] [GEOS-10904] Bump jettison from 1.5.3 to 1.5.4

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -751,7 +751,7 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.4</version>
       </dependency>
       <dependency>
         <groupId>lucene</groupId>


### PR DESCRIPTION
[![GEOS-10904](https://badgen.net/badge/JIRA/GEOS-10904/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10904)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6706
 **Authored by:** @dependabot[bot]