### PR TITLE
[Backport 2.22.x] [GEOS-10932] csw-iso: should only add 'xsi:nil = false' attribute (pa…

### DIFF
--- a/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/response/MetaDataTransformer.java
+++ b/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/response/MetaDataTransformer.java
@@ -184,13 +184,9 @@ public class MetaDataTransformer extends AbstractRecordTransformer {
             String name = dn.getLocalPart();
             String prefix = MetaDataDescriptor.NAMESPACES.getPrefix(dn.getNamespaceURI());
             AttributesImpl attributes = new AttributesImpl();
-            if (p.isNillable()) {
+            if (p.isNillable() && Strings.isNullOrEmpty(value)) {
                 attributes.addAttribute(
-                        "http://www.w3.org/2001/XMLSchema-instance",
-                        "nil",
-                        "xsi:nil",
-                        "",
-                        Strings.isNullOrEmpty(value) ? "true" : "false");
+                        "http://www.w3.org/2001/XMLSchema-instance", "nil", "xsi:nil", "", "true");
             }
             element(prefix + ":" + name, value, attributes);
         }

--- a/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordsTest.java
+++ b/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/GetRecordsTest.java
@@ -230,6 +230,9 @@ public class GetRecordsTest extends MDTestSupport {
                 "-90.0",
                 "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:northBoundLatitude/gco:Decimal",
                 d);
+        assertXpathNotExists(
+                "//gmd:MD_Metadata[gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString='Forests']/gmd:dateStamp/gco:Date/@xsi:nil",
+                d);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-10932](https://badgen.net/badge/JIRA/GEOS-10932/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10932)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6907
 **Authored by:** @NielsCharlier