### PR TITLE
[GEOS-11235] preauthentication filters - session reuse even after having logout

### DIFF
--- a/src/main/src/test/java/org/geoserver/security/filter/GeoServerRequestHeaderAuthenticationFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/security/filter/GeoServerRequestHeaderAuthenticationFilterTest.java
@@ -1,0 +1,71 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import javax.servlet.http.HttpServletResponse;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+public class GeoServerRequestHeaderAuthenticationFilterTest {
+
+    @Test
+    public void testAuthenticationViaPreAuthChanging() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        HttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+        SecurityContext sc = new SecurityContextImpl();
+        sc.setAuthentication(new PreAuthenticatedAuthenticationToken("testadmin", null));
+        SecurityContextHolder.setContext(sc);
+        GeoServerRequestHeaderAuthenticationFilter toTest =
+                new GeoServerRequestHeaderAuthenticationFilter();
+        toTest.setPrincipalHeaderAttribute("sec-username");
+        request.addHeader("sec-username", "testuser");
+        toTest.setSecurityManager(
+                new GeoServerSecurityManager(new GeoServerDataDirectory(new File("/tmp"))));
+        toTest.setRoleSource(
+                PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource.Header);
+
+        toTest.doFilter(request, response, filterChain);
+
+        assertEquals(
+                "testuser",
+                SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+    }
+
+    @Test
+    public void testAuthenticationViaPreAuthNoHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        HttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+        SecurityContext sc = new SecurityContextImpl();
+        sc.setAuthentication(new PreAuthenticatedAuthenticationToken("testadmin", null));
+        SecurityContextHolder.setContext(sc);
+        GeoServerRequestHeaderAuthenticationFilter toTest =
+                new GeoServerRequestHeaderAuthenticationFilter();
+        toTest.setPrincipalHeaderAttribute("sec-username");
+        toTest.setSecurityManager(
+                new GeoServerSecurityManager(new GeoServerDataDirectory(new File("/tmp"))));
+        toTest.setRoleSource(
+                PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource.Header);
+
+        toTest.doFilter(request, response, filterChain);
+
+        // The security context should have been cleared
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}


### PR DESCRIPTION
[![GEOS-11235](https://badgen.net/badge/JIRA/GEOS-11235/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11235) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

or if no preauth headers are provided anymore.

See https://osgeo-org.atlassian.net/browse/GEOS-11235 for more details.

Without this change, we can end up with a persisting session across logout.

Tests: adding utests specific to this change. Runtime tested into a docker composition.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).