### PR TITLE
[Backport 2.23.x] [GEOS-11130] Add a new role > parent role dropdown is not in any discernable order

### DIFF
--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/AbstractRolePage.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/AbstractRolePage.java
@@ -127,6 +127,7 @@ public abstract class AbstractRolePage extends AbstractSecurityPage {
             // if no parent mappings, return empty list
             if (parentMappings == null || parentMappings.isEmpty()) return Collections.emptyList();
 
+            List<String> parentRoles;
             if (role != null && StringUtils.hasLength(role.getAuthority())) {
                 // filter out roles already used as parents
                 RoleHierarchyHelper helper = new RoleHierarchyHelper(parentMappings);
@@ -134,12 +135,14 @@ public abstract class AbstractRolePage extends AbstractSecurityPage {
                 Set<String> parents = new HashSet<>(parentMappings.keySet());
                 parents.removeAll(helper.getDescendants(role.getAuthority()));
                 parents.remove(role.getAuthority());
-                return new ArrayList<>(parents);
+                parentRoles = new ArrayList<>(parents);
 
             } else {
                 // no rolename given, we are creating a new one
-                return new ArrayList<>(parentMappings.keySet());
+                parentRoles = new ArrayList<>(parentMappings.keySet());
             }
+            Collections.sort(parentRoles);
+            return parentRoles;
         }
 
         @Override


### PR DESCRIPTION
[![GEOS-11130](https://badgen.net/badge/JIRA/GEOS-11130/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11130) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7130
 **Authored by:** @petersmythe