### PR TITLE
[GEOS-11276] Use style_body to define CSS style for a layer

### DIFF
--- a/doc/en/user/source/styling/css/directives.rst
+++ b/doc/en/user/source/styling/css/directives.rst
@@ -15,6 +15,7 @@ For example:
 .. code-block:: scss
 
   @mode 'Flat';
+  @styleName 'The name';
   @styleTitle 'The title;
   @styleAbstract 'This is a longer description'
   
@@ -43,6 +44,10 @@ Supported directives
       * Controls how the CSS is translated to SLD. ``Exclusive``, ``Simple`` and ``Auto`` are cascaded modes, ``Flat`` turns off cascading and has the CSS 
         behave like a simplified syntax SLD sheet. See :ref:`css_cascading` for an explanation of how the various modes work
       * false
+    - * ``styleName``
+      * String
+      * The generated SLD style name
+      * No
     - * ``styleTitle``
       * String
       * The generated SLD style title  

--- a/src/extension/css/src/test/java/org/geoserver/community/css/web/CssHandlerTest.java
+++ b/src/extension/css/src/test/java/org/geoserver/community/css/web/CssHandlerTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.community.css.web;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
@@ -13,6 +14,8 @@ import org.geotools.api.style.PolygonSymbolizer;
 import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.styling.SLD;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 public class CssHandlerTest extends GeoServerSystemTestSupport {
 
@@ -24,5 +27,29 @@ public class CssHandlerTest extends GeoServerSystemTestSupport {
 
         PolygonSymbolizer ps = SLD.polySymbolizer(Styles.style(sld));
         assertNotNull(ps);
+    }
+
+    @Test
+    public void testCssStyleIsAppliedToLayer() throws Exception {
+        String wmsRequest =
+                "wms?service=WMS&version=1.1.1&request=GetFeatureInfo&format=image/png&"
+                        + "query_layers=sf:AggregateGeoFeature&layers=sf:AggregateGeoFeature&info_format=text/xml&"
+                        + "feature_count=10&x=50&y=50&width=101&height=101&bbox=70.9,30.9,73.1,33.0";
+
+        // GetFeatureInfo near a point but without overlapping it
+        Document responseWithDefaultStyle = getAsDOM(wmsRequest);
+        NodeList featuresWithDefaultStyle =
+                responseWithDefaultStyle.getElementsByTagName("gml:featureMember");
+        assertEquals(0, featuresWithDefaultStyle.getLength());
+
+        // GetFeatureInfo in the same point but with a style that increases the mark size so that
+        // now the point should overlap the feature marker
+        String css =
+                "@styleName 'sf:AggregateGeoFeature'; *{mark: symbol(square); mark-size: 100px;}";
+        Document responseWithCssStyle =
+                getAsDOM(wmsRequest + "&style_format=css&style_body=" + css);
+        NodeList featuresWithCssStyle =
+                responseWithCssStyle.getElementsByTagName("gml:featureMember");
+        assertEquals(1, featuresWithCssStyle.getLength());
     }
 }


### PR DESCRIPTION
[![GEOS-11276](https://badgen.net/badge/JIRA/GEOS-11276/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11276) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This commit adds a test to check that a CSS string passed as STYLE_BODY with STYLE_FORMAT=css is applied to the layer if the style name is the same of the queried layer.

Documentation is also updated for the new directive.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).