### PR TITLE
[GEOS-11069] Layer configuration page doesn't work for broken layers

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/AttributeTypeInfoEditor.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/AttributeTypeInfoEditor.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.web.data.resource;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -126,10 +127,18 @@ class AttributeTypeInfoEditor extends Panel {
             return resourcePool.loadAttributes(typeInfo);
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Grabbing the attribute list failed", e);
+            String errorMessage = e.getMessage();
+            if (e.getCause() != null && e.getCause() instanceof SQLException) {
+                errorMessage = e.getCause().getMessage();
+            }
             String error =
-                    new ParamResourceModel("attributeListingFailed", component, e.getMessage())
+                    new ParamResourceModel("attributeListingFailed", component, errorMessage)
                             .getString();
-            component.getPage().error(error);
+            try {
+                component.getPage().error(error);
+            } catch (Exception e1) {
+                LOGGER.log(Level.SEVERE, "Grabbing the attribute list failed", e1.getMessage());
+            }
             return Collections.emptyList();
         }
     }

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
@@ -82,15 +82,23 @@ import org.geoserver.web.data.store.panel.ParamPanel;
 import org.geoserver.web.data.store.panel.TextParamPanel;
 import org.geoserver.web.util.MapModel;
 import org.geotools.data.DataAccess;
+import org.geotools.data.DataStore;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.data.wfs.WFSDataStoreFactory;
+import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.NameImpl;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.gce.imagemosaic.ImageMosaicFormat;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.jdbc.VirtualTable;
 import org.geotools.referencing.CRS;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.locationtech.jts.io.WKTReader;
 import org.opengis.referencing.FactoryException;
 import org.springframework.security.core.Authentication;
 
@@ -945,5 +953,85 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
         assertEquals(
                 "attribute described", att.getDescription().toString(GeoServerDefaultLocale.get()));
         assertEquals(cql, att.getSource());
+    }
+
+    @Test
+    public void testCustomizeAttributesJdbc() throws Exception {
+        Catalog cat = getCatalog();
+        DataStoreInfo ds = cat.getFactory().createDataStore();
+        ds.setName("foo");
+        ds.setWorkspace(cat.getDefaultWorkspace());
+        ds.setEnabled(true);
+        Map<String, Serializable> params = ds.getConnectionParameters();
+        params.put("dbtype", "h2");
+        params.put("database", getTestData().getDataDirectoryRoot().getAbsolutePath() + "/foo");
+        cat.add(ds);
+        SimpleFeatureSource fs1 = getFeatureSource(SystemTestData.FORESTS);
+        DataStore store = (DataStore) ds.getDataStore(null);
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.init(fs1.getSchema());
+        store.createSchema(tb.buildFeatureType());
+        CatalogBuilder cb = new CatalogBuilder(cat);
+        cb.setStore(ds);
+
+        SimpleFeatureStore fs = (SimpleFeatureStore) store.getFeatureSource("Forests");
+        fs.addFeatures(fs1.getFeatures());
+        addFeature(
+                fs,
+                "MULTIPOLYGON (((0.008151604330777 -0.0023208963631571, 0.0086527358638763 -0.0012374917185382, 0.0097553137885805 -0.0004505798694767, 0.0156132468328575 0.001226912691216, 0.0164282119026783 0.0012863836826631, 0.0171241513076058 0.0011195104764988, 0.0181763809803841 0.0003258121477801, 0.018663180519973 -0.0007914339515293, 0.0187 -0.0054, 0.0185427596344991 -0.0062643098258021, 0.0178950534559435 -0.0072336706251426, 0.0166538015456463 -0.0078538015456464, 0.0160336706251426 -0.0090950534559435, 0.0150643098258021 -0.0097427596344991, 0.0142 -0.0099, 0.0086 -0.0099, 0.0077356901741979 -0.0097427596344991, 0.0067663293748574 -0.0090950534559435, 0.0062572403655009 -0.0082643098258021, 0.0061 -0.0074, 0.0061055767515099 -0.0046945371967831, 0.0062818025956546 -0.0038730531083409, 0.0066527358638763 -0.0032374917185382, 0.0072813143786463 -0.0026800146279973, 0.008151604330777 -0.0023208963631571)))",
+                "110",
+                "Foo Forest");
+        addFeature(
+                fs,
+                "MULTIPOLYGON (((-0.0023852705061082 -0.005664537521815, -0.0026781637249217 -0.0063716443030016, -0.0033852705061082 -0.006664537521815, -0.0040923772872948 -0.0063716443030016, -0.0043852705061082 -0.005664537521815, -0.0040923772872947 -0.0049574307406285, -0.0033852705061082 -0.004664537521815, -0.0026781637249217 -0.0049574307406285, -0.0023852705061082 -0.005664537521815)))",
+                "111",
+                "Bar Forest");
+        FeatureTypeInfo ft = cb.buildFeatureType(fs);
+        VirtualTable vt = new VirtualTable("test", "SELECT FID,NAD FROM \"Forests\"");
+        ft.getMetadata().put(FeatureTypeInfo.JDBC_VIRTUAL_TABLE, vt);
+
+        cat.add(ft);
+        LayerInfo layer = cat.getFactory().createLayer();
+        layer.setResource(ft);
+        login();
+        tester.startPage(new ResourceConfigurationPage(layer, false));
+        String text = tester.getLastResponse().getDocument();
+
+        assertTrue(text.contains("gs:Forests"));
+        assertTrue(text.contains("Basic Resource Info"));
+        assertTrue(text.contains("Feature Type Details"));
+        assertTrue(text.contains("Edit sql view"));
+        assertTrue(
+                text.contains(
+                        "Failed to load attribute list, internal error is: Column NAD not found"));
+
+        // After updating SQL view correctly error message should not be present
+        VirtualTable vt1 = new VirtualTable("test", "SELECT FID,NAME FROM \"Forests\"");
+        ft.getMetadata().put(FeatureTypeInfo.JDBC_VIRTUAL_TABLE, vt1);
+
+        LayerInfo layer1 = cat.getFactory().createLayer();
+        layer1.setResource(ft);
+        tester.startPage(new ResourceConfigurationPage(layer1, false));
+        String text1 = tester.getLastResponse().getDocument();
+
+        assertTrue(text1.contains("gs:Forests"));
+        assertTrue(text1.contains("Basic Resource Info"));
+        assertTrue(text1.contains("Feature Type Details"));
+        assertTrue(text1.contains("Edit sql view"));
+        assertFalse(
+                text1.contains(
+                        "Failed to load attribute list, internal error is: Column NAD not found"));
+    }
+
+    void addFeature(SimpleFeatureStore store, String wkt, Object... atts) throws Exception {
+        SimpleFeatureBuilder b = new SimpleFeatureBuilder(store.getSchema());
+        b.add(new WKTReader().read(wkt));
+        for (Object att : atts) {
+            b.add(att);
+        }
+
+        DefaultFeatureCollection features = new DefaultFeatureCollection(null, null);
+        features.add(b.buildFeature(null));
+        store.addFeatures(features);
     }
 }


### PR DESCRIPTION
[![GEOS-11069](https://badgen.net/badge/JIRA/GEOS-11069/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11069)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->