### PR TITLE
[Backport 2.24.x] [GEOS-11155] Add the X-Content-Type-Options header

### DIFF
--- a/doc/en/user/source/production/config.rst
+++ b/doc/en/user/source/production/config.rst
@@ -165,6 +165,19 @@ If you wish to change this behavior you can do so through the following properti
 These properties can be set either via Java system property, command line argument (-D), environment
 variable or web.xml init parameter.
 
+X-Content-Type-Options Policy
+-----------------------------
+
+In order to mitigate MIME confusion attacks (which often results in Cross-Site Scripting), GeoServer defaults to setting the ``X-Content-Type-Options: nosniff`` HTTP header.
+See the `OWASP X-Content-Type-Options entry <https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options>`_ for details.
+
+If you wish to change this behavior you can do so through the following property:
+
+* ``geoserver.xContentType.shouldSetPolicy``: controls whether the X-Content-Type-Options header should be set. Default is true.
+
+This property can be set either via Java system property, command line argument (-D), environment
+variable or web.xml init parameter.
+
 OWS ServiceException XML mimeType
 --------------------------------------------------
 

--- a/src/main/src/main/java/org/geoserver/filters/XFrameOptionsFilter.java
+++ b/src/main/src/main/java/org/geoserver/filters/XFrameOptionsFilter.java
@@ -37,6 +37,10 @@ public class XFrameOptionsFilter implements Filter {
     /** The system property for the value of the X-Frame-Options header */
     public static final String GEOSERVER_XFRAME_POLICY = "geoserver.xframe.policy";
 
+    /** The system property to set whether the X-Content-Type-Options header should be set */
+    public static final String GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY =
+            "geoserver.xContentType.shouldSetPolicy";
+
     /**
      * Whether the X-Frame-Option header should be set at all. Check this on the fly for easier
      * testing and in order to potentially make this a GUI controlled option in the future.
@@ -62,6 +66,22 @@ public class XFrameOptionsFilter implements Filter {
         return framePolicy;
     }
 
+    /**
+     * Whether the X-Content-Type-Options header should be set at all. Check this on the fly for
+     * easier testing and in order to potentially make this a GUI controlled option in the future.
+     */
+    private static boolean shouldSetContentTypePolicy() {
+        boolean shouldSetPolicy = true;
+        if (StringUtils.isNotEmpty(
+                GeoServerExtensions.getProperty(GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY))) {
+            shouldSetPolicy =
+                    Boolean.parseBoolean(
+                            GeoServerExtensions.getProperty(
+                                    GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY));
+        }
+        return shouldSetPolicy;
+    }
+
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {}
 
@@ -69,9 +89,12 @@ public class XFrameOptionsFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
         if (shouldSetPolicy()) {
-            HttpServletResponse httpResponse = (HttpServletResponse) response;
             httpResponse.setHeader(X_FRAME_OPTIONS, getFramePolicy());
+        }
+        if (shouldSetContentTypePolicy()) {
+            httpResponse.setHeader("X-Content-Type-Options", "nosniff");
         }
 
         chain.doFilter(request, response);

--- a/src/main/src/test/java/org/geoserver/filters/XFrameOptionsFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/XFrameOptionsFilterTest.java
@@ -19,7 +19,7 @@ public class XFrameOptionsFilterTest {
 
     @Test
     public void doFilter() throws Exception {
-        String header = getXStreamHeader();
+        String header = getHeader("X-Frame-Options");
         assertEquals("Expect default XFrameOption to be DENY", "SAMEORIGIN", header);
     }
 
@@ -28,7 +28,7 @@ public class XFrameOptionsFilterTest {
         String currentShouldSetProperty =
                 System.getProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY);
         System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY, "false");
-        String header = getXStreamHeader();
+        String header = getHeader("X-Frame-Options");
 
         assertNull("Expect default XFrameOption to be null", header);
 
@@ -44,7 +44,7 @@ public class XFrameOptionsFilterTest {
         String currentShouldSetProperty =
                 System.getProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY);
         System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY, "DENY");
-        String header = getXStreamHeader();
+        String header = getHeader("X-Frame-Options");
 
         assertEquals("Expect default XFrameOption to be DENY", "DENY", header);
 
@@ -54,7 +54,39 @@ public class XFrameOptionsFilterTest {
         }
     }
 
-    private String getXStreamHeader() throws IOException, ServletException {
+    @Test
+    public void testFilterWithoutContentTypeOptions() throws IOException, ServletException {
+        String currentShouldSetProperty =
+                System.getProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY);
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY, "false");
+        String header = getHeader("X-Content-Type-Options");
+
+        assertNull("Expect X-Content-Type-Options to be null", header);
+
+        if (currentShouldSetProperty != null) {
+            System.setProperty(
+                    XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY,
+                    currentShouldSetProperty);
+        }
+    }
+
+    @Test
+    public void testFilterWithContentTypeOptions() throws IOException, ServletException {
+        String currentShouldSetProperty =
+                System.getProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY);
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY, "true");
+        String header = getHeader("X-Content-Type-Options");
+
+        assertEquals("Expect X-Content-Type-Options to be nosniff", "nosniff", header);
+
+        if (currentShouldSetProperty != null) {
+            System.setProperty(
+                    XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY,
+                    currentShouldSetProperty);
+        }
+    }
+
+    private String getHeader(String name) throws IOException, ServletException {
         MockHttpServletRequest request =
                 new MockHttpServletRequest("GET", "http://www.geoserver.org");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -63,6 +95,6 @@ public class XFrameOptionsFilterTest {
 
         filter.doFilter(request, response, mockChain);
 
-        return response.getHeader("X-Frame-Options");
+        return response.getHeader(name);
     }
 }


### PR DESCRIPTION
[![GEOS-11155](https://badgen.net/badge/JIRA/GEOS-11155/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11155) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7181
 **Authored by:** @sikeoka