### PR TITLE
[Backport 2.22.x] [GEOS-10979] metadata: don't crash on missing properties file

### DIFF
--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/ConfigurationServiceImpl.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/ConfigurationServiceImpl.java
@@ -84,6 +84,10 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                         });
     }
 
+    public void reload() {
+        readConfiguration();
+    }
+
     private void readCustomTranslations() {
         application
                 .getApplicationListeners()

--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/web/resource/WicketResourceResourceLoader.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/web/resource/WicketResourceResourceLoader.java
@@ -74,7 +74,7 @@ public class WicketResourceResourceLoader implements IStringResourceLoader {
                         string = findString(key, string, resourceBundle);
                     }
                 }
-            } catch (IOException e) {
+            } catch (IOException | IllegalStateException e) {
                 if (shouldThrowExceptionForMissingResource()) {
                     throw new WicketRuntimeException(
                             String.format(

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractMetadataTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractMetadataTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractMetadataTest {
 
     protected static MockData DATA_DIRECTORY;
 
-    private static File metadata;
+    protected static File metadata;
 
     private static File metadataTemplates;
 

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/EmptyConfigurationTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/EmptyConfigurationTest.java
@@ -1,0 +1,45 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.metadata;
+
+import org.apache.wicket.util.file.File;
+import org.geoserver.metadata.web.MetadataTemplatesPage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests that metadata module works 'out of the box', without any configuration present yet.
+ *
+ * @author niels
+ */
+public class EmptyConfigurationTest extends AbstractWicketMetadataTest {
+
+    private File metadataRenamed =
+            new File(DATA_DIRECTORY.getDataDirectoryRoot(), "metadata.renamed");
+
+    @Before
+    public void initEmptyConfiguration() throws Exception {
+        metadata.renameTo(metadataRenamed);
+    }
+
+    @After
+    public void restoreConfiguration() throws Exception {
+        metadataRenamed.renameTo(metadata);
+    }
+
+    @Test
+    public void testRenderPage() {
+        // just check if a page is rendered
+
+        login();
+
+        // Load the page
+        MetadataTemplatesPage page = new MetadataTemplatesPage();
+        tester.startPage(page);
+        tester.assertRenderedPage(MetadataTemplatesPage.class);
+    }
+}

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/EmptyConfigurationTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/EmptyConfigurationTest.java
@@ -6,10 +6,12 @@
 package org.geoserver.metadata;
 
 import org.apache.wicket.util.file.File;
+import org.geoserver.metadata.data.service.impl.ConfigurationServiceImpl;
 import org.geoserver.metadata.web.MetadataTemplatesPage;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Tests that metadata module works 'out of the box', without any configuration present yet.
@@ -17,6 +19,8 @@ import org.junit.Test;
  * @author niels
  */
 public class EmptyConfigurationTest extends AbstractWicketMetadataTest {
+
+    @Autowired protected ConfigurationServiceImpl configService;
 
     private File metadataRenamed =
             new File(DATA_DIRECTORY.getDataDirectoryRoot(), "metadata.renamed");
@@ -29,6 +33,7 @@ public class EmptyConfigurationTest extends AbstractWicketMetadataTest {
     @After
     public void restoreConfiguration() throws Exception {
         metadataRenamed.renameTo(metadata);
+        configService.reload();
     }
 
     @Test
@@ -41,5 +46,7 @@ public class EmptyConfigurationTest extends AbstractWicketMetadataTest {
         MetadataTemplatesPage page = new MetadataTemplatesPage();
         tester.startPage(page);
         tester.assertRenderedPage(MetadataTemplatesPage.class);
+
+        logout();
     }
 }


### PR DESCRIPTION
[![GEOS-10979](https://badgen.net/badge/JIRA/GEOS-10979/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10979)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6908
 **Authored by:** @NielsCharlier