### PR TITLE
[GEOS-10965] Start in web/app does not work any longer

### DIFF
--- a/src/web/app/src/test/java/org/geoserver/web/Start.java
+++ b/src/web/app/src/test/java/org/geoserver/web/Start.java
@@ -116,28 +116,18 @@ public class Start {
              * while debugging in eclipse. Can't catch CTRL-C to emulate SIGINT as the eclipse
              * console is not propagating that event
              */
-            Thread stopThread =
-                    new Thread() {
-                        @Override
-                        public void run() {
-                            String line;
-                            try (BufferedReader reader =
-                                    new BufferedReader(new InputStreamReader(System.in))) {
-                                while (true) {
-                                    line = reader.readLine();
-                                    if ("stop".equals(line)) {
-                                        jettyServer.stop();
-                                        System.exit(0);
-                                    }
-                                }
-                            } catch (Exception e) {
-                                e.printStackTrace(); // NOPMD
-                                System.exit(1);
-                            }
-                        }
-                    };
-            stopThread.setDaemon(true);
-            stopThread.start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+                while (true) {
+                    String line = reader.readLine();
+                    if ("stop".equals(line)) {
+                        jettyServer.stop();
+                        System.exit(0);
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace(); // NOPMD
+                System.exit(1);
+            }
 
             // use this to test normal stop behaviour, that is, to check stuff that
             // need to be done on container shutdown (and yes, this will make


### PR DESCRIPTION
[![GEOS-10965](https://badgen.net/badge/JIRA/GEOS-10965/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10965)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Changing from thread.run to thread.start bricked it. But calling "run" does not really start a new thread, is just executes the internal runnable, so it's easier to execute that code directly instead.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->