### PR TITLE
[Backport 2.23.x] [GEOS-10985] B/R of Geoserver catalog is broken with Geoserver 2.23.0

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/reader/CatalogFileReader.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/reader/CatalogFileReader.java
@@ -280,7 +280,7 @@ public class CatalogFileReader<T> extends CatalogReader<T> {
      */
     private Object unmarshal(Source source)
             throws TransformerException, XMLStreamException, UnsupportedEncodingException {
-        TransformerFactory tf = TransformerFactory.newInstance();
+        TransformerFactory tf = TransformerFactory.newDefaultInstance();
         Transformer t = tf.newTransformer();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         Result result = new StreamResult(os);


### PR DESCRIPTION
[![GEOS-10985](https://badgen.net/badge/JIRA/GEOS-10985/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10985)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6850
 **Authored by:** @afabiani