### PR TITLE
[GEOS-11070] Introduce mf.version to pom.xml to manage mapfish-print version

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -124,6 +124,7 @@
     <interactive.image>false</interactive.image>
     <windows.leniency>true</windows.leniency>
     <gf.version>3.6.0</gf.version>
+    <mf.version>2.2.0</mf.version>
     <jasypt.version>1.9.2</jasypt.version>
     <hibernate-version>3.6.9.Final</hibernate-version>
     <hibernate-generic-dao-version>1.1.0</hibernate-generic-dao-version>
@@ -1120,7 +1121,7 @@
       <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>2.2.0</version>
+        <version>${mf.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.librepdf</groupId>


### PR DESCRIPTION
[![GEOS-11070](https://badgen.net/badge/JIRA/GEOS-11070/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11070) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A small build change to assist with https://github.com/geotools/geotools/pull/4367 testing.

This will allow GeoServer change ``mf.version`` to 2.3-SNAPSHOT which is deployed to repo.osgeo.org.