### PR TITLE
[GEOS-10905] Default CSW properties do not allow sorting by identifiers

### DIFF
--- a/src/extension/csw/core/src/main/resources/org/geoserver/csw/store/internal/Record.default.properties
+++ b/src/extension/csw/core/src/main/resources/org/geoserver/csw/store/internal/Record.default.properties
@@ -1,4 +1,4 @@
-@identifier.value=if_then_else(isNull(prefixedName), name, prefixedName)
+@identifier.value=prefixedName
 title.value=if_then_else(isNull(title), name, title)
 creator.value='GeoServer Catalog'
 subject.value=keywords

--- a/src/extension/csw/csw-iso/src/main/resources/org/geoserver/csw/store/internal/MD_Metadata.default.properties
+++ b/src/extension/csw/csw-iso/src/main/resources/org/geoserver/csw/store/internal/MD_Metadata.default.properties
@@ -1,4 +1,4 @@
-@fileIdentifier.CharacterString=if_then_else(isNull(prefixedName), name, prefixedName)
+@fileIdentifier.CharacterString=prefixedName
 identificationInfo.MD_DataIdentification.citation.CI_Citation.title.CharacterString=if_then_else(isNull(title), name, title)
 identificationInfo.MD_DataIdentification.descriptiveKeywords.MD_Keywords.keyword.CharacterString=keywords
 identificationInfo.MD_DataIdentification.abstract.CharacterString=abstract


### PR DESCRIPTION
[![GEOS-10905](https://badgen.net/badge/JIRA/GEOS-10905/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10905)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR replaces the if_then_else function call with a simple property name to allow sorting by identifiers when using the default CSW properties files.  The if_then_else identifier was probably needed a long time ago before layer groups were allowed in workspaces but every layer and layer groups now has a prefixedName value.  The default files are only used if the properties file is missing from the data directory so this PR will only affect new GeoServer installations.  

The CSW unit tests use separate properties files in the src/test/resources directory that do not use if_then_else in the identifier so hopefully unit tests aren't required for this PR since it is just updating properties files.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->