### PR TITLE
[GEOS-10979] metadata: don't crash on missing properties file

### DIFF
--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/web/resource/WicketResourceResourceLoader.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/web/resource/WicketResourceResourceLoader.java
@@ -74,7 +74,7 @@ public class WicketResourceResourceLoader implements IStringResourceLoader {
                         string = findString(key, string, resourceBundle);
                     }
                 }
-            } catch (IOException e) {
+            } catch (IOException | IllegalStateException e) {
                 if (shouldThrowExceptionForMissingResource()) {
                     throw new WicketRuntimeException(
                             String.format(

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractMetadataTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractMetadataTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractMetadataTest {
 
     protected static MockData DATA_DIRECTORY;
 
-    private static File metadata;
+    protected static File metadata;
 
     private static File metadataTemplates;
 

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/EmptyConfigurationTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/EmptyConfigurationTest.java
@@ -1,0 +1,45 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.metadata;
+
+import org.apache.wicket.util.file.File;
+import org.geoserver.metadata.web.MetadataTemplatesPage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests that metadata module works 'out of the box', without any configuration present yet.
+ *
+ * @author niels
+ */
+public class EmptyConfigurationTest extends AbstractWicketMetadataTest {
+
+    private File metadataRenamed =
+            new File(DATA_DIRECTORY.getDataDirectoryRoot(), "metadata.renamed");
+
+    @Before
+    public void initEmptyConfiguration() throws Exception {
+        metadata.renameTo(metadataRenamed);
+    }
+
+    @After
+    public void restoreConfiguration() throws Exception {
+        metadataRenamed.renameTo(metadata);
+    }
+
+    @Test
+    public void testRenderPage() {
+        // just check if a page is rendered
+
+        login();
+
+        // Load the page
+        MetadataTemplatesPage page = new MetadataTemplatesPage();
+        tester.startPage(page);
+        tester.assertRenderedPage(MetadataTemplatesPage.class);
+    }
+}


### PR DESCRIPTION
[![GEOS-10979](https://badgen.net/badge/JIRA/GEOS-10979/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10979)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->