### PR TITLE
[GEOS-10999] Make GeoServer KML module rely on HSQLDB instead of H2

### DIFF
--- a/src/kml/pom.xml
+++ b/src/kml/pom.xml
@@ -52,8 +52,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/kml/src/main/java/org/geoserver/kml/regionate/CachedHierarchyRegionatingStrategy.java
+++ b/src/kml/src/main/java/org/geoserver/kml/regionate/CachedHierarchyRegionatingStrategy.java
@@ -174,6 +174,8 @@ public abstract class CachedHierarchyRegionatingStrategy implements RegionatingS
         }
     }
 
+    @SuppressFBWarnings(
+            "DMI_CONSTANT_DB_PASSWORD") // well spotted, but the db contents are not sensitive
     private static Connection getHsqlConnection(String dbDir, String dbName) throws SQLException {
         return DriverManager.getConnection(
                 "jdbc:hsqldb:file:" + dbDir + "/hsqlcache_" + dbName, "geoserver", "geopass");
@@ -251,8 +253,6 @@ public abstract class CachedHierarchyRegionatingStrategy implements RegionatingS
     }
 
     /** Open/creates the db and then reads/computes the tile features */
-    @SuppressFBWarnings(
-            "DMI_CONSTANT_DB_PASSWORD") // well spotted, but the db contents are not sensitive
     private Set<String> getFeaturesForTile(String dataDir, Tile tile) throws Exception {
 
         // build the synchonization token

--- a/src/kml/src/main/java/org/geoserver/kml/regionate/CachedHierarchyRegionatingStrategy.java
+++ b/src/kml/src/main/java/org/geoserver/kml/regionate/CachedHierarchyRegionatingStrategy.java
@@ -269,7 +269,7 @@ public abstract class CachedHierarchyRegionatingStrategy implements RegionatingS
                     // try to create the table, if it's already there this will fail
                     Statement st = conn.createStatement()) {
                 st.execute(
-                        "CREATE TABLE IF NOT EXISTS TILECACHE( " //
+                        "CREATE CACHED TABLE IF NOT EXISTS TILECACHE( " //
                                 + "x BIGINT, " //
                                 + "y BIGINT, " //
                                 + "z INT, " //

--- a/src/kml/src/main/java/org/geoserver/kml/regionate/ExternalSortRegionatingStrategy.java
+++ b/src/kml/src/main/java/org/geoserver/kml/regionate/ExternalSortRegionatingStrategy.java
@@ -166,7 +166,7 @@ public class ExternalSortRegionatingStrategy extends CachedHierarchyRegionatingS
     void buildIndex(Connection conn) throws Exception {
         try (Statement st = conn.createStatement()) {
             st.execute(
-                    "CREATE TABLE FEATUREIDX(" //
+                    "CREATE CACHED TABLE FEATUREIDX(" //
                             + "X DOUBLE, " //
                             + "Y DOUBLE, " //
                             + "FID VARCHAR(64), " //

--- a/src/kml/src/main/java/org/geoserver/kml/regionate/GeometryRegionatingStrategy.java
+++ b/src/kml/src/main/java/org/geoserver/kml/regionate/GeometryRegionatingStrategy.java
@@ -59,7 +59,7 @@ public class GeometryRegionatingStrategy extends ExternalSortRegionatingStrategy
         }
 
         // geometry size is a double
-        h2Type = "DOUBLE";
+        hsqlType = "DOUBLE";
     }
 
     @Override

--- a/src/kml/src/main/java/org/geoserver/kml/regionate/Tile.java
+++ b/src/kml/src/main/java/org/geoserver/kml/regionate/Tile.java
@@ -36,8 +36,8 @@ public class Tile {
             WORLD_BOUNDS = new ReferencedEnvelope(new Envelope(180.0, -180.0, 90.0, -90.0), WGS84);
             MAX_TILE_WIDTH = WORLD_BOUNDS.getWidth() / 2.0;
 
-            // make sure, once and for all, that H2 is around
-            Class.forName("org.h2.Driver");
+            // make sure, once and for all, that HSQL is around
+            Class.forName("org.hsqldb.jdbcDriver");
         } catch (Exception e) {
             throw new RuntimeException("Could not initialize the class constants", e);
         }

--- a/src/kml/src/test/java/org/geoserver/kml/GeoSearchKMLTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/GeoSearchKMLTest.java
@@ -11,10 +11,12 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.logging.Level;
 import org.apache.commons.io.FileUtils;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
+import org.geoserver.kml.regionate.CachedHierarchyRegionatingStrategy;
 import org.geotools.util.logging.Logging;
 import org.junit.After;
 import org.junit.Before;
@@ -33,8 +35,9 @@ public class GeoSearchKMLTest extends RegionatingTestSupport {
     }
 
     @After
-    public void cleanupRegionationDatabases() throws IOException {
+    public void cleanupRegionationDatabases() throws IOException, SQLException {
         File dir = getDataDirectory().findOrCreateDir("geosearch");
+        CachedHierarchyRegionatingStrategy.clearAllHsqlDatabases(dir);
         FileUtils.deleteDirectory(dir);
     }
 

--- a/src/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
@@ -55,6 +55,7 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.kml.regionate.CachedHierarchyRegionatingStrategy;
 import org.geoserver.ows.kvp.FormatOptionsKvpParser;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.wms.GetMapRequest;
@@ -100,6 +101,13 @@ public class KMLReflectorTest extends WMSTestSupport {
         new File(stylesDir, "graphics").mkdir();
         testData.copyTo(
                 getClass().getResourceAsStream("bridge.png"), "styles/graphics/bridgesubdir.png");
+    }
+
+    @Override
+    protected void onTearDown(SystemTestData testData) throws Exception {
+        File dir = getDataDirectory().findOrCreateDir("geosearch");
+        CachedHierarchyRegionatingStrategy.clearAllHsqlDatabases(dir);
+        super.onTearDown(testData);
     }
 
     /**

--- a/src/kml/src/test/java/org/geoserver/kml/KMLSuperOverlayTest.java
+++ b/src/kml/src/test/java/org/geoserver/kml/KMLSuperOverlayTest.java
@@ -10,6 +10,7 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +22,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.data.test.SystemTestData.LayerProperty;
+import org.geoserver.kml.regionate.CachedHierarchyRegionatingStrategy;
 import org.geoserver.ows.util.KvpUtils;
 import org.geoserver.wms.WMSTestSupport;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -76,6 +78,13 @@ public class KMLSuperOverlayTest extends WMSTestSupport {
         FeatureTypeInfo ft = getCatalog().getFeatureTypeByName(getLayerId(MockData.BASIC_POLYGONS));
         ft.getMetadata().put("kml.regionateFeatureLimit", 1);
         getCatalog().save(ft);
+    }
+
+    @Override
+    protected void onTearDown(SystemTestData testData) throws Exception {
+        File dir = getDataDirectory().findOrCreateDir("geosearch");
+        CachedHierarchyRegionatingStrategy.clearAllHsqlDatabases(dir);
+        super.onTearDown(testData);
     }
 
     /** Verify that the tiles are produced for a request that encompasses the world. */

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -158,6 +158,7 @@
     <errorProne.version>2.18.0</errorProne.version>
     <javac.version>9+181-r4173-1</javac.version>
     <pmd.version>6.42.0</pmd.version>
+    <hsql.version>2.7.1</hsql.version>
     <checkstyle.skip>false</checkstyle.skip>
     <qa>false</qa>
     <lint>deprecation,unchecked</lint>
@@ -1303,6 +1304,11 @@
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>1.1.119</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hsqldb</groupId>
+        <artifactId>hsqldb</artifactId>
+        <version>${hsql.version}</version>
       </dependency>
       <dependency>
         <groupId>com.ibm.icu</groupId>


### PR DESCRIPTION
[![GEOS-10999](https://badgen.net/badge/JIRA/GEOS-10999/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10999)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Replaced H2 with HSQL for gs-kml module.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->