### PR TITLE
[Backport 2.23.x] [GEOS-11060] charts and mssql extension zips are missing the extension

### DIFF
--- a/src/release/ext-charts.xml
+++ b/src/release/ext-charts.xml
@@ -9,6 +9,7 @@
       <directory>release/target/dependency</directory>
       <outputDirectory></outputDirectory>
       <includes>
+        <include>gs-charts-*.jar</include>
         <include>gt-charts-*.jar</include>
         <include>jfreechart*.jar</include>
         <include>jcommon*.jar</include>

--- a/src/release/ext-sqlserver.xml
+++ b/src/release/ext-sqlserver.xml
@@ -18,6 +18,7 @@
       <includes>
         <include>gt-jdbc-core-*.jar</include>
         <include>gt-jdbc-sqlserver-*.jar</include>
+        <include>gs-sqlserver-*.jar</include>
         <include>mssql-jdbc*</include>
       </includes>
       <excludes>


### PR DESCRIPTION
[![GEOS-11060](https://badgen.net/badge/JIRA/GEOS-11060/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11060)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #6996
 **Authored by:** @hyperman2