### PR TITLE
Revert javadoc maven plugin upgrade, add build to ensure aggregate works

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,49 @@
+name: Linux JDK 11 GitHub CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/src/main/resources/GeoServerApplication_*.properties'
+      - '!**/src/main/resources/GeoServerApplication_fr.properties'
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
+
+jobs:
+  javadoc:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            jdk: 11
+            dist: 'temurin'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # 500 commits, set to 0 to get all
+        fetch-depth: 500
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ matrix.jdk }}
+        distribution: ${{ matrix.dist }}
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.4
+    - name: Maven repository caching
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: gs-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          gs-${{ runner.os }}-maven-
+    - name: Build with Maven
+      run: mvn -B -fae -Dspotless.apply.skip=true -f src/pom.xml  clean install -DskipTests
+    - name: Build aggregate javadocs
+      run: mvn -B -fae -Dspotless.apply.skip=true -f src/pom.xml javadoc:aggregate
+    - name: Remove SNAPSHOT jars from repository
+      run: |
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
+

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1718,7 +1718,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>2.10.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
@@ -2006,10 +2006,10 @@
           </tags>
 
           <links>
-            <link>http://docs.oracle.com/javase/8/docs/api/</link>
+            <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
             <link>http://docs.oracle.com/javaee/7/api/</link>
             <link>http://jscience.org/api/</link>
-            <link>http://tsusiatsoftware.net/jts/javadoc</link>
+            <link>https://locationtech.github.io/jts/javadoc/</link>
             <link>http://docs.geotools.org/latest/javadocs/</link>
             <link>http://xmlgraphics.apache.org/batik/javadoc</link>
             <link>http://freemarker.sourceforge.net/docs/api/</link>


### PR DESCRIPTION
The current javadoc:aggregate fails, despite the flag asking the javadoc plugin not to fail on errors.
This PR reverts the javadoc plugin upgrade, and adds a new javadoc aggregation build to guard against javadoc generation failure (just checks it can generate javadocs, we can switch to a strict check once the actual errors are resolved).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->