### PR TITLE
[GEOS-11026] Only WARN on h2 unload failure if H2 driver available

### DIFF
--- a/src/main/src/main/java/org/geoserver/GeoserverInitStartupListener.java
+++ b/src/main/src/main/java/org/geoserver/GeoserverInitStartupListener.java
@@ -298,6 +298,12 @@ public class GeoserverInitStartupListener implements ServletContextListener {
                 Class<?> h2Driver = Class.forName("org.h2.Driver");
                 Method m = h2Driver.getMethod("unload");
                 m.invoke(null);
+            } catch (java.lang.ClassNotFoundException notIncluded) {
+                if ("org.h2.Driver".equalsIgnoreCase(notIncluded.getMessage())) {
+                    LOGGER.log(Level.FINE, "H2 driver not included, skipping unload");
+                } else {
+                    LOGGER.log(Level.WARNING, "Failed to unload the H2 driver", notIncluded);
+                }
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Failed to unload the H2 driver", e);
             }


### PR DESCRIPTION
[![GEOS-11026](https://badgen.net/badge/JIRA/GEOS-11026/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11026)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

No functional change change to logging, was missed during [GEOS-10992] activity. 

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->