### PR TITLE
[GEOS-11086] Taskmanager: database access improvements

### DIFF
--- a/doc/en/user/source/community/taskmanager/user.rst
+++ b/doc/en/user/source/community/taskmanager/user.rst
@@ -54,8 +54,8 @@ Databases
 
 Task Manager allows any number of databases to be used both as sources
 and targets for data transfer operations. These are configured via the
-Spring configuration file. Currently only PostGIS is fully supported,
-either via JNDI or directly via JDBC.
+Spring configuration file. Currently only PostGIS is supported as 
+a target (as well as a source), either via JNDI or directly via JDBC.
 
 .. code:: xml
 
@@ -98,17 +98,61 @@ either via JNDI or directly via JDBC.
 
 Roles can be specified for `security <#security>`__ purposes.
 
-There is also support for Informix, but it only works as a source
-database (not for publishing).
+Other database systems should generally work as a source database (not for publishing)
+using the GenericDbSourceImpl (this has been tested with MS SQL).
+
+.. code:: xml
+
+    <bean class="org.geoserver.taskmanager.external.impl.GenericDbSourceImpl">
+        <property name="name" value="mysqldb" />
+        <property name="driver" value="com.microsoft.sqlserver.jdbc.SQLServerDriver"/> 
+        <property name="connectionUrl" value="jdbc:sqlserver://mysqldbhost:1433;database=mydb" /> 
+        <property name="username" value="username" />
+        <property name="password" value="password" /> 
+        <property name="schema" value="dbo" /> 
+    </bean>
+
+There is also specific support for Informix as a source database (not for publishing).
 
 .. code:: xml
 
     <bean class="org.geoserver.taskmanager.external.impl.InformixDbSourceImpl">
+        <property name="name" value="myinformixdb" />
         <property name="driver" value="com.informix.jdbc.IfxDriver"/> 
         <property name="connectionUrl" value="jdbc:informix-sqli://informix-server:1539" /> 
         <property name="username" value="username" />
         <property name="password" value="password" /> 
     </bean>
