### PR TITLE
[GEOS-11170] OGC API Features "/api" link is broken in OpenAPI page

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
@@ -51,7 +51,7 @@ paths:
           $ref: '#/components/responses/LandingPage'
         '500':
           $ref: '#/components/responses/ServerError'
-  '/api':
+  '/openapi':
     get:
       tags:
         - Capabilities
@@ -61,7 +61,7 @@ paths:
       operationId: getOpenApiDocument
       responses:
         '200':
-          $ref: '#/components/responses/ConformanceDeclaration'
+          $ref: '#/components/responses/OpenAPI'
         '500':
           $ref: '#/components/responses/ServerError'
   '/conformance':
@@ -1137,11 +1137,11 @@ components:
                 rel: self
                 type: application/json
                 title: this document
-              - href: 'http://data.example.org/api'
+              - href: 'http://data.example.org/openapi'
                 rel: service-desc
                 type: application/vnd.oai.openapi+json;version=3.0
                 title: the API definition
-              - href: 'http://data.example.org/api.html'
+              - href: 'http://data.example.org/openapi.html'
                 rel: service-doc
                 type: text/html
                 title: the API documentation
@@ -1156,6 +1156,10 @@ components:
         text/html:
           schema:
             type: string
+    OpenAPI:
+      description: |-
+        The OpenAPI page provides an Open API (aka Swagger) view
+        of the OGC API - Feature interface.
     ConformanceDeclaration:
       description: |-
         The URIs of all conformance classes supported by the server.


### PR DESCRIPTION
[![GEOS-11170](https://badgen.net/badge/JIRA/GEOS-11170/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11170) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As identified at tutorial session today. Just a left-over from the change from api -> openapi.

I also found the descriptive text was a link to the Conformance stuff, updated that too. It is a bit weak, but at least its no longer wrong.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->