### PR TITLE
[GEOS-11148] Update response headers for the Resources REST API

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceController.java
@@ -9,11 +9,8 @@ import static org.geoserver.rest.RestBaseController.ROOT_PATH;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import freemarker.template.ObjectWrapper;
-import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -23,6 +20,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,6 +51,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -129,24 +128,18 @@ public class ResourceController extends RestBaseController {
      * @return Content type requested
      */
     protected static MediaType getMediaType(Resource resource, HttpServletRequest request) {
-        if (resource.getType() == Resource.Type.DIRECTORY) {
-            return getFormat(request);
-        } else if (resource.getType() == Resource.Type.RESOURCE) {
-            String mimeType = URLConnection.guessContentTypeFromName(resource.name());
-            if (mimeType == null
-                    || MediaType.APPLICATION_OCTET_STREAM.toString().equals(mimeType)) {
-                // try guessing from data
-                try (InputStream is = new BufferedInputStream(resource.in())) {
-                    mimeType = URLConnection.guessContentTypeFromStream(is);
-                } catch (IOException e) {
-                    // do nothing, we'll just use application/octet-stream
-                }
-            }
-            return mimeType == null
-                    ? MediaType.APPLICATION_OCTET_STREAM
-                    : MediaType.valueOf(mimeType);
-        } else {
-            return null;
+        switch (resource.getType()) {
+            case DIRECTORY:
+                return getFormat(request);
+            case RESOURCE:
+                // set the mime if known by the servlet container, otherwise default to
+                // application/octet-stream to mitigate potential cross-site scripting
+                return Optional.ofNullable(request.getServletContext())
+                        .map(sc -> sc.getMimeType(resource.name()))
+                        .map(MediaType::valueOf)
+                        .orElse(MediaType.APPLICATION_OCTET_STREAM);
+            default:
+                throw new ResourceNotFoundException("Undefined resource path.");
         }
     }
 
@@ -265,13 +258,13 @@ public class ResourceController extends RestBaseController {
         Resource resource = resource(request);
         Operation operation = operation(operationName);
         Object result;
-        response.setContentType(getFormat(format).toString());
 
         if (operation == Operation.METADATA) {
             result =
                     wrapObject(
                             new ResourceMetadataInfo(resource, request),
                             ResourceMetadataInfo.class);
+            response.setContentType(getFormat(format).toString());
         } else {
             if (resource.getType() == Resource.Type.UNDEFINED) {
                 throw new ResourceNotFoundException("Undefined resource path.");
@@ -279,7 +272,13 @@ public class ResourceController extends RestBaseController {
                 HttpHeaders responseHeaders = new HttpHeaders();
                 MediaType mediaType = getMediaType(resource, request);
                 responseHeaders.setContentType(mediaType);
-                response.setContentType(mediaType.toString());
+                if (resource.getType() == Resource.Type.RESOURCE) {
+                    // Use Content-Disposition: attachment to mitigate potential XSS issues
+                    responseHeaders.setContentDisposition(
+                            ContentDisposition.builder("attachment")
+                                    .filename(resource.name())
+                                    .build());
+                }
 
                 if (request.getMethod().equals("HEAD")) {
                     result = new ResponseEntity<>("", responseHeaders, HttpStatus.OK);
@@ -288,6 +287,7 @@ public class ResourceController extends RestBaseController {
                             wrapObject(
                                     new ResourceDirectoryInfo(resource, request),
                                     ResourceDirectoryInfo.class);
+                    response.setContentType(mediaType.toString());
                 } else {
                     result = new ResponseEntity<>(resource.in(), responseHeaders, HttpStatus.OK);
                 }

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
@@ -5,13 +5,13 @@
 package org.geoserver.rest.resources;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.text.DateFormat;
@@ -239,6 +239,11 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
     public void testResourceHeaders() throws Exception {
         MockHttpServletResponse response =
                 getAsServletResponse(RestBaseController.ROOT_PATH + "/resource/mydir2/fake.png");
+        assertEquals(
+                "http://localhost:8080/geoserver"
+                        + RestBaseController.ROOT_PATH
+                        + "/resource/mydir2/fake.png",
+                response.getHeader("Location"));
         Assert.assertEquals(
                 FORMAT_HEADER.format(getDataDirectory().get("mydir2/fake.png").lastmodified()),
                 response.getHeader("Last-Modified"));
@@ -249,12 +254,19 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
                 response.getHeader("Resource-Parent"));
         Assert.assertEquals("resource", response.getHeader("Resource-Type"));
         assertContentType("image/png", response);
+        assertEquals(
+                "attachment; filename=\"fake.png\"", response.getHeader("Content-Disposition"));
     }
 
     @Test
     public void testResourceHead() throws Exception {
         MockHttpServletResponse response =
                 headAsServletResponse(RestBaseController.ROOT_PATH + "/resource/mydir2/fake.png");
+        assertEquals(
+                "http://localhost:8080/geoserver"
+                        + RestBaseController.ROOT_PATH
+                        + "/resource/mydir2/fake.png",
+                response.getHeader("Location"));
         Assert.assertEquals(
                 FORMAT_HEADER.format(getDataDirectory().get("mydir2/fake.png").lastmodified()),
                 response.getHeader("Last-Modified"));
@@ -265,6 +277,8 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
                 response.getHeader("Resource-Parent"));
         Assert.assertEquals("resource", response.getHeader("Resource-Type"));
         assertContentType("image/png", response);
+        assertEquals(
+                "attachment; filename=\"fake.png\"", response.getHeader("Content-Disposition"));
     }
 
     @Test
@@ -409,7 +423,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
                         + "      'link':       {\n"
                         + "        'href': 'http://localhost:8080/geoserver/rest/resource/mydir2/imagewithoutextension',\n"
                         + "        'rel': 'alternate',\n"
-                        + "        'type': 'image/png'\n"
+                        + "        'type': 'application/octet-stream'\n"
                         + "      }\n"
                         + "    },\n"
                         + "        {\n"
@@ -417,7 +431,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
                         + "      'link':       {\n"
                         + "        'href': 'http://localhost:8080/geoserver/rest/resource/mydir2/myres.json',\n"
                         + "        'rel': 'alternate',\n"
-                        + "        'type': 'application/octet-stream'\n"
+                        + "        'type': 'application/json'\n"
                         + "      }\n"
                         + "    },\n"
                         + "        {\n"
@@ -430,9 +444,6 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
                         + "    }\n"
                         + "  ]}\n"
                         + "}}";
-        // starting with JDK 17 (v3?) json is correctly recognized, the test output
-        String jsonType = URLConnection.guessContentTypeFromName("test.json");
-        if (jsonType != null) expected = expected.replace("application/octet-stream", jsonType);
         JSONAssert.assertEquals(expected, (JSONObject) json);
     }
 
@@ -508,7 +519,7 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
         Document doc = getAsDOM(RestBaseController.ROOT_PATH + "/resource/mydir2?format=xml");
         // print(doc);
         XMLAssert.assertXpathEvaluatesTo(
-                "image/png",
+                "application/octet-stream",
                 "/ResourceDirectory/children/child[name='imagewithoutextension']/atom:link/@type",
                 doc);
         XMLAssert.assertXpathEvaluatesTo(


### PR DESCRIPTION
[![GEOS-11148](https://badgen.net/badge/JIRA/GEOS-11148/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11148) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR sets the "Content-Disposition: attachment" response header when getting files from the Resources REST API which mitigates a security issue and also fixes a bug where web browsers often download files as "f.txt".  The file's Content-Type is now determined from the servlet context which seems to be more robust than the URLConnection methods and is also more controllable by the server administrator.

Note that with this PR and https://github.com/geoserver/geoserver/pull/7162, the Classpath/File/Style Publisher and Resources REST API will always return the same Content-Type for a particular resource.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->