### PR TITLE
[GEOS-11205] Layer page: style image fails if it is in isolated works…

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/LegendGraphicAjaxUpdater.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/LegendGraphicAjaxUpdater.java
@@ -11,6 +11,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.image.Image;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.geoserver.catalog.StyleInfo;
 
 /**
@@ -29,26 +30,34 @@ class LegendGraphicAjaxUpdater implements Serializable {
     private IModel<StyleInfo> styleInfoModel;
     private IModel<String> urlModel;
 
-    private String wmsURL;
-
-    public LegendGraphicAjaxUpdater(
-            final String wmsURL, final Image image, final IModel<StyleInfo> styleInfoModel) {
-        this.wmsURL = wmsURL;
+    public LegendGraphicAjaxUpdater(final Image image, final IModel<StyleInfo> styleInfoModel) {
         this.image = image;
         this.styleInfoModel = styleInfoModel;
-        this.urlModel = new Model<>(wmsURL);
+        this.urlModel = new Model<>();
         this.image.add(new AttributeModifier("src", urlModel));
         updateStyleImage(null);
     }
 
     public void updateStyleImage(AjaxRequestTarget target) {
-        String url =
-                wmsURL
-                        + "REQUEST=GetLegendGraphic&VERSION=1.0.0&FORMAT=image/png&WIDTH=20&HEIGHT=20&STRICT=false&style=";
         StyleInfo styleInfo = styleInfoModel.getObject();
         if (styleInfo != null) {
+            String url;
+            if (styleInfo.getWorkspace() == null) {
+                // the wms url is build without qualification to allow usage of global styles,
+                // the style name and layer name will be ws qualified instead
+                url = RequestCycle.get().getUrlRenderer().renderContextRelativeUrl("wms") + "?";
+            } else {
+                url =
+                        RequestCycle.get()
+                                        .getUrlRenderer()
+                                        .renderContextRelativeUrl(
+                                                styleInfo.getWorkspace().getName() + "/wms")
+                                + "?";
+            }
             String style = styleInfo.prefixedName();
-            url += style;
+            url +=
+                    "REQUEST=GetLegendGraphic&VERSION=1.0.0&FORMAT=image/png&WIDTH=20&HEIGHT=20&STRICT=false&style="
+                            + style;
             urlModel.setObject(url);
             if (target != null) {
                 target.add(image);

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/publish/WMSLayerConfig.java
@@ -30,7 +30,6 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.model.util.CollectionModel;
-import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
@@ -82,12 +81,8 @@ public class WMSLayerConfig extends PublishedConfigurationPanel<LayerInfo> {
         defStyleImg.setOutputMarkupId(true);
         styleContainer.add(defStyleImg);
 
-        // the wms url is build without qualification to allow usage of global styles,
-        // the style name and layer name will be ws qualified instead
-        String wmsURL = RequestCycle.get().getUrlRenderer().renderContextRelativeUrl("wms") + "?";
-
         final LegendGraphicAjaxUpdater defaultStyleUpdater =
-                new LegendGraphicAjaxUpdater(wmsURL, defStyleImg, defaultStyleModel);
+                new LegendGraphicAjaxUpdater(defStyleImg, defaultStyleModel);
 
         defaultStyle.add(
                 new OnChangeAjaxBehavior() {

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/publish/WMSLayerConfigTest.java
@@ -131,8 +131,37 @@ public class WMSLayerConfigTest extends GeoServerWicketTestSupport {
         assertTrue(img.getBehaviors().get(0) instanceof AttributeModifier);
 
         AttributeModifier mod = (AttributeModifier) img.getBehaviors().get(0);
-        assertTrue(mod.toString().contains("wms?REQUEST=GetLegendGraphic"));
+        assertTrue(mod.toString().contains("cite/wms?REQUEST=GetLegendGraphic"));
         assertTrue(mod.toString().contains("style=cite:Ponds"));
+        assertFalse(cascadedControlsVisible(tester));
+
+        // restore style
+        style.setWorkspace(null);
+        catalog.save(style);
+    }
+
+    @Test
+    public void testLegendGraphicURLNoWorkspace() throws Exception {
+        final LayerInfo layer = getCatalog().getLayerByName(MockData.PONDS.getLocalPart());
+        FormTestPage page =
+                new FormTestPage(
+                        (ComponentBuilder) id -> new WMSLayerConfig(id, new Model<>(layer)));
+        tester.startPage(page);
+        tester.assertRenderedPage(FormTestPage.class);
+        tester.debugComponentTrees();
+
+        Image img =
+                (Image)
+                        tester.getComponentFromLastRenderedPage(
+                                "form:panel:styles:defaultStyleLegendGraphic");
+        assertNotNull(img);
+        assertEquals(1, img.getBehaviors().size());
+        assertTrue(img.getBehaviors().get(0) instanceof AttributeModifier);
+
+        AttributeModifier mod = (AttributeModifier) img.getBehaviors().get(0);
+        assertFalse(mod.toString().contains("cite/wms?REQUEST=GetLegendGraphic"));
+        assertTrue(mod.toString().contains("wms?REQUEST=GetLegendGraphic"));
+        assertTrue(mod.toString().contains("style=Ponds"));
         assertFalse(cascadedControlsVisible(tester));
     }
 


### PR DESCRIPTION
[![GEOS-11205](https://badgen.net/badge/JIRA/GEOS-11205/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11205) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…pace


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->