### PR TITLE
[GEOS-10922] Features templating exception on text/plain format

### DIFF
--- a/src/community/features-templating/features-templating-ows/pom.xml
+++ b/src/community/features-templating/features-templating-ows/pom.xml
@@ -58,6 +58,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-wfs</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-referencing</artifactId>
     </dependency>

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/TemplateCallback.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/TemplateCallback.java
@@ -33,7 +33,6 @@ import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.util.logging.Logging;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
-import org.springframework.http.MediaType;
 
 /**
  * This {@link DispatcherCallback} implementation checks on operation dispatched event if a json-ld
@@ -185,11 +184,7 @@ public class TemplateCallback extends AbstractDispatcherCallback {
         Response response = null;
         if (param1 instanceof GetFeatureInfoRequest) {
             GetFeatureInfoRequest request = (GetFeatureInfoRequest) param1;
-            // Checking that template format is specified and that it's not text/plain because it's
-            // not supported,
-            // but is default if nothing is specified
-            if (request.getInfoFormat() != null
-                    && !request.getInfoFormat().equals(MediaType.TEXT_PLAIN_VALUE)) {
+            if (request.getInfoFormat() != null) {
                 response = getTemplateFeatureInfoResponse(request);
             }
         } else {
@@ -212,23 +207,27 @@ public class TemplateCallback extends AbstractDispatcherCallback {
         String infoFormat = request.getInfoFormat();
         TemplateIdentifier identifier =
                 TemplateIdentifier.fromOutputFormat(request.getInfoFormat());
-        int nTemplates = 0;
-        for (MapLayerInfo li : layerInfos) {
-            if (li != null && li.getResource() instanceof FeatureTypeInfo) {
-                if (ensureTemplatesExist(li.getFeature(), identifier.getOutputFormat()) != null)
-                    nTemplates++;
-            }
-        }
         Response result = null;
-        if (nTemplates > 0) {
-            int size = layerInfos.size();
-            if (size != nTemplates)
-                throw new ServiceException(
-                        "To get a features templating getFeatureInfo a template is needed for every FeatureType but "
-                                + (size - nTemplates)
-                                + " among the requested ones are missing a template");
+        if (identifier != null) {
+            int nTemplates = 0;
+            for (MapLayerInfo li : layerInfos) {
+                if (li != null && li.getResource() instanceof FeatureTypeInfo) {
+                    if (ensureTemplatesExist(li.getFeature(), identifier.getOutputFormat()) != null)
+                        nTemplates++;
+                }
+            }
+            if (nTemplates > 0) {
+                int size = layerInfos.size();
+                if (size != nTemplates)
+                    throw new ServiceException(
+                            "To get a features templating getFeatureInfo a template is needed for every FeatureType but "
+                                    + (size - nTemplates)
+                                    + " among the requested ones are missing a template");
 
-            result = OWSResponseFactory.getInstance().featureInfoResponse(identifier, infoFormat);
+                result =
+                        OWSResponseFactory.getInstance()
+                                .featureInfoResponse(identifier, infoFormat);
+            }
         }
         return result;
     }

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/HTMLTemplateResponse.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/HTMLTemplateResponse.java
@@ -39,6 +39,8 @@ import org.opengis.feature.Feature;
 /** A template response able to write an HTML output format. */
 public class HTMLTemplateResponse extends BaseTemplateGetFeatureResponse {
 
+    private static final String ELEMENT_NAME = "HTML";
+
     public HTMLTemplateResponse(GeoServer gs, TemplateLoader configuration) {
         super(gs, configuration, TemplateIdentifier.HTML);
     }
@@ -173,5 +175,10 @@ public class HTMLTemplateResponse extends BaseTemplateGetFeatureResponse {
                 && ftName != null
                 && "FEATURES".equalsIgnoreCase(request.getService())
                 && outputFormat != null;
+    }
+
+    @Override
+    public String getCapabilitiesElementName() {
+        return ELEMENT_NAME;
     }
 }

