### PR TITLE
[GEOS-10933] Fix keycloak plugin logout

### DIFF
--- a/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/GeoServerKeycloakFilter.java
+++ b/src/community/security/keycloak/src/main/java/org/geoserver/security/keycloak/GeoServerKeycloakFilter.java
@@ -114,20 +114,25 @@ public class GeoServerKeycloakFilter extends GeoServerPreAuthenticatedUserNameFi
         String referer = request.getHeader(HttpHeaders.REFERER);
         String refererNoParams = referer.split("\\?")[0];
 
-        // let geoserver know what to do with this
-        request.setAttribute(
-                GeoServerLogoutFilter.LOGOUT_REDIRECT_ATTR,
-                deployment
-                        .getLogoutUrl()
-                        .queryParam(OAuth2Constants.REDIRECT_URI, refererNoParams)
-                        .queryParam(
-                                ID_TOKEN_HINT,
-                                ((org.keycloak.adapters.OidcKeycloakAccount)
-                                                authentication.getDetails())
-                                        .getKeycloakSecurityContext()
-                                        .getIdTokenString())
-                        .build()
-                        .toString());
+        if (authentication
+                .getDetails()
+                .getClass()
+                .isAssignableFrom(org.keycloak.adapters.OidcKeycloakAccount.class)) {
+            // let geoserver know what to do with this
+            request.setAttribute(
+                    GeoServerLogoutFilter.LOGOUT_REDIRECT_ATTR,
+                    deployment
+                            .getLogoutUrl()
+                            .queryParam(OAuth2Constants.REDIRECT_URI, refererNoParams)
+                            .queryParam(
+                                    ID_TOKEN_HINT,
+                                    ((org.keycloak.adapters.OidcKeycloakAccount)
+                                                    authentication.getDetails())
+                                            .getKeycloakSecurityContext()
+                                            .getIdTokenString())
+                            .build()
+                            .toString());
+        }
     }
 
     /** Cache based on the "Authorization" HTTP header. */

--- a/src/community/security/keycloak/src/test/java/org/geoserver/web/security/keycloak/KeycloakLoginButtonTest.java
+++ b/src/community/security/keycloak/src/test/java/org/geoserver/web/security/keycloak/KeycloakLoginButtonTest.java
@@ -66,7 +66,7 @@ public class KeycloakLoginButtonTest extends GeoServerWicketTestSupport {
         // the login form is there and has the link
         assertTrue(
                 html.contains(
-                        "<form style=\"display: inline-block;\" method=\"post\" action=\"http://localhost/context/web?j_spring_keycloak_login=true\">"));
+                        "<form class=\"d-inline-block\" method=\"post\" action=\"http://localhost/context/web?j_spring_keycloak_login=true\">"));
         // the img is there as well
         assertTrue(
                 html.contains(


### PR DESCRIPTION
[![GEOS-10933](https://badgen.net/badge/JIRA/GEOS-10933/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10933) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This fixes the failing logout when using the keycloak plugin. Also fixes a failing test in the plugin due do HTML changes.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).