### PR TITLE
[Backport 2.22.x] [GEOS-10593] Regression: Creating SQL View via REST API and explicit attribute list is no-longer possible

### DIFF
--- a/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CatalogImplTest.java
@@ -1350,6 +1350,7 @@ public class CatalogImplTest extends GeoServerSystemTestSupport {
         assertEquals(1, catalog.getLayers().size());
 
         LayerInfo l2 = catalog.getFactory().createLayer();
+        ((LayerInfoImpl) l2).setId("foobar");
         try {
             catalog.add(l2);
             fail("adding with no name should throw exception");


### PR DESCRIPTION
Backport #6702
 **Authored by:** @aaime