### PR TITLE
[GEOS-11050] Refactor Resources and Paths API to support alternative …

### DIFF
--- a/doc/en/developer/source/programming-guide/config/resource.rst
+++ b/doc/en/developer/source/programming-guide/config/resource.rst
@@ -21,8 +21,8 @@ Reference:
 
    The methods in the Resource API use String parameter names consistently:
 
- * ``resource path`` path to a resource in the resource store. (For instance in the case of the default FileSystemResourceStore, this is file path that is relative with respect to the data directory, but for perserving generic behaviour compatible with any resource store, developers should not assume this to be the case). Resource paths do not support the `.` and `..` relative directory names. Resource paths use forward slashes, similar to URL's and unix style file paths, and are OS-independent.
- * ``file path`` absolute path to a file in the file system. While these are OS dependent (with regard to the root of the absolute path) but they must always forward slashes, as supported by all operating systems and compatible with resource paths as well as file URL's. Note that ``Resource.path()`` for resources obtained by ``Files.asResource(file)`` will return a file path rather than a resource path.  
+ * ``resource path`` path to a resource in the resource store. (For instance in the case of the default FileSystemResourceStore, this is file path that is relative with respect to the data directory, but to preserve generic behaviour compatible with any resource store, developers should not assume this to be the case). Resource paths do not support the `.` and `..` relative directory names. Resource paths use forward slashes, similar to URL's and unix style file paths, and are OS-independent.
+ * ``file path`` absolute path to a file in the file system. While these are OS dependent (with regard to the root of the absolute path) but they must always use forward slashes, as supported by all operating systems and compatible with resource paths as well as file URL's. Note that ``Resource.path()`` for resources obtained by ``Files.asResource(file)`` will return a file path rather than a resource path.  
  * ``file`` a java File reference.  
  * ``url`` a location resolved with respect to the resource store. A number of special cases developed over time distilled into ``Resources.fromUrl(base,url)`` and ``Files.url(base,url)`` methods.  
 

--- a/doc/en/developer/source/programming-guide/config/resource.rst
+++ b/doc/en/developer/source/programming-guide/config/resource.rst
@@ -21,17 +21,21 @@ Reference:
 
    The methods in the Resource API use String parameter names consistently:
 
-   * ``path`` relative location of resource within the data directory.
-  
-     Paths are represented similar to a File URL, ``file://`` prefix used internally and
-     by the resource REST API.
-   
-   * ``file`` a java File reference.
-  
-   * ``url`` a location resolved with respect to the data directory.
-  
-     A large number of special cases developed over time distilled into  ``Resources.fromUrl(base,url)`` and ``Files.url(base,url)`` methods.
-  
+ * ``resource path`` path to a resource in the resource store. (For instance in the case of the default FileSystemResourceStore, this is file path that is relative with respect to the data directory, but for perserving generic behaviour compatible with any resource store, developers should not assume this to be the case). Resource paths do not support the `.` and `..` relative directory names. Resource paths use forward slashes, similar to URL's and unix style file paths, and are OS-independent.
+ * ``file path`` absolute path to a file in the file system. While these are OS dependent (with regard to the root of the absolute path) but they must always forward slashes, as supported by all operating systems and compatible with resource paths as well as file URL's. Note that ``Resource.path()`` for resources obtained by ``Files.asResource(file)`` will return a file path rather than a resource path.  
+ * ``file`` a java File reference.  
+ * ``url`` a location resolved with respect to the resource store. A number of special cases developed over time distilled into ``Resources.fromUrl(base,url)`` and ``Files.url(base,url)`` methods.  
+
+General Guidelines
+------------------
+
+All geoserver developers should be wary of the following general principles when contributing or reviewing:
+
+ * Avoid as much as possible using the file system directly. The only acceptable exception is when third party libraries require this, and even then the Resources API should be used maximally.
+ * For custom configuration files with a fixed location, always use ``ResourceStore``. ``GeoServerResourceLoader`` and ``GeoServerDataDirectory`` are legacy and should not be used in new code.
+ * For URL's provided by user configuration (such as templates, style sheets, etc), use ``Resources.fromURL``.
+ * For input/output, always use ``Resource.in()`` and ``Resource.out()``.
+ * Avoid the usage of ``Resource.file()`` and ``Resource.directory()``. These methods are only necessary for third party libraries that require usage of the file system, and only for input.  They should never be used for permanent output: Since there are alternative implementations of the ResourceStore that do not use the file system as underlying storage device, modifying them does not necessarily have a lasting effect
 
 ResourceStore
 -------------
@@ -83,9 +87,9 @@ Resource contents are streamed using ``out()`` and ``in()`` methods. The entire 
 
 Resource ``path()`` provides the complete path relative to the ``ResourceStore`` base directory. Use ``name()`` to retrieve the resource name (as the last component in the path name sequence).
 
-Resource creation is handled in a lazy fashion, use ``file()`` or ``out()`` and the resource will be created as required.
+Resource creation is handled in a lazy fashion, use ``out()`` and the resource will be created as required, including any required parent directories are created to produce the completed path.
 
-Use ``dir()`` to create a empty directory. Directories have the ability to ``list()`` their contents:
+Directory resources have the ability to ``list()`` their contents:
 
 .. code-block:: java
    
@@ -93,7 +97,9 @@ Use ``dir()`` to create a empty directory. Directories have the ability to ``lis
       ...    
    }
 
