### PR TITLE
[GEOS-11255] Add support for multiple inserts with different idGen

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/Transaction.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/Transaction.java
@@ -18,7 +18,10 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
+import net.opengis.wfs.IdentifierGenerationOptionType;
+import net.opengis.wfs.InsertElementType;
 import net.opengis.wfs.TransactionType;
+import org.eclipse.emf.ecore.EObject;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.ows.Dispatcher;
@@ -709,7 +712,7 @@ public class Transaction {
          */
         private boolean canAggregate(TransactionElement pElem) {
             if (aggrTargetElement instanceof Insert && pElem instanceof Insert) {
-                return true;
+                return idGenEquals(getIdGen((Insert) aggrTargetElement), getIdGen((Insert) pElem));
             }
             if (aggrTargetElement instanceof Delete && pElem instanceof Delete) {
                 if (aggrDeleteCount >= maxDeleteCount - 1) {
@@ -724,6 +727,22 @@ public class Transaction {
                 }
             }
             return false;
+        }
+
+        private IdentifierGenerationOptionType getIdGen(Insert insert) {
+            EObject adaptee = insert.getAdaptee();
+            if (adaptee instanceof InsertElementType) {
+                return ((InsertElementType) adaptee).getIdgen();
+            }
+            return null;
+        }
+
+        private boolean idGenEquals(
+                IdentifierGenerationOptionType i1, IdentifierGenerationOptionType i2) {
+            return i1 == i2
+                    // GenerateNew is the default value
+                    || (i1 == IdentifierGenerationOptionType.GENERATE_NEW_LITERAL && i2 == null)
+                    || (i2 == IdentifierGenerationOptionType.GENERATE_NEW_LITERAL && i1 == null);
         }
 
         /**


### PR DESCRIPTION
[![GEOS-11255](https://badgen.net/badge/JIRA/GEOS-11255/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11255) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hi

This a a PR for [GEOS-11255](https://osgeo-org.atlassian.net/browse/GEOS-11255)

It disables bulk inserts in transactions for those cases in which different strategies are selected in the 'idgen' attribute. Additionally, some tests are added to confirm this behavior

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).