### PR TITLE
[Backport 2.23.x] [GEOS-11084] Fix the readonly style of an input field

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -437,10 +437,6 @@ select {
   color: #000;
 }
 
-input[readonly] {
-  border: 1px solid Lightgrey;
-}
-
 form ul,
 ul.form-data {
   margin: 0; /* override blueprint's settings for unordered lists */
@@ -567,6 +563,9 @@ width: 25em;
 input[type=text], input[type=number], input[type=password] {
   border: 1px solid #7c7c7c;
   border-color: #7c7c7c #c3c3c3 #ddd;
+}
+input[readonly] {
+  border: 1px solid Lightgrey;
 }
 
 input.longtext {


### PR DESCRIPTION
[![GEOS-11084](https://badgen.net/badge/JIRA/GEOS-11084/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11084)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7035
 **Authored by:** @MichelGabriel