### PR TITLE
[Backport 2.23.x] [GEOS-11140] WPS download can leak image references in the RasterCleaner

### DIFF
--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadAnimationProcess.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadAnimationProcess.java
@@ -30,6 +30,7 @@ import org.geoserver.ows.Request;
 import org.geoserver.ows.kvp.TimeParser;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.util.HTTPWarningAppender;
+import org.geoserver.wms.RasterCleaner;
 import org.geoserver.wps.WPSException;
 import org.geoserver.wps.gs.GeoServerProcess;
 import org.geoserver.wps.process.RawData;
@@ -75,12 +76,14 @@ public class DownloadAnimationProcess implements GeoServerProcess {
     private final DateTimeFormatter formatter;
     private final DownloadServiceConfigurationGenerator confiGenerator;
     private final HTTPWarningAppender warningAppender;
+    private final RasterCleaner rasterCleaner;
 
     public DownloadAnimationProcess(
             DownloadMapProcess mapper,
             WPSResourceManager resourceManager,
             DownloadServiceConfigurationGenerator downloadServiceConfigurationGenerator,
-            HTTPWarningAppender warningAppender) {
+            HTTPWarningAppender warningAppender,
+            RasterCleaner rasterCleaner) {
         this.mapper = mapper;
         this.resourceManager = resourceManager;
         this.confiGenerator = downloadServiceConfigurationGenerator;
@@ -90,6 +93,7 @@ public class DownloadAnimationProcess implements GeoServerProcess {
                 DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")
                         .withLocale(Locale.ENGLISH)
                         .withZone(ZoneId.of("GMT"));
+        this.rasterCleaner = rasterCleaner;
     }
 
     @DescribeResults({
@@ -194,6 +198,7 @@ public class DownloadAnimationProcess implements GeoServerProcess {
                                 BufferedImage frame;
                                 while ((frame = renderingQueue.take()) != STOP) {
                                     enc.encodeImage(frame);
+                                    RasterCleaner.disposeImage(frame);
                                     listener.progress(90 * (((float) count) / totalTimes));
                                     String message =
                                             "Generated frames " + count + " out of " + totalTimes;
@@ -241,13 +246,16 @@ public class DownloadAnimationProcess implements GeoServerProcess {
                 renderingQueue.put(STOP);
                 // wait for encoder to finish
                 future.get();
-                progressListener.progress(100);
             } finally {
                 // force encoding thread to stop in case we got here due to an exception
                 abortEncoding.set(true);
                 executor.shutdown();
+                // clean up the images collected during the execution, in case the
+                // clean ups above did not do the job
+                rasterCleaner.finished(null);
                 warningAppender.finished(request);
             }
+            progressListener.progress(100);
             enc.finish();
 
             // it's a derived property, but XStream does not like to use getters
@@ -266,6 +274,7 @@ public class DownloadAnimationProcess implements GeoServerProcess {
             frame = (BufferedImage) image;
         } else {
             frame = PlanarImage.wrapRenderedImage(image).getAsBufferedImage();
+            RasterCleaner.disposeImage(image);
         }
         return frame;
     }

--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadMapProcess.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/DownloadMapProcess.java
@@ -44,6 +44,7 @@ import org.geoserver.platform.Service;
 import org.geoserver.util.HTTPWarningAppender;
 import org.geoserver.wms.GetMap;
 import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.RasterCleaner;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.map.AbstractMapOutputFormat;
@@ -94,12 +95,14 @@ public class DownloadMapProcess implements GeoServerProcess, ApplicationContextA
     private final WMS wms;
     private final GetMapKvpRequestReader getMapReader;
     private final HTTPWarningAppender warningAppender;
+    private final RasterCleaner rasterCleaner;
     private Service service;
     // defaulting to a stateless but reliable http client
     private Supplier<org.geotools.http.HTTPClient> httpClientSupplier =
             () -> HTTPClientFinder.createClient();
 
-    public DownloadMapProcess(GeoServer geoServer, HTTPWarningAppender warningAppender) {
+    public DownloadMapProcess(
+            GeoServer geoServer, HTTPWarningAppender warningAppender, RasterCleaner rasterCleaner) {
         // TODO: make these configurable
         this.wms =
                 new WMS(geoServer) {
@@ -115,6 +118,7 @@ public class DownloadMapProcess implements GeoServerProcess, ApplicationContextA
                 };
         this.getMapReader = new GetMapKvpRequestReader(wms);
         this.warningAppender = warningAppender;
+        this.rasterCleaner = rasterCleaner;
     }
 
     /** This process returns a potentially large map */
@@ -252,6 +256,11 @@ public class DownloadMapProcess implements GeoServerProcess, ApplicationContextA
         } finally {
             // avoid accumulation of warnings in the executor thread that run this request
             warningAppender.finished(Dispatcher.REQUEST.get());
+            // clean up images, this process runs in a background thread, it won't get
+            // the callback invoked and the thread locals would accumulate images
+            rasterCleaner.finished(null);
+            // not wrong, and allows tests to check the raster cleaner has done its job
+            progressListener.progress(100);
         }
 
         // we got here, no supported format found
@@ -521,7 +530,7 @@ public class DownloadMapProcess implements GeoServerProcess, ApplicationContextA
             progressListener.progress(95f * (++i) / layers.length / 2);
         }
 
-        progressListener.progress(100);
+        progressListener.progress(90);
 
         return result;
     }

--- a/src/extension/wps-download/src/main/resources/applicationContext.xml
+++ b/src/extension/wps-download/src/main/resources/applicationContext.xml
@@ -45,6 +45,8 @@
 		<constructor-arg index="0" ref="downloadMapProcess"/>
 		<constructor-arg index="1" ref="wpsResourceManager"/>
 		<constructor-arg index="2" ref="downloadServiceConfigurationWatcher" />
+		<constructor-arg index="3" ref="httpWarningAppender"/>
+		<constructor-arg index="4" ref="rasterCleaner" />
 	</bean>
 	
 	<bean id="animationMetadataPPIO" class="org.geoserver.wps.gs.download.AnimationMetadataPPIO"/>

--- a/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/BaseDownloadImageProcessTest.java
+++ b/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/BaseDownloadImageProcessTest.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.xml.namespace.QName;
 import org.apache.commons.io.FileUtils;
@@ -25,6 +26,12 @@ public class BaseDownloadImageProcessTest extends WPSTestSupport {
     protected static final String UNIT_SYMBOL = "ft";
     protected static QName GIANT_POLYGON =
             new QName(MockData.CITE_URI, "giantPolygon", MockData.CITE_PREFIX);
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:TestContext.xml");
+    }
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {

--- a/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadAnimationProcessTest.java
+++ b/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadAnimationProcessTest.java
@@ -49,14 +49,6 @@ public class DownloadAnimationProcessTest extends BaseDownloadImageProcessTest {
         void accept(T t, U u) throws Exception;
     }
 
-    @Override
-    protected String getLogConfiguration() {
-        if (isQuietTests()) {
-            return "QUIET_LOGGING";
-        }
-        return "DEFAULT_LOGGING";
-    }
-
     @Test
     public void testDescribeProcess() throws Exception {
         Document d =

--- a/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/RasterCleanerProcessListener.java
+++ b/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/RasterCleanerProcessListener.java
@@ -1,0 +1,50 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps.gs.download;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.geoserver.wms.RasterCleaner;
+import org.geoserver.wps.ProcessEvent;
+import org.geoserver.wps.ProcessListenerAdapter;
+import org.geoserver.wps.WPSException;
+import org.geoserver.wps.executor.ExecutionStatus;
+import org.junit.Assert;
+
+public class RasterCleanerProcessListener extends ProcessListenerAdapter {
+
+    private final RasterCleaner cleaner;
+    Map<String, Integer> cleanerStatus = new HashMap<>();
+
+    public RasterCleanerProcessListener(RasterCleaner cleaner) {
+        this.cleaner = cleaner;
+    }
+
+    @Override
+    public void succeeded(ProcessEvent event) throws WPSException {
+        Integer count = cleanerStatus.get(event.getStatus().getExecutionId());
+        if (count != null && count != 0) {
+            Assert.fail("RasterCleaner did not clean up all images");
+        }
+    }
+
+    @Override
+    public void progress(ProcessEvent event) throws WPSException {
+        ExecutionStatus status = event.getStatus();
+        String processName = status.getProcessName().getLocalPart();
+        if (("DownloadMap".equals(processName) || "DownloadAnimation".equals(processName))) {
+            cleanerStatus.put(
+                    status.getExecutionId(),
+                    collectionSize(cleaner.getImages()) + collectionSize(cleaner.getCoverages()));
+        }
+    }
+
+    private Integer collectionSize(List<? extends Object> images) {
+        return Optional.ofNullable(images).map(Collection::size).orElse(0);
+    }
+}

--- a/src/extension/wps-download/src/test/resources/TestContext.xml
+++ b/src/extension/wps-download/src/test/resources/TestContext.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ Copyright (C) 2023 Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean id="imageryListener" class="org.geoserver.wps.gs.download.RasterCleanerProcessListener">
+        <constructor-arg index="0" ref="rasterCleaner"/>
+    </bean>
+</beans>

--- a/src/wms/src/main/java/org/geoserver/wms/RasterCleaner.java
+++ b/src/wms/src/main/java/org/geoserver/wms/RasterCleaner.java
@@ -82,7 +82,8 @@ public class RasterCleaner extends AbstractDispatcherCallback {
         }
     }
 
-    private void disposeImage(RenderedImage image) {
+    /** Immediately disposes an image, the image might not be usable any longer after this call */
+    public static void disposeImage(RenderedImage image) {
         if (image instanceof PlanarImage) {
             ImageUtilities.disposePlanarImageChain((PlanarImage) image);
         } else if (image instanceof BufferedImage) {


### PR DESCRIPTION
[![GEOS-11140](https://badgen.net/badge/JIRA/GEOS-11140/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11140) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7150
 **Authored by:** @aaime