### PR TITLE
[Backport 2.23.x][GEOS-11290] With Oauth enabled, anon users get random auth requests

### DIFF
--- a/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuthAuthenticationFilter.java
+++ b/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuthAuthenticationFilter.java
@@ -119,9 +119,6 @@ public abstract class GeoServerOAuthAuthenticationFilter
                 || authentication instanceof AnonymousAuthenticationToken
                 || accessToken != null) {
 
-            if (authentication instanceof AnonymousAuthenticationToken) {
-                SecurityContextHolder.getContext().setAuthentication(null);
-            }
             OAuth2AccessToken token = restTemplate.getOAuth2ClientContext().getAccessToken();
 
             if (accessToken != null && token != null && !token.getValue().equals(accessToken)) {
@@ -369,8 +366,8 @@ public abstract class GeoServerOAuthAuthenticationFilter
                 result = new PreAuthenticatedAuthenticationToken(principal, null, roles);
             }
             result.setDetails(getAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(result);
         }
-        SecurityContextHolder.getContext().setAuthentication(result);
     }
 
     @Override


### PR DESCRIPTION
[![GEOS-11290](https://badgen.net/badge/JIRA/GEOS-11290/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11290) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As per description in GEOS issue:
With many WMS concurrent requests as anonymous user to a public layer, sometimes a request gets a 401.
This only happens when in the default filter chain there’s an oauth filter.

Problem is probably caused by a race condition where `null` is put into the SecurityContextHolder, and another thread reads it while expecting an anonymous context.

Since the error pops out once in hundred requests (when many tiles for the same layer are requested by the same client), it's quite difficult to replicate programmatically.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->