### PR TITLE
[Backport 2.24.x] [GEOS-11176] Add validation to file wrapper resource paths

### DIFF
--- a/src/platform/src/main/java/org/geoserver/platform/resource/URIs.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/URIs.java
@@ -28,6 +28,7 @@ public final class URIs {
         private URL url;
 
         public ResourceAdaptor(URL url) {
+            Paths.valid(url.getPath());
             this.url = url;
         }
 

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -32,7 +32,9 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.geoserver.platform.resource.Resource.Type;
+import org.junit.Test;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
@@ -489,5 +491,25 @@ public abstract class ResourceTheoryTest {
 
         final Resource res = getResource(Paths.convert(file.getPath()));
         assertTrue(Paths.isAbsolute(res.path()));
+    }
+
+    @Test
+    public void testPathTraversal() {
+        assertInvalidPath("..");
+        assertInvalidPath("../foo/bar");
+        assertInvalidPath("foo/../bar");
+        assertInvalidPath("foo/bar/..");
+    }
+
+    @Test
+    public void testPathTraversalWindows() {
+        assumeTrue(SystemUtils.IS_OS_WINDOWS);
+        assertInvalidPath("..\\foo\\bar");
+        assertInvalidPath("foo\\..\\bar");
+        assertInvalidPath("foo\\bar\\..");
+    }
+
+    protected final void assertInvalidPath(String path) {
+        assertThrows(IllegalArgumentException.class, () -> getResource(path));
     }
 }


### PR DESCRIPTION
[![GEOS-11176](https://badgen.net/badge/JIRA/GEOS-11176/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11176) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7222
 **Authored by:** @sikeoka