### PR TITLE
Remove unecessary org.opengis.geometry.Geometry usage from OGC API modules

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AttributeType.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/AttributeType.java
@@ -75,8 +75,7 @@ public enum AttributeType {
             }
         } else if (Boolean.class.isAssignableFrom(binding)) {
             return AttributeType.BOOL;
-        } else if (Geometry.class.isAssignableFrom(binding)
-                || org.opengis.geometry.Geometry.class.isAssignableFrom(binding)) {
+        } else if (Geometry.class.isAssignableFrom(binding)) {
             return AttributeType.GEOMETRY;
         } else {
             // fallback

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FunctionsDocument.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FunctionsDocument.java
@@ -104,7 +104,6 @@ public class FunctionsDocument {
                     && !Number.class.isAssignableFrom(type)
                     && !Date.class.isAssignableFrom(type)
                     && !Geometry.class.isAssignableFrom(type)
-                    && !org.opengis.geometry.Geometry.class.isAssignableFrom(type)
                     && !Boolean.class.isAssignableFrom(type)) {
                 return false;
             }

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StyleAttributeExtractor.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StyleAttributeExtractor.java
@@ -64,13 +64,13 @@ import org.geotools.styling.Symbolizer;
 import org.geotools.styling.TextSymbolizer;
 import org.geotools.styling.TextSymbolizer2;
 import org.geotools.styling.UserLayer;
+import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.filter.Filter;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
-import org.opengis.geometry.Geometry;
 import org.opengis.style.GraphicalSymbol;
 
 /**


### PR DESCRIPTION
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->