-When creating a resource with ``file()``, ``out()`` or ``dir()`` any required parent directories are created to produce the completed path).
+The method ``isInternal()`` returns whether the resource is part of the resource store or rather a wrapped file obtained by ``File.asResource``. If this method returns `false` then ``path()`` returns a file path rather than a resource path.
+
+The methods ``file()`` and ``dir()`` may be used to obtain a file system representation of the resource. Depending on the resource store implementation, this may be the underlying storage entity (in the case of the default FileSystemResourceStore), or merely a cached entity. Changes to these should not be assumed to be permanent. These methods should only be used for input when a third library requires a file and does not support passing on streams.
 
 Once created resources can be managed with ``delete()``, ``renameTo(resource)`` methods.
 
@@ -104,7 +110,7 @@ Resource ``lock()`` is also supported.
 Paths
 -----
 
-The ``Paths`` facade provides methods for working with the relative paths used by ResourceStore.
+The ``Paths`` facade provides methods for working with resource paths used by ResourceStore.
 
 Helpful methods are provided for working with paths and names:
 
@@ -114,14 +120,21 @@ Helpful methods are provided for working with paths and names:
 * ``sidecar(path, extension)``
 * ``names(path)`` processes the path into a list of names as discussed below.
 
-The definition of a path has been expanded to work with the external locations (with ``Paths.isAbsolute(path)`` and ``Paths.names(path)``).
-
 Paths are broken down into a sequence of names, as listed by ``Paths.names(path)``:
 
 * ``Path.names("data/tasmania/roads.shp")`` is represented as a list of ``data``, ``tasmania``, ``roads.shp``.
-* On linux ``Path.names("/src/gis/cadaster/district.geopkg")`` starts with a marker to indicate an absolute path, resulting in ``/``, ``src``, ``gis``, ``cadaster``, ``district.geopkg``.
-* On windows ``Path.names("D:/gis/cadaster/district.geopkg")`` starts with a marker to indicate an absolute path, resulting in ``D:/``, ``gis``, ``cadaster``, ``district.geopkg``.
 
+For file paths that are OS dependent, use FilePaths.names instead.
+
+FilePaths
+---------
+
+The ``FilePaths`` facade provides methods for working with file paths.
+
+Paths are broken down into a sequence of names, as listed by ``Paths.names(path)``:
+
+* On linux ``FilePath.names("/src/gis/cadaster/district.geopkg")`` starts with a marker to indicate an absolute path, resulting in ``/``, ``src``, ``gis``, ``cadaster``, ``district.geopkg``.
+* On windows ``FilePath.names("D:/gis/cadaster/district.geopkg")`` starts with a marker to indicate an absolute path, resulting in ``D:/``, ``gis``, ``cadaster``, ``district.geopkg``.
 
 
 Paths.convert
@@ -167,14 +180,20 @@ There are also method for working with directories recursively and filtering con
 Resources.fromUrl
 ^^^^^^^^^^^^^^^^^
 
-There is an important method ``Resources.fromURL( baseDirectory, url)`` that is used by a lot of code trying to understand data references:
+The interpretation of the URLs is as follows:
 
+* ``resource:`` prefix - interpreted as a resource path, returns resource from the resource store.
+* ``file:`` prefix with absolute path - interpreted as file path, returns resource created by Files.asResource that refers to file in the file system.
+* ``file:`` prefix with relative path (deprecated) - interpreted as a resource path, returns resource from the resource store.
+
+Examples:
+
+* ``Resources.fromURL( baseDirectory, "resource:images/image.png")`` - resource path
+* ``Resources.fromURL( baseDirectory, "file:images/image.png")`` - resource path (deprecated)
 * ``Resources.fromURL( null, "/src/gis/cadaster/district.geopgk")`` - absolute file path (linux)
 * ``Resources.fromURL( baseDirectory, "D:\\gis\\cadaster\\district.geopkg")`` - absolute file path (windows)
 * ``Resources.fromURL( baseDirectory, "file:///D:/gis/cadaster/district.geopkg")`` - absolute file url (windows)
 * ``Resources.fromURL( baseDirectory, "ftp://veftp.gsfc.nasa.gov/bluemarble/")`` - null (external reference)
-
-For the absolute file references above, see the next section on ``Files.url``.
 
 Files
 -----
@@ -187,6 +206,7 @@ Files.url
 ^^^^^^^^^
 
 The other key method is ``Files.url( baseDirectory, url)`` which is used to look up files based on a user provided URL (or path).
