### PR TITLE
[Backport 2.24.x] [GEOS-11170] OGC API Features "/api" link is broken in OpenAPI page

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
@@ -51,7 +51,7 @@ paths:
           $ref: '#/components/responses/LandingPage'
         '500':
           $ref: '#/components/responses/ServerError'
-  '/api':
+  '/openapi':
     get:
       tags:
         - Capabilities
@@ -61,7 +61,7 @@ paths:
       operationId: getOpenApiDocument
       responses:
         '200':
-          $ref: '#/components/responses/ConformanceDeclaration'
+          $ref: '#/components/responses/OpenAPI'
         '500':
           $ref: '#/components/responses/ServerError'
   '/conformance':
@@ -935,11 +935,11 @@ components:
                 rel: self
                 type: application/json
                 title: this document
-              - href: 'http://data.example.org/api'
+              - href: 'http://data.example.org/openapi'
                 rel: service-desc
                 type: application/vnd.oai.openapi+json;version=3.0
                 title: the API definition
-              - href: 'http://data.example.org/api.html'
+              - href: 'http://data.example.org/openapi.html'
                 rel: service-doc
                 type: text/html
                 title: the API documentation
@@ -954,6 +954,10 @@ components:
         text/html:
           schema:
             type: string
+    OpenAPI:
+      description: |-
+        The OpenAPI page provides an Open API (aka Swagger) view
+        of the OGC API - Feature interface.
     ConformanceDeclaration:
       description: |-
         The URIs of all conformance classes supported by the server.


### PR DESCRIPTION
[![GEOS-11170](https://badgen.net/badge/JIRA/GEOS-11170/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11170) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7214
 **Authored by:** @bradh