### PR TITLE
Updates following up GeoTools update to pass down max features to WFS 2.0 servers

### DIFF
--- a/src/wfs/src/test/java/org/geoserver/wfs/remote/v2_0/WfsRemoteStoreTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/remote/v2_0/WfsRemoteStoreTest.java
@@ -67,7 +67,8 @@ public class WfsRemoteStoreTest extends WFS20TestSupport {
                         + "&RESULTTYPE=RESULTS"
                         + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
                         + "&VERSION=2.0.0"
-                        + "&SERVICE=WFS",
+                        + "&SERVICE=WFS"
+                        + "&COUNT=1000000",
                 "tiger_roads_get_feature_resp_1.xml",
                 environment);
         registerHttpGetFromResource(
@@ -78,7 +79,8 @@ public class WfsRemoteStoreTest extends WFS20TestSupport {
                         + "&RESULTTYPE=RESULTS"
                         + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
                         + "&VERSION=2.0.0"
-                        + "&SERVICE=WFS",
+                        + "&SERVICE=WFS"
+                        + "&COUNT=1000000",
                 "tiger_roads_get_feature_resp_1.xml",
                 environment);
 
@@ -148,7 +150,8 @@ public class WfsRemoteStoreTest extends WFS20TestSupport {
                         + "&RESULTTYPE=RESULTS"
                         + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
                         + "&VERSION=2.0.0"
-                        + "&SERVICE=WFS",
+                        + "&SERVICE=WFS"
+                        + "&COUNT=1000000",
                 "tiger_roads_get_feature_resp_special_chars.xml",
                 environment);
         registerHttpGetFromResource(
@@ -159,7 +162,8 @@ public class WfsRemoteStoreTest extends WFS20TestSupport {
                         + "&RESULTTYPE=RESULTS"
                         + "&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2"
                         + "&VERSION=2.0.0"
-                        + "&SERVICE=WFS",
+                        + "&SERVICE=WFS"
+                        + "&COUNT=1000000",
                 "tiger_roads_get_feature_resp_special_chars.xml",
                 environment);
 


### PR DESCRIPTION
Update mock test expectations for GeoTools WFS store ability to pass down max features against WFS 2.0 servers, see:
https://github.com/geotools/geotools/pull/4563

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
