### PR TITLE
Use threads to read altitude in wps-longitudinal-profile community module

### DIFF
--- a/doc/en/user/source/community/wps-longitudinal-profile/index.rst
+++ b/doc/en/user/source/community/wps-longitudinal-profile/index.rst
@@ -79,3 +79,4 @@ The profile object contains an array of points.
 
 .. note::
    It's possible to set wpsLongitudinalMaxThreadPoolSize (integer value) environment variable to limit the size of the extension's thread pool.
+   It's possible to set wpsLongitudinalVerticesChunkSize (integer value) environment variable to define number of vertices processed in a chunk.

--- a/doc/en/user/source/community/wps-longitudinal-profile/index.rst
+++ b/doc/en/user/source/community/wps-longitudinal-profile/index.rst
@@ -75,3 +75,7 @@ The profile object contains an array of points.
 #. representation - target CRS of resulting points
 #. processedpoints - total number of processed points
 #. executedtime - duration of process execution in milliseconds
+
+
+.. note::
+   It's possible to set wpsLongitudinalMaxThreadPoolSize (integer value) environment variable to limit the size of the extension's thread pool.

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
@@ -7,7 +7,7 @@ package org.geoserver.wps.longitudinal;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Vector;
+import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
 import org.geotools.api.data.FeatureSource;
@@ -21,17 +21,17 @@ import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.geometry.Position2D;
 import org.geotools.util.logging.Logging;
 
