### PR TITLE
[GEOS-10957] Support ResourceAccessManager implementations returning custom subclasess of AccessLimits

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/AccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/AccessLimits.java
@@ -8,11 +8,17 @@ package org.geoserver.security;
 import java.io.Serializable;
 
 /**
- * Base class for all AccessLimits declared by a {@link ResourceAccessManager}
+ * Base class for all AccessLimits declared by a {@link ResourceAccessManager}.
+ *
+ * <p>AccessLimits are used to limit the access to a resource (workspace, layer, style, catalog *
+ * resource). While the hierarchy of access limits has well known classes matching the associated
+ * resource, a ResourceAccessManager can also create subclasses of them, thus, if any customization
+ * to access limits is needed, one can clone the {@link AccessLimits} object and change its
+ * settings. For this purpose, AccessLimits implements {@link Cloneable}.
  *
  * @author Andrea Aime - GeoSolutions
  */
-public class AccessLimits implements Serializable {
+public class AccessLimits implements Serializable, Cloneable {
     private static final long serialVersionUID = 8521276966116962954L;
 
     /** Gets the catalog mode for this layer */
@@ -46,5 +52,14 @@ public class AccessLimits implements Serializable {
             if (other.mode != null) return false;
         } else if (!mode.equals(other.mode)) return false;
         return true;
+    }
+
+    @Override
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/src/main/java/org/geoserver/security/CoverageAccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/CoverageAccessLimits.java
@@ -44,12 +44,40 @@ public class CoverageAccessLimits extends DataAccessLimits {
         this.params = params;
     }
 
+    /**
+     * Returns the clipping polygon
+     *
+     * @return The clipping polygon
+     */
     public MultiPolygon getRasterFilter() {
         return rasterFilter;
     }
 
+    /**
+     * Returns the read parameters overrides
+     *
+     * @return
+     */
     public GeneralParameterValue[] getParams() {
         return params;
+    }
+
+    /**
+     * Sets the polygon that will clip the raster data
+     *
+     * @param rasterFilter The polygon clip
+     */
+    public void setRasterFilter(MultiPolygon rasterFilter) {
+        this.rasterFilter = rasterFilter;
+    }
+
+    /**
+     * Sets the read parameters overrides
+     *
+     * @param params The read parameters overrides
+     */
+    public void setParams(GeneralParameterValue[] params) {
+        this.params = params;
     }
 
     @Override

--- a/src/main/src/main/java/org/geoserver/security/DataAccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/DataAccessLimits.java
@@ -52,6 +52,15 @@ public class DataAccessLimits extends AccessLimits {
         return readFilter;
     }
 
+    /**
+     * Updates the read filter for this access limits object
+     *
+     * @param readFilter the new read filter
+     */
+    public void setReadFilter(Filter readFilter) {
+        this.readFilter = readFilter;
+    }
+
     /** The catalog mode for this layer */
     @Override
     public CatalogMode getMode() {

--- a/src/main/src/main/java/org/geoserver/security/VectorAccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/VectorAccessLimits.java
@@ -76,9 +76,36 @@ public class VectorAccessLimits extends DataAccessLimits {
         return readAttributes;
     }
 
+    /**
+     * The list of attributes the user is allowed to read
+     *
+     * @param readAttributes the list of attributes the user is allowed to read
+     */
+    public void setReadAttributes(List<PropertyName> readAttributes) {
+        this.readAttributes = readAttributes;
+    }
+
     /** The list of attributes the user is allowed to write */
     public List<PropertyName> getWriteAttributes() {
         return writeAttributes;
+    }
+
+    /**
+     * Sets the list of attributes the user is allowed to write
+     *
+     * @param writeAttributes
+     */
+    public void setWriteAttributes(List<PropertyName> writeAttributes) {
+        this.writeAttributes = writeAttributes;
+    }
+
+    /**
+     * Sets the filter that limits the features the user can write onto
+     *
+     * @param writeFilter
+     */
+    public void setWriteFilter(Filter writeFilter) {
+        this.writeFilter = writeFilter;
     }
 
     /** Identifies the features the user can write onto */

--- a/src/main/src/main/java/org/geoserver/security/WMSAccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/WMSAccessLimits.java
@@ -41,9 +41,17 @@ public class WMSAccessLimits extends DataAccessLimits {
         return rasterFilter;
     }
 
+    public void setRasterFilter(MultiPolygon rasterFilter) {
+        this.rasterFilter = rasterFilter;
+    }
+
     /** Wheter to allow GetFeatureInfo cascading or not */
     public boolean isAllowFeatureInfo() {
         return allowFeatureInfo;
+    }
+
+    public void setAllowFeatureInfo(boolean allowFeatureInfo) {
+        this.allowFeatureInfo = allowFeatureInfo;
     }
 
     @Override

--- a/src/main/src/main/java/org/geoserver/security/WMTSAccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/WMTSAccessLimits.java
@@ -34,6 +34,15 @@ public class WMTSAccessLimits extends DataAccessLimits {
         return rasterFilter;
     }
 
+    /**
+     * Sets the polygon that will clip the returned images
+     *
+     * @param rasterFilter the polygon that will clip the returned images
+     */
+    public void setRasterFilter(MultiPolygon rasterFilter) {
+        this.rasterFilter = rasterFilter;
+    }
+
     @Override
     public String toString() {
         return "WMTSAccessLimits [rasterFilter=" + rasterFilter + ", mode=" + mode + "]";

--- a/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/security/decorators/SecuredFeatureTypeInfo.java
@@ -124,13 +124,9 @@ public class SecuredFeatureTypeInfo extends DecoratingFeatureTypeInfo {
     private WrapperPolicy computeWrapperPolicy(Request request) {
         if (isGetCapabilities(request) && policy.getLimits() instanceof VectorAccessLimits) {
             VectorAccessLimits accessLimits = (VectorAccessLimits) policy.getLimits();
-            VectorAccessLimits newLimits =
-                    new VectorAccessLimits(
-                            accessLimits.getMode(),
-                            null,
-                            Filter.INCLUDE,
-                            accessLimits.getWriteAttributes(),
-                            accessLimits.getWriteFilter());
+            VectorAccessLimits newLimits = (VectorAccessLimits) accessLimits.clone();
+            newLimits.setReadAttributes(null);
+            newLimits.setReadFilter(Filter.INCLUDE);
             WrapperPolicy newPolicy = WrapperPolicy.readOnlyChallenge(newLimits);
             return newPolicy;
         }


### PR DESCRIPTION
[![GEOS-10957](https://badgen.net/badge/JIRA/GEOS-10957/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10957)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->