### PR TITLE
[GEOS-10998] LayerGroupContainmentCache is being rebuilt on each ApplicationEvent

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/LayerGroupContainmentCache.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/LayerGroupContainmentCache.java
@@ -29,8 +29,8 @@ import org.geoserver.catalog.event.CatalogModifyEvent;
 import org.geoserver.catalog.event.CatalogPostModifyEvent;
 import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geoserver.catalog.impl.LayerGroupStyleListener;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
 
 /**
  * A cache for layer group containment, it speeds up looking up layer groups containing a particular
@@ -38,7 +38,7 @@ import org.springframework.context.ApplicationListener;
  *
  * @author Andrea Aime - GeoSolutions
  */
-public class LayerGroupContainmentCache implements ApplicationListener {
+public class LayerGroupContainmentCache implements ApplicationListener<ContextRefreshedEvent> {
 
     /** Builds a concurrent set wrapping a {@link ConcurrentHashMap} */
     static final Function<? super String, ? extends Set<LayerGroupSummary>> CONCURRENT_SET_BUILDER =
@@ -193,7 +193,7 @@ public class LayerGroupContainmentCache implements ApplicationListener {
     }
 
     @Override
-    public void onApplicationEvent(ApplicationEvent applicationEvent) {
+    public void onApplicationEvent(ContextRefreshedEvent event) {
         buildLayerGroupCaches();
     }
 


### PR DESCRIPTION
[![GEOS-10998](https://badgen.net/badge/JIRA/GEOS-10998/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10998)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[[GEOS-10998] LayerGroupContainmentCache is being rebuilt on each ApplicationEvent](https://osgeo-org.atlassian.net/browse/GEOS-10998)

Layer group cache was being rebuild on most of GS actions, which resulted in performance drop. Changed code to rebuild only on ContextRefreshedEvent

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->