### PR TITLE
[Backport 2.23.x] [GEOS-11118] Add Temporal Extents domain and datetime parameter to Maps API

### DIFF
--- a/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/v1/maps/MapsService.java
+++ b/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/v1/maps/MapsService.java
@@ -4,18 +4,24 @@
  */
 package org.geoserver.ogcapi.v1.maps;
 
+import static org.geoserver.ogcapi.APIException.INVALID_PARAMETER_VALUE;
+
 import java.awt.Color;
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import net.opengis.wfs.FeatureCollectionType;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.ogcapi.APIBBoxParser;
@@ -27,6 +33,7 @@ import org.geoserver.ogcapi.ConformanceClass;
 import org.geoserver.ogcapi.ConformanceDocument;
 import org.geoserver.ogcapi.HTMLResponseBody;
 import org.geoserver.ogcapi.StyleDocument;
+import org.geoserver.ows.kvp.TimeParser;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.DefaultWebMapService;
 import org.geoserver.wms.GetFeatureInfoRequest;
@@ -65,6 +72,7 @@ public class MapsService {
             "http://www.opengis.net/spec/ogcapi-maps-2/1.0/conf/crs";
 
     private static final String DISPLAY_NAME = "OGC API Maps";
+    private TimeParser timeParser = new TimeParser();
 
     private final GeoServer geoServer;
     private final WebMapService wms;
@@ -114,7 +122,8 @@ public class MapsService {
     @GetMapping(path = "collections/{collectionId}", name = "describeCollection")
     @ResponseBody
     @HTMLResponseBody(templateName = "collection.ftl", fileName = "collection.html")
-    public CollectionDocument collection(@PathVariable(name = "collectionId") String collectionId) {
+    public CollectionDocument collection(@PathVariable(name = "collectionId") String collectionId)
+            throws IOException {
         PublishedInfo p = getPublished(collectionId);
         CollectionDocument collection = new CollectionDocument(geoServer, p);
 
@@ -158,13 +167,14 @@ public class MapsService {
             @RequestParam(name = "f") String format,
             @RequestParam(name = "bbox", required = false) String bbox,
             @RequestParam(name = "crs", required = false) String crs,
+            @RequestParam(name = "datetime", required = false) String datetime,
             @RequestParam(name = "width", required = false) Integer width,
             @RequestParam(name = "height", required = false) Integer height,
             @RequestParam(name = "transparent", required = false, defaultValue = "true")
                     boolean transparent,
             @RequestParam(name = "bgcolor", required = false) String bgcolor
             // TODO: add all the vendor parameters we normally support in WMS
-            ) throws IOException, FactoryException {
+            ) throws IOException, FactoryException, ParseException {
         GetMapRequest request =
                 toGetMapRequest(
                         collectionId,
@@ -172,6 +182,7 @@ public class MapsService {
                         format,
                         bbox,
                         crs,
+                        datetime,
                         width,
                         height,
                         transparent,
@@ -229,6 +240,7 @@ public class MapsService {
             @RequestParam(name = "f") String format,
             @RequestParam(name = "bbox", required = false) String bbox,
             @RequestParam(name = "crs", required = false) String crs,
+            @RequestParam(name = "datetime", required = false) String datetime,
             @RequestParam(name = "width", required = false) Integer width,
             @RequestParam(name = "height", required = false) Integer height,
             @RequestParam(name = "transparent", required = false, defaultValue = "true")
@@ -237,7 +249,7 @@ public class MapsService {
             @RequestParam(name = "i") int i,
             @RequestParam(name = "j") int j
             // TODO: add all the vendor parameters we normally support in WMS
-            ) throws IOException, FactoryException {
+            ) throws IOException, FactoryException, ParseException {
         GetMapRequest getMapRequest =
                 toGetMapRequest(
                         collectionId,
@@ -245,6 +257,7 @@ public class MapsService {
                         "image/png",
                         bbox,
                         crs,
+                        datetime,
                         width,
                         height,
                         transparent,
@@ -268,11 +281,12 @@ public class MapsService {
             String format,
             String bbox,
             String crs,
+            String datetime,
             Integer width,
             Integer height,
             boolean transparent,
             String bgcolor)
-            throws IOException, FactoryException {
+            throws IOException, FactoryException, ParseException {
         PublishedInfo p = getPublished(collectionId);
         checkStyle(p, styleId);
         StyleInfo styleInfo = getCatalog().getStyleByName(styleId);
@@ -297,6 +311,9 @@ public class MapsService {
         if (height != null) request.setHeight(height);
         if (bgcolor != null) request.setBgColor(Color.decode(bgcolor));
         request.setTransparent(transparent);
+        if (datetime != null) {
+            setupTimeSubset(datetime, p, request);
+        }
         Map<String, String> rawParamers = new LinkedHashMap<>();
         if (bbox != null) rawParamers.put("bbox", bbox);
         if (crs != null) rawParamers.put("crs", crs);
@@ -304,8 +321,37 @@ public class MapsService {
         rawParamers.put("height", String.valueOf(height));
         rawParamers.put("layers", collectionId);
         rawParamers.put("styles", styleId);
+        rawParamers.put("datetime", datetime);
         request.setRawKvp(rawParamers);
         // TODO: add other parameters
         return request;
+    }
+
+    private void setupTimeSubset(String datetime, PublishedInfo p, GetMapRequest request)
+            throws ParseException {
+        if (!(p instanceof LayerInfo)) {
+            throw new APIException(
+                    APIException.INVALID_PARAMETER_VALUE,
+                    "Can only handle time subset on layers, not layer groups",
+                    HttpStatus.BAD_REQUEST);
+        }
+        LayerInfo layer = (LayerInfo) p;
+        DimensionInfo time =
+                layer.getResource().getMetadata().get(ResourceInfo.TIME, DimensionInfo.class);
+        if (time == null || !time.isEnabled()) {
+            throw new APIException(
+                    INVALID_PARAMETER_VALUE,
+                    "Time dimension is not enabled in this coverage",
+                    HttpStatus.BAD_REQUEST);
+        }
+        @SuppressWarnings("unchecked")
+        Collection<Object> times = timeParser.parse(datetime);
+        if (times.size() != 1) {
+            throw new APIException(
+                    INVALID_PARAMETER_VALUE,
+                    "Invalid datetime specification, must be a single time, or a time range",
+                    HttpStatus.BAD_REQUEST);
+        }
+        request.setTime(List.copyOf(times));
     }
 }

--- a/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/collection_include.ftl
@@ -13,6 +13,10 @@
       </#list>
       </ul>
       </li>
+      <#if collection.extent.temporal??>
+            <#assign temporal = collection.extent.temporal>
+            <li id="${collection.htmlId}_temporal"><b>Temporal extent</b>: ${temporal.minValue?datetime?iso_utc}/${temporal.maxValue?datetime?iso_utc}</li>
+      </#if>
       <li> <a id="html_${collection.htmlId}_link" href="${collection.getLinkUrl('styles', 'text/html')!}">Map styles</a>.
                  
       <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping --> 

--- a/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/CollectionTest.java
@@ -4,11 +4,13 @@
  */
 package org.geoserver.ogcapi.v1.maps;
 
+import static org.geoserver.catalog.ResourceInfo.TIME;
 import static org.junit.Assert.assertEquals;
 
 import com.jayway.jsonpath.DocumentContext;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -81,5 +83,28 @@ public class CollectionTest extends MapsTestSupport {
         assertEquals(-90, spatial.read("$[1]"), 0d);
         assertEquals(180, spatial.read("$[2]"), 0d);
         assertEquals(90, spatial.read("$[3]"), 0d);
+    }
+
+    @Test
+    public void testTemporalCollectionHTML() throws Exception {
+        setupRasterDimension(TIMESERIES, TIME, DimensionPresentation.LIST, null, null, null);
+        org.jsoup.nodes.Document document =
+                getAsJSoup("ogc/maps/v1/collections/sf:timeseries?f=html");
+
+        String id = getLayerId(TIMESERIES).replace(":", "__");
+
+        // check temporal extent
+        assertEquals(
+                "Temporal extent: 2014-01-01T00:00:00Z/2019-01-01T00:00:00Z",
+                document.select("#" + id + "_temporal").text());
+    }
+
+    @Test
+    public void testCollectionJson() throws Exception {
+        setupRasterDimension(TIMESERIES, TIME, DimensionPresentation.LIST, null, null, null);
+        DocumentContext json = getAsJSONPath("ogc/maps/v1/collections/sf:timeseries", 200);
+
+        assertEquals("2014-01-01T00:00:00Z", json.read("$.extent.temporal.interval[0][0]"));
+        assertEquals("2019-01-01T00:00:00Z", json.read("$.extent.temporal.interval[0][1]"));
     }
 }

--- a/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTest.java
+++ b/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTest.java
@@ -1,0 +1,69 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.maps;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jayway.jsonpath.DocumentContext;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.nodes.DataNode;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.Test;
+
+public class MapsTest extends MapsTestSupport {
+    @Test
+    public void testDatetimeJson() throws Exception {
+        setupStartEndTimeDimension(
+                TIME_WITH_START_END.getLocalPart(), "time", "startTime", "endTime");
+        Integer[] values = {1, 1, 1, 1, 0, 1};
+        // work with different time resolutions
+        String[] dates = {
+            "2012",
+            "2012-02",
+            "2012-02-11",
+            "2012-02-11T00:00:00Z",
+            "2012-02-14T00:00:00.000Z",
+            "2012-02-12T00:00:00Z"
+        };
+        for (int i = 0; i < 6; i++) {
+            DocumentContext json =
+                    getAsJSONPath(
+                            "ogc/maps/v1/collections/sf:TimeWithStartEnd/styles/Default/map/info?i=50&j=50&f=application%2Fjson&datetime="
+                                    + dates[i],
+                            200);
+            assertEquals(values[i], json.read("$.numberReturned", Integer.class));
+        }
+    }
+
+    @Test
+    public void testDatetimeHTMLMapsFormat() throws Exception {
+        setupStartEndTimeDimension(
+                TIME_WITH_START_END.getLocalPart(), "time", "startTime", "endTime");
+        Document document =
+                getAsJSoup(
+                        "ogc/maps/v1/collections/sf:TimeWithStartEnd/styles/Default/map?f=html&datetime=2012-02-12T00:00:00Z");
+        Elements scriptsOnPage = document.select("script");
+        Matcher matcher = null;
+        // check that the datetime is in the javascript parameters
+        String keyToFind = "datetime";
+        Pattern pattern = Pattern.compile("\"" + keyToFind + "\":\\s*'(.*?)'");
+        boolean found = false;
+        for (Element element : scriptsOnPage) {
+            for (DataNode node : element.dataNodes()) {
+                matcher = pattern.matcher(node.getWholeData());
+                while (matcher.find()) {
+                    if (matcher.group().equals("\"datetime\": '2012-02-12T00:00:00Z'")) {
+                        found = true;
+                    }
+                }
+            }
+        }
+        assertTrue(found);
+    }
+}

--- a/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTestSupport.java
+++ b/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTestSupport.java
@@ -4,10 +4,21 @@
  */
 package org.geoserver.ogcapi.v1.maps;
 
+import java.util.Collections;
+import javax.xml.namespace.QName;
+import org.geoserver.catalog.DimensionInfo;
+import org.geoserver.catalog.DimensionPresentation;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.impl.DimensionInfoImpl;
+import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.ogcapi.OGCApiTestSupport;
 
 public class MapsTestSupport extends OGCApiTestSupport {
+    protected static final QName TIMESERIES =
+            new QName(MockData.SF_URI, "timeseries", MockData.SF_PREFIX);
+    static final QName TIME_WITH_START_END =
+            new QName(MockData.SF_URI, "TimeWithStartEnd", MockData.SF_PREFIX);
 
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
@@ -18,5 +29,25 @@ public class MapsTestSupport extends OGCApiTestSupport {
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         super.onSetUp(testData);
+        // add temporal layer
+        testData.addRasterLayer(TIMESERIES, "timeseries.zip", null, getCatalog());
+        testData.addVectorLayer(
+                TIME_WITH_START_END,
+                Collections.emptyMap(),
+                "TimeElevationWithStartEnd.properties",
+                getClass(),
+                getCatalog());
+    }
+
+    protected void setupStartEndTimeDimension(
+            String featureTypeName, String dimension, String start, String end) {
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName(featureTypeName);
+        DimensionInfo di = new DimensionInfoImpl();
+        di.setEnabled(true);
+        di.setAttribute(start);
+        di.setEndAttribute(end);
+        di.setPresentation(DimensionPresentation.LIST);
+        info.getMetadata().put(dimension, di);
+        getCatalog().save(info);
     }
 }

--- a/src/community/ogcapi/ogcapi-maps/src/test/resources/org/geoserver/ogcapi/v1/maps/TimeElevationWithStartEnd.properties
+++ b/src/community/ogcapi/ogcapi-maps/src/test/resources/org/geoserver/ogcapi/v1/maps/TimeElevationWithStartEnd.properties
@@ -1,0 +1,4 @@
+_=id:java.lang.Integer,startTime:java.util.Date,endTime:java.util.Date,startElevation:double,endElevation:double,geom:Polygon:srid=4326
+TimeElevationWithStartEnd.0=0|2012-02-11Z|2012-02-12Z|1.0|2.0|POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))
+TimeElevationWithStartEnd.1=1|2012-02-12Z|2012-02-13Z|2.0|3.0|POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))
+TimeElevationWithStartEnd.2=2|2012-02-11Z|2012-02-14Z|1.0|3.0|POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))


### PR DESCRIPTION
[![GEOS-11118](https://badgen.net/badge/JIRA/GEOS-11118/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11118) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7113
 **Authored by:** @turingtestfail