### PR TITLE
[GEOS-11068] Keycloak: custom admin role not picked up

### DIFF
--- a/src/community/security/keycloak/src/test/java/org/geoserver/security/keycloak/GeoServerKeycloakFilterTest.java
+++ b/src/community/security/keycloak/src/test/java/org/geoserver/security/keycloak/GeoServerKeycloakFilterTest.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.geoserver.security.GeoServerSecurityTestSupport;
 import org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig;
 import org.geoserver.security.filter.GeoServerSecurityFilter;
+import org.geoserver.security.impl.AbstractRoleService;
 import org.geoserver.security.impl.GeoServerRole;
 import org.junit.After;
 import org.junit.Before;
@@ -113,6 +114,12 @@ public class GeoServerKeycloakFilterTest extends GeoServerSecurityTestSupport {
         when(request.getHeaders(anyString())).thenReturn(Collections.emptyEnumeration());
         response = mock(HttpServletResponse.class);
         chain = mock(FilterChain.class);
+
+        AbstractRoleService mockRoleService = mock(AbstractRoleService.class);
+        GeoServerRole admin = new GeoServerRole("admin");
+        when(mockRoleService.getRoleByName("admin")).thenReturn(admin);
+        when(mockRoleService.getAdminRole()).thenReturn(admin);
+        getSecurityManager().setActiveRoleService(mockRoleService);
     }
 
     // remove any possible side-effects to avoid interfering with the next test
@@ -251,6 +258,7 @@ public class GeoServerKeycloakFilterTest extends GeoServerSecurityTestSupport {
         assertTrue(roles.contains("create-realm"));
         assertTrue(roles.contains("admin"));
         assertTrue(roles.contains("uma_authorization"));
+        assertTrue(roles.contains(GeoServerRole.ADMIN_ROLE.getAuthority()));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11068](https://badgen.net/badge/JIRA/GEOS-11068/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11068)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->