### PR TITLE
[GEOS-11074] GeoFence may not load property file at boot

### DIFF
--- a/src/extension/geofence/geofence/src/main/java/org/geoserver/geofence/config/GeoFenceConfigurationManager.java
+++ b/src/extension/geofence/geofence/src/main/java/org/geoserver/geofence/config/GeoFenceConfigurationManager.java
@@ -8,15 +8,18 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.lang3.BooleanUtils;
 import org.geoserver.geofence.GeofenceAccessManager;
 import org.geoserver.geofence.cache.CacheConfiguration;
 import org.geoserver.platform.resource.Resource;
 import org.geotools.util.logging.Logging;
+import org.springframework.beans.factory.InitializingBean;
 
 /** @author ETj (etj at geo-solutions.it) */
-public class GeoFenceConfigurationManager {
+public class GeoFenceConfigurationManager implements InitializingBean {
 
     private static final Logger LOGGER = Logging.getLogger(GeofenceAccessManager.class);
 
@@ -26,19 +29,44 @@ public class GeoFenceConfigurationManager {
 
     private CacheConfiguration cacheConfiguration;
 
+    private static final String PROP_INSTANCE_NAME = "instanceName";
+    private static final String PROP_SERVICES_URL = "servicesUrl";
+    private static final String PROP_ALLOW_REMOTE = "allowRemoteAndInlineLayers";
+    private static final String PROP_GRANT_WRITE = "grantWriteToWorkspacesToAuthenticatedUsers";
+    private static final String PROP_USE_ROLES = "useRolesToFilter";
+    private static final String PROP_ACCEPTED_ROLES = "acceptedRoles";
+    private static final String PROP_GWCCONTEXTSUFFIX = "gwc.context.suffix";
+    private static final String PROP_ORGGEOSERVERREST =
+            "org.geoserver.rest.DefaultUserGroupServiceName";
+    private static final String PROP_CACHE_EXPIRE = "cacheExpire";
+    private static final String PROP_CACHE_REFRESH = "cacheRefresh";
+    private static final String PROP_CACHE_SIZE = "cacheSize";
+
+    private static final String[] ALL_GEOFENCE_PROPS = {
+        PROP_INSTANCE_NAME,
+        PROP_SERVICES_URL,
+        PROP_ALLOW_REMOTE,
+        PROP_GRANT_WRITE,
+        PROP_USE_ROLES,
+        PROP_ACCEPTED_ROLES,
+        PROP_GWCCONTEXTSUFFIX,
+        PROP_ORGGEOSERVERREST,
+    };
+    private static final String[] ALL_CACHE_PROPS = {
+        PROP_CACHE_SIZE, PROP_CACHE_REFRESH, PROP_CACHE_EXPIRE,
+    };
+
     public GeoFenceConfiguration getConfiguration() {
         return geofenceConfiguration;
     }
 
     /** Updates the configuration. */
-    public void setConfiguration(GeoFenceConfiguration configuration) {
+    public void setConfiguration(GeoFenceConfiguration cfg) {
 
-        this.geofenceConfiguration = configuration;
+        this.geofenceConfiguration = cfg;
 
         LOGGER.log(
-                Level.INFO,
-                "GeoFence configuration: instance name is {0}",
-                configuration.getInstanceName());
+                Level.INFO, "GeoFence configuration: instance name is {0}", cfg.getInstanceName());
     }
 
     public CacheConfiguration getCacheConfiguration() {
@@ -66,43 +94,120 @@ public class GeoFenceConfigurationManager {
     }
 
     /** Saves current configuration to disk. */
-    protected void saveConfiguration(Writer writer, GeoFenceConfiguration configuration)
-            throws IOException {
+    protected void saveConfiguration(Writer writer, GeoFenceConfiguration cfg) throws IOException {
 
         writer.write("### GeoFence main configuration\n\n");
+        Properties props = configAsProperties(cfg);
+        for (String propname : ALL_GEOFENCE_PROPS) {
+            saveConfig(writer, propname, props.getProperty(propname));
+        }
+    }
 
-        saveConfig(writer, "instanceName", configuration.getInstanceName());
-        saveConfig(writer, "servicesUrl", configuration.getServicesUrl());
-        saveConfig(
-                writer, "allowRemoteAndInlineLayers", configuration.isAllowRemoteAndInlineLayers());
-        saveConfig(
-                writer,
-                "grantWriteToWorkspacesToAuthenticatedUsers",
-                configuration.isGrantWriteToWorkspacesToAuthenticatedUsers());
-        saveConfig(writer, "useRolesToFilter", configuration.isUseRolesToFilter());
-        saveConfig(writer, "acceptedRoles", configuration.getAcceptedRoles());
-        saveConfig(writer, "gwc.context.suffix", configuration.getGwcContextSuffix());
-        saveConfig(
-                writer,
-                "org.geoserver.rest.DefaultUserGroupServiceName",
-                configuration.getDefaultUserGroupServiceName());
+    public void saveConfiguration(Writer writer, CacheConfiguration cfg) throws IOException {
+
+        writer.write("\n\n### Cache configuration\n\n");
+        Properties props = configAsProperties(cfg);
+        for (String propname : ALL_CACHE_PROPS) {
+            saveConfig(writer, propname, props.getProperty(propname));
+        }
     }
 
     protected void saveConfig(Writer writer, String name, Object value) throws IOException {
         writer.write(name + "=" + String.valueOf(value) + "\n");
     }
 
-    public void saveConfiguration(Writer writer, CacheConfiguration params) throws IOException {
-
-        writer.write("\n\n### Cache configuration\n\n");
-
-        saveConfig(writer, "cacheSize", params.getSize());
-        saveConfig(writer, "cacheRefresh", params.getRefreshMilliSec());
-        saveConfig(writer, "cacheExpire", params.getExpireMilliSec());
-    }
-
     /** Returns a copy of the configuration. */
     public void setConfigurer(GeoFencePropertyPlaceholderConfigurer configurer) {
         this.configurer = configurer;
+    }
+
+    /**
+     * The PropertyPlaceholderConfigurer may have race conditions sometimes, so we're going to read
+     * the props from the file and assign them to the GeoFenceConfiguration
+     */
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        LOGGER.log(
+                Level.INFO,
+                "GeoFence configuration: force setting properties from {0}",
+                configurer.getConfigFile().path());
+
+        if (loadConfiguration())
+            LOGGER.log(
+                    Level.INFO,
+                    "GeoFence configuration: instance name is {0}",
+                    geofenceConfiguration.getInstanceName());
+    }
+
+    public boolean loadConfiguration() throws IOException {
+        Resource configurationFile = configurer.getConfigFile();
+
+        Properties defaults = configAsProperties(geofenceConfiguration);
+        defaults.putAll(configAsProperties(cacheConfiguration));
+
+        Properties props = new Properties(defaults);
+
+        try {
+            props.load(configurationFile.in());
+        } catch (IllegalStateException e) {
+
+            LOGGER.log(
+                    Level.INFO,
+                    "GeoFence configuration: could not open property file {0}",
+                    configurer.getConfigFile().path());
+            return false;
+        }
+
+        loadConfiguration(props, geofenceConfiguration);
+        loadConfiguration(props, cacheConfiguration);
+        return true;
+    }
+
+    private void loadConfiguration(Properties props, GeoFenceConfiguration cfg) {
+        cfg.setInstanceName(props.getProperty(PROP_INSTANCE_NAME));
+        cfg.setServicesUrl(props.getProperty(PROP_SERVICES_URL));
+        cfg.setAllowRemoteAndInlineLayers(
+                BooleanUtils.toBoolean(props.getProperty(PROP_ALLOW_REMOTE)));
+        cfg.setGrantWriteToWorkspacesToAuthenticatedUsers(
+                BooleanUtils.toBoolean(props.getProperty(PROP_GRANT_WRITE)));
+        cfg.setUseRolesToFilter(BooleanUtils.toBoolean(props.getProperty(PROP_USE_ROLES)));
+        cfg.setAcceptedRoles(props.getProperty(PROP_ACCEPTED_ROLES));
+        cfg.setGwcContextSuffix(props.getProperty(PROP_GWCCONTEXTSUFFIX));
+    }
+
+    private void loadConfiguration(Properties props, CacheConfiguration cfg) {
+        cfg.setSize(Long.parseLong(props.getProperty(PROP_CACHE_SIZE)));
+        cfg.setRefreshMilliSec(Long.parseLong(props.getProperty(PROP_CACHE_REFRESH)));
+        cfg.setExpireMilliSec(Long.parseLong(props.getProperty(PROP_CACHE_EXPIRE)));
+    }
+
+    public Properties configAsProperties(GeoFenceConfiguration cfg) {
+        Properties props = new Properties(10);
+        props.setProperty(PROP_INSTANCE_NAME, cfg.getInstanceName());
+        props.setProperty(PROP_SERVICES_URL, cfg.getServicesUrl());
+        props.setProperty(PROP_ALLOW_REMOTE, format_prop(cfg.isAllowRemoteAndInlineLayers()));
+        props.setProperty(
+                PROP_GRANT_WRITE, format_prop(cfg.isGrantWriteToWorkspacesToAuthenticatedUsers()));
+        props.setProperty(PROP_USE_ROLES, format_prop(cfg.isUseRolesToFilter()));
+        props.setProperty(PROP_ACCEPTED_ROLES, format_prop(cfg.getAcceptedRoles()));
+        props.setProperty(PROP_GWCCONTEXTSUFFIX, format_prop(cfg.getGwcContextSuffix()));
+        props.setProperty(PROP_ORGGEOSERVERREST, format_prop(cfg.getDefaultUserGroupServiceName()));
+        return props;
+    }
+
+    public Properties configAsProperties(CacheConfiguration cfg) {
+        Properties props = new Properties(3);
+        props.setProperty(PROP_CACHE_SIZE, String.valueOf(cfg.getSize()));
+        props.setProperty(PROP_CACHE_REFRESH, String.valueOf(cfg.getRefreshMilliSec()));
+        props.setProperty(PROP_CACHE_EXPIRE, String.valueOf(cfg.getExpireMilliSec()));
+        return props;
+    }
+
+    static String format_prop(String s) {
+        return s != null ? s : "";
+    }
+
+    static String format_prop(boolean b) {
+        return String.valueOf(b);
     }
 }


### PR DESCRIPTION
[![GEOS-11074](https://badgen.net/badge/JIRA/GEOS-11074/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11074)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The values in `geofence/geofence-server.properties` are not always read into the configuration class.

It happens randomly, so it seems it may a be a race condition.

The proposed fix is to programmatically load the property file using an InitializingBean:afterPropertiesSet() callback. In this way we'll also provide an entrypoint method to reload the configuration on request -- pls note that the GeoFence plugin is not realoading the configuration at runtime yet.

The basic changes are only related to the adding of the `afterPropertiesSet()` and `loadConfiguration()`, anyway prop names and save procedure have been refactored a lot, in order to allow furter clean up ASAP; we dont want to backport future cleanup if not required..


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->