### PR TITLE
[GEOS-11051] Env parametrization does not save correctly in AuthKey extension

### DIFF
--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
@@ -220,7 +220,7 @@ public class OpenIdConnectIntegrationTest extends GeoServerSystemTestSupport {
     public void testClientConfidential() throws Exception {
         GeoServerSecurityManager manager = getSecurityManager();
         OpenIdConnectFilterConfig config =
-                (OpenIdConnectFilterConfig) manager.loadFilterConfig("openidconnect");
+                (OpenIdConnectFilterConfig) manager.loadFilterConfig("openidconnect", true);
         config.setSendClientSecret(true);
         manager.saveFilter(config);
 
@@ -245,7 +245,7 @@ public class OpenIdConnectIntegrationTest extends GeoServerSystemTestSupport {
     public void testIdTokenHintInEndSessionURI() throws Exception {
         GeoServerSecurityManager manager = getSecurityManager();
         OpenIdConnectFilterConfig config =
-                (OpenIdConnectFilterConfig) manager.loadFilterConfig("openidconnect");
+                (OpenIdConnectFilterConfig) manager.loadFilterConfig("openidconnect", true);
         config.setSendClientSecret(true);
         config.setPostLogoutRedirectUri(null);
         manager.saveFilter(config);

--- a/src/extension/authkey/src/test/java/org/geoserver/security/AuthKeyAuthenticationTest.java
+++ b/src/extension/authkey/src/test/java/org/geoserver/security/AuthKeyAuthenticationTest.java
@@ -183,6 +183,44 @@ public class AuthKeyAuthenticationTest extends AbstractAuthenticationProviderTes
     }
 
     @Test
+    public void testMapperParametersFromEnvWhenDisabled() throws Exception {
+        String authKeyUrlParam = "myAuthKeyParams";
+        String filterName = "testAuthKeyParams2";
+
+        AuthenticationKeyFilterConfig config = new AuthenticationKeyFilterConfig();
+        config.setClassName(GeoServerAuthenticationKeyFilter.class.getName());
+        config.setName(filterName);
+        config.setUserGroupServiceName("ug1");
+        config.setAuthKeyParamName(authKeyUrlParam);
+        config.setAuthKeyMapperName("fakeMapper");
+
+        System.setProperty("authkey_param1", "value1");
+        System.setProperty("authkey_param2", "value2");
+        System.setProperty("ALLOW_ENV_PARAMETRIZATION", "false");
+        GeoServerEnvironment.reloadAllowEnvParametrization();
+        try {
+            Map<String, String> mapperParams = new HashMap<>();
+            mapperParams.put("param1", "${authkey_param1}");
+            mapperParams.put("param2", "${authkey_param2}");
+            config.setMapperParameters(mapperParams);
+
+            getSecurityManager().saveFilter(config);
+
+            GeoServerAuthenticationKeyFilter filter =
+                    (GeoServerAuthenticationKeyFilter) getSecurityManager().loadFilter(filterName);
+            assertTrue(filter.getMapper() instanceof FakeMapper);
+            FakeMapper fakeMapper = (FakeMapper) filter.getMapper();
+            assertEquals("${authkey_param1}", fakeMapper.getMapperParameter("param1"));
+            assertEquals("${authkey_param2}", fakeMapper.getMapperParameter("param2"));
+        } finally {
+            System.clearProperty("authkey_param1");
+            System.clearProperty("authkey_param2");
+            System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
+            GeoServerEnvironment.reloadAllowEnvParametrization();
+        }
+    }
+
+    @Test
     public void testMapperParamsFilterConfigValidation() throws Exception {
 
         AuthenticationKeyFilterConfigValidator validator =

--- a/src/extension/authkey/src/test/java/org/geoserver/security/AuthKeyAuthenticationTest.java
+++ b/src/extension/authkey/src/test/java/org/geoserver/security/AuthKeyAuthenticationTest.java
@@ -185,7 +185,7 @@ public class AuthKeyAuthenticationTest extends AbstractAuthenticationProviderTes
     @Test
     public void testMapperParametersFromEnvWhenDisabled() throws Exception {
         String authKeyUrlParam = "myAuthKeyParams";
-        String filterName = "testAuthKeyParams2";
+        String filterName = "testAuthKeyParams3";
 
         AuthenticationKeyFilterConfig config = new AuthenticationKeyFilterConfig();
         config.setClassName(GeoServerAuthenticationKeyFilter.class.getName());

--- a/src/extension/authkey/src/test/java/org/geoserver/security/AuthenticationKeyOWSTest.java
+++ b/src/extension/authkey/src/test/java/org/geoserver/security/AuthenticationKeyOWSTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 
-public class AuthencationKeyOWSTest extends GeoServerSystemTestSupport {
+public class AuthenticationKeyOWSTest extends GeoServerSystemTestSupport {
 
     private static String adminKey;
 

--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
@@ -855,7 +855,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      * @param name The name of the role service configuration.
      */
     public SecurityRoleServiceConfig loadRoleServiceConfig(String name) throws IOException {
-        return roleServiceHelper.loadConfig(name);
+        return roleServiceHelper.loadConfig(name, true);
     }
 
     /**
@@ -890,7 +890,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      * @param name The name of the password policy configuration.
      */
     public PasswordPolicyConfig loadPasswordPolicyConfig(String name) throws IOException {
-        return passwordValidatorHelper.loadConfig(name);
+        return passwordValidatorHelper.loadConfig(name, true);
     }
 
     /**
@@ -1014,7 +1014,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      * <p>This method does the determination by trying to encrypt a value with AES 256 Bit
      * encryption.
      *
-     * @return True if strong encryption avaialble, otherwise false.
+     * @return True if strong encryption available, otherwise false.
      */
     public boolean isStrongEncryptionAvailable() {
         if (strongEncryptionAvaialble != null) return strongEncryptionAvaialble;
@@ -1056,7 +1056,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
             validator.validateAddRoleService(config);
         } else {
             validator.validateModifiedRoleService(
-                    config, roleServiceHelper.loadConfig(config.getName()));
+                    config, roleServiceHelper.loadConfig(config.getName(), true));
         }
 
         roleServiceHelper.saveConfig(config);
@@ -1083,7 +1083,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
             validator.validateAddPasswordPolicy(config);
         } else {
             validator.validateModifiedPasswordPolicy(
-                    config, passwordValidatorHelper.loadConfig(config.getName()));
+                    config, passwordValidatorHelper.loadConfig(config.getName(), true));
         }
 
         passwordValidatorHelper.saveConfig(config);
@@ -1206,7 +1206,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      */
     public SecurityUserGroupServiceConfig loadUserGroupServiceConfig(String name)
             throws IOException {
-        return userGroupServiceHelper.loadConfig(name);
+        return userGroupServiceHelper.loadConfig(name, true);
     }
 
     /** Saves/persists a user group service configuration. */
@@ -1221,7 +1221,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
             validator.validateAddUserGroupService(config);
         } else {
             validator.validateModifiedUserGroupService(
-                    config, userGroupServiceHelper.loadConfig(config.getName()));
+                    config, userGroupServiceHelper.loadConfig(config.getName(), true));
         }
 
         userGroupServiceHelper.saveConfig(config);
@@ -1270,7 +1270,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      */
     public SecurityAuthProviderConfig loadAuthenticationProviderConfig(String name)
             throws IOException {
-        return authProviderHelper.loadConfig(name);
+        return authProviderHelper.loadConfig(name, true);
     }
 
     public void saveAuthenticationProvider(SecurityAuthProviderConfig config)
@@ -1284,7 +1284,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
             validator.validateAddAuthProvider(config);
         } else {
             validator.validateModifiedAuthProvider(
-                    config, authProviderHelper.loadConfig(config.getName()));
+                    config, authProviderHelper.loadConfig(config.getName(), true));
         }
 
         // update the running auth providers
