### PR TITLE
Features templating html double escaping fix

### DIFF
--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/writers/XMLTemplateWriter.java
@@ -68,7 +68,8 @@ public abstract class XMLTemplateWriter extends TemplateOutputWriter {
             else {
                 streamWriter.writeStartElement(name);
                 evaluateChildren(encodingHints);
-                streamWriter.writeCharacters(staticContent.toString());
+                streamWriter.writeCharacters(
+                        StringEscapeUtils.escapeHtml(staticContent.toString()));
                 streamWriter.writeEndElement();
             }
         } catch (XMLStreamException e) {

--- a/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLMappedFeature.xhtml
+++ b/src/community/features-templating/features-templating-core/src/test/resources/org/geoserver/featurestemplating/response/HTMLMappedFeature.xhtml
@@ -67,7 +67,7 @@ ul, #myUL {
                 <li>
                     <span class="caret">Degrees</span>
                     <ul class="nested">
-                        <li>60&amp;deg;</li>
+                        <li>60°</li>
                     </ul>
                 </li>
                 <li gft:isCollection="true" gft:source="gsml:specification/gsml:GeologicUnit">

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/TemplateGetFeatureResponseHelper.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/TemplateGetFeatureResponseHelper.java
@@ -70,7 +70,7 @@ public class TemplateGetFeatureResponseHelper {
             case GML31:
             case GML32:
             case HTML:
-                XMLOutputFactory xMLOutputFactory = XMLOutputFactory.newInstance();
+                XMLOutputFactory xMLOutputFactory = XMLOutputFactory.newDefaultFactory();
                 // we do ourselves the escaping in the template writer since the one provided in the
                 // XMLStreamWriter implementation
                 // doesn't handle all the characters.

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/TemplateGetFeatureResponseHelper.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/TemplateGetFeatureResponseHelper.java
@@ -4,15 +4,19 @@
  */
 package org.geoserver.featurestemplating.ows.wfs;
 
+import com.ctc.wstx.stax.WstxOutputFactory;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.Optional;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import org.codehaus.stax2.io.EscapingWriterFactory;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.featurestemplating.configuration.TemplateIdentifier;
@@ -93,6 +97,39 @@ public class TemplateGetFeatureResponseHelper {
                 break;
         }
         return outputWriter;
+    }
+
+    private static XMLOutputFactory getNonEscapingXmlOutputFactory() {
+        XMLOutputFactory xMLOutputFactory = XMLOutputFactory.newInstance();
+        // we do ourselves the escaping in the template writer since the one provided in the
+        // XMLStreamWriter implementation
+        // doesn't handle all the characters.
+        if (xMLOutputFactory.isPropertySupported(ESCAPE_CHARS)) {
+            xMLOutputFactory.setProperty(ESCAPE_CHARS, false);
+        } else {
+            // If escaping property isn't available we will use WstxOutputFactory and provide
+            // anonymous implementation
+            // of EscapingWriterFactory that doesn't modify writer
+            if (!(xMLOutputFactory instanceof WstxOutputFactory)) {
+                xMLOutputFactory = new WstxOutputFactory();
+            }
+            ((WstxOutputFactory) xMLOutputFactory)
+                    .getConfig()
+                    .setTextEscaperFactory(
+                            new EscapingWriterFactory() {
+                                @Override
+                                public Writer createEscapingWriterFor(Writer writer, String s) {
+                                    return writer;
+                                }
+
+                                @Override
+                                public Writer createEscapingWriterFor(
+                                        OutputStream outputStream, String s) {
+                                    return new OutputStreamWriter(outputStream);
+                                }
+                            });
+        }
+        return xMLOutputFactory;
     }
 
     FeatureTypeInfo getFirstFeatureTypeInfo(Object request) {

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/ComplexGetFeatureInfoTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/ComplexGetFeatureInfoTest.java
@@ -84,43 +84,44 @@ public class ComplexGetFeatureInfoTest extends TemplateComplexTestSupport {
     }
 
     @Test
-    public void testHTML() {
+    public void testHTML() throws Exception {
         String request =
                 "wms?request=GetFeatureInfo&SRS=EPSG:4326&BBOX=-1.3,52,0,52.5&LAYERS=gsml:MappedFeature&QUERY_LAYERS=gsml:MappedFeature&X=0&Y=0&width=100&height=100&INFO_FORMAT=text/html"
                         + MF_HTML_PARAM;
-        Document doc = getAsDOM(request);
-        assertXpathCount(1, "//html/head/script", doc);
-        assertXpathCount(1, "//html/head/style", doc);
-        assertXpathCount(1, "//html/body/ul/li[./span = 'MappedFeature']", doc);
-        assertXpathCount(1, "//html/body/ul/li/ul[./li = 'mf2']", doc);
+        org.jsoup.nodes.Document doc = getAsJSoup(request);
+        assertEquals(1, doc.select("script").size());
+        assertEquals(1, doc.select("style").size());
+        assertEquals(1, doc.select("span.caret:contains(MappedFeature)").size());
+        assertEquals(1, doc.select("li ul li:contains(mf2)").size());
 
-        assertXpathCount(1, "//html/body/ul/li/ul/li/ul[./li = 'MERCIA MUDSTONE GROUP']", doc);
+        assertEquals(1, doc.select("ul li ul li ul li:contains(MERCIA MUDSTONE GROUP)").size());
 
-        assertXpathCount(1, "//html/body/ul/li/ul/li[./span = 'Shape']", doc);
+        assertEquals(1, doc.select("span:contains(Shape)").size());
 
-        assertXpathCount(1, "//html/body/ul/li/ul/li[./span = 'Specifications']", doc);
-        assertXpathCount(1, "//html/body/ul/li/ul/li/ul/li[./span = 'Geologic Unit']", doc);
-        assertXpathCount(1, "//html/body/ul/li/ul/li/ul/li/ul/li[./span = 'Purpose']", doc);
-        assertXpathCount(1, "//html/body/ul/li/ul/li/ul/li/ul/li/ul[./li = 'instance']", doc);
+        assertEquals(1, doc.select("ul li ul li span:contains(Specifications)").size());
+        assertEquals(1, doc.select("ul li ul li span:contains(Geologic Unit)").size());
+        assertEquals(1, doc.select("ul li ul li span:contains(Purpose)").size());
+        assertEquals(1, doc.select("ul li ul li ul li ul li ul li:contains(instance)").size());
 
-        assertXpathCount(
+        assertEquals(
                 1,
-                "//html/body/ul/li/ul/li/ul/li/ul/li/ul[./li = 'Yaugher Volcanic Group 1']",
-                doc);
-        assertXpathCount(
+                doc.select("ul li ul li ul li ul li ul li:contains(Yaugher Volcanic Group 1)")
+                        .size());
+        assertEquals(
                 1,
-                "//html/body/ul/li/ul/li/ul/li/ul/li/ul[./li = 'Yaugher Volcanic Group 2']",
-                doc);
-        assertXpathCount(1, "//html/body/ul/li/ul/li/ul/li/ul/li/ul[./li = '-Py']", doc);
-        assertXpathCount(
-                2, "//html/body/ul/li/ul/li/ul/li/ul/li[./span = 'Composition Parts']", doc);
-        assertXpathCount(2, "//html/body/ul/li/ul/li/ul/li/ul/li/ul/li[./span = 'Part']", doc);
-        assertXpathCount(
-                2, "//html/body/ul/li/ul/li/ul/li/ul/li/ul/li/ul/li[./span = 'Role']", doc);
-        assertXpathCount(
+                doc.select("ul li ul li ul li ul li ul li:contains(Yaugher Volcanic Group 2)")
+                        .size());
+
+        assertEquals(1, doc.select("ul li ul li ul li ul li ul li:contains(-Py)").size());
+        assertEquals(
+                2, doc.select("ul li ul li ul li ul li span:contains(Composition Parts)").size());
+        assertEquals(2, doc.select("ul li ul li ul li ul li ul li span:contains(Part)").size());
+        assertEquals(2, doc.select("ul li ul li ul li ul li ul li span:contains(Role)").size());
+        assertEquals(
                 2,
-                "//html/body/ul/li/ul/li/ul/li/ul/li/ul/li/ul/li/ul[./li = 'interbedded component']",
-                doc);
+                doc.select(
+                                "ul li ul li ul li ul li ul li ul li ul li:contains(interbedded component)")
+                        .size());
     }
 
     @Test

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetComplexFeatureResponseTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetComplexFeatureResponseTest.java
@@ -1,6 +1,7 @@
 package org.geoserver.featurestemplating.response;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -66,13 +67,13 @@ public class HTMLGetComplexFeatureResponseTest extends TemplateComplexTestSuppor
     }
 
     @Test
-    public void getMappedFeature() {
-        Document doc =
-                getAsDOM(
+    public void getMappedFeature() throws Exception {
+        org.jsoup.nodes.Document doc =
+                getAsJSoup(
                         "wfs?request=GetFeature&version=1.1.0&typename=gsml:MappedFeature"
                                 + "&outputFormat=text/html"
                                 + MF_HTML_PARAM);
-        assertXpathCount(1, "//html/head/script", doc);
+        assertEquals(1, doc.select("script").size());
         assertHTMLResult(doc);
     }
 
@@ -104,7 +105,7 @@ public class HTMLGetComplexFeatureResponseTest extends TemplateComplexTestSuppor
             }
         }
 
-        assertHTMLResult(doc);
+        assertHTMLResultXPath(doc);
     }
 
     @Test
@@ -118,20 +119,17 @@ public class HTMLGetComplexFeatureResponseTest extends TemplateComplexTestSuppor
     }
 
     @Test
