### PR TITLE
[Backport 2.21.x] [GEOS-10920] Excel output format packaging misses dependencies, cannot produce .xls

### DIFF
--- a/src/release/ext-excel.xml
+++ b/src/release/ext-excel.xml
@@ -14,6 +14,8 @@
         <include>xmlbeans-*.jar</include>
         <include>dom4j-*.jar</include>
         <include>commons-compress-*.jar</include>
+        <include>commons-math3-*.jar</include>
+        <include>curvesapi*.jar</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
[![GEOS-10920](https://badgen.net/badge/JIRA/GEOS-10920/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10920)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6750
 **Authored by:** @aaime