### PR TITLE
[GEOS-10932] csw-iso: should only add 'xsi:nil = false' attribute (pa…

### DIFF
--- a/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/response/MetaDataTransformer.java
+++ b/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/response/MetaDataTransformer.java
@@ -184,13 +184,9 @@ public class MetaDataTransformer extends AbstractRecordTransformer {
             String name = dn.getLocalPart();
             String prefix = MetaDataDescriptor.NAMESPACES.getPrefix(dn.getNamespaceURI());
             AttributesImpl attributes = new AttributesImpl();
-            if (p.isNillable()) {
+            if (p.isNillable() && Strings.isNullOrEmpty(value)) {
                 attributes.addAttribute(
-                        "http://www.w3.org/2001/XMLSchema-instance",
-                        "nil",
-                        "xsi:nil",
-                        "",
-                        Strings.isNullOrEmpty(value) ? "true" : "false");
+                        "http://www.w3.org/2001/XMLSchema-instance", "nil", "xsi:nil", "", "true");
             }
             element(prefix + ":" + name, value, attributes);
         }

--- a/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordsTest.java
+++ b/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordsTest.java
@@ -230,6 +230,9 @@ public class GetRecordsTest extends MDTestSupport {
                 "-90.0",
                 "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:northBoundLatitude/gco:Decimal",
                 d);
+        assertXpathNotExists(
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:dateStamp/gco:Date/@xsi:nil",
+                d);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10932](https://badgen.net/badge/JIRA/GEOS-10932/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10932)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…rt II)

Following up to earlier PR for same issue, appears it happened in two different places so I had to reopen the issue.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->