### PR TITLE
[GEOS-10937] JSON-FG reprojected output should respect authority axis order

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeaturesResponse.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeaturesResponse.java
@@ -108,7 +108,18 @@ public class JSONFGFeaturesResponse extends RFCGeoJSONFeaturesResponse {
                         && !CRS.equalsIgnoreMetadata(
                                 DefaultGeographicCRS.WGS84,
                                 descriptor.getCoordinateReferenceSystem());
-        String key = otherCRS ? "place" : "geometry";
+        String key = "geometry";
+        if (otherCRS) {
+            // make sure the JSON writer does not try to un-flip the coordinates
+            // as per GeoJSON spec, quoting:
+            //  A position is an array of numbers.  There MUST be two or more
+            //   elements.  The first two elements are longitude and latitude, or
+            //   easting and northing, precisely in that order and using decimal
+            //   numbers.  Altitude or elevation MAY be included as an optional third
+            //   element.
+            jsonWriter.setAxisOrder(CRS.AxisOrder.EAST_NORTH);
+            key = "place";
+        }
         jsonWriter.key(key);
         if (aGeom != null) {
             jsonWriter.writeGeom(aGeom);

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
@@ -872,6 +872,36 @@ public class FeatureTest extends FeaturesTestSupport {
                 typeLink.read("href"));
     }
 
+    /**
+     * JSON-FG output respect axis order as mandated by the authority
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testJSONFGSingleFeatureETRS89() throws Exception {
+        String bridges = ResponseUtils.urlEncode(getLayerId(MockData.BRIDGES));
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/v1/collections/"
+                                + bridges
+                                + "/items/Bridges.1107531599613"
+                                + "?crs=http://www.opengis.net/def/crs/EPSG/0/4258&f="
+                                + ResponseUtils.urlEncode(JSONFGFeaturesResponse.MIME_TYPE),
+                        200);
+
+        assertEquals("Feature", json.read("type", String.class));
+        // the coord ref sys is not included in the response, as it's the default one
+        assertEquals(
+                "http://www.opengis.net/def/crs/EPSG/0/4258",
+                json.read(COORD_REF_SYS, String.class));
+        // we have place, but not geometry
+        assertThrows(PathNotFoundException.class, () -> json.read("geometry"));
+        assertEquals("Point", json.read("place.type"));
+        // mind that axis flip
+        assertArrayEquals(
+                new double[] {7E-4, 2E-4}, json.read("place.coordinates", double[].class), 1e-4);
+    }
+
     @Test
     public void testJSONFG_CRS84() throws Exception {
         String bridges = ResponseUtils.urlEncode(getLayerId(MockData.BRIDGES));


### PR DESCRIPTION
[![GEOS-10937](https://badgen.net/badge/JIRA/GEOS-10937/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10937)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Unlike GeoJSON.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->