+
+It is also possible to use a source that does not support geometries, and translate them
+automatically from some raw type. To do this, one must create a table in the database
+that contains a list of all geometry columns that need to be translated. This can be
+configured as follows:
+
+.. code:: xml
+
+    <bean name="geomtable" class="org.geoserver.taskmanager.external.impl.GeometryTableImpl">
+        <!-- the name of your metadata table -->
+       <property name="nameTable" value="Metadata_Geo" />
+        <!-- the attribute name that contains table name -->
+       <property name="attributeNameTable" value="table_name" />
+        <!-- the attribute name that contains column name -->
+       <property name="attributeNameGeometry" value="column_name" />
+        <!-- the attribute name that contains geometry type -->
+       <property name="attributeNameType" value="geometry_type" />
+        <!-- the attribute name that contains SRID code -->
+       <property name="attributeNameSrid" value="srid" />
+        <!-- the type of conversion: WKT (string to geometry), WKB (binary to geometry), WKB_HEX (hex string to geometry) -->
+       <property name="type" value="WKB_HEX" />
+    </bean>
+
+    <bean class="org.geoserver.taskmanager.external.impl.GenericDbSourceImpl">
+        ....  
+        <property name="rawGeometryTable" ref="geomtable"/>
+    </bean>
+
+
+
 
 External GeoServers
 ~~~~~~~~~~~~~~~~~~~

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/DbSource.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/DbSource.java
@@ -60,6 +60,10 @@ public interface DbSource extends Secured {
     /** The dialect specific actions for taskmanager. */
     Dialect getDialect();
 
+    default GeometryTable getRawGeometryTable() {
+        return null;
+    }
+
     /*
      * these methods could serve an alternative table copy implementation
      * that doesn't use jdbc but uses direct database commands and sends SQL commands

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/Dialect.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/Dialect.java
@@ -8,6 +8,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -21,6 +22,13 @@ public interface Dialect {
         String getName() throws SQLException;
 
         String getTypeEtc() throws SQLException;
+    }
+
+    public interface GeometryColumn {
+
+        String getType();
+
+        int getSrid();
     }
 
     /**
@@ -70,5 +78,29 @@ public interface Dialect {
      * @throws SQLException
      */
     List<Column> getColumns(Connection connection, String tableName, ResultSet rs)
+            throws SQLException;
+
+    /** Return a geometry type */
+    String getGeometryType(String type, int srid);
+
+    /**
+     * Return expression that translates wkt string to geometry type
+     *
+     * @param wkt
+     * @return
+     */
+    String getConvertedGeometry(GeometryTable.Type type);
+
+    /**
+     * Return spatial columns that are encoded as wkt strings and need to be translated
+     *
+     * @param geometryTable
+     * @param connection
+     * @param tableName
+     * @return
+     * @throws SQLException
+     */
+    Map<String, GeometryColumn> getRawSpatialColumns(
+            GeometryTable geometryTable, Connection connection, String tableName)
             throws SQLException;
 }

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/GeometryTable.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/GeometryTable.java
@@ -1,0 +1,22 @@
+package org.geoserver.taskmanager.external;
+
+public interface GeometryTable {
+
+    public enum Type {
+        WKT,
+        WKB,
+        WKB_HEX
+    };
+
+    String getNameTable();
+
+    String getAttributeNameTable();
+
+    String getAttributeNameGeometry();
+
+    String getAttributeNameType();
+
+    String getAttributeNameSrid();
+
+    Type getType();
+}

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/AbstractDbSourceImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/AbstractDbSourceImpl.java
@@ -1,0 +1,19 @@
+package org.geoserver.taskmanager.external.impl;
+
+import org.geoserver.taskmanager.external.DbSource;
+import org.geoserver.taskmanager.external.GeometryTable;
+import org.geoserver.taskmanager.util.SecuredImpl;
+
+public abstract class AbstractDbSourceImpl extends SecuredImpl implements DbSource {
+
+    private GeometryTable rawGeometryTable;
+
+    @Override
+    public GeometryTable getRawGeometryTable() {
+        return rawGeometryTable;
+    }
+
+    public void setRawGeometryTable(GeometryTable rawGeometryTable) {
+        this.rawGeometryTable = rawGeometryTable;
+    }
+}

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/DefaultDialectImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/DefaultDialectImpl.java
@@ -5,6 +5,7 @@
 package org.geoserver.taskmanager.external.impl;
 
 import java.sql.Connection;
