### PR TITLE
[GEOS-11203] WMS GetFeatureInfo bad WKT exception for label-geometry

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
@@ -61,7 +61,7 @@ class FeatureInfoStylePreprocessor extends SymbolizerFilteringVisitor {
 
     private PropertyName defaultGeometryExpression;
 
-    private boolean addSolidLineSymbolier;
+    private boolean addSolidLineSymbolizer;
 
     public FeatureInfoStylePreprocessor(FeatureType schema) {
         this.schema = schema;
@@ -204,10 +204,10 @@ class FeatureInfoStylePreprocessor extends SymbolizerFilteringVisitor {
         geometriesOnPolygonSymbolizer.clear();
         geometriesOnPointSymbolizer.clear();
         geometriesOnTextSymbolizer.clear();
-        addSolidLineSymbolier = false;
+        addSolidLineSymbolizer = false;
         super.visit(rule);
         Rule copy = (Rule) pages.peek();
-        if (addSolidLineSymbolier) {
+        if (addSolidLineSymbolizer) {
             // add also a black line to make sure we get something in output even
             // if the user clicks in between symbols or dashes
             LineSymbolizer ls = sb.createLineSymbolizer(Color.BLACK);
@@ -319,7 +319,7 @@ class FeatureInfoStylePreprocessor extends SymbolizerFilteringVisitor {
             List<Expression> dashArray = stroke.dashArray();
             Graphic graphicStroke = stroke.getGraphicStroke();
             if (graphicStroke != null || dashArray != null && !dashArray.isEmpty()) {
-                addSolidLineSymbolier = true;
+                addSolidLineSymbolizer = true;
             }
         }
     }

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java
@@ -308,7 +308,7 @@ class FeatureInfoStylePreprocessor extends SymbolizerFilteringVisitor {
                 // see if we are dealing with a polygon
                 return ((GeometryDescriptor) descriptor).getType().getBinding();
             }
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             // Default to generic geometry if the type evaluation fails
             return Geometry.class;
         }

--- a/src/wms/src/test/java/org/geoserver/wms/featureinfo/RenderingBasedFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/featureinfo/RenderingBasedFeatureInfoTest.java
@@ -75,6 +75,8 @@ public class RenderingBasedFeatureInfoTest extends WMSTestSupport {
     public static QName REPEATED = new QName(MockData.CITE_URI, "repeated", MockData.CITE_PREFIX);
     public static QName GIANT_POLYGON =
             new QName(MockData.CITE_URI, "giantPolygon", MockData.CITE_PREFIX);
+    public static QName GEOM_FUNCTION =
+            new QName(MockData.CITE_URI, "geom-function", MockData.CITE_PREFIX);
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
@@ -105,6 +107,12 @@ public class RenderingBasedFeatureInfoTest extends WMSTestSupport {
                 "giantPolygon.properties",
                 SystemTestData.class,
                 getCatalog());
+        testData.addVectorLayer(
+                GEOM_FUNCTION,
+                Collections.emptyMap(),
+                "geom-function.properties",
+                RenderingBasedFeatureInfoTest.class,
+                getCatalog());
 
         testData.addStyle("ranged", "ranged.sld", this.getClass(), getCatalog());
         testData.addStyle("dynamic", "dynamic.sld", this.getClass(), getCatalog());
@@ -117,6 +125,7 @@ public class RenderingBasedFeatureInfoTest extends WMSTestSupport {
         testData.addStyle("doublepoly", "doublepoly.sld", this.getClass(), getCatalog());
         testData.addStyle("pureLabel", "purelabel.sld", this.getClass(), getCatalog());
         testData.addStyle("transform", "transform.sld", this.getClass(), getCatalog());
+        testData.addStyle("geom-function", "geom-function.sld", this.getClass(), getCatalog());
     }
 
     @After
@@ -712,6 +721,25 @@ public class RenderingBasedFeatureInfoTest extends WMSTestSupport {
                                 + "gml:interior/gml:LinearRing/gml:posList/text()",
                         result);
         checkCoordinates(interiorLinearRing, 0.0001, 2, 61.5, 2, 62.5, 4, 62, 2, 61.5);
+    }
+
+    @Test
+    public void testGeomFunction() throws Exception {
+        String layer = getLayerId(GEOM_FUNCTION);
+        String request =
+                "wms?version=1.1.1&bbox=1.2,0.2,1.8,0.7&format=jpeg"
+                        + "&request=GetFeatureInfo&layers="
+                        + layer
+                        + "&query_layers="
+                        + layer
+                        + "&styles=geom-function"
+                        + "&width=20&height=20&x=10&y=10"
+                        + "&info_format=application/json&feature_count=50";
+
+        JSONObject result = (JSONObject) getAsJSON(request);
+        // we used to get a bad-wkt exception here
+        // print(result);
+        assertEquals(1, result.getJSONArray("features").size());
     }
 
     /**

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetFeatureInfoTest.java
@@ -751,7 +751,7 @@ public class GetFeatureInfoTest extends WMSTestSupport {
      * text format as in https://osgeo-org.atlassian.net/browse/GEOS-1924
      */
     @Test
-    public void testUknownFormat() throws Exception {
+    public void testUnknownFormat() throws Exception {
         String layer = MockData.FORESTS.getPrefix() + ":" + MockData.FORESTS.getLocalPart();
         String request =
                 "wms?version=1.1.1&bbox=-0.002,-0.002,0.002,0.002&styles=&format=jpeg&info_format=unknown/format&request=GetFeatureInfo&layers="
@@ -887,7 +887,7 @@ public class GetFeatureInfoTest extends WMSTestSupport {
 
     /** Check we report back an exception when query_layer contains layers not part of LAYERS */
     @Test
-    public void testUnkonwnQueryLayer() throws Exception {
+    public void testUnknownQueryLayer() throws Exception {
         String layers1 = getLayerId(MockData.FORESTS) + "," + getLayerId(MockData.LAKES);
         String layers2 = getLayerId(MockData.FORESTS) + "," + getLayerId(MockData.BRIDGES);
         String request =

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/geom-function.properties
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/geom-function.properties
@@ -1,0 +1,4 @@
+_=geom:Polygon:srid=4326,id:int,x:Float,y:Float
+grid.0=POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))|0|0.5|0.5
+grid.1=POLYGON((1 0, 1 1, 2 1, 2 0, 1 0))|1|1.5|0.5
+grid.2=POLYGON((2 0, 2 1, 3 1, 3 0, 2 0))|2|2.5|0.5

--- a/src/wms/src/test/resources/org/geoserver/wms/featureinfo/geom-function.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/featureinfo/geom-function.sld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+    xmlns:sld="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:gml="http://www.opengis.net/gml"
+    version="1.0.0">
+  <sld:NamedLayer>
+    <sld:Name></sld:Name>
+    <sld:UserStyle>
+
+      <sld:FeatureTypeStyle>
+        <sld:Rule>
+          <sld:Name></sld:Name>
+          <sld:PolygonSymbolizer>
+            <sld:Fill>
+              <sld:CssParameter name="fill">#8DD3C7</sld:CssParameter>
+              <sld:CssParameter name="fill-opacity">0.5</sld:CssParameter>
+            </sld:Fill>
+          </sld:PolygonSymbolizer>
+          
+          <sld:TextSymbolizer>
+            <sld:Geometry>
+              <ogc:Function name="geomFromWKT">
+                <ogc:Function name="Concatenate">
+                  <ogc:Literal>POINT(</ogc:Literal>
+                  <ogc:PropertyName>x</ogc:PropertyName>
+                  <ogc:Literal><![CDATA[ ]]></ogc:Literal>
+                  <ogc:PropertyName>y</ogc:PropertyName>
+                  <ogc:Literal>)</ogc:Literal>
+                </ogc:Function>
+              </ogc:Function>
+            </sld:Geometry>
+            <sld:Label>
+              <ogc:PropertyName>id</ogc:PropertyName>
+            </sld:Label>
+          </sld:TextSymbolizer>        
+          
+        </sld:Rule>
+      </sld:FeatureTypeStyle>
+    </sld:UserStyle>
+  </sld:NamedLayer>
+</sld:StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-11203](https://badgen.net/badge/JIRA/GEOS-11203/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11203) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://osgeo-org.atlassian.net/browse/GEOS-11203

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->