### PR TITLE
[Backport 2.23.x] [GEOS-10907] Update spring.version from 5.3.25 to 5.3.26 and spring.security.version from 5.7.6 to 5.7.7

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -92,8 +92,8 @@
     <gt.version>29-SNAPSHOT</gt.version>
     <gwc.version>1.23-SNAPSHOT</gwc.version>
     <jts.version>1.19.0</jts.version>
-    <spring.version>5.3.25</spring.version>
-    <spring.security.version>5.7.6</spring.security.version>
+    <spring.version>5.3.26</spring.version>
+    <spring.security.version>5.7.7</spring.security.version>
     <spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
     <servlet-api.version>3.1.0</servlet-api.version>
     <jetty.version>9.4.48.v20220622</jetty.version>


### PR DESCRIPTION
[![GEOS-10907](https://badgen.net/badge/JIRA/GEOS-10907/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10907)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6718
 **Authored by:** @mprins