### PR TITLE
[GEOS-10858] support isolated workspaces other catalogfacades

### DIFF
--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/catalog/CatalogImplWithJDBCFacadeTest.java
@@ -354,16 +354,6 @@ public class CatalogImplWithJDBCFacadeTest extends org.geoserver.catalog.impl.Ca
         test.testOrderBy();
     }
 
-    // not supported
-    @Override
-    @Test
-    public void testAddIsolatedWorkspace() {}
-
-    // not supported
-    @Override
-    @Test
-    public void testAddIsolatedNamespace() {}
-
     @Test
     public void testConcurrentListLoad() throws Exception {
         addDataStore();

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -113,11 +113,7 @@ public class CatalogImpl implements Catalog {
     protected boolean extendedValidation = true;
 
     public CatalogImpl() {
-        facade = new DefaultCatalogFacade(this);
-        // wrap the default catalog facade with the facade capable of handling isolated workspaces
-        // behavior
-        facade = new IsolatedCatalogFacade(facade);
-        setFacade(facade);
+        setFacade(new DefaultCatalogFacade(this));
         resourcePool = ResourcePool.create(this);
     }
 
@@ -147,10 +143,14 @@ public class CatalogImpl implements Catalog {
     public void setFacade(CatalogFacade facade) {
         final GeoServerConfigurationLock configurationLock =
                 GeoServerExtensions.bean(GeoServerConfigurationLock.class);
+        // wrap the default catalog facade with the facade capable of handling isolated workspaces
+        // behavior
+        facade = new IsolatedCatalogFacade(facade);
         if (configurationLock != null) {
             facade = LockingCatalogFacade.create(facade, configurationLock);
         }
         this.facade = facade;
+        this.facade.setCatalog(this);
         facade.setCatalog(this);
     }
 


### PR DESCRIPTION
[![GEOS-10858](https://badgen.net/badge/JIRA/GEOS-10858/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10858)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->