### PR TITLE
[GEOS-10946] WMS GetLegendGraphic throws FootprintsTransformation can…

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/LegendLayoutTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/LegendLayoutTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.wms.legendgraphic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -25,8 +26,11 @@ import org.geoserver.wms.GetLegendGraphicRequest;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.util.FeatureUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.image.util.ImageUtilities;
 import org.geotools.styling.Style;
+import org.geotools.styling.StyleFactory;
+import org.geotools.xml.styling.SLDParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridCoverage;
@@ -89,6 +93,23 @@ public class LegendLayoutTest extends BaseLegendTest<BufferedImageLegendGraphicB
         }
     }
 
+    private static Style readSLD(String sldName, Class<?> context) throws IOException {
+        StyleFactory styleFactory = CommonFactoryFinder.getStyleFactory(null);
+        SLDParser stylereader = new SLDParser(styleFactory, context.getResource(sldName));
+        Style[] readStyles = stylereader.readXML();
+
+        Style style = readStyles[0];
+        return style;
+    }
+    /** Tests that rendering transformations can handle non-process functions */
+    @Test
+    public void testCheckForRenderingTransformations() throws Exception {
+        Style footprints = readSLD("footprints.sld", LegendLayoutTest.class);
+        LegendGraphicBuilder legendGraphicBuilder = this.legendProducer;
+        assertFalse(legendGraphicBuilder.hasVectorTransformation);
+        legendGraphicBuilder.checkForRenderingTransformations(footprints);
+        assertTrue(legendGraphicBuilder.hasVectorTransformation);
+    }
     /** Tests horizontal layout for raster with CLASSES */
     @org.junit.Test
     public void testClassesHorizontalRaster() throws Exception {

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -49,6 +49,7 @@ public class GetLegendGraphicTest extends WMSTestSupport {
 
     public static final QName SF_STATES = new QName(MockData.SF_URI, "states", MockData.SF_PREFIX);
     private static final String SF_STATES_ID = "sf:states";
+    private static final String FOOTPRINTS_STYLE = "footprints";
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
@@ -62,6 +63,7 @@ public class GetLegendGraphicTest extends WMSTestSupport {
         testData.addStyle("Population", "Population.sld", getClass(), catalog);
         testData.addStyle("uom", "uomStroke.sld", getClass(), catalog);
         testData.addStyle("scaleDependent", "scaleDependent.sld", getClass(), catalog);
+        testData.addStyle(FOOTPRINTS_STYLE, "footprints.sld", getClass(), catalog);
 
         testData.addVectorLayer(
                 SF_STATES, Collections.emptyMap(), "states.properties", getClass(), catalog);
@@ -114,6 +116,25 @@ public class GetLegendGraphicTest extends WMSTestSupport {
                                 + "&format=image/png&width=20&height=20",
                         "image/png");
         assertPixel(image, 10, 10, Converters.convert("#4040C0", Color.class));
+    }
+
+    /**
+     * Tests that GetLegendGraphic works with a style that has a non-process function
+     *
+     * @throws Exception if something goes wrong
+     */
+    @Test
+    public void testFootprints() throws Exception {
+        BufferedImage image =
+                getAsImage(
+                        "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                                + "&layer="
+                                + getLayerId(MockData.LAKES)
+                                + "&style="
+                                + FOOTPRINTS_STYLE
+                                + "&format=image/png&width=20&height=20",
+                        "image/png");
+        assertPixel(image, 10, 10, Converters.convert("#d4d4d4", Color.class));
     }
 
     @Test

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/footprints.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/footprints.sld
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <Name>test_layer</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Transformation>
+                    <ogc:Function name="footprints"/>
+                </Transformation>
+                <Rule>
+                    <MinScaleDenominator>100000</MinScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#000000</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                        <Fill>
+                            <CssParameter name="fill">#AAAAAA</CssParameter>
+                            <CssParameter name="fill-opacity">0.5</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>100000</MaxScaleDenominator>
+                    <RasterSymbolizer/>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-10946](https://badgen.net/badge/JIRA/GEOS-10946/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10946)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…not be cast to ProcessFunction Exception

tests


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->