-    public void testEscaping() {
-        Document doc =
-                getAsDOM(
+    public void testEscaping() throws Exception {
+        org.jsoup.nodes.Document doc =
+                getAsJSoup(
                         "wfs?request=GetFeature&version=1.1.0&typename=gsml:MappedFeature"
                                 + "&outputFormat=text/html"
                                 + MF_HTML_PARAM);
-        assertXpathMatches(
-                "60&deg;",
-                "//html/body/ul/li[./span = 'MappedFeature']/ul/li[./span = 'Degrees']/ul/li",
-                doc);
+        assertFalse(doc.select("script").isEmpty());
         assertHTMLResult(doc);
     }
 
-    private void assertHTMLResult(Document doc) {
+    private void assertHTMLResultXPath(Document doc) {
         assertXpathCount(1, "//html/head/style", doc);
         assertXpathCount(5, "//html/body/ul/li[./span = 'MappedFeature']", doc);
         assertXpathCount(1, "//html/body/ul/li/ul[./li = 'mf1']", doc);
@@ -178,5 +176,61 @@ public class HTMLGetComplexFeatureResponseTest extends TemplateComplexTestSuppor
                 1,
                 "//html/body/ul/li/ul/li/ul/li/ul/li/ul/li/ul/li/ul[./li = 'fictitious component']",
                 doc);
+    }
+
+    private void assertHTMLResult(org.jsoup.nodes.Document doc) {
+        assertEquals(1, doc.select("style").size());
+        assertEquals(5, doc.select("span.caret:contains(MappedFeature)").size());
+        assertEquals(1, doc.select("li ul li:contains(mf1)").size());
+        assertEquals(1, doc.select("li ul li:contains(mf2)").size());
+        assertEquals(1, doc.select("li ul li:contains(mf3)").size());
+        assertEquals(1, doc.select("li ul li:contains(mf4)").size());
+        assertEquals(1, doc.select("li ul li:contains(mf5)").size());
+
+        assertEquals(1, doc.select("ul li ul li ul li:contains(GUNTHORPE FORMATION)").size());
+        assertEquals(1, doc.select("ul li ul li ul li:contains(MERCIA MUDSTONE GROUP)").size());
+        assertEquals(1, doc.select("ul li ul li ul li:contains(CLIFTON FORMATION)").size());
+        assertEquals(1, doc.select("ul li ul li ul li:contains(MURRADUC BASALT)").size());
+        assertEquals(1, doc.select("ul li ul li ul li:contains(IDONTKNOW)").size());
+
+        assertEquals(5, doc.select("span:contains(Shape)").size());
+
+        assertEquals(4, doc.select("ul li ul li span:contains(Specifications)").size());
+        assertEquals(4, doc.select("ul li ul li span:contains(Geologic Unit)").size());
+        assertEquals(4, doc.select("ul li ul li span:contains(Purpose)").size());
+        assertEquals(4, doc.select("ul li ul li ul li ul li ul li:contains(instance)").size());
+        assertEquals(1, doc.select("ul li ul li ul li ul li ul li:contains(New Group)").size());
+        assertEquals(1, doc.select("ul li ul li ul li ul li ul li:contains(-Xy)").size());
+
+        assertEquals(
+                "Yaugher Volcanic Group",
+                doc.select(
+                                "ul li ul li ul li ul li ul li:contains(Yaugher Volcanic Group):first-child")
+                        .get(0)
+                        .text());
+        assertEquals(
+                2,
+                doc.select("ul li ul li ul li ul li ul li:contains(Yaugher Volcanic Group 1)")
+                        .size());
+        assertEquals(
+                2,
+                doc.select("ul li ul li ul li ul li ul li:contains(Yaugher Volcanic Group 2)")
+                        .size());
+
+        assertEquals(3, doc.select("ul li ul li ul li ul li ul li:contains(-Py)").size());
+        assertEquals(
+                6, doc.select("ul li ul li ul li ul li span:contains(Composition Parts)").size());
+        assertEquals(6, doc.select("ul li ul li ul li ul li ul li span:contains(Part)").size());
+        assertEquals(6, doc.select("ul li ul li ul li ul li ul li span:contains(Role)").size());
+        assertEquals(
+                5,
+                doc.select(
+                                "ul li ul li ul li ul li ul li ul li ul li:contains(interbedded component)")
+                        .size());
+        assertEquals(
+                1,
+                doc.select(
+                                "ul li ul li ul li ul li ul li ul li ul li:contains(fictitious component)")
+                        .size());
     }
 }

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetComplexFeatureResponseTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetComplexFeatureResponseTest.java
@@ -125,7 +125,7 @@ public class HTMLGetComplexFeatureResponseTest extends TemplateComplexTestSuppor
                         "wfs?request=GetFeature&version=1.1.0&typename=gsml:MappedFeature"
                                 + "&outputFormat=text/html"
                                 + MF_HTML_PARAM);