-public class AltitudeReaderThread implements Callable<Vector<ProfileVertice>> {
+public class AltitudeReaderThread implements Callable<ArrayList<ProfileVertice>> {
     static final Logger LOGGER = Logging.getLogger(AltitudeReaderThread.class);
 
-    private Vector<ProfileVertice> pvs;
+    private ArrayList<ProfileVertice> pvs;
     GridCoverage2D gridCoverage2D;
     private int altitudeIndex;
     FeatureSource adjustmentFeatureSource;
     String altitudeName;
 
     public AltitudeReaderThread(
-            Vector<ProfileVertice> pvs,
+            ArrayList<ProfileVertice> pvs,
             int altitudeIndex,
             FeatureSource adjustmentFeatureSource,
             String altitudeName,
@@ -44,7 +44,7 @@ public class AltitudeReaderThread implements Callable<Vector<ProfileVertice>> {
     }
 
     @Override
-    public Vector<ProfileVertice> call() throws Exception {
+    public ArrayList<ProfileVertice> call() throws Exception {
         for (ProfileVertice pv : pvs) {
             LOGGER.fine("processing position:" + pv.getCoordinate());
             double altitude =

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
@@ -1,3 +1,7 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.wps.longitudinal;
 
 import java.io.IOException;

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
@@ -4,20 +4,12 @@
  */
 package org.geoserver.wps.longitudinal;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
-import org.geotools.api.data.FeatureSource;
-import org.geotools.api.data.Query;
-import org.geotools.api.feature.Feature;
-import org.geotools.api.filter.Filter;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.feature.FeatureIterator;
-import org.geotools.filter.text.cql2.CQL;
-import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.geometry.Position2D;
 import org.geotools.util.logging.Logging;
 
@@ -27,52 +19,30 @@ public class AltitudeReaderThread implements Callable<ArrayList<ProfileVertice>>
     private ArrayList<ProfileVertice> pvs;
     GridCoverage2D gridCoverage2D;
     private int altitudeIndex;
-    FeatureSource adjustmentFeatureSource;
-    String altitudeName;
 
     public AltitudeReaderThread(
-            ArrayList<ProfileVertice> pvs,
-            int altitudeIndex,
-            FeatureSource adjustmentFeatureSource,
-            String altitudeName,
-            GridCoverage2D gridCoverage2D) {
+            ArrayList<ProfileVertice> pvs, int altitudeIndex, GridCoverage2D gridCoverage2D) {
         this.pvs = pvs;
         this.gridCoverage2D = gridCoverage2D;
         this.altitudeIndex = altitudeIndex;
-        this.adjustmentFeatureSource = adjustmentFeatureSource;
-        this.altitudeName = altitudeName;
     }
 
     @Override
     public ArrayList<ProfileVertice> call() throws Exception {
         for (ProfileVertice pv : pvs) {
             LOGGER.fine("processing position:" + pv.getCoordinate());
-            double altitude =
-                    getAltitude(
-                            adjustmentFeatureSource,
-                            gridCoverage2D,
-                            pv.getCoordinate(),
-                            altitudeIndex,
-                            altitudeName);
-            pv.setAltitude(altitude);
+            double altitude = getAltitude(gridCoverage2D, pv.getCoordinate(), altitudeIndex);
+            pv.setAltitude(altitude - pv.getAltitude());
         }
         return pvs;
     }
 
     private static double getAltitude(
-            FeatureSource featureSource,
-            GridCoverage2D gridCoverage2D,
-            Position2D position2D,
-            int altitudeIndex,
-            String altitudeName)
-            throws IOException, CQLException {
+            GridCoverage2D gridCoverage2D, Position2D position2D, int altitudeIndex) {
         double altitude = calculateAltitude(gridCoverage2D.evaluate(position2D), altitudeIndex);
         // Round altitude
         altitude = BigDecimal.valueOf(altitude).setScale(2, RoundingMode.HALF_UP).doubleValue();
 
-        if (featureSource != null) {
-            altitude = getAdjustedAltitude(featureSource, position2D, altitude, altitudeName);
-        }
         return altitude;
     }
 
@@ -93,42 +63,5 @@ public class AltitudeReaderThread implements Callable<ArrayList<ProfileVertice>>
             }
         }
         throw new IllegalArgumentException();
-    }
-
-    /**
-     * Process altitude using adjustment layer. Method attempts to find feature that contains
-     * provided parameter point geometry, and if found, subtracts its altitude value from provided
-     * parameter altitude
-     *
-     * @param featureSource
-     * @param coordinate
-     * @param altitude
-     * @return
-     * @throws IOException
-     */
-    private static double getAdjustedAltitude(
-            FeatureSource featureSource,
-            Position2D coordinate,
-            double altitude,
-            String altitudeName)
-            throws IOException, CQLException {
-        Query query;
-        Filter filter;
-        filter =
-                CQL.toFilter(
-                        "CONTAINS(the_geom, POINT("
-                                + coordinate.getX()
-                                + " "
-                                + coordinate.getY()
-                                + "))");
-        query = new Query(featureSource.getSchema().getName().getLocalPart(), filter);
-        try (FeatureIterator featureIterator = featureSource.getFeatures(query).features()) {
-            if (featureIterator.hasNext()) {
-                Feature feature = featureIterator.next();
-                Double adjLayerAltitude = (Double) feature.getProperty(altitudeName).getValue();
-                altitude = altitude - adjLayerAltitude;
-            }
-        }
-        return altitude;
     }
 }

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
@@ -1,0 +1,130 @@
+package org.geoserver.wps.longitudinal;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Vector;
+import java.util.concurrent.Callable;
+import java.util.logging.Logger;
+import org.geotools.api.data.FeatureSource;
+import org.geotools.api.data.Query;
+import org.geotools.api.feature.Feature;
+import org.geotools.api.filter.Filter;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.filter.text.cql2.CQL;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.geometry.Position2D;
+import org.geotools.util.logging.Logging;
+
+public class AltitudeReaderThread implements Callable<Vector<ProfileVertice>> {
+    static final Logger LOGGER = Logging.getLogger(AltitudeReaderThread.class);
+
+    private Vector<ProfileVertice> pvs;
+    GridCoverage2D gridCoverage2D;
+    private int altitudeIndex;
+    FeatureSource adjustmentFeatureSource;
+    String altitudeName;
+
+    public AltitudeReaderThread(
+            Vector<ProfileVertice> pvs,
+            int altitudeIndex,
+            FeatureSource adjustmentFeatureSource,
+            String altitudeName,
+            GridCoverage2D gridCoverage2D) {
+        this.pvs = pvs;
+        this.gridCoverage2D = gridCoverage2D;
+        this.altitudeIndex = altitudeIndex;
+        this.adjustmentFeatureSource = adjustmentFeatureSource;
+        this.altitudeName = altitudeName;
+    }
+
+    @Override
+    public Vector<ProfileVertice> call() throws Exception {
+        for (ProfileVertice pv : pvs) {
+            LOGGER.fine("processing position:" + pv.getCoordinate());
+            double altitude =
+                    getAltitude(
+                            adjustmentFeatureSource,
+                            gridCoverage2D,
+                            pv.getCoordinate(),
+                            altitudeIndex,
+                            altitudeName);
+            pv.setAltitude(altitude);
+        }
+        return pvs;
+    }
+
+    private static double getAltitude(
+            FeatureSource featureSource,
+            GridCoverage2D gridCoverage2D,
+            Position2D position2D,
+            int altitudeIndex,
+            String altitudeName)
+            throws IOException, CQLException {
+        double altitude = calculateAltitude(gridCoverage2D.evaluate(position2D), altitudeIndex);
+        // Round altitude
+        altitude = BigDecimal.valueOf(altitude).setScale(2, RoundingMode.HALF_UP).doubleValue();
+
+        if (featureSource != null) {
+            altitude = getAdjustedAltitude(featureSource, position2D, altitude, altitudeName);
+        }
+        return altitude;
+    }
+
+    private static double calculateAltitude(Object obj, int altitudeIndex) {
+        Class<?> objectClass = obj.getClass();
+        if (objectClass.isArray()) {
+            switch (objectClass.getComponentType().getName()) {
+                case "byte":
+                    return ((byte[]) obj)[altitudeIndex];
+                case "int":
+                    return ((int[]) obj)[altitudeIndex];
+                case "float":
+                    return ((float[]) obj)[altitudeIndex];
+                case "double":
+                    return ((double[]) obj)[altitudeIndex];
+                default:
+                    // Do nothing
+            }
+        }
+        throw new IllegalArgumentException();
+    }
+
+    /**
+     * Process altitude using adjustment layer. Method attempts to find feature that contains
+     * provided parameter point geometry, and if found, subtracts its altitude value from provided
+     * parameter altitude
+     *
+     * @param featureSource
+     * @param coordinate
+     * @param altitude
+     * @return
+     * @throws IOException
+     */
+    private static double getAdjustedAltitude(
+            FeatureSource featureSource,
+            Position2D coordinate,
+            double altitude,
+            String altitudeName)
+            throws IOException, CQLException {
+        Query query;
+        Filter filter;
+        filter =
+                CQL.toFilter(
+                        "CONTAINS(the_geom, POINT("
+                                + coordinate.getX()
+                                + " "
+                                + coordinate.getY()
+                                + "))");
+        query = new Query(featureSource.getSchema().getName().getLocalPart(), filter);
+        try (FeatureIterator featureIterator = featureSource.getFeatures(query).features()) {
+            if (featureIterator.hasNext()) {
+                Feature feature = featureIterator.next();
+                Double adjLayerAltitude = (Double) feature.getProperty(altitudeName).getValue();
+                altitude = altitude - adjLayerAltitude;
+            }
+        }
+        return altitude;
+    }
+}

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcess.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcess.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Stack;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -193,7 +192,7 @@ public class LongitudinalProfileProcess implements GeoServerProcess, DisposableB
 
         // Create a stack with all geometry vertices
         Coordinate[] coords = denseLine.getCoordinates();
-        Stack<ProfileVertice> vertices = new Stack<ProfileVertice>();
+        ArrayList<ProfileVertice> vertices = new ArrayList<ProfileVertice>();
         for (int i = 0; i < coords.length; i++) {
             vertices.add(
                     new ProfileVertice(
@@ -207,21 +206,21 @@ public class LongitudinalProfileProcess implements GeoServerProcess, DisposableB
         int chunkSize = total / cores;
         int overflow = total % cores;
 
-        Stack<ArrayList<ProfileVertice>> chunks = new Stack<ArrayList<ProfileVertice>>();
+        ArrayList<ArrayList<ProfileVertice>> chunks = new ArrayList<ArrayList<ProfileVertice>>();
         for (int i = 0; i < cores; i++) {
             ArrayList<ProfileVertice> chunk = new ArrayList<ProfileVertice>();
             for (int j = 0; j < chunkSize; j++) {
-                chunk.add(vertices.pop());
+                chunk.add(vertices.remove(0));
             }
             if (overflow > 0) {
-                chunk.add(vertices.pop());
+                chunk.add(vertices.remove(0));
                 overflow = overflow - 1;
             }
             chunks.add(chunk);
         }
 
-        Stack<Future<ArrayList<ProfileVertice>>> treated =
-                new Stack<Future<ArrayList<ProfileVertice>>>();
+        ArrayList<Future<ArrayList<ProfileVertice>>> treated =
+                new ArrayList<Future<ArrayList<ProfileVertice>>>();
         GridCoverage2DReader gridCoverageReader =
                 (GridCoverage2DReader) coverageInfo.getGridCoverageReader(null, null);
         GridCoverage2D gridCoverage2D = gridCoverageReader.read(null);
@@ -231,7 +230,7 @@ public class LongitudinalProfileProcess implements GeoServerProcess, DisposableB
             treated.add(
                     executor.submit(
                             new AltitudeReaderThread(
-                                    chunks.pop(),
+                                    chunks.remove(0),
                                     altitudeIndex,
                                     adjustmentFeatureSource,
                                     altitudeName,

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcess.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcess.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Stack;
-import java.util.Vector;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -187,9 +186,9 @@ public class LongitudinalProfileProcess implements GeoServerProcess {
         int chunkSize = total / cores;
         int overflow = total % cores;
 
-        Stack<Vector<ProfileVertice>> chunks = new Stack<Vector<ProfileVertice>>();
+        Stack<ArrayList<ProfileVertice>> chunks = new Stack<ArrayList<ProfileVertice>>();
         for (int i = 0; i < cores; i++) {
-            Vector<ProfileVertice> chunk = new Vector<ProfileVertice>();
+            ArrayList<ProfileVertice> chunk = new ArrayList<ProfileVertice>();
             for (int j = 0; j < chunkSize; j++) {
                 chunk.add(vertices.pop());
             }
@@ -202,8 +201,8 @@ public class LongitudinalProfileProcess implements GeoServerProcess {
 
         // Create threads executor
         ExecutorService executor = Executors.newFixedThreadPool(cores);
-        Stack<Future<Vector<ProfileVertice>>> treated = new Stack<Future<Vector<ProfileVertice>>>();
-
+        Stack<Future<ArrayList<ProfileVertice>>> treated =
+                new Stack<Future<ArrayList<ProfileVertice>>>();
         GridCoverage2DReader gridCoverageReader =
                 (GridCoverage2DReader) coverageInfo.getGridCoverageReader(null, null);
         GridCoverage2D gridCoverage2D = gridCoverageReader.read(null);
@@ -219,9 +218,9 @@ public class LongitudinalProfileProcess implements GeoServerProcess {
                                     altitudeName,
                                     gridCoverage2D)));
         }
-        Vector<ProfileVertice> result = new Vector<ProfileVertice>();
+        ArrayList<ProfileVertice> result = new ArrayList<ProfileVertice>();
         try {
-            for (Future<Vector<ProfileVertice>> f : treated) {
+            for (Future<ArrayList<ProfileVertice>> f : treated) {
                 result.addAll(f.get());
             }
         } finally {

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
@@ -1,0 +1,42 @@
+package org.geoserver.wps.longitudinal;
+
+import org.geotools.geometry.Position2D;
+
+public class ProfileVertice {
+    Integer number;
+    Position2D coordinate;
+    Double altitude;
+
+    public ProfileVertice() {}
+
+    public ProfileVertice(Integer number, Position2D coordinate, Double altitude) {
+        super();
+        this.number = number;
+        this.coordinate = coordinate;
+        this.altitude = altitude;
+    }
+
+    public Integer getNumber() {
+        return number;
+    }
+
+    public void setNumber(Integer number) {
+        this.number = number;
+    }
+
+    public Position2D getCoordinate() {
+        return coordinate;
+    }
+
+    public void setCoordinate(Position2D coordinate) {
+        this.coordinate = coordinate;
+    }
+
+    public Double getAltitude() {
+        return altitude;
+    }
+
+    public void setAltitude(Double altitude) {
+        this.altitude = altitude;
+    }
+}

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
@@ -1,3 +1,7 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
 package org.geoserver.wps.longitudinal;
 
 import org.geotools.geometry.Position2D;

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
@@ -4,16 +4,16 @@
  */
 package org.geoserver.wps.longitudinal;
 
-import org.geotools.geometry.Position2D;
+import org.locationtech.jts.geom.Coordinate;
 
 public class ProfileVertice {
     Integer number;
-    Position2D coordinate;
+    Coordinate coordinate;
     Double altitude;
 
     public ProfileVertice() {}
 
-    public ProfileVertice(Integer number, Position2D coordinate, Double altitude) {
+    public ProfileVertice(Integer number, Coordinate coordinate, Double altitude) {
         super();
         this.number = number;
         this.coordinate = coordinate;
@@ -28,11 +28,11 @@ public class ProfileVertice {
         this.number = number;
     }
 
-    public Position2D getCoordinate() {
+    public Coordinate getCoordinate() {
         return coordinate;
     }
 
-    public void setCoordinate(Position2D coordinate) {
+    public void setCoordinate(Coordinate coordinate) {
         this.coordinate = coordinate;
     }
 


### PR DESCRIPTION
This PR modify the wps-longitudinal-profile community module to use thread for altitude reading.
This way it allow to process more points in less time, depending on available number of cores.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).