### PR TITLE
[Backport 2.21.x] [GEOS-11196] NPE in VectorDownload if ROI not defined

### DIFF
--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/VectorDownload.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/VectorDownload.java
@@ -167,7 +167,9 @@ class VectorDownload {
         // do we need to reproject?
         SimpleFeatureCollection reprojectedFeatures;
         if (targetCRS != null && !CRS.equalsIgnoreMetadata(nativeCRS, targetCRS)) {
-            roiManager.useTargetCRS(targetCRS);
+            if (hasROI) {
+                roiManager.useTargetCRS(targetCRS);
+            }
             // testing reprojection...
             final MathTransform targetTX = CRS.findMathTransform(nativeCRS, targetCRS, true);
             if (!targetTX.isIdentity()) {

--- a/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
+++ b/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
@@ -404,6 +404,37 @@ public class DownloadProcessTest extends WPSTestSupport {
     }
 
     @Test
+    public void testGetFeaturesWithNoROIAsShapefile() throws Exception {
+        // Creates the new process for the download
+        DownloadProcess downloadProcess = createDefaultTestingDownloadProcess();
+
+        FeatureTypeInfo ti = getCatalog().getFeatureTypeByName(getLayerId(MockData.POLYGONS));
+        SimpleFeatureCollection rawSource =
+                (SimpleFeatureCollection) ti.getFeatureSource(null, null).getFeatures();
+        // Download
+        RawData shpeZip =
+                executeVectorDownload(
+                        downloadProcess,
+                        MockData.POLYGONS,
+                        "application/zip",
+                        "application/zip",
+                        null,
+                        null,
+                        false,
+                        "EPSG:4326");
+
+        try (AutoCloseableResource resource =
+                        new AutoCloseableResource(getResourceManager(), shpeZip);
+                InputStream is = new FileInputStream(resource.getFile())) {
+            ShapefileDataStore store = decodeShape(is);
+            SimpleFeatureCollection rawTarget = store.getFeatureSource().getFeatures();
+            Assert.assertNotNull(rawTarget);
+            Assert.assertEquals(rawSource.size(), rawTarget.size());
+            store.dispose();
+        }
+    }
+
+    @Test
     public void testGetFeaturesAsGeoPackageZipped() throws Exception {
         // Creates the new process for the download
         DownloadProcess downloadProcess = createDefaultTestingDownloadProcess();
@@ -648,13 +679,34 @@ public class DownloadProcessTest extends WPSTestSupport {
             Polygon roi,
             boolean cropToGeometry)
             throws FactoryException {
+        return executeVectorDownload(
+                downloadProcess,
+                polygons,
+                mimeType,
+                outputFormat,
+                roiCRS,
+                roi,
+                cropToGeometry,
+                null);
+    }
+
+    private RawData executeVectorDownload(
+            DownloadProcess downloadProcess,
+            QName polygons,
+            String mimeType,
+            String outputFormat,
+            String roiCRS,
+            Polygon roi,
+            boolean cropToGeometry,
+            String targetCRS)
+            throws FactoryException {
         return downloadProcess.execute(
                 getLayerId(polygons), // layerName
                 null, // filter
                 mimeType,
                 outputFormat,
-                null, // targetCRS
-                CRS.decode(roiCRS), // roiCRS
+                targetCRS == null ? null : CRS.decode(targetCRS), // targetCRS
+                roiCRS == null ? null : CRS.decode(roiCRS), // roiCRS
                 roi, // roi
                 cropToGeometry, // cropToGeometry
                 null, // interpolation


### PR DESCRIPTION
[![GEOS-11196](https://badgen.net/badge/JIRA/GEOS-11196/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11196) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7263
 **Authored by:** @etj