### PR TITLE
[GEOS-11223] Layer not visible in preview/capabilities if security closes the workspace, but allows access to the layer

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
@@ -734,6 +734,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
                 wsNamePropertyFilter = Predicates.equal("store.workspace.name", wsName);
             }
 
+            // need to set up a wsFilter if the workspace is an exception compared to the root
             Filter wsFilter = null;
             if (rootAccess && !wsAccess) {
                 wsFilter = Predicates.not(wsNamePropertyFilter);
@@ -748,11 +749,18 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
             } else {
                 Filter id = Predicates.in("id", layerExceptionIds);
 
+                // if we can access the workspace, the ids are the ones we want to exclude,
+                // otherwise, the ids are the ones we want to make an exception for instead
                 if (wsAccess) {
                     id = Predicates.not(id);
                 }
                 if (wsFilter != null) {
-                    filters.add(Predicates.and(wsFilter, id));
+                    if (wsAccess)
+                        // ws is the one, but exclude selected layers in it
+                        filters.add(Predicates.and(wsFilter, id));
+                    else
+                        // ws is not the one, but make an exception for selected layers in it
+                        filters.add(Predicates.or(wsFilter, id));
                 } else {
                     filters.add(id);
                 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException.properties
@@ -1,0 +1,7 @@
+# ws is an exception to root, layer is an exception to workspace
+*.*.r=MILITARY
+*.*.w=NO_ONE
+# topp, open, READER can see it
+topp.*.r=READER
+# but states is an exception 
+topp.states.r=MILITARY

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException2.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException2.properties
@@ -1,0 +1,7 @@
+# ws is same as root, layer is an exception to workspace
+*.*.r=READER
+*.*.w=NO_ONE
+# topp, locked down, READER cannot see it
+topp.*.r=READER
+# but states is an exception 
+topp.states.r=MILITARY

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException.properties
@@ -1,0 +1,7 @@
+# ws is an exception to root, layer is an exception to workspace
+*.*.r=READER
+*.*.w=NO_ONE
+# topp, locked down, READER cannot see it
+topp.*.r=MILITARY
+# but states is an exception 
+topp.states.r=READER

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException2.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException2.properties
@@ -1,0 +1,7 @@
+# ws and root agree, layer is an exception
+*.*.r=MILITARY
+*.*.w=NO_ONE
+# topp, locked down, READER cannot see it
+topp.*.r=MILITARY
+# but states is an exception 
+topp.states.r=READER


### PR DESCRIPTION
[![GEOS-11223](https://badgen.net/badge/JIRA/GEOS-11223/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11223) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->