### PR TITLE
[Backport 2.23.x] Use Guava version as specified in parent dependencyManagement (gs-notification community module)

### DIFF
--- a/src/community/notification/pom.xml
+++ b/src/community/notification/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backport #7037
 **Authored by:** @mprins