### PR TITLE
[GEOS-11241] ModificationProxy breaks information hidding on CatalogInfo.accept(CatalogVisitor)

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxy.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxy.java
@@ -23,9 +23,21 @@ import java.util.function.UnaryOperator;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CatalogVisitor;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.Info;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MetadataMap;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.ows.util.ClassProperties;
 import org.geoserver.ows.util.OwsUtils;
 import org.geoserver.platform.GeoServerExtensions;
@@ -75,7 +87,9 @@ public class ModificationProxy implements WrappingProxy, Serializable {
         return cp;
     }
 
-    /** Intercepts getter and setter methods. */
+    /**
+     * Intercepts getter and setter methods, as well as {@link CatalogInfo#accept(CatalogVisitor)}.
+     */
     @Override
     @SuppressWarnings("unchecked") // lots of generic behavior, cannot use params
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
@@ -133,11 +147,8 @@ public class ModificationProxy implements WrappingProxy, Serializable {
                 && method.getParameters().length == 1
                 && method.getParameters()[0].getType().equals(CatalogVisitor.class)) {
             CatalogVisitor visitor = (CatalogVisitor) args[0];
-
-            if (proxy instanceof FeatureTypeInfo) {
-                visitor.visit((FeatureTypeInfo) proxy);
-                return null;
-            }
+            accept((CatalogInfo) proxy, visitor);
+            return null;
         }
 
         try {
@@ -168,6 +179,36 @@ public class ModificationProxy implements WrappingProxy, Serializable {
         } catch (InvocationTargetException e) {
             Throwable targetException = e.getTargetException();
             throw targetException;
+        }
+    }
+
+    private void accept(CatalogInfo proxy, CatalogVisitor visitor) {
+        if (proxy instanceof WorkspaceInfo) {
+            visitor.visit((WorkspaceInfo) proxy);
+        } else if (proxy instanceof NamespaceInfo) {
+            visitor.visit((NamespaceInfo) proxy);
+        } else if (proxy instanceof CoverageStoreInfo) {
+            visitor.visit((CoverageStoreInfo) proxy);
+        } else if (proxy instanceof DataStoreInfo) {
+            visitor.visit((DataStoreInfo) proxy);
+        } else if (proxy instanceof WMSStoreInfo) {
+            visitor.visit((WMSStoreInfo) proxy);
+        } else if (proxy instanceof WMTSStoreInfo) {
+            visitor.visit((WMTSStoreInfo) proxy);
+        } else if (proxy instanceof CoverageInfo) {
+            visitor.visit((CoverageInfo) proxy);
+        } else if (proxy instanceof FeatureTypeInfo) {
+            visitor.visit((FeatureTypeInfo) proxy);
+        } else if (proxy instanceof WMSLayerInfo) {
+            visitor.visit((WMSLayerInfo) proxy);
+        } else if (proxy instanceof WMTSLayerInfo) {
+            visitor.visit((WMTSLayerInfo) proxy);
+        } else if (proxy instanceof LayerInfo) {
+            visitor.visit((LayerInfo) proxy);
+        } else if (proxy instanceof LayerGroupInfo) {
+            visitor.visit((LayerGroupInfo) proxy);
+        } else if (proxy instanceof StyleInfo) {
+            visitor.visit((StyleInfo) proxy);
         }
     }
 


### PR DESCRIPTION
[![GEOS-11241](https://badgen.net/badge/JIRA/GEOS-11241/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11241) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`ModificationProxy` breaks information hidding on `CatalogInfo.accept(CatalogVisitor)`, exposing the proxied object.

Follow up on commit 01bd2f2deb6fee761ca96b7035f6178996c6a16e (from GEOS-10356) which fixed it only for `FeatureTypeInfo`, by calling the appropriate `CatalogVisitor.visit(...)` overload method with the `ModificationProxy` proxy object and not with its internal `CatalogInfo`.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->