--- a/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/JSONLDGetFeatureResponse.java
+++ b/src/community/features-templating/features-templating-ows/src/main/java/org/geoserver/featurestemplating/ows/wfs/JSONLDGetFeatureResponse.java
@@ -34,6 +34,8 @@ import org.opengis.feature.Feature;
  */
 public class JSONLDGetFeatureResponse extends BaseTemplateGetFeatureResponse {
 
+    private static final String ELEMENT_NAME = "JSON-LD";
+
     public JSONLDGetFeatureResponse(GeoServer gs, TemplateLoader configuration) {
         super(gs, configuration, TemplateIdentifier.JSONLD);
         this.configuration = configuration;
@@ -137,5 +139,10 @@ public class JSONLDGetFeatureResponse extends BaseTemplateGetFeatureResponse {
             result = Boolean.valueOf(value.toString());
         }
         return result;
+    }
+
+    @Override
+    public String getCapabilitiesElementName() {
+        return ELEMENT_NAME;
     }
 }

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wfs/GetCapabilitiesTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wfs/GetCapabilitiesTest.java
@@ -19,7 +19,7 @@ public class GetCapabilitiesTest extends WFSTestSupport {
 
     /**
      * Checks if features templating specific result formats are present in output and represented
-     * correctly
+     * correctly.
      *
      * @throws Exception
      */

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wfs/GetCapabilitiesTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wfs/GetCapabilitiesTest.java
@@ -1,0 +1,42 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.featurestemplating.wfs;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import java.util.TreeSet;
+import org.geoserver.wfs.WFSTestSupport;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/** GetCapabilities test for features templating module */
+public class GetCapabilitiesTest extends WFSTestSupport {
+
+    /**
+     * Checks if features templating specific result formats are present in output and represented
+     * correctly
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOutputFormats() throws Exception {
+        Document doc = getAsDOM("wfs?service=WFS&request=getCapabilities&version=1.0.0");
+
+        Element outputFormats = getFirstElementByTagName(doc, "ResultFormat");
+        NodeList formats = outputFormats.getChildNodes();
+
+        Set<String> s1 = new TreeSet<>();
+        for (int i = 0; i < formats.getLength(); i++) {
+            String format = formats.item(i).getNodeName();
+            s1.add(format);
+        }
+
+        assertTrue(s1.contains("JSON-LD"));
+        assertTrue(s1.contains("HTML"));
+    }
+}

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wfs/WfsGetCapabilitiesTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wfs/WfsGetCapabilitiesTest.java
@@ -14,8 +14,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-/** GetCapabilities test for features templating module */
-public class GetCapabilitiesTest extends WFSTestSupport {
+/** WFS service GetCapabilities test for features templating module */
+public class WfsGetCapabilitiesTest extends WFSTestSupport {
 
     /**
      * Checks if features templating specific result formats are present in output and represented

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetCapabilitiesTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetCapabilitiesTest.java
@@ -1,0 +1,43 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.featurestemplating.wms;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import java.util.TreeSet;
+import org.geoserver.wms.WMSTestSupport;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/** WMS service GetCapabilities test for features templating module */
+public class WmsGetCapabilitiesTest extends WMSTestSupport {
+
+    /**
+     * Checks if features templating specific result formats are present in output and represented
+     * correctly.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testOutputFormats() throws Exception {
+        Document doc = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.0.0");
+
+        Element outputFormats = getFirstElementByTagName(doc, "GetFeatureInfo");
+        NodeList childNodes = outputFormats.getChildNodes();
+
+        Set<String> formats = new TreeSet<>();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node item = childNodes.item(i);
+            if ("Format".equals(item.getNodeName())) {
+                formats.add(item.getTextContent());
+            }
+        }
+        assertTrue(formats.contains("application/ld+json"));
+    }
+}

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetFeatureInfoTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetFeatureInfoTest.java
@@ -1,0 +1,48 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.featurestemplating.wms;
+
+import static org.junit.Assert.assertFalse;
+
+import org.geoserver.test.AbstractAppSchemaTestSupport;
+import org.geoserver.test.WmsSupportMockData;
+import org.junit.Test;
+
+/** GetFeatureInfo tests for feature templating module */
+public class WmsGetFeatureInfoTest extends AbstractAppSchemaTestSupport {
+
+    private static final String URL =
+            "wms?request=GetFeatureInfo&SRS=EPSG:4326&BBOX=-1.3,52,0,52.5&LAYERS=gsml:MappedFeature&QUERY_LAYERS=gsml:MappedFeature&X=0&Y=0&width=100&height=100";
+
+    @Override
+    protected WmsSupportMockData createTestData() {
+        WmsSupportMockData mockData = new WmsSupportMockData();
+        mockData.addStyle("Default", "styles/Default.sld");
+        mockData.addStyle("positionalaccuracy21", "styles/positionalaccuracy21.sld");
+        return mockData;
+    }
+
+    /**
+     * Checks if submitting features templating request without format doesn't throw exception
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetFeatureInfoEmptyFormat() throws Exception {
+        String response = getAsString(URL);
+        assertFalse(response.contains("NullPointerException"));
+    }
+    /**
+     * Checks if submitting features templating request with text/html format doesn't throw
+     * exception
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetFeatureInfoTextPlain() throws Exception {
+        String response = getAsString(URL + "&INFO_FORMAT=text/plain");
+        assertFalse(response.contains("NullPointerException"));
+    }
+}

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetFeatureInfoTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetFeatureInfoTest.java
@@ -25,7 +25,7 @@ public class WmsGetFeatureInfoTest extends AbstractAppSchemaTestSupport {
     }
 
     /**
-     * Checks if submitting features templating request without format doesn't throw exception
+     * Checks if submitting features templating request without format doesn't throw an exception
      *
      * @throws Exception
      */
@@ -36,8 +36,8 @@ public class WmsGetFeatureInfoTest extends AbstractAppSchemaTestSupport {
     }
 
     /**
-     * Checks if submitting features templating request with not supported template format doesn't throw
-     * exception
+     * Checks if submitting features templating request with not supported template format doesn't
+     * throw an exception
      *
      * @throws Exception
      */

--- a/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetFeatureInfoTest.java
+++ b/src/community/features-templating/features-templating-ows/src/test/java/org/geoserver/featurestemplating/wms/WmsGetFeatureInfoTest.java
@@ -34,8 +34,9 @@ public class WmsGetFeatureInfoTest extends AbstractAppSchemaTestSupport {
         String response = getAsString(URL);
         assertFalse(response.contains("NullPointerException"));
     }
+
     /**
-     * Checks if submitting features templating request with text/html format doesn't throw
+     * Checks if submitting features templating request with not supported template format doesn't throw
      * exception
      *
      * @throws Exception


### PR DESCRIPTION
[![GEOS-10922](https://badgen.net/badge/JIRA/GEOS-10922/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10922)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Submitting GetCapabilities request with features-templating enabled results in exception due to 
WFSGetFeatureOutputFormat#getCapabilitiesElementName not being overriden for child classes present in features-templating (Fixed). Added test.
Features templating callback is executed for layers which doesn’t have template (for example during GetFeatureInfo) and without defined INFO_FORMAT param results in NullPointerException. Added additinal checkes to TemplateCallback's operationDispatched and responseDispatched methods to support only WMS GetFeatureInfo and WFS GetFeature requests.
Added check for ignoring template if INFO_FORMAT is text/plain (default if empty) because templates do not support it.
Added test for exception on text/plain.
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->