### PR TITLE
[GEOS-11024] metadata: add datetime field type to feature catalog

### DIFF
--- a/src/extension/metadata/src/main/resources/org/geoserver/metadata/data/service/impl/featureCatalog.yaml
+++ b/src/extension/metadata/src/main/resources/org/geoserver/metadata/data/service/impl/featureCatalog.yaml
@@ -10,6 +10,7 @@ types:
           values:
               - String
               - Date
+              - Datetime
               - Number
               - Geometry
               - Boolean

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/data/service/ConfigurationServiceTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/data/service/ConfigurationServiceTest.java
@@ -4,10 +4,14 @@
  */
 package org.geoserver.metadata.data.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.util.List;
 import org.geoserver.metadata.AbstractMetadataTest;
 import org.geoserver.metadata.data.dto.AttributeConfiguration;
+import org.geoserver.metadata.data.dto.AttributeTypeConfiguration;
 import org.geoserver.metadata.data.dto.GeonetworkMappingConfiguration;
 import org.geoserver.metadata.data.dto.MetadataConfiguration;
 import org.junit.Assert;
@@ -51,6 +55,16 @@ public class ConfigurationServiceTest extends AbstractMetadataTest {
         List<AttributeConfiguration> complexAttributes =
                 configuration.findType("referencesystem").getAttributes();
         Assert.assertEquals("Code", findAttribute(complexAttributes, "code").getLabel());
+    }
+
+    @Test
+    public void testFeatureCatalog() {
+        AttributeTypeConfiguration featureAtt =
+                yamlService.getMetadataConfiguration().findType("featureAttribute");
+        assertNotNull(featureAtt);
+        AttributeConfiguration attType = featureAtt.findAttribute("type");
+        assertNotNull(attType);
+        assertEquals(7, attType.getValues().size());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11024](https://badgen.net/badge/JIRA/GEOS-11024/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11024)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->