### PR TITLE
[Backport 2.24.x] [GEOS-11184] ncwms module has a compile dependency on gs-web-core test jar

### DIFF
--- a/src/community/ncwms/pom.xml
+++ b/src/community/ncwms/pom.xml
@@ -67,6 +67,13 @@
       <artifactId>gs-web-core</artifactId>
       <version>${project.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-iau-wkt</artifactId>
+      <version>${gt.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
[![GEOS-11184](https://badgen.net/badge/JIRA/GEOS-11184/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11184) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7244
 **Authored by:** @aaime