### PR TITLE
[Backport 2.20.x] [GEOS-11196] NPE in VectorDownload if ROI not defined

### DIFF
--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/VectorDownload.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/VectorDownload.java
@@ -167,7 +167,9 @@ class VectorDownload {
         // do we need to reproject?
         SimpleFeatureCollection reprojectedFeatures;
         if (targetCRS != null && !CRS.equalsIgnoreMetadata(nativeCRS, targetCRS)) {
-            roiManager.useTargetCRS(targetCRS);
+            if (hasROI) {
+                roiManager.useTargetCRS(targetCRS);
+            }
             // testing reprojection...
             final MathTransform targetTX = CRS.findMathTransform(nativeCRS, targetCRS, true);
             if (!targetTX.isIdentity()) {


### PR DESCRIPTION
[![GEOS-11196](https://badgen.net/badge/JIRA/GEOS-11196/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11196) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7263
 **Authored by:** @etj