### PR TITLE
[GEOS-10941] Update ErrorProne to 2.18

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaMockData.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaMockData.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.test;
 
+import static java.util.Map.entry;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -23,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 import org.geoserver.data.CatalogWriter;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
@@ -63,38 +64,30 @@ public abstract class AbstractAppSchemaMockData extends SystemTestData
     /** Map of namespace prefix to namespace URI for GML 32 schema. */
     @SuppressWarnings("serial")
     protected static final Map<String, String> GML32_NAMESPACES =
-            Collections.unmodifiableMap(
-                    new TreeMap<String, String>() {
-                        {
-                            put("cgu", "urn:cgi:xmlns:CGI:Utilities:3.0.0");
-                            put("gco", "http://www.isotc211.org/2005/gco");
-                            put("gmd", "http://www.isotc211.org/2005/gmd");
-                            put("gml", "http://www.opengis.net/gml/3.2");
-                            put("gsml", "urn:cgi:xmlns:CGI:GeoSciML-Core:3.0.0");
-                            put("sa", "http://www.opengis.net/sampling/2.0");
-                            put("spec", "http://www.opengis.net/samplingSpecimen/2.0");
-                            put("swe", "http://www.opengis.net/swe/1.0/gml32");
-                            put("wfs", "http://www.opengis.net/wfs/2.0");
-                            put("xlink", "http://www.w3.org/1999/xlink");
-                        }
-                    });
+            Map.ofEntries(
+                    entry("cgu", "urn:cgi:xmlns:CGI:Utilities:3.0.0"),
+                    entry("gco", "http://www.isotc211.org/2005/gco"),
+                    entry("gmd", "http://www.isotc211.org/2005/gmd"),
+                    entry("gml", "http://www.opengis.net/gml/3.2"),
+                    entry("gsml", "urn:cgi:xmlns:CGI:GeoSciML-Core:3.0.0"),
+                    entry("sa", "http://www.opengis.net/sampling/2.0"),
+                    entry("spec", "http://www.opengis.net/samplingSpecimen/2.0"),
+                    entry("swe", "http://www.opengis.net/swe/1.0/gml32"),
+                    entry("wfs", "http://www.opengis.net/wfs/2.0"),
+                    entry("xlink", "http://www.w3.org/1999/xlink"));
 
     /** Map of namespace prefix to namespace URI. */
     @SuppressWarnings("serial")
     private static final Map<String, String> NAMESPACES =
-            Collections.unmodifiableMap(
-                    new LinkedHashMap<String, String>() {
-                        {
-                            put(GSML_PREFIX, GSML_URI);
-                            put("gml", "http://www.opengis.net/gml");
-                            put("xlink", "http://www.w3.org/1999/xlink");
-                            put("sa", "http://www.opengis.net/sampling/1.0");
-                            put("om", "http://www.opengis.net/om/1.0");
-                            put("cv", "http://www.opengis.net/cv/0.2.1");
-                            put("swe", "http://www.opengis.net/swe/1.0.1");
-                            put("sml", "http://www.opengis.net/sensorML/1.0.1");
-                        }
-                    });
+            Map.ofEntries(
+                    entry(GSML_PREFIX, GSML_URI),
+                    entry("gml", "http://www.opengis.net/gml"),
+                    entry("xlink", "http://www.w3.org/1999/xlink"),
+                    entry("sa", "http://www.opengis.net/sampling/1.0"),
+                    entry("om", "http://www.opengis.net/om/1.0"),
+                    entry("cv", "http://www.opengis.net/cv/0.2.1"),
+                    entry("swe", "http://www.opengis.net/swe/1.0.1"),
+                    entry("sml", "http://www.opengis.net/sensorML/1.0.1"));
 
     /** Use FeatureTypeInfo constants for srs handling as values */
     static final String KEY_SRS_HANDLINGS = "srsHandling";
