### PR TITLE
[GEOS-10973] DWITHIN delegation to mongoDB

### DIFF
--- a/src/community/schemaless-features/mongodb-schemaless/src/main/java/org/geoserver/schemalessfeatures/mongodb/data/MongoComplexContentDataAccess.java
+++ b/src/community/schemaless-features/mongodb-schemaless/src/main/java/org/geoserver/schemalessfeatures/mongodb/data/MongoComplexContentDataAccess.java
@@ -26,6 +26,7 @@ import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.spatial.BBOX;
+import org.opengis.filter.spatial.DWithin;
 import org.opengis.filter.spatial.Intersects;
 import org.opengis.filter.spatial.Within;
 
@@ -110,6 +111,7 @@ public class MongoComplexContentDataAccess extends ComplexContentDataAccess {
             capabilities.addType(BBOX.class);
             capabilities.addType(Intersects.class);
             capabilities.addType(Within.class);
+            capabilities.addType(DWithin.class);
 
             capabilities.addType(Id.class);
 

--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/AttributeEditPage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/AttributeEditPage.html
@@ -19,10 +19,11 @@
     </div>
     <div wicket:id="sizeContainer" class="mb-3">
       <label for="size"><wicket:message key="size">size</wicket:message></label>
-      <input id="size" class="text" type="text" wicket:id="size"/></div>
+      <input id="size" class="text" type="text" wicket:id="size"/>
+    </div>
     <div wicket:id="crsContainer" class="mb-3">
       <label for="crs"><wicket:message key="crs">cRS</wicket:message></label>
-      <span wicket:id="crs"></span></div>
+      <span wicket:id="crs"></span>
     </div>
 
     <div class="button-group toolbar-sticky selfclear">


### PR DESCRIPTION
[![GEOS-10973](https://badgen.net/badge/JIRA/GEOS-10973/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10973)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->
  
Added delegation of dwithin filter in cql to mongoDB for mongo schemaless plugin

Relies on [GEOT-7360](https://osgeo-org.atlassian.net/browse/GEOT-7360) DWITHIN support for mongo schemaless
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->