### PR TITLE
[GEOS-11033] Fix the readonly style of an input field

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -440,10 +440,6 @@ select {
   color: #000;
 }
 
-input[readonly] {
-  border: 1px solid Lightgrey;
-}
-
 form ul,
 ul.form-data {
   margin: 0; /* override blueprint's settings for unordered lists */
@@ -570,6 +566,9 @@ width: 25em;
 input[type=text], input[type=number], input[type=password] {
   border: 1px solid #7c7c7c;
   border-color: #7c7c7c #c3c3c3 #ddd;
+}
+input[readonly] {
+  border: 1px solid Lightgrey;
 }
 
 input.longtext {


### PR DESCRIPTION
[![GEOS-11033](https://badgen.net/badge/JIRA/GEOS-11033/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11033)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-11033] WCS 2.0.1 DescribeCoverage axis order using layer projection policy (https://github.com/geoserver/geoserver/pull/6962)

Fix for the bug as mentioned in the issue above.

Change the order of CSS declarations (make it the last one) so the readonly style for the input is not overridden with other input styles.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->