### PR TITLE
[GEOS-10903] WMS filtering with Filter 2.0 fails

### DIFF
--- a/doc/en/user/source/services/wms/vendor.rst
+++ b/doc/en/user/source/services/wms/vendor.rst
@@ -191,6 +191,14 @@ An example of an OGC filter encoded in a GET request is::
 
    filter=%3CFilter%20xmlns:gml=%22http://www.opengis.net/gml%22%3E%3CIntersects%3E%3CPropertyName%3Ethe_geom%3C/PropertyName%3E%3Cgml:Point%20srsName=%224326%22%3E%3Cgml:coordinates%3E-74.817265,40.5296504%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E
 
+An example of an OGC filter encoding standard 2.0 in a GET request is::
+
+   filter=%3Cfes%3AFilter%20xmlns%3Axsi%3D%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema-instance%22%20xmlns%3Agml%3D%22http%3A%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%20xmlns%3Awfs%3D%22http%3A%2F%2Fwww.opengis.net%2Fwfs%22%20xmlns%3D%22http%3A%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns%3Afes%3D%22http%3A%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%3E%3Cfes%3APropertyIsLike%20wildCard%3D%22*%22%20singleChar%3D%22.%22%20escapeChar%3D%22!%22%3E%3Cfes%3AValueReference%3ENAME%3C%2Ffes%3AValueReference%3E%3Cfes%3ALiteral%3E*United*%3C%2Ffes%3ALiteral%3E%3C%2Ffes%3APropertyIsLike%3E%3C%2Ffes%3AFilter%3E  
+
+An example of an OGC filter encoding standard 2.0 ::
+	
+	<fes:Filter xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:wfs="http://www.opengis.net/wfs" xmlns="http://www.opengis.net/fes/2.0" xmlns:fes="http://www.opengis.net/fes/2.0"><fes:PropertyIsLike wildCard="*" singleChar="." escapeChar="!"><fes:ValueReference>NAME</fes:ValueReference><fes:Literal>*United*</fes:Literal></fes:PropertyIsLike></fes:Filter>
+
 .. _format_options:
 
 format_options

--- a/src/wms/src/main/java/applicationContext.xml
+++ b/src/wms/src/main/java/applicationContext.xml
@@ -857,4 +857,9 @@
     <bean id="wmsCiteComplianceCallback" class="org.geoserver.wms.CiteComplianceCallback">
         <constructor-arg ref="geoServer"/>
     </bean>
+
+    <bean id="wmsFilterKvpParser" class="org.geoserver.wms.kvp.FilterKvpParser">
+        <constructor-arg ref="entityResolverProvider"/>
+        <property name="service"><value>WMS</value></property>
+    </bean>
 </beans>

--- a/src/wms/src/test/java/org/geoserver/wms/map/png/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/png/GetMapIntegrationTest.java
@@ -146,4 +146,139 @@ public class GetMapIntegrationTest extends WMSTestSupport {
             assertEquals(Transparency.TRANSLUCENT, cm.getTransparency());
         }
     }
