### PR TITLE
[Backport 2.24.x] [GEOS-11235] preauthentication filters - session reuse even after having logout

### DIFF
--- a/src/main/src/test/java/org/geoserver/security/filter/GeoServerRequestHeaderAuthenticationFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/security/filter/GeoServerRequestHeaderAuthenticationFilterTest.java
@@ -1,0 +1,71 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import javax.servlet.http.HttpServletResponse;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+public class GeoServerRequestHeaderAuthenticationFilterTest {
+
+    @Test
+    public void testAuthenticationViaPreAuthChanging() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        HttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+        SecurityContext sc = new SecurityContextImpl();
+        sc.setAuthentication(new PreAuthenticatedAuthenticationToken("testadmin", null));
+        SecurityContextHolder.setContext(sc);
+        GeoServerRequestHeaderAuthenticationFilter toTest =
+                new GeoServerRequestHeaderAuthenticationFilter();
+        toTest.setPrincipalHeaderAttribute("sec-username");
+        request.addHeader("sec-username", "testuser");
+        toTest.setSecurityManager(
+                new GeoServerSecurityManager(new GeoServerDataDirectory(new File("/tmp"))));
+        toTest.setRoleSource(
+                PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource.Header);
+
+        toTest.doFilter(request, response, filterChain);
+
+        assertEquals(
+                "testuser",
+                SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+    }
+
+    @Test
+    public void testAuthenticationViaPreAuthNoHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        HttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+        SecurityContext sc = new SecurityContextImpl();
+        sc.setAuthentication(new PreAuthenticatedAuthenticationToken("testadmin", null));
+        SecurityContextHolder.setContext(sc);
+        GeoServerRequestHeaderAuthenticationFilter toTest =
+                new GeoServerRequestHeaderAuthenticationFilter();
+        toTest.setPrincipalHeaderAttribute("sec-username");
+        toTest.setSecurityManager(
+                new GeoServerSecurityManager(new GeoServerDataDirectory(new File("/tmp"))));
+        toTest.setRoleSource(
+                PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource.Header);
+
+        toTest.doFilter(request, response, filterChain);
+
+        // The security context should have been cleared
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}


### PR DESCRIPTION
[![GEOS-11235](https://badgen.net/badge/JIRA/GEOS-11235/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11235) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7326
 **Authored by:** @pmauduit