### PR TITLE
[Backport 2.23.x] [GEOS-11036] The OAuth2*/OIDC security filters do not work as expected anymore after the spring-security-core depencency update to 5.7.8

### DIFF
--- a/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuth2SecurityConfiguration.java
+++ b/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuth2SecurityConfiguration.java
@@ -58,9 +58,8 @@ public abstract class GeoServerOAuth2SecurityConfiguration implements OAuth2Secu
     /** Details for an OAuth2-protected resource. */
     @Override
     public OAuth2ProtectedResourceDetails geoServerOAuth2Resource() {
-        AuthorizationCodeResourceDetails details = new GeoServerAuthorizatoionCodeResrouceDetails();
+        AuthorizationCodeResourceDetails details = new GeoServerAuthorizationCodeResourceDetails();
         details.setId(getDetailsId());
-
         details.setGrantType("authorization_code");
         details.setAuthenticationScheme(AuthenticationScheme.header);
         details.setClientAuthenticationScheme(AuthenticationScheme.form);
@@ -116,8 +115,12 @@ public abstract class GeoServerOAuth2SecurityConfiguration implements OAuth2Secu
                 geoServerOAuth2Resource(), new DefaultOAuth2ClientContext(getAccessTokenRequest()));
     }
 
-    private class GeoServerAuthorizatoionCodeResrouceDetails
+    /** Custom {@link AuthorizationCodeResourceDetails} */
+    protected static class GeoServerAuthorizationCodeResourceDetails
             extends AuthorizationCodeResourceDetails {
+
+        /** @return true if the client is only a client and does not have any user related */
+        @Override
         public boolean isClientOnly() {
             return true;
         }

--- a/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuth2SecurityConfiguration.java
+++ b/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuth2SecurityConfiguration.java
@@ -58,7 +58,7 @@ public abstract class GeoServerOAuth2SecurityConfiguration implements OAuth2Secu
     /** Details for an OAuth2-protected resource. */
     @Override
     public OAuth2ProtectedResourceDetails geoServerOAuth2Resource() {
-        AuthorizationCodeResourceDetails details = new AuthorizationCodeResourceDetails();
+        AuthorizationCodeResourceDetails details = new GeoServerAuthorizatoionCodeResrouceDetails();
         details.setId(getDetailsId());
 
         details.setGrantType("authorization_code");
@@ -115,4 +115,11 @@ public abstract class GeoServerOAuth2SecurityConfiguration implements OAuth2Secu
         return new OAuth2RestTemplate(
                 geoServerOAuth2Resource(), new DefaultOAuth2ClientContext(getAccessTokenRequest()));
     }
+
+    private class GeoServerAuthorizatoionCodeResrouceDetails
+            extends AuthorizationCodeResourceDetails {
+        public boolean isClientOnly() {
+            return true;
+        }
+    };
 }


### PR DESCRIPTION
[![GEOS-11036](https://badgen.net/badge/JIRA/GEOS-11036/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11036)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6938
 **Authored by:** @afabiani