### PR TITLE
[Backport 2.24.x] Bump org.apache.avro:avro from 1.7.5 to 1.11.3 in /src/community/geomesa

### DIFF
--- a/src/community/geomesa/pom.xml
+++ b/src/community/geomesa/pom.xml
@@ -48,7 +48,7 @@ application directory.
         <slf4j.version>1.7.5</slf4j.version>
         <scalalogging.version>1.1.0</scalalogging.version>
 
-        <avro.version>1.7.5</avro.version>
+        <avro.version>1.11.3</avro.version>
     </properties>
 
 


### PR DESCRIPTION
Backport #7139
 **Authored by:** @dependabot[bot]