### PR TITLE
Style endpoint doc update

### DIFF
--- a/doc/en/api/1.0.0/styles.yaml
+++ b/doc/en/api/1.0.0/styles.yaml
@@ -118,7 +118,9 @@ paths:
       description: |
         Retrieves a single style. Used to both request the style info and the style definition body, depending on the media type requested. The media type can be specified either by using the "Accept:" header or by appending an extension to the endpoint. For example, a style info can be requested in XML format using "/styles/{style}.xml" or "Accept: application/xml". (Also available: "{style}.json", "Accept: application/json" "{style}.html", and "Accept: text/html").
         
-        The style definition body can be requested by either appending the file extension of the style file (e.g., "{style}.sld" or "{style}.css") or by specifying the correct media type for the style definition in the "Accept" header. Below are common style formats and the corresponding media types that can be used in the Accept header to request the style definition body.
+        The style definition body can be requested by either appending the file extension of the style file (e.g., "{style}.sld" or "{style}.css") or by specifying the correct media type for the style definition in the "Accept" header.
+        Be aware that by default, if extension is specified, it will override media type. For example if you use SLD 1.1.0 style and specify .sld extension (which provides SLD 1.0.0 result), but use application/vnd.ogc.se+xml media type (which provides SLD 1.1.0 result), response still will be presented in sld version 1.0.0
+        Below are common style formats and the corresponding media types that can be used in the Accept header to request the style definition body.
         
         - application/vnd.ogc.sld+xml for SLD 1.0.0 SLDs
         - application/vnd.ogc.se+xml for SLD 1.1.0 SLDs
@@ -412,7 +414,9 @@ paths:
       description: |
         Retrieves a single style. Used to both request the style info and the style definition body, depending on the media type requested. The media type can be specified either by using the "Accept:" header or by appending an extension to the endpoint. For example, a style info can be requested in XML format using "/styles/{style}.xml" or "Accept: application/xml". (Also available: "{style}.json", "Accept: application/json" "{style}.html", and "Accept: text/html").
         
-        The style definition body can be requested by either appending the file extension of the style file (e.g., "{style}.sld" or "{style}.css") or by specifying the correct media type for the style definition in the "Accept" header. Below are common style formats and the corresponding media types that can be used in the Accept header to request the style definition body.
+        The style definition body can be requested by either appending the file extension of the style file (e.g., "{style}.sld" or "{style}.css") or by specifying the correct media type for the style definition in the "Accept" header.
+        Be aware that by default, if extension is specified, it will override media type. For example if you use SLD 1.1.0 style and specify .sld extension (which provides SLD 1.0.0 result), but use application/vnd.ogc.se+xml media type (which provides SLD 1.1.0 result), response still will be presented in sld version 1.0.0
+        Below are common style formats and the corresponding media types that can be used in the Accept header to request the style definition body.
         
         - application/vnd.ogc.sld+xml for SLD 1.0.0 SLDs
         - application/vnd.ogc.se+xml for SLD 1.1.0 SLDs


### PR DESCRIPTION
Documentation update on style endpoints regarding extension precedence over content type header

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->