@@ -1391,7 +1391,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
     public SortedSet<String> listFilters(Class<?> type) throws IOException {
         SortedSet<String> configs = new TreeSet<>();
         for (String name : listFilters()) {
-            SecurityFilterConfig config = loadFilterConfig(name);
+            SecurityFilterConfig config = loadFilterConfig(name, true);
             if (config.getClassName() == null) {
                 continue;
             }
@@ -1426,7 +1426,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      */
     public SecurityFilterConfig loadFilterConfig(String name, MigrationHelper migrationHelper)
             throws IOException {
-        return filterHelper.loadConfig(name, migrationHelper);
+        return filterHelper.loadConfig(name, migrationHelper, true);
     }
 
     /**
@@ -1435,8 +1435,9 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      *
      * @param name The name of the authentication provider service configuration.
      */
-    public SecurityFilterConfig loadFilterConfig(String name) throws IOException {
-        return filterHelper.loadConfig(name);
+    public SecurityFilterConfig loadFilterConfig(String name, boolean allowEnvParametrization)
+            throws IOException {
+        return filterHelper.loadConfig(name, allowEnvParametrization);
     }
 
     public void saveFilter(SecurityNamedServiceConfig config)
@@ -1457,7 +1458,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
             validator.validateAddFilter(config);
         } else {
             validator.validateModifiedFilter(
-                    config, filterHelper.loadConfig(config.getName(), migrationHelper));
+                    config, filterHelper.loadConfig(config.getName(), migrationHelper, true));
             // remove all cached authentications for this filter
             getAuthenticationCache().removeAll(config.getName());
             if (!securityConfig
@@ -1627,7 +1628,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
                 // updateConfigurationFilesWithEncryptedFields();
                 // }
             } catch (IOException e) {
-                // error occured, roll back
+                // error occurred, roll back
                 ksProvider.abortMasterPasswordChange();
 
                 // revert to old master password config
@@ -1666,7 +1667,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         try {
             if (forLogin
                     && !this.masterPasswordProviderHelper
-                            .loadConfig(this.masterPasswordConfig.getProviderName())
+                            .loadConfig(this.masterPasswordConfig.getProviderName(), true)
                             .isLoginEnabled()) {
                 return false;
             }
@@ -1779,7 +1780,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      */
     public MasterPasswordProviderConfig loadMasterPassswordProviderConfig(String name)
             throws IOException {
-        return masterPasswordProviderHelper.loadConfig(name);
+        return masterPasswordProviderHelper.loadConfig(name, true);
     }
 
     /**
@@ -1819,7 +1820,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         } else {
             if (validate) {
                 validator.validateModifiedMasterPasswordProvider(
-                        config, masterPasswordProviderHelper.loadConfig(config.getName()));
+                        config, masterPasswordProviderHelper.loadConfig(config.getName(), true));
             }
         }
 
@@ -2477,7 +2478,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
                     logoutFilterDir.get("config.xml").in(), oldLogoutFilterConfig.out());
         LogoutFilterConfig loConfig =
                 (LogoutFilterConfig)
-                        loadFilterConfig(GeoServerSecurityFilterChain.FORM_LOGOUT_FILTER);
+                        loadFilterConfig(GeoServerSecurityFilterChain.FORM_LOGOUT_FILTER, true);
         loConfig.setRedirectURL(GeoServerLogoutFilter.URL_AFTER_LOGOUT);
         saveFilter(loConfig);
 
@@ -2539,7 +2540,8 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         }
         // gui filter not needed any more
         removeFilter(
-                loadFilterConfig(GeoServerSecurityFilterChain.GUI_EXCEPTION_TRANSLATION_FILTER));
+                loadFilterConfig(
+                        GeoServerSecurityFilterChain.GUI_EXCEPTION_TRANSLATION_FILTER, true));
         saveSecurityConfig(config);
 
         // load and store all filter configuration
@@ -2548,7 +2550,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         // the alias should be used instead, this was bug fixed during GSIP 82
         if (!migratedFrom21) {
             for (String fName : listFilters()) {
-                SecurityFilterConfig fConfig = loadFilterConfig(fName);
+                SecurityFilterConfig fConfig = loadFilterConfig(fName, true);
                 if (fConfig != null) saveFilter(fConfig);
             }
         }
@@ -2586,7 +2588,8 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         ExceptionTranslationFilterConfig config =
                 (ExceptionTranslationFilterConfig)
                         loadFilterConfig(
-                                GeoServerSecurityFilterChain.DYNAMIC_EXCEPTION_TRANSLATION_FILTER);
+                                GeoServerSecurityFilterChain.DYNAMIC_EXCEPTION_TRANSLATION_FILTER,
+                                true);
         if (config != null && "/accessDenied.jsp".equals(config.getAccessDeniedErrorPage())) {
             config.setAccessDeniedErrorPage(null);
             saveFilter(config);
@@ -2595,7 +2598,8 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         config =
                 (ExceptionTranslationFilterConfig)
                         loadFilterConfig(
-                                GeoServerSecurityFilterChain.GUI_EXCEPTION_TRANSLATION_FILTER);
+                                GeoServerSecurityFilterChain.GUI_EXCEPTION_TRANSLATION_FILTER,
+                                true);
         if (config != null && "/accessDenied.jsp".equals(config.getAccessDeniedErrorPage())) {
             config.setAccessDeniedErrorPage(null);
             saveFilter(config);
@@ -2685,7 +2689,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      * loads the global security config
      */
     public SecurityManagerConfig loadSecurityConfig() throws IOException {
-        return (SecurityManagerConfig) loadConfigFile(security(), globalPersister());
+        return (SecurityManagerConfig) loadConfigFile(security(), globalPersister(), true);
     }
 
     /*
@@ -2705,10 +2709,14 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         }
     }
     /** reads a config file from the specified directly using the specified xstream persister */
-    SecurityConfig loadConfigFile(Resource directory, String filename, XStreamPersister xp)
+    SecurityConfig loadConfigFile(
+            Resource directory,
+            String filename,
+            XStreamPersister xp,
+            boolean allowEnvParametrization)
             throws IOException {
         try (InputStream fin = directory.get(filename).in()) {
-            return xp.load(fin, SecurityConfig.class).clone(true);
+            return xp.load(fin, SecurityConfig.class).clone(allowEnvParametrization);
         }
     }
 
@@ -2716,8 +2724,10 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
      * reads a file named {@value #CONFIG_FILENAME} from the specified directly using the specified
      * xstream persister
      */
-    SecurityConfig loadConfigFile(Resource directory, XStreamPersister xp) throws IOException {
-        return loadConfigFile(directory, CONFIG_FILENAME, xp);
+    SecurityConfig loadConfigFile(
+            Resource directory, XStreamPersister xp, boolean allowEnvParametrization)
+            throws IOException {
+        return loadConfigFile(directory, CONFIG_FILENAME, xp, allowEnvParametrization);
     }
 
     /** saves a config file to the specified directly using the specified xstream persister */
@@ -2748,7 +2758,9 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         public abstract T load(String name) throws IOException;
 
         /** loads the named entity config from persistence */
-        public C loadConfig(String name, MigrationHelper migrationHelper) throws IOException {
+        public C loadConfig(
+                String name, MigrationHelper migrationHelper, boolean allowEnvParametrization)
+                throws IOException {
             Resource dir = getRoot().get(name);
             if (dir.getType() != Type.DIRECTORY) {
                 return null;
@@ -2759,13 +2771,13 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
                 migrationHelper.migrationPersister(xp);
             }
             @SuppressWarnings("unchecked")
-            C config = (C) loadConfigFile(dir, xp);
+            C config = (C) loadConfigFile(dir, xp, allowEnvParametrization);
             return config;
         }
 
         /** loads the named entity config from persistence */
-        public C loadConfig(String name) throws IOException {
-            return loadConfig(name, null);
+        public C loadConfig(String name, boolean allowEnvParametrization) throws IOException {
+            return loadConfig(name, null, allowEnvParametrization);
         }
 
         /** saves the user group service config to persistence */
@@ -2814,7 +2826,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         @Override
         public GeoServerUserGroupService load(String name) throws IOException {
 
-            SecurityNamedServiceConfig config = loadConfig(name);
+            SecurityNamedServiceConfig config = loadConfig(name, true);
             if (config == null) {
                 // no such config
                 return null;
@@ -2882,7 +2894,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         @Override
         public GeoServerRoleService load(String name) throws IOException {
 
-            SecurityNamedServiceConfig config = loadConfig(name);
+            SecurityNamedServiceConfig config = loadConfig(name, true);
             if (config == null) {
                 // no such config
                 return null;
@@ -2976,7 +2988,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         @Override
         public PasswordValidator load(String name) throws IOException {
 
-            PasswordPolicyConfig config = loadConfig(name);
+            PasswordPolicyConfig config = loadConfig(name, true);
             if (config == null) {
                 // no such config
                 return null;
@@ -3013,7 +3025,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
 
         @Override
         public MasterPasswordProvider load(String name) throws IOException {
-            MasterPasswordProviderConfig config = loadConfig(name);
+            MasterPasswordProviderConfig config = loadConfig(name, true);
             if (config == null) {
                 return null;
             }
@@ -3094,7 +3106,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         }
 
         for (String name : listPasswordValidators()) {
-            PasswordPolicyConfig config = passwordValidatorHelper.loadConfig(name);
+            PasswordPolicyConfig config = passwordValidatorHelper.loadConfig(name, true);
             for (Class<?> classWithEncryption : configClasses) {
                 if (config.getClass().isAssignableFrom(classWithEncryption)) {
                     passwordValidatorHelper.saveConfig(config);
@@ -3103,7 +3115,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
             }
         }
         for (String name : listRoleServices()) {
-            SecurityNamedServiceConfig config = roleServiceHelper.loadConfig(name);
+            SecurityNamedServiceConfig config = roleServiceHelper.loadConfig(name, true);
             for (Class<?> classWithEncryption : configClasses) {
                 if (config.getClass().isAssignableFrom(classWithEncryption)) {
                     roleServiceHelper.saveConfig(config);
@@ -3112,7 +3124,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
             }
         }
         for (String name : listUserGroupServices()) {
-            SecurityNamedServiceConfig config = userGroupServiceHelper.loadConfig(name);
+            SecurityNamedServiceConfig config = userGroupServiceHelper.loadConfig(name, true);
             for (Class<?> classWithEncryption : configClasses) {
                 if (config.getClass().isAssignableFrom(classWithEncryption)) {
                     userGroupServiceHelper.saveConfig(config);
@@ -3122,7 +3134,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         }
 
         for (String name : listAuthenticationProviders()) {
-            SecurityNamedServiceConfig config = authProviderHelper.loadConfig(name);
+            SecurityNamedServiceConfig config = authProviderHelper.loadConfig(name, true);
             for (Class<?> classWithEncryption : configClasses) {
                 if (config.getClass().isAssignableFrom(classWithEncryption)) {
                     authProviderHelper.saveConfig(config);
@@ -3132,7 +3144,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         }
 
         for (String name : listFilters()) {
-            SecurityNamedServiceConfig config = filterHelper.loadConfig(name);
+            SecurityNamedServiceConfig config = filterHelper.loadConfig(name, true);
             for (Class<?> classWithEncryption : configClasses) {
                 if (config.getClass().isAssignableFrom(classWithEncryption)) {
                     filterHelper.saveConfig(config);
@@ -3170,7 +3182,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         @Override
         public GeoServerAuthenticationProvider load(String name) throws IOException {
 
-            SecurityNamedServiceConfig config = loadConfig(name);
+            SecurityNamedServiceConfig config = loadConfig(name, true);
             if (config == null) {
                 // no such config
                 return null;
@@ -3211,7 +3223,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         @Override
         public GeoServerSecurityFilter load(String name) throws IOException {
 
-            SecurityNamedServiceConfig config = loadConfig(name);
+            SecurityNamedServiceConfig config = loadConfig(name, true);
             if (config == null) {
                 // no such config
                 return null;

--- a/src/main/src/main/java/org/geoserver/security/validation/FilterConfigValidator.java
+++ b/src/main/src/main/java/org/geoserver/security/validation/FilterConfigValidator.java
@@ -258,7 +258,7 @@ public class FilterConfigValidator extends SecurityConfigValidator {
         if (isNotEmpty(config.getAuthenticationFilterName())) {
             try {
                 SecurityNamedServiceConfig filterConfig =
-                        manager.loadFilterConfig(config.getAuthenticationFilterName());
+                        manager.loadFilterConfig(config.getAuthenticationFilterName(), true);
                 if (filterConfig == null)
                     throw createFilterException(
                             FilterConfigException.INVALID_ENTRY_POINT,

--- a/src/main/src/test/java/org/geoserver/data/test/MockCreator.java
+++ b/src/main/src/test/java/org/geoserver/data/test/MockCreator.java
@@ -298,7 +298,9 @@ public class MockCreator implements Callback {
         // security filters
         SecurityInterceptorFilterConfig filterConfig =
                 createNiceMock(SecurityInterceptorFilterConfig.class);
-        expect(secMgr.loadFilterConfig(GeoServerSecurityFilterChain.FILTER_SECURITY_INTERCEPTOR))
+        expect(
+                        secMgr.loadFilterConfig(
+                                GeoServerSecurityFilterChain.FILTER_SECURITY_INTERCEPTOR, true))
                 .andReturn(filterConfig)
                 .anyTimes();
 

--- a/src/security/security-tests/src/test/java/org/geoserver/security/GeoServerCustomFilterTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/GeoServerCustomFilterTest.java
@@ -53,7 +53,7 @@ public class GeoServerCustomFilterTest extends GeoServerSystemTestSupport {
     public void removeCustomFilterConfig() throws Exception {
         GeoServerSecurityManager secMgr = getSecurityManager();
         if (secMgr.listFilters().contains("custom")) {
-            secMgr.removeFilter(secMgr.loadFilterConfig("custom"));
+            secMgr.removeFilter(secMgr.loadFilterConfig("custom", true));
         }
         secMgr.getSecurityConfig().getFilterChain().remove("custom");
 

--- a/src/security/security-tests/src/test/java/org/geoserver/security/MigrateFrom_2_2_Test.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/MigrateFrom_2_2_Test.java
@@ -51,21 +51,22 @@ public class MigrateFrom_2_2_Test extends GeoServerSystemTestSupport {
         RoleFilterConfig rfConfig =
                 (RoleFilterConfig)
                         getSecurityManager()
-                                .loadFilterConfig(GeoServerSecurityFilterChain.ROLE_FILTER);
+                                .loadFilterConfig(GeoServerSecurityFilterChain.ROLE_FILTER, true);
 
         assertNotNull(rfConfig);
 
         SSLFilterConfig sslConfig =
                 (SSLFilterConfig)
                         getSecurityManager()
-                                .loadFilterConfig(GeoServerSecurityFilterChain.SSL_FILTER);
+                                .loadFilterConfig(GeoServerSecurityFilterChain.SSL_FILTER, true);
 
         assertNotNull(sslConfig);
 
         assertNull(
                 getSecurityManager()
                         .loadFilterConfig(
-                                GeoServerSecurityFilterChain.GUI_EXCEPTION_TRANSLATION_FILTER));
+                                GeoServerSecurityFilterChain.GUI_EXCEPTION_TRANSLATION_FILTER,
+                                true));
 
         SecurityManagerConfig config = getSecurityManager().loadSecurityConfig();
         for (RequestFilterChain chain : config.getFilterChain().getRequestChains()) {

--- a/src/security/security-tests/src/test/java/org/geoserver/security/auth/AuthenticationFilterTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/auth/AuthenticationFilterTest.java
@@ -98,7 +98,7 @@ public class AuthenticationFilterTest extends AbstractAuthenticationProviderTest
     public void revertFilters() throws Exception {
         GeoServerSecurityManager secMgr = getSecurityManager();
         if (secMgr.listFilters().contains(testFilterName2)) {
-            SecurityFilterConfig config = secMgr.loadFilterConfig(testFilterName2);
+            SecurityFilterConfig config = secMgr.loadFilterConfig(testFilterName2, true);
             secMgr.removeFilter(config);
         }
     }

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
@@ -151,7 +151,7 @@ public class GeoServerBasePage extends WebPage implements IAjaxIndicatorAware {
         List<String> securityFilterClassNames = new ArrayList<>();
         for (String name : securityFiltersNames) {
             try {
-                SecurityFilterConfig config = securityManager.loadFilterConfig(name);
+                SecurityFilterConfig config = securityManager.loadFilterConfig(name, true);
                 securityFilterClassNames.add(config.getClassName());
             } catch (Exception e) {
                 LOGGER.log(Level.FINE, "Could not load security filter config for " + name, e);

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/auth/AuthenticationFiltersProvider.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/auth/AuthenticationFiltersProvider.java
@@ -21,7 +21,9 @@ public class AuthenticationFiltersProvider
         try {
             for (String name :
                     getSecurityManager().listFilters(GeoServerAuthenticationFilter.class)) {
-                result.add((SecurityAuthFilterConfig) getSecurityManager().loadFilterConfig(name));
+                result.add(
+                        (SecurityAuthFilterConfig)
+                                getSecurityManager().loadFilterConfig(name, false));
             }
         } catch (IOException ex) {
             throw new RuntimeException(ex);

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/auth/AuthenticationPage.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/auth/AuthenticationPage.java
@@ -104,7 +104,7 @@ public class AuthenticationPage extends AbstractSecurityPage {
                     (LogoutFilterConfig)
                             getSecurityManager()
                                     .loadFilterConfig(
-                                            GeoServerSecurityFilterChain.FORM_LOGOUT_FILTER);
+                                            GeoServerSecurityFilterChain.FORM_LOGOUT_FILTER, true);
         } catch (IOException e1) {
             throw new RuntimeException(e1);
         }
@@ -117,7 +117,8 @@ public class AuthenticationPage extends AbstractSecurityPage {
             sslFilterConfig =
                     (SSLFilterConfig)
                             getSecurityManager()
-                                    .loadFilterConfig(GeoServerSecurityFilterChain.SSL_FILTER);
+                                    .loadFilterConfig(
+                                            GeoServerSecurityFilterChain.SSL_FILTER, true);
         } catch (IOException e1) {
             throw new RuntimeException(e1);
         }


### PR DESCRIPTION
[![GEOS-11051](https://badgen.net/badge/JIRA/GEOS-11051/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11051) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**A parameterised webServiceUrl, when loaded from XML is not displayed as parameterised and when saved again, overwrites the parameterisation.  See the above issue for more details/screenshots.**

The problem is that when the filter config is cloned in order to be displayed for editing, the mapperParameters are resolved (i.e. `${...}` placeholders are converted into their real values).  This real value is then saved to the XML file, instead of the unresolved placeholders.

The solution identified [exactly where](https://github.com/geoserver/geoserver/blob/95d0ad588e7d43a58e09a7672ca70c55deac0cbf/src/web/security/core/src/main/java/org/geoserver/security/web/auth/AuthenticationFiltersProvider.java#L26C79-L26C79) the filter configs are created for editing purposes, and only this instance of `loadFilterConfig` is modified to not resolve placeholders, leaving all other instances to resolve, as before.  

This means that the edit box displays the unresolved placeholders, as expected, which is consistent with other edit boxes that typically contain ENV parameter placeholders, e.g. Data store JDBC connection strings, Global proxy base URL, etc.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->