### PR TITLE
[Backport 2.24.x] [GEOS-11134] build fix for literal include language markdown reference

### DIFF
--- a/doc/en/developer/source/policies/community-modules.rst
+++ b/doc/en/developer/source/policies/community-modules.rst
@@ -282,7 +282,7 @@ Process
          Follow the :download:`h2-LICENSE.md </../../../../src/release/extensions/h2/h2-LICENSE.md>` example:
          
          .. literalinclude:: /../../../../src/release/extensions/h2/h2-LICENSE.md
-            :language: Markdown
+            :language: markdown
 
       #. A readme called :file:`<module>-README.md` which contains instructions 
          on how to install the extension.
@@ -290,7 +290,7 @@ Process
          Follow the :download:`h2-README.md </../../../../src/release/extensions/h2/h2-README.md>` example:
          
          .. literalinclude:: /../../../../src/release/extensions/h2/h2-README.md
-            :language: Markdown
+            :language: markdown
             
          .. warning::
 


### PR DESCRIPTION
[![GEOS-11134](https://badgen.net/badge/JIRA/GEOS-11134/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11134) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7188
 **Authored by:** @jodygarnett