### PR TITLE
[GEOS-10997] Data Security Layer groups

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
@@ -674,7 +674,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
         }
     }
 
-    private Filter buildInFunctionResourceFilter(
+    protected Filter buildInFunctionResourceFilter(
             Authentication user, Class<? extends CatalogInfo> clazz) {
         // base access
         boolean rootAccess = canAccess(user, root);
@@ -705,9 +705,12 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
                 }
                 boolean layerAccess = canAccess(user, layerNode);
                 if (layerAccess != wsAccess) {
-                    if (clazz.isAssignableFrom(published.getClass()))
+                    if (ResourceInfo.class.isAssignableFrom(clazz)
+                            && published instanceof LayerInfo) {
+                        layerExceptionIds.add(((LayerInfo) published).getResource().getId());
+                    } else {
                         layerExceptionIds.add(published.getId());
-                    else layerExceptionIds.add(((LayerInfo) published).getResource().getId());
+                    }
                 }
             }
 

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/AbstractAuthorizationTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/AbstractAuthorizationTest.java
@@ -595,6 +595,11 @@ public abstract class AbstractAuthorizationTest extends SecureObjectsTest {
                 expect(catalog.getLayerGroupByName(lg.getWorkspace().getName(), lg.getName()))
                         .andReturn(lg)
                         .anyTimes();
+                expect(
+                                catalog.getLayerGroupByName(
+                                        lg.getWorkspace().getName() + ":" + lg.getName()))
+                        .andReturn(lg)
+                        .anyTimes();
             }
         }
 

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/DefaultDataAccessManagerTreeTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/DefaultDataAccessManagerTreeTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 import java.util.Set;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.security.AccessMode;
 import org.junit.Before;
 import org.junit.Test;
@@ -90,7 +92,7 @@ public class DefaultDataAccessManagerTreeTest extends AbstractAuthorizationTest 
         assertEquals(2, root.children.size());
         SecureTreeNode topp = root.getChild("topp");
         assertNotNull(topp);
-        assertEquals(3, topp.children.size());
+        assertEquals(4, topp.children.size());
         SecureTreeNode states = topp.getChild("states");
         SecureTreeNode landmarks = topp.getChild("landmarks");
         SecureTreeNode bases = topp.getChild("bases");
@@ -134,5 +136,23 @@ public class DefaultDataAccessManagerTreeTest extends AbstractAuthorizationTest 
         assertFalse(landmarks.canAccess(milUser, AccessMode.WRITE));
         assertTrue(bases.canAccess(milUser, AccessMode.READ));
         assertTrue(bases.canAccess(milUser, AccessMode.WRITE));
+    }
+
+    @Test
+    public void testBuildInFunctionResourceFilter() throws Exception {
+        DefaultResourceAccessManager defaultResourceAccessManager =
+                (DefaultResourceAccessManager) buildManager("complex.properties");
+        // validate that the filter is built correctly and there are no casting issues when
+        // populating layerExceptionIds
+        assertEquals(
+                "[[ NOT [ in([id], [arc.grid-id]) = true ] ] AND [ NOT [ in([id], [bases-id]) = true ] ]]",
+                defaultResourceAccessManager
+                        .buildInFunctionResourceFilter(rwUser, ResourceInfo.class)
+                        .toString());
+        assertEquals(
+                "[[ NOT [ in([id], [arc.grid-lid]) = true ] ] AND [ NOT [ in([id], [bases-lid]) = true ] ]]",
+                defaultResourceAccessManager
+                        .buildInFunctionResourceFilter(rwUser, WorkspaceInfo.class)
+                        .toString());
     }
 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -1155,8 +1155,8 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
         Collection<PublishedInfo> filteredPublished =
                 Collections2.filter(publisheds, new PredicateFilter(securityAnonymous));
         assertEquals("anonymous layers", 4, filteredLayers.size());
-        assertEquals("anonymous layer groups", 2, filteredGroups.size());
-        assertEquals("anonymous published", 6, filteredPublished.size());
+        assertEquals("anonymous layer groups", 1, filteredGroups.size());
+        assertEquals("anonymous published", 5, filteredPublished.size());
         // ANON
         Iterator<LayerInfo> it1 =
                 Iterators.filter(layers.iterator(), new PredicateFilter(securityAnonymous));
@@ -1267,6 +1267,15 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
         clazz = ResourceInfo.class;
         // Creating filter for anonymous user
         securityAnonymous = resourceManager.getSecurityFilter(anonymous, clazz);
+        // When the filter gets created, if evaluating a ResourceInfo where there is a mismatch
+        // between layer and workspace access, get the resource and get its id rather than the layer
+        // id
+        // in order to exclude it
+        assertTrue(securityAnonymous.toString().contains("[states-id]"));
+        assertFalse(securityAnonymous.toString().contains("[states-lid]"));
+        // Confirming that the security filter creation process can handle a LayerGroup when there
+        // is a layer-workspace mismatch
+        assertTrue(securityAnonymous.toString().contains("[topp:layerGroupTopp-id]"));
         // Creating filter for read write user
         securityReadWriteUser = resourceManager.getSecurityFilter(rwUser, clazz);
         // Creating filter for military user

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/complex.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/complex.properties
@@ -6,6 +6,9 @@ topp.*.r=*
 # states is secret, only authenticated can read, only WRITER can write 
 topp.states.r=READER
 topp.states.w=WRITER
+# layerGroupTopp is secret layer group, only authenticated can read, only WRITER can write
+topp.layerGroupTopp.r=READER
+topp.layerGroupTopp.w=WRITER
 # poly is wide open for read, but can edited only by WRITER  
 topp.landmarks.w=WRITER
 # military is even more closed, to read and write you got to be in the MILITARY


### PR DESCRIPTION
[![GEOS-10997](https://badgen.net/badge/JIRA/GEOS-10997/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10997)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

fixed reversed superclass

more fixed super


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->