### PR TITLE
[Backport 2.24.x] Bump com.rabbitmq:amqp-client from 5.9.0 to 5.18.0 in /src/community/notification

### DIFF
--- a/src/community/notification/pom.xml
+++ b/src/community/notification/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.9.0</version>
+      <version>5.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Backport #7213
 **Authored by:** @dependabot[bot]