### PR TITLE
[Backport 2.24.x] Bump com.rabbitmq:amqp-client from 5.9.0 to 5.18.0 in /src/community/notification-common

### DIFF
--- a/src/community/notification-common/pom.xml
+++ b/src/community/notification-common/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.9.0</version>
+      <version>5.18.0</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Backport #7212
 **Authored by:** @dependabot[bot]