### PR TITLE
[GEOS-10856] geoserver monitor plugin - scaling troubles

### DIFF
--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorConfig.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorConfig.java
@@ -65,6 +65,10 @@ public class MonitorConfig implements GeoServerPluginConfigurator, ApplicationCo
     Exception error;
     private GeoServerResourceLoader loader;
 
+    static final int POSTPROCES_THREADS_DEFAULT = 2;
+
+    static final String DNS_CACHE_DEFAULT = "expireAfterWrite=15m";
+
     public MonitorConfig() {
         props = new PropertyFileWatcher.LinkedProperties();
         props.put("storage", "memory");
@@ -301,5 +305,34 @@ public class MonitorConfig implements GeoServerPluginConfigurator, ApplicationCo
                 fw.setKnownLastModified(System.currentTimeMillis());
             }
         }
+    }
+
+    public int getPostProcessorThreads() {
+        Properties props = props();
+        String key = "postprocessorthreads";
+        String svalue = props.getProperty(key);
+        if (svalue != null) {
+            try {
+                int nvalue = Integer.parseInt(svalue.trim());
+                if (nvalue < 1) {
+                    LOGGER.warning(key + " is not 1 or more :" + svalue + "!");
+                } else {
+                    return nvalue;
+                }
+            } catch (NumberFormatException e) {
+                LOGGER.warning(key + " has non-integer value:" + svalue + "!");
+            }
+        }
+        return POSTPROCES_THREADS_DEFAULT;
+    }
+
+    public String getDNSCacheConfiguration() {
+        Properties props = props();
+        String key = "dnscacheconfiguration";
+        String value = props.getProperty(key);
+        if (value == null) {
+            value = DNS_CACHE_DEFAULT;
+        }
+        return value;
     }
 }

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
@@ -54,21 +54,22 @@ public class MonitorFilter implements GeoServerFilter {
         this.monitor = monitor;
         this.requestFilter = requestFilter;
 
-        postProcessExecutor = Executors.newFixedThreadPool(
-            monitor.getConfig().getPostProcessorThreads(),
-            new ThreadFactory() {
-                //This wrapper overrides the thread names
-                ThreadFactory parent = Executors.defaultThreadFactory();
-                int count = 1;
+        postProcessExecutor =
+                Executors.newFixedThreadPool(
+                        monitor.getConfig().getPostProcessorThreads(),
+                        new ThreadFactory() {
+                            // This wrapper overrides the thread names
+                            ThreadFactory parent = Executors.defaultThreadFactory();
+                            int count = 1;
 
-                @Override
-                public synchronized Thread newThread(Runnable runnable) {
-                    Thread t = parent.newThread(runnable);
-                    t.setName("monitor-" + count);
-                    count++;
-                    return t;
-                }
-            });
+                            @Override
+                            public synchronized Thread newThread(Runnable runnable) {
+                                Thread t = parent.newThread(runnable);
+                                t.setName("monitor-" + count);
+                                count++;
+                                return t;
+                            }
+                        });
         if (monitor.isEnabled()) {
             LOGGER.info("Monitor extension enabled");
         } else {

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/MonitorFilter.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,8 +54,21 @@ public class MonitorFilter implements GeoServerFilter {
         this.monitor = monitor;
         this.requestFilter = requestFilter;
 
-        postProcessExecutor = Executors.newFixedThreadPool(2);
+        postProcessExecutor = Executors.newFixedThreadPool(
+            monitor.getConfig().getPostProcessorThreads(),
+            new ThreadFactory() {
+                //This wrapper overrides the thread names
+                ThreadFactory parent = Executors.defaultThreadFactory();
+                int count = 1;
 
+                @Override
+                public synchronized Thread newThread(Runnable runnable) {
+                    Thread t = parent.newThread(runnable);
+                    t.setName("monitor-" + count);
+                    count++;
+                    return t;
+                }
+            });
         if (monitor.isEnabled()) {
             LOGGER.info("Monitor extension enabled");
         } else {
@@ -293,7 +307,8 @@ public class MonitorFilter implements GeoServerFilter {
             try {
                 SecurityContextHolder.getContext().setAuthentication(propagatedAuth);
                 List<RequestPostProcessor> pp = new ArrayList<>();
-                pp.add(new ReverseDNSPostProcessor());
+
+                pp.add(ReverseDNSPostProcessor.get(monitor.getConfig()));
                 pp.addAll(GeoServerExtensions.extensions(RequestPostProcessor.class));
                 Set<String> ignoreList = this.monitor.getConfig().getIgnorePostProcessors();
 

--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ReverseDNSPostProcessor.java
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/ReverseDNSPostProcessor.java
@@ -5,41 +5,79 @@
  */
 package org.geoserver.monitor;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.geotools.util.SoftValueHashMap;
 import org.geotools.util.logging.Logging;
 
 public class ReverseDNSPostProcessor implements RequestPostProcessor {
-    static final Logger LOGGER = Logging.getLogger(ReverseDNSPostProcessor.class);
 
-    static Map<String, String> reverseLookupCache = new SoftValueHashMap<>(100);
+    private static final class DNSCacheLoader extends CacheLoader<String, String> {
+        public String load(String remoteAddr) {
+            try {
+                InetAddress addr = InetAddress.getByName(remoteAddr);
+                return addr.getHostName();
+            } catch (UnknownHostException e) {
+                LOGGER.log(Level.FINE, "Error reverse looking up " + remoteAddr, e);
+                // We also cache failures, they are expensive to calculate
+                return remoteAddr;
+            }
+        }
+    }
+
+    static final Logger LOGGER = Logging.getLogger(ReverseDNSPostProcessor.class);
 
     static final String PROCESSOR_NAME = "reverseDNS";
 
-    @Override
-    public void run(RequestData data, HttpServletRequest request, HttpServletResponse response)
-            throws Exception {
-        String host = reverseLookupCache.get(data.getRemoteAddr());
-        if (host == null) {
-            try {
-                InetAddress addr = InetAddress.getByName(data.getRemoteAddr());
-                host = addr.getHostName();
-            } catch (UnknownHostException e) {
-                LOGGER.log(Level.FINE, "Error reverse looking up " + data.getRemoteAddr(), e);
-            }
-        }
+    final LoadingCache<String, String> reverseLookupCache; // Not private for test
 
+    private static RequestPostProcessor INSTANCE;
+
+    public ReverseDNSPostProcessor(MonitorConfig config) {
+        String cacheConfiguration = config.getDNSCacheConfiguration();
+        LoadingCache<String, String> cache;
+        try {
+            cache = CacheBuilder.from(cacheConfiguration).build(new DNSCacheLoader());
+        } catch (Throwable e) {
+            LOGGER.warning(
+                    "Invalid config "
+                            + cacheConfiguration
+                            + ", reverting to default."
+                            + e.getMessage());
+            cache = CacheBuilder.from(MonitorConfig.DNS_CACHE_DEFAULT).build(new DNSCacheLoader());
+        }
+        reverseLookupCache = cache;
+    }
+
+    @Override
+    public void run(RequestData data, HttpServletRequest request, HttpServletResponse response) {
+        String addr = data.getRemoteAddr();
+        String host;
+        try {
+            host = reverseLookupCache.get(addr);
+        } catch (ExecutionException e) {
+            LOGGER.log(Level.WARNING, "Internal error", e);
+            host = addr;
+        }
         data.setRemoteHost(host);
     }
 
     @Override
     public String getName() {
         return PROCESSOR_NAME;
+    }
+
+    public static synchronized RequestPostProcessor get(MonitorConfig config) {
+        if (INSTANCE == null) {
+            INSTANCE = new ReverseDNSPostProcessor(config);
+        }
+        return INSTANCE;
     }
 }

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/MonitorConfigTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/MonitorConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * (c) 2023 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.monitor;
+
+import java.net.InetAddress;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MonitorConfigTest {
+
+    @Test
+    public void shouldPostProcessorThreadsReturnDefault() {
+        MonitorConfig config = new MonitorConfig();
+        // Don't set a value form the property here
+        int actual = config.getPostProcessorThreads();
+        Assert.assertEquals(MonitorConfig.POSTPROCES_THREADS_DEFAULT, actual);
+    }
+
+    @Test
+    public void shouldPostProcessorThreadsReturnConfiguredValue() {
+        MonitorConfig config = new MonitorConfig();
+        config.props().put("postprocessorthreads", " 5 ");
+        int actual = config.getPostProcessorThreads();
+        Assert.assertEquals(5, actual);
+    }
+
+    @Test
+    public void shouldPostProcessorThreadsIgnoreNonNumber() {
+        MonitorConfig config = new MonitorConfig();
+        config.props().put("postprocessorthreads", "not a number");
+        int actual = config.getPostProcessorThreads();
+        Assert.assertEquals(MonitorConfig.POSTPROCES_THREADS_DEFAULT, actual);
+    }
+
+    @Test
+    public void shouldPostProcessorThreadsIgnoreTooSmall() {
+        MonitorConfig config = new MonitorConfig();
+        config.props().put("postprocessorthreads", "0");
+        int actual = config.getPostProcessorThreads();
+        Assert.assertEquals(MonitorConfig.POSTPROCES_THREADS_DEFAULT, actual);
+    }
+
+    @Test
+    public void shouldDNSCacheUseDefaultConfig() throws Exception {
+        MonitorConfig config = new MonitorConfig();
+        ReverseDNSPostProcessor dut = new ReverseDNSPostProcessor(config);
+        RequestData req = new RequestData();
+        req.setRemoteAddr(InetAddress.getLocalHost().getHostAddress());
+        dut.run(req, null, null);
+        Assert.assertNotNull(req.getRemoteHost());
+        Assert.assertTrue("Cache should be working", dut.reverseLookupCache.size() > 0);
+    }
+
+    @Test
+    public void shouldDNSCacheIgnoreInvalidConfig() throws Exception {
+        MonitorConfig config = new MonitorConfig();
+        config.props().put("dnscacheconfiguration", "this makes no sense");
+        ReverseDNSPostProcessor dut = new ReverseDNSPostProcessor(config);
+        RequestData req = new RequestData();
+        req.setRemoteAddr(InetAddress.getLocalHost().getHostAddress());
+        dut.run(req, null, null);
+        Assert.assertNotNull(req.getRemoteHost());
+        Assert.assertTrue("Cache should be working", dut.reverseLookupCache.size() > 0);
+    }
+
+    @Test
+    public void shouldDNSCacheUseConfig() throws Exception {
+        MonitorConfig config = new MonitorConfig();
+        config.props().put("dnscacheconfiguration", "maximumSize=0");
+        ReverseDNSPostProcessor dut = new ReverseDNSPostProcessor(config);
+        RequestData req = new RequestData();
+        req.setRemoteAddr(InetAddress.getLocalHost().getHostAddress());
+        dut.run(req, null, null);
+        Assert.assertNotNull(req.getRemoteHost());
+        Assert.assertTrue(
+                "maximumSize=0 violated",
+                dut.reverseLookupCache.size() == 0); // Still empty as max size=0
+    }
+}


### PR DESCRIPTION
[![GEOS-10856](https://badgen.net/badge/JIRA/GEOS-10856/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10856)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->