### PR TITLE
[Backport 2.23.x] [GEOS-11200] GetFeatureInfo can fail on rendering transformations tha t generate a different raster

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
@@ -51,6 +51,7 @@ import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.filter.function.RenderingTransformation;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.TransformedDirectPosition;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -443,8 +444,12 @@ public class RasterLayerIdentifier implements LayerIdentifier<GridCoverage2DRead
         }
 
         // otherwise read, evaluate if a transformation is needed
-        GridCoverage2D coverage = reader.read(parameters);
         Expression transformation = getTransformation(visitor);
+        if (transformation != null && transformation instanceof RenderingTransformation) {
+            ((RenderingTransformation) transformation).customizeReadParams(reader, parameters);
+        }
+        GridCoverage2D coverage = reader.read(parameters);
+
         if (transformation != null) {
             RenderingTransformationHelper helper =
                     new RenderingTransformationHelper() {

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/GetFeatureInfoJSONTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/GetFeatureInfoJSONTest.java
@@ -7,6 +7,8 @@ package org.geoserver.wms.featureinfo;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.geoserver.data.test.MockData.TASMANIA_DEM;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -22,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.function.Function;
 import javax.xml.namespace.QName;
 import net.opengis.wfs.FeatureCollectionType;
 import net.opengis.wfs.WfsFactory;
@@ -30,6 +33,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.emf.common.util.EList;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -46,12 +50,19 @@ import org.geoserver.platform.resource.Resource;
 import org.geoserver.wfs.json.JSONType;
 import org.geoserver.wms.GetFeatureInfoRequest;
 import org.geoserver.wms.MapLayerInfo;
+import org.geoserver.wms.tiffspy.GeoTIFFSpyFormat;
+import org.geoserver.wms.tiffspy.GeoTIFFSpyReader;
 import org.geoserver.wms.wms_1_1_1.GetFeatureInfoTest;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.NameImpl;
+import org.geotools.parameter.DefaultParameterDescriptor;
 import org.geotools.util.NumberRange;
 import org.geotools.util.factory.Hints;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
+import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValue;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 public class GetFeatureInfoJSONTest extends GetFeatureInfoTest {
@@ -76,35 +87,37 @@ public class GetFeatureInfoJSONTest extends GetFeatureInfoTest {
 
     public static final String FOOTPRINT_RASTER = "footprintsRaster";
 
+    public static final String JIFFLE_CONDITION = "jiffleCondition";
+
+    public static final QName TASMANIA_SPY = new QName(WCS_URI, "BlueMarbleSpy", WCS_PREFIX);
+
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         super.onSetUp(testData);
+        Catalog catalog = getCatalog();
         testData.addVectorLayer(
                 TEMPORAL_DATA,
                 Collections.emptyMap(),
                 "TemporalData.properties",
                 SystemTestData.class,
-                getCatalog());
-        testData.addStyle(LABEL_IN_FEATURE_INFO_STYLE_DEM, getClass(), getCatalog());
-        testData.addStyle(LABEL_CUSTOM_NAME_STYLE_DEM, getClass(), getCatalog());
-        testData.addStyle(LABEL_IN_FEATURE_INFO_DEM_REPLACE, getClass(), getCatalog());
-        testData.addStyle(LABEL_IN_FEATURE_INFO_DEM_NONE, getClass(), getCatalog());
-        testData.addStyle(LABEL_IN_FEATURE_INFO_DEM_VALUES, getClass(), getCatalog());
-        testData.addStyle(LABEL_IN_FEATURE_INFO_MULTIPLE_SYMBOLIZERS, getClass(), getCatalog());
-        testData.addStyle(LABEL_IN_FEATURE_INFO_STYLE_BM, getClass(), getCatalog());
-        testData.addStyle(
-                LABEL_IN_FEATURE_INFO_STYLE_MULTIPLE_SYMBLOZERS2, getClass(), getCatalog());
-        testData.addStyle(RASTER_VECTOR, getClass(), getCatalog());
-        testData.addStyle(FOOTPRINT_RASTER, getClass(), getCatalog());
+                catalog);
+        testData.addStyle(LABEL_IN_FEATURE_INFO_STYLE_DEM, getClass(), catalog);
+        testData.addStyle(LABEL_CUSTOM_NAME_STYLE_DEM, getClass(), catalog);
+        testData.addStyle(LABEL_IN_FEATURE_INFO_DEM_REPLACE, getClass(), catalog);
+        testData.addStyle(LABEL_IN_FEATURE_INFO_DEM_NONE, getClass(), catalog);
+        testData.addStyle(LABEL_IN_FEATURE_INFO_DEM_VALUES, getClass(), catalog);
+        testData.addStyle(LABEL_IN_FEATURE_INFO_MULTIPLE_SYMBOLIZERS, getClass(), catalog);
+        testData.addStyle(LABEL_IN_FEATURE_INFO_STYLE_BM, getClass(), catalog);
+        testData.addStyle(LABEL_IN_FEATURE_INFO_STYLE_MULTIPLE_SYMBLOZERS2, getClass(), catalog);
+        testData.addStyle(RASTER_VECTOR, getClass(), catalog);
+        testData.addStyle(JIFFLE_CONDITION, getClass(), catalog);
+        testData.addStyle(FOOTPRINT_RASTER, getClass(), catalog);
         Map<SystemTestData.LayerProperty, Object> propertyMap = new HashMap<>();
         propertyMap.put(SystemTestData.LayerProperty.STYLE, "raster");
         testData.addRasterLayer(
-                TASMANIA_DEM,
-                "tazdem.tiff",
-                "tiff",
-                propertyMap,
-                SystemTestData.class,
-                getCatalog());
+                TASMANIA_DEM, "tazdem.tiff", "tiff", propertyMap, SystemTestData.class, catalog);
+        testData.addRasterLayer(
+                TASMANIA_SPY, "tazbm.tiff", "tiff", propertyMap, SystemTestData.class, catalog);
     }
 
     /** Tests JSONP outside of expected polygon */
@@ -1196,5 +1209,86 @@ public class GetFeatureInfoJSONTest extends GetFeatureInfoTest {
         assertEquals(0, rasterProps.getInt("RED_BAND"));
         assertEquals(255, rasterProps.getInt("GREEN_BAND"));
         assertEquals(0, rasterProps.getInt("BLUE_BAND"));
+    }
+
+    @Test
+    public void testFeatureInfoRTMultiband() throws Exception {
+        // use the request as is, ping one point in the middle where the condition applies
+        // and one in the top/left corner where it doesn't
+        checkFeatureInfoRTMultiband(r -> r, 25);
+        checkFeatureInfoRTMultiband(r -> r.replace("&X=50&Y=50", "&X=0&Y=0"), 0);
+    }
+
+    @Test
+    public void testFeatureInfoRTMultibandSelection() throws Exception {
+        // add a property selection (the code turns the original band names into band indexes,
+        // has no way to know the result will be named in a different way... a fix for another day)
+        checkFeatureInfoRTMultiband(r -> r + "&propertyNames=RED_BAND", 25);
+        checkFeatureInfoRTMultiband(
+                r -> (r + "&propertyNames=RED_BAND").replace("&X=50&Y=50", "&X=0&Y=0"), 0);
+    }
+
+    private void checkFeatureInfoRTMultiband(
+            Function<String, String> requestCustomizer, int expected) throws Exception {
+        // set up the layer to use the spy format
+        GeoTIFFSpyFormat.ENABLED = true;
+        Catalog catalog = getCatalog();
+        CoverageStoreInfo spyStore =
+                catalog.getCoverageStoreByName(
+                        TASMANIA_SPY.getPrefix(), TASMANIA_SPY.getLocalPart());
+        spyStore.setType(GeoTIFFSpyFormat.NAME);
+        catalog.save(spyStore);
+        catalog.getResourcePool().clear(spyStore);
+
+        try {
+            String layerId = getLayerId(TASMANIA_SPY);
+            String request =
+                    "wms?version=1.1.1"
+                            + "&styles="
+                            + JIFFLE_CONDITION
+                            + "&format=jpeg"
+                            + "&request=GetFeatureInfo&layers="
+                            + layerId
+                            + "&query_layers="
+                            + layerId
+                            + "&X=50&Y=50"
+                            + "&SRS=EPSG:4326&WIDTH=101&HEIGHT=101"
+                            + "&BBOX=146.5,-44.5,148,-43"
+                            + "&info_format="
+                            + JSONType.json;
+            request = requestCustomizer.apply(request);
+            JSONObject json = (JSONObject) getAsJSON(request);
+
+            JSONObject properties =
+                    json.getJSONArray("features").getJSONObject(0).getJSONObject("properties");
+            assertTrue(properties.has("jiffle"));
+            assertEquals(expected, properties.getInt("jiffle"));
+
+            // the read is gathering all bands required
+            GeneralParameterValue[] params = GeoTIFFSpyReader.getLastParams();
+            GeneralParameterValue bands = getParameterValue(params, AbstractGridFormat.BANDS);
+            assertNotNull(bands);
+            assertThat(bands, CoreMatchers.instanceOf(ParameterValue.class));
+            assertThat(((ParameterValue) bands).intValueList(), equalTo(new int[] {0, 2}));
+        } finally {
+            GeoTIFFSpyFormat.ENABLED = false;
+        }
+    }
+
+    /**
+     * Returns the matching {@link GeneralParameterValue} from the given array of parameters
+     *
+     * @param params
+     * @param bands
+     * @return
+     */
+    private GeneralParameterValue getParameterValue(
+            GeneralParameterValue[] params, DefaultParameterDescriptor<?> parameter) {
+        for (GeneralParameterValue param : params) {
+            if (param.getDescriptor().equals(parameter)) {
+                return param;
+            }
+        }
+        return null;
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormat.java
+++ b/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormat.java
@@ -1,0 +1,58 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.tiffspy;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geotools.data.DataSourceException;
+import org.geotools.gce.geotiff.GeoTiffFormat;
+import org.geotools.gce.geotiff.GeoTiffReader;
+import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
+
+/** Extension to GeoTIFF format allowing to spy read parameters */
+public class GeoTIFFSpyFormat extends GeoTiffFormat {
+
+    /** Can be used to enable/disable this format during tests */
+    public static boolean ENABLED = false;
+
+    static final Logger LOGGER = Logging.getLogger(GeoTIFFSpyFormat.class);
+    public static final String NAME = "GeoTIFFSpy";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean accepts(Object source) {
+        return ENABLED && super.accepts(source);
+    }
+
+    @Override
+    public boolean accepts(Object o, Hints hints) {
+        return ENABLED && super.accepts(o);
+    }
+
+    @Override
+    public GeoTiffReader getReader(Object source) {
+        try {
+            return new GeoTIFFSpyReader(source);
+        } catch (DataSourceException e) {
+            LOGGER.log(Level.INFO, "Failed to create GeoTIFFSpyReader", e);
+            return null;
+        }
+    }
+
+    @Override
+    public GeoTiffReader getReader(Object source, Hints hints) {
+        try {
+            return new GeoTIFFSpyReader(source, hints);
+        } catch (DataSourceException e) {
+            LOGGER.log(Level.INFO, "Failed to create GeoTIFFSpyReader", e);
+            return null;
+        }
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormatFactory.java
+++ b/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyFormatFactory.java
@@ -1,0 +1,22 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.tiffspy;
+
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.coverage.grid.io.GridFormatFactorySpi;
+
+/** Extension to GeoTIFF format allowing to spy read parameters */
+public class GeoTIFFSpyFormatFactory implements GridFormatFactorySpi {
+
+    @Override
+    public AbstractGridFormat createFormat() {
+        return new GeoTIFFSpyFormat();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+}

--- a/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyReader.java
+++ b/src/wms/src/test/java/org/geoserver/wms/tiffspy/GeoTIFFSpyReader.java
@@ -1,0 +1,36 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.tiffspy;
+
+import java.io.IOException;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.data.DataSourceException;
+import org.geotools.gce.geotiff.GeoTiffReader;
+import org.geotools.util.factory.Hints;
+import org.opengis.parameter.GeneralParameterValue;
+
+/** Extension to GeoTIFF reader allowing to spy read parameters */
+public class GeoTIFFSpyReader extends GeoTiffReader {
+
+    public static GeneralParameterValue[] getLastParams() {
+        return LAST_PARAMS;
+    }
+
+    static GeneralParameterValue[] LAST_PARAMS;
+
+    public GeoTIFFSpyReader(Object input) throws DataSourceException {
+        super(input);
+    }
+
+    public GeoTIFFSpyReader(Object input, Hints uHints) throws DataSourceException {
+        super(input, uHints);
+    }
+
+    @Override
+    public GridCoverage2D read(GeneralParameterValue[] params) throws IOException {
+        LAST_PARAMS = params;
+        return super.read(params);
+    }
+}

--- a/src/wms/src/test/resources/META-INF/services/org.geotools.coverage.grid.io.GridFormatFactorySpi
+++ b/src/wms/src/test/resources/META-INF/services/org.geotools.coverage.grid.io.GridFormatFactorySpi
@@ -1,1 +1,2 @@
 org.geoserver.wms.staticRasterStore.StaticRasterFormatFactory
+org.geoserver.wms.tiffspy.GeoTIFFSpyFormatFactory

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/jiffleCondition.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/jiffleCondition.sld
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <Name>dem</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Transformation>
+                    <ogc:Function name="ras:Jiffle">
+                        <ogc:Function name="parameter">
+                            <ogc:Literal>coverage</ogc:Literal>
+                        </ogc:Function>
+                        <ogc:Function name="parameter">
+                            <ogc:Literal>script</ogc:Literal>
+                            <!-- Condition designed to check that band section on reader 
+                                 is propagaged correctly, e.g., we want one band from the
+                                 output, but we are going to read two from the input -->
+                            <ogc:Literal>
+                                dest = src[2] > 100 ? src[0] : 0;
+                            </ogc:Literal>
+                        </ogc:Function>
+                    </ogc:Function>
+                </Transformation>
+                <Rule>
+                    <PointSymbolizer/>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-11200](https://badgen.net/badge/JIRA/GEOS-11200/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11200) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport of https://github.com/geoserver/geoserver/pull/7264 to 2.23.x

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->