### PR TITLE
[Backport 2.22.x] [GEOS-10932] csw-iso: should only add 'xsi:nil = false' attribute

### DIFF
--- a/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/response/MetaDataTransformer.java
+++ b/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/response/MetaDataTransformer.java
@@ -83,12 +83,14 @@ public class MetaDataTransformer extends AbstractRecordTransformer {
                                     .getProperty(ComplexFeatureConstants.SIMPLE_CONTENT);
                     boolean nil =
                             prop == null || prop.getValue() == null || prop.getValue().equals("");
-                    atts.addAttribute(
-                            "http://www.w3.org/2001/XMLSchema-instance",
-                            "nil",
-                            "xsi:nil",
-                            "",
-                            nil ? "true" : "false");
+                    if (nil) {
+                        atts.addAttribute(
+                                "http://www.w3.org/2001/XMLSchema-instance",
+                                "nil",
+                                "xsi:nil",
+                                "",
+                                "true");
+                    }
                 }
 
                 for (Property p2 : ((ComplexAttribute) p).getProperties()) {

--- a/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/FeatureCatalogueTest.java
+++ b/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/FeatureCatalogueTest.java
@@ -5,6 +5,7 @@
 package org.geoserver.csw.store.internal.iso;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -180,8 +181,7 @@ public class FeatureCatalogueTest extends MDTestSupport {
                 "//gfc:FC_FeatureCatalogue/gfc:featureType/gfc:FC_FeatureType/gfc:carrierOfCharacteristics[1]/gfc:FC_FeatureAttribute/gfc:cardinality/gco:Multiplicity/gco:range/gco:MultiplicityRange/gco:upper/gco:UnlimitedInteger/@isInfinite",
                 d);
 
-        assertXpathEvaluatesTo(
-                "false",
+        assertXpathNotExists(
                 "//gfc:FC_FeatureCatalogue/gfc:featureType/gfc:FC_FeatureType/gfc:carrierOfCharacteristics[1]/gfc:FC_FeatureAttribute/gfc:cardinality/gco:Multiplicity/gco:range/gco:MultiplicityRange/gco:upper/gco:UnlimitedInteger/@xsi:nil",
                 d);
 


### PR DESCRIPTION
[![GEOS-10932](https://badgen.net/badge/JIRA/GEOS-10932/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10932)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6767
 **Authored by:** @NielsCharlier