### PR TITLE
[Backport 2.24.x] Bump org.apache.activemq:activemq-client from 5.15.11 to 5.15.16 in /src/community/jms-cluster/jms-geoserver

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/pom.xml
+++ b/src/community/jms-cluster/jms-geoserver/pom.xml
@@ -15,7 +15,7 @@
   <name>GeoServer JMS clustering module</name>
 
   <properties>
-    <amq.version>5.15.11</amq.version>
+    <amq.version>5.15.16</amq.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Backport #7235
 **Authored by:** @dependabot[bot]