### PR TITLE
[GEOS-10929] isolated workspace may cause broken links between catalo…

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogEventDispatcher.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogEventDispatcher.java
@@ -1,0 +1,86 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogBeforeAddEvent;
+import org.geoserver.catalog.event.CatalogEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
+import org.geoserver.platform.ExtensionPriority;
+import org.geotools.util.logging.Logging;
+
+public class CatalogEventDispatcher {
+    /** logger */
+    private static final Logger LOGGER = Logging.getLogger(CatalogImpl.class);
+
+    /** listeners */
+    protected List<CatalogListener> listeners = new CopyOnWriteArrayList<>();
+
+    public Collection<CatalogListener> getListeners() {
+        return Collections.unmodifiableCollection(listeners);
+    }
+
+    public void addListener(CatalogListener listener) {
+        listeners.add(listener);
+        Collections.sort(listeners, ExtensionPriority.COMPARATOR);
+    }
+
+    public void removeListener(CatalogListener listener) {
+        listeners.remove(listener);
+    }
+
+    public void removeListeners(Class<? extends CatalogListener> listenerClass) {
+        new ArrayList<>(listeners)
+                .stream()
+                        .filter(l -> listenerClass.isInstance(l))
+                        .forEach(l -> listeners.remove(l));
+    }
+
+    public void dispatch(CatalogEvent event) {
+        CatalogException toThrow = null;
+
+        for (CatalogListener listener : listeners) {
+            try {
+                if (event instanceof CatalogAddEvent) {
+                    listener.handleAddEvent((CatalogAddEvent) event);
+                } else if (event instanceof CatalogRemoveEvent) {
+                    listener.handleRemoveEvent((CatalogRemoveEvent) event);
+                } else if (event instanceof CatalogModifyEvent) {
+                    listener.handleModifyEvent((CatalogModifyEvent) event);
+                } else if (event instanceof CatalogPostModifyEvent) {
+                    listener.handlePostModifyEvent((CatalogPostModifyEvent) event);
+                } else if (event instanceof CatalogBeforeAddEvent) {
+                    listener.handlePreAddEvent((CatalogBeforeAddEvent) event);
+                }
+            } catch (Throwable t) {
+                if (t instanceof CatalogException && toThrow == null) {
+                    toThrow = (CatalogException) t;
+                } else if (LOGGER.isLoggable(Level.WARNING)) {
+                    LOGGER.log(
+                            Level.WARNING, "Catalog listener threw exception handling event.", t);
+                }
+            }
+        }
+
+        if (toThrow != null) {
+            throw toThrow;
+        }
+    }
+
+    public void syncTo(CatalogEventDispatcher dispatcher) {
+        dispatcher.listeners = listeners;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/catalog/impl/ResolvingProxy.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ResolvingProxy.java
@@ -66,6 +66,10 @@ public class ResolvingProxy extends ProxyBase {
         if (object instanceof Proxy) {
             InvocationHandler h = Proxy.getInvocationHandler(object);
             if (h instanceof ResolvingProxy) {
+                if (catalog instanceof CatalogImpl) {
+                    catalog = ((CatalogImpl) catalog).getRawCatalog();
+                }
+
                 String ref = ((ResolvingProxy) h).getRef();
                 String pre = ((ResolvingProxy) h).getPrefix();
 


### PR DESCRIPTION
[![GEOS-10929](https://badgen.net/badge/JIRA/GEOS-10929/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10929)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…g objects


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->