### PR TITLE
[Backport 2.23.x] [GEOS-11024] metadata: add datetime field type to feature catalog

### DIFF
--- a/src/extension/metadata/src/main/resources/org/geoserver/metadata/data/service/impl/featureCatalog.yaml
+++ b/src/extension/metadata/src/main/resources/org/geoserver/metadata/data/service/impl/featureCatalog.yaml
@@ -10,6 +10,7 @@ types:
           values:
               - String
               - Date
+              - Datetime
               - Number
               - Geometry
               - Boolean

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/data/service/ConfigurationServiceTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/data/service/ConfigurationServiceTest.java
@@ -4,10 +4,14 @@
  */
 package org.geoserver.metadata.data.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.util.List;
 import org.geoserver.metadata.AbstractMetadataTest;
 import org.geoserver.metadata.data.dto.AttributeConfiguration;
+import org.geoserver.metadata.data.dto.AttributeTypeConfiguration;
 import org.geoserver.metadata.data.dto.GeonetworkMappingConfiguration;
 import org.geoserver.metadata.data.dto.MetadataConfiguration;
 import org.junit.Assert;
@@ -51,6 +55,16 @@ public class ConfigurationServiceTest extends AbstractMetadataTest {
         List<AttributeConfiguration> complexAttributes =
                 configuration.findType("referencesystem").getAttributes();
         Assert.assertEquals("Code", findAttribute(complexAttributes, "code").getLabel());
+    }
+
+    @Test
+    public void testFeatureCatalog() {
+        AttributeTypeConfiguration featureAtt =
+                yamlService.getMetadataConfiguration().findType("featureAttribute");
+        assertNotNull(featureAtt);
+        AttributeConfiguration attType = featureAtt.findAttribute("type");
+        assertNotNull(attType);
+        assertEquals(7, attType.getValues().size());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11024](https://badgen.net/badge/JIRA/GEOS-11024/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11024)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6928
 **Authored by:** @NielsCharlier