### PR TITLE
[GEOS-11035] Enabling OSEO from Workspace Edit Page Results in an NPE

### DIFF
--- a/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/OSEOFactoryExtension.java
+++ b/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/OSEOFactoryExtension.java
@@ -1,0 +1,21 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.opensearch.eo;
+
+import org.geoserver.config.ServiceFactoryExtension;
+
+/** Factory extension for OSEOInfoImpl */
+public class OSEOFactoryExtension extends ServiceFactoryExtension<OSEOInfo> {
+    /** Creates a new instance of OSEOFactoryExtension */
+    public OSEOFactoryExtension() {
+        super(OSEOInfo.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T create(Class<T> clazz) {
+        return (T) new OSEOInfoImpl();
+    }
+}

--- a/src/community/oseo/oseo-core/src/main/resources/applicationContext.xml
+++ b/src/community/oseo/oseo-core/src/main/resources/applicationContext.xml
@@ -18,5 +18,7 @@
     <bean id="openSearchAccessProvider" class="org.geoserver.opensearch.eo.OpenSearchAccessProvider">
         <constructor-arg ref="geoServer" />
     </bean>
+
+    <bean id="oseoFactoryExtension" class="org.geoserver.opensearch.eo.OSEOFactoryExtension"/>
     
 </beans>

--- a/src/community/oseo/oseo-core/src/test/java/org/geoserver/opensearch/eo/OSEOFactoryExtensionTest.java
+++ b/src/community/oseo/oseo-core/src/test/java/org/geoserver/opensearch/eo/OSEOFactoryExtensionTest.java
@@ -1,0 +1,26 @@
+package org.geoserver.opensearch.eo;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+
+public class OSEOFactoryExtensionTest extends GeoServerSystemTestSupport {
+    @Test
+    public void testDirectCreate() throws Exception {
+        OSEOFactoryExtension oseo = new OSEOFactoryExtension();
+        OSEOInfo oseoInfo = oseo.create(OSEOInfo.class);
+        assertTrue(oseoInfo instanceof OSEOInfoImpl);
+    }
+
+    @Test
+    public void testCreateViaFactory() throws Exception {
+        GeoServer geoServer = getGeoServer();
+        WorkspaceInfo ws = geoServer.getCatalog().getWorkspaceByName("sf");
+        OSEOInfo oseoInfo = geoServer.getFactory().create(OSEOInfo.class);
+        assertNotNull(oseoInfo);
+    }
+}


### PR DESCRIPTION
[![GEOS-11035](https://badgen.net/badge/JIRA/GEOS-11035/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11035)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

tests


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->