### PR TITLE
Fix URLcheck heading, grammar

### DIFF
--- a/src/web/security/core/src/main/resources/GeoServerApplication.properties
+++ b/src/web/security/core/src/main/resources/GeoServerApplication.properties
@@ -760,7 +760,7 @@ URLChecksPage.confirmDeleteMessage={0} URL Checks will be deleted
 URLChecksPage.urlChecks = URL Check list
 URLChecksPage.th.name    = Name
 URLChecksPage.th.description    = Description
-URLChecksPage.th.regex  = Regular Expression
+URLChecksPage.th.configuration  = Regular Expression
 URLChecksPage.th.enabled  = Enabled
 URLChecksPage.testChecks= Test URL Checks with external URL
 URLChecksPage.testInput= URL to check
@@ -777,7 +777,7 @@ URLChecksPage.checksDisabled = URL checks are NOT enabled
 
 
 RegexCheckPage.title=Configure Regular Expression URL check
-RegexCheckPage.description=Configure a regular expressions to control outgoing requests
+RegexCheckPage.description=Configure a regular expression to control outgoing requests
 RegexCheckPage.nameLabel=Name
 RegexCheckPage.descriptionLabel=Description
 RegexCheckPage.regexLabel=Regular Expression


### PR DESCRIPTION
Fixes label (was `configuration`)  
![image](https://github.com/geoserver/geoserver/assets/5699667/41a2f5b9-de06-45ef-b8a4-79cddc4a782a)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->