### PR TITLE
[GEOS-10901] GetCapabilities lists the same style multiple times when…

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/LayerInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerInfo.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.catalog;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -65,6 +66,18 @@ public interface LayerInfo extends PublishedInfo {
      *     inverse="resourceInfo:org.geoserver.catalog.StyleInfo"
      */
     Set<StyleInfo> getStyles();
+
+    /**
+     * The non default styles available for the layer.
+     *
+     * @return non default Style Information
+     */
+    default Set<StyleInfo> styles() {
+        HashSet<StyleInfo> styles = new HashSet<>();
+        if (getStyles() != null) styles.addAll(getStyles());
+        if (getDefaultStyle() != null) styles.remove(getDefaultStyle());
+        return styles;
+    }
 
     /**
      * The resource referenced by this layer.

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1217,7 +1217,7 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
 
             // TODO: FeatureListURL
 
-            handleLayerStyles(layerName, layer.getDefaultStyle(), layer.getStyles());
+            handleLayerStyles(layerName, layer.getDefaultStyle(), layer.styles());
 
             handleScaleDenominator(layer);
 

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -1141,7 +1141,7 @@ public class GetCapabilitiesTransformer extends TransformerBase {
             // cascaded named styles
             // in the future (when we add support for that)
             if (!(layer.getResource() instanceof WMTSLayerInfo)) {
-                handleStyles(layerName, layer.getDefaultStyle(), layer.getStyles());
+                handleStyles(layerName, layer.getDefaultStyle(), layer.styles());
             }
 
             handleScaleHint(layer);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CapabilitiesTest.java
@@ -405,6 +405,16 @@ public class CapabilitiesTest extends WMSTestSupport {
         assertTrue(href.contains("GetLegendGraphic"));
         assertTrue(href.contains("layer=cdf%3AFifteen"));
         assertTrue(href.contains("style=point"));
+
+        // Default style set to point
+        layer.setDefaultStyle(pointStyle);
+        getCatalog().save(layer);
+        Document document = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.1.1", true);
+        assertXpathEvaluatesTo("1", "count(//Layer[Name='cdf:Fifteen'])", document);
+        assertXpathEvaluatesTo("1", "count(//Layer[Name='cdf:Fifteen']/Style)", document);
+        // getStyles() has the default style, styles() doesnt have default style
+        assertTrue(layer.getStyles().contains(pointStyle));
+        assertFalse(layer.styles().contains(pointStyle));
     }
 
     @Test

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesIntegrationTest.java
@@ -352,6 +352,17 @@ public class CapabilitiesIntegrationTest extends WMSTestSupport {
         assertTrue(href.contains("GetLegendGraphic"));
         assertTrue(href.contains("layer=cdf%3AFifteen"));
         assertTrue(href.contains("style=point"));
+
+        // Default style set to point
+        layer.setDefaultStyle(pointStyle);
+        getCatalog().save(layer);
+        Document document = getAsDOM("wms?service=WMS&request=getCapabilities&version=1.3.0", true);
+        assertXpathEvaluatesTo("1", "count(//wms:Layer[wms:Name='cdf:Fifteen'])", document);
+        assertXpathEvaluatesTo(
+                "1", "count(//wms:Layer[wms:Name='cdf:Fifteen']/wms:Style)", document);
+        // getStyles() has the default style, styles() doesnt have default style
+        assertTrue(layer.getStyles().contains(pointStyle));
+        assertFalse(layer.styles().contains(pointStyle));
     }
 
     @org.junit.Test


### PR DESCRIPTION
[![GEOS-10901](https://badgen.net/badge/JIRA/GEOS-10901/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10901)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… used as both a default and alternate style


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->