### PR TITLE
[Backport 2.24.x] [GEOS-11173] Default to using HttpOnly session cookies

### DIFF
--- a/doc/en/user/source/production/config.rst
+++ b/doc/en/user/source/production/config.rst
@@ -205,3 +205,16 @@ GeoServer provides a number of facilities to control external entity resolution:
 * To turn off all restrictions (allowing ``http``, ``https``, and ``file`` references) use the global setting :ref:`config_globalsettings_external_entities`.
   
   This setting prevents ``ENTITY_RESOLUTION_ALLOWLIST`` from being used.
+
+Session Management
+------------------
+
+GeoServer defaults to managing user sessions using cookies with the ``HttpOnly`` flag set to prevent attackers from using cross-site scripting (XSS) attacks to steal
+a user's session token. You can configure the session behavior by modifying the :file:`web.xml` file of your GeoServer instance.
+
+It is strongly recommended that production environments also set the ``Secure`` flag on session cookies. This can be enabled by uncommenting the following in the :file:`web.xml`
+file if the web interface is only being accessed through HTTPS but the flag may need to be set by a proxy server if the web interface needs to support both HTTP and HTTPS.
+
+.. code-block:: xml
+
+   <secure>true</secure>

--- a/src/web/app/src/main/webapp/WEB-INF/web.xml
+++ b/src/web/app/src/main/webapp/WEB-INF/web.xml
@@ -277,6 +277,17 @@
         <servlet-name>dispatcher</servlet-name>
         <url-pattern>/*</url-pattern>
     </servlet-mapping>
+
+    <session-config>
+        <cookie-config>
+            <http-only>true</http-only>
+            <!-- The Secure flag should be set on session cookies but is commented out by default since it -->
+            <!-- will break non-HTTPS web UI access and may cause problems with some proxy configurations. -->
+            <!-- Uncomment the following line to add the Secure flag to session cookies. -->
+            <!-- <secure>true</secure> -->
+        </cookie-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
     
     <mime-mapping>
       <extension>xsl</extension>


### PR DESCRIPTION
[![GEOS-11173](https://badgen.net/badge/JIRA/GEOS-11173/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11173) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7218
 **Authored by:** @sikeoka