### PR TITLE
[GEOS-11022] Taskmanager: support isolated catalog facades

### DIFF
--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/ExtTypes.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/ExtTypes.java
@@ -210,9 +210,19 @@ public class ExtTypes {
                         if (ns == null) {
                             return null;
                         }
-                        return geoServer
-                                .getCatalog()
-                                .getLayerByName(new NameImpl(ns.getURI(), value));
+                        ResourceInfo resource =
+                                geoServer
+                                        .getCatalog()
+                                        .getResourceByName(ns, value, ResourceInfo.class);
+                        if (resource == null) {
+                            return null;
+                        }
+                        List<LayerInfo> layers = geoServer.getCatalog().getLayers(resource);
+                        if (layers.size() == 1) {
+                            return layers.get(0);
+                        } else {
+                            return null;
+                        }
                     } else {
                         return geoServer.getCatalog().getLayerByName(value);
                     }

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/DbLocalPublicationTaskTypeImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/DbLocalPublicationTaskTypeImpl.java
@@ -112,7 +112,7 @@ public class DbLocalPublicationTaskTypeImpl implements TaskType {
         CatalogFactory catalogFac = new CatalogFactoryImpl(catalog);
 
         final NamespaceInfo ns = catalog.getNamespaceByURI(layerName.getNamespaceURI());
-        final WorkspaceInfo ws = catalog.getWorkspaceByName(ns.getName());
+        final WorkspaceInfo ws = getWorkspace(ctx, ns);
 
         final boolean createLayer = catalog.getLayerByName(layerName) == null;
         final boolean createStore;
@@ -217,18 +217,29 @@ public class DbLocalPublicationTaskTypeImpl implements TaskType {
         };
     }
 
+    private WorkspaceInfo getWorkspace(TaskContext ctx, NamespaceInfo ns) throws TaskException {
+        WorkspaceInfo ws = (WorkspaceInfo) ctx.getParameterValues().get(PARAM_WORKSPACE);
+        if (ws == null) {
+            ws = catalog.getWorkspaceByName(ns.getName());
+        }
+        return ws;
+    }
+
     @Override
     public void cleanup(TaskContext ctx) throws TaskException {
         final DbSource db = (DbSource) ctx.getParameterValues().get(PARAM_DB_NAME);
         final Name layerName = (Name) ctx.getParameterValues().get(PARAM_LAYER);
-        final String workspace = catalog.getNamespaceByURI(layerName.getNamespaceURI()).getPrefix();
+
+        final WorkspaceInfo ws =
+                getWorkspace(ctx, catalog.getNamespaceByURI(layerName.getNamespaceURI()));
 
         final DbTable table = (DbTable) ctx.getParameterValues().get(PARAM_TABLE_NAME);
         String schema = SqlUtil.schema(table.getTableName());
         String dbName = schema == null ? db.getName() : (db.getName() + "_" + schema);
 
         final LayerInfo layer = catalog.getLayerByName(layerName);
-        final DataStoreInfo store = catalog.getStoreByName(workspace, dbName, DataStoreInfo.class);
+        final DataStoreInfo store =
+                catalog.getStoreByName(ws.getName(), dbName, DataStoreInfo.class);
         final FeatureTypeInfo resource =
                 catalog.getResourceByName(layerName, FeatureTypeInfo.class);
 

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/FileLocalPublicationTaskTypeImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/FileLocalPublicationTaskTypeImpl.java
@@ -92,8 +92,8 @@ public class FileLocalPublicationTaskTypeImpl implements TaskType {
         CatalogFactory catalogFac = new CatalogFactoryImpl(catalog);
 
         final Name layerName = (Name) ctx.getParameterValues().get(PARAM_LAYER);
-        final NamespaceInfo ns = catalog.getNamespaceByURI(layerName.getNamespaceURI());
-        final WorkspaceInfo ws = catalog.getWorkspaceByName(ns.getName());
+        final WorkspaceInfo ws =
+                getWorkspace(ctx, catalog.getNamespaceByURI(layerName.getNamespaceURI()));
 
         FileReference fileRef =
                 (FileReference)
@@ -276,14 +276,23 @@ public class FileLocalPublicationTaskTypeImpl implements TaskType {
         };
     }
 
+    private WorkspaceInfo getWorkspace(TaskContext ctx, NamespaceInfo ns) throws TaskException {
+        WorkspaceInfo ws = (WorkspaceInfo) ctx.getParameterValues().get(PARAM_WORKSPACE);
+        if (ws == null) {
+            ws = catalog.getWorkspaceByName(ns.getName());
+        }
+        return ws;
+    }
+
     @Override
     public void cleanup(TaskContext ctx) throws TaskException {
         final Name layerName = (Name) ctx.getParameterValues().get(PARAM_LAYER);
-        final String workspace = catalog.getNamespaceByURI(layerName.getNamespaceURI()).getPrefix();
+        final WorkspaceInfo ws =
+                getWorkspace(ctx, catalog.getNamespaceByURI(layerName.getNamespaceURI()));
 
         final LayerInfo layer = catalog.getLayerByName(layerName);
         final StoreInfo store =
-                catalog.getStoreByName(workspace, layerName.getLocalPart(), StoreInfo.class);
+                catalog.getStoreByName(ws.getName(), layerName.getLocalPart(), StoreInfo.class);
         final ResourceInfo resource = catalog.getResourceByName(layerName, ResourceInfo.class);
 
         catalog.remove(layer);


### PR DESCRIPTION
[![GEOS-11022](https://badgen.net/badge/JIRA/GEOS-11022/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11022)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->