+import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -99,12 +100,19 @@ public class DefaultDialectImpl implements Dialect {
 
                         @Override
                         public String getTypeEtc() throws SQLException {
-                            String typeName = rsmd.getColumnTypeName(col);
-                            StringBuffer sb = new StringBuffer(typeName);
-                            if (("char".equals(typeName) || "varchar".equals(typeName))
-                                    && rsmd.getColumnDisplaySize(col) > 0
-                                    && rsmd.getColumnDisplaySize(col) < Integer.MAX_VALUE) {
-                                typeName += " (" + rsmd.getColumnDisplaySize(col) + " ) ";
+                            StringBuffer sb = new StringBuffer();
+                            JDBCType type = JDBCType.valueOf(rsmd.getColumnType(col));
+                            if (type == JDBCType.OTHER) {
+                                sb.append(rsmd.getColumnTypeName(col));
+                            } else {
+                                sb.append(type.name());
+                                if ((type == JDBCType.CHAR || type == JDBCType.VARCHAR)
+                                        && rsmd.getColumnDisplaySize(col) > 0
+                                        && rsmd.getColumnDisplaySize(col) < Integer.MAX_VALUE) {
+                                    sb.append(" (")
+                                            .append(rsmd.getColumnDisplaySize(col))
+                                            .append(" ) ");
+                                }
                             }
                             switch (isNullable(rsmd.isNullable(col))) {
                                 case ResultSetMetaData.columnNoNulls:

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/DefaultDialectImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/DefaultDialectImpl.java
@@ -5,8 +5,8 @@
 package org.geoserver.taskmanager.external.impl;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.JDBCType;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/GenericDbSourceImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/GenericDbSourceImpl.java
@@ -8,11 +8,9 @@ import it.geosolutions.geoserver.rest.encoder.GSAbstractStoreEncoder;
 import java.io.Serializable;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.geoserver.taskmanager.external.DbSource;
 import org.geoserver.taskmanager.external.DbTable;
 import org.geoserver.taskmanager.external.Dialect;
 import org.geoserver.taskmanager.external.ExternalGS;
-import org.geoserver.taskmanager.util.SecuredImpl;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 /**
@@ -21,7 +19,7 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
  *
  * @author Timothy De Bock
  */
-public class GenericDbSourceImpl extends SecuredImpl implements DbSource {
+public class GenericDbSourceImpl extends AbstractDbSourceImpl {
 
     private String connectionUrl;
 

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/GeometryTableImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/GeometryTableImpl.java
@@ -1,0 +1,74 @@
+package org.geoserver.taskmanager.external.impl;
+
+import org.geoserver.taskmanager.external.GeometryTable;
+
+public class GeometryTableImpl implements GeometryTable {
+
+    private String nameTable;
+
+    private String attributeNameTable;
+
+    private String attributeNameGeometry;
+
+    private String attributeNameType;
+
+    private String attributeNameSrid;
+
+    private Type type;
+
+    private GeometryTableImpl() {}
+
+    @Override
+    public String getNameTable() {
+        return nameTable;
+    }
+
+    public void setNameTable(String nameTable) {
+        this.nameTable = nameTable;
+    }
+
+    @Override
+    public String getAttributeNameTable() {
+        return attributeNameTable;
+    }
+
+    public void setAttributeNameTable(String attributeNameTable) {
+        this.attributeNameTable = attributeNameTable;
+    }
+
+    @Override
+    public String getAttributeNameGeometry() {
+        return attributeNameGeometry;
+    }
+
+    public void setAttributeNameGeometry(String attributeNameGeometry) {
+        this.attributeNameGeometry = attributeNameGeometry;
+    }
+
+    @Override
+    public String getAttributeNameType() {
+        return attributeNameType;
+    }
+
+    public void setAttributeNameType(String attributeNameType) {
+        this.attributeNameType = attributeNameType;
+    }
+
+    @Override
+    public String getAttributeNameSrid() {
+        return attributeNameSrid;
+    }
+
+    public void setAttributeNameSrid(String attributeNameSrid) {
+        this.attributeNameSrid = attributeNameSrid;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+}

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/H2DbSourceImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/H2DbSourceImpl.java
@@ -15,11 +15,9 @@ import java.sql.SQLException;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
-import org.geoserver.taskmanager.external.DbSource;
 import org.geoserver.taskmanager.external.DbTable;
 import org.geoserver.taskmanager.external.Dialect;
 import org.geoserver.taskmanager.external.ExternalGS;
-import org.geoserver.taskmanager.util.SecuredImpl;
 import org.h2.tools.RunScript;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -29,7 +27,7 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
  *
  * @author Timothy De Bock
  */
-public class H2DbSourceImpl extends SecuredImpl implements DbSource {
+public class H2DbSourceImpl extends AbstractDbSourceImpl {
 
     private String path;
 

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/InformixDbSourceImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/InformixDbSourceImpl.java
@@ -8,11 +8,9 @@ import it.geosolutions.geoserver.rest.encoder.GSAbstractStoreEncoder;
 import java.io.Serializable;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.geoserver.taskmanager.external.DbSource;
 import org.geoserver.taskmanager.external.DbTable;
 import org.geoserver.taskmanager.external.Dialect;
 import org.geoserver.taskmanager.external.ExternalGS;
-import org.geoserver.taskmanager.util.SecuredImpl;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 /**
@@ -21,7 +19,7 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
  *
  * @author Timothy De Bock
  */
-public class InformixDbSourceImpl extends SecuredImpl implements DbSource {
+public class InformixDbSourceImpl extends AbstractDbSourceImpl {
 
     private String connectionUrl;
 

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/PostgisDbSourceImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/external/impl/PostgisDbSourceImpl.java
@@ -10,11 +10,9 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.geoserver.taskmanager.external.DbSource;
 import org.geoserver.taskmanager.external.DbTable;
 import org.geoserver.taskmanager.external.Dialect;
 import org.geoserver.taskmanager.external.ExternalGS;
-import org.geoserver.taskmanager.util.SecuredImpl;
 import org.geoserver.taskmanager.util.SqlUtil;
 import org.geotools.data.postgis.PostgisNGDataStoreFactory;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -24,7 +22,7 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
  *
  * @author Niels Charlier
  */
-public class PostgisDbSourceImpl extends SecuredImpl implements DbSource {
+public class PostgisDbSourceImpl extends AbstractDbSourceImpl {
 
     private String host;
 

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/CopyTableTaskTypeImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/CopyTableTaskTypeImpl.java
@@ -156,7 +156,7 @@ public class CopyTableTaskTypeImpl implements TaskType {
 
                     for (String indexName : indexAndColumnMap.keySet()) {
                         Set<String> columnNames = indexAndColumnMap.get(indexName);
-                        if (!columnNames.equals(primaryKey)) {
+                        if (!columnNames.equals(primaryKey) && !columnNames.isEmpty()) {
                             boolean isSpatialIndex =
                                     columnNames.size() == 1
                                             && spatialColumns.contains(
@@ -390,7 +390,9 @@ public class CopyTableTaskTypeImpl implements TaskType {
                 if (!result.containsKey(indexName)) {
                     result.put(indexName, new HashSet<>());
                 }
-                result.get(indexName).add(dbColumnName);
+                if (dbColumnName != null) {
+                    result.get(indexName).add(dbColumnName);
+                }
             }
         }
         return result;

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/FileRemotePublicationTaskTypeImpl.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/tasks/FileRemotePublicationTaskTypeImpl.java
@@ -35,7 +35,6 @@ import org.geoserver.taskmanager.schedule.ParameterInfo;
 import org.geoserver.taskmanager.schedule.ParameterType;
 import org.geoserver.taskmanager.schedule.TaskContext;
 import org.geoserver.taskmanager.schedule.TaskException;
-import org.geoserver.taskmanager.tasks.AbstractRemotePublicationTaskTypeImpl.Finalizer;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/util/TaskManagerBeans.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/util/TaskManagerBeans.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.taskmanager.util;
 
+import java.util.Collections;
 import java.util.List;
 import org.geoserver.taskmanager.data.TaskManagerDao;
 import org.geoserver.taskmanager.data.TaskManagerFactory;
@@ -36,7 +37,8 @@ public class TaskManagerBeans {
 
     @Autowired private ReportBuilder reportBuilder;
 
-    @Autowired private List<ReportService> reportServices;
+    @Autowired(required = false)
+    private List<ReportService> reportServices = Collections.emptyList();
 
     @Autowired private BatchJobService bjService;
 

--- a/src/community/taskmanager/core/src/test/resources/applicationContext.xml
+++ b/src/community/taskmanager/core/src/test/resources/applicationContext.xml
@@ -10,12 +10,23 @@
     <context:component-scan base-package="org.geoserver.taskmanager.fileservice"/>
 
     <!--H2 setup -->
+    <bean name="geomtable" class="org.geoserver.taskmanager.external.impl.GeometryTableImpl">
+        <property name="nameTable" value="gw_beleid.geomtable" />
+        <property name="attributeNameTable" value="table_name" />
+        <property name="attributeNameGeometry" value="column_name" />
+        <property name="attributeNameType" value="geometry_type" />
+        <property name="attributeNameSrid" value="epsg" />
+        <property name="type" value="WKT" />
+    </bean>
+    
     <bean class="org.geoserver.taskmanager.external.impl.H2DbSourceImpl">
         <property name="name" value="testsourcedb"/>
         <property name="path" value="mem"/>
         <property name="db" value="testsourcedb"/>
-        <property name="createDBSqlResource" value="classpath:h2/dbsource/create-source.sql"/>
+        <property name="createDBSqlResource" value="classpath:h2/dbsource/create-source.sql"/>     
+        <property name="rawGeometryTable" ref="geomtable"/>
     </bean>
+    
     <bean class="org.geoserver.taskmanager.external.impl.H2DbSourceImpl">
         <property name="name" value="testtargetdb"/>
         <property name="path" value="mem"/>

--- a/src/community/taskmanager/core/src/test/resources/h2/dbsource/create-source.sql
+++ b/src/community/taskmanager/core/src/test/resources/h2/dbsource/create-source.sql
@@ -18,8 +18,25 @@ CREATE TABLE gw_beleid.grondwaterlichamen_new (
     CONSTRAINT unique_on_gwl UNIQUE (gwl)
 );
 
+CREATE TABLE gw_beleid.waterlichamen_wkt (
+    id INTEGER NOT NULL,
+    wkb_polygon character varying (2058),
+    wkb_line character varying (2058),
+    wkb_mixed character varying (2058)
+);
+
+CREATE TABLE gw_beleid.geomtable (
+    table_name character varying(255),
+    column_name character varying(255),
+    geometry_type character varying (255),
+    epsg character varying(255)
+);
+
 ALTER TABLE  gw_beleid.grondwaterlichamen_new
     ADD CONSTRAINT gw_beleid.grondwaterlichamen_new_pkey PRIMARY KEY (dataengine_id);
+
+ALTER TABLE  gw_beleid.waterlichamen_wkt
+    ADD CONSTRAINT gw_beleid.waterlichamen_wkt_pkey PRIMARY KEY (id);
 
 CREATE INDEX multipleColumns ON gw_beleid.grondwaterlichamen_new (dataengine_id, gwl);
 
@@ -244,3 +261,14 @@ INSERT INTO gw_beleid.grondwaterlichamen_new VALUES (191, '         <BR> BLKS_06
 -- Data for Name: codetable_country;
 --
 INSERT INTO  gw_beleid.codetable_country VALUES ('BE', 'BELGIUM');
+
+
+
+
+
+INSERT INTO gw_beleid.geomtable VALUES('gw_beleid.waterlichamen_wkt', 'WKB_POLYGON', 'MULTIPOLYGON', '4326');
+INSERT INTO gw_beleid.geomtable VALUES('gw_beleid.waterlichamen_wkt', 'WKB_LINE', 'MULTILINESTRING', '4326');
+INSERT INTO gw_beleid.geomtable VALUES('gw_beleid.waterlichamen_wkt', 'WKB_MIXED', 'GEOMETRY', '4326');
+
+
+INSERT INTO gw_beleid.waterlichamen_wkt VALUES(1, 'MULTIPOLYGON(((10.689 -25.092, 34.595 -20.170, 38.814 -35.639, 13.502 -39.155, 10.689 -25.092)))', 'MULTILINESTRING((0 0, 1 2, 3 4),(2 3, 3 4, 6 7))', 'TRIANGLE ((0 0, 0 1, 1 1, 0 0))');

--- a/src/community/taskmanager/pom.xml
+++ b/src/community/taskmanager/pom.xml
@@ -27,6 +27,16 @@
       <artifactId>geoserver-manager</artifactId>
       <version>1.8.5</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-api</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jcl-over-slf4j</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[![GEOS-11086](https://badgen.net/badge/JIRA/GEOS-11086/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11086)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->