### PR TITLE
[Backport 2.23.x] [GEOS-11145] The GUI "wait spinner" is not visible any longer

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
@@ -97,7 +97,9 @@
     </div><!-- /#page -->
     </div><!-- /.wrap> -->
   </div><!-- /#main -->
-  <div id="ajaxFeedback" class="d-none">
+  <!-- The feebdback component needs a local style so that the Wicket Ajax support can flip
+       its value to "display: true". Will not work with a class, do not use one here -->
+  <div id="ajaxFeedback" style="display: none">
     <img alt="Loading..." wicket:id="ajaxFeedbackImage"/>
   </div>
 </body>


### PR DESCRIPTION
[![GEOS-11145](https://badgen.net/badge/JIRA/GEOS-11145/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11145) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7157
 **Authored by:** @aaime