### PR TITLE
[Backport 2.23.x] [GEOS-11030] Update jetty-server from 9.4.48.v20220622 to 9.4.51.v20230217 in /src

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -97,7 +97,7 @@
     <spring-integration.version>5.5.18</spring-integration.version>
     <spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
     <servlet-api.version>3.1.0</servlet-api.version>
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <jetty.servlet-api.version>3.1.0</jetty.servlet-api.version>
     <poi.version>4.1.1</poi.version>
     <wicket.version>7.18.0</wicket.version>


### PR DESCRIPTION
[![GEOS-11030](https://badgen.net/badge/JIRA/GEOS-11030/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11030)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6935
 **Authored by:** @dependabot[bot]