### PR TITLE
[GEOS-10980] CSS extension lacks ASM JARs as of 2.23.0, stops rendering layer when style references a file

### DIFF
--- a/src/release/ext-css.xml
+++ b/src/release/ext-css.xml
@@ -13,7 +13,7 @@
         <include>gt-css-*.jar</include>
         <include>gt-brewer-*.jar</include>
         <include>parboiled*.jar</include>
-        <include>asm*6.2.1.jar</include>
+        <include>asm*9.2.jar</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
[![GEOS-10980](https://badgen.net/badge/JIRA/GEOS-10980/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10980)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->