### PR TITLE
[Backport 2.22.x] [GEOS-8162] ResourcePool relative path processing for CVSDataStore file parameter

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
+++ b/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java
@@ -758,7 +758,7 @@ public class ResourcePool {
                                 true);
                 entry.setValue((V) URLs.fileToUrl(fixedPath));
             } else if ((key != null)
-                    && (key.equals("directory") || key.equals("database"))
+                    && (key.equals("directory") || key.equals("database") || key.equals("file"))
                     && value instanceof String) {
                 String path = (String) value;
                 // if a url is used for a directory (for example property store), convert it to path

--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -894,6 +894,19 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
     }
 
     @Test
+    public void testGetParamsFixesCSVFilePath() {
+        Catalog catalog = getCatalog();
+        ResourcePool pool = new ResourcePool(catalog);
+        DataStoreInfo ds = getCatalog().getFactory().createDataStore();
+        ds.getConnectionParameters().put("file", "file:data/locations.csv");
+        Map newParams = pool.getParams(ds.getConnectionParameters(), getResourceLoader());
+        GeoServerDataDirectory dataDir = new GeoServerDataDirectory(getResourceLoader());
+        String absolutePath = dataDir.get("data/locations.csv").file().getAbsolutePath();
+        assertNotEquals(newParams.get("file"), "file:locations.csv");
+        assertTrue(((String) newParams.get("file")).contains(absolutePath));
+    }
+
+    @Test
     public void testEmptySort() throws IOException, IllegalAccessException {
         SimpleFeatureSource fsp = getFeatureSource(SystemTestData.PRIMITIVEGEOFEATURE);
         Query q = new Query();


### PR DESCRIPTION
[![GEOS-8162](https://badgen.net/badge/JIRA/GEOS-8162/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-8162)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6846
 **Authored by:** @jodygarnett