### PR TITLE
[GEOS-11087] Fix IsolatedCatalogFacade unnecessary performance overhead

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/IsolatedCatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/IsolatedCatalogFacade.java
@@ -4,7 +4,8 @@
  */
 package org.geoserver.catalog.impl;
 
-import java.util.ArrayList;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterators;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -485,15 +486,13 @@ final class IsolatedCatalogFacade implements CatalogFacade {
 
     @Override
     public <T extends CatalogInfo> int count(Class<T> of, Filter filter) {
-        CloseableIterator<T> found = facade.list(of, filter, null, null);
-        try (CloseableIterator<T> filtered = filterIsolated(of, found)) {
-            int count = 0;
-            while (filtered.hasNext()) {
-                count++;
-                filtered.next();
+        if (isOwsRequest()) {
+            CloseableIterator<T> found = facade.list(of, filter, null, null);
+            try (CloseableIterator<T> filtered = filterIsolated(of, found)) {
+                return Iterators.size(filtered);
             }
-            return count;
         }
+        return facade.count(of, filter);
     }
 
     @Override
@@ -648,7 +647,7 @@ final class IsolatedCatalogFacade implements CatalogFacade {
                 || workspace == CatalogFacade.ANY_WORKSPACE
                 || workspace == null
                 || !workspace.isIsolated()
-                || Dispatcher.REQUEST.get() == null) {
+                || !isOwsRequest()) {
             // the workspace content is visible in this context
             return true;
         }
@@ -657,6 +656,10 @@ final class IsolatedCatalogFacade implements CatalogFacade {
         // of its virtual services
         return localWorkspace != null
                 && Objects.equals(localWorkspace.getName(), workspace.getName());
+    }
+
+    private boolean isOwsRequest() {
+        return Dispatcher.REQUEST.get() != null;
     }
 
     /**
@@ -670,15 +673,18 @@ final class IsolatedCatalogFacade implements CatalogFacade {
      */
     private <T extends CatalogInfo> List<T> filterIsolated(
             List<T> objects, Class<T> type, Function<T, T> filter) {
-        // unwrap the catalog objects list
-        List<T> unwrapped = ModificationProxy.unwrap(objects);
-        // filter the non visible catalog objects and wrap the resulting list with a modification
-        // proxy
-        return ModificationProxy.createList(
-                unwrapped.stream()
-                        .filter(store -> filter.apply(store) != null)
-                        .collect(Collectors.toList()),
-                type);
+        if (isOwsRequest()) {
+            // unwrap the catalog objects list
+            List<T> unwrapped = ModificationProxy.unwrap(objects);
+            // filter the non visible catalog objects and wrap the resulting list with a
+            // modification proxy
+            return ModificationProxy.createList(
+                    unwrapped.stream()
+                            .filter(store -> filter.apply(store) != null)
+                            .collect(Collectors.toList()),
+                    type);
+        }
+        return objects;
     }
 
     /**
@@ -691,17 +697,13 @@ final class IsolatedCatalogFacade implements CatalogFacade {
      */
     private <T extends CatalogInfo> CloseableIterator<T> filterIsolated(
             CloseableIterator<T> objects, Function<T, T> filter) {
-        List<T> iterable = new ArrayList<>();
-        // consume the iterator
-        while (objects.hasNext()) {
-            T object = objects.next();
-            if (filter.apply(object) != null) {
-                // this catalog object is visible in the current context
-                iterable.add(object);
-            }
+
+        if (isOwsRequest()) {
+            Predicate<T> predicate = t -> filter.apply(t) != null;
+            objects = CloseableIteratorAdapter.filter(objects, predicate);
         }
-        // create an iterator for the visible catalog objects
-        return new CloseableIteratorAdapter<>(iterable.iterator());
+
+        return objects;
     }
 
     /**


### PR DESCRIPTION
[![GEOS-11087](https://badgen.net/badge/JIRA/GEOS-11087/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11087)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Filter the iterator created by list(...) directly instead of building an ArrayList first
* Apply in-process filter to iterator in count() only if required, delegate to the proxied facade's count() method if `Dispatcher.REQUEST.get() == null`


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->