### PR TITLE
[GEOS-11145] The GUI "wait spinner" is not visible any longer

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
@@ -97,7 +97,9 @@
     </div><!-- /#page -->
     </div><!-- /.wrap> -->
   </div><!-- /#main -->
-  <div id="ajaxFeedback" class="d-none">
+  <!-- The feebdback component needs a local style so that the Wicket Ajax support can flip
+       its value to "display: true". Will not work with a class, do not use one here -->
+  <div id="ajaxFeedback" style="display: none">
     <img alt="Loading..." wicket:id="ajaxFeedbackImage"/>
   </div>
 </body>


### PR DESCRIPTION
Regression in 2.23.0 due to [GSIP-213](https://github.com/geoserver/geoserver/wiki/GSIP-213), simple fix with explanation. Can't think of a way to test this, as all the action is happening client side, in javascript.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
