### PR TITLE
[Backport 2.23.x] [GEOS-10988] Update spring.version from 5.3.26 to 5.3.27 and spring-integration.version from 5.5.17 to 5.5.18

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -92,9 +92,9 @@
     <gt.version>29-SNAPSHOT</gt.version>
     <gwc.version>1.23-SNAPSHOT</gwc.version>
     <jts.version>1.19.0</jts.version>
-    <spring.version>5.3.26</spring.version>
+    <spring.version>5.3.27</spring.version>
     <spring.security.version>5.7.8</spring.security.version>
-    <spring-integration.version>5.5.17</spring-integration.version>
+    <spring-integration.version>5.5.18</spring-integration.version>
     <spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
     <servlet-api.version>3.1.0</servlet-api.version>
     <jetty.version>9.4.48.v20220622</jetty.version>


### PR DESCRIPTION
[![GEOS-10988](https://badgen.net/badge/JIRA/GEOS-10988/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10988)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6852
 **Authored by:** @mprins