### PR TITLE
[Backport 2.23.x] [GEOS-10936] YSLD and OGC API modules are incompatible

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -136,8 +136,8 @@
     <git.commit.runOnlyOnce>true</git.commit.runOnlyOnce>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>
     <jackson1.version>1.9.13</jackson1.version>
-    <jackson2.version>2.13.2</jackson2.version>
-    <jackson2.databind.version>2.13.4.2</jackson2.databind.version>
+    <jackson2.version>2.15.2</jackson2.version>
+    <jackson2.databind.version>2.15.2</jackson2.databind.version>
     <compress-lzf.version>1.0.3</compress-lzf.version>
     <marlin.version>0.9.3</marlin.version>
     <postgresql.jdbc.version>42.6.0</postgresql.jdbc.version>


### PR DESCRIPTION
[![GEOS-10936](https://badgen.net/badge/JIRA/GEOS-10936/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10936)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6885
 **Authored by:** @canmehteroglu