### PR TITLE
[Backport 2.23.x] [GEOS-11223] Layer not visible in preview/capabilities if security closes the workspace, but allows access to the layer

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DefaultResourceAccessManager.java
@@ -734,6 +734,7 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
                 wsNamePropertyFilter = Predicates.equal("store.workspace.name", wsName);
             }
 
+            // need to set up a wsFilter if the workspace is an exception compared to the root
             Filter wsFilter = null;
             if (rootAccess && !wsAccess) {
                 wsFilter = Predicates.not(wsNamePropertyFilter);
@@ -748,11 +749,18 @@ public class DefaultResourceAccessManager implements ResourceAccessManager {
             } else {
                 Filter id = Predicates.in("id", layerExceptionIds);
 
+                // if we can access the workspace, the ids are the ones we want to exclude,
+                // otherwise, the ids are the ones we want to make an exception for instead
                 if (wsAccess) {
                     id = Predicates.not(id);
                 }
                 if (wsFilter != null) {
-                    filters.add(Predicates.and(wsFilter, id));
+                    if (wsAccess)
+                        // ws is the one, but exclude selected layers in it
+                        filters.add(Predicates.and(wsFilter, id));
+                    else
+                        // ws is not the one, but make an exception for selected layers in it
+                        filters.add(Predicates.or(wsFilter, id));
                 } else {
                     filters.add(id);
                 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/SecureCatalogImplTest.java
@@ -77,6 +77,7 @@ import org.geoserver.security.decorators.SecuredLayerGroupInfo;
 import org.geoserver.security.decorators.SecuredLayerInfo;
 import org.geoserver.security.decorators.SecuredWMSLayerInfo;
 import org.geoserver.security.decorators.SecuredWMTSLayerInfo;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.util.logging.Logging;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -85,6 +86,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.sort.SortBy;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -92,6 +96,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class SecureCatalogImplTest extends AbstractAuthorizationTest {
 
     public static final Logger LOGGER = Logging.getLogger(SecureCatalogImplTest.class);
+
+    private static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
+    public static final PropertyName RESOURCE_WS_NAME =
+            FF.property("resource.store.workspace.name");
 
     @Rule
     public GeoServerExtensionsHelper.ExtensionsHelperRule extensions =
@@ -1850,5 +1858,92 @@ public class SecureCatalogImplTest extends AbstractAuthorizationTest {
             assertEquals(1, groups.size());
             assertEquals("wsContainerD", groups.get(0).getName());
         }
+    }
+
+    @Test
+    public void testLayerPositiveException() throws Exception {
+        // prepare the stage
+        ResourceAccessManager manager = buildManager("layerPositiveException.properties");
+
+        // try with read only user
+        SecurityContextHolder.getContext().setAuthentication(roUser);
+
+        // direct invocation, state is allowed, others not
+        assertNotNull(sc.getLayerByName("topp:states"));
+        assertNull(sc.getLayerByName("topp:roads"));
+
+        // now check the security filter
+        Filter securityFilter = manager.getSecurityFilter(roUser, LayerInfo.class);
+        Filter expected =
+                FF.or(
+                        FF.not(FF.equal(RESOURCE_WS_NAME, FF.literal("topp"), false)),
+                        layerIdFilter("states-lid"));
+        assertEquals(expected, securityFilter);
+    }
+
+    @Test
+    public void testLayerPositiveException2() throws Exception {
+        // prepare the stage
+        ResourceAccessManager manager = buildManager("layerPositiveException2.properties");
+
+        // try with read only user
+        SecurityContextHolder.getContext().setAuthentication(roUser);
+
+        // direct invocation, state is allowed, others not
+        assertNotNull(sc.getLayerByName("topp:states"));
+        assertNull(sc.getLayerByName("topp:roads"));
+
+        // now check the security filter
+        Filter securityFilter = manager.getSecurityFilter(roUser, LayerInfo.class);
+        Filter expected = layerIdFilter("states-lid");
+        assertEquals(expected, securityFilter);
+    }
+
+    @Test
+    public void testLayerNegativeException() throws Exception {
+        // prepare the stage
+        ResourceAccessManager manager = buildManager("layerNegativeException.properties");
+
+        // try with read only user
+        SecurityContextHolder.getContext().setAuthentication(roUser);
+
+        // direct invocation, state is not allowed, others are
+        assertNull(sc.getLayerByName("topp:states"));
+        assertNotNull(sc.getLayerByName("topp:roads"));
+
+        // now check the security filter
+        Filter securityFilter = manager.getSecurityFilter(roUser, LayerInfo.class);
+        Filter expected =
+                FF.and(
+                        (FF.equal(RESOURCE_WS_NAME, FF.literal("topp"), false)),
+                        FF.not(layerIdFilter("states-lid")));
+        assertEquals(expected, securityFilter);
+    }
+
+    @Test
+    public void testLayerNegativeException2() throws Exception {
+        // prepare the stage
+        ResourceAccessManager manager = buildManager("layerNegativeException2.properties");
+
+        // try with read only user
+        SecurityContextHolder.getContext().setAuthentication(roUser);
+
+        // direct invocation, state is not allowed, others are
+        assertNull(sc.getLayerByName("topp:states"));
+        assertNotNull(sc.getLayerByName("topp:roads"));
+
+        // now check the security filter
+        Filter securityFilter = manager.getSecurityFilter(roUser, LayerInfo.class);
+        Filter expected = FF.not(layerIdFilter("states-lid"));
+        assertEquals(expected, securityFilter);
+    }
+
+    /**
+     * Builds a filter matching a single identifier using the "in" function (same way the
+     * DefaultResourceAccessManager builds a filter)
+     */
+    private static PropertyIsEqualTo layerIdFilter(String id) {
+        return FF.equal(
+                FF.function("in", FF.property("id"), FF.literal(id)), FF.literal(true), false);
     }
 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException.properties
@@ -1,0 +1,7 @@
+# ws is an exception to root, layer is an exception to workspace
+*.*.r=MILITARY
+*.*.w=NO_ONE
+# topp, open, READER can see it
+topp.*.r=READER
+# but states is an exception 
+topp.states.r=MILITARY

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException2.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerNegativeException2.properties
@@ -1,0 +1,7 @@
+# ws is same as root, layer is an exception to workspace
+*.*.r=READER
+*.*.w=NO_ONE
+# topp, locked down, READER cannot see it
+topp.*.r=READER
+# but states is an exception 
+topp.states.r=MILITARY

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException.properties
@@ -1,0 +1,7 @@
+# ws is an exception to root, layer is an exception to workspace
+*.*.r=READER
+*.*.w=NO_ONE
+# topp, locked down, READER cannot see it
+topp.*.r=MILITARY
+# but states is an exception 
+topp.states.r=READER

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException2.properties
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/layerPositiveException2.properties
@@ -1,0 +1,7 @@
+# ws and root agree, layer is an exception
+*.*.r=MILITARY
+*.*.w=NO_ONE
+# topp, locked down, READER cannot see it
+topp.*.r=MILITARY
+# but states is an exception 
+topp.states.r=READER


### PR DESCRIPTION
[![GEOS-11223](https://badgen.net/badge/JIRA/GEOS-11223/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11223) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport to 2.23.x

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->