### PR TITLE
[Backport 2.23.x] [GEOS-11166] OGC API Maps HTML representation fail without datetime parameter

### DIFF
--- a/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/v1/maps/MapsService.java
+++ b/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/v1/maps/MapsService.java
@@ -321,7 +321,7 @@ public class MapsService {
         rawParamers.put("height", String.valueOf(height));
         rawParamers.put("layers", collectionId);
         rawParamers.put("styles", styleId);
-        rawParamers.put("datetime", datetime);
+        if (datetime != null) rawParamers.put("datetime", datetime);
         request.setRawKvp(rawParamers);
         // TODO: add other parameters
         return request;


### PR DESCRIPTION
[![GEOS-11166](https://badgen.net/badge/JIRA/GEOS-11166/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11166) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7198
 **Authored by:** @aaime