### PR TITLE
[Backport 2.24.x] [GEOS-11200] GetFeatureInfo can fail on rendering transformations that generate a different raster

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
@@ -72,6 +72,7 @@ import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.filter.function.RenderingTransformation;
 import org.geotools.geometry.Position2D;
 import org.geotools.geometry.TransformedPosition;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -443,8 +444,12 @@ public class RasterLayerIdentifier implements LayerIdentifier<GridCoverage2DRead
         }
 
         // otherwise read, evaluate if a transformation is needed
-        GridCoverage2D coverage = reader.read(parameters);
         Expression transformation = getTransformation(visitor);
+        if (transformation != null && transformation instanceof RenderingTransformation) {
+            ((RenderingTransformation) transformation).customizeReadParams(reader, parameters);
+        }
+        GridCoverage2D coverage = reader.read(parameters);
+
         if (transformation != null) {
             RenderingTransformationHelper helper =
                     new RenderingTransformationHelper() {

--- a/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormat.java
+++ b/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormat.java
@@ -1,0 +1,58 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.tiffspy;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geotools.api.data.DataSourceException;
+import org.geotools.gce.geotiff.GeoTiffFormat;
+import org.geotools.gce.geotiff.GeoTiffReader;
+import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
+
+/** Extension to GeoTIFF format allowing to spy read parameters */
+public class GeoTIFFSpyFormat extends GeoTiffFormat {
+
+    /** Can be used to enable/disable this format during tests */
+    public static boolean ENABLED = false;
+
+    static final Logger LOGGER = Logging.getLogger(GeoTIFFSpyFormat.class);
+    public static final String NAME = "GeoTIFFSpy";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean accepts(Object source) {
+        return ENABLED && super.accepts(source);
+    }
+
+    @Override
+    public boolean accepts(Object o, Hints hints) {
+        return ENABLED && super.accepts(o);
+    }
+
+    @Override
+    public GeoTiffReader getReader(Object source) {
+        try {
+            return new GeoTIFFSpyReader(source);
+        } catch (DataSourceException e) {
+            LOGGER.log(Level.INFO, "Failed to create GeoTIFFSpyReader", e);
+            return null;
+        }
+    }
+
+    @Override
+    public GeoTiffReader getReader(Object source, Hints hints) {
+        try {
+            return new GeoTIFFSpyReader(source, hints);
+        } catch (DataSourceException e) {
+            LOGGER.log(Level.INFO, "Failed to create GeoTIFFSpyReader", e);
+            return null;
+        }
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormatFactory.java
+++ b/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormatFactory.java
@@ -1,0 +1,22 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.tiffspy;
+
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.coverage.grid.io.GridFormatFactorySpi;
+
+/** Extension to GeoTIFF format allowing to spy read parameters */
+public class GeoTIFFSpyFormatFactory implements GridFormatFactorySpi {
+
+    @Override
+    public AbstractGridFormat createFormat() {
+        return new GeoTIFFSpyFormat();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyReader.java
+++ b/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyReader.java
@@ -1,0 +1,36 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.tiffspy;
+
+import java.io.IOException;
+import org.geotools.api.data.DataSourceException;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.gce.geotiff.GeoTiffReader;
+import org.geotools.util.factory.Hints;
+
+/** Extension to GeoTIFF reader allowing to spy read parameters */
+public class GeoTIFFSpyReader extends GeoTiffReader {
+
+    public static GeneralParameterValue[] getLastParams() {
+        return LAST_PARAMS;
+    }
+
+    static GeneralParameterValue[] LAST_PARAMS;
+
+    public GeoTIFFSpyReader(Object input) throws DataSourceException {
+        super(input);
+    }
+
+    public GeoTIFFSpyReader(Object input, Hints uHints) throws DataSourceException {
+        super(input, uHints);
+    }
+
+    @Override
+    public GridCoverage2D read(GeneralParameterValue[] params) throws IOException {
+        LAST_PARAMS = params;
+        return super.read(params);
+    }
+}

--- a/src/wms/src/test/resources/META-INF/services/org.geotools.coverage.grid.io.GridFormatFactorySpi
+++ b/src/wms/src/test/resources/META-INF/services/org.geotools.coverage.grid.io.GridFormatFactorySpi
@@ -1,1 +1,2 @@
 org.geoserver.wms.staticRasterStore.StaticRasterFormatFactory
+org.geoserver.wms.tiffspy.GeoTIFFSpyFormatFactory

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/jiffleCondition.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/jiffleCondition.sld
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <Name>dem</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Transformation>
+                    <ogc:Function name="ras:Jiffle">
+                        <ogc:Function name="parameter">
+                            <ogc:Literal>coverage</ogc:Literal>
+                        </ogc:Function>
+                        <ogc:Function name="parameter">
+                            <ogc:Literal>script</ogc:Literal>
+                            <!-- Condition designed to check that band section on reader 
+                                 is propagaged correctly, e.g., we want one band from the
+                                 output, but we are going to read two from the input -->
+                            <ogc:Literal>
+                                dest = src[2] > 100 ? src[0] : 0;
+                            </ogc:Literal>
+                        </ogc:Function>
+                    </ogc:Function>
+                </Transformation>
+                <Rule>
+                    <PointSymbolizer/>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-11200](https://badgen.net/badge/JIRA/GEOS-11200/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11200) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7264
 **Authored by:** @aaime