-        assertFalse(doc.select("script").isEmpty());
+        assertFalse(doc.select("li:contains(60°)").isEmpty());
         assertHTMLResult(doc);
     }
 

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetSimpleFeaturesResponseWFSTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/response/HTMLGetSimpleFeaturesResponseWFSTest.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.featurestemplating.response;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Collections;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.Catalog;
@@ -11,8 +13,8 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.CiteTestData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.featurestemplating.configuration.SupportedFormat;
+import org.jsoup.nodes.Document;
 import org.junit.Test;
-import org.w3c.dom.Document;
 
 public class HTMLGetSimpleFeaturesResponseWFSTest extends TemplateComplexTestSupport {
 
@@ -42,16 +44,17 @@ public class HTMLGetSimpleFeaturesResponseWFSTest extends TemplateComplexTestSup
                 htmlFeatures);
     }
 
+    /**
+     * Tests if GetFeature response is escaped correctly
+     *
+     * @throws Exception
+     */
     @Test
     public void testHtmlResponse() throws Exception {
         StringBuilder sb = new StringBuilder("wfs?request=GetFeature&version=2.0");
         sb.append("&TYPENAME=cite:HtmlFeatures&outputFormat=");
         sb.append("text/html&cql_filter=NAME='Features1'&html=true");
-        String t = getAsString(sb.toString());
-        Document doc = getAsDOM(sb.toString());
-        assertXpathMatches(
-                "60&deg;",
-                "//html/body/ul/li[./span = 'HTML Features']/ul/li[./span = 'Degrees']/ul/li",
-                doc);
+        Document doc = getAsJSoup(sb.toString());
+        assertEquals(1, doc.select("ul.nested li ul.nested li:contains(60°)").size());
     }
 }

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -2057,8 +2057,7 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
     protected org.jsoup.nodes.Document getAsJSoup(String url) throws Exception {
         MockHttpServletResponse response = getAsServletResponse(url);
         assertEquals(200, response.getStatus());
-        assertEquals("text/html", response.getContentType());
-
+        assertContentType("text/html", response);
         LOGGER.log(Level.INFO, "Last request returned\n:" + response.getContentAsString());
 
         // parse the HTML


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-10921

- Fix for double escaping of html when features-templating module is enabled. Changed used for features-templating XMLFactory [here](https://github.com/geosolutions-it/geoserver/blob/44c5b94bc172e116b7bddf74e31935d5966c24eb/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/TemplateGetFeatureResponseHelper.java#L73) to default, because previous version doesn't support non escaping property. Problem was with degree sign being escaped to \&deg; and then to \&amp;deg; by factory.
- Fixed existing tests to use Jsoup for HTML. Previously HTML responses were validated using XPath and requests were processed with getAsDom which escaped incorrect (for HTML) character \&amp;deg; from response to correct \&deg;. Because of tests that were checking escaping were passing, but actual requests outside tests had incorrect symbol in response.
Had to change couple of tests to Jsoup because &deg is not valid XML entity (but valid HTML) and getAsDom throws an exception when encountering it.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->