### PR TITLE
[Backport 2.22.x] [GEOS-10969] Empty CQL_FILTER-parameter should be ignored

### DIFF
--- a/src/main/src/main/java/org/geoserver/ows/kvp/CQLFilterKvpParser.java
+++ b/src/main/src/main/java/org/geoserver/ows/kvp/CQLFilterKvpParser.java
@@ -24,6 +24,9 @@ public class CQLFilterKvpParser extends KvpParser {
     @Override
     public Object parse(String value) throws Exception {
         try {
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
             return XCQL.toFilterList(value);
         } catch (CQLException pe) {
             throw new ServiceException("Could not parse CQL filter list.", pe);

--- a/src/main/src/test/java/org/geoserver/ows/kvp/CQLFilterKvpParserTest.java
+++ b/src/main/src/test/java/org/geoserver/ows/kvp/CQLFilterKvpParserTest.java
@@ -1,3 +1,7 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.ows.kvp;
 
 import static org.junit.Assert.assertNull;

--- a/src/main/src/test/java/org/geoserver/ows/kvp/CQLFilterKvpParserTest.java
+++ b/src/main/src/test/java/org/geoserver/ows/kvp/CQLFilterKvpParserTest.java
@@ -1,0 +1,28 @@
+package org.geoserver.ows.kvp;
+
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class CQLFilterKvpParserTest {
+
+    private CQLFilterKvpParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new CQLFilterKvpParser();
+    }
+
+    @Test
+    public void testNull() throws Exception {
+        Object parsed = parser.parse(null);
+        assertNull(parsed);
+    }
+
+    @Test
+    public void testEmpty() throws Exception {
+        Object parsed = parser.parse("");
+        assertNull(parsed);
+    }
+}

--- a/src/wfs/src/main/java/org/geoserver/wfs/kvp/BaseFeatureKvpRequestReader.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/kvp/BaseFeatureKvpRequestReader.java
@@ -176,7 +176,9 @@ public abstract class BaseFeatureKvpRequestReader extends WFSKvpRequestReader {
             @SuppressWarnings("unchecked")
             List<Filter> filter = (List) kvp.get("filter");
             querySet(eObject, "filter", filter);
-        } else if (kvp.containsKey("cql_filter")) {
+        }
+        // when cql_filter is empty, its type will be a string and we will skip it
+        else if (kvp.containsKey("cql_filter") && kvp.get("cql_filter") instanceof List) {
             @SuppressWarnings("unchecked")
             List<Filter> filter = (List) kvp.get("cql_filter");
             querySet(eObject, "filter", filter);

--- a/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/GetFeatureTest.java
@@ -99,6 +99,12 @@ public class GetFeatureTest extends WFSTestSupport {
     }
 
     @Test
+    public void testGetCqlFilterEmpty() throws Exception {
+        testGetFifteenAll(
+                "wfs?request=GetFeature&typename=cdf:Fifteen&version=1.0.0&service=wfs&cql_filter=");
+    }
+
+    @Test
     public void testGetPropertyNameStar() throws Exception {
         testGetFifteenAll(
                 "wfs?request=GetFeature&typename=cdf:Fifteen&version=1.0.0&service=wfs&propertyname=*");

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapIntegrationTest.java
@@ -204,6 +204,16 @@ public class GetMapIntegrationTest extends WMSTestSupport {
         assertEquals(Color.GREEN, getPixelColor(image, 5, 10));
     }
 
+    @Test
+    public void testEmptyCQLFilter() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
+                                + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=0,0,1,1&WIDTH=150&HEIGHT=150&transparent=false&CQL_FILTER=");
+
+        assertEquals("image/png", response.getContentType());
+    }
+
     /**
      * Clip on rasters used to lose the request parameters, that included the CQL_FILTER, among the
      * others


### PR DESCRIPTION
[![GEOS-10969](https://badgen.net/badge/JIRA/GEOS-10969/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10969)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6842
 **Authored by:** @canmehteroglu