### PR TITLE
[GEOS-11130] Add a new role > parent role dropdown is not in any discernable order

### DIFF
--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/AbstractRolePage.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/AbstractRolePage.java
@@ -127,6 +127,7 @@ public abstract class AbstractRolePage extends AbstractSecurityPage {
             // if no parent mappings, return empty list
             if (parentMappings == null || parentMappings.isEmpty()) return Collections.emptyList();
 
+            List<String> parentRoles;
             if (role != null && StringUtils.hasLength(role.getAuthority())) {
                 // filter out roles already used as parents
                 RoleHierarchyHelper helper = new RoleHierarchyHelper(parentMappings);
@@ -134,12 +135,14 @@ public abstract class AbstractRolePage extends AbstractSecurityPage {
                 Set<String> parents = new HashSet<>(parentMappings.keySet());
                 parents.removeAll(helper.getDescendants(role.getAuthority()));
                 parents.remove(role.getAuthority());
-                return new ArrayList<>(parents);
+                parentRoles = new ArrayList<>(parents);
 
             } else {
                 // no rolename given, we are creating a new one
-                return new ArrayList<>(parentMappings.keySet());
+                parentRoles = new ArrayList<>(parentMappings.keySet());
             }
+            Collections.sort(parentRoles);
+            return parentRoles;
         }
 
         @Override


### PR DESCRIPTION
[![GEOS-11130](https://badgen.net/badge/JIRA/GEOS-11130/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11130) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Return a sorted list

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->