### PR TITLE
[Backport 2.23.x] [GEOS-10905] Default CSW properties do not allow sorting by identifiers

### DIFF
--- a/src/extension/csw/core/src/main/resources/org/geoserver/csw/store/internal/Record.default.properties
+++ b/src/extension/csw/core/src/main/resources/org/geoserver/csw/store/internal/Record.default.properties
@@ -1,4 +1,4 @@
-@identifier.value=if_then_else(isNull(prefixedName), name, prefixedName)
+@identifier.value=prefixedName
 title.value=if_then_else(isNull(title), name, title)
 creator.value='GeoServer Catalog'
 subject.value=keywords

--- a/src/extension/csw/csw-iso/src/main/resources/org/geoserver/csw/store/internal/MD_Metadata.default.properties
+++ b/src/extension/csw/csw-iso/src/main/resources/org/geoserver/csw/store/internal/MD_Metadata.default.properties
@@ -1,4 +1,4 @@
-@fileIdentifier.CharacterString=if_then_else(isNull(prefixedName), name, prefixedName)
+@fileIdentifier.CharacterString=prefixedName
 identificationInfo.MD_DataIdentification.citation.CI_Citation.title.CharacterString=if_then_else(isNull(title), name, title)
 identificationInfo.MD_DataIdentification.descriptiveKeywords.MD_Keywords.keyword.CharacterString=keywords
 identificationInfo.MD_DataIdentification.abstract.CharacterString=abstract


### PR DESCRIPTION
Backport #6711
 **Authored by:** @sikeoka