### PR TITLE
[GEOS-11288] Improve input validation in ClasspathPublisher

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/ClasspathPublisher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/ClasspathPublisher.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.ows;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -54,10 +55,10 @@ public class ClasspathPublisher extends AbstractURLPublisher {
 
     @Override
     protected URL getUrl(HttpServletRequest request) throws IOException {
-        String ctxPath = request.getContextPath();
-        String reqPath = request.getRequestURI();
-        reqPath = URLDecoder.decode(reqPath, "UTF-8");
-        reqPath = reqPath.substring(ctxPath.length());
+        String reqPath =
+                URLDecoder.decode(request.getRequestURI(), "UTF-8")
+                        .substring(request.getContextPath().length())
+                        .replace(File.separatorChar, '/');
         if (Arrays.stream(reqPath.split("/")).anyMatch(".."::equals)) {
             throw new IllegalArgumentException("Contains invalid '..' path: " + reqPath);
         }

--- a/src/ows/src/test/java/org/geoserver/ows/ClasspathPublisherTest.java
+++ b/src/ows/src/test/java/org/geoserver/ows/ClasspathPublisherTest.java
@@ -4,9 +4,12 @@
  */
 package org.geoserver.ows;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeTrue;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -14,8 +17,17 @@ import org.springframework.mock.web.MockHttpServletResponse;
 public class ClasspathPublisherTest {
 
     @Test
-    public void testPathTraversal() throws Exception {
-        String path = "/schemas/../META-INF/MANIFEST.MF";
+    public void testPathTraversalAnyOS() {
+        doTestPathTraversal("/schemas/../META-INF/MANIFEST.MF");
+    }
+
+    @Test
+    public void testPathTraversalWindowsOnly() {
+        assumeTrue(SystemUtils.IS_OS_WINDOWS);
+        doTestPathTraversal("/schemas/..\\META-INF/MANIFEST.MF");
+    }
+
+    private static void doTestPathTraversal(String path) {
         ClasspathPublisher publisher = new ClasspathPublisher();
         MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -23,6 +35,6 @@ public class ClasspathPublisherTest {
                 assertThrows(
                         IllegalArgumentException.class,
                         () -> publisher.handleRequest(request, response));
-        assertEquals("Contains invalid '..' path: " + path, exception.getMessage());
+        assertThat(exception.getMessage(), startsWith("Contains invalid '..' path: "));
     }
 }


### PR DESCRIPTION
[![GEOS-11288](https://badgen.net/badge/JIRA/GEOS-11288/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11288) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR updates ClasspathPublisher to prevent using backslash characters on Windows to traverse directories.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->