### PR TITLE
[Backport 2.24.x] [GEOS-9757] Return a service exception when client provided WMS dimensions are not a match

### DIFF
--- a/doc/en/user/source/services/wms/webadmin.rst
+++ b/doc/en/user/source/services/wms/webadmin.rst
@@ -46,6 +46,18 @@ The Web Map Service Interface Standard (WMS) provides a simple way to request an
 
 **Bicubic** -Looks at the sixteen nearest cells and fits a smooth curve through the points to find the output value. Bicubic interpolation may both change the input value as well as place the output value outside of the range of input values. Bicubic interpolation is recommended for smoothing continuous data, but this incurs a processing performance overhead.
 
+Dimensions settings
+-------------------
+
+The WMS specification mandates the throwing of an ``InvalidDimensionValue`` exception when a dimension value is not valid, and the nearest match is not enabled. 
+This is the default behavior of GeoServer starting with version 2.25, while older versions simply ignored the invalid value and returned empty responses.
+
+The behavior can be controlled in the **Dimension Settings** section, with a choice of three possible values:
+
+* **Use GS version default**. Will return an exception if version is greater or equal than 2.25, otherwise will ignore the invalid value.
+* **Return InvalidDimensionValue**. Will return an exception on invalid value, unless nearest neighbor match has been enabled for the layer (standard compliant behavior).
+* **Ignore invalid value**. Will ignore invalid values and return an empty map/info (legacy behavior).
+
 Watermark Settings
 ------------------
 
@@ -200,7 +212,7 @@ When the flag is checked, GetFeatureInfo requests results will not be transforme
 
 .. note:: **WMS Specification**
 
-  While this option provides a way to revert to the behavior that was used in older GeoServer versions (<2.21.0), the WMS specification states that ``The GetFeatureInfo operation is designed to provide clients of a WMS with more information about features in the pictures of maps that were returned by previous Map requests`` so using this option might not be the behavior as the specification intended it.
+  While this option provides a way to revert to the behavior that was used in older GeoServer versions (<2.21.0), the WMS specification states that "The GetFeatureInfo operation is designed to provide clients of a WMS with more information about features in the pictures of maps that were returned by previous Map requests" so using this option might not be the behavior as the specification intended it.
 
 Enabling GetFeatureInfo requests results HTML auto-escaping
 -----------------------------------------------------------

