### PR TITLE
[GEOS-11213] Improve REST external upload method unzipping

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/AbstractStoreUploadController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/AbstractStoreUploadController.java
@@ -95,23 +95,36 @@ public abstract class AbstractStoreUploadController extends AbstractCatalogContr
         // handle the case that the uploaded file was a zip file, if so unzip it
         if (RESTUtils.isZipMediaType(request)) {
             // rename to .zip if need be
-            if (!uploadedFile.name().endsWith(".zip")) {
+            if (external || !uploadedFile.name().endsWith(".zip")) {
+                // for file and url upload methods, rename files in their current directory
+                // for external upload method, copy the file into a directory where it can
+                // be more safely unzipped
                 Resource newUploadedFile =
-                        uploadedFile
-                                .parent()
+                        (external ? directory : uploadedFile.parent())
                                 .get(FilenameUtils.getBaseName(uploadedFile.path()) + ".zip");
                 String oldFileName = uploadedFile.name();
-                if (!uploadedFile.renameTo(newUploadedFile)) {
-                    String errorMessage =
-                            "Error renaming zip file from "
-                                    + oldFileName
-                                    + " -> "
-                                    + newUploadedFile.name();
+                String errorMessage =
+                        "Error renaming zip file from "
+                                + oldFileName
+                                + " -> "
+                                + newUploadedFile.name();
+                // do not rename or copy directories (only possible with external upload)
+                // do not allow renaming/copying to overwrite an existing directory
+                if (uploadedFile.getType() != Resource.Type.RESOURCE
+                        || newUploadedFile.getType() == Resource.Type.DIRECTORY
+                        || (!external && !uploadedFile.renameTo(newUploadedFile))) {
                     throw new RestException(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+                } else if (external) {
+                    try {
+                        Resources.copy(uploadedFile, newUploadedFile);
+                    } catch (Exception e) {
+                        throw new RestException(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR, e);
+                    }
                 }
                 uploadedFile = newUploadedFile;
             }
             // unzip the file
+            boolean success = false;
             try {
                 // Unzipping of the file and, if it is a POST request, filling of the File List
                 RESTUtils.unzipFile(uploadedFile, directory, workspace, store, files, external);
@@ -121,6 +134,7 @@ public abstract class AbstractStoreUploadController extends AbstractCatalogContr
                 Resource primaryFile = findPrimaryFile(directory, format);
                 if (primaryFile != null) {
                     uploadedFile = primaryFile;
+                    success = true;
                 } else {
                     throw new RestException(
                             "Could not find appropriate " + format + " file in archive",
@@ -131,6 +145,12 @@ public abstract class AbstractStoreUploadController extends AbstractCatalogContr
             } catch (Exception e) {
                 throw new RestException(
                         "Error occured unzipping file", HttpStatus.INTERNAL_SERVER_ERROR, e);
+            } finally {
+                if (!success) {
+                    // clean up files if not successful
+                    files.forEach(Resource::delete);
+                    uploadedFile.delete();
+                }
             }
         }
         // If the File List is empty then the uploaded file must be added

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreFileController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/CoverageStoreFileController.java
@@ -443,16 +443,14 @@ public class CoverageStoreFileController extends AbstractStoreUploadController {
         boolean postRequest =
                 request != null && HttpMethod.POST.name().equalsIgnoreCase(request.getMethod());
 
-        // Prepare the directory only in case this is not an external upload
-        if (method.isInline()) {
-            // Mapping of the input directory
-            if (method == UploadMethod.url) {
-                // For URL upload method, workspace and StoreName are not considered
-                directory = RESTUtils.createUploadRoot(catalog, null, null, postRequest);
-            } else {
-                directory =
-                        RESTUtils.createUploadRoot(catalog, workspaceName, storeName, postRequest);
-            }
+        // Mapping of the input directory
+        if (method == UploadMethod.url) {
+            // For URL upload method, workspace and StoreName are not considered
+            directory = RESTUtils.createUploadRoot(catalog, null, null, postRequest);
+        } else if (method == UploadMethod.file
+                || (method == UploadMethod.external && RESTUtils.isZipMediaType(request))) {
+            // Prepare the directory for file upload or external upload of a zip file
+            directory = RESTUtils.createUploadRoot(catalog, workspaceName, storeName, postRequest);
         }
         return handleFileUpload(
                 storeName, workspaceName, filename, method, format, directory, request);

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreFileController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/DataStoreFileController.java
@@ -40,6 +40,7 @@ import org.geoserver.rest.RestBaseController;
 import org.geoserver.rest.RestException;
 import org.geoserver.rest.util.IOUtils;
 import org.geoserver.rest.util.RESTUploadPathMapper;
+import org.geoserver.rest.util.RESTUtils;
 import org.geotools.api.data.DataAccess;
 import org.geotools.api.data.DataAccessFactory;
 import org.geotools.api.data.DataStore;
@@ -567,15 +568,14 @@ public class DataStoreFileController extends AbstractStoreUploadController {
         boolean postRequest =
                 request != null && HttpMethod.POST.name().equalsIgnoreCase(request.getMethod());
 
-        // Prepare the directory only in case this is not an external upload
-        if (method.isInline()) {
-            // Mapping of the input directory
-            if (method == UploadMethod.url) {
-                // For URL upload method, workspace and StoreName are not considered
-                directory = createFinalRoot(null, null, postRequest);
-            } else {
-                directory = createFinalRoot(workspaceName, storeName, postRequest);
-            }
+        // Mapping of the input directory
+        if (method == UploadMethod.url) {
+            // For URL upload method, workspace and StoreName are not considered
+            directory = createFinalRoot(null, null, postRequest);
+        } else if (method == UploadMethod.file
+                || (method == UploadMethod.external && RESTUtils.isZipMediaType(request))) {
+            // Prepare the directory for file upload or external upload of a zip file
+            directory = createFinalRoot(workspaceName, storeName, postRequest);
         }
         return handleFileUpload(
                 storeName, workspaceName, filename, method, format, directory, request);

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageStoreFileUploadTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/CoverageStoreFileUploadTest.java
@@ -5,9 +5,14 @@
  */
 package org.geoserver.rest.catalog;
 
+import static org.geoserver.rest.RestBaseController.ROOT_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
@@ -50,14 +55,18 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.URLs;
 import org.geotools.util.factory.GeoTools;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 
 public class CoverageStoreFileUploadTest extends CatalogRESTTestSupport {
+
+    @ClassRule public static TemporaryFolder temp = new TemporaryFolder();
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
@@ -83,6 +92,7 @@ public class CoverageStoreFileUploadTest extends CatalogRESTTestSupport {
             removeStore(
                     coverage.getStore().getWorkspace().getName(), coverage.getStore().getName());
         }
+        removeStore("sf", "usa");
     }
 
     @Test
@@ -753,5 +763,97 @@ public class CoverageStoreFileUploadTest extends CatalogRESTTestSupport {
                     catalog.getCoverageByCoverageStore(storeInfo, name).getNativeBoundingBox();
             assertConsumer.accept(current, old);
         }
+    }
+
+    @Test
+    public void testWorldImageUploadExternalZipDirectory() throws Exception {
+        // get the path to a directory
+        File file = temp.getRoot();
+        String body = file.getAbsolutePath();
+        // the request will fail since it won't attempt to copy a directory
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        ROOT_PATH + "/workspaces/foo/coveragestores/bar/external.worldimage",
+                        body,
+                        "application/zip");
+        assertEquals(500, response.getStatus());
+        assertThat(response.getContentAsString(), startsWith("Error renaming zip file from "));
+        // verify that the external file was not deleted
+        assertTrue("The external file was unexpectedly deleted", file.exists());
+    }
+
+    @Test
+    public void testWorldImageUploadExternalZipExistingDirectory() throws Exception {
+        // create a file to copy and get its path
+        File file1 = temp.newFile("test1.zip");
+        String body = file1.getAbsolutePath();
+        // create the file in the data directory
+        File file2 = getResourceLoader().createDirectory("data/foo/bar1/test1.zip");
+        // the request will fail since it won't overwrite an existing zip file
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        ROOT_PATH + "/workspaces/foo/coveragestores/bar1/external.worldimage",
+                        body,
+                        "application/zip");
+        assertEquals(500, response.getStatus());
+        assertThat(response.getContentAsString(), startsWith("Error renaming zip file from "));
+        // verify that the external file was not deleted
+        assertTrue("The external file was unexpectedly deleted", file1.exists());
+        // verify that the file in the data directory was not deleted
+        assertTrue("The file in the data directory was unexpectedly deleted", file2.isDirectory());
+    }
+
+    @Test
+    public void testWorldImageUploadExternalZipBadFile() throws Exception {
+        // create a file that is not a valid zip file and get its path
+        File file = temp.newFile("test2.zip");
+        String body = file.getAbsolutePath();
+        // the request will fail unzipping since it is not a valid zip fail
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        ROOT_PATH + "/workspaces/foo/coveragestores/bar2/external.worldimage",
+                        body,
+                        "application/zip");
+        assertEquals(500, response.getStatus());
+        assertEquals("Error occured unzipping file", response.getContentAsString());
+        // verify that the external file was not deleted
+        assertTrue("The external file was unexpectedly deleted", file.exists());
+        // verify that the zip file was deleted from the data directory
+        assertEquals(
+                "The data directory file was not deleted",
+                Resource.Type.UNDEFINED,
+                getResourceLoader().get("data/foo/bar2/test2.zip").getType());
+    }
+
+    @Test
+    public void testWorldImageUploadExternalZipValid() throws Exception {
+        // create a valid zip file and get its path
+        File file = temp.newFile("test3.zip");
+        FileUtils.copyURLToFile(getClass().getResource("test-data/usa.zip"), file);
+        String body = file.getAbsolutePath();
+        // verify that the coverage does not already exist
+        assertNull(getCatalog().getCoverageStoreByName("sf", "usa"));
+        assertNull(getCatalog().getCoverageByName("sf", "usa"));
+        // the request should succeed
+        MockHttpServletResponse response =
+                putAsServletResponse(
+                        ROOT_PATH + "/workspaces/sf/coveragestores/usa/external.worldimage",
+                        body,
+                        "application/zip");
+        assertEquals(201, response.getStatus());
+        assertEquals(MediaType.APPLICATION_XML_VALUE, response.getContentType());
+        String content = response.getContentAsString();
+        Document d = dom(new ByteArrayInputStream(content.getBytes()));
+        assertEquals("coverageStore", d.getDocumentElement().getNodeName());
+        // verify that the coverage was created successfully
+        assertNotNull(getCatalog().getCoverageStoreByName("sf", "usa"));
+        assertNotNull(getCatalog().getCoverageByName("sf", "usa"));
+        // verify that the external file was not deleted
+        assertTrue("The external file was unexpectedly deleted", file.exists());
+        // verify that the zip file was deleted from the data directory
+        assertEquals(
+                "The data directory file was not deleted",
+                Resource.Type.UNDEFINED,
+                getResourceLoader().get("data/sf/usa/test3.zip").getType());
     }
 }


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
For requests using the file, url or external upload methods with a zip mime type:
1. An exception will be thrown if the renamed .zip file is an existing directory instead of replacing the directory with the zip file.
2. If unzipping is unsuccessful or the primary store file could not be found, all uploaded files are deleted.  Current behavior is to delete the zip file after successful unzipping only and leave the unzipped files behind if unzipping was partially successful or the primary store file could not be found.

Additionally, for requests using the external upload method with a zip mime type:
1. An exception will be thrown early if the external file is a directory since unzipping is guaranteed to fail later anyways.
2. The external file will be left as is and be copied in to GEOSERVER_DATA_DIR/data for unzipping rather than allowing potentially harmful manipulation of external files.

All other file upload requests are not affected.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
