### PR TITLE
[GEOS-11019] Upgrade commons-io from 2.8.0 to 2.12.0

### DIFF
--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/geojson/GeoJsonWMSBuilder.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/geojson/GeoJsonWMSBuilder.java
@@ -40,7 +40,12 @@ public class GeoJsonWMSBuilder implements VectorTileBuilder {
     public GeoJsonWMSBuilder(Rectangle mapSize, ReferencedEnvelope mapArea) {
 
         final int memotyBufferThreshold = 8096;
-        out = new DeferredFileOutputStream(memotyBufferThreshold, "geojson", ".geojson", null);
+        out =
+                DeferredFileOutputStream.builder()
+                        .setThreshold(memotyBufferThreshold)
+                        .setPrefix("geojson")
+                        .setSuffix(".geojson")
+                        .get();
         writer = new OutputStreamWriter(out, Charsets.UTF_8);
         jsonWriter = new org.geoserver.wfs.json.GeoJSONBuilder(writer);
         jsonWriter.object(); // start root object

--- a/src/extension/vectortiles/src/main/java/org/geoserver/wms/topojson/TopologyBuilder.java
+++ b/src/extension/vectortiles/src/main/java/org/geoserver/wms/topojson/TopologyBuilder.java
@@ -106,7 +106,11 @@ public class TopologyBuilder implements VectorTileBuilder {
 
         final int threshold = 8096;
         try (DeferredFileOutputStream out =
-                        new DeferredFileOutputStream(threshold, "topology", ".topojson", null);
+                        DeferredFileOutputStream.builder()
+                                .setThreshold(threshold)
+                                .setPrefix("topology")
+                                .setSuffix(".topojson")
+                                .get();
                 Writer writer = new OutputStreamWriter(out, Charsets.UTF_8)) {
             TopoJSONEncoder encoder = new TopoJSONEncoder();
 

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/topojson/TopoJSONEncoderTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/topojson/TopoJSONEncoderTest.java
@@ -39,7 +39,7 @@ public class TopoJSONEncoderTest {
         layers.put("topp:states", layer);
 
         Topology topology = new Topology(identity, arcs, layers);
-        try (Writer writer = new OutputStreamWriter(NullOutputStream.NULL_OUTPUT_STREAM)) {
+        try (Writer writer = new OutputStreamWriter(NullOutputStream.INSTANCE)) {
             encoder.encode(topology, writer);
         }
     }
@@ -69,7 +69,7 @@ public class TopoJSONEncoderTest {
         layers.put("topp:states", layer);
         Topology topology = new Topology(tx, arcs, layers);
 
-        try (Writer writer = new OutputStreamWriter(NullOutputStream.NULL_OUTPUT_STREAM)) {
+        try (Writer writer = new OutputStreamWriter(NullOutputStream.INSTANCE)) {
             encoder.encode(topology, writer);
         }
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/CDataEncoderDelegate.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/CDataEncoderDelegate.java
@@ -6,6 +6,8 @@
 
 package org.geoserver.wps;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
@@ -35,7 +37,11 @@ public class CDataEncoderDelegate implements EncoderDelegate {
     @Override
     public void encode(ContentHandler output) throws Exception {
         ((LexicalHandler) output).startCDATA();
-        try (OutputStream os = new WriterOutputStream(new ContentHandlerWriter(output), "UTF-8")) {
+        try (OutputStream os =
+                WriterOutputStream.builder()
+                        .setWriter(new ContentHandlerWriter(output))
+                        .setCharset(UTF_8)
+                        .get()) {
             ppio.encode(object, os);
         }
         ((LexicalHandler) output).endCDATA();

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -840,7 +840,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
+        <version>2.12.0</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>

--- a/src/rest/src/main/java/org/geoserver/rest/util/IOUtils.java
+++ b/src/rest/src/main/java/org/geoserver/rest/util/IOUtils.java
@@ -762,6 +762,7 @@ public class IOUtils extends org.apache.commons.io.IOUtils {
         }
     }
 
-    /** Singleton */
+    /** Singleton - it will not be possible to extend org.apache.commons.io.IOUtils in 3.0. */
+    @SuppressWarnings("deprecation")
     private IOUtils() {}
 }

--- a/src/wms/src/test/java/org/geoserver/wms/map/RawMapTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/RawMapTest.java
@@ -12,6 +12,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
 import java.io.InputStream;
+import org.apache.commons.io.output.NullOutputStream;
 import org.geoserver.wms.WMSMapContent;
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class RawMapTest {
         WMSMapContent map = createNiceMock(WMSMapContent.class);
         replay(map);
 
-        new RawMap(map, stream, "text/plain").writeTo(null);
+        new RawMap(map, stream, "text/plain").writeTo(NullOutputStream.INSTANCE);
         verify(stream);
     }
 }


### PR DESCRIPTION
[![GEOS-11019](https://badgen.net/badge/JIRA/GEOS-11019/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11019)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Dependency upgrade with bug fixes and new features. Backport is optional for this PR.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->