+This method is deprecated because resources should always be used over files.
 
 * ``Files.fromURL( null, "resource:styles/logo.svg")`` - internal url format restricted to data directory content
 * ``Files.fromURL( null, "/src/gis/cadaster/district.geopgk")`` - absolute file path (linux)

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/ResourceWriterTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/ResourceWriterTest.java
@@ -55,25 +55,15 @@ public class ResourceWriterTest extends BackupRestoreTestSupport {
         GeoServerDataDirectory td = new GeoServerDataDirectory(root);
 
         Resource srcTemplatesDir = BackupUtils.dir(dd.get(Paths.BASE), "templates");
-        File srcTitleFtl =
-                Resources.createNewFile(
-                        Files.asResource(new File(srcTemplatesDir.dir(), "title.ftl")));
+        File srcTitleFtl = srcTemplatesDir.get("title.ftl").file();
         File srcHeaderFtl =
-                Resources.createNewFile(
-                        Files.asResource(
-                                new File(
-                                        Paths.toFile(
-                                                dd.get(Paths.BASE).dir(),
-                                                Paths.path("workspaces", "gs", "foo", "t1")),
-                                        "header.ftl")));
+                dd.get(Paths.BASE)
+                        .get(Paths.path("workspaces", "gs", "foo", "t1", "header.ftl"))
+                        .file();
         File srcFakeFtl =
-                Resources.createNewFile(
-                        Files.asResource(
-                                new File(
-                                        Paths.toFile(
-                                                dd.get(Paths.BASE).dir(),
-                                                Paths.path("workspaces", "gs", "foo", "t1")),
-                                        "fake.ftl")));
+                dd.get(Paths.BASE)
+                        .get(Paths.path("workspaces", "gs", "foo", "t1", "fake.ftl"))
+                        .file();
 
         assertTrue(Resources.exists(Files.asResource(srcTitleFtl)));
         assertTrue(Resources.exists(Files.asResource(srcHeaderFtl)));
@@ -90,21 +80,11 @@ public class ResourceWriterTest extends BackupRestoreTestSupport {
 
         assertTrue(Resources.exists(trgTemplatesDir));
 
-        Resource trgTitleFtl = Files.asResource(new File(trgTemplatesDir.dir(), "title.ftl"));
+        Resource trgTitleFtl = trgTemplatesDir.get("title.ftl");
         Resource trgHeaderFtl =
-                Files.asResource(
-                        new File(
-                                Paths.toFile(
-                                        td.get(Paths.BASE).dir(),
-                                        Paths.path("workspaces", "gs", "foo", "t1")),
-                                "header.ftl"));
+                td.get(Paths.BASE).get(Paths.path("workspaces", "gs", "foo", "t1", "header.ftl"));
         Resource trgFakeFtl =
-                Files.asResource(
-                        new File(
-                                Paths.toFile(
-                                        td.get(Paths.BASE).dir(),
-                                        Paths.path("workspaces", "gs", "foo", "t1")),
-                                "fake.ftl"));
+                td.get(Paths.BASE).get(Paths.path("workspaces", "gs", "foo", "t1", "fake.ftl"));
 
         assertTrue(Resources.exists(trgTitleFtl));
         assertTrue(Resources.exists(trgHeaderFtl));

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/DataFormat.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/DataFormat.java
@@ -8,6 +8,8 @@ package org.geoserver.importer;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -19,7 +21,7 @@ import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.importer.job.ProgressMonitor;
 import org.geoserver.platform.GeoServerExtensions;
-import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.FilePaths;
 import org.geoserver.platform.resource.Paths;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.GridFormatFinder;
@@ -114,9 +116,19 @@ public abstract class DataFormat implements Serializable {
             return url;
         }
         File baseDirectory = catalog.getResourceLoader().getBaseDirectory();
-        File f = Files.url(baseDirectory, url);
+        File f;
+        try {
+            f = new File(new URL(url).getFile());
+        } catch (MalformedURLException e) {
+            f = new File(url);
+        }
 
-        return f == null ? url : "file:" + Paths.convert(baseDirectory, f);
+        String relativePath = Paths.convert(baseDirectory, f);
+        if (!FilePaths.isAbsolute(relativePath)) {
+            return "file:" + relativePath;
+        } else {
+            return url;
+        }
     }
 
     public abstract String getName();

--- a/src/extension/web-resource/src/main/java/org/geoserver/web/resources/PageResourceBrowser.java
+++ b/src/extension/web-resource/src/main/java/org/geoserver/web/resources/PageResourceBrowser.java
@@ -361,7 +361,7 @@ public class PageResourceBrowser extends GeoServerSecuredPage {
                             for (int i = 1; Resources.exists(store().get(dest)); i++) {
                                 dest = getIthPath(i);
                             }
-                            editPanel = new PanelEdit(id, dest, true, "");
+                            editPanel = new PanelEdit(id, store().get(dest), true, "");
                             return editPanel;
                         }
 
@@ -380,11 +380,7 @@ public class PageResourceBrowser extends GeoServerSecuredPage {
                         protected boolean onSubmit(AjaxRequestTarget target, Component contents) {
                             editPanel.getFeedbackMessages().clear();
                             String resourcePath = editPanel.getResource();
-                            if (Paths.isAbsolute(resourcePath)) {
-                                // although ResourceStore.get(path) is limited to relative paths
-                                // out of an abundance of caution we will reject
-                                error(getLocalizer().getString("pathUnsupported", getPage()));
-                            } else if (!Paths.isValid(resourcePath)) {
+                            if (!Paths.isValid(resourcePath)) {
                                 try {
                                     Paths.valid(resourcePath);
                                 } catch (IllegalArgumentException reason) {
@@ -465,7 +461,7 @@ public class PageResourceBrowser extends GeoServerSecuredPage {
 
                             @Override
                             protected Component getContents(String id) {
-                                editPanel = new PanelEdit(id, resource.path(), false, contents);
+                                editPanel = new PanelEdit(id, resource, false, contents);
                                 return editPanel;
                             }
 

--- a/src/extension/web-resource/src/main/java/org/geoserver/web/resources/PanelEdit.java
+++ b/src/extension/web-resource/src/main/java/org/geoserver/web/resources/PanelEdit.java
@@ -11,7 +11,7 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.Model;
-import org.geoserver.platform.resource.Paths;
+import org.geoserver.platform.resource.Resource;
 
 /**
  * Panel for editing.
@@ -22,16 +22,16 @@ public class PanelEdit extends Panel {
 
     private static final long serialVersionUID = -31594049414032328L;
 
-    public PanelEdit(String id, String resource, boolean isNew, String contents) {
+    public PanelEdit(String id, Resource resource, boolean isNew, String contents) {
         super(id);
-        if (Paths.isAbsolute(resource)) {
+        if (!resource.isInternal()) {
             // double check resource browser cannot be used to edit
-            // absolute path locations
+            // files outside of resource store
             throw new IllegalStateException("Path location not supported by Resource Browser");
         }
         add(new FeedbackPanel("feedback").setOutputMarkupId(true));
         add(
-                new TextField<String>("resource", new Model<>(resource)) {
+                new TextField<String>("resource", new Model<>(resource.toString())) {
                     private static final long serialVersionUID = 1019950718780805835L;
 
                     @Override

--- a/src/extension/web-resource/src/main/java/org/geoserver/web/resources/ResourceNode.java
+++ b/src/extension/web-resource/src/main/java/org/geoserver/web/resources/ResourceNode.java
@@ -9,7 +9,6 @@ import java.util.Base64;
 import java.util.Set;
 import java.util.TreeSet;
 import org.apache.wicket.model.IModel;
-import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
 import org.geoserver.web.treeview.TreeNode;
@@ -30,9 +29,9 @@ public class ResourceNode implements TreeNode<Resource>, Comparable<ResourceNode
     private String uniqueId;
 
     public ResourceNode(Resource resource, ResourceExpandedStates expandedStates) {
-        if (Paths.isAbsolute(resource.path())) {
+        if (!resource.isInternal()) {
             // double check resource browser cannot be used to edit
-            // absolute path locations
+            // files outside of resource store
             throw new IllegalStateException("Path location not supported by Resource Browser");
         }
         this.resource = Resources.serializable(resource);

--- a/src/extension/web-resource/src/main/java/org/geoserver/web/resources/WicketResourceAdaptor.java
+++ b/src/extension/web-resource/src/main/java/org/geoserver/web/resources/WicketResourceAdaptor.java
@@ -11,7 +11,6 @@ import java.net.URLConnection;
 import org.apache.wicket.util.resource.AbstractResourceStream;
 import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
 import org.apache.wicket.util.time.Time;
-import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
 
 /**
@@ -26,9 +25,9 @@ public class WicketResourceAdaptor extends AbstractResourceStream {
     protected Resource resource;
 
     public WicketResourceAdaptor(Resource resource) {
-        if (Paths.isAbsolute(resource.path())) {
+        if (!resource.isInternal()) {
             // double check resource browser cannot be used to edit
-            // absolute path locations
+            // files outside of resource store
             throw new IllegalStateException("Path location not supported by Resource Browser");
         }
         this.resource = resource;

--- a/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
@@ -33,6 +33,7 @@ import org.geoserver.catalog.WMTSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.FilePaths;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resource.Type;
@@ -929,7 +930,7 @@ public class GeoServerDataDirectory {
                     file = resource.file();
                 } else {
                     // GEOS-7025: Just get the path; don't try to create the file
-                    file = Paths.toFile(root(), resource.path());
+                    file = FilePaths.toFile(root(), resource.path());
                 }
 
                 URL u = fileToUrlPreservingCqlTemplates(file);

--- a/src/platform/src/main/java/org/geoserver/platform/GeoServerExtensions.java
+++ b/src/platform/src/main/java/org/geoserver/platform/GeoServerExtensions.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletContext;
-import org.geoserver.platform.resource.Paths;
+import org.geoserver.platform.resource.FilePaths;
 import org.geotools.util.SoftValueHashMap;
 import org.geotools.util.SuppressFBWarnings;
 import org.geotools.util.factory.FactoryRegistry;
@@ -567,7 +567,7 @@ public class GeoServerExtensions implements ApplicationContextAware, Application
                     return file;
                 }
             } else {
-                List<String> items = Paths.names(path);
+                List<String> items = FilePaths.names(path);
                 int index = 0;
                 if (index < items.size()) {
 

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FilePaths.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FilePaths.java
@@ -42,7 +42,7 @@ public class FilePaths {
      * marker.
      *
      * <p>Linux absolute paths are start with leading slash character ({@code / } ). <br>
-     * {@code convert("/srv/gis/cadaster/district.geopg") --> "/srv/gis/cadaster/district.geopg" <br>
+     * {@code convert("/srv/gis/cadaster/district.geopkg") --> "/srv/gis/cadaster/district.geopkg" <br>
      * {@code names("/srv/gis/cadaster/district.geopkg) --> {"/", "srv","gis", "cadaster",
      * "district.geopkg"}}. <br>
      * This agrees with URL representation of

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FilePaths.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FilePaths.java
@@ -1,0 +1,178 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.platform.resource;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.SystemUtils;
+
+/**
+ * Utility class for handling File paths in a consistent fashion.
+ *
+ * <p>File paths differ from resource paths because they refer to a file in the file system rather
+ * than a resource in the resource store, and therefore they are not OS independent. Absolute paths
+ * are supported, with Linux systems using a leading {@code /}, and windows using {@code L:}.
+ *
+ * @author Jody Garnett
+ */
+public class FilePaths {
+
+    /**
+     * Pattern used to recognize absolute path in Windows, as indicated by driver letter reference
+     * (included {@code :}), followed by as slash character.
+     *
+     * <p>Aside: A drive letter reference on its own results in a relative path (relative to the
+     * current directory for that drive).
+     */
+    static final Pattern WINDOWS_DRIVE_LETTER = Pattern.compile("^\\w\\:/.*$");
+
+    /**
+     * File Path components listed into absolute prefix, directory names, and final file name or
+     * directory name.
+     *
+     * <p><b>Relative</b>: Relative paths are represented in a straight forward fashion with: {@code
+     * Paths.names("data/tasmania/roads.shp"} --> {"data","tasmania","roads.shp"}}.
+     *
+     * <p><b>Absolute path</b>: When working with an absolute path the list starts with a special
+     * marker.
+     *
+     * <p>Linux absolute paths are start with leading slash character ({@code / } ). <br>
+     * {@code convert("/srv/gis/cadaster/district.geopg") --> "/srv/gis/cadaster/district.geopg" <br>
+     * {@code names("/srv/gis/cadaster/district.geopkg) --> {"/", "srv","gis", "cadaster",
+     * "district.geopkg"}}. <br>
+     * This agrees with URL representation of
+     * {@code file:///srv/gis/cadaster/district.geopkg}.
+     *
+     * <p>Windows absolute drive letter and slash ( {@code C:\ } ). <br>
+     * {@code names("D:\\gis\cadaster\district.geopkg") --> {"D:", "gis", "cadaster",
+     * "district.geopkg"}}. This agrees with URL representation of
+     * {@code file:///D:/gis/cadaster/district.geopkg}.
+     *
+     * @param path Path used for reference lookup
+     * @return List of path components divided into absolute prefix, directory names, and final file
+     *     name or directory name.
+     */
+    public static List<String> names(String path) {
+        if (path == null || path.length() == 0) {
+            return Collections.emptyList();
+        }
+        int index = 0;
+        int split = path.indexOf('/');
+        if (split == -1) {
+            return Collections.singletonList(path);
+        }
+        ArrayList<String> names = new ArrayList<>(3);
+        String item;
+
+        do {
+            if (index == 0 && isAbsolute(path)) {
+                item = path.substring(0, split + 1);
+            } else {
+                item = path.substring(index, split);
+            }
+            // ignoring zero length items resulting from double slash
+            // path breaks (occasionally produced when concatenating paths without due care).
+            if (item.length() != 0) {
+                names.add(item);
+            }
+            index = split + 1;
+            split = path.indexOf('/', index);
+        } while (split != -1);
+        item = path.substring(index);
+        if (item != null && item.length() != 0 && !item.equals("/")) {
+            names.add(item);
+        }
+
+        return names;
+    }
+
+    /**
+     * While paths are primarily intended as paths relative to the GeoServer data directory, there
+     * is some support for absolute paths.
+     *
+     * <p><b>Linux</b>: Linux absolute paths start with a leading {@code /} character. As this slash
+     * character is also used as the path separator special handling is required. Notably {@link
+     * #names(String)} will represent an absolute path as: {@code { "/", "srv" "gis", "cadaster",
+     * "district.geopkg"}}
+     *
+     * <p><b>Windows</b>: Windows absolute paths start with a drive letter, colon, and slash
+     * characters.{@link #names(String)} will represent an absolute path on windows as: {@code {
+     * "D:/, "gis", "cadaster", "district.geopkg"}}
+     *
+     * <p>Aside: A drive letter reference on its own results in a relative path (relative to the
+     * current directory for that drive).
+     *
+     * <p><b>Guidance</b>: On both platforms an absolute path should agree with the file URL
+     * representation while dropping the {@code file:/} prefix
+     *
+     * @param path Resource path reference
+     * @return {@code true} if path forms an absolute reference to a location outside the data
+     *     directory.
+     */
+    public static boolean isAbsolute(String path) {
+        return isAbsolute(path, SystemUtils.IS_OS_WINDOWS);
+    }
+
+    // package visibility for test case coverage on all platforms
+    static boolean isAbsolute(String path, boolean isWindows) {
+        if (isWindows) return WINDOWS_DRIVE_LETTER.matcher(path).matches();
+        else return path != null && path.startsWith("/");
+    }
+
+    /**
+     * Carefully look up a filesystem root directory (matching {@code /} or {@code C:\} as
+     * appropriate).
+     *
+     * @param name
+     * @return filesystem root directory matching name, or {@code null} if not found.
+     */
+    private static File root(String name) {
+        for (File root : File.listRoots()) {
+            if (root.getPath().equalsIgnoreCase(name)) {
+                return root;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Convert a file path to file reference for provided base directory.
+     *
+     * <p>This method requires the base directory of the ResourceStore. Note ResourceStore
+     * implementations may not create the file until needed.
+     *
+     * <p>In the case of an absolute path, base should be null. Both linux {@code /} and windows
+     * {@code Z:/} absolute resource paths are supported.
+     *
+     * <p>Relative paths when base is {@code null}, are not supported.
+     *
+     * @param base Base directory, often GeoServer Data Directory
+     * @param path Resource path reference
+     * @return File reference (will be an absolute file reference)
+     */
+    public static File toFile(File base, String path) {
+        if (isAbsolute(path)) {
+            if (base != null) {
+                // To be forgiving we will ignore duplicate slash between base and relative path
+                if (path.startsWith("/")) {
+                    path = path.substring(1);
+                } else {
+                    base = null;
+                }
+            }
+        }
+        for (String item : names(path)) {
+            if (base == null && isAbsolute(item)) {
+                base = root(item.replace('/', File.separatorChar));
+            } else {
+                base = new File(base, item);
+            }
+        }
+        return base;
+    }
+}

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
@@ -124,7 +124,7 @@ public class FileSystemResourceStore implements ResourceStore {
     public boolean remove(String path) {
         path = Paths.valid(path);
 
-        File file = Paths.toFile(baseDirectory, path);
+        File file = new File(baseDirectory, path);
 
         return Files.delete(file);
     }
@@ -134,8 +134,8 @@ public class FileSystemResourceStore implements ResourceStore {
         path = Paths.valid(path);
         target = Paths.valid(target);
 
-        File file = Paths.toFile(baseDirectory, path);
-        File dest = Paths.toFile(baseDirectory, target);
+        File file = new File(baseDirectory, path);
+        File dest = new File(baseDirectory, target);
 
         if (!file.exists() && !dest.exists()) {
             return true; // moving an undefined resource
@@ -170,8 +170,8 @@ public class FileSystemResourceStore implements ResourceStore {
         File file;
 
         public FileSystemResource(String path) {
-            this.path = path;
-            this.file = Paths.toFile(baseDirectory, path);
+            this.file = new File(baseDirectory, path);
+            this.path = Paths.convert(baseDirectory, file);
         }
 
         @Override
@@ -186,7 +186,7 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public Lock lock() {
-            return lockProvider.acquire(path);
+            return lockProvider.acquire(path());
         }
 
         @Override
@@ -452,7 +452,7 @@ public class FileSystemResourceStore implements ResourceStore {
         public int hashCode() {
             final int prime = 31;
             int result = 1;
-            result = prime * result + ((path == null) ? 0 : path.hashCode());
+            result = prime * result + path.hashCode();
             return result;
         }
 
@@ -462,9 +462,7 @@ public class FileSystemResourceStore implements ResourceStore {
             if (obj == null) return false;
             if (getClass() != obj.getClass()) return false;
             FileSystemResource other = (FileSystemResource) obj;
-            if (path == null) {
-                if (other.path != null) return false;
-            } else if (!path.equals(other.path)) return false;
+            if (!file.equals(other.file)) return false;
             return true;
         }
 
@@ -485,7 +483,7 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public boolean renameTo(Resource dest) {
-            if (dest.parent().path().contains(path())) {
+            if (dest.parent().path().contains(path)) {
                 LOGGER.log(Level.FINE, "Cannot rename a resource to a descendant of itself");
                 return false;
             }
@@ -559,7 +557,7 @@ public class FileSystemResourceStore implements ResourceStore {
                             v ->
                                     v == null
                                             ? new FileSystemWatcher(
-                                                    path -> Paths.toFile(baseDirectory, path))
+                                                    path -> new File(baseDirectory, path))
                                             : v);
         }
         return instance;

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -261,6 +261,11 @@ public final class Files {
             } else if (!file.equals(other.file)) return false;
             return true;
         }
+
+        @Override
+        public boolean isInternal() {
+            return false;
+        }
     }
 
     private static final Logger LOGGER = Logging.getLogger(Files.class);
@@ -300,7 +305,9 @@ public final class Files {
      * @param baseDirectory Optional base directory used to resolve relative file URLs
      * @param url File URL or path relative to data directory
      * @return File indicated by provided URL location
+     * @deprecated use resources.
      */
+    @Deprecated
     public static File url(File baseDirectory, String url) {
         String ss;
         if (!Objects.equals(url, ss = StringUtils.removeStart(url, "resource:"))) {

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Resource.java
@@ -206,4 +206,16 @@ public interface Resource {
             IOUtils.write(byteArray, os);
         }
     }
+
+    /**
+     * Flag that says if this resource is a true resource, part of the internal resource store (and
+     * not for instance a resource adaptor of a file that may be anywhere on the hard drive.) Can
+     * for instance be used for security purposes. If this returns 'false', then path() will return
+     * a file path rather than a resource path.
+     *
+     * @return
+     */
+    default boolean isInternal() {
+        return true;
+    }
 }

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FilePathsTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FilePathsTest.java
@@ -1,0 +1,85 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.platform.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+
+public class FilePathsTest {
+
+    @Test
+    public void isAbsolutePath() {
+        assertFalse("data directory relative", FilePaths.isAbsolute("data/tasmania/roads.shp"));
+        assertTrue(
+                "linux absolute", FilePaths.isAbsolute("/srv/gis/cadaster/district.geopkg", false));
+        assertTrue(
+                "windows drive absolute",
+                FilePaths.isAbsolute("D:/gis/cadaster/district.geopkg", true));
+        assertFalse("windows drive relative", FilePaths.isAbsolute("D:fail.shp", true));
+    }
+
+    @Test
+    public void naming() throws IOException {
+        File home = new File(System.getProperty("user.home")).getCanonicalFile();
+        String absolutePath = Paths.convert(home.getPath());
+
+        assertTrue("home", FilePaths.isAbsolute(absolutePath));
+        String root = FilePaths.names(absolutePath).get(0);
+        assertTrue("system root '" + root + "'", FilePaths.isAbsolute(root));
+    }
+
+    @Test
+    public void roundTripFileTests() throws IOException {
+        File home = new File(System.getProperty("user.home")).getCanonicalFile();
+        File directory = new File(home, "directory");
+        File file = new File(directory, "file");
+
+        // absolute paths
+        absolutePathCheck(home);
+        absolutePathCheck(directory);
+        absolutePathCheck(file);
+
+        // relative paths
+        File base = new File(home, "data");
+        relativePathCheck(base, new File("folder"));
+        relativePathCheck(base, new File(new File("folder"), "file"));
+    }
+
+    public void absolutePathCheck(File file) {
+        String filePath = file.getPath();
+        String path1 = Paths.convert(filePath);
+        assertTrue("absolute: " + path1, FilePaths.isAbsolute(path1));
+
+        List<String> names = FilePaths.names(path1);
+        assertTrue("absolute: " + names.get(0), FilePaths.isAbsolute(names.get(0)));
+
+        String path2 = Paths.toPath(names);
+        assertTrue("absolute:" + path2, FilePaths.isAbsolute(path2));
+
+        File file2 = FilePaths.toFile(null, path2);
+        assertEquals(file2.getName(), file, file2);
+    }
+
+    public void relativePathCheck(File base, File file) {
+        String path1 = Paths.convert(base, file);
+        assertFalse("absolute: " + path1, FilePaths.isAbsolute(path1));
+
+        List<String> names = Paths.names(path1);
+        assertFalse("absolute: " + names.get(0), FilePaths.isAbsolute(names.get(0)));
+
+        String path2 = Paths.toPath(names);
+        assertFalse("absolute:" + path2, FilePaths.isAbsolute(path2));
+
+        File file2 = FilePaths.toFile(base, path2);
+        assertTrue("absolute:" + file2.getPath(), file2.isAbsolute());
+        assertEquals(file2.getName(), new File(base, file.getPath()), file2);
+    }
+}

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceTheoryTest.java
@@ -105,7 +105,7 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
 
     @Test
     public void fileEvents() throws Exception {
-        File fileD = Paths.toFile(store.baseDirectory, "DirC/FileD");
+        File fileD = new File(store.baseDirectory, "DirC/FileD");
 
         AwaitResourceListener listener = new AwaitResourceListener();
 
@@ -184,8 +184,8 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
 
     @Test
     public void directoryEvents() throws Exception {
-        File fileA = Paths.toFile(store.baseDirectory, "FileA");
-        File fileB = Paths.toFile(store.baseDirectory, "FileB");
+        File fileA = new File(store.baseDirectory, "FileA");
+        File fileB = new File(store.baseDirectory, "FileB");
 
         AwaitResourceListener listener = new AwaitResourceListener();
         store.get(Paths.BASE).addListener(listener);
@@ -227,7 +227,7 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
     @Test
     public void emptyDirectoryCreateEventShouldNotBeRaised() throws Exception {
         final String dirName = testName.getMethodName();
-        File watchedDir = Paths.toFile(store.baseDirectory, dirName);
+        File watchedDir = new File(store.baseDirectory, dirName);
 
         FileSystemWatcher watcher = (FileSystemWatcher) store.getResourceNotificationDispatcher();
         // set a shorter poll delay
@@ -247,7 +247,7 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
     @Test
     public void directoryCreateEventWithContents() throws Exception {
         final String dirName = testName.getMethodName();
-        File watchedDir = Paths.toFile(store.baseDirectory, dirName);
+        File watchedDir = new File(store.baseDirectory, dirName);
         File fileA = new File(watchedDir, "FileA");
 
         FileSystemWatcher watcher = (FileSystemWatcher) store.getResourceNotificationDispatcher();
@@ -275,7 +275,7 @@ public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
     @Test
     public void dynamicAsyncDirectoryEvents() throws Exception {
         final String dirName = testName.getMethodName();
-        final File watchedDir = Paths.toFile(store.baseDirectory, dirName);
+        final File watchedDir = new File(store.baseDirectory, dirName);
 
         FileSystemWatcher watcher = (FileSystemWatcher) store.getResourceNotificationDispatcher();
         // set a shorter poll delay

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileWrapperResourceTheoryTest.java
@@ -40,7 +40,7 @@ public class FileWrapperResourceTheoryTest extends ResourceTheoryTest {
      */
     @Override
     protected Resource getResource(String path) throws Exception {
-        File file = Paths.toFile(folder.getRoot(), path);
+        File file = FilePaths.toFile(folder.getRoot(), path);
         return Files.asResource(file);
     }
 

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -19,6 +19,8 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
@@ -482,12 +484,22 @@ public abstract class ResourceTheoryTest {
         assertTrue(res.delete());
     }
 
-    @Theory
-    public void theoryRootIsAbsolute(String path) throws Exception {
+    public void theoryNoAbsoluteFiles(String path) throws Exception {
         File home = new File(System.getProperty("user.home")).getCanonicalFile();
-        File file = Paths.toFile(home, path);
+        File file = new File(home, path);
 
         final Resource res = getResource(Paths.convert(file.getPath()));
-        assertTrue(Paths.isAbsolute(res.path()));
+        assertFalse(FilePaths.isAbsolute(res.path()));
+    }
+
+    @Theory
+    public void theoryObsoleteSlashIsIgnored(String path) throws Exception {
+        final Resource res = getResource(path);
+        final Resource res2 = getResource("/" + path);
+        final Resource res3 = getResource(path + "/");
+        assertEquals(res, res2);
+        assertEquals(res.path(), res2.path());
+        assertEquals(res, res3);
+        assertEquals(res.path(), res3.path());
     }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/panel/FileModel.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/panel/FileModel.java
@@ -7,13 +7,15 @@ package org.geoserver.web.data.store.panel;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.wicket.model.IModel;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
-import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.FilePaths;
+import org.geoserver.platform.resource.Paths;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -40,13 +42,6 @@ public class FileModel implements IModel<String> {
         this.rootDir = rootDir;
     }
 
-    private boolean isSubfile(File root, File selection) {
-        if (selection == null || "".equals(selection.getPath())) return false;
-        if (selection.equals(root)) return true;
-
-        return isSubfile(root, selection.getParentFile());
-    }
-
     @Override
     public String getObject() {
         Object obj = delegate.getObject();
@@ -67,27 +62,18 @@ public class FileModel implements IModel<String> {
     public void setObject(String location) {
 
         if (location != null) {
-            File dataDirectory = canonicalize(rootDir);
-            File file = canonicalize(new File(location));
-            if (isSubfile(dataDirectory, file)) {
-                File curr = file;
-                String path = null;
-                // paranoid check to avoid infinite loops
-                while (curr != null && !curr.equals(dataDirectory)) {
-                    if (path == null) {
-                        path = curr.getName();
-                    } else {
-                        path = curr.getName() + "/" + path;
-                    }
-                    curr = curr.getParentFile();
-                }
-                location = "file:" + path;
-            } else {
-                File dataFile = Files.url(rootDir, location);
-                if (dataFile == null || dataFile.equals(file)) {
-                    // not relative to the data directory, does not need fixing
-                    location = "file://" + file.getAbsolutePath();
-                }
+            location = Paths.convert(location);
+            String locationPath;
+            try {
+                locationPath = new URL(location).getFile();
+            } catch (MalformedURLException e) {
+                locationPath = location;
+            }
+            locationPath = Paths.convert(rootDir, new File(locationPath));
+            if (FilePaths.isAbsolute(locationPath)) {
+                location = "file://" + locationPath;
+            } else if (!locationPath.equals(location)) {
+                location = "file:" + locationPath;
             }
         }
         delegate.setObject(location);

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/FileExistsValidator.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/FileExistsValidator.java
@@ -81,16 +81,15 @@ public class FileExistsValidator implements IValidator<String> {
         File relFile = null;
 
         GeoServerResourceLoader loader = GeoServerExtensions.bean(GeoServerResourceLoader.class);
-        if (baseDirectory != null) {
-            // local to provided baseDirectory
-            relFile = Files.url(baseDirectory, uriSpec);
-        } else if (loader != null) {
-            // local to data directory?
-            relFile =
-                    Resources.find(
-                            Resources.fromURL(Files.asResource(loader.getBaseDirectory()), uriSpec),
-                            true);
-        }
+        relFile =
+                Resources.find(
+                        Resources.fromURL(
+                                Files.asResource(
+                                        baseDirectory == null
+                                                ? loader.getBaseDirectory()
+                                                : baseDirectory),
+                                uriSpec),
+                        true);
 
         if (relFile == null || !relFile.exists()) {
             IValidationError err =

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/panel/FileModelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/panel/FileModelTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.wicket.model.Model;
 import org.geoserver.data.test.MockData;
+import org.geoserver.platform.resource.Paths;
 import org.geoserver.web.util.MapModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +40,7 @@ public class FileModelTest {
             FileModel model = new FileModel(new Model<>(), root);
             model.setObject(f.getAbsolutePath());
             String path = model.getObject();
-            assertEquals("file://" + f.getAbsolutePath(), path);
+            assertEquals("file://" + Paths.convert(f.getAbsolutePath()), path);
         } finally {
             f.delete();
         }


### PR DESCRIPTION
Following the rather difficult discussion between Jody and I on the mailing list, I have attempted to find a solution for this issue that addresses each of our concerns. As a guideline I have implemented the points we ended up agreeing on, with the exception of one unresolved matter (the API distinction between two kinds of paths), that can still be modified after discussing an alternative solution. The main ideas behind the suggested changes can be read in the documentation changes/additions inside this PR, but I will add some more notes here regarding my motivation. The two main concerns that are somewhat conflicting and needed to be reconciled are:

1) (Niels' main concern, the matter of proper generic development) The resource API should be entirely independent of matters related to Operating Systems (such as the distinction absolute/relative paths), and make no assumption about being part of a File System. The resource store is an entity of its own and has its own 'root'. Developers should be informed not to use the file system but rather consciously use the resource API in the intended, completely generic way. 

Note that the usage of the resource store does not limit itself to internal matters. For instance, style sheets that refer to images must still work on alternative resource stores (such as JDBC or otherwise), which is why point 2 is relevant.

2) (Jody's main concern, the matter of intuitive and predictable user experience without technical knowledge requirements) What looks like an absolute file system path, should be an absolute file system path. Only pure 'relative' paths (on linux this implies starting with a name, not a slash) should be sent to the resource store; in order to assure predictability for the end user.

My proposed solution is 
1) Formally distinguish 'file paths' from 'resource paths' on the API and implementation level. To avoid any confusion with developers and to encourage proper API usage, they are no longer lumped together as 'paths'. The resource store + paths API is entirely separate from OS-dependent matters such as the relative/absolute distinction. A separate 'FilePaths' utility class was created to address the distinction between absolute/relative file paths.  The ResourceStore takes only resource paths, is OS independent, and always starts from its own root.
Note that Files.asResource does not return a 'true' resource (from the resource store) but a wrapper that allows files to be used in resource aware API. Its only proper usage is for user provided paths/urls (see point 2), and really should never be called by developers directly.
In order to distinguish between true resources and wrappers, without having to rely on the OS-dependent relative/absolute distinction, a method 'isInternal' was added to the Resource class to verify a resource is indeed, part of the resource store and its path can be interpreted as such.

2) For any URL or path provided by the end user (in configuration, templates etc) the method URLs.asResource is used to translate to a 'resource' (either a true resource from the resource store, or some kind of wrapper).
This method follows for file: URLs (or simple paths) the principle of Jody: only paths that are considered relative in the Operating System are interpreted as resources, anything else are files (such as a path starting with leading slash on linux).
Note: since file paths without leading slash violate the URL standard, the original idea was to replace them with "resource:" URL's. This is an option that may be less confusing for some people, but is entirely optional and backwards compatibility of relative file: URLs will continue to be respected. (This is not new)

[![GEOS-11050](https://badgen.net/badge/JIRA/GEOS-11050/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11050) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…ResourceStore implementations


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->