### PR TITLE
[GEOS-11089] Performance penalty adding namespaces while loading catalog

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogInfoLookup.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogInfoLookup.java
@@ -138,15 +138,17 @@ class CatalogInfoLookup<T extends CatalogInfo> {
      * things going on)
      */
     <U extends CatalogInfo> List<U> list(Class<U> clazz, Predicate<U> predicate) {
-        ArrayList<U> result = new ArrayList<>();
+        List<U> result = List.of(); // replaced by ArrayList if there are matches
         for (Class<T> key : nameMultiMap.keySet()) {
             if (clazz.isAssignableFrom(key)) {
                 Map<Name, T> valueMap = nameMultiMap.get(key);
                 if (valueMap != null) {
                     for (T v : valueMap.values()) {
-                        @SuppressWarnings("unchecked")
-                        final U u = (U) v;
+                        final U u = clazz.cast(v);
                         if (predicate == TRUE || predicate.test(u)) {
+                            if (result.isEmpty()) {
+                                result = new ArrayList<>();
+                            }
                             result.add(u);
                         }
                     }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/DefaultCatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/DefaultCatalogFacade.java
@@ -49,6 +49,9 @@ import org.opengis.filter.sort.SortOrder;
  *
  * @author Justin Deoliveira, OpenGeo
  *     <p>TODO: look for any exceptions, move them back to catalog as they indicate logic
+ * @see CatalogInfoLookup
+ * @see LayerInfoLookup
+ * @see NamespaceInfoLookup
  */
 public class DefaultCatalogFacade extends AbstractCatalogFacade implements CatalogFacade {
 
@@ -135,8 +138,7 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
     protected volatile NamespaceInfo defaultNamespace;
 
     /** namespaces */
-    protected CatalogInfoLookup<NamespaceInfo> namespaces =
-            new CatalogInfoLookup<>(NAMESPACE_NAME_MAPPER);
+    protected NamespaceInfoLookup namespaces = new NamespaceInfoLookup();
 
     /** The default workspace */
     protected volatile WorkspaceInfo defaultWorkspace;
@@ -747,9 +749,7 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
 
     @Override
     public List<NamespaceInfo> getNamespacesByURI(String uri) {
-        List<NamespaceInfo> found =
-                namespaces.list(
-                        NamespaceInfo.class, namespaceInfo -> namespaceInfo.getURI().equals(uri));
+        List<NamespaceInfo> found = namespaces.findAllByUri(uri);
         return ModificationProxy.createList(found, NamespaceInfo.class);
     }
 
@@ -974,7 +974,7 @@ public class DefaultCatalogFacade extends AbstractCatalogFacade implements Catal
 
         // namespaces
         if (namespaces == null) {
-            namespaces = new CatalogInfoLookup<>(NAMESPACE_NAME_MAPPER);
+            namespaces = new NamespaceInfoLookup();
         }
         for (NamespaceInfo ns : namespaces.values()) {
             resolve(ns);

--- a/src/main/src/main/java/org/geoserver/catalog/impl/NamespaceInfoLookup.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/NamespaceInfoLookup.java
@@ -1,0 +1,144 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.NamespaceInfo;
+
+/**
+ * {@link CatalogInfoLookup} adding a {@link NamespaceInfo#getURI() URI} multi-valued index for
+ * {@link #findAllByUri(String) fast lookup} of namespaces by uri.
+ *
+ * <p>All {@link CatalogInfoLookup} mutating methods are overridden to maintain the index
+ * consistency
+ */
+class NamespaceInfoLookup extends CatalogInfoLookup<NamespaceInfo> {
+
+    private ConcurrentHashMap<String, List<NamespaceInfo>> index = new ConcurrentHashMap<>();
+
+    /** guards modifications to the index and its ArrayList values */
+    private ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private static Comparator<NamespaceInfo> VALUE_ORDER =
+            (n1, n2) -> n1.getId().compareTo(n2.getId());
+
+    public NamespaceInfoLookup() {
+        super(DefaultCatalogFacade.NAMESPACE_NAME_MAPPER);
+    }
+
+    /** Uses the internal URI index to locate all the {@link NamespaceInfo}s with such URI */
+    public List<NamespaceInfo> findAllByUri(String uri) {
+        lock.readLock().lock();
+        try {
+            return List.copyOf(valueList(uri, false));
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /** type-narrowing for the return type */
+    @Override
+    public NamespaceInfoLookup setCatalog(Catalog catalog) {
+        super.setCatalog(catalog);
+        return this;
+    }
+
+    @Override
+    public NamespaceInfo add(NamespaceInfo value) {
+        lock.writeLock().lock();
+        try {
+            NamespaceInfo ns = super.add(value);
+            addInternal(value);
+            return ns;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void addInternal(NamespaceInfo value) {
+        List<NamespaceInfo> values = valueList(value.getURI(), true);
+        values.add(ModificationProxy.unwrap(value));
+        values.sort(VALUE_ORDER);
+    }
+
+    @Override
+    public void clear() {
+        lock.writeLock().lock();
+        try {
+            super.clear();
+            index.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public NamespaceInfo remove(NamespaceInfo value) {
+        lock.writeLock().lock();
+        try {
+            String uri = value.getURI();
+            NamespaceInfo ns = super.remove(value);
+            removeInternal(value, uri);
+            return ns;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void removeInternal(NamespaceInfo value, String uri) {
+        List<NamespaceInfo> list = valueList(uri, false);
+        if (!list.isEmpty()) list.remove(ModificationProxy.unwrap(value));
+        if (list.isEmpty()) {
+            index.remove(uri);
+        }
+    }
+
+    @Override
+    public void update(NamespaceInfo value) {
+        lock.writeLock().lock();
+        try {
+            ModificationProxy h = (ModificationProxy) Proxy.getInvocationHandler(value);
+            NamespaceInfo actualValue = (NamespaceInfo) h.getProxyObject();
+
+            String oldUri = actualValue.getURI();
+            String newUri = value.getURI();
+
+            final boolean uriChanged = !Objects.equals(oldUri, newUri);
+            super.update(value);
+
+            if (uriChanged) {
+                removeInternal(value, oldUri);
+                addInternal(value);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Looks up the list of values associated to the given {@code uri}
+     *
+     * @param uri the index key
+     * @param create whether to create the index entry list if it doesn't exist
+     * @return the index entry, may an unmodifiable empty list if it doesn't exist and {@code create
+     *     == false}
+     */
+    @VisibleForTesting
+    List<NamespaceInfo> valueList(String uri, boolean create) {
+        if (create) {
+            return index.computeIfAbsent(uri, v -> new ArrayList<>());
+        }
+        return index.getOrDefault(uri, List.of());
+    }
+}

--- a/src/main/src/test/java/org/geoserver/catalog/impl/NamespaceInfoLookupTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/NamespaceInfoLookupTest.java
@@ -1,0 +1,137 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.geoserver.catalog.NamespaceInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test suite for {@link NamespaceInfoLookup} */
+public class NamespaceInfoLookupTest {
+
+    private static final String URI_1 = "http://gs.test.com/ns1";
+    private static final String URI_2 = "http://gs.test.com/ns2";
+
+    private NamespaceInfo uri1_1, uri1_2, uri2_1, uri2_2;
+
+    private NamespaceInfoLookup lookup;
+
+    @Before
+    public void setUp() {
+        uri1_1 = create("uri1_1", URI_1);
+        uri1_2 = create("uri1_2", URI_1);
+        uri2_1 = create("uri2_1", URI_2);
+        uri2_2 = create("uri2_2", URI_2);
+        lookup = new NamespaceInfoLookup();
+    }
+
+    private NamespaceInfo create(String prefix, String uri) {
+        NamespaceInfoImpl ns = new NamespaceInfoImpl();
+        ns.setId(prefix + "-id");
+        ns.setPrefix(prefix);
+        ns.setURI(uri);
+        return ns;
+    }
+
+    private void addAll(NamespaceInfo... values) {
+        for (NamespaceInfo ns : values) lookup.add(ns);
+    }
+
+    @Test
+    public void testAdd() {
+        lookup.add(uri1_2);
+        assertEquals(List.of(uri1_2), lookup.valueList(URI_1, false));
+
+        lookup.add(uri1_1);
+        assertEquals(List.of(uri1_1, uri1_2), lookup.valueList(URI_1, false));
+
+        assertSame(uri1_1, lookup.findById(uri1_1.getId(), NamespaceInfo.class));
+        assertSame(uri1_2, lookup.findById(uri1_2.getId(), NamespaceInfo.class));
+    }
+
+    @Test
+    public void testClear() {
+        addAll(uri1_1, uri1_2, uri2_1, uri2_2);
+        lookup.clear();
+        assertEquals(List.of(), lookup.values());
+    }
+
+    @Test
+    public void testRemove() {
+        addAll(uri1_1, uri1_2, uri2_1, uri2_2);
+        testRemove(uri1_1);
+        testRemove(uri1_2);
+        testRemove(uri2_1);
+        testRemove(uri2_2);
+        lookup.remove(uri1_1);
+    }
+
+    private void testRemove(NamespaceInfo ns) {
+        NamespaceInfo current = lookup.findById(ns.getId(), NamespaceInfo.class);
+        NamespaceInfo removed = lookup.remove(ns);
+        assertSame(current, removed);
+        assertNull(lookup.findById(ns.getId(), NamespaceInfo.class));
+    }
+
+    @Test
+    public void testUpdate() {
+        addAll(uri1_1, uri1_2, uri2_1, uri2_2);
+
+        testUpdate(uri1_1, URI_2, List.of(uri1_1, uri2_1, uri2_2));
+        testUpdate(uri2_2, URI_1, List.of(uri1_2, uri2_2));
+    }
+
+    private void testUpdate(NamespaceInfo ns, String newUri, List<NamespaceInfo> expected) {
+        String oldUri = ns.getURI();
+        assertTrue(lookup.valueList(oldUri, false).contains(ns));
+
+        NamespaceInfo proxied = ModificationProxy.create(ns, NamespaceInfo.class);
+        proxied.setURI(newUri);
+        lookup.update(proxied);
+        ModificationProxy.handler(proxied).commit();
+        assertEquals(expected, lookup.valueList(newUri, false));
+
+        assertFalse(lookup.valueList(oldUri, false).contains(ns));
+    }
+
+    @Test
+    public void testFindAllByUri() {
+        assertTrue(lookup.findAllByUri(URI_1).isEmpty());
+        assertTrue(lookup.findAllByUri(URI_2).isEmpty());
+
+        lookup.add(uri1_1);
+        assertEquals(List.of(uri1_1), lookup.findAllByUri(URI_1));
+
+        lookup.add(uri2_1);
+        assertEquals(List.of(uri1_1), lookup.findAllByUri(URI_1));
+        assertEquals(List.of(uri2_1), lookup.findAllByUri(URI_2));
+
+        lookup.add(uri1_2);
+        lookup.add(uri2_2);
+        assertEquals(List.of(uri1_1, uri1_2), lookup.findAllByUri(URI_1));
+        assertEquals(List.of(uri2_1, uri2_2), lookup.findAllByUri(URI_2));
+    }
+
+    @Test
+    public void testFindAllByUri_stable_order() {
+        addAll(uri1_1, uri1_2);
+
+        final List<NamespaceInfo> expected = List.of(uri1_1, uri1_2);
+        assertEquals(expected, lookup.findAllByUri(URI_1));
+
+        lookup.clear();
+        assertTrue(lookup.findAllByUri(URI_1).isEmpty());
+
+        addAll(uri1_2, uri1_1);
+        assertEquals(expected, lookup.findAllByUri(URI_1));
+    }
+}


### PR DESCRIPTION
[![GEOS-11089](https://badgen.net/badge/JIRA/GEOS-11089/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11089)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Use a specialization of `CatalogInfoLookup` for `NamespaceInfo` that speeds up lookup of namespaces by URI.

With this patch and the one for [GEOS-11088](https://github.com/geoserver/geoserver/pull/7050), starting up from a catalog with 120k workspaces and 600k layers, goes from 18 to 4 minutes with the default geoserver loader, and down to less than a minute with the [datadir-catalog-loader](https://github.com/geoserver/geoserver/tree/580221af6da9aedcd4e0333ea205e92277ca4c44/src/community/datadir-catalog-loader) community module.

```
                                     before   after
default loader                        1113s    294s
datadir-catalog-loader (4 trheads)     587s     98s
datadir-catalog-loader (8 trheads)     334s     69s
datadir-catalog-loader (16 trheads)    245s     57s
```

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->