### PR TITLE
[Backport 2.23.x] [GEOS-10980] CSS extension lacks ASM JARs as of 2.23.0, stops rendering layer when style references a file

### DIFF
--- a/src/release/ext-css.xml
+++ b/src/release/ext-css.xml
@@ -13,7 +13,7 @@
         <include>gt-css-*.jar</include>
         <include>gt-brewer-*.jar</include>
         <include>parboiled*.jar</include>
-        <include>asm*6.2.1.jar</include>
+        <include>asm*9.2.jar</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
[![GEOS-10980](https://badgen.net/badge/JIRA/GEOS-10980/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10980)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6884
 **Authored by:** @aaime