### PR TITLE
Update translation doc (transifex -> weblate)

### DIFF
--- a/doc/en/developer/source/translation.rst
+++ b/doc/en/developer/source/translation.rst
@@ -24,14 +24,14 @@ Once created, each line in the files represents a string that will need to be tr
 
 .. warning:: property files must always be encoded in ISO-8859 (or something equivalent like us-ascii or latin1). If you need a whole unicode file, the extension of the file must be `utf8.properties`. 
 
-Translating in Transifex
+Translating in WebLate
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-A GeoServer project is maintained on the Transifex website to allow people to participate to the translation of the UI without going into the source code of GeoServer. Transifex requires an account to log in but GitHub accounts can be used.
+A GeoServer project is maintained on the WebLate website hosted by OSGEO to allow people to participate to the translation of the UI without going into the source code of GeoServer. WebLate requires an  OSGEO account to log in (accounts can be created at https://id.osgeo.org/ldap/create).
 
-The project is available here : https://www.transifex.com/GeoServer/geoserver-github-integration/dashboard/.
+The project is available here : https://weblate.osgeo.org/projects/geoserver/.
 
-The administrators of the project update the Transifex resources on a regular basis and synchronize the translations in GeoServer at the same time.
+The WebLate project is automatically synchronized with the GitHub repository of GeoServer. The administrators of the WebLate projects are responsible for pushing translations from WebLate to GitHub.
 
 Editing in Eclipse
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Update documentation on translation to match the migration from Transifex to WebLate

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->