@@ -497,16 +490,14 @@ public abstract class AbstractAppSchemaMockData extends SystemTestData
             final File featureTypesBaseDir,
             final String dataStoreName) {
         try {
-            return new LinkedHashMap<String, Serializable>() {
-                {
-                    put("dbtype", "app-schema");
-                    put(
+            return Map.ofEntries(
+                    entry("dbtype", "app-schema"),
+                    entry(
                             "url",
                             new File(new File(featureTypesBaseDir, dataStoreName), mappingFileName)
                                     .toURI()
-                                    .toURL());
-                }
-            };
+                                    .toURL()));
+
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaTestSupport.java
@@ -6,6 +6,7 @@
 
 package org.geoserver.test;
 
+import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -21,7 +22,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,22 +94,17 @@ public abstract class AbstractAppSchemaTestSupport extends GeoServerSystemTestSu
     /** WFS namespaces, for use by XMLUnit. A seen in WFSTestSupport, plus xlink. */
     @SuppressWarnings("serial")
     private final Map<String, String> WFS_NAMESPACES =
-            Collections.unmodifiableMap(
-                    new HashMap<String, String>() {
-                        {
-                            put("wfs", "http://www.opengis.net/wfs");
-                            put("ows", "http://www.opengis.net/ows");
-                            put("ogc", "http://www.opengis.net/ogc");
-                            put("xs", "http://www.w3.org/2001/XMLSchema");
-                            put("xsd", "http://www.w3.org/2001/XMLSchema");
-                            put("gml", "http://www.opengis.net/gml");
-                            put("xlink", "http://www.w3.org/1999/xlink");
-                            put("xsi", "http://www.w3.org/2001/XMLSchema-instance");
-                            put(
-                                    "wms",
-                                    "http://www.opengis.net/wms"); // NC - wms added for wms tests
-                        }
-                    });
+            Map.ofEntries(
+                    entry("wfs", "http://www.opengis.net/wfs"),
+                    entry("ows", "http://www.opengis.net/ows"),
+                    entry("ogc", "http://www.opengis.net/ogc"),
+                    entry("xs", "http://www.w3.org/2001/XMLSchema"),
+                    entry("xsd", "http://www.w3.org/2001/XMLSchema"),
+                    entry("gml", "http://www.opengis.net/gml"),
+                    entry("xlink", "http://www.w3.org/1999/xlink"),
+                    entry("xsi", "http://www.w3.org/2001/XMLSchema-instance"),
+                    entry("wms", "http://www.opengis.net/wms") // NC - wms added for wms tests
+                    );
 
     /** The XpathEngine to be used for this namespace context. */
     private XpathEngine xpathEngine;

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/FeatureChainingWfsTest.java
@@ -340,15 +340,11 @@ public class FeatureChainingWfsTest extends AbstractAppSchemaTestSupport {
         if (targetNamespace.equals(FeatureChainingMockData.EX_URI)) {
             assertEquals(2, numberOfImports);
             assertEquals(3, numberOfIncludes);
-            @SuppressWarnings("serial")
             Set<String> expectedExSchemaLocations =
-                    new HashSet<String>() {
-                        {
-                            add(getExSchemaOneLocation());
-                            add(getExSchemaTwoLocation());
-                            add(getExSchemaThreeLocation());
-                        }
-                    };
+                    Set.of(
+                            getExSchemaOneLocation(),
+                            getExSchemaTwoLocation(),
+                            getExSchemaThreeLocation());
             // ensure expected schemaLocations are distinct
             assertEquals(numberOfIncludes, expectedExSchemaLocations.size());
             // check that found schemaLocations are as expected

--- a/src/extension/app-schema/sample-data-access-test/src/test/java/org/geoserver/test/SampleDataAccessMockData.java
+++ b/src/extension/app-schema/sample-data-access-test/src/test/java/org/geoserver/test/SampleDataAccessMockData.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -131,29 +130,16 @@ public class SampleDataAccessMockData extends SystemTestData {
     protected void setUpCatalog() throws IOException {
         CatalogWriter writer = new CatalogWriter();
         writer.dataStores(
-                new HashMap<String, Map<String, Serializable>>() {
-                    {
-                        put(DATASTORE_NAME, SampleDataAccessFactory.PARAMS);
-                    }
-                },
-                new HashMap<String, String>() {
-                    {
-                        put(DATASTORE_NAME, SampleDataAccessData.NAMESPACE_PREFIX);
-                    }
-                },
+                Map.of(DATASTORE_NAME, SampleDataAccessFactory.PARAMS),
+                Map.of(DATASTORE_NAME, SampleDataAccessData.NAMESPACE_PREFIX),
                 Collections.<String>emptySet());
         writer.coverageStores(
                 new HashMap<String, Map<String, String>>(),
                 new HashMap<String, String>(),
                 Collections.<String>emptySet());
         writer.namespaces(
-                new HashMap<String, String>() {
-                    {
-                        put(
-                                SampleDataAccessData.NAMESPACE_PREFIX,
-                                SampleDataAccessData.NAMESPACE_URI);
-                    }
-                });
+                Map.of(SampleDataAccessData.NAMESPACE_PREFIX, SampleDataAccessData.NAMESPACE_URI));
+
         writer.styles(Collections.<String, String>emptyMap());
         writer.write(new File(data, "catalog.xml"));
     }

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/format/GMLFileFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/format/GMLFileFormat.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.importer.format;
 
+import static java.util.Map.entry;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 import java.io.File;
@@ -84,12 +85,9 @@ public class GMLFileFormat extends VectorFormat {
             Arrays.asList("name", "description", "boundedBy", "location");
 
     private static final Map<Class<?>, Class<?>> TYPE_PROMOTIONS =
-            new HashMap<Class<?>, Class<?>>() {
-                {
-                    put(Integer.class, Long.class);
-                    put(Long.class, Double.class);
-                }
-            };
+            Map.ofEntries(
+                    entry(Integer.class, Long.class), //
+                    entry(Long.class, Double.class));
 
     private static final String GML_VERSION_KEY = "version";
 

--- a/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTestSupport.java
+++ b/src/extension/importer/core/src/test/java/org/geoserver/importer/ImporterTestSupport.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -54,15 +53,12 @@ public abstract class ImporterTestSupport extends GeoServerSystemTestSupport {
     static Logger LOGGER = Logging.getLogger(ImporterTestSupport.class);
 
     static final Set<String> DEFAULT_STYLEs =
-            new HashSet<String>() {
-                {
-                    add(StyleInfo.DEFAULT_POINT);
-                    add(StyleInfo.DEFAULT_LINE);
-                    add(StyleInfo.DEFAULT_GENERIC);
-                    add(StyleInfo.DEFAULT_POLYGON);
-                    add(StyleInfo.DEFAULT_RASTER);
-                }
-            };
+            Set.of(
+                    StyleInfo.DEFAULT_POINT,
+                    StyleInfo.DEFAULT_LINE,
+                    StyleInfo.DEFAULT_GENERIC,
+                    StyleInfo.DEFAULT_POLYGON,
+                    StyleInfo.DEFAULT_RASTER);
 
     protected Importer importer;
 

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/AbstractNetCDFEncoder.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/AbstractNetCDFEncoder.java
@@ -70,31 +70,21 @@ public abstract class AbstractNetCDFEncoder implements NetCDFEncoder {
      */
     @SuppressWarnings("serial")
     protected static final Set<String> COPY_ATTRIBUTES_BLACKLIST =
-            new HashSet<String>() {
-                {
+            Set.of(
                     // coordinate variable names are usually changed
-                    add("coordinates");
-                    // these do not survive type change or packing and should be set from nodata
-                    // value
-                    add("_FillValue");
-                    add("missing_value");
-                    // this one is better not copied over in case of subsetting instead
-                    add("_ChunkSizes");
-                }
-            };
+                    "coordinates",
+                    // do not survive type change or packing and should be set from no-data value
+                    "_FillValue",
+                    "missing_value",
+                    // this one is better not copied over in case of sub-setting instead
+                    "_ChunkSizes");
 
     /**
      * Global Attributes that are never copied from a NetCDF/GRIB source because they require
      * special handling.
      */
     @SuppressWarnings("serial")
-    protected static final Set<String> COPY_GLOBAL_ATTRIBUTES_BLACKLIST =
-            new HashSet<String>() {
-                {
-                    // Not copying this since the UCAR writer will create it again
-                    add("_NCProperties");
-                }
-            };
+    protected static final Set<String> COPY_GLOBAL_ATTRIBUTES_BLACKLIST = Set.of("_NCProperties");
 
     /** Bean related to the {@link NetCDFCFParser} */
     protected static NetCDFParserBean parserBean = GeoServerExtensions.bean(NetCDFParserBean.class);

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/NetCDFCoverageResponseDelegate.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/NetCDFCoverageResponseDelegate.java
@@ -5,13 +5,18 @@
  */
 package org.geoserver.wcs.responses;
 
+import static java.util.Map.entry;
+import static org.geotools.imageio.netcdf.utilities.NetCDFUtilities.NETCDF;
+import static org.geotools.imageio.netcdf.utilities.NetCDFUtilities.NETCDF3_MIMETYPE;
+import static org.geotools.imageio.netcdf.utilities.NetCDFUtilities.NETCDF4;
+import static org.geotools.imageio.netcdf.utilities.NetCDFUtilities.NETCDF4_MIMETYPE;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -22,7 +27,6 @@ import org.geoserver.platform.ServiceException;
 import org.geoserver.wcs2_0.response.GranuleStack;
 import org.geoserver.wcs2_0.response.MultidimensionalCoverageResponse;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
 import org.geotools.util.logging.Logging;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -47,30 +51,20 @@ public class NetCDFCoverageResponseDelegate extends BaseCoverageResponseDelegate
     public NetCDFCoverageResponseDelegate(GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList(NetCDFUtilities.NETCDF, NetCDFUtilities.NETCDF4),
-                new HashMap<String, String>() { // file extensions
-                    {
-                        put(NetCDFUtilities.NETCDF, "nc");
-                        put(NetCDFUtilities.NETCDF.toLowerCase(), "nc");
-                        put(NetCDFUtilities.NETCDF.toUpperCase(), "nc");
-                        put(NetCDFUtilities.NETCDF3_MIMETYPE, "nc");
-                        put(NetCDFUtilities.NETCDF4_MIMETYPE, "nc");
-                    }
-                },
-                new HashMap<String, String>() { // mime types
-                    {
-                        put(NetCDFUtilities.NETCDF, NetCDFUtilities.NETCDF3_MIMETYPE);
-                        put(NetCDFUtilities.NETCDF.toLowerCase(), NetCDFUtilities.NETCDF3_MIMETYPE);
-                        put(NetCDFUtilities.NETCDF.toUpperCase(), NetCDFUtilities.NETCDF3_MIMETYPE);
-                        put(NetCDFUtilities.NETCDF4, NetCDFUtilities.NETCDF4_MIMETYPE);
-                        put(
-                                NetCDFUtilities.NETCDF4.toLowerCase(),
-                                NetCDFUtilities.NETCDF4_MIMETYPE);
-                        put(
-                                NetCDFUtilities.NETCDF4.toUpperCase(),
-                                NetCDFUtilities.NETCDF4_MIMETYPE);
-                    }
-                });
+                Arrays.asList(NETCDF, NETCDF4),
+                Map.ofEntries(
+                        entry(NETCDF, "nc"),
+                        entry(NETCDF.toLowerCase(), "nc"),
+                        entry(NETCDF.toUpperCase(), "nc"),
+                        entry(NETCDF3_MIMETYPE, "nc"),
+                        entry(NETCDF4_MIMETYPE, "nc")),
+                Map.ofEntries(
+                        entry(NETCDF, NETCDF3_MIMETYPE),
+                        entry(NETCDF.toLowerCase(), NETCDF3_MIMETYPE),
+                        entry(NETCDF.toUpperCase(), NETCDF3_MIMETYPE),
+                        entry(NETCDF4, NETCDF4_MIMETYPE),
+                        entry(NETCDF4.toLowerCase(), NETCDF4_MIMETYPE),
+                        entry(NETCDF4.toUpperCase(), NETCDF4_MIMETYPE)));
     }
 
     @Override

--- a/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSResponseInterceptor.java
+++ b/src/extension/netcdf-out/src/test/java/org/geoserver/wcs2_0/WCSResponseInterceptor.java
@@ -8,7 +8,6 @@ package org.geoserver.wcs2_0;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import org.geoserver.config.GeoServer;
 import org.geoserver.platform.ServiceException;
@@ -28,17 +27,8 @@ public final class WCSResponseInterceptor extends BaseCoverageResponseDelegate
         super(
                 geoserver,
                 Arrays.asList("MyOutput"),
-                new HashMap<String, String>() { // file
-                    // extensions
-                    {
-                        put(MIME_TYPE, "zip");
-                    }
-                },
-                new HashMap<String, String>() { // mime types
-                    {
-                        put("MyOutput", MIME_TYPE);
-                    }
-                });
+                Map.of(MIME_TYPE, "zip"),
+                Map.of("MyOutput", MIME_TYPE));
     }
 
     @Override

--- a/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrOutputFormat.java
+++ b/src/extension/ogr/ogr-wfs/src/main/java/org/geoserver/wfs/response/Ogr2OgrOutputFormat.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -60,17 +59,14 @@ public class Ogr2OgrOutputFormat extends WFSGetFeatureOutputFormat
 
     /** The types of geometries a shapefile can handle */
     private static final Set<Class<?>> SHAPEFILE_GEOM_TYPES =
-            new HashSet<Class<?>>() {
-                {
-                    add(Point.class);
-                    add(LineString.class);
-                    add(LinearRing.class);
-                    add(Polygon.class);
-                    add(MultiPoint.class);
-                    add(MultiLineString.class);
-                    add(MultiPolygon.class);
-                }
-            };
+            Set.of(
+                    Point.class,
+                    LineString.class,
+                    LinearRing.class,
+                    Polygon.class,
+                    MultiPoint.class,
+                    MultiLineString.class,
+                    MultiPolygon.class);
 
     /** Factory to create the ogr2ogr wrapper. */
     ToolWrapperFactory ogrWrapperFactory;

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/PolygonExtractionProcessTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/PolygonExtractionProcessTest.java
@@ -8,7 +8,7 @@ package org.geoserver.wps.gs;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
+import java.util.List;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
@@ -47,12 +47,9 @@ public class PolygonExtractionProcessTest extends BaseRasterToVectorTest {
                         true,
                         null,
                         null,
-                        new ArrayList<Range>() {
-                            {
-                                add(new Range<>(0d, true, 1000d, false));
-                                add(new Range<>(1000d, true, 2000d, false));
-                            }
-                        },
+                        List.of(
+                                new Range<>(0d, true, 1000d, false),
+                                new Range<>(1000d, true, 2000d, false)),
                         new NullProgressListener());
 
         assertNotNull(fc);

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -2135,9 +2135,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
 
             checkArgument(
                     !tileLayerExists(name),
-                    "Can't auto configure Layer, a tile layer named '",
-                    name,
-                    "' already exists.");
+                    "Can't auto configure Layer, a tile layer named '%s' already exists.",
+                    name);
 
             GeoServerTileLayer tileLayer = null;
             LayerInfo layer = catalog.getLayerByName(name);

--- a/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfig.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfig.java
@@ -386,7 +386,7 @@ public class GWCConfig implements Cloneable, Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         GWCConfig gwcConfig = (GWCConfig) o;
         return directWMSIntegrationEnabled == gwcConfig.directWMSIntegrationEnabled
-                && requireTiledParameter == gwcConfig.requireTiledParameter
+                && Objects.equals(requireTiledParameter, gwcConfig.requireTiledParameter)
                 && WMSCEnabled == gwcConfig.WMSCEnabled
                 && TMSEnabled == gwcConfig.TMSEnabled
                 && securityEnabled == gwcConfig.securityEnabled

--- a/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfigPersister.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfigPersister.java
@@ -67,7 +67,7 @@ public class GWCConfigPersister {
 
     private synchronized void loadConfig() throws IOException {
         Resource configFile = findConfigFile();
-        checkNotNull(configFile, "gwc config file does not exist: ", GWC_CONFIG_FILE);
+        checkNotNull(configFile, "gwc config file does not exist: %s", GWC_CONFIG_FILE);
 
         XStreamPersister xmlPersister = this.persisterFactory.createXMLPersister();
         configureXstream(xmlPersister.getXStream());

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/CatalogConfiguration.java
@@ -431,7 +431,7 @@ public class CatalogConfiguration implements TileLayerConfiguration {
     @Override
     public synchronized void addLayer(final TileLayer tl) {
         checkNotNull(tl);
-        checkArgument(canSave(tl), "Can't save TileLayer of type ", tl.getClass());
+        checkArgument(canSave(tl), "Can't save TileLayer of type %s", tl.getClass());
         GeoServerTileLayer tileLayer = (GeoServerTileLayer) tl;
         checkNotNull(tileLayer.getInfo(), "GeoServerTileLayerInfo is null");
         checkNotNull(tileLayer.getInfo().getId(), "id is null");
@@ -474,7 +474,7 @@ public class CatalogConfiguration implements TileLayerConfiguration {
     @Override
     public synchronized void modifyLayer(TileLayer tl) throws NoSuchElementException {
         checkNotNull(tl, "TileLayer is null");
-        checkArgument(canSave(tl), "Can't save TileLayer of type ", tl.getClass());
+        checkArgument(canSave(tl), "Can't save TileLayer of type: %s ", tl.getClass());
 
         GeoServerTileLayer tileLayer = (GeoServerTileLayer) tl;
 
@@ -511,7 +511,7 @@ public class CatalogConfiguration implements TileLayerConfiguration {
                                 () ->
                                         new NullPointerException(
                                                 "TileLayer " + oldName + " not found"));
-        checkArgument(canSave(tl), "Can't rename TileLayer of type ", tl.getClass());
+        checkArgument(canSave(tl), "Can't rename TileLayer of type %s", tl.getClass());
 
         GeoServerTileLayer tileLayer = (GeoServerTileLayer) tl;
 

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.config.util;
 
+import static java.util.Map.entry;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1277,36 +1277,29 @@ public class XStreamPersisterTest {
         assertEquals(vtc.getName(), "sqlview");
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testVirtualTableMultipleGeoms() throws IOException {
         Map<String, String> types =
-                new HashMap<String, String>() {
-                    {
-                        put("southernmost_point", "org.locationtech.jts.geom.Geometry");
-                        put("location_polygon", "org.locationtech.jts.geom.Geometry");
-                        put("centroid", "org.locationtech.jts.geom.Geometry");
-                        put("northernmost_point", "org.locationtech.jts.geom.Geometry");
-                        put("easternmost_point", "org.locationtech.jts.geom.Geometry");
-                        put("location", "org.locationtech.jts.geom.Geometry");
-                        put("location_original", "org.locationtech.jts.geom.Geometry");
-                        put("westernmost_point", "org.locationtech.jts.geom.Geometry");
-                    }
-                };
+                Map.ofEntries(
+                        entry("southernmost_point", "org.locationtech.jts.geom.Geometry"),
+                        entry("location_polygon", "org.locationtech.jts.geom.Geometry"),
+                        entry("centroid", "org.locationtech.jts.geom.Geometry"),
+                        entry("northernmost_point", "org.locationtech.jts.geom.Geometry"),
+                        entry("easternmost_point", "org.locationtech.jts.geom.Geometry"),
+                        entry("location", "org.locationtech.jts.geom.Geometry"),
+                        entry("location_original", "org.locationtech.jts.geom.Geometry"),
+                        entry("westernmost_point", "org.locationtech.jts.geom.Geometry"));
 
         Map<String, Integer> srids =
-                new HashMap<String, Integer>() {
-                    {
-                        put("southernmost_point", 4326);
-                        put("location_polygon", 3003);
-                        put("centroid", 3004);
-                        put("northernmost_point", 3857);
-                        put("easternmost_point", 4326);
-                        put("location", 3003);
-                        put("location_original", 3004);
-                        put("westernmost_point", 3857);
-                    }
-                };
+                Map.ofEntries(
+                        entry("southernmost_point", 4326),
+                        entry("location_polygon", 3003),
+                        entry("centroid", 3004),
+                        entry("northernmost_point", 3857),
+                        entry("easternmost_point", 4326),
+                        entry("location", 3003),
+                        entry("location_original", 3004),
+                        entry("westernmost_point", 3857));
 
         FeatureTypeInfo ft =
                 persister.load(

--- a/src/ows/src/test/java/org/geoserver/ows/kvp/FormatOptionsKvpParserTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/kvp/FormatOptionsKvpParserTest.java
@@ -5,8 +5,9 @@
  */
 package org.geoserver.ows.kvp;
 
+import static java.util.Map.entry;
+
 import java.text.ParseException;
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,14 +35,11 @@ public class FormatOptionsKvpParserTest {
     @Test
     public void testPairs() throws Exception {
         Map<String, String> expected =
-                new HashMap<String, String>() {
-                    {
-                        put("key1", "value1");
-                        put("key2", "value2");
-                        put("key3", "true");
-                        put("key4", "value4");
-                    }
-                };
+                Map.ofEntries(
+                        entry("key1", "value1"),
+                        entry("key2", "value2"),
+                        entry("key3", "true"),
+                        entry("key4", "value4"));
 
         @SuppressWarnings("unchecked")
         Map<String, String> actual =
@@ -57,13 +55,10 @@ public class FormatOptionsKvpParserTest {
     @Test
     public void testEscapedSeparators() throws Exception {
         Map<String, String> expected =
-                new HashMap<String, String>() {
-                    {
-                        put("key1", "value:1");
-                        put("key2", "value:2");
-                        put("key3", "value:3;ZZZ");
-                    }
-                };
+                Map.ofEntries(
+                        entry("key1", "value:1"),
+                        entry("key2", "value:2"),
+                        entry("key3", "value:3;ZZZ"));
 
         @SuppressWarnings("unchecked")
         Map<String, String> actual =
@@ -80,13 +75,10 @@ public class FormatOptionsKvpParserTest {
     @Test
     public void testEmbeddedSeparators() throws Exception {
         Map<String, String> expected =
-                new HashMap<String, String>() {
-                    {
-                        put("key1", "value:1");
-                        put("key2", "value:2");
-                        put("key3", "value:3:ZZ;XX");
-                    }
-                };
+                Map.ofEntries(
+                        entry("key1", "value:1"),
+                        entry("key2", "value:2"),
+                        entry("key3", "value:3:ZZ;XX"));
 
         @SuppressWarnings("unchecked")
         Map<String, String> actual =
@@ -103,13 +95,10 @@ public class FormatOptionsKvpParserTest {
     @Test
     public void testErrors() throws Exception {
         Map<String, String> expected =
-                new HashMap<String, String>() {
-                    {
-                        put("key1", "value:1");
-                        put("key2", "value:2");
-                        put("key3", "value:3");
-                    }
-                };
+                Map.ofEntries(
+                        entry("key1", "value:1"),
+                        entry("key2", "value:2"),
+                        entry("key3", "value:3"));
 
         @SuppressWarnings("unchecked")
         Map<String, String> actual =

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -153,7 +153,7 @@
     <pom.fmt.action>sort</pom.fmt.action>
     <pom.fmt.skip>${spotless.apply.skip}</pom.fmt.skip>
     <errorProneFlags></errorProneFlags>
-    <errorProne.version>2.10.0</errorProne.version>
+    <errorProne.version>2.18.0</errorProne.version>
     <javac.version>9+181-r4173-1</javac.version>
     <pmd.version>6.42.0</pmd.version>
     <checkstyle.skip>false</checkstyle.skip>

--- a/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
+++ b/src/security/ldap/src/main/java/org/geoserver/security/ldap/LDAPUserGroupService.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  *
  * @author Niels Charlier
  */
+@SuppressWarnings("BanJNDI")
 public class LDAPUserGroupService extends LDAPBaseSecurityService
         implements GeoServerUserGroupService {
 

--- a/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPTestUtils.java
+++ b/src/security/ldap/src/test/java/org/geoserver/security/ldap/LDAPTestUtils.java
@@ -247,7 +247,7 @@ public class LDAPTestUtils {
         loadLdif(contextSource, ldifFile);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "BanJNDI"})
     private static void loadLdif(DirContext context, Resource ldifFile) throws IOException {
         try {
             LdapName baseDn =

--- a/src/wcs/src/main/java/org/geoserver/wcs/responses/AscCoverageResponseDelegate.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/responses/AscCoverageResponseDelegate.java
@@ -5,10 +5,11 @@
  */
 package org.geoserver.wcs.responses;
 
+import static java.util.Map.entry;
+
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 import org.geoserver.config.GeoServer;
@@ -34,33 +35,28 @@ public class AscCoverageResponseDelegate extends BaseCoverageResponseDelegate
     private static final String ARCGRID_FILE_EXTENSION = "asc";
     private static final String ARCGRID_COMPRESSED_FILE_EXTENSION = "asc.gz";
 
-    @SuppressWarnings("serial")
     public AscCoverageResponseDelegate(GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList(
+                List.of(
                         ARCGRID_COVERAGE_FORMAT,
                         ARCGRID_COMPRESSED_COVERAGE_FORMAT,
                         "ArcGrid",
                         "ArcGrid-GZIP"), // output formats
-                new HashMap<String, String>() { // file extensions
-                    {
-                        put("ArcGrid", ARCGRID_FILE_EXTENSION);
-                        put("ArcGrid-GZIP", ARCGRID_COMPRESSED_FILE_EXTENSION);
-                        put(ARCGRID_MIME_TYPE, ARCGRID_FILE_EXTENSION);
-                        put(ARCGRID_COMPRESSED_MIME_TYPE, ARCGRID_COMPRESSED_FILE_EXTENSION);
-                        put(ARCGRID_COVERAGE_FORMAT, ARCGRID_FILE_EXTENSION);
-                        put(ARCGRID_COMPRESSED_COVERAGE_FORMAT, ARCGRID_COMPRESSED_FILE_EXTENSION);
-                    }
-                },
-                new HashMap<String, String>() { // mime types
-                    {
-                        put("ArcGrid", ARCGRID_MIME_TYPE);
-                        put("ArcGrid-GZIP", ARCGRID_COMPRESSED_MIME_TYPE);
-                        put(ARCGRID_COVERAGE_FORMAT, ARCGRID_MIME_TYPE);
-                        put(ARCGRID_COMPRESSED_COVERAGE_FORMAT, ARCGRID_COMPRESSED_MIME_TYPE);
-                    }
-                });
+                Map.ofEntries( // file extensions
+                        entry("ArcGrid", ARCGRID_FILE_EXTENSION),
+                        entry("ArcGrid-GZIP", ARCGRID_COMPRESSED_FILE_EXTENSION),
+                        entry(ARCGRID_MIME_TYPE, ARCGRID_FILE_EXTENSION),
+                        entry(ARCGRID_COMPRESSED_MIME_TYPE, ARCGRID_COMPRESSED_FILE_EXTENSION),
+                        entry(ARCGRID_COVERAGE_FORMAT, ARCGRID_FILE_EXTENSION),
+                        entry(
+                                ARCGRID_COMPRESSED_COVERAGE_FORMAT,
+                                ARCGRID_COMPRESSED_FILE_EXTENSION)),
+                Map.ofEntries( // mime types
+                        entry("ArcGrid", ARCGRID_MIME_TYPE),
+                        entry("ArcGrid-GZIP", ARCGRID_COMPRESSED_MIME_TYPE),
+                        entry(ARCGRID_COVERAGE_FORMAT, ARCGRID_MIME_TYPE),
+                        entry(ARCGRID_COMPRESSED_COVERAGE_FORMAT, ARCGRID_COMPRESSED_MIME_TYPE)));
     }
 
     private boolean isOutputCompressed(String outputFormat) {

--- a/src/wcs/src/main/java/org/geoserver/wcs/responses/DebugCoverageResponseDelegate.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/responses/DebugCoverageResponseDelegate.java
@@ -5,14 +5,15 @@
  */
 package org.geoserver.wcs.responses;
 
+import static java.util.Map.entry;
+
 import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.geoserver.config.GeoServer;
 import org.geoserver.platform.ServiceException;
@@ -31,20 +32,13 @@ public class DebugCoverageResponseDelegate extends BaseCoverageResponseDelegate
     public DebugCoverageResponseDelegate(GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList("DEBUG", "text/debug"), // output formats
-                new HashMap<String, String>() { // file extensions
-                    {
-                        put("DEBUG", "txt");
-                        put("text/debug", "txt");
-                        put("text/plain", "txt");
-                    }
-                },
-                new HashMap<String, String>() { // mime types
-                    {
-                        put("DEBUG", "text/plain");
-                        put("text/debug", "text/plain");
-                    }
-                });
+                List.of("DEBUG", "text/debug"), // output formats
+                Map.ofEntries( // file extensions
+                        entry("DEBUG", "txt"),
+                        entry("text/debug", "txt"),
+                        entry("text/plain", "txt")),
+                Map.ofEntries( // mime types
+                        entry("DEBUG", "text/plain"), entry("text/debug", "text/plain")));
     }
 
     @Override

--- a/src/wcs/src/main/java/org/geoserver/wcs/responses/GeoTIFFCoverageResponseDelegate.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/responses/GeoTIFFCoverageResponseDelegate.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.wcs.responses;
 
+import static java.util.Map.entry;
+
 import com.sun.media.imageio.plugins.tiff.BaselineTIFFTagSet;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFLZWCompressor;
 import java.awt.Dimension;
@@ -12,8 +14,7 @@ import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.geoserver.config.GeoServer;
@@ -55,11 +56,10 @@ public class GeoTIFFCoverageResponseDelegate extends BaseCoverageResponseDelegat
     /** Parameter controlling the compression type */
     public static final String COMPRESSION = "compression";
 
-    @SuppressWarnings("serial")
     public GeoTIFFCoverageResponseDelegate(GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList(
+                List.of(
                         "tif",
                         "tiff",
                         "geotiff",
@@ -68,31 +68,24 @@ public class GeoTIFFCoverageResponseDelegate extends BaseCoverageResponseDelegat
                         "GeoTIFF",
                         "image/geotiff",
                         "image/tiff;application=geotiff"), // output formats
-                new HashMap<String, String>() { // file extensions
-                    {
-                        put("tiff", "tif");
-                        put("tiff", "tif");
-                        put("geotiff", "tif");
-                        put("TIFF", "tif");
-                        put("GEOTIFF", "tif");
-                        put("GeoTIFF", "tif");
-                        put("image/geotiff", "tif");
-                        put("image/tiff", "tif");
-                        put("image/tiff;application=geotiff", "tif");
-                    }
-                },
-                new HashMap<String, String>() { // mime types
-                    {
-                        put("tiff", "image/tiff");
-                        put("tif", "image/tiff");
-                        put("geotiff", "image/tiff");
-                        put("TIFF", "image/tiff");
-                        put("GEOTIFF", "image/tiff");
-                        put("GeoTIFF", "image/tiff");
-                        put("image/geotiff", "image/tiff");
-                        put("image/tiff;application=geotiff", "image/tiff;application=geotiff");
-                    }
-                });
+                Map.ofEntries( // file extensions
+                        entry("tiff", "tif"),
+                        entry("geotiff", "tif"),
+                        entry("TIFF", "tif"),
+                        entry("GEOTIFF", "tif"),
+                        entry("GeoTIFF", "tif"),
+                        entry("image/geotiff", "tif"),
+                        entry("image/tiff", "tif"),
+                        entry("image/tiff;application=geotiff", "tif")),
+                Map.ofEntries( // mime types
+                        entry("tiff", "image/tiff"),
+                        entry("tif", "image/tiff"),
+                        entry("geotiff", "image/tiff"),
+                        entry("TIFF", "image/tiff"),
+                        entry("GEOTIFF", "image/tiff"),
+                        entry("GeoTIFF", "image/tiff"),
+                        entry("image/geotiff", "image/tiff"),
+                        entry("image/tiff;application=geotiff", "image/tiff;application=geotiff")));
     }
 
     @Override

--- a/src/wcs/src/main/java/org/geoserver/wcs/responses/IMGCoverageResponseDelegate.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/responses/IMGCoverageResponseDelegate.java
@@ -5,10 +5,11 @@
  */
 package org.geoserver.wcs.responses;
 
+import static java.util.Map.entry;
+
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.geoserver.config.GeoServer;
 import org.geoserver.platform.ServiceException;
@@ -31,32 +32,24 @@ import org.opengis.parameter.ParameterValueGroup;
 public class IMGCoverageResponseDelegate extends BaseCoverageResponseDelegate
         implements CoverageResponseDelegate {
 
-    @SuppressWarnings("serial")
     public IMGCoverageResponseDelegate(GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList(
-                        "png", "jpeg", "JPEG", "PNG", "image/png", "image/jpeg"), // output formats
-                new HashMap<String, String>() { // file extensions
-                    {
-                        put("png", "png");
-                        put("jpeg", "jpeg");
-                        put("JPEG", "jpeg");
-                        put("PNG", "png");
-                        put("image/png", "png");
-                        put("image/jpeg", "jpeg");
-                    }
-                },
-                new HashMap<String, String>() { // mime types
-                    {
-                        put("png", "image/png");
-                        put("jpeg", "image/jpeg");
-                        put("PNG", "image/png");
-                        put("JPEG", "image/jpeg");
-                        put("image/png", "image/png");
-                        put("image/jpeg", "image/jpeg");
-                    }
-                });
+                List.of("png", "jpeg", "JPEG", "PNG", "image/png", "image/jpeg"), // output formats
+                Map.ofEntries( // file extensions
+                        entry("png", "png"),
+                        entry("jpeg", "jpeg"),
+                        entry("JPEG", "jpeg"),
+                        entry("PNG", "png"),
+                        entry("image/png", "png"),
+                        entry("image/jpeg", "jpeg")),
+                Map.ofEntries( // mime types
+                        entry("png", "image/png"),
+                        entry("jpeg", "image/jpeg"),
+                        entry("PNG", "image/png"),
+                        entry("JPEG", "image/jpeg"),
+                        entry("image/png", "image/png"),
+                        entry("image/jpeg", "image/jpeg")));
     }
 
     @Override

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
@@ -13,7 +13,6 @@ import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -254,13 +253,7 @@ public class WCSCapsTransformer extends TransformerBase {
             start("ows:OperationsMetadata");
             handleOperation("GetCapabilities", null);
             handleOperation("DescribeCoverage", null);
-            handleOperation(
-                    "GetCoverage",
-                    new HashMap<String, List<String>>() {
-                        {
-                            put("store", Arrays.asList("True", "False"));
-                        }
-                    });
+            handleOperation("GetCoverage", Map.of("store", List.of("True", "False")));
 
             // specify that we do support xml post encoding, clause 8.3.2.2 of
             // the WCS 1.1.1 spec

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/GMLCoverageResponseDelegate.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/GMLCoverageResponseDelegate.java
@@ -5,10 +5,11 @@
  */
 package org.geoserver.wcs2_0.response;
 
+import static java.util.Map.entry;
+
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.xml.transform.TransformerException;
 import org.geoserver.config.GeoServer;
@@ -41,19 +42,14 @@ public class GMLCoverageResponseDelegate extends BaseCoverageResponseDelegate
             EnvelopeAxesLabelsMapper envelopeDimensionsMapper, GeoServer geoserver) {
         super(
                 geoserver,
-                Arrays.asList(FILE_EXTENSION, MIME_TYPE), // output formats
-                new HashMap<String, String>() { // file extensions
-                    {
-                        put(MIME_TYPE, FILE_EXTENSION);
-                        put(FILE_EXTENSION, FILE_EXTENSION);
-                    }
-                },
-                new HashMap<String, String>() { // mime types
-                    {
-                        put(MIME_TYPE, MIME_TYPE);
-                        put(FILE_EXTENSION, MIME_TYPE);
-                    }
-                });
+                List.of(FILE_EXTENSION, MIME_TYPE), // output formats
+                Map.ofEntries( // file extensions
+                        entry(MIME_TYPE, FILE_EXTENSION), //
+                        entry(FILE_EXTENSION, FILE_EXTENSION)),
+                Map.ofEntries( // mime types
+                        entry(MIME_TYPE, MIME_TYPE), //
+                        entry(FILE_EXTENSION, MIME_TYPE)));
+
         this.envelopeDimensionsMapper = envelopeDimensionsMapper;
     }
 

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsHelper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/WCSDimensionsHelper.java
@@ -103,14 +103,7 @@ public class WCSDimensionsHelper {
             final GridCoverage2DReader reader,
             final String coverageId)
             throws IOException {
-        this(
-                new HashMap<String, DimensionInfo>() {
-                    {
-                        put(ResourceInfo.TIME, timeDimension);
-                    }
-                },
-                reader,
-                coverageId);
+        this(Map.of(ResourceInfo.TIME, timeDimension), reader, coverageId);
     }
 
     public WCSDimensionsHelper(

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSTestSupport.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSTestSupport.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.wcs2_0;
 
+import static java.util.Map.entry;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -113,33 +114,30 @@ public abstract class WCSTestSupport extends GeoServerSystemTestSupport {
     protected static Schema getWcs20Schema() {
         if (WCS20_SCHEMA == null) {
             final Map<String, String> namespaceMap =
-                    new HashMap<String, String>() {
-                        {
-                            put("http://www.opengis.net/wcs/2.0", "/schemas/wcs/2.0/");
-                            put("http://www.opengis.net/gmlcov/1.0", "/schemas/gmlcov/1.0/");
-                            put("http://www.opengis.net/gml/3.2", "/schemas/gml/3.2.1/");
-                            put("http://www.w3.org/1999/xlink", "/schemas/xlink/");
-                            put("http://www.w3.org/XML/1998/namespace", "/schemas/xml/");
-                            put(
+                    Map.ofEntries(
+                            entry("http://www.opengis.net/wcs/2.0", "/schemas/wcs/2.0/"),
+                            entry("http://www.opengis.net/gmlcov/1.0", "/schemas/gmlcov/1.0/"),
+                            entry("http://www.opengis.net/gml/3.2", "/schemas/gml/3.2.1/"),
+                            entry("http://www.w3.org/1999/xlink", "/schemas/xlink/"),
+                            entry("http://www.w3.org/XML/1998/namespace", "/schemas/xml/"),
+                            entry(
                                     "http://www.isotc211.org/2005/gmd",
-                                    "/schemas/iso/19139/20070417/gmd/");
-                            put(
+                                    "/schemas/iso/19139/20070417/gmd/"),
+                            entry(
                                     "http://www.isotc211.org/2005/gco",
-                                    "/schemas/iso/19139/20070417/gco/");
-                            put(
+                                    "/schemas/iso/19139/20070417/gco/"),
+                            entry(
                                     "http://www.isotc211.org/2005/gss",
-                                    "/schemas/iso/19139/20070417/gss/");
-                            put(
+                                    "/schemas/iso/19139/20070417/gss/"),
+                            entry(
                                     "http://www.isotc211.org/2005/gts",
-                                    "/schemas/iso/19139/20070417/gts/");
-                            put(
+                                    "/schemas/iso/19139/20070417/gts/"),
+                            entry(
                                     "http://www.isotc211.org/2005/gsr",
-                                    "/schemas/iso/19139/20070417/gsr/");
-                            put("http://www.opengis.net/swe/2.0", "/schemas/sweCommon/2.0/");
-                            put("http://www.opengis.net/ows/2.0", "/schemas/ows/2.0/");
-                            put("http://www.geoserver.org/wcsgs/2.0", "/schemas/wcs/2.0/");
-                        }
-                    };
+                                    "/schemas/iso/19139/20070417/gsr/"),
+                            entry("http://www.opengis.net/swe/2.0", "/schemas/sweCommon/2.0/"),
+                            entry("http://www.opengis.net/ows/2.0", "/schemas/ows/2.0/"),
+                            entry("http://www.geoserver.org/wcsgs/2.0", "/schemas/wcs/2.0/"));
 
             try {
                 final SchemaFactory factory =

--- a/src/web/app/src/test/java/org/geoserver/web/Start.java
+++ b/src/web/app/src/test/java/org/geoserver/web/Start.java
@@ -137,7 +137,7 @@ public class Start {
                         }
                     };
             stopThread.setDaemon(true);
-            stopThread.run();
+            stopThread.start();
 
             // use this to test normal stop behaviour, that is, to check stuff that
             // need to be done on container shutdown (and yes, this will make

--- a/src/wfs/src/main/java/org/geoserver/wfs/UpdateElementHandler.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/UpdateElementHandler.java
@@ -5,10 +5,10 @@
  */
 package org.geoserver.wfs;
 
+import static java.util.Map.entry;
+
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -70,22 +70,18 @@ import org.opengis.referencing.operation.MathTransform;
 public class UpdateElementHandler extends AbstractTransactionElementHandler {
 
     static final Map<String, Class<?>> GML_PROPERTIES_BINDINGS =
-            new HashMap<String, Class<?>>() {
-                {
-                    put("name", String.class);
-                    put("description", String.class);
-                    put("boundedBy", Geometry.class);
-                    put("location", Geometry.class);
-                    put("metaDataProperty", String.class);
-                }
-            };
+            Map.ofEntries(
+                    entry("name", String.class),
+                    entry("description", String.class),
+                    entry("boundedBy", Geometry.class),
+                    entry("location", Geometry.class),
+                    entry("metaDataProperty", String.class));
 
     static final Set<String> GML_NAMESPACES =
-            new HashSet<>(
-                    Arrays.asList(
-                            GML.NAMESPACE,
-                            org.geotools.gml3.GML.NAMESPACE,
-                            org.geotools.gml3.v3_2.GML.NAMESPACE));
+            Set.of(
+                    GML.NAMESPACE,
+                    /* org.geotools.gml3.GML.NAMESPACE, same as GML.NAMESPACE */
+                    org.geotools.gml3.v3_2.GML.NAMESPACE);
 
     /** logger */
     static Logger LOGGER = org.geotools.util.logging.Logging.getLogger("org.geoserver.wfs");

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
@@ -5,12 +5,12 @@
  */
 package org.geoserver.wfs.json;
 
+import static java.util.Map.entry;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -328,13 +328,8 @@ public class GeoJSONBuilderTest {
     @Test
     public void testWriteStringStringMap() throws Exception {
         final Map<String, String> map =
-                new HashMap<String, String>() {
-                    {
-                        put("a", "1");
-                        put("b", "2");
-                        put("c", "3");
-                    }
-                };
+                Map.ofEntries(entry("a", "1"), entry("b", "2"), entry("c", "3"));
+
         builder.writeMap(map);
         final JSONObject root = JSONObject.fromObject(writer.toString());
         assertEquals(3, root.size());
@@ -346,13 +341,11 @@ public class GeoJSONBuilderTest {
     @Test
     public void testWriteStringIntMap() throws Exception {
         final Map<String, Integer> map =
-                new HashMap<String, Integer>() {
-                    {
-                        put("a", Integer.MAX_VALUE);
-                        put("b", Integer.MIN_VALUE);
-                        put("c", 3);
-                    }
-                };
+                Map.ofEntries(
+                        entry("a", Integer.MAX_VALUE),
+                        entry("b", Integer.MIN_VALUE),
+                        entry("c", 3));
+
         builder.writeMap(map);
         final JSONObject root = JSONObject.fromObject(writer.toString());
         assertEquals(3, root.size());
@@ -365,23 +358,11 @@ public class GeoJSONBuilderTest {
     public void testWriteListOfMaps() throws Exception {
         final UUID u1 = UUID.fromString("12345678-1234-1234-1234-123456781234");
         final Map<String, Object> tuple1 =
-                new HashMap<String, Object>() {
-                    {
-                        put("a", 1);
-                        put("b", u1);
-                        put("c", "object1");
-                    }
-                };
+                Map.ofEntries(entry("a", 1), entry("b", u1), entry("c", "object1"));
 
         final UUID u2 = UUID.fromString("00000000-0000-0000-0000-000000000000");
         final Map<String, Object> tuple2 =
-                new HashMap<String, Object>() {
-                    {
-                        put("a", 2);
-                        put("b", u2);
-                        put("c", "object2");
-                    }
-                };
+                Map.ofEntries(entry("a", 2), entry("b", u2), entry("c", "object2"));
 
         final List<Map<String, Object>> tupleList = Arrays.asList(tuple1, tuple2);
         builder.writeList(tupleList);


### PR DESCRIPTION
[![GEOS-10941](https://badgen.net/badge/JIRA/GEOS-10941/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10941)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Follow up to https://github.com/geotools/geotools/pull/4247
Mostly nice code cleanups for static maps, but also some actual bugs in string expansion handling.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->