### PR TITLE
[Backport 2.22.x] [GEOS-11067] Upgrade wiremock to 2.35.0

### DIFF
--- a/src/community/security/keycloak/pom.xml
+++ b/src/community/security/keycloak/pom.xml
@@ -138,8 +138,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.1.12</version>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
@@ -126,8 +126,7 @@
 
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.1.12</version>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/community/web-service-auth/pom.xml
+++ b/src/community/web-service-auth/pom.xml
@@ -61,8 +61,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.18.0</version>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/wps/wps-core/pom.xml
+++ b/src/extension/wps/wps-core/pom.xml
@@ -150,7 +150,6 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8-standalone</artifactId>
-      <version>2.33.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1493,8 +1493,8 @@
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-standalone</artifactId>
-        <version>2.27.2</version>
+        <artifactId>wiremock-jre8-standalone</artifactId>
+        <version>2.35.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -139,7 +139,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -167,7 +167,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
[![GEOS-11067](https://badgen.net/badge/JIRA/GEOS-11067/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11067)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7016
 **Authored by:** @sikeoka