### PR TITLE
Graticule store/process improvements, round 2

### DIFF
--- a/doc/en/user/source/community/graticules/index.rst
+++ b/doc/en/user/source/community/graticules/index.rst
@@ -136,8 +136,8 @@ to simplify the labelling process:
 
 The process itself takes the following parameters:
 
-* "grid" is the grid lines being processed (the graticule layer)
-* "boundingBox" is the bounding box of the map being rendered, which is used to clip lines and to calculate the label points, 
+* "grid" is the grid lines being processed (the graticule layer).
+* "boundingBox" is the bounding box of the map being rendered, which is used to clip lines and to calculate the label points. This parameter is optional, if missing the labels will be generated at the end of the graticule lines no matter what the display area is. For un-tiled maps, the usage of "boundingBox" helps having the labels as a reference in every map, while for tiled maps it's better to omit it, or the labels will be repeated at the border of every (meta)tile.
 * "offset" is the offset of the label from the grid line (used to compute the values of "offsetX" and "offsetY"), which can be provided using the current request bounding box using the ``wms_bbox`` environment variable (:ref:`sld_variable_substitution`).
 * "positions" indicates which groups of labels should be generated, and can be one of "top", "bottom", "left", "right" or "topleft", "topright", "bottomleft", "bottomright", or the default value "both" which generates labels on all four sides of the map.
 

--- a/src/community/graticule/pom.xml
+++ b/src/community/graticule/pom.xml
@@ -87,6 +87,13 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+      <version>${gs.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/src/community/graticule/src/main/java/org/geoserver/web/data/store/graticule/GraticulePanel.java
+++ b/src/community/graticule/src/main/java/org/geoserver/web/data/store/graticule/GraticulePanel.java
@@ -59,8 +59,9 @@ public class GraticulePanel extends Panel {
                                 "bounds",
                                 new MapModel<org.geotools.geometry.jts.ReferencedEnvelope>(
                                         paramsModel, "bounds")));
-
-        bounds.setDefaultModelObject(new ReferencedEnvelope(DEFAULT_CRS));
+        if (bounds.getModelObject() == null) {
+            bounds.setDefaultModelObject(new ReferencedEnvelope(DEFAULT_CRS));
+        }
         bounds.setRequired(true);
         bounds.setCRSFieldVisible(true);
         bounds.setCrsRequired(true);

