### PR TITLE
Resolve geoserverBaseDir maven property using standard means

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -88,6 +88,7 @@
   </distributionManagement>
 
   <properties>
+    <geoserverBaseDir>${maven.multiModuleProjectDirectory}</geoserverBaseDir>
     <gs.version>2.25-SNAPSHOT</gs.version>
     <gt.version>31-SNAPSHOT</gt.version>
     <gwc.version>1.25-SNAPSHOT</gwc.version>
@@ -2064,24 +2065,6 @@
           <verifyFail>stop</verifyFail>
           <verifyFailOn>strict</verifyFailOn>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.commonjava.maven.plugins</groupId>
-        <artifactId>directory-maven-plugin</artifactId>
-        <version>0.3.1</version>
-        <executions>
-          <execution>
-            <id>directories</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>highest-basedir</goal>
-            </goals>
-            <configuration>
-              <property>geoserverBaseDir</property>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
Use the standard (since maven 3.3.1) `${maven.multiModuleProjectDirectory}` expression to resolve the `geoserverBaseDir` property, replacing the `org.commonjava.maven.plugins:directory-maven-plugin` plugin.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->