### PR TITLE
[GEOS-10225] Fix for missing getImageLayout implementation

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -1239,7 +1239,7 @@ public class CatalogBuilder {
                                 + format.getName());
             }
             SampleModel sm = imageLayout.getSampleModel(null);
-            if (cm == null) {
+            if (sm == null) {
                 throw new Exception(
                         "Unable to acquire test coverage and sample model for format:"
                                 + format.getName());


### PR DESCRIPTION
[![GEOS-10225](https://badgen.net/badge/JIRA/GEOS-10225/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10225) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fixes a problem with publishing layers from GeoPackage Mosaic files in GeoServer.

To reproduce the problem:
1. Download the example file from https://github.com/ngageoint/GeoPackage/blob/master/docs/examples/java/example.gpkg
2. In GeoServer, add a new DataSource and select GeoPackage Mosaic
3. Select the file and click okey.
4. Try and publish a layer from the Datasource.
5. GeoServer web application shows a NullPoint exception.

This happens because the class `SingleGridCoverage2DReader` relies on that the inherited class has `layout `set. This is not the case. `return delegate.getImageLayout(coverageName);` will always return null.

This should resolve issue: https://osgeo-org.atlassian.net/browse/GEOS-10225

(This PR also fixes a typo in one of the null checks.)

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->