### PR TITLE
[GEOS-11090] Use Catalog streaming API in WorkspacePage

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceProvider.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/workspace/WorkspaceProvider.java
@@ -5,24 +5,60 @@
  */
 package org.geoserver.web.data.workspace;
 
-import java.util.Arrays;
+import static org.geoserver.catalog.Predicates.sortBy;
+
+import com.google.common.collect.Streams;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder;
+import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.lang.Objects;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.Predicates;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.util.CloseableIterator;
+import org.geoserver.config.SettingsInfo;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.GeoServerDataProvider;
-import org.geoserver.web.wicket.GeoServerDataProvider.Property;
+import org.opengis.filter.Filter;
+import org.opengis.filter.sort.SortBy;
 
-/** {@link GeoServerDataProvider} for the list of workspaces available in the {@link Catalog} */
+/**
+ * {@link GeoServerDataProvider} for the list of workspaces available in the {@link Catalog}
+ *
+ * @implNote This class overrides the following methods in order to leverage the Catalog filtering
+ *     and paging support:
+ *     <ul>
+ *       <li>{@link #size()}: in order to call {@link Catalog#count(Class, Filter)} with any filter
+ *           criteria set on the page
+ *       <li>{@link #fullSize()}: in order to call {@link Catalog#count(Class, Filter)} with {@link
+ *           Predicates#acceptAll()}
+ *       <li>{@link #iterator}: in order to ask the catalog for paged and sorted contents directly
+ *           through {@link Catalog#list(Class, Filter, Integer, Integer, SortBy)}
+ *       <li>{@link #getItems()} throws an unsupported operation exception, as given the above it
+ *           should not be called
+ *     </ul>
+ */
 public class WorkspaceProvider extends GeoServerDataProvider<WorkspaceInfo> {
 
     private static final long serialVersionUID = -2464073552094977958L;
 
     public static Property<WorkspaceInfo> NAME = new BeanProperty<>("name", "name");
 
+    /**
+     * "Default" is not a {@link WorkspaceInfo} attribute, this property relies on {@link
+     * #iterator()} decorating the default workspace, so {@link Catalog#getDefaultWorkspace()}
+     * doesn't need to be called for each item.
+     *
+     * @see #decorateDefault(WorkspaceInfo, WorkspaceInfo)
+     * @see #isDefaultWorkspace(WorkspaceInfo)
+     */
     public static Property<WorkspaceInfo> DEFAULT =
             new AbstractProperty<WorkspaceInfo>("default") {
 
@@ -30,16 +66,13 @@ public class WorkspaceProvider extends GeoServerDataProvider<WorkspaceInfo> {
 
                 @Override
                 public Object getPropertyValue(WorkspaceInfo item) {
-                    Catalog catalog = GeoServerApplication.get().getCatalog();
-                    WorkspaceInfo defaultWorkspace = catalog.getDefaultWorkspace();
-                    return Boolean.valueOf(
-                            defaultWorkspace != null && defaultWorkspace.equals(item));
+                    return isDefaultWorkspace(item);
                 }
             };
 
     public static Property<WorkspaceInfo> ISOLATED = new BeanProperty<>("isolated", "isolated");
 
-    static List<Property<WorkspaceInfo>> PROPERTIES = Arrays.asList(NAME, DEFAULT, ISOLATED);
+    static List<Property<WorkspaceInfo>> PROPERTIES = List.of(NAME, DEFAULT, ISOLATED);
 
     public static final Property<WorkspaceInfo> MODIFIED_TIMESTAMP =
             new BeanProperty<>("datemodfied", "dateModified");
@@ -53,29 +86,121 @@ public class WorkspaceProvider extends GeoServerDataProvider<WorkspaceInfo> {
 
     @Override
     protected List<WorkspaceInfo> getItems() {
-        return getCatalog().getWorkspaces();
+        // forced to implement this method as its abstract in the super class
+        throw new UnsupportedOperationException(
+                "This method should not be being called! We use the catalog streaming API");
+    }
+
+    @Override
+    public long size() {
+        Filter filter = getFilter();
+        int count = getCatalog().count(WorkspaceInfo.class, filter);
+        return count;
+    }
+
+    @Override
+    public int fullSize() {
+        Filter filter = Predicates.acceptAll();
+        int count = getCatalog().count(WorkspaceInfo.class, filter);
+        return count;
+    }
+
+    @Override
+    public Iterator<WorkspaceInfo> iterator(final long first, final long count) {
+        validate(first, count);
+        final Catalog catalog = getCatalog();
+
+        // global sorting
+        final SortParam<Object> sort = getSort();
+        final Property<WorkspaceInfo> property = getProperty(sort);
+        Filter filter = getFilter();
+        WorkspaceInfo defaultWorkspace = catalog.getDefaultWorkspace();
+        SortBy sortOrder = null;
+        if (property instanceof BeanProperty) {
+            String sortProperty = ((BeanProperty<WorkspaceInfo>) property).getPropertyPath();
+            sortOrder = sortBy(sortProperty, sort.isAscending());
+        } else if (property == DEFAULT) {
+            // "default" is not a WorkspaceInfo property
+            if (null != defaultWorkspace && filter.evaluate(defaultWorkspace)) {
+                // filter out default workspace
+                Filter excludeDefault = Predicates.notEqual("id", defaultWorkspace.getId());
+                filter = Predicates.and(excludeDefault, filter);
+                // and add it to the head or tail as appropriate below
+            } else {
+                defaultWorkspace = null;
+            }
+        } else if (null != property) {
+            throw new IllegalStateException("Unknown sort property " + property);
+        }
+
+        LinkedList<WorkspaceInfo> list;
+        try (CloseableIterator<WorkspaceInfo> items =
+                catalog.list(WorkspaceInfo.class, filter, (int) first, (int) count, sortOrder)) {
+            Stream<WorkspaceInfo> stream = Streams.stream(items);
+            if (null != defaultWorkspace) {
+                WorkspaceInfo def = defaultWorkspace;
+                stream = stream.map(item -> decorateDefault(def, item));
+            }
+            list = stream.collect(Collectors.toCollection(LinkedList::new));
+        }
+        if (property == DEFAULT && defaultWorkspace != null) {
+            // and add it to the head or tail as appropriate
+            if (sort.isAscending()) {
+                list.addFirst(defaultWorkspace);
+            } else {
+                list.addLast(defaultWorkspace);
+            }
+        }
+        return list.iterator();
     }
 
     @Override
     protected List<Property<WorkspaceInfo>> getProperties() {
-        List<Property<WorkspaceInfo>> modifiedPropertiesList =
-                PROPERTIES.stream().map(c -> c).collect(Collectors.toList());
+        List<Property<WorkspaceInfo>> modifiedPropertiesList = new ArrayList<>(PROPERTIES);
         // check geoserver properties
-        if (GeoServerApplication.get()
-                .getGeoServer()
-                .getSettings()
-                .isShowCreatedTimeColumnsInAdminList())
+        SettingsInfo settings = getSettings();
+        if (settings.isShowCreatedTimeColumnsInAdminList())
             modifiedPropertiesList.add(CREATED_TIMESTAMP);
-        if (GeoServerApplication.get()
-                .getGeoServer()
-                .getSettings()
-                .isShowModifiedTimeColumnsInAdminList())
+        if (settings.isShowModifiedTimeColumnsInAdminList())
             modifiedPropertiesList.add(MODIFIED_TIMESTAMP);
         return modifiedPropertiesList;
+    }
+
+    protected SettingsInfo getSettings() {
+        return GeoServerApplication.get().getGeoServer().getSettings();
     }
 
     @Override
     protected IModel<WorkspaceInfo> newModel(WorkspaceInfo object) {
         return new WorkspaceDetachableModel(object);
+    }
+
+    private void validate(Long first, Long count) {
+        if (first > Integer.MAX_VALUE
+                || first < Integer.MIN_VALUE
+                || count > Integer.MAX_VALUE
+                || count < Integer.MIN_VALUE) {
+            throw new IllegalArgumentException(); // TODO Possibly change catalog API to use long
+        }
+    }
+
+    /**
+     * Uses the items metadata map to mark it as the default workspace if {@code item} is the same
+     * as {@code defaultWorkspace}
+     *
+     * @param defaultWorkspace the catalog's default workspace
+     * @param item the item to mark as the default workspace or not, for the {@link #DEFAULT}
+     *     property to get the property value
+     */
+    static WorkspaceInfo decorateDefault(WorkspaceInfo defaultWorkspace, WorkspaceInfo item) {
+        if (Objects.equal(defaultWorkspace.getId(), item.getId())) {
+            item = ModificationProxy.create(ModificationProxy.unwrap(item), WorkspaceInfo.class);
+            item.getMetadata().put("defaultWorkspace", Boolean.TRUE);
+        }
+        return item;
+    }
+
+    static boolean isDefaultWorkspace(WorkspaceInfo item) {
+        return Boolean.TRUE.equals(item.getMetadata().get("defaultWorkspace"));
     }
 }

--- a/src/web/core/src/test/java/org/geoserver/web/data/workspace/WorkspaceProviderTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/workspace/WorkspaceProviderTest.java
@@ -1,0 +1,168 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.data.workspace;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.impl.SettingsInfoImpl;
+import org.geoserver.ows.util.OwsUtils;
+import org.geoserver.web.wicket.GeoServerDataProvider.Property;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WorkspaceProviderTest {
+
+    private WorkspaceProvider provider;
+
+    private Catalog catalog;
+
+    private WorkspaceInfo w1, w2, w3, w4;
+    private SettingsInfo settings;
+
+    @Before
+    @SuppressWarnings("serial")
+    public void setUp() {
+        catalog = new CatalogImpl();
+        w1 = add("w1");
+        w2 = add("w2");
+        w3 = add("w3");
+        w4 = add("w4");
+        settings = new SettingsInfoImpl();
+        provider =
+                new WorkspaceProvider() {
+                    @Override
+                    public Catalog getCatalog() {
+                        return catalog;
+                    }
+
+                    @Override
+                    protected SettingsInfo getSettings() {
+                        return settings;
+                    }
+                };
+    }
+
+    private WorkspaceInfo add(String name) {
+        WorkspaceInfo w = catalog.getFactory().createWorkspace();
+        OwsUtils.set(w, "id", name + "-id");
+        w.setName(name);
+        catalog.add(w);
+        return catalog.getWorkspaceByName(name);
+    }
+
+    @Test
+    public void testSize() {
+        assertEquals(4, provider.size());
+        provider.setKeywords(new String[] {"w2"});
+        assertEquals(1, provider.size());
+    }
+
+    @Test
+    public void testFullSize() {
+        assertEquals(4, provider.fullSize());
+        provider.setKeywords(new String[] {"w2"});
+        assertEquals(4, provider.fullSize());
+    }
+
+    @Test
+    public void testGetProperties() {
+        assertNotSame(WorkspaceProvider.PROPERTIES, provider.getProperties());
+        assertEquals(WorkspaceProvider.PROPERTIES, provider.getProperties());
+
+        List<Property<WorkspaceInfo>> expected = new ArrayList<>(WorkspaceProvider.PROPERTIES);
+
+        settings.setShowCreatedTimeColumnsInAdminList(true);
+        expected.add(WorkspaceProvider.CREATED_TIMESTAMP);
+        assertEquals(expected, provider.getProperties());
+
+        settings.setShowModifiedTimeColumnsInAdminList(true);
+        expected.add(WorkspaceProvider.MODIFIED_TIMESTAMP);
+        assertEquals(expected, provider.getProperties());
+    }
+
+    @Test
+    public void testGetItems_is_unsupported() {
+        assertThrows(UnsupportedOperationException.class, provider::getItems);
+    }
+
+    @Test
+    public void testIterator_preconditions() {
+        final Class<IllegalArgumentException> iae = IllegalArgumentException.class;
+        assertThrows(iae, () -> provider.iterator(Integer.MAX_VALUE + 1L, 1L));
+        assertThrows(iae, () -> provider.iterator(Integer.MIN_VALUE - 1L, 1L));
+        assertThrows(iae, () -> provider.iterator(0, Integer.MAX_VALUE + 1L));
+        assertThrows(iae, () -> provider.iterator(0, Integer.MIN_VALUE - 1L));
+    }
+
+    @Test
+    public void testIterator_all() {
+        List<WorkspaceInfo> expected = List.of(w1, w2, w3, w4);
+        List<WorkspaceInfo> actual = Lists.newArrayList(provider.iterator(0, 25));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testIterator_orderbyName() {
+        provider.setSort("name", SortOrder.DESCENDING);
+        List<WorkspaceInfo> actual = Lists.newArrayList(provider.iterator(0, 25));
+        assertEquals(List.of(w4, w3, w2, w1), actual);
+    }
+
+    @Test
+    public void testIterator_orderbyIsolated() {
+        w2.setIsolated(true);
+        catalog.save(w2);
+
+        w3.setIsolated(true);
+        catalog.save(w3);
+
+        provider.setSort("isolated", SortOrder.ASCENDING);
+        List<WorkspaceInfo> actual = Lists.newArrayList(provider.iterator(0, 25));
+        assertEquals(List.of(w1, w4, w2, w3), actual);
+
+        provider.setSort("isolated", SortOrder.DESCENDING);
+        actual = Lists.newArrayList(provider.iterator(0, 25));
+        assertEquals(List.of(w2, w3, w1, w4), actual);
+    }
+
+    @Test
+    public void testIterator_orderbyDefault() {
+        catalog.setDefaultWorkspace(w3);
+
+        provider.setSort("default", SortOrder.ASCENDING);
+        List<WorkspaceInfo> actual = Lists.newArrayList(provider.iterator(0, 25));
+        assertEquals(List.of(w3, w1, w2, w4), actual);
+
+        provider.setSort("default", SortOrder.DESCENDING);
+        actual = Lists.newArrayList(provider.iterator(0, 25));
+        assertEquals(List.of(w1, w2, w4, w3), actual);
+    }
+
+    @Test
+    public void testOrderByDefaultProperty() {
+        catalog.setDefaultWorkspace(w3);
+        provider.setSort("name", SortOrder.ASCENDING);
+        List<WorkspaceInfo> actual = Lists.newArrayList(provider.iterator(0, 25));
+        assertEquals(4, actual.size());
+        WorkspaceInfo decoratedWithDefault = actual.get(2);
+        assertEquals(w3.getId(), decoratedWithDefault.getId());
+
+        assertEquals(
+                Boolean.TRUE, WorkspaceProvider.DEFAULT.getPropertyValue(decoratedWithDefault));
+        assertEquals(Boolean.FALSE, WorkspaceProvider.DEFAULT.getPropertyValue(actual.get(0)));
+        assertEquals(Boolean.FALSE, WorkspaceProvider.DEFAULT.getPropertyValue(actual.get(1)));
+        assertEquals(Boolean.FALSE, WorkspaceProvider.DEFAULT.getPropertyValue(actual.get(3)));
+    }
+}


### PR DESCRIPTION
[![GEOS-11090](https://badgen.net/badge/JIRA/GEOS-11090/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11090)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Make webui's `WorkspaceProvider` use streaming catalog access


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->