--- a/src/community/graticule/src/main/java/org/geoserver/web/data/store/graticule/GraticulePanel.java
+++ b/src/community/graticule/src/main/java/org/geoserver/web/data/store/graticule/GraticulePanel.java
@@ -36,7 +36,7 @@ public class GraticulePanel extends Panel {
 
     static {
         try {
-            DEFAULT_CRS = CRS.decode("EPSG:4326");
+            DEFAULT_CRS = CRS.decode("EPSG:4326", true);
         } catch (FactoryException e) {
             LOGGER.log(Level.FINER, e.getMessage(), e);
         }

--- a/src/community/graticule/src/main/java/org/geotools/data/graticule/GraticuleDataStoreFactory.java
+++ b/src/community/graticule/src/main/java/org/geotools/data/graticule/GraticuleDataStoreFactory.java
@@ -26,6 +26,8 @@ import org.geotools.util.KVP;
 public class GraticuleDataStoreFactory implements DataStoreFactorySpi {
     static final Logger log = Logger.getLogger("GraticuleDataStoreFactory");
 
+    public static final String DISPLAY_NAME = "Graticule";
+
     /** Optional - uri of the FeatureType's namespace */
     public static final Param NAMESPACEP =
             new Param(
@@ -119,7 +121,7 @@ public class GraticuleDataStoreFactory implements DataStoreFactorySpi {
 
     @Override
     public String getDisplayName() {
-        return "Graticule";
+        return DISPLAY_NAME;
     }
 
     @Override

--- a/src/community/graticule/src/main/java/org/geotools/data/graticule/GraticuleFeatureSource.java
+++ b/src/community/graticule/src/main/java/org/geotools/data/graticule/GraticuleFeatureSource.java
@@ -71,6 +71,7 @@ public class GraticuleFeatureSource extends ContentFeatureSource {
         tb.add(LineFeatureBuilder.VALUE_LABEL_NAME, String.class);
         tb.add(LineFeatureBuilder.VALUE_ATTRIBUTE_NAME, Double.class);
         tb.add(LineFeatureBuilder.HORIZONTAL, Boolean.class);
+        tb.add(LineFeatureBuilder.SEQUENCE, String.class);
         SimpleFeatureType type = tb.buildFeatureType();
         return type;
     }

--- a/src/community/graticule/src/main/java/org/geotools/data/graticule/gridsupport/LineFeatureBuilder.java
+++ b/src/community/graticule/src/main/java/org/geotools/data/graticule/gridsupport/LineFeatureBuilder.java
@@ -45,6 +45,17 @@ public class LineFeatureBuilder extends GridFeatureBuilder {
 
     public static final String OFFSET_Y = "offsetY";
 
+    /**
+     * "start", "mid", "end" to indicate where this line belongs in the progression of horizontal or
+     * vertical lines
+     */
+    public static final String SEQUENCE = "sequence";
+
+    public static final String SEQUENCE_START = "start";
+    public static final String SEQUENCE_MID = "mid";
+
+    public static final String SEQUENCE_END = "end";
+
     private boolean projected;
 
     protected int id;

--- a/src/community/graticule/src/main/java/org/geotools/process/vector/GraticuleLabelPointProcess.java
+++ b/src/community/graticule/src/main/java/org/geotools/process/vector/GraticuleLabelPointProcess.java
@@ -5,6 +5,11 @@
 
 package org.geotools.process.vector;
 
+import static org.geotools.data.graticule.gridsupport.LineFeatureBuilder.HORIZONTAL;
+import static org.geotools.data.graticule.gridsupport.LineFeatureBuilder.SEQUENCE;
+import static org.geotools.data.graticule.gridsupport.LineFeatureBuilder.SEQUENCE_END;
+import static org.geotools.data.graticule.gridsupport.LineFeatureBuilder.SEQUENCE_START;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -156,7 +161,7 @@ public class GraticuleLabelPointProcess implements VectorProcess {
             SimpleFeature feature, PreparedGeometry bounds, PositionEnum position, double offset) {
 
         LineString line = (LineString) feature.getDefaultGeometry();
-        boolean horizontal = (boolean) feature.getAttribute(LineFeatureBuilder.HORIZONTAL);
+        boolean horizontal = (boolean) feature.getAttribute(HORIZONTAL);
         Point p = null;
         // find the location of the new point
         if (bounds == null || bounds.contains(line)) {
@@ -316,13 +321,29 @@ public class GraticuleLabelPointProcess implements VectorProcess {
         double anchorY = 0.5;
         double offsetX = 0;
         double offsetY = 0;
-        if (Boolean.TRUE.equals(feature.getAttribute(LineFeatureBuilder.HORIZONTAL))) {
+        String startEndMid = (String) feature.getAttribute(SEQUENCE);
+        if (Boolean.TRUE.equals(feature.getAttribute(HORIZONTAL))) {
             anchorX = left ? 0 : 1;
             offsetX = offset * (left ? 1 : -1);
+            if (SEQUENCE_START.equals(startEndMid)) {
+                anchorY = 0;
+                offsetY = offset;
+            } else if (SEQUENCE_END.equals(startEndMid)) {
+                anchorY = 1;
+                offsetY = -offset;
+            }
         } else {
             anchorY = top ? 1 : 0;
             offsetY = offset * (top ? -1 : 1);
+            if (SEQUENCE_START.equals(startEndMid)) {
+                anchorX = 0;
+                offsetX = offset;
+            } else if (SEQUENCE_END.equals(startEndMid)) {
+                anchorX = 1;
+                offsetX = -offset;
+            }
         }
+
         builder.set(LineFeatureBuilder.ANCHOR_X, anchorX);
         builder.set(LineFeatureBuilder.ANCHOR_Y, anchorY);
         builder.set(LineFeatureBuilder.OFFSET_X, offsetX);

--- a/src/community/graticule/src/main/java/org/geotools/process/vector/GraticuleLabelPointProcess.java
+++ b/src/community/graticule/src/main/java/org/geotools/process/vector/GraticuleLabelPointProcess.java
@@ -8,6 +8,7 @@ package org.geotools.process.vector;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.api.feature.GeometryAttribute;
 import org.geotools.api.feature.Property;
@@ -15,6 +16,8 @@ import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.feature.type.GeometryDescriptor;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.data.graticule.gridsupport.LineFeatureBuilder;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
@@ -27,9 +30,12 @@ import org.geotools.process.ProcessException;
 import org.geotools.process.factory.DescribeParameter;
 import org.geotools.process.factory.DescribeProcess;
 import org.geotools.process.factory.DescribeResult;
+import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 
 @DescribeProcess(
         title = "Graticule Label Placement",
@@ -70,10 +76,10 @@ public class GraticuleLabelPointProcess implements VectorProcess {
     @DescribeResult(name = "labels", description = "Positions for labels")
     public SimpleFeatureCollection execute(
             @DescribeParameter(name = "grid") SimpleFeatureCollection features,
-            @DescribeParameter(name = "boundingBox") ReferencedEnvelope bounds,
+            @DescribeParameter(name = "boundingBox", min = 0) ReferencedEnvelope bounds,
             @DescribeParameter(name = "offset", min = 0, max = 1, defaultValue = "0") Double offset,
             @DescribeParameter(name = "positions", min = 0, max = 1) String placement)
-            throws ProcessException {
+            throws ProcessException, FactoryException, TransformException {
         PositionEnum position;
         if (placement == null) {
             position = PositionEnum.BOTH;
@@ -91,18 +97,30 @@ public class GraticuleLabelPointProcess implements VectorProcess {
         builder = new SimpleFeatureBuilder(schema);
         DefaultFeatureCollection results = new DefaultFeatureCollection();
 
+        // in case of reprojection, transform the bounds to the features CRS
+        PreparedGeometry clipper = null;
+        if (bounds != null) {
+            if (CRS.isTransformationRequired(
+                    bounds.getCoordinateReferenceSystem(),
+                    features.getSchema().getCoordinateReferenceSystem())) {
+                bounds =
+                        bounds.transform(features.getSchema().getCoordinateReferenceSystem(), true);
+            }
+            clipper = PreparedGeometryFactory.prepare(JTS.toGeometry(bounds));
+        }
+
         try (SimpleFeatureIterator itr = features.features()) {
             while (itr.hasNext()) {
                 SimpleFeature feature = itr.next();
 
                 if (position.equals(PositionEnum.BOTH)) {
                     log.finest("Doing both ");
-                    SimpleFeature f = setPoint(feature, bounds, PositionEnum.TOPLEFT, offset);
+                    SimpleFeature f = setPoint(feature, clipper, PositionEnum.TOPLEFT, offset);
                     if (f != null) results.add(f);
-                    f = setPoint(feature, bounds, PositionEnum.BOTTOMRIGHT, offset);
+                    f = setPoint(feature, clipper, PositionEnum.BOTTOMRIGHT, offset);
                     if (f != null) results.add(f);
                 } else {
-                    SimpleFeature f = setPoint(feature, bounds, position, offset);
+                    SimpleFeature f = setPoint(feature, clipper, position, offset);
 
                     if (f != null) results.add(f);
                 }
@@ -135,17 +153,13 @@ public class GraticuleLabelPointProcess implements VectorProcess {
     }
 
     private SimpleFeature setPoint(
-            SimpleFeature feature,
-            ReferencedEnvelope bounds,
-            PositionEnum position,
-            double offset) {
+            SimpleFeature feature, PreparedGeometry bounds, PositionEnum position, double offset) {
 
         LineString line = (LineString) feature.getDefaultGeometry();
         boolean horizontal = (boolean) feature.getAttribute(LineFeatureBuilder.HORIZONTAL);
         Point p = null;
-        Geometry box = JTS.toGeometry(bounds);
         // find the location of the new point
-        if (bounds.contains(line.getEnvelopeInternal())) {
+        if (bounds == null || bounds.contains(line)) {
             log.finest("bounds contains line - choosing start or end");
             switch (position) {
                 case BOTTOMLEFT:
@@ -175,17 +189,19 @@ public class GraticuleLabelPointProcess implements VectorProcess {
             }
 
         } else {
-
-            Geometry points = line.intersection(box);
-            log.finest("line contained bounds " + points + " " + feature.getAttribute("label"));
-            log.finest("bbox:" + box);
+            Geometry points = line.intersection(bounds.getGeometry());
+            if (log.isLoggable(Level.FINE)) {
+                log.finest("line contained bounds " + points + " " + feature.getAttribute("label"));
+                log.finest("bounds:" + bounds);
+            }
             if (points.getGeometryType() == Geometry.TYPENAME_LINESTRING && !points.isEmpty()) {
                 Point[] ps = new Point[2];
                 ps[0] = ((LineString) points).getStartPoint();
                 ps[1] = ((LineString) points).getEndPoint();
 
                 // get left most
-                log.finest("Got a multipoint intersection " + ps[0] + " " + ps[1]);
+                if (log.isLoggable(Level.FINEST))
+                    log.finest("Got a multipoint intersection " + ps[0] + " " + ps[1]);
                 Point left = null;
                 Point right = null;
                 Point top = null;
@@ -253,14 +269,16 @@ public class GraticuleLabelPointProcess implements VectorProcess {
                         }
                         break;
                 }
-                log.finest("produced " + p + " " + feature.getAttribute("label"));
+                if (log.isLoggable(Level.FINEST))
+                    log.finest("produced " + p + " " + feature.getAttribute("label"));
             } else {
                 // no intersection
                 log.finest("No intersection");
             }
         }
         if (p != null) {
-            log.finest("buiding point at " + p + " " + feature.getAttribute("label"));
+            if (log.isLoggable(Level.FINEST))
+                log.finest("buiding point at " + p + " " + feature.getAttribute("label"));
             SimpleFeature result = buildFeature(p, feature, position, offset);
             return result;
         }

--- a/src/community/graticule/src/test/java/org/geoserver/web/data/store/graticule/GraticuleStoreEditPanelTest.java
+++ b/src/community/graticule/src/test/java/org/geoserver/web/data/store/graticule/GraticuleStoreEditPanelTest.java
@@ -1,0 +1,73 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.data.store.graticule;
+
+import static org.geotools.data.graticule.GraticuleDataStoreFactory.BOUNDS;
+import static org.geotools.data.graticule.GraticuleDataStoreFactory.STEPS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.wicket.util.tester.FormTester;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.data.store.DataAccessEditPage;
+import org.geoserver.web.data.store.DataAccessNewPage;
+import org.geotools.data.graticule.GraticuleDataStoreFactory;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.util.Converters;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GraticuleStoreEditPanelTest extends GeoServerWicketTestSupport {
+
+    @Override
+    protected void setUpTestData(SystemTestData testData) throws Exception {
+        // no data needed
+    }
+
+    @Before
+    public void loginBefore() {
+        super.login();
+    }
+
+    @Test
+    public void testCreateModify() throws Exception {
+        tester.startPage(new DataAccessNewPage(GraticuleDataStoreFactory.DISPLAY_NAME));
+        tester.assertNoErrorMessage();
+
+        tester.executeAjaxEvent(
+                "dataStoreForm:parametersPanel:configsContainer:gratpanel:generateBoundsFromCRS",
+                "click");
+        FormTester ft = tester.newFormTester("dataStoreForm");
+        ft.setValue(
+                "parametersPanel:configsContainer:gratpanel:steps:border:border_body:paramValue",
+                "10");
+        ft.setValue("dataStoreNamePanel:border:border_body:paramValue", "graticule10");
+        ft.submit("save");
+
+        tester.assertNoErrorMessage();
+
+        // check the store has been created
+        DataStoreInfo graticule10 = getCatalog().getDataStoreByName("graticule10");
+        assertNotNull(graticule10);
+        Map<String, Serializable> parameters = graticule10.getConnectionParameters();
+        assertEquals("10", parameters.get(STEPS.key));
+        ReferencedEnvelope world =
+                new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
+        assertEquals(
+                world, Converters.convert(parameters.get(BOUNDS.key), ReferencedEnvelope.class));
+
+        // open again, and save (used to fail due to empty bounds forced during panel construction)
+        tester.startPage(new DataAccessEditPage(graticule10.getId()));
+        tester.assertNoErrorMessage();
+        ft = tester.newFormTester("dataStoreForm");
+        ft.submit("save");
+        tester.assertNoErrorMessage();
+    }
+}

--- a/src/community/graticule/src/test/java/org/geoserver/web/data/store/graticule/GraticuleStoreEditPanelTest.java
+++ b/src/community/graticule/src/test/java/org/geoserver/web/data/store/graticule/GraticuleStoreEditPanelTest.java
@@ -59,7 +59,7 @@ public class GraticuleStoreEditPanelTest extends GeoServerWicketTestSupport {
         Map<String, Serializable> parameters = graticule10.getConnectionParameters();
         assertEquals("10", parameters.get(STEPS.key));
         ReferencedEnvelope world =
-                new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
+                new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326", true));
         assertEquals(
                 world, Converters.convert(parameters.get(BOUNDS.key), ReferencedEnvelope.class));
 

--- a/src/community/graticule/src/test/java/org/geotools/data/graticule/GraticuleFeatureReaderTest.java
+++ b/src/community/graticule/src/test/java/org/geotools/data/graticule/GraticuleFeatureReaderTest.java
@@ -9,6 +9,7 @@ import org.geotools.api.data.FeatureReader;
 import org.geotools.api.data.Query;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.data.graticule.gridsupport.LineFeatureBuilder;
 import org.geotools.process.vector.GraticuleLabelTestSupport;
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,6 +26,29 @@ public class GraticuleFeatureReaderTest extends GraticuleLabelTestSupport {
                 SimpleFeature f = reader.next();
                 int level = (int) f.getAttribute("level");
                 counts[level]++;
+
+                // check the sequence value is properly computed
+                Double value = (Double) f.getAttribute(LineFeatureBuilder.VALUE_ATTRIBUTE_NAME);
+                Boolean horizontal = (Boolean) f.getAttribute(LineFeatureBuilder.HORIZONTAL);
+                String sequence = (String) f.getAttribute(LineFeatureBuilder.SEQUENCE);
+
+                if (horizontal) {
+                    if (value.equals(-90d)) {
+                        Assert.assertEquals(LineFeatureBuilder.SEQUENCE_START, sequence);
+                    } else if (value.equals(90d)) {
+                        Assert.assertEquals(LineFeatureBuilder.SEQUENCE_END, sequence);
+                    } else {
+                        Assert.assertEquals(LineFeatureBuilder.SEQUENCE_MID, sequence);
+                    }
+                } else {
+                    if (value.equals(-180d)) {
+                        Assert.assertEquals(LineFeatureBuilder.SEQUENCE_START, sequence);
+                    } else if (value.equals(180d)) {
+                        Assert.assertEquals(LineFeatureBuilder.SEQUENCE_END, sequence);
+                    } else {
+                        Assert.assertEquals(LineFeatureBuilder.SEQUENCE_MID, sequence);
+                    }
+                }
             }
             Assert.assertEquals(56.0, counts[0], 0.00001);
             Assert.assertEquals(20.0, counts[1], 0.00001);

--- a/src/community/graticule/src/test/java/org/geotools/process/vector/GraticuleLabelPointProcessTest.java
+++ b/src/community/graticule/src/test/java/org/geotools/process/vector/GraticuleLabelPointProcessTest.java
@@ -5,21 +5,24 @@
 
 package org.geotools.process.vector;
 
+import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import java.util.logging.Level;
 import org.geotools.api.feature.Property;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.referencing.CRS;
 import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.jts.geom.Point;
 
 public class GraticuleLabelPointProcessTest extends GraticuleLabelTestSupport {
+
+    public static final ReferencedEnvelope LARGE_BOX =
+            new ReferencedEnvelope(-260.1562, 279.8437, -97.7343, 172.2656, WGS84);
 
     @Test
     public void testBothLabelGrid() throws Exception {
@@ -30,31 +33,49 @@ public class GraticuleLabelPointProcessTest extends GraticuleLabelTestSupport {
 
     @Test
     public void testBottomBigBBox() throws Exception {
-        ReferencedEnvelope bbox =
-                new ReferencedEnvelope(
-                        -260.15625, 279.84375, -97.734375, 172.265625, DefaultGeographicCRS.WGS84);
-        SimpleFeatureCollection features = runLabels(bbox, "bottom");
+        SimpleFeatureCollection features = runLabels(LARGE_BOX, "bottom");
         checkLabels(features, "bottom");
     }
 
     @Test
     public void testBigBBox() throws Exception {
-        ReferencedEnvelope bbox =
+        SimpleFeatureCollection features = runLabels(LARGE_BOX, "both");
+        checkLabels(features, "both");
+    }
+
+    @Test
+    public void testBigBBoxLatLon() throws Exception {
+        ReferencedEnvelope bboxLatLon =
                 new ReferencedEnvelope(
-                        -260.15625, 279.84375, -97.734375, 172.265625, DefaultGeographicCRS.WGS84);
-        SimpleFeatureCollection features = runLabels(bbox, "both");
+                        LARGE_BOX.getMinY(),
+                        LARGE_BOX.getMaxY(),
+                        LARGE_BOX.getMinX(),
+                        LARGE_BOX.getMaxX(),
+                        CRS.decode("urn:ogc:def:crs:EPSG::4326"));
+        SimpleFeatureCollection features = runLabels(bboxLatLon, LARGE_BOX, "both");
+        checkLabels(features, "both");
+    }
+
+    @Test
+    public void testReprojectedBBox() throws Exception {
+        // basically north/east quadrant
+        ReferencedEnvelope renderingBox =
+                new ReferencedEnvelope(0, 21000000, 0, 21000000, CRS.decode("EPSG:3857"));
+        ReferencedEnvelope testBox = new ReferencedEnvelope(0, 180, 0, 85, WGS84);
+        SimpleFeatureCollection features = runLabels(renderingBox, testBox, "both");
+        checkLabels(features, "both");
+    }
+
+    @Test
+    public void testNoBounds() throws Exception {
+        SimpleFeatureCollection features = runLabels(null, LARGE_BOX, "both");
         checkLabels(features, "both");
     }
 
     @Test
     public void testSmallBBox() throws Exception {
         ReferencedEnvelope bbox =
-                new ReferencedEnvelope(
-                        -92.724609375,
-                        -25.224609375,
-                        -0.615234375,
-                        33.134765625,
-                        DefaultGeographicCRS.WGS84);
+                new ReferencedEnvelope(-92.7246, -25.2246, -0.6152, 33.1347, WGS84);
         runLabels(bbox, "both");
         SimpleFeatureCollection features = runLabels(bbox, "topright");
         checkLabels(features, "topright");
@@ -119,14 +140,18 @@ public class GraticuleLabelPointProcessTest extends GraticuleLabelTestSupport {
         }
     }
 
-    private SimpleFeatureCollection runLabels(ReferencedEnvelope box, String pos)
-            throws IOException {
+    private SimpleFeatureCollection runLabels(ReferencedEnvelope box, String pos) throws Exception {
+        return runLabels(box, box, pos);
+    }
+
+    private SimpleFeatureCollection runLabels(
+            ReferencedEnvelope processBox, ReferencedEnvelope testBox, String pos)
+            throws Exception {
         SimpleFeatureCollection features = store.getFeatureSource("Graticule_10_30").getFeatures();
 
         GraticuleLabelPointProcess process = new GraticuleLabelPointProcess();
 
-        SimpleFeatureCollection results = process.execute(features, box, 0d, pos);
-        // assertEquals(features.size() * 2, results.size());
+        SimpleFeatureCollection results = process.execute(features, processBox, 0d, pos);
         try (SimpleFeatureIterator iterator = results.features()) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
@@ -145,14 +170,14 @@ public class GraticuleLabelPointProcessTest extends GraticuleLabelTestSupport {
                     if (left) {
                         assertEquals(
                                 "wrong left",
-                                Math.floor(Math.max(bounds.getMinimum(0), box.getMinimum(0))),
+                                Math.floor(Math.max(bounds.getMinimum(0), testBox.getMinimum(0))),
                                 Math.floor(p.getX()),
                                 0.1);
                     }
                     if (!left) {
                         assertEquals(
                                 "wrong right",
-                                Math.ceil(Math.min(bounds.getMaximum(0), box.getMaximum(0))),
+                                Math.ceil(Math.min(bounds.getMaximum(0), testBox.getMaximum(0))),
                                 Math.ceil(p.getX() + GraticuleLabelPointProcess.DELTA),
                                 0.1);
                     }
@@ -160,14 +185,14 @@ public class GraticuleLabelPointProcessTest extends GraticuleLabelTestSupport {
                     if (top) {
                         assertEquals(
                                 "wrong top",
-                                Math.floor(Math.min(bounds.getMaximum(1), box.getMaximum(1))),
+                                Math.floor(Math.min(bounds.getMaximum(1), testBox.getMaximum(1))),
                                 Math.floor(p.getY()),
                                 0.1);
                     }
                     if (!top) {
                         assertEquals(
                                 "wrong bottom",
-                                Math.ceil(Math.max(bounds.getMinimum(1), box.getMinimum(1))),
+                                Math.ceil(Math.max(bounds.getMinimum(1), testBox.getMinimum(1))),
                                 Math.ceil(p.getY() + GraticuleLabelPointProcess.DELTA),
                                 0.1);
                     }


### PR DESCRIPTION
Another set of improvements for the graticule subsystem, to fix: 
* A GUI issue (the envelope would always reset to the empty one on editing the store)
* Support multiple projections (graticule in one projection, display in another)
* Keep the labels always within the graticule bounds (the ones at the 4 corners fell out)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->