+
+    @Test
+    public void testwms2_0_0Filter() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wms?bbox="
+                                + bbox
+                                + "&styles=&layers="
+                                + layers
+                                + "&Format=image/png8"
+                                + "&request=GetMap"
+                                + "&width=550"
+                                + "&height=250"
+                                + "&srs=EPSG:4326&transparent=true");
+        assertEquals("image/png; mode=8bit", response.getContentType());
+
+        try (InputStream is = getBinaryInputStream(response)) {
+            BufferedImage bi = ImageIO.read(is);
+            IndexColorModel cm = (IndexColorModel) bi.getColorModel();
+            assertEquals(Transparency.TRANSLUCENT, cm.getTransparency());
+            assertEquals(cm.getMapSize(), 256);
+        }
+
+        MockHttpServletResponse response1 =
+                getAsServletResponse(
+                        "wms?bbox="
+                                + bbox
+                                + "&styles=&layers="
+                                + layers
+                                + "&SERVICE=WMS&VERSION=1.1.1"
+                                + "&Format=image/png8"
+                                + "&request=GetMap"
+                                + "&width=550"
+                                + "&height=250"
+                                + "&srs=EPSG:4326&transparent=true"
+                                + "&FILTER=%3Cfes%3AFilter%20xmlns%3Axsi%3D%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema-instance%22%20xmlns%3Agml%3D%22http%3A%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%20xmlns%3Awfs%3D%22http%3A%2F%2Fwww.opengis.net%2Fwfs%22%20xmlns%3D%22http%3A%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns%3Afes%3D%22http%3A%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%3E%3Cfes%3APropertyIsLike%20wildCard%3D%22*%22%20singleChar%3D%22.%22%20escapeChar%3D%22!%22%3E%3Cfes%3AValueReference%3EID%3C%2Ffes%3AValueReference%3E%3Cfes%3ALiteral%3E*0*%3C%2Ffes%3ALiteral%3E%3C%2Ffes%3APropertyIsLike%3E%3C%2Ffes%3AFilter%3E");
+        assertEquals("image/png; mode=8bit", response1.getContentType());
+
+        try (InputStream is1 = getBinaryInputStream(response1)) {
+            BufferedImage bi1 = ImageIO.read(is1);
+            IndexColorModel cm1 = (IndexColorModel) bi1.getColorModel();
+            assertEquals(Transparency.BITMASK, cm1.getTransparency());
+            assertTrue(cm1.getMapSize() < 256);
+        }
+    }
+
+    @Test
+    public void testwms1_1_0Filter() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wms?bbox="
+                                + bbox
+                                + "&styles=&layers="
+                                + layers
+                                + "&Format=image/png8"
+                                + "&request=GetMap"
+                                + "&width=550"
+                                + "&height=250"
+                                + "&srs=EPSG:4326&transparent=true");
+        assertEquals("image/png; mode=8bit", response.getContentType());
+
+        try (InputStream is = getBinaryInputStream(response)) {
+            BufferedImage bi = ImageIO.read(is);
+            IndexColorModel cm = (IndexColorModel) bi.getColorModel();
+            assertEquals(Transparency.TRANSLUCENT, cm.getTransparency());
+            assertEquals(cm.getMapSize(), 256);
+        }
+
+        MockHttpServletResponse response1 =
+                getAsServletResponse(
+                        "wms?bbox="
+                                + bbox
+                                + "&styles=&layers="
+                                + layers
+                                + "&SERVICE=WMS&VERSION=1.1.1"
+                                + "&Format=image/png8"
+                                + "&request=GetMap"
+                                + "&width=550"
+                                + "&height=250"
+                                + "&srs=EPSG:4326&transparent=true"
+                                + "&FILTER=%3Cogc%3AFilter%0A%09xmlns%3Agml%3D%22http%3A%2F%2Fwww.opengis.net%2Fgml%22%0A%09xmlns%3Aogc%3D%22http%3A%2F%2Fwww.opengis.net%2Fogc%22%3E%0A%09%3Cogc%3APropertyIsLike%20wildCard%3D%22*%22%20singleChar%3D%22.%22%20escapeChar%3D%22!%22%20matchCase%3D%22false%22%3E%0A%09%09%3Cogc%3APropertyName%3EID%3C%2Fogc%3APropertyName%3E%0A%09%09%3Cogc%3ALiteral%3E*1*%3C%2Fogc%3ALiteral%3E%0A%09%3C%2Fogc%3APropertyIsLike%3E%0A%09%3Cogc%3ASortBy%3E%0A%20%20%20%20%3Cogc%3APropertyName%3EID%3C%2Fogc%3APropertyName%3E%0A%20%20%20%20%3Cogc%3ASortOrderType%3EASCENDING%3C%2Fogc%3ASortOrderType%3E%0A%20%20%3C%2Fogc%3ASortBy%3E%0A%3C%2Fogc%3AFilter%3E");
+        assertEquals("image/png; mode=8bit", response.getContentType());
+
+        try (InputStream is1 = getBinaryInputStream(response1)) {
+            BufferedImage bi1 = ImageIO.read(is1);
+            IndexColorModel cm1 = (IndexColorModel) bi1.getColorModel();
+            assertEquals(Transparency.BITMASK, cm1.getTransparency());
+            assertTrue(cm1.getMapSize() < 256);
+        }
+    }
+
+    @Test
+    public void testwms1_0_0Filter() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse(
+                        "wms?bbox="
+                                + bbox
+                                + "&styles=&layers="
+                                + layers
+                                + "&Format=image/png8"
+                                + "&request=GetMap"
+                                + "&width=550"
+                                + "&height=250"
+                                + "&srs=EPSG:4326&transparent=true");
+        assertEquals("image/png; mode=8bit", response.getContentType());
+
+        try (InputStream is = getBinaryInputStream(response)) {
+            BufferedImage bi = ImageIO.read(is);
+            IndexColorModel cm = (IndexColorModel) bi.getColorModel();
+            assertEquals(Transparency.TRANSLUCENT, cm.getTransparency());
+            assertEquals(cm.getMapSize(), 256);
+        }
+
+        MockHttpServletResponse response1 =
+                getAsServletResponse(
+                        "wms?bbox="
+                                + bbox
+                                + "&styles=&layers="
+                                + layers
+                                + "&SERVICE=WMS&VERSION=1.1.1"
+                                + "&Format=image/png8"
+                                + "&request=GetMap"
+                                + "&width=550"
+                                + "&height=250"
+                                + "&srs=EPSG:4326&transparent=true"
+                                + "&FILTER=%3Cogc%3AFilter%0A%09xmlns%3Agml%3D%22http%3A%2F%2Fwww.opengis.net%2Fgml%22%0A%09xmlns%3Aogc%3D%22http%3A%2F%2Fwww.opengis.net%2Fogc%22%3E%0A%09%3Cogc%3APropertyIsLike%20wildCard%3D%22*%22%20singleChar%3D%22.%22%20escapeChar%3D%22!%22%20%3E%0A%09%09%3Cogc%3APropertyName%3EID%3C%2Fogc%3APropertyName%3E%0A%09%09%3Cogc%3ALiteral%3E*1*%3C%2Fogc%3ALiteral%3E%0A%09%3C%2Fogc%3APropertyIsLike%3E%0A%3C%2Fogc%3AFilter%3E");
+        assertEquals("image/png; mode=8bit", response1.getContentType());
+
+        try (InputStream is1 = getBinaryInputStream(response1)) {
+            BufferedImage bi1 = ImageIO.read(is1);
+            IndexColorModel cm1 = (IndexColorModel) bi1.getColorModel();
+            assertEquals(Transparency.BITMASK, cm1.getTransparency());
+            assertTrue(cm1.getMapSize() < 256);
+        }
+    }
 }


### PR DESCRIPTION
[![GEOS-10903](https://badgen.net/badge/JIRA/GEOS-10903/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10903)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->