--- a/src/main/src/main/java/org/geoserver/catalog/Predicates.java
+++ b/src/main/src/main/java/org/geoserver/catalog/Predicates.java
@@ -240,8 +240,11 @@ public class Predicates {
      * a false predicate is found.
      */
     public static Filter and(Filter... operands) {
+        if (operands == null || operands.length == 0) return Filter.INCLUDE;
+        else if (operands.length == 1) return operands[0];
+
         List<Filter> anded = Lists.newArrayList(operands);
-        return factory.and(anded);
+        return and(anded);
     }
 
     /**

--- a/src/main/src/main/java/org/geoserver/catalog/util/ReaderDimensionsAccessor.java
+++ b/src/main/src/main/java/org/geoserver/catalog/util/ReaderDimensionsAccessor.java
@@ -26,7 +26,9 @@ import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StructuredCoverageViewReader;
+import org.geoserver.data.DimensionFilterBuilder;
 import org.geoserver.ows.kvp.TimeParser;
 import org.geotools.api.data.Query;
 import org.geotools.api.filter.FilterFactory;
@@ -37,6 +39,7 @@ import org.geotools.coverage.grid.io.DimensionDescriptor;
 import org.geotools.coverage.grid.io.GranuleSource;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
+import org.geotools.data.DataUtilities;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.visitor.UniqueVisitor;
@@ -532,5 +535,112 @@ public class ReaderDimensionsAccessor {
         }
 
         return list;
+    }
+
+    /** Checks if the reader has any time in the specified list of times */
+    public boolean hasAnyTime(List<Object> times) throws IOException {
+        if (reader instanceof StructuredGridCoverage2DReader) {
+            return hasAnyValueStructured(ResourceInfo.TIME, times);
+        }
+        // dump search in the domain
+        TreeSet<Object> timeDomain = getTimeDomain();
+        for (Object time : times) {
+            // check if the time is in the domain, using the floor and ceiling functions
+            // to quickly locate nearby elements, without having to compare them all
+            Object floor = timeDomain.floor(time);
+            if (timeIntersection(floor, time)) return true;
+            Object ceiling = timeDomain.ceiling(time);
+            if (timeIntersection(ceiling, time)) return true;
+        }
+
+        return false;
+    }
+
+    /** Checks if the reader has any time in the specified list of times */
+    public boolean hasAnyElevation(List<Object> elevations) throws IOException {
+        if (reader instanceof StructuredGridCoverage2DReader) {
+            return hasAnyValueStructured(ResourceInfo.ELEVATION, elevations);
+        }
+        // dump search in the domain
+        TreeSet<Object> elevationDomain = getElevationDomain();
+        for (Object elevation : elevations) {
+            // check if the elevation is in the domain, using the floor and ceiling functions
+            // to quickly locate nearby elements, without having to compare them all
+            Object floor = elevationDomain.floor(elevation);
+            if (elevationIntersection(floor, elevation)) return true;
+            Object ceiling = elevationDomain.ceiling(elevation);
+            if (elevationIntersection(ceiling, elevation)) return true;
+        }
+        return false;
+    }
+
+    public boolean hasAnyCustomDimension(String name, List<String> values) throws IOException {
+        if (reader instanceof StructuredGridCoverage2DReader) {
+            return hasAnyValueStructured(name, values);
+        }
+        // dump search in the domain
+        Set<String> domain = new HashSet<>(getDomain(name));
+        for (String value : values) {
+            if (domain.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasAnyValueStructured(String dimensionName, List<?> values) throws IOException {
+        StructuredGridCoverage2DReader sr = (StructuredGridCoverage2DReader) reader;
+        final String name = sr.getGridCoverageNames()[0];
+        List<DimensionDescriptor> descriptors = sr.getDimensionDescriptors(name);
+        for (DimensionDescriptor descriptor : descriptors) {
+            // do we find the time, and can we optimize?
+            if (dimensionName.equalsIgnoreCase(descriptor.getName())) {
+                GranuleSource gs = sr.getGranules(name, true);
+                final Query query = new Query(gs.getSchema().getName().getLocalPart());
+                DimensionFilterBuilder builder = new DimensionFilterBuilder(FF);
+                builder.appendFilters(
+                        descriptor.getStartAttribute(), descriptor.getEndAttribute(), values);
+                query.setFilter(builder.getFilter());
+                return DataUtilities.first(gs.getGranules(query)) != null;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the two objects intersect in time. The objects can be either {@link Date} or {@link
+     * DateRange} objects.
+     */
+    private boolean timeIntersection(Object a, Object b) {
+        if (a == null) {
+            return false;
+        }
+        if (a instanceof Date) {
+            if (b instanceof Date) return ((Date) a).equals(b);
+            else if (b instanceof DateRange) return ((DateRange) b).contains((Date) a);
+        } else if (a instanceof DateRange) {
+            if (b instanceof DateRange) return ((DateRange) a).intersects((DateRange) b);
+            else if (b instanceof Date) return ((DateRange) a).contains((Date) b);
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the two objects intersect as numbers. The objects can be either {@link Double} or
+     * {@link NumberRange} objects.
+     */
+    @SuppressWarnings("unchecked") // un-qualified NumberRange
+    private boolean elevationIntersection(Object a, Object b) {
+        if (a == null) {
+            return false;
+        }
+        if (a instanceof Double) {
+            if (b instanceof Double) return ((Double) a).equals(b);
+            else if (b instanceof NumberRange) return ((NumberRange) b).contains((Number) a);
+        } else if (a instanceof NumberRange) {
+            if (b instanceof NumberRange) return ((NumberRange) a).intersects((NumberRange) b);
+            else if (b instanceof Double) return ((NumberRange) a).contains((Number) b);
+        }
+        return false;
     }
 }

--- a/src/main/src/main/java/org/geoserver/data/DimensionFilterBuilder.java
+++ b/src/main/src/main/java/org/geoserver/data/DimensionFilterBuilder.java
@@ -30,8 +30,7 @@ public class DimensionFilterBuilder {
         this.ff = ff;
     }
 
-    public void appendFilters(
-            String startAttributeName, String endAttributeName, List<Object> ranges) {
+    public void appendFilters(String startAttributeName, String endAttributeName, List<?> ranges) {
         if (ranges == null || ranges.isEmpty()) {
             return;
         }
@@ -41,8 +40,8 @@ public class DimensionFilterBuilder {
         final PropertyName endAttribute =
                 endAttributeName == null ? null : ff.property(endAttributeName);
 
-        for (Object datetime : ranges) {
-            timeFilters.add(buildDimensionFilter(datetime, attribute, endAttribute));
+        for (Object range : ranges) {
+            timeFilters.add(buildDimensionFilter(range, attribute, endAttribute));
         }
         final int size = timeFilters.size();
         Filter result;

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.html
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.html
@@ -136,6 +136,16 @@
     </fieldset>
 
     <fieldset>
+      <legend><span><wicket:message key="dimensionSettings">Dimensions settings</wicket:message></span></legend>
+      <ul>
+        <li>
+          <label><wicket:message key="exceptionOnInvalidDimension">exceptionOnInvalidDimension</wicket:message></label>
+          <select wicket:id="exceptionOnInvalidDimension"></select>
+        </li>
+      </ul>
+    </fieldset>
+
+    <fieldset>
       <legend><span><wicket:message key="watermarkSettings">Watermark Settings</wicket:message></span></legend>
       <ul>
         <li class="choiceItem">

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/WMSAdminPage.java
@@ -212,6 +212,13 @@ public class WMSAdminPage extends BaseServiceAdminPage<WMSInfo> {
         TextField<Integer> maxBuffer = new TextField<>("maxBuffer");
         maxBuffer.add(RangeValidator.minimum(0));
         form.add(maxBuffer);
+        // throwing exceptions on invalid dimension
+        List<Boolean> exceptionValues = Arrays.asList(Boolean.TRUE, Boolean.FALSE);
+        DropDownChoice<Boolean> invalidDimensionThrow =
+                new DropDownChoice<>("exceptionOnInvalidDimension", exceptionValues);
+        invalidDimensionThrow.setChoiceRenderer(new ExceptionChoiceRenderer());
+        invalidDimensionThrow.setNullValid(true);
+        form.add(invalidDimensionThrow);
         // max dimension values
         TextField<Integer> maxRequestedDimensionValues =
                 new TextField<>("maxRequestedDimensionValues");
@@ -547,6 +554,7 @@ public class WMSAdminPage extends BaseServiceAdminPage<WMSInfo> {
                 }
                 super.onBeforeRender();
             }
+
             /** Override otherwise the header is not i18n'ized */
             @Override
             public Component newSelectedHeader(final String componentId) {
@@ -702,5 +710,20 @@ public class WMSAdminPage extends BaseServiceAdminPage<WMSInfo> {
     @Override
     protected boolean supportInternationalContent() {
         return true;
+    }
+
+    private class ExceptionChoiceRenderer extends ChoiceRenderer<Boolean> {
+
+        @Override
+        public Object getDisplayValue(Boolean object) {
+            return new ParamResourceModel(
+                            "exceptionOnInvalidDimension." + object, WMSAdminPage.this)
+                    .getString();
+        }
+
+        @Override
+        public String getIdValue(Boolean object, int index) {
+            return String.valueOf(object);
+        }
     }
 }

--- a/src/web/wms/src/main/resources/GeoServerApplication.properties
+++ b/src/web/wms/src/main/resources/GeoServerApplication.properties
@@ -159,6 +159,11 @@ WMSAdminPage.disableTransformFeatureInfoTitle = GetFeatureInfo results transform
 WMSAdminPage.disableTransformFeatureInfo = Disable applying rendering transformation to raster data for GetFeatureInfo requests
 WMSAdminPage.autoEscapeTemplateValuesTitle = GetFeatureInfo results auto-escaping
 WMSAdminPage.autoEscapeTemplateValues = Enable auto-escaping for HTML GetFeatureInfo template values
+WMSAdminPage.exceptionOnInvalidDimension=Throw an InvalidDimensionValue on invalid dimension values
+WMSAdminPage.exceptionOnInvalidDimension.true=Return InvalidDimensionValue (standard compliant)
+WMSAdminPage.exceptionOnInvalidDimension.false=Ignore invalid value (legacy)
+WMSAdminPage.exceptionOnInvalidDimension.nullValid=Use GS version default
+WMSAdminPage.dimensionSettings=Dimension Settings
 
 WMSAdminPage.remoteStylesCache = Remote Styles Cache
 WMSAdminPage.cacheEnabled = Enabled

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/WMSAdminPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/WMSAdminPageTest.java
@@ -8,6 +8,7 @@ package org.geoserver.wms.web.data;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -285,5 +286,33 @@ public class WMSAdminPageTest extends GeoServerWicketTestSupport {
         tester.assertErrorMessages(
                 String.format(
                         "The provided values are not valid HTTP urls: [%s]", reportedInvalidURLs));
+    }
+
+    /** Comprehensive test as a drop-down with default value is a tricky component to test. */
+    @Test
+    public void testInvalidDimensionsFlag() throws Exception {
+        wms.setExceptionOnInvalidDimension(true);
+        getGeoServer().save(wms);
+
+        // set to false
+        tester.startPage(WMSAdminPage.class);
+        FormTester ft = tester.newFormTester("form");
+        ft.select("exceptionOnInvalidDimension", 1);
+        ft.submit("submit");
+        assertFalse(wms.isExceptionOnInvalidDimension());
+
+        // reset to default
+        tester.startPage(WMSAdminPage.class);
+        ft = tester.newFormTester("form");
+        ft.setValue("exceptionOnInvalidDimension", null);
+        ft.submit("submit");
+        assertNull(wms.isExceptionOnInvalidDimension());
+
+        // set to true
+        tester.startPage(WMSAdminPage.class);
+        ft = tester.newFormTester("form");
+        ft.select("exceptionOnInvalidDimension", 0);
+        ft.submit("submit");
+        assertTrue(wms.isExceptionOnInvalidDimension());
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/CustomDimensionFilterConverter.java
+++ b/src/wms/src/main/java/org/geoserver/wms/CustomDimensionFilterConverter.java
@@ -5,7 +5,6 @@
 package org.geoserver.wms;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -17,7 +16,6 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.MetadataMap;
@@ -25,10 +23,8 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.data.DimensionFilterBuilder;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wms.dimension.DimensionDefaultValueSelectionStrategy;
-import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.feature.type.PropertyDescriptor;
 import org.geotools.api.filter.Filter;
-import org.geotools.api.filter.FilterFactory;
 import org.geotools.util.Converters;
 import org.geotools.util.Range;
 import org.geotools.util.logging.Logging;
@@ -42,81 +38,89 @@ class CustomDimensionFilterConverter {
 
     private static final Logger LOGGER = Logging.getLogger(CustomDimensionFilterConverter.class);
 
-    private DefaultValueStrategyFactory defaultValueStrategyFactory;
-    private final FilterFactory ff;
+    private final FeatureTypeInfo typeInfo;
+    private final DefaultValueStrategyFactory defaultValueStrategyFactory;
+
+    private final Map<String, DimensionInfo> customDimensions;
 
     private static Collection<ValueConverter> converters;
 
     CustomDimensionFilterConverter(
-            DefaultValueStrategyFactory defaultValueStrategyFactory, FilterFactory ff) {
-        this.ff = ff;
+            FeatureTypeInfo typeInfo, DefaultValueStrategyFactory defaultValueStrategyFactory) {
         this.defaultValueStrategyFactory = defaultValueStrategyFactory;
+        this.typeInfo = typeInfo;
+        this.customDimensions = getCustomDimensions();
     }
 
     /**
      * Builds a filter in base to KVP map and Feature type info provided parameters.
      *
      * @param rawKVP Request KVP values
-     * @param typeInfo Feature type info
      * @return builded filter
      */
     public Filter getDimensionsToFilter(
-            final Map<String, String> rawKVP, final FeatureTypeInfo typeInfo) {
+            final Map<String, String> rawKVP, DimensionFilterBuilder filterBuilder) {
+        // build a filter for each
+        for (Map.Entry<String, DimensionInfo> entry : customDimensions.entrySet()) {
+            final String dimensionName = entry.getKey();
+            DimensionInfo dimension = entry.getValue();
+            buildDimensionFilter(rawKVP, filterBuilder, dimensionName, dimension);
+        }
+
+        return filterBuilder.getFilter();
+    }
+
+    public void buildDimensionFilter(
+            Map<String, String> rawKVP,
+            DimensionFilterBuilder filterBuilder,
+            String dimensionName,
+            DimensionInfo dimension) {
         try {
-            // get the list of configured custom dimensions for this Feature Type
-            final MetadataMap metadataMap = typeInfo.getMetadata();
-            final FeatureType featureType = typeInfo.getFeatureType();
-            final Map<String, Pair<DimensionInfo, String>> rawValuesMap =
-                    getRawDimensionValues(rawKVP, metadataMap);
-            final List<Filter> filters = new ArrayList<>();
-            // convert raw value strings to proper types
-            for (Map.Entry<String, Pair<DimensionInfo, String>> entry : rawValuesMap.entrySet()) {
-                final String dimensionName = entry.getKey();
-                final String attributeName = entry.getValue().getKey().getAttribute();
-                final PropertyDescriptor descriptor = featureType.getDescriptor(attributeName);
-                if (descriptor == null) {
-                    throw new IllegalArgumentException(
-                            "Attribute Name '" + attributeName + "' not found.");
-                }
-                final Class<?> binding = descriptor.getType().getBinding();
-                if (StringUtils.isBlank(attributeName)) {
-                    LOGGER.severe(
-                            "Required attribute name is empty for dimension='"
-                                    + dimensionName
-                                    + "'");
-                    continue;
-                }
-                final String endAttributeName = entry.getValue().getKey().getEndAttribute();
-                final String rawValue = entry.getValue().getRight();
-                // convert values
-                final List<Object> convertedValues =
-                        convertValues(
-                                rawValue,
-                                binding,
-                                () ->
-                                        getDefaultCustomDimension(
-                                                rollDimPrefix(dimensionName), typeInfo, binding));
-                // generate a Filter for every value in convertedValues
-                filters.add(buildFilter(convertedValues, attributeName, endAttributeName));
+            final String attributeName = dimension.getAttribute();
+            final PropertyDescriptor descriptor =
+                    typeInfo.getFeatureType().getDescriptor(attributeName);
+            if (descriptor == null) {
+                throw new IllegalArgumentException(
+                        "Attribute Name '" + attributeName + "' not found.");
             }
-            return ff.and(filters);
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
+            final Class<?> binding = descriptor.getType().getBinding();
+            if (StringUtils.isBlank(attributeName)) {
+                LOGGER.severe(
+                        "Required attribute name is empty for dimension='" + dimensionName + "'");
+                return;
+            }
+            final String endAttributeName = dimension.getEndAttribute();
+            final String rawValue = rawKVP.get((WMS.DIM_ + dimensionName).toUpperCase());
+            // convert values
+            final List<Object> convertedValues =
+                    convertValues(
+                            rawValue,
+                            binding,
+                            () -> getDefaultCustomDimension(rollDimPrefix(dimensionName), binding));
+            // generate a Filter for every value in convertedValues
+            filterBuilder.appendFilters(attributeName, endAttributeName, convertedValues);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 
-    /** Maps each configured dimension to the KVP key/value found in the request */
-    private Map<String, Pair<DimensionInfo, String>> getRawDimensionValues(
-            Map<String, String> rawKVP, MetadataMap metadataMap) {
+    /**
+     * Collects all enabled vector custom dimensions from feature type metadata.
+     *
+     * @return
+     */
+    public Map<String, DimensionInfo> getCustomDimensions() {
+        final MetadataMap metadataMap = typeInfo.getMetadata();
         return metadataMap.entrySet().stream()
-                .filter(e -> e.getValue() instanceof DimensionInfo && e.getKey().startsWith("dim_"))
+                .filter(
+                        e ->
+                                e.getValue() instanceof DimensionInfo
+                                        && e.getKey().startsWith(WMS.DIM_))
+                .filter(e -> ((DimensionInfo) e.getValue()).isEnabled())
                 .collect(
                         Collectors.toMap(
                                 e -> unrollDimPrefix(e.getKey()),
-                                e ->
-                                        Pair.of(
-                                                (DimensionInfo) e.getValue(),
-                                                rawKVP.get(e.getKey().toUpperCase()))));
+                                e -> (DimensionInfo) e.getValue()));
     }
 
     private List<Object> convertValues(
@@ -131,17 +135,11 @@ class CustomDimensionFilterConverter {
     }
 
     private String unrollDimPrefix(String key) {
-        return key.replaceFirst("dim_", "");
+        return key.replaceFirst(WMS.DIM_, "");
     }
 
     private String rollDimPrefix(String name) {
-        return "dim_" + name;
-    }
-
-    private Filter buildFilter(List<Object> values, String attributeName, String endAttributeName) {
-        DimensionFilterBuilder builder = new DimensionFilterBuilder(ff);
-        builder.appendFilters(attributeName, endAttributeName, values);
-        return builder.getFilter();
+        return WMS.DIM_ + name;
     }
 
     private List<String> splitStringValue(String value) {
@@ -149,21 +147,18 @@ class CustomDimensionFilterConverter {
         return Arrays.asList(strings);
     }
 
-    private Object getDefaultCustomDimension(
-            String name, ResourceInfo resourceInfo, Class<?> binding) {
+    private Object getDefaultCustomDimension(String name, Class<?> binding) {
         // check the time metadata
-        final DimensionInfo dimensionInfo =
-                resourceInfo.getMetadata().get(name, DimensionInfo.class);
+        final DimensionInfo dimensionInfo = customDimensions.get(name);
         if (dimensionInfo == null || !dimensionInfo.isEnabled()) {
             throw new ServiceException(
                     "Layer "
-                            + resourceInfo.prefixedName()
+                            + typeInfo.prefixedName()
                             + " does not have custom dimension support enabled");
         }
         DimensionDefaultValueSelectionStrategy strategy =
-                defaultValueStrategyFactory.getDefaultValueStrategy(
-                        resourceInfo, name, dimensionInfo);
-        return strategy.getDefaultValue(resourceInfo, name, dimensionInfo, binding);
+                defaultValueStrategyFactory.getDefaultValueStrategy(typeInfo, name, dimensionInfo);
+        return strategy.getDefaultValue(typeInfo, name, dimensionInfo, binding);
     }
 
     private List<Object> convertValues(List<String> rawValues, Class<?> binding) {

--- a/src/wms/src/main/java/org/geoserver/wms/GetFeatureInfo.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetFeatureInfo.java
@@ -101,6 +101,7 @@ public class GetFeatureInfo {
                     }
                 }
             } catch (Exception e) {
+                if (e instanceof ServiceException) throw e;
                 throw new ServiceException(
                         "Failed to run GetFeatureInfo on layer " + layer.getName(), e);
             }

--- a/src/wms/src/main/java/org/geoserver/wms/WMSInfo.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSInfo.java
@@ -7,6 +7,7 @@ package org.geoserver.wms;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.geoserver.catalog.AuthorityURLInfo;
 import org.geoserver.catalog.DimensionInfo;
@@ -21,6 +22,13 @@ import org.geotools.util.GrowableInternationalString;
  * @author Justin Deoliveira, The Open Planning Project
  */
 public interface WMSInfo extends ServiceInfo {
+
+    public static final String EXCEPTION_ON_INVALID_DIMENSION_KEY =
+            "org.geoserver.wms.exceptionOnInvalidDimension";
+
+    /** Default value for the exceptionOnInvalidDimension */
+    public static final boolean EXCEPTION_ON_INVALID_DIMENSION_DEFAULT =
+            Boolean.valueOf(System.getProperty(EXCEPTION_ON_INVALID_DIMENSION_KEY, "false"));
 
     enum WMSInterpolation {
         Nearest,
@@ -240,4 +248,33 @@ public interface WMSInfo extends ServiceInfo {
 
     /** Sets whether to enable auto-escaping HTML FreeMarker template values */
     void setAutoEscapeTemplateValues(boolean autoEscapeTemplateValues);
+
+    /**
+     * Same as {@link #isExceptionOnInvalidDimension()}, but in case of null, uses the default value
+     * for the field which can be overrideen using EXCEPTION_ON_INVALID_DIMENSION_DEFAULT
+     *
+     * @return
+     */
+    public default boolean exceptionOnInvalidDimension() {
+        return Optional.ofNullable(isExceptionOnInvalidDimension())
+                .orElse(EXCEPTION_ON_INVALID_DIMENSION_DEFAULT);
+    }
+
+    /**
+     * This property controls the behavior when an invalid dimension is encountered. If set to
+     * <code>true</code>, an <code>InvalidDimensionException</code> will be thrown. If set to <code>
+     * false</code>, an empty response will be used. The standard compliant behavior is obtained
+     * with <code>true</code>.
+     *
+     * @return true if an exception should be thrown on invalid dimension, false otherwise
+     */
+    Boolean isExceptionOnInvalidDimension();
+
+    /**
+     * Sets the behavior when an invalid dimension is encountered.
+     *
+     * @param exceptionOnInvalidDimension true if an exception should be thrown on invalid dimension
+     *     value, false otherwise
+     */
+    void setExceptionOnInvalidDimension(Boolean exceptionOnInvalidDimension);
 }

--- a/src/wms/src/main/java/org/geoserver/wms/WMSInfoImpl.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSInfoImpl.java
@@ -88,6 +88,8 @@ public class WMSInfoImpl extends ServiceInfoImpl implements WMSInfo {
 
     private boolean autoEscapeTemplateValues;
 
+    private Boolean exceptionOnInvalidDimension;
+
     public WMSInfoImpl() {
         authorityURLs = new ArrayList<>(2);
         identifiers = new ArrayList<>(2);
@@ -391,5 +393,15 @@ public class WMSInfoImpl extends ServiceInfoImpl implements WMSInfo {
     @Override
     public void setAutoEscapeTemplateValues(boolean autoEscapeTemplateValues) {
         this.autoEscapeTemplateValues = autoEscapeTemplateValues;
+    }
+
+    @Override
+    public Boolean isExceptionOnInvalidDimension() {
+        return exceptionOnInvalidDimension;
+    }
+
+    @Override
+    public void setExceptionOnInvalidDimension(Boolean exceptionOnInvalidDimension) {
+        this.exceptionOnInvalidDimension = exceptionOnInvalidDimension;
     }
 }

--- a/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMSRequests.java
@@ -365,7 +365,7 @@ public class WMSRequests {
             params.put("elevation", kvpMap.get("elevation"));
         }
         kvpMap.entrySet().stream()
-                .filter(e -> e.getKey().toLowerCase().startsWith("dim_"))
+                .filter(e -> e.getKey().toLowerCase().startsWith(WMS.DIM_))
                 .forEach(e -> params.put(e.getKey().toLowerCase(), e.getValue()));
 
         // image params

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/DimensionHelper.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/DimensionHelper.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.wms.capabilities;
 
+import static org.geoserver.wms.WMS.DIM_;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -170,7 +172,7 @@ public abstract class DimensionHelper {
                 metadata = "";
             }
             String defaultValue =
-                    getDefaultValueRepresentation(featureTypeInfo, "dim_" + customDim.getKey(), "");
+                    getDefaultValueRepresentation(featureTypeInfo, DIM_ + customDim.getKey(), "");
             writeCustomDimensionVector(
                     customDim.getKey(), values, metadata, units, unitSymbol, defaultValue);
         } catch (IOException e) {
@@ -188,14 +190,10 @@ public abstract class DimensionHelper {
                         e ->
                                 e.getValue() instanceof DimensionInfo
                                         && e.getKey() != null
-                                        && e.getKey().startsWith("dim_")
+                                        && e.getKey().startsWith(DIM_)
                                         && !ResourceInfo.ELEVATION.equals(e.getKey())
                                         && !ResourceInfo.TIME.equals(e.getKey()))
-                .map(
-                        e ->
-                                Pair.of(
-                                        e.getKey().replaceFirst("dim_", ""),
-                                        (DimensionInfo) e.getValue()))
+                .map(e -> Pair.of(e.getKey().replaceFirst(DIM_, ""), (DimensionInfo) e.getValue()))
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
     }
 

--- a/src/wms/src/main/java/org/geoserver/wms/dimension/impl/DimensionDefaultValueSelectionStrategyFactoryImpl.java
+++ b/src/wms/src/main/java/org/geoserver/wms/dimension/impl/DimensionDefaultValueSelectionStrategyFactoryImpl.java
@@ -17,6 +17,7 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.ows.kvp.ElevationParser;
 import org.geoserver.ows.kvp.TimeParser;
 import org.geoserver.platform.ServiceException;
+import org.geoserver.wms.WMS;
 import org.geoserver.wms.dimension.DimensionDefaultValueSelectionStrategy;
 import org.geoserver.wms.dimension.DimensionDefaultValueSelectionStrategyFactory;
 import org.geoserver.wms.dimension.FixedValueStrategyFactory;
@@ -36,8 +37,6 @@ import org.geotools.feature.type.DateUtil;
  */
 public class DimensionDefaultValueSelectionStrategyFactoryImpl
         implements DimensionDefaultValueSelectionStrategyFactory {
-
-    private static final String VECTOR_CUSTOM_DIMENSION_PREFIX = "dim_";
 
     // Initialized in the applicationContext:
     private DimensionDefaultValueSelectionStrategy featureTimeMinimumStrategy;
@@ -104,7 +103,7 @@ public class DimensionDefaultValueSelectionStrategyFactoryImpl
                 retval = coverageElevationMinimumStrategy;
             }
         } else if (dimensionName.startsWith(ResourceInfo.CUSTOM_DIMENSION_PREFIX)
-                || dimensionName.startsWith(VECTOR_CUSTOM_DIMENSION_PREFIX)) {
+                || dimensionName.startsWith(WMS.DIM_)) {
             if (resource instanceof FeatureTypeInfo) {
                 retval = featureCustomDimensionMinimumStrategy;
             } else if (resource instanceof CoverageInfo) {

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
@@ -235,16 +235,12 @@ public class RasterLayerIdentifier implements LayerIdentifier<GridCoverage2DRead
             throws IOException, TransformException, ServiceException {
         // read from the request
         GetMapRequest getMap = requestParams.getGetMapRequest();
+        List<Object> times = requestParams.getTimes();
+        List<Object> elevations = requestParams.getElevations();
+        wms.validateRasterDimensions(times, elevations, layer, requestParams.getGetMapRequest());
         GeneralParameterValue[] parameters =
                 wms.getWMSReadParameters(
-                        getMap,
-                        layer,
-                        filter,
-                        sort,
-                        requestParams.getTimes(),
-                        requestParams.getElevations(),
-                        reader,
-                        true);
+                        getMap, layer, filter, sort, times, elevations, reader, true);
 
         // now get the position in raster space using the world to grid related to
         // corner

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorRenderingLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/VectorRenderingLayerIdentifier.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageTypeSpecifier;
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.platform.ExtensionPriority;
 import org.geoserver.platform.ServiceException;
@@ -63,6 +64,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.filter.Filters;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.map.FeatureLayer;
@@ -358,23 +360,14 @@ public class VectorRenderingLayerIdentifier extends AbstractVectorLayerIdentifie
         List<Object> elevations = params.getElevations();
         Filter layerFilter = params.getFilter();
         MapLayerInfo layer = params.getLayer();
-        Filter staticDimensionFilter =
-                wms.getTimeElevationToFilter(times, elevations, layer.getFeature());
-        Filter customDimensionsFilter =
-                wms.getDimensionsToFilter(
-                        params.getGetMapRequest().getRawKvp(), layer.getFeature());
-        final Filter dimensionFilter =
-                FF.and(Arrays.asList(staticDimensionFilter, customDimensionsFilter));
-        Filter filter;
-        if (layerFilter == null) {
-            filter = dimensionFilter;
-        } else if (dimensionFilter == null) {
-            filter = layerFilter;
-        } else {
-            filter = FF.and(Arrays.asList(layerFilter, dimensionFilter));
-        }
+        GetMapRequest getMapRequest = params.getGetMapRequest();
+        FeatureTypeInfo featureInfo = layer.getFeature();
+        wms.validateVectorDimensions(times, elevations, featureInfo, getMapRequest);
+        Filter dimensionFilter =
+                wms.getDimensionFilter(times, elevations, featureInfo, getMapRequest);
+        Filter filter = Filters.and(FF, dimensionFilter, layerFilter);
 
-        GetMapRequest getMap = params.getGetMapRequest();
+        GetMapRequest getMap = getMapRequest;
         FeatureSource<? extends FeatureType, ? extends Feature> featureSource =
                 super.handleClipParam(params, layer.getFeatureSource(true, getMap.getCrs()));
         final Query definitionQuery = new Query(featureSource.getSchema().getName().getLocalPart());

--- a/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSDimensionsTestSupport.java
@@ -23,6 +23,7 @@ import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.impl.DimensionInfoImpl;
+import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
@@ -76,6 +77,18 @@ public abstract class WMSDimensionsTestSupport extends WMSTestSupport {
         getCatalog().save(te);
         teEmpty.getMetadata().clear();
         getCatalog().save(teEmpty);
+    }
+
+    @After
+    public void restoreWMSExceptions() throws Exception {
+        setExceptionsOnInvalidDimension(null);
+    }
+
+    protected void setExceptionsOnInvalidDimension(Boolean value) throws Exception {
+        GeoServer gs = getGeoServer();
+        WMSInfo wms = gs.getService(WMSInfo.class);
+        wms.setExceptionOnInvalidDimension(value);
+        gs.save(wms);
     }
 
     @Override

--- a/src/wms/src/test/java/org/geoserver/wms/WMSTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSTest.java
@@ -28,11 +28,13 @@ import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.impl.DimensionInfoImpl;
+import org.geoserver.data.DimensionFilterBuilder;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.platform.ServiceException;
 import org.geotools.api.data.FeatureSource;
 import org.geotools.api.filter.Filter;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.renderer.style.DynamicSymbolFactoryFinder;
@@ -163,7 +165,11 @@ public class WMSTest extends WMSTestSupport {
         List<Object> times = time == null ? null : Arrays.asList(time);
         List<Object> elevations = elevation == null ? null : Arrays.asList(elevation);
 
-        Filter filter = wms.getTimeElevationToFilter(times, elevations, timeWithStartEnd);
+        DimensionFilterBuilder builder =
+                new DimensionFilterBuilder(CommonFactoryFinder.getFilterFactory());
+        wms.getTimeFilter(times, timeWithStartEnd, builder);
+        wms.getElevationFilter(elevations, timeWithStartEnd, builder);
+        Filter filter = builder.getFilter();
         FeatureCollection features = fs.getFeatures(filter);
 
         Set<Integer> results = new HashSet<>();

--- a/src/wms/src/test/java/org/geoserver/wms/dimension/CustomDimensionTimeAndNumberTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/dimension/CustomDimensionTimeAndNumberTest.java
@@ -5,18 +5,19 @@
  */
 package org.geoserver.wms.dimension;
 
+import static org.geoserver.wms.WMS.DIM_;
 import static org.junit.Assert.assertEquals;
 
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.testreader.CustomFormat;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ows.util.KvpMap;
 import org.geoserver.wms.GetMapRequest;
 import org.geoserver.wms.MapLayerInfo;
 import org.geoserver.wms.WMS;
@@ -81,10 +82,10 @@ public class CustomDimensionTimeAndNumberTest extends WMSTestSupport {
                 new MapLayerInfo(getCatalog().getLayerByName(WATTEMP_TIME.getLocalPart()));
         final GridCoverage2DReader reader = (GridCoverage2DReader) mapLayerInfo.getCoverageReader();
         GetMapRequest req = new GetMapRequest();
-        req.setRawKvp(new HashMap<>());
+        req.setRawKvp(new KvpMap<>());
         req.getRawKvp()
                 .put(
-                        "DIM_" + CustomFormat.CUSTOM_DIMENSION_NAME,
+                        DIM_ + CustomFormat.CUSTOM_DIMENSION_NAME,
                         "2001-05-01T00:00:00.000Z, 2001-05-02T00:00:00.000Z");
 
         GeneralParameterValue[] readParam =
@@ -104,8 +105,8 @@ public class CustomDimensionTimeAndNumberTest extends WMSTestSupport {
                 new MapLayerInfo(getCatalog().getLayerByName(WATTEMP_DEPTH.getLocalPart()));
         final GridCoverage2DReader reader = (GridCoverage2DReader) mapLayerInfo.getCoverageReader();
         GetMapRequest req = new GetMapRequest();
-        req.setRawKvp(new HashMap<>());
-        req.getRawKvp().put("DIM_" + CustomFormat.CUSTOM_DIMENSION_NAME, "10/50");
+        req.setRawKvp(new KvpMap<>());
+        req.getRawKvp().put(DIM_ + CustomFormat.CUSTOM_DIMENSION_NAME, "10/50");
 
         GeneralParameterValue[] readParam =
                 wms.getWMSReadParameters(
@@ -122,8 +123,8 @@ public class CustomDimensionTimeAndNumberTest extends WMSTestSupport {
                 new MapLayerInfo(getCatalog().getLayerByName(WATTEMP_DEPTH.getLocalPart()));
         final GridCoverage2DReader reader = (GridCoverage2DReader) mapLayerInfo.getCoverageReader();
         GetMapRequest req = new GetMapRequest();
-        req.setRawKvp(new HashMap<>());
-        req.getRawKvp().put("DIM_" + CustomFormat.CUSTOM_DIMENSION_NAME, "10,50");
+        req.setRawKvp(new KvpMap<>());
+        req.getRawKvp().put(DIM_ + CustomFormat.CUSTOM_DIMENSION_NAME, "10,50");
 
         GeneralParameterValue[] readParam =
                 wms.getWMSReadParameters(

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CustomDimensionsTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/CustomDimensionsTest.java
@@ -32,15 +32,15 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.data.test.SystemTestData.LayerProperty;
+import org.geoserver.wms.WMSDimensionsTestSupport;
 import org.geoserver.wms.WMSInfo;
-import org.geoserver.wms.WMSTestSupport;
 import org.geotools.image.io.ImageIOExt;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 
-public class CustomDimensionsTest extends WMSTestSupport {
+public class CustomDimensionsTest extends WMSDimensionsTestSupport {
 
     private static final QName WATTEMP =
             new QName(MockData.DEFAULT_URI, "watertemp", MockData.DEFAULT_PREFIX);
@@ -159,6 +159,7 @@ public class CustomDimensionsTest extends WMSTestSupport {
 
         setupRasterDimension(
                 CUSTOM_DIMENSION_NAME, DimensionPresentation.LIST, "nano meters", "nm");
+        setExceptionsOnInvalidDimension(false);
 
         // check that we get no data when requesting an incorrect value for custom dimension
         MockHttpServletResponse response =

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorGetMapTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/DimensionsVectorGetMapTest.java
@@ -6,6 +6,9 @@
 package org.geoserver.wms.wms_1_1_1;
 
 import static org.geoserver.catalog.DimensionInfo.NearestFailBehavior.EXCEPTION;
+import static org.geoserver.catalog.DimensionPresentation.LIST;
+import static org.geoserver.catalog.ResourceInfo.ELEVATION;
+import static org.geoserver.catalog.ResourceInfo.TIME;
 import static org.geoserver.platform.ServiceException.INVALID_DIMENSION_VALUE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -18,7 +21,6 @@ import org.custommonkey.xmlunit.XpathEngine;
 import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionDefaultValueSetting.Strategy;
 import org.geoserver.catalog.DimensionInfo;
-import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.data.test.SystemTestData;
@@ -49,13 +51,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testElevationDefault() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.ELEVATION,
-                "elevation",
-                DimensionPresentation.LIST,
-                null,
-                UNITS,
-                UNIT_SYMBOL);
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -72,14 +68,24 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     }
 
     @Test
+    public void testElevationInvalid() throws Exception {
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
+        setExceptionsOnInvalidDimension(true);
+        Document dom =
+                getAsDOM(
+                        "wms?service=WMS&version=1.1.1&request=GetMap"
+                                + "&bbox=-180,-90,180,90&styles=&Format=image/png&width=80&height=40&srs=EPSG:4326"
+                                + "&layers="
+                                + getLayerId(V_TIME_ELEVATION)
+                                + "&elevation=-10");
+
+        String message = checkLegacyException(dom, INVALID_DIMENSION_VALUE, ELEVATION);
+        assertEquals("Could not find a match for 'elevation' value: '-10'", message.trim());
+    }
+
+    @Test
     public void testElevationSingle() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.ELEVATION,
-                "elevation",
-                DimensionPresentation.LIST,
-                null,
-                UNITS,
-                UNIT_SYMBOL);
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -98,13 +104,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testElevationListMulti() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.ELEVATION,
-                "elevation",
-                DimensionPresentation.LIST,
-                null,
-                UNITS,
-                UNIT_SYMBOL);
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -124,13 +124,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testElevationListExtra() throws Exception {
         // adding a extra elevation that is simply not there, should not break
-        setupVectorDimension(
-                ResourceInfo.ELEVATION,
-                "elevation",
-                DimensionPresentation.LIST,
-                null,
-                UNITS,
-                UNIT_SYMBOL);
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -150,13 +144,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testElevationInterval() throws Exception {
         // adding a extra elevation that is simply not there, should not break
-        setupVectorDimension(
-                ResourceInfo.ELEVATION,
-                "elevation",
-                DimensionPresentation.LIST,
-                null,
-                UNITS,
-                UNIT_SYMBOL);
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -176,13 +164,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testElevationIntervalResolution() throws Exception {
         // adding a extra elevation that is simply not there, should not break
-        setupVectorDimension(
-                ResourceInfo.ELEVATION,
-                "elevation",
-                DimensionPresentation.LIST,
-                null,
-                UNITS,
-                UNIT_SYMBOL);
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -202,13 +184,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testElevationIntervalResolutionTooManyDefault() throws Exception {
         // adding a extra elevation that is simply not there, should not break
-        setupVectorDimension(
-                ResourceInfo.ELEVATION,
-                "elevation",
-                DimensionPresentation.LIST,
-                null,
-                UNITS,
-                UNIT_SYMBOL);
+        setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         MockHttpServletResponse response =
                 getAsServletResponse(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -238,13 +214,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
         gs.save(wms);
         try {
             // adding a extra elevation that is simply not there, should not break
-            setupVectorDimension(
-                    ResourceInfo.ELEVATION,
-                    "elevation",
-                    DimensionPresentation.LIST,
-                    null,
-                    UNITS,
-                    UNIT_SYMBOL);
+            setupVectorDimension(ELEVATION, "elevation", LIST, null, UNITS, UNIT_SYMBOL);
             MockHttpServletResponse response =
                     getAsServletResponse(
                             "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -269,8 +239,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testTimeDefault() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        setupVectorDimension(TIME, "time", LIST, null, null, null);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -288,8 +257,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testTimeCurrent() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        setupVectorDimension(TIME, "time", LIST, null, null, null);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -308,14 +276,8 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testTimeCurrentForEmptyLayer() throws Exception {
-        setupVectorDimension(
-                "TimeElevationEmpty",
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                null,
-                null);
+        setupVectorDimension("TimeElevationEmpty", TIME, "time", LIST, null, null, null);
+        setExceptionsOnInvalidDimension(false);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -333,9 +295,23 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     }
 
     @Test
+    public void testTimeCurrentForEmptyLayerException() throws Exception {
+        setupVectorDimension("TimeElevationEmpty", TIME, "time", LIST, null, null, null);
+        setExceptionsOnInvalidDimension(true);
+        Document dom =
+                getAsDOM(
+                        "wms?service=WMS&version=1.1.1&request=GetMap"
+                                + "&bbox=-180,-90,180,90&styles=&Format=image/png&width=80&height=40&srs=EPSG:4326"
+                                + "&layers="
+                                + getLayerId(V_TIME_ELEVATION_EMPTY)
+                                + "&time=CURRENT");
+        String message = checkLegacyException(dom, INVALID_DIMENSION_VALUE, "time");
+        assertEquals("Could not find a match for 'time' value: 'CURRENT'", message.trim());
+    }
+
+    @Test
     public void testTimeSingle() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        setupVectorDimension(TIME, "time", LIST, null, null, null);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -353,15 +329,10 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     }
 
     @Test
-    public void testTimeSingleNoNearestClose() throws Exception {
+    public void testTimeSingleNoNearestEmptyResult() throws Exception {
         // check it works the same if we enable nearest match
-        setupVectorDimension(
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                ResourceInfo.TIME_UNIT,
-                null);
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
+        setExceptionsOnInvalidDimension(false);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -379,16 +350,27 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     }
 
     @Test
+    public void testTimeSingleNoNearestException() throws Exception {
+        // no exact value, no nearest match, expect exception
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
+        setExceptionsOnInvalidDimension(true);
+        Document dom =
+                getAsDOM(
+                        "wms?service=WMS&version=1.1.1&request=GetMap"
+                                + "&bbox=-180,-90,180,90&styles=&Format=image/png&width=80&height=40&srs=EPSG:4326"
+                                + "&layers="
+                                + getLayerId(V_TIME_ELEVATION)
+                                + "&time=2011-05-02T01:00:00Z");
+        String message = checkLegacyException(dom, INVALID_DIMENSION_VALUE, TIME);
+        assertEquals(
+                "Could not find a match for 'time' value: '2011-05-02T01:00:00Z'", message.trim());
+    }
+
+    @Test
     public void testTimeSingleNearestClose() throws Exception {
         // check it works the same if we enable nearest match
-        setupVectorDimension(
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                ResourceInfo.TIME_UNIT,
-                null);
-        setupNearestMatch(V_TIME_ELEVATION, ResourceInfo.TIME, true);
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
+        setupNearestMatch(V_TIME_ELEVATION, TIME, true);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -410,13 +392,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testTimeSingleNearestAcceptableRange() throws Exception {
         // check it works the same if we enable nearest match
-        setupVectorDimension(
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                ResourceInfo.TIME_UNIT,
-                null);
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
 
         String baseURL =
                 "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -425,19 +401,19 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
                         + getLayerId(V_TIME_ELEVATION);
 
         // big enough range
-        setupNearestMatch(V_TIME_ELEVATION, ResourceInfo.TIME, true, "P1D");
+        setupNearestMatch(V_TIME_ELEVATION, TIME, true, "P1D");
         getAsImage(baseURL + "&time=2011-05-02T01:00:00Z", "image/png");
         assertWarningCount(1);
         assertNearestTimeWarning(getLayerId(V_TIME_ELEVATION), "2011-05-02T00:00:00.000Z");
 
         // too small range, won't match
-        setupNearestMatch(V_TIME_ELEVATION, ResourceInfo.TIME, true, "PT1M");
+        setupNearestMatch(V_TIME_ELEVATION, TIME, true, "PT1M");
         getAsImage(baseURL + "&time=2011-05-02T01:00:00Z", "image/png");
         assertWarningCount(1);
-        assertNoNearestWarning(getLayerId(V_TIME_ELEVATION), ResourceInfo.TIME);
+        assertNoNearestWarning(getLayerId(V_TIME_ELEVATION), TIME);
 
         // same as above, but with exception on failed match
-        setupNearestMatch(V_TIME_ELEVATION, ResourceInfo.TIME, true, "PT1M", EXCEPTION, false);
+        setupNearestMatch(V_TIME_ELEVATION, TIME, true, "PT1M", EXCEPTION, false);
         Document dom = getAsDOM(baseURL + "&time=2011-05-02T01:00:00Z");
         String message = checkLegacyException(dom, INVALID_DIMENSION_VALUE, "time");
         assertThat(
@@ -445,7 +421,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
                 containsString("No nearest match found on sf:TimeElevation for time dimension"));
 
         // big enough towards future
-        setupNearestMatch(V_TIME_ELEVATION, ResourceInfo.TIME, true, "PT0M/P1D");
+        setupNearestMatch(V_TIME_ELEVATION, TIME, true, "PT0M/P1D");
         getAsImage(baseURL + "&time=2011-05-02T01:00:00Z", "image/png");
         assertWarningCount(1);
         assertNearestTimeWarning(getLayerId(V_TIME_ELEVATION), "2011-05-03T00:00:00.000Z");
@@ -454,14 +430,8 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testTimeSingleNearestAfter() throws Exception {
         // check it works the same if we enable nearest match
-        setupVectorDimension(
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                ResourceInfo.TIME_UNIT,
-                null);
-        setupNearestMatch(V_TIME_ELEVATION, ResourceInfo.TIME, true);
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
+        setupNearestMatch(V_TIME_ELEVATION, TIME, true);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -484,14 +454,8 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testTimeSingleNearestBefore() throws Exception {
         // check it works the same if we enable nearest match
-        setupVectorDimension(
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                ResourceInfo.TIME_UNIT,
-                null);
-        setupNearestMatch(V_TIME_ELEVATION, ResourceInfo.TIME, true);
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
+        setupNearestMatch(V_TIME_ELEVATION, TIME, true);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -513,13 +477,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testTimeListMulti() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                ResourceInfo.TIME_UNIT,
-                null);
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -539,13 +497,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testTimeListExtra() throws Exception {
         // adding a extra elevation that is simply not there, should not break
-        setupVectorDimension(
-                ResourceInfo.TIME,
-                "time",
-                DimensionPresentation.LIST,
-                null,
-                ResourceInfo.TIME_UNIT,
-                null);
+        setupVectorDimension(TIME, "time", LIST, null, ResourceInfo.TIME_UNIT, null);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -565,8 +517,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     @Test
     public void testTimeInterval() throws Exception {
         // adding a extra elevation that is simply not there, should not break
-        setupVectorDimension(
-                ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        setupVectorDimension(TIME, "time", LIST, null, null, null);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -585,8 +536,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testTimeIntervalResolution() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        setupVectorDimension(TIME, "time", LIST, null, null, null);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -605,8 +555,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testTimeIntervalResolutionTooManyDefault() throws Exception {
-        setupVectorDimension(
-                ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+        setupVectorDimension(TIME, "time", LIST, null, null, null);
         MockHttpServletResponse response =
                 getAsServletResponse(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -633,8 +582,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
         wms.setMaxRequestedDimensionValues(2);
         gs.save(wms);
         try {
-            setupVectorDimension(
-                    ResourceInfo.TIME, "time", DimensionPresentation.LIST, null, null, null);
+            setupVectorDimension(TIME, "time", LIST, null, null, null);
             MockHttpServletResponse response =
                     getAsServletResponse(
                             "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -664,7 +612,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
         defaultValueSetting.setStrategyType(Strategy.FIXED);
         defaultValueSetting.setReferenceValue("1/3");
         setupResourceDimensionDefaultValue(
-                V_TIME_ELEVATION, ResourceInfo.ELEVATION, defaultValueSetting, "elevation");
+                V_TIME_ELEVATION, ELEVATION, defaultValueSetting, "elevation");
 
         // request with default values
         BufferedImage image =
@@ -690,8 +638,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
         DimensionDefaultValueSetting defaultValueSetting = new DimensionDefaultValueSetting();
         defaultValueSetting.setStrategyType(Strategy.FIXED);
         defaultValueSetting.setReferenceValue("2011-05-02/2011-05-03");
-        setupResourceDimensionDefaultValue(
-                V_TIME_ELEVATION, ResourceInfo.TIME, defaultValueSetting, "time");
+        setupResourceDimensionDefaultValue(V_TIME_ELEVATION, TIME, defaultValueSetting, "time");
 
         // request with default values
         BufferedImage image =
@@ -815,7 +762,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
                 "dim_custom",
                 //    			ResourceInfo.ELEVATION,
                 "elevation",
-                DimensionPresentation.LIST,
+                LIST,
                 null,
                 UNITS,
                 UNIT_SYMBOL);
@@ -836,8 +783,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testCustomDimensionRange() throws Exception {
-        setupVectorDimension(
-                "dim_custom", "elevation", DimensionPresentation.LIST, null, UNITS, UNIT_SYMBOL);
+        setupVectorDimension("dim_custom", "elevation", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -855,8 +801,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testCustomDimensionString() throws Exception {
-        setupVectorDimension(
-                "dim_custom", "shared_key", DimensionPresentation.LIST, null, UNITS, UNIT_SYMBOL);
+        setupVectorDimension("dim_custom", "shared_key", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -873,9 +818,44 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
     }
 
     @Test
+    public void testCustomDimensionStringInvalidException() throws Exception {
+        setupVectorDimension("dim_custom", "shared_key", LIST, null, UNITS, UNIT_SYMBOL);
+        setExceptionsOnInvalidDimension(true);
+        Document dom =
+                getAsDOM(
+                        "wms?service=WMS&version=1.1.1&request=GetMap"
+                                + "&bbox=-180,-90,180,90&styles=&Format=image/png&width=80&height=40&srs=EPSG:4326"
+                                + "&layers="
+                                + getLayerId(V_TIME_ELEVATION)
+                                + "&dim_custom=IAmNotThere");
+
+        String message = checkLegacyException(dom, INVALID_DIMENSION_VALUE, "DIM_CUSTOM");
+        assertEquals("Could not find a match for 'custom' value: 'IAmNotThere'", message.trim());
+    }
+
+    @Test
+    public void testCustomDimensionStringInvalidIgnore() throws Exception {
+        setupVectorDimension("dim_custom", "shared_key", LIST, null, UNITS, UNIT_SYMBOL);
+        setExceptionsOnInvalidDimension(false);
+        BufferedImage image =
+                getAsImage(
+                        "wms?service=WMS&version=1.1.1&request=GetMap"
+                                + "&bbox=-180,-90,180,90&styles=&Format=image/png&width=80&height=40&srs=EPSG:4326"
+                                + "&layers="
+                                + getLayerId(V_TIME_ELEVATION)
+                                + "&dim_custom=IAmNotThere",
+                        "image/png");
+
+        // finding nothing, but no exception either
+        assertPixel(image, 20, 10, Color.WHITE);
+        assertPixel(image, 60, 10, Color.WHITE);
+        assertPixel(image, 20, 30, Color.WHITE);
+        assertPixel(image, 60, 30, Color.WHITE);
+    }
+
+    @Test
     public void testCustomDimensionBoolean() throws Exception {
-        setupVectorDimension(
-                "dim_custom", "enabled", DimensionPresentation.LIST, null, UNITS, UNIT_SYMBOL);
+        setupVectorDimension("dim_custom", "enabled", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -893,8 +873,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testCustomDimensionDate() throws Exception {
-        setupVectorDimension(
-                "dim_custom", "time", DimensionPresentation.LIST, null, UNITS, UNIT_SYMBOL);
+        setupVectorDimension("dim_custom", "time", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"
@@ -912,8 +891,7 @@ public class DimensionsVectorGetMapTest extends WMSDimensionsTestSupport {
 
     @Test
     public void testCustomDimensionDateRange() throws Exception {
-        setupVectorDimension(
-                "dim_custom", "time", DimensionPresentation.LIST, null, UNITS, UNIT_SYMBOL);
+        setupVectorDimension("dim_custom", "time", LIST, null, UNITS, UNIT_SYMBOL);
         BufferedImage image =
                 getAsImage(
                         "wms?service=WMS&version=1.1.1&request=GetMap"

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CustomDimensionsTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CustomDimensionsTest.java
@@ -28,15 +28,15 @@ import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.data.test.SystemTestData.LayerProperty;
+import org.geoserver.wms.WMSDimensionsTestSupport;
 import org.geoserver.wms.WMSInfo;
-import org.geoserver.wms.WMSTestSupport;
 import org.geotools.image.io.ImageIOExt;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 
-public class CustomDimensionsTest extends WMSTestSupport {
+public class CustomDimensionsTest extends WMSDimensionsTestSupport {
 
     private static final QName WATTEMP =
             new QName(MockData.DEFAULT_URI, "watertemp", MockData.DEFAULT_PREFIX);
@@ -136,6 +136,7 @@ public class CustomDimensionsTest extends WMSTestSupport {
     @Test
     public void testGetMap() throws Exception {
         ImageIOExt.allowNativeCodec("tif", ImageReaderSpi.class, false);
+        setExceptionsOnInvalidDimension(false);
 
         setupRasterDimension(DIMENSION_NAME, DimensionPresentation.LIST, null, null);
         // check that we get no data when requesting an incorrect value for custom dimension


### PR DESCRIPTION
Backport of https://github.com/geoserver/geoserver/pull/7292, with defaults flipped

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
