### PR TITLE
[GEOS-10955] STAC templates are initialised in the wrong location

### DIFF
--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACTemplates.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACTemplates.java
@@ -58,8 +58,8 @@ public class STACTemplates extends AbstractTemplates {
     }
 
     /** Copies over all HTML templates, to allow customization */
-    private void copyHTMLTemplates() throws IOException {
-        Resource stac = dd.get("templates/ogc/stac");
+    protected void copyHTMLTemplates() throws IOException {
+        Resource stac = dd.get("templates/ogc/stac/v1");
         stac.dir();
         String path =
                 "classpath:/" + getClass().getPackage().getName().replace(".", "/") + "/*.ftl";
@@ -111,7 +111,7 @@ public class STACTemplates extends AbstractTemplates {
     private void reloadItemTemplate(GeoServerDataDirectory dd, NamespaceSupport namespaces)
             throws IOException {
         // setup the items template
-        Resource items = dd.get("templates/ogc/stac/items.json");
+        Resource items = dd.get("templates/ogc/stac/v1/items.json");
         copyDefault(items, "items.json");
         this.defaultItemTemplate = new Template(items, new TemplateReaderConfiguration(namespaces));
     }
@@ -119,7 +119,7 @@ public class STACTemplates extends AbstractTemplates {
     private void reloadCollectionTemplate(GeoServerDataDirectory dd, NamespaceSupport namespaces)
             throws IOException {
         // setup the collections template
-        Resource collections = dd.get("templates/ogc/stac/collections.json");
+        Resource collections = dd.get("templates/ogc/stac/v1/collections.json");
         copyDefault(collections, "collections.json");
         TemplateReaderConfiguration configuration =
                 new TemplateReaderConfiguration(namespaces, COLLECTIONS);
@@ -134,7 +134,8 @@ public class STACTemplates extends AbstractTemplates {
         Template template = defaultCollectionTemplate;
         // See if a collection specific template has been setup, if so use it as an override
         if (collectionId != null) {
-            Resource resource = dd.get("templates/ogc/stac/collections-" + collectionId + ".json");
+            Resource resource =
+                    dd.get("templates/ogc/stac/v1/collections-" + collectionId + ".json");
             if (resource.getType().equals(Resource.Type.RESOURCE)) {
                 template = collectionTemplates.get(collectionId);
                 if (template == null) {
@@ -173,7 +174,7 @@ public class STACTemplates extends AbstractTemplates {
      * @return
      */
     public Set<String> getCustomItemTemplates() throws IOException {
-        Resource resource = dd.get("templates/ogc/stac/");
+        Resource resource = dd.get("templates/ogc/stac/v1/");
         if (resource.getType() != Resource.Type.DIRECTORY) return Collections.emptySet();
 
         Set<String> candidates =
@@ -215,7 +216,7 @@ public class STACTemplates extends AbstractTemplates {
         Template template = defaultItemTemplate;
         // See if a collection specific template has been setup, if so use it as an override
         if (collectionId != null) {
-            Resource resource = dd.get("templates/ogc/stac/items-" + collectionId + ".json");
+            Resource resource = dd.get("templates/ogc/stac/v1/items-" + collectionId + ".json");
             if (resource.getType().equals(Resource.Type.RESOURCE)) {
                 template = itemTemplates.get(collectionId);
                 if (template == null) {

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/CollectionsTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/CollectionsTest.java
@@ -42,7 +42,7 @@ public class CollectionsTest extends STACTestSupport {
     @Test
     public void testTemplatesCopy() throws Exception {
         GeoServerDataDirectory dd = getDataDirectory();
-        Resource templates = dd.get("templates/ogc/stac");
+        Resource templates = dd.get("templates/ogc/stac/v1");
         assertEquals(Resource.Type.RESOURCE, templates.get("collections.json").getType());
         assertEquals(Resource.Type.RESOURCE, templates.get("items.json").getType());
     }

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/STACTestSupport.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/STACTestSupport.java
@@ -109,7 +109,7 @@ public class STACTestSupport extends OGCApiTestSupport {
      * test class.
      */
     protected void copyTemplate(String template) throws IOException {
-        copyTemplate(template, "templates/ogc/stac/");
+        copyTemplate(template, "templates/ogc/stac/v1/");
     }
     /**
      * Copies the given template from the classpath to the data directory. Lookup is relative to the

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/TemplatePropertyMapperTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/TemplatePropertyMapperTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.opensearch.eo.OSEOInfo;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.resource.Resource;
 import org.geotools.filter.text.ecql.ECQL;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -25,12 +26,33 @@ public class TemplatePropertyMapperTest extends STACTestSupport {
         copyTemplate("/items-LANDSAT8.json");
     }
 
+    private STACTemplates getTemplates() {
+        return GeoServerExtensions.bean(STACTemplates.class);
+    }
+
     public TemplatePropertyMapper getPropertyMapper() {
-        STACTemplates templates = GeoServerExtensions.bean(STACTemplates.class);
+        STACTemplates templates = getTemplates();
         SampleFeatures sampleFeatures = GeoServerExtensions.bean(SampleFeatures.class);
         CollectionsCache collectionsCache = GeoServerExtensions.bean(CollectionsCache.class);
         OSEOInfo oseoInfo = GeoServerExtensions.bean(OSEOInfo.class);
         return new TemplatePropertyMapper(templates, sampleFeatures, collectionsCache, oseoInfo);
+    }
+
+    /**
+     * Test that the templates are copied to the right place
+     *
+     * @throws Exception Issue with copying the templates
+     */
+    @Test
+    public void testCopyHTMLTemplates() throws Exception {
+        STACTemplates templates = getTemplates();
+        templates.copyHTMLTemplates();
+        assertEquals(
+                Resource.Type.RESOURCE,
+                getDataDirectory().get("templates/ogc/stac/v1/collections.ftl").getType());
+        assertEquals(
+                Resource.Type.UNDEFINED,
+                getDataDirectory().get("templates/ogc/stac/collections.ftl").getType());
     }
 
     @Test

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/collections.ftl
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/collections.ftl
@@ -1,0 +1,24 @@
+<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>Collections</li>">
+<#include "common-header.ftl">
+
+  <h1 id="title">GeoServer STAC Collections</h1>
+  <p class="my-4">
+    This document lists all the collections available in the SpatioTemporal Asset Catalog.<br/>
+    <#-- This document is also available as <#list model.getLinksExcept(null, "text/html") as link><a href="${link.href}">${link.type}</a><#if link_has_next>, </#if></#list>. -->
+  </p>
+  
+  <div class="row">
+    <#list model.collections.features as collection>
+    <#assign a = collection.attributes />
+    <div class="col-xs-12 col-md-6 col-lg-4 pb-4">
+      <div class="card h-100  mb-3">
+        <div class="card-header">
+          <h2><a href="${serviceLink("collections/${a.name.value}")}">${a.name.value}</a></h2>
+        </div>
+        <#include "collection_include.ftl">
+      </div>
+    </div>
+    </#list>
+  </div>
+
+<#include "common-footer.ftl">


### PR DESCRIPTION
[![GEOS-10955](https://badgen.net/badge/JIRA/GEOS-10955/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10955)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->