### PR TITLE
[Backport 2.23.x] [GEOS-11094] Bump org.hsqldb:hsqldb:2.7.1 to 2.7.2

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -158,7 +158,7 @@
     <errorProne.version>2.10.0</errorProne.version>
     <javac.version>9+181-r4173-1</javac.version>
     <pmd.version>6.42.0</pmd.version>
-    <hsql.version>2.7.1</hsql.version>
+    <hsql.version>2.7.2</hsql.version>
     <checkstyle.skip>false</checkstyle.skip>
     <qa>false</qa>
     <lint>deprecation,unchecked</lint>


### PR DESCRIPTION
[![GEOS-11094](https://badgen.net/badge/JIRA/GEOS-11094/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11094)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7056
 **Authored by:** @groldan