### PR TITLE
[Backport 2.22.x] Small fix to docker docs:  correction for --mount and --env examples

### DIFF
--- a/doc/en/user/source/installation/docker.rst
+++ b/doc/en/user/source/installation/docker.rst
@@ -48,8 +48,7 @@ This will run the container with a local data directory.  The data directory wil
 
 #. Run the container
 
-      docker run --mount type=bind,src=/MY/DATADIRECTORY,target=/opt/geoserver_data -it -p8080:8080 docker.osgeo.org/geoserver:|release|
-
+    docker run \-\-mount type=bind,src=/MY/DATADIRECTORY,target=/opt/geoserver_data -it -p8080:8080 docker.osgeo.org/geoserver:|release|
 
 #. In a web browser, navigate to ``http://localhost:8080/geoserver``.
 
@@ -66,7 +65,7 @@ Adding Geoserver Extensions
 
 You can add Geoserver Extensions - the container will download them during startup.
 
-      docker run  -it -p8080:8080 --env INSTALL_EXTENSIONS=true --env STABLE_EXTENSIONS="ysld,h2" docker.osgeo.org/geoserver:|release|
+      docker run  -it -p8080:8080 \-\-env INSTALL_EXTENSIONS=true \-\-env STABLE_EXTENSIONS="ysld,h2" docker.osgeo.org/geoserver:|release|
 
 This will download and install the YSLD and H2 extension.
 


### PR DESCRIPTION
Backport #6803
 **Authored by:** @jodygarnett