### PR TITLE
[GEOS-11263] hideEmptyRules not working in JSON LegendGraphic

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
@@ -292,6 +292,10 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
                 applicableRules = LegendUtils.getApplicableRules(ftStyles, scaleDenominator);
             }
 
+            if (countProcessor != null && !forceLabelsOff) {
+                applicableRules = updateRuleTitles(countProcessor, legend, applicableRules);
+            }
+
             ArrayList<JSONObject> jRules = new ArrayList<>();
             if (legend instanceof CascadedLegendRequest) {
                 CascadedLegendRequest cascadedLegend = (CascadedLegendRequest) legend;
@@ -385,6 +389,11 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
         /* }*/
 
         return response;
+    }
+
+    protected Rule[] updateRuleTitles(
+            FeatureCountProcessor processor, LegendRequest legend, Rule[] applicableRules) {
+        return processor.preProcessRules(legend, applicableRules);
     }
 
     private JSONObject getLayerTitle(JSONObject in, LegendRequest legend) {

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
@@ -8,6 +8,7 @@ import java.awt.Color;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -18,6 +19,7 @@ import javax.measure.quantity.Length;
 import javax.swing.Icon;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang3.ArrayUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -292,7 +294,9 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
                 applicableRules = LegendUtils.getApplicableRules(ftStyles, scaleDenominator);
             }
 
-            if (countProcessor != null && !forceLabelsOff) {
+            if (countProcessor != null
+                    && request.getKvp() != null
+                    && request.getKvp().containsKey("bbox")) {
                 applicableRules = updateRuleTitles(countProcessor, legend, applicableRules);
             }
 
@@ -393,7 +397,35 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
 
     protected Rule[] updateRuleTitles(
             FeatureCountProcessor processor, LegendRequest legend, Rule[] applicableRules) {
-        return processor.preProcessRules(legend, applicableRules);
+        // skip rules with RasterSymbolizers, as they are not counted
+        Rule[] rasterRules = rasterRules(applicableRules);
+        Rule[] nonRasterRules = nonRasterRules(applicableRules);
+        Rule[] filteredRules = processor.preProcessRules(legend, nonRasterRules);
+        return ArrayUtils.addAll(filteredRules, rasterRules);
+    }
+
+    private Rule[] rasterRules(Rule[] applicableRules) {
+        return Arrays.stream(applicableRules)
+                .filter(r -> allRaster(r.getSymbolizers()))
+                .toArray(Rule[]::new);
+    }
+
+    private Rule[] nonRasterRules(Rule[] applicableRules) {
+        return Arrays.stream(applicableRules)
+                .filter(r -> !allRaster(r.getSymbolizers()))
+                .toArray(Rule[]::new);
+    }
+
+    private <T> boolean allRaster(T[] symbolizers) {
+        if (ArrayUtils.isEmpty(symbolizers)) {
+            return false;
+        }
+        for (T symbolizer : symbolizers) {
+            if (!(symbolizer instanceof RasterSymbolizer)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private JSONObject getLayerTitle(JSONObject in, LegendRequest legend) {

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
@@ -1982,4 +1982,23 @@ public class JSONLegendGraphicOutputFormatTest extends BaseLegendTest<JSONLegend
             if (group != null) catalog.remove(group);
         }
     }
+
+    @Test
+    public void testHideEmptyRules() throws Exception {
+        String url =
+                "wms?LAYER="
+                        + MockData.NAMED_PLACES.getLocalPart()
+                        + "&FORMAT=application/json"
+                        + "&SERVICE=WMS&REQUEST=GetLegendGraphic&VERSION=1.0.0&WIDTH=20&HEIGHT=20";
+        JSONObject legend = (JSONObject) getAsJSON(url);
+        JSONArray rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
+        assertEquals(2, rules.size());
+        assertEquals("ashton", rules.getJSONObject(0).get("name"));
+        assertEquals("goose_island", rules.getJSONObject(1).get("name"));
+
+        url += "&LEGEND_OPTIONS=hideEmptyRules:true&BBOX=0,0,0.1,0.1";
+        legend = (JSONObject) getAsJSON(url);
+        rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
+        assertEquals(1, rules.size());
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
@@ -1993,12 +1993,14 @@ public class JSONLegendGraphicOutputFormatTest extends BaseLegendTest<JSONLegend
         JSONObject legend = (JSONObject) getAsJSON(url);
         JSONArray rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
         assertEquals(2, rules.size());
-        assertEquals("ashton", rules.getJSONObject(0).get("name"));
-        assertEquals("goose_island", rules.getJSONObject(1).get("name"));
+        assertEquals("ashton", rules.getJSONObject(0).getString("name"));
+        assertEquals("goose_island", rules.getJSONObject(1).getString("name"));
 
+        // goose_island is placed on negative Y ordinates
         url += "&LEGEND_OPTIONS=hideEmptyRules:true&BBOX=0,0,0.1,0.1";
         legend = (JSONObject) getAsJSON(url);
         rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
         assertEquals(1, rules.size());
+        assertEquals("ashton", rules.getJSONObject(0).getString("name"));
     }
 }


### PR DESCRIPTION
[![GEOS-11263](https://badgen.net/badge/JIRA/GEOS-11263/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11263) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hi

This a a PR for [GEOS-11263](https://osgeo-org.atlassian.net/browse/GEOS-11263)

It applies the same strategy in ``BufferedImageLegendGraphicBuilder`` but in JSONLegendGraphicBuilder to filter out all rules with no features in the BBOX.
  
# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->