### PR TITLE
[GEOS-11242] Remove the Xalan library

### DIFF
--- a/src/extension/csw/core/pom.xml
+++ b/src/extension/csw/core/pom.xml
@@ -25,16 +25,6 @@
       <artifactId>gs-csw-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>serializer</artifactId>
-      <exclusions>
-        <exclusion>
-          <artifactId>xml-apis</artifactId>
-          <groupId>xml-apis</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/response/AcknowledgementTransformer.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/response/AcknowledgementTransformer.java
@@ -10,8 +10,10 @@ import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.sax.SAXResult;
 import net.opengis.cat.csw20.RequestBaseType;
-import org.apache.xml.serializer.TreeWalker;
 import org.geoserver.csw.xml.v2_0_2.CSWRecordingXmlReader;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
@@ -106,8 +108,9 @@ public class AcknowledgementTransformer extends AbstractCSWTransformer {
 
         private void dumpAsXML(Document document) {
             try {
-                TreeWalker tw = new TreeWalker(contentHandler);
-                tw.traverse(document);
+                TransformerFactory.newInstance()
+                        .newTransformer()
+                        .transform(new DOMSource(document), new SAXResult(contentHandler));
             } catch (Exception e) {
                 throw new ServiceException(
                         "Failed to re-encode the original request in the Acknowledgement response");

--- a/src/extension/csw/csw-iso/pom.xml
+++ b/src/extension/csw/csw-iso/pom.xml
@@ -30,10 +30,6 @@
       <artifactId>gs-csw-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>serializer</artifactId>
-    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/src/extension/sldService/pom.xml
+++ b/src/extension/sldService/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>xom</groupId>
       <artifactId>xom</artifactId>
-      <version>1.1</version>
+      <version>1.3.9</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/ClassifierTest.java
+++ b/src/extension/sldService/src/test/java/org/geoserver/sldservice/rest/ClassifierTest.java
@@ -639,7 +639,7 @@ public class ClassifierTest extends SLDServiceBaseTest {
         Document dom = getAsDOM(restPath, 200);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         print(dom, baos);
-        String resultXml = baos.toString().replace("\r", "").replace("\n", "");
+        String resultXml = trimTitles(baos.toString()).replace("\r", "").replace("\n", "");
         Rule[] rules =
                 checkRules(
                         resultXml.replace("<Rules>", sldPrefix).replace("</Rules>", sldPostfix), 4);
@@ -649,6 +649,11 @@ public class ClassifierTest extends SLDServiceBaseTest {
         assertEquals(" >= 43.0 AND < 61.0", rules[1].getDescription().getTitle().toString());
         assertEquals(" >= 61.0 AND < 90.0", rules[2].getDescription().getTitle().toString());
         assertEquals(" >= 90.0", rules[3].getDescription().getTitle().toString());
+    }
+
+    /** Trim whitespace in Title elements preserving a single leading space character. */
+    private static String trimTitles(String xml) {
+        return xml.replaceAll("<Title>\\s+", "<Title> ").replaceAll("\\s+</Title>", "</Title>");
     }
 
     @Test
@@ -661,7 +666,7 @@ public class ClassifierTest extends SLDServiceBaseTest {
                         + "attribute=foo&intervals=5&open=true&method=equalArea&stddevs=1";
         MockHttpServletResponse response = getAsServletResponse(restPath);
         assertEquals(200, response.getStatus());
-        String resultXml = response.getContentAsString();
+        String resultXml = trimTitles(response.getContentAsString());
         // System.out.println(resultXml);
         Rule[] rules =
                 checkRules(
@@ -687,7 +692,7 @@ public class ClassifierTest extends SLDServiceBaseTest {
         Document dom = getAsDOM(restPath, 200);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         print(dom, baos);
-        String resultXml = baos.toString().replace("\r", "").replace("\n", "");
+        String resultXml = trimTitles(baos.toString()).replace("\r", "").replace("\n", "");
         Rule[] rules =
                 checkRules(
                         resultXml.replace("<Rules>", sldPrefix).replace("</Rules>", sldPostfix), 3);
@@ -2670,7 +2675,7 @@ public class ClassifierTest extends SLDServiceBaseTest {
         print(domArea);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         print(domArea, baos);
-        String result = baos.toString().replace("\r", "").replace("\n", "");
+        String result = trimTitles(baos.toString()).replace("\r", "").replace("\n", "");
         Rule[] rules =
                 checkSLD(result.replace("<Rules>", sldPrefix).replace("</Rules>", sldPostfix));
 

--- a/src/extension/wps/web-wps/pom.xml
+++ b/src/extension/wps/web-wps/pom.xml
@@ -36,16 +36,6 @@
       <version>${gs.version}</version>
     </dependency>
     <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>serializer</artifactId>
-      <exclusions>
-        <exclusion>
-          <artifactId>xml-apis</artifactId>
-          <groupId>xml-apis</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
       <version>${gs.version}</version>

--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSExecuteTransformerTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/WPSExecuteTransformerTest.java
@@ -57,8 +57,8 @@ public class WPSExecuteTransformerTest extends GeoServerWicketTestSupport {
     }
 
     @Test
-    public void testSingleProcess() throws Exception {
-        ExecuteRequest executeBuffer = getExecuteBuffer();
+    public void testSingleProcessInputWKT() throws Exception {
+        ExecuteRequest executeBuffer = getExecuteBuffer(true);
 
         WPSExecuteTransformer tx = new WPSExecuteTransformer();
         tx.setIndentation(2);
@@ -103,13 +103,63 @@ public class WPSExecuteTransformerTest extends GeoServerWicketTestSupport {
     }
 
     @Test
-    public void testSubprocess() throws Exception {
+    public void testSingleProcessInputGML() throws Exception {
+        ExecuteRequest executeBuffer = getExecuteBuffer(false);
+
+        WPSExecuteTransformer tx = new WPSExecuteTransformer();
+        tx.setIndentation(2);
+        String xml = tx.transform(executeBuffer);
+        // System.out.println(xml);
+
+        String expected =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+                        + "xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" "
+                        + "xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" "
+                        + "xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" "
+                        + "xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" "
+                        + "xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
+                        + "  <ows:Identifier>JTS:buffer</ows:Identifier>\n"
+                        + "  <wps:DataInputs>\n"
+                        + "    <wps:Input>\n"
+                        + "      <ows:Identifier>geom</ows:Identifier>\n"
+                        + "      <wps:Data>\n"
+                        + "        <wps:ComplexData mimeType=\"text/xml; subtype=gml/2.1.2\">\n"
+                        + "          <gml:Point xmlns:gml=\"http://www.opengis.net/gml\">\n"
+                        + "            <gml:coordinates>0,0</gml:coordinates>\n"
+                        + "          </gml:Point>\n"
+                        + "        </wps:ComplexData>\n"
+                        + "      </wps:Data>\n"
+                        + "    </wps:Input>\n"
+                        + "    <wps:Input>\n"
+                        + "      <ows:Identifier>distance</ows:Identifier>\n"
+                        + "      <wps:Data>\n"
+                        + "        <wps:LiteralData>10</wps:LiteralData>\n"
+                        + "      </wps:Data>\n"
+                        + "    </wps:Input>\n"
+                        + "  </wps:DataInputs>\n"
+                        + "  <wps:ResponseForm>\n"
+                        + "    <wps:RawDataOutput mimeType=\"text/xml; subtype=gml/3.1.1\">\n"
+                        + "      <ows:Identifier>result</ows:Identifier>\n"
+                        + "    </wps:RawDataOutput>\n"
+                        + "  </wps:ResponseForm>\n"
+                        + "</wps:Execute>";
+
+        Document test = XMLUnit.buildTestDocument(xml);
+        checkValidationErrors(test);
+        Document control = XMLUnit.buildControlDocument(expected);
+
+        assertXMLEqual(control, test);
+    }
+
+    @Test
+    public void testSubprocessInputWKT() throws Exception {
         Name areaName = new NameImpl("JTS", "area");
 
         InputParameterValues areaGeomValues = new InputParameterValues(areaName, "geom");
         ParameterValue geom = areaGeomValues.values.get(0);
         geom.setType(ParameterType.SUBPROCESS);
-        geom.setValue(getExecuteBuffer());
+        geom.setValue(getExecuteBuffer(true));
 
         OutputParameter bufferOutput = new OutputParameter(areaName, "result");
 
@@ -140,6 +190,81 @@ public class WPSExecuteTransformerTest extends GeoServerWicketTestSupport {
                         + "                <ows:Identifier>geom</ows:Identifier>\n"
                         + "                <wps:Data>\n"
                         + "                  <wps:ComplexData mimeType=\"application/wkt\"><![CDATA[POINT(0 0)]]></wps:ComplexData>\n"
+                        + "                </wps:Data>\n"
+                        + "              </wps:Input>\n"
+                        + "              <wps:Input>\n"
+                        + "                <ows:Identifier>distance</ows:Identifier>\n"
+                        + "                <wps:Data>\n"
+                        + "                  <wps:LiteralData>10</wps:LiteralData>\n"
+                        + "                </wps:Data>\n"
+                        + "              </wps:Input>\n"
+                        + "            </wps:DataInputs>\n"
+                        + "            <wps:ResponseForm>\n"
+                        + "              <wps:RawDataOutput mimeType=\"text/xml; subtype=gml/3.1.1\">\n"
+                        + "                <ows:Identifier>result</ows:Identifier>\n"
+                        + "              </wps:RawDataOutput>\n"
+                        + "            </wps:ResponseForm>\n"
+                        + "          </wps:Execute>\n"
+                        + "        </wps:Body>\n"
+                        + "      </wps:Reference>\n"
+                        + "    </wps:Input>\n"
+                        + "  </wps:DataInputs>\n"
+                        + "  <wps:ResponseForm>\n"
+                        + "    <wps:RawDataOutput>\n"
+                        + "      <ows:Identifier>result</ows:Identifier>\n"
+                        + "    </wps:RawDataOutput>\n"
+                        + "  </wps:ResponseForm>\n"
+                        + "</wps:Execute>";
+
+        Document test = XMLUnit.buildTestDocument(xml);
+        checkValidationErrors(test);
+        Document control = XMLUnit.buildControlDocument(expected);
+
+        assertXMLEqual(control, test);
+    }
+
+    @Test
+    public void testSubprocessInputGML() throws Exception {
+        Name areaName = new NameImpl("JTS", "area");
+
+        InputParameterValues areaGeomValues = new InputParameterValues(areaName, "geom");
+        ParameterValue geom = areaGeomValues.values.get(0);
+        geom.setType(ParameterType.SUBPROCESS);
+        geom.setValue(getExecuteBuffer(false));
+
+        OutputParameter bufferOutput = new OutputParameter(areaName, "result");
+
+        ExecuteRequest executeArea =
+                new ExecuteRequest(
+                        areaName.getURI(),
+                        Arrays.asList(areaGeomValues),
+                        Arrays.asList(bufferOutput));
+
+        WPSExecuteTransformer tx = new WPSExecuteTransformer();
+        tx.setIndentation(2);
+        String xml = tx.transform(executeArea);
+        // System.out.println(xml);
+
+        String expected =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
+                        + "  <ows:Identifier>JTS:area</ows:Identifier>\n"
+                        + "  <wps:DataInputs>\n"
+                        + "    <wps:Input>\n"
+                        + "      <ows:Identifier>geom</ows:Identifier>\n"
+                        + "      <wps:Reference mimeType=\"text/xml; subtype=gml/3.1.1\" xlink:href=\"http://geoserver/wps\" method=\"POST\">\n"
+                        + "        <wps:Body>\n"
+                        + "          <wps:Execute version=\"1.0.0\" service=\"WPS\">\n"
+                        + "            <ows:Identifier>JTS:buffer</ows:Identifier>\n"
+                        + "            <wps:DataInputs>\n"
+                        + "              <wps:Input>\n"
+                        + "                <ows:Identifier>geom</ows:Identifier>\n"
+                        + "                <wps:Data>\n"
+                        + "                  <wps:ComplexData mimeType=\"text/xml; subtype=gml/2.1.2\">\n"
+                        + "                    <gml:Point xmlns:gml=\"http://www.opengis.net/gml\">\n"
+                        + "                      <gml:coordinates>0,0</gml:coordinates>\n"
+                        + "                    </gml:Point>\n"
+                        + "                  </wps:ComplexData>\n"
                         + "                </wps:Data>\n"
                         + "              </wps:Input>\n"
                         + "              <wps:Input>\n"
@@ -288,13 +413,16 @@ public class WPSExecuteTransformerTest extends GeoServerWicketTestSupport {
         return executeBuffer;
     }
 
-    private ExecuteRequest getExecuteBuffer() {
+    private ExecuteRequest getExecuteBuffer(boolean wkt) {
         Name bufferName = new NameImpl("JTS", "buffer");
         InputParameterValues bufferGeomValues = new InputParameterValues(bufferName, "geom");
         ParameterValue geom = bufferGeomValues.values.get(0);
-        geom.setMime("application/wkt");
+        geom.setMime(wkt ? "application/wkt" : "text/xml; subtype=gml/2.1.2");
         geom.setType(ParameterType.TEXT);
-        geom.setValue("POINT(0 0)");
+        geom.setValue(
+                wkt
+                        ? "POINT(0 0)"
+                        : "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\"><gml:coordinates>0,0</gml:coordinates></gml:Point>");
 
         InputParameterValues bufferDistanceValues =
                 new InputParameterValues(bufferName, "distance");

--- a/src/ows/pom.xml
+++ b/src/ows/pom.xml
@@ -81,22 +81,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>xml-apis</artifactId>
-          <groupId>xml-apis</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>serializer</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>jakarta.mail</artifactId>
       <scope>test</scope>

--- a/src/release/ext-wps.xml
+++ b/src/release/ext-wps.xml
@@ -14,7 +14,6 @@
         <include>gt-process-geometry*</include>
         <include>gt-xsd-wps*</include>
         <include>net.opengis.wps*</include>
-        <include>serializer*</include>
         <include>gt-csv*</include>
         <include>opencsv*</include>
         <!-- kmlppio dependencies -->

--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -86,20 +86,6 @@
       <artifactId>pngj</artifactId>
     </dependency>
     <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <exclusions>
-        <exclusion>
-          <artifactId>xml-apis</artifactId>
-          <groupId>xml-apis</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>serializer</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/RasterLayerIdentifier.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.media.jai.PlanarImage;
-import org.apache.xml.utils.XMLChar;
+import org.eclipse.emf.ecore.xml.type.internal.DataValue.XMLChar;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.wms.FeatureInfoRequestParameters;

--- a/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformerTest.java
@@ -481,9 +481,8 @@ public class GetCapabilitiesTransformerTest extends WMSTestSupport {
         String xml = sw.toString();
         xml =
                 xml.replace(
-                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                                + "<!DOCTYPE WMT_MS_Capabilities SYSTEM \"WMS_MS_Capabilities.dtd\">");
+                        "<WMT_MS_Capabilities ",
+                        "<!DOCTYPE WMT_MS_Capabilities SYSTEM \"WMS_MS_Capabilities.dtd\"><WMT_MS_Capabilities ");
 
         return xml;
     }


### PR DESCRIPTION
[![GEOS-11242](https://badgen.net/badge/JIRA/GEOS-11242/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11242) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR contains the following changes to completely remove the xalan:xalan and xalan:serializer dependencies:

1. WMS: Replaced the Xalan XMLChar class in RasterLayerIdentifier with the Eclipse EMF XMLChar class (covered by org.geoserver.wms.featureinfo.RasterLayerIdentifierTest). Updated the WMS GetCapabilities DTD unit test to be more lenient with the XML prolog.
2. OWS: Refactored unit tests to use the XPath API from XMLUnit instead of Xalan (like other tests do).
3. CSW: Refactored main code to remove xalan:serializer dependency (covered by org.geoserver.csw.GetRecordsTest.testValidatePost).
4. WPS: Refactored main code to remove xalan:serializer dependency and added new unit tests (the UTF-16 to UTF-8 change was necessary for unit tests to pass).
5. SLD Service: Upgraded XOM dependency to remove transitive Xalan dependency and updated unit tests to be more lenient with leading/trailing whitespace.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->