### PR TITLE
[GEOS-11114] Improve extensibility in Pre-Authentication scenarios

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerPreAuthenticationFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerPreAuthenticationFilter.java
@@ -21,6 +21,7 @@ import org.geoserver.security.impl.GeoServerRole;
 import org.geoserver.security.impl.GeoServerUser;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
@@ -101,7 +102,7 @@ public abstract class GeoServerPreAuthenticationFilter extends GeoServerSecurity
         PreAuthenticatedAuthenticationToken result = null;
         if (GeoServerUser.ROOT_USERNAME.equals(principal)) {
             result =
-                    new PreAuthenticatedAuthenticationToken(
+                    createPreAuthenticatedAuthenticationToken(
                             principal, null, Collections.singleton(GeoServerRole.ADMIN_ROLE));
         } else {
             Collection<GeoServerRole> roles = null;
@@ -112,11 +113,22 @@ public abstract class GeoServerPreAuthenticationFilter extends GeoServerSecurity
             }
             if (roles.contains(GeoServerRole.AUTHENTICATED_ROLE) == false)
                 roles.add(GeoServerRole.AUTHENTICATED_ROLE);
-            result = new PreAuthenticatedAuthenticationToken(principal, null, roles);
+            result = createPreAuthenticatedAuthenticationToken(principal, null, roles);
         }
 
         result.setDetails(authenticationDetailsSource.buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(result);
+    }
+
+    /**
+     * @param principal
+     * @param credentials
+     * @param roles
+     * @return a new token, setup with the given parameters.
+     */
+    protected PreAuthenticatedAuthenticationToken createPreAuthenticatedAuthenticationToken(
+            String principal, Object credentials, Collection<? extends GrantedAuthority> roles) {
+        return new PreAuthenticatedAuthenticationToken(principal, credentials, roles);
     }
 
     public AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails>


### PR DESCRIPTION
[![GEOS-11114](https://badgen.net/badge/JIRA/GEOS-11114/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11114) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

From GEOS-11114:

> We are using GeoServer in a Pre-Authentication scenario. GeoServerPreAuthenticationFilter is used as a basis for an own implementation which performs custom logic for retrieval of roles and also uses a custom principal implementation for certain reasons.
> 
> However currently we have to patch GeoServerPreAuthenticationFilter to integrate the required logic. Through a very small adjustment projects depending on custom login can maintain their stack more easily.
> 
> I will propose a pull request to introduce a small factory method within PreAuthenticatedAuthenticationToken, rather than using the constructor for the token inline.
> 
> Thanks for considering this and best regards,
> 
> Andreas

# Checklist

- [ x ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ x ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ x ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ x ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ x ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ x ] Bug fixes and small new features are presented as a single commit.
- [ x ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).