### PR TITLE
[GEOS-11274] Fix JSON Legend with external reference

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/icons/IconProperties.java
+++ b/src/wms/src/main/java/org/geoserver/wms/icons/IconProperties.java
@@ -8,8 +8,11 @@ package org.geoserver.wms.icons;
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 import org.geoserver.config.GeoServerDataDirectory;
@@ -44,6 +47,10 @@ public abstract class IconProperties {
     public abstract String getIconName(Style style);
 
     public abstract boolean isExternal();
+
+    public String uriData() {
+        return null;
+    }
 
     public static IconProperties generator(
             final Double opacity,
@@ -166,8 +173,15 @@ public abstract class IconProperties {
                                                 .substring(styles.getAbsolutePath().length() + 1);
                                 file = new File(relativePath);
                             } else {
-                                // we wont' transform this, other dirs are not published
-                                file = null;
+                                // other dirs are not published, serialize uri-data
+                                Path path = file.toPath();
+                                String contentType = Files.probeContentType(path);
+                                byte[] bytes = Files.readAllBytes(path);
+                                return new StringBuilder("data:")
+                                        .append(contentType)
+                                        .append(";base64,")
+                                        .append(Base64.getEncoder().encodeToString(bytes))
+                                        .toString();
                             }
 
                             // rebuild the icon href accordingly

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
@@ -18,6 +18,7 @@ import javax.measure.quantity.Length;
 import javax.swing.Icon;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -516,7 +517,7 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
                 IconPropertyExtractor.extractProperties(newStyle, (SimpleFeature) feature);
 
         String iconUrl = props.href(baseURL, wsName, styleName);
-        int index = iconUrl.indexOf('?');
+        int index = StringUtils.indexOf(iconUrl, '?');
         if (index >= 0) {
             String base = iconUrl.substring(0, index + 1);
             String[] refs = iconUrl.substring(index + 1).split("&");

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.xml.transform.TransformerException;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 import org.custommonkey.xmlunit.NamespaceContext;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -1981,5 +1982,28 @@ public class JSONLegendGraphicOutputFormatTest extends BaseLegendTest<JSONLegend
         } finally {
             if (group != null) catalog.remove(group);
         }
+    }
+
+    @Test
+    public void testExternalReferenceGraphic() throws Exception {
+        Style style = readSLD("ExternalReferenceGraphic.sld");
+        GetLegendGraphicRequest req = getRequest();
+        FeatureTypeInfo ftInfo =
+                getCatalog()
+                        .getFeatureTypeByName(
+                                MockData.BRIDGES.getNamespaceURI(),
+                                MockData.BRIDGES.getLocalPart());
+        req.setLayer(ftInfo.getFeatureType());
+        req.setStyle(style);
+        req.setLegendOptions(new HashMap<String, String>());
+
+        JSONObject result = this.legendProducer.buildLegendGraphic(req);
+        assertNotNull(result);
+        JSONArray legend = result.getJSONArray("Legend");
+        JSONArray rules = legend.getJSONObject(0).getJSONArray("rules");
+        JSONArray symbolizers = rules.getJSONObject(0).getJSONArray("symbolizers");
+        JSONObject point = symbolizers.getJSONObject(0).getJSONObject("Point");
+        assertTrue(point.has("url"));
+        assertTrue(StringUtils.startsWith(point.getString("url"), "data:image/png;base64,"));
     }
 }

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ExternalReferenceGraphic.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/ExternalReferenceGraphic.sld
@@ -1,0 +1,28 @@
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
+  version="1.0.0">
+  <NamedLayer>
+    <Name>ExternalReferenceGraphic</Name>
+    <UserStyle>
+      <Name>ExternalReferenceGraphic</Name>
+      <Title>ExternalReferenceGraphic</Title>
+      <FeatureTypeStyle>
+        <Name>ExternalReferenceGraphic</Name>
+        <Rule>
+        <Title>Red flag</Title>
+          <PointSymbolizer>
+            <Graphic>
+              <ExternalGraphic>
+                 <OnlineResource 
+                    xlink:type="simple"
+                    xlink:href="ExternalGraphicIcon.png" />
+               <Format>image/png</Format>
+             </ExternalGraphic>
+             <Size>25</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
This a a PR for [GEOS-11274](https://osgeo-org.atlassian.net/browse/GEOS-11274)

It prevents NullPointerException providing links in the form of URI Data for unresolvable urls and excluding ``url`` and ``external-graphic-url`` when not possible.
  
# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [X] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [X] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

