### PR TITLE
[Backport 2.23.x] [GEOS-11165] STAC Datacube switch eoSummaries bounds output to individual values

### DIFF
--- a/doc/en/user/source/community/opensearch-eo/STAC.rst
+++ b/doc/en/user/source/community/opensearch-eo/STAC.rst
@@ -84,7 +84,7 @@ Support for the `STAC Datacube Extension <https://github.com/stac-extensions/dat
 * min - The minimum value of the field in the collection
 * max - The maximum value of the field in the collection
 * distinct - An array of distinct values of the field in the collection
-* bounds - Minimum and maximum dimension values of the spatial bounding box of the collection (either x or y, presented as a two value array)
+* bounds - Minimum and maximum dimension values of the spatial bounding box of the collection (either x or y, presented as a two value array or xmin, xmax, ymin, ymax presented as individual dimension values)
 
 `eoSummaries` has three arguments:
 
@@ -92,28 +92,39 @@ Support for the `STAC Datacube Extension <https://github.com/stac-extensions/dat
 * collectionIdentifier - The name of the collection that is being summarized.
 * property - The name of the property being summarized.  
 	
-	* Note that for the "bounds" aggregate, this value should either be "x" or "y".
+	* Note that for the "bounds" aggregate, this value should either be "x","y","xmin","ymin","xmax", or "ymax".
 
 **JSON Template Example**:
 
 .. code-block:: none
 
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          "$${eoSummaries('bounds',eo:parentIdentifier,'xmin')}",
+          "$${eoSummaries('bounds',eo:parentIdentifier,'ymin')}",
+          "$${eoSummaries('bounds',eo:parentIdentifier,'xmax')}",
+          "$${eoSummaries('bounds',eo:parentIdentifier,'ymax')}"
+        ]
+      ]
+    },
 	"cube:dimensions"\: {
      "x": {
       	"type": "spatial",
       	"axis": "x",
-      	"extent": "$${eoSummaries('bounds',eop:parentIdentifier,'x')}",
+      	"extent": "$${eoSummaries('bounds',eo:parentIdentifier,'x')}",
       	"reference_system": 4326},
 			"y": {
      		"type": "spatial",
      		"axis": "y",
-     		"extent": "$${eoSummaries('bounds',eop:parentIdentifier,'y')}",
+     		"extent": "$${eoSummaries('bounds',eo:parentIdentifier,'y')}",
      		"reference_system": 4326},
      		"time": 
      			{"type": "temporal",
      			"extent": 
-     				["$${eoSummaries('min',eop:parentIdentifier,'timeStart')}",
-     			"$${eoSummaries('min',eop:parentIdentifier,'timeEnd')}"]
+     				["$${eoSummaries('min',eo:parentIdentifier,'timeStart')}",
+     			"$${eoSummaries('min',eo:parentIdentifier,'timeEnd')}"]
      			}
      	}
     

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/AggregateFactory.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/AggregateFactory.java
@@ -84,6 +84,16 @@ public class AggregateFactory {
                     return new EnvelopeWrapper(envelope).getX();
                 } else if ("y".equals(property)) {
                     return new EnvelopeWrapper(envelope).getY();
+                } else if ("xmin".equals(property)) {
+                    return envelope.getMinX();
+                } else if ("xmax".equals(property)) {
+                    return envelope.getMaxX();
+                } else if ("ymin".equals(property)) {
+                    return envelope.getMinY();
+                } else if ("ymax".equals(property)) {
+                    return envelope.getMaxY();
+                } else {
+                    return new EnvelopeWrapper(envelope);
                 }
             } else {
                 return new EnvelopeWrapper(null);

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/functions/EoSummaries.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/functions/EoSummaries.java
@@ -96,9 +96,15 @@ public class EoSummaries extends FunctionImpl {
         if (property == null) {
             throw new IllegalArgumentException("Property cannot be null");
         }
-        if (BOUNDS.equals(aggregate) && !"x".equals(property) && !"y".equals(property)) {
+        if (BOUNDS.equals(aggregate)
+                && !"x".equals(property)
+                && !"y".equals(property)
+                && !"xmin".equals(property)
+                && !"xmax".equals(property)
+                && !"ymin".equals(property)
+                && !"ymax".equals(property)) {
             throw new IllegalArgumentException(
-                    "Property must be 'x' or 'y' when aggregate is 'bounds'");
+                    "Property must be 'x' or 'y' or 'xmin' or 'xmax' or 'ymin' or 'ymax' when aggregate is 'bounds'");
         }
     }
 

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/CollectionsTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/CollectionsTest.java
@@ -175,7 +175,7 @@ public class CollectionsTest extends STACTestSupport {
                                 + "satellites"));
         assertEquals(STACService.STAC_VERSION, s2.read("stac_version"));
         assertEquals("CC-BY-NC-ND-3.0-IGO", s2.read("license"));
