### PR TITLE
[Backport 2.24.x] [GEOS-11250] WFS GeoJSON encoder fails with an exception if an infinity number is used in the geometry

### DIFF
--- a/doc/en/user/source/services/wfs/outputformats.rst
+++ b/doc/en/user/source/services/wfs/outputformats.rst
@@ -137,6 +137,7 @@ JSON output ``system properties``:
 
 * ``json.maxDepth=<max_value>`` is used to determine the max number of allowed JSON nested objects on encoding phase.  By default the value is 100.
 
+.. note:: Coordinates with a value equal to :math:`\pm \infty` will be encoded with their string representation ``"Infinity"`` or ``"-Infinity"``
 
 CSV output
 ----------------

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
@@ -201,9 +201,9 @@ public class GeoJSONBuilder extends JSONBuilder {
      *
      * <p>If the value is {@link Double#NaN} then the value will not be written.
      *
-     * <p>If the value is {@link Double#POSITIVE_INFINITY} or {@link Double#NEGATIVE_INFINITY} then it will be encoded as
-     * {@code "Infinity"} or {@code "-Infinity"}, respectively, this avoids a {@link JSONException} in case the value
-     * is infinite.
+     * <p>If the value is {@link Double#POSITIVE_INFINITY} or {@link Double#NEGATIVE_INFINITY} then
+     * it will be encoded as {@code "Infinity"} or {@code "-Infinity"}, respectively, this avoids a
+     * {@link JSONException} in case the value is infinite.
      *
      * @param value value to encode
      * @see #setNumberOfDecimals(int)

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
@@ -171,7 +171,7 @@ public class GeoJSONBuilder extends JSONBuilder {
      * @param y X ordinate
      * @param z Z ordinate, can be {@code NaN}
      * @param m M ordinate, can be {@code NaN}
-     * @return the JSON builder instance, this allow chained calls
+     * @return the JSON builder instance, this allows chained calls
      */
     private JSONBuilder writeCoordinate(double x, double y, double z, double m) {
         // start encoding JSON array
@@ -179,29 +179,36 @@ public class GeoJSONBuilder extends JSONBuilder {
         // adjust the order of X and Y ordinates if needed
         if (axisOrder == CRS.AxisOrder.NORTH_EAST) {
             // encode latitude first and then longitude
-            if (!Double.isNaN(y)) { // for 1d linear referencing cases
-                roundedValue(y);
-            }
-            roundedValue(x);
+            encodeCoordinateIfAvailable(y);
+            encodeCoordinateIfAvailable(x);
         } else {
             // encode longitude first and then latitude
-            roundedValue(x);
-            if (!Double.isNaN(y)) { // for 1d linear referencing cases
-                roundedValue(y);
-            }
+            encodeCoordinateIfAvailable(x);
+            encodeCoordinateIfAvailable(y);
         }
         // if Z value is not available but we have a measure, we set Z value to zero
         z = Double.isNaN(z) && !Double.isNaN(m) ? 0 : z;
         // encode Z value if available
-        if (!Double.isNaN(z)) {
-            roundedValue(z);
-        }
+        encodeCoordinateIfAvailable(z);
         // encode M value if available
-        if (!Double.isNaN(m)) {
-            roundedValue(m);
-        }
+        encodeCoordinateIfAvailable(m);
         // we are done with the array
         return this.endArray();
+    }
+
+    private void encodeCoordinateIfAvailable(double value) {
+        if (Double.isNaN(value)) {
+            // the value is not available then we don't encode it
+            return;
+        }
+
+        if (Double.isInfinite(value)) {
+            // the value is +- infinity then we write its value as a String representation
+            super.value(String.valueOf(value));
+        } else {
+            // the value is a finite number then we write it as a rounded double
+            roundedValue(value);
+        }
     }
 
     private void roundedValue(double value) {

--- a/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/GeoJSONBuilder.java
@@ -179,24 +179,36 @@ public class GeoJSONBuilder extends JSONBuilder {
         // adjust the order of X and Y ordinates if needed
         if (axisOrder == CRS.AxisOrder.NORTH_EAST) {
             // encode latitude first and then longitude
-            encodeCoordinateIfAvailable(y);
-            encodeCoordinateIfAvailable(x);
+            encodeOrdinate(y);
+            encodeOrdinate(x);
         } else {
             // encode longitude first and then latitude
-            encodeCoordinateIfAvailable(x);
-            encodeCoordinateIfAvailable(y);
+            encodeOrdinate(x);
+            encodeOrdinate(y);
         }
         // if Z value is not available but we have a measure, we set Z value to zero
         z = Double.isNaN(z) && !Double.isNaN(m) ? 0 : z;
         // encode Z value if available
-        encodeCoordinateIfAvailable(z);
+        encodeOrdinate(z);
         // encode M value if available
-        encodeCoordinateIfAvailable(m);
+        encodeOrdinate(m);
         // we are done with the array
         return this.endArray();
     }
 
-    private void encodeCoordinateIfAvailable(double value) {
+    /**
+     * Writes a double value as a rounded number.
+     *
+     * <p>If the value is {@link Double#NaN} then the value will not be written.
+     *
+     * <p>If the value is {@link Double#POSITIVE_INFINITY} or {@link Double#NEGATIVE_INFINITY} then it will be encoded as
+     * {@code "Infinity"} or {@code "-Infinity"}, respectively, this avoids a {@link JSONException} in case the value
+     * is infinite.
+     *
+     * @param value value to encode
+     * @see #setNumberOfDecimals(int)
+     */
+    private void encodeOrdinate(double value) {
         if (Double.isNaN(value)) {
             // the value is not available then we don't encode it
             return;

--- a/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/json/GeoJSONBuilderTest.java
@@ -498,6 +498,39 @@ public class GeoJSONBuilderTest {
         }
     }
 
+    @Test
+    public void testWrite3DPointWithInfiniteCoordinates() throws Exception {
+        Geometry g = new WKTReader().read("POINT(Infinity -Infinity 1)");
+        builder.writeGeom(g);
+        assertEquals(
+                "{\"type\":\"Point\",\"coordinates\":[\"Infinity\",\"-Infinity\",1]}",
+                writer.toString());
+    }
+
+    @Test
+    public void testWritePolygonZMWithInfiniteCoordinates() throws Exception {
+        Geometry g =
+                new WKTReader()
+                        .read(
+                                "POLYGON ZM((0 0 0 0, 0 Infinity 0 0, 10 -Infinity 0 0, 10 0 Infinity -Infinity, 0 0 0 0))");
+        builder.writeGeom(g);
+        assertEquals(
+                "{\"type\":\"Polygon\",\"coordinates\":[[[0,0,0,0],[0,\"Infinity\",0,0],[10,\"-Infinity\",0,0],[10,0,\"Infinity\",\"-Infinity\"],[0,0,0,0]]]}",
+                writer.toString());
+    }
+
+    @Test
+    public void testWrite3DLineWithInfiniteCoordinates() throws Exception {
+        Geometry g =
+                new WKTReader()
+                        .read(
+                                "LINESTRING(0 0 0, 0 Infinity 0, 10 -Infinity 0, 10 0 Infinity, 0 0 0)");
+        builder.writeGeom(g);
+        assertEquals(
+                "{\"type\":\"LineString\",\"coordinates\":[[0,0,0],[0,\"Infinity\",0],[10,\"-Infinity\",0],[10,0,\"Infinity\"],[0,0,0]]}",
+                writer.toString());
+    }
+
     private void addLevels(final GeoJSONBuilder builder, int level, final int max) {
         if (level >= max) return;
         level++;


### PR DESCRIPTION
[![GEOS-11250](https://badgen.net/badge/JIRA/GEOS-11250/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11250) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7343
 **Authored by:** @mirco-romagnoli