### PR TITLE
[Backport 2.23.x] [GEOS-11026] Only WARN on h2 unload failure if H2 driver available

### DIFF
--- a/src/main/src/main/java/org/geoserver/GeoserverInitStartupListener.java
+++ b/src/main/src/main/java/org/geoserver/GeoserverInitStartupListener.java
@@ -298,6 +298,12 @@ public class GeoserverInitStartupListener implements ServletContextListener {
                 Class<?> h2Driver = Class.forName("org.h2.Driver");
                 Method m = h2Driver.getMethod("unload");
                 m.invoke(null);
+            } catch (java.lang.ClassNotFoundException notIncluded) {
+                if ("org.h2.Driver".equalsIgnoreCase(notIncluded.getMessage())) {
+                    LOGGER.log(Level.FINE, "H2 driver not included, skipping unload");
+                } else {
+                    LOGGER.log(Level.WARNING, "Failed to unload the H2 driver", notIncluded);
+                }
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Failed to unload the H2 driver", e);
             }


### PR DESCRIPTION
[![GEOS-11026](https://badgen.net/badge/JIRA/GEOS-11026/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11026)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6939
 **Authored by:** @jodygarnett