### PR TITLE
[Backport 2.22.x] [GEOS-11116] GetMap/GetFeatureInfo with groups and view params can with mismatched layers/params (+Java8Fix)

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -1127,10 +1127,12 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
 
         List<Map<String, String>> viewParamsList = request.getViewParams();
         assertEquals(4, viewParamsList.size());
-        assertEquals(Map.of("test", "123"), viewParamsList.get(0));
-        assertEquals(Map.of("test", "123"), viewParamsList.get(1));
-        assertEquals(Map.of("where", "WHERE PERSONS > 1000000"), viewParamsList.get(2));
-        assertEquals(Map.of("str", "ABCD"), viewParamsList.get(3));
+        assertEquals(Collections.singletonMap("test", "123"), viewParamsList.get(0));
+        assertEquals(Collections.singletonMap("test", "123"), viewParamsList.get(1));
+        assertEquals(
+                Collections.singletonMap("where", "WHERE PERSONS > 1000000"),
+                viewParamsList.get(2));
+        assertEquals(Collections.singletonMap("str", "ABCD"), viewParamsList.get(3));
     }
 
     @Test
@@ -1144,10 +1146,12 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
 
         List<Map<String, String>> viewParamsList = request.getViewParams();
         assertEquals(4, viewParamsList.size());
-        assertEquals(Map.of("where", "WHERE PERSONS > 1000000"), viewParamsList.get(0));
-        assertEquals(Map.of("test", "123"), viewParamsList.get(1));
-        assertEquals(Map.of("test", "123"), viewParamsList.get(2));
-        assertEquals(Map.of("str", "ABCD"), viewParamsList.get(3));
+        assertEquals(
+                Collections.singletonMap("where", "WHERE PERSONS > 1000000"),
+                viewParamsList.get(0));
+        assertEquals(Collections.singletonMap("test", "123"), viewParamsList.get(1));
+        assertEquals(Collections.singletonMap("test", "123"), viewParamsList.get(2));
+        assertEquals(Collections.singletonMap("str", "ABCD"), viewParamsList.get(3));
     }
 
     @Test
@@ -1163,10 +1167,12 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
 
         List<Map<String, String>> viewParamsList = request.getViewParams();
         assertEquals(4, viewParamsList.size());
-        assertEquals(Map.of("where", "WHERE PERSONS > 1000000"), viewParamsList.get(0));
-        assertEquals(Map.of("str", "ABCD"), viewParamsList.get(1));
-        assertEquals(Map.of("test", "123"), viewParamsList.get(2));
-        assertEquals(Map.of("test", "123"), viewParamsList.get(3));
+        assertEquals(
+                Collections.singletonMap("where", "WHERE PERSONS > 1000000"),
+                viewParamsList.get(0));
+        assertEquals(Collections.singletonMap("str", "ABCD"), viewParamsList.get(1));
+        assertEquals(Collections.singletonMap("test", "123"), viewParamsList.get(2));
+        assertEquals(Collections.singletonMap("test", "123"), viewParamsList.get(3));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11116](https://badgen.net/badge/JIRA/GEOS-11116/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11116) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7107
 **Authored by:** @dromagnoli