-        // Sentinel 2 bounding box
+        // Sentinel 2 bounding box, uses the eoSummaries function in the collections.json template
         DocumentContext s2bbox = readContext(s2, "extent.spatial.bbox");
         assertEquals(-179, s2bbox.read("$[0][0]"), 0d);
         assertEquals(-89, s2bbox.read("$[0][1]"), 0d);

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/functions/EoSummariesTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/functions/EoSummariesTest.java
@@ -90,7 +90,7 @@ public class EoSummariesTest extends STACTestSupport {
     }
 
     @Test
-    public void testBounds() {
+    public void testBoundsX() {
         List<Expression> parameters =
                 List.of(ff.literal("bounds"), ff.literal("SENTINEL2"), ff.literal("x"));
         when(eoSummaries.getParameters()).thenReturn(parameters);
@@ -98,6 +98,38 @@ public class EoSummariesTest extends STACTestSupport {
                 Double.valueOf(-119.173780060482),
                 ((List<Double>) eoSummaries.evaluate(null)).get(0),
                 0.1);
+    }
+
+    @Test
+    public void testBoundsXMin() {
+        List<Expression> parameters =
+                List.of(ff.literal("bounds"), ff.literal("SENTINEL2"), ff.literal("xmin"));
+        when(eoSummaries.getParameters()).thenReturn(parameters);
+        assertEquals(Double.valueOf(-119.173780060482), (Double) eoSummaries.evaluate(null), 0.1);
+    }
+
+    @Test
+    public void testBoundsYMin() {
+        List<Expression> parameters =
+                List.of(ff.literal("bounds"), ff.literal("SENTINEL2"), ff.literal("ymin"));
+        when(eoSummaries.getParameters()).thenReturn(parameters);
+        assertEquals(Double.valueOf(33.3327671071438), (Double) eoSummaries.evaluate(null), 0.1);
+    }
+
+    @Test
+    public void testBoundsXMax() {
+        List<Expression> parameters =
+                List.of(ff.literal("bounds"), ff.literal("SENTINEL2"), ff.literal("xmax"));
+        when(eoSummaries.getParameters()).thenReturn(parameters);
+        assertEquals(Double.valueOf(16.3544473299751), (Double) eoSummaries.evaluate(null), 0.1);
+    }
+
+    @Test
+    public void testBoundsYMax() {
+        List<Expression> parameters =
+                List.of(ff.literal("bounds"), ff.literal("SENTINEL2"), ff.literal("ymax"));
+        when(eoSummaries.getParameters()).thenReturn(parameters);
+        assertEquals(Double.valueOf(44.2465509344875), (Double) eoSummaries.evaluate(null), 0.1);
     }
 
     class MyMinVisitor extends MinVisitor {

--- a/src/community/oseo/oseo-stac/src/test/resources/collections.json
+++ b/src/community/oseo/oseo-stac/src/test/resources/collections.json
@@ -14,10 +14,10 @@
         "spatial": {
           "bbox": [
             [
-              "$${minx(footprint)}",
-              "$${miny(footprint)}",
-              "$${maxx(footprint)}",
-              "$${maxy(footprint)}"
+              "$${eoSummaries('bounds',name,'xmin')}",
+              "$${eoSummaries('bounds',name,'ymin')}",
+              "$${eoSummaries('bounds',name,'xmax')}",
+              "$${eoSummaries('bounds',name,'ymax')}"
             ]
           ]
         },


### PR DESCRIPTION
[![GEOS-11165](https://badgen.net/badge/JIRA/GEOS-11165/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11165) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7195
 **Authored by:** @turingtestfail