### PR TITLE
[GEOS-10895] Fix for /geoserver path causing an out of bounds exception (when trying to get to the home page)

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/LandingPageSlashFilter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/LandingPageSlashFilter.java
@@ -57,10 +57,10 @@ public class LandingPageSlashFilter implements GeoServerFilter, ApplicationConte
     }
 
     private boolean isLandingPageWithSlash(HttpServletRequest servletRequest) {
-        String path =
-                servletRequest
-                        .getRequestURI()
-                        .substring(servletRequest.getContextPath().length() + 1);
+        String requestURI = servletRequest.getRequestURI();
+        int contextPathLength = servletRequest.getContextPath().length();
+        if (requestURI.length() <= contextPathLength) return false;
+        String path = requestURI.substring(contextPathLength + 1);
         // no point checking services if it does not end with a slash anyway
         if (!path.endsWith("/")) return false;
 

--- a/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/HelloServiceTrailingSlashOffTest.java
+++ b/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/HelloServiceTrailingSlashOffTest.java
@@ -14,6 +14,7 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.data.test.SystemTestData;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /** Tests trailing slash match disabled, with exception for landing page */
@@ -32,6 +33,19 @@ public class HelloServiceTrailingSlashOffTest extends OGCApiTestSupport {
         try (FileOutputStream fos = new FileOutputStream(file)) {
             xs.toXML(gs, fos);
         }
+    }
+
+    @Test
+    public void testContextPath() throws Exception {
+        MockHttpServletRequest request = createRequest("", false);
+        request.setContextPath("/geoserver");
+        request.setRequestURI("/geoserver");
+        request.setMethod("GET");
+        request.setContent(new byte[] {});
+
+        MockHttpServletResponse sr = dispatch(request, null);
+        System.out.println(sr.getStatus());
+        System.out.println(sr.getContentAsString());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10895](https://badgen.net/badge/JIRA/GEOS-10895/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10895)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Still part of the GEOS-10895 series, found out there is an index out of bounds exception when accessing "http://localhost:8080/geoserver" due to the landing page exception filter.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->