### PR TITLE
[Backport 2.23.x] [GEOS-11290] With Oauth enabled, anon users get random auth requests

### DIFF
--- a/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuthAuthenticationFilter.java
+++ b/src/community/security/oauth2/oauth2-core/src/main/java/org/geoserver/security/oauth2/GeoServerOAuthAuthenticationFilter.java
@@ -119,9 +119,6 @@ public abstract class GeoServerOAuthAuthenticationFilter
                 || authentication instanceof AnonymousAuthenticationToken
                 || accessToken != null) {
 
-            if (authentication instanceof AnonymousAuthenticationToken) {
-                SecurityContextHolder.getContext().setAuthentication(null);
-            }
             OAuth2AccessToken token = restTemplate.getOAuth2ClientContext().getAccessToken();
 
             if (accessToken != null && token != null && !token.getValue().equals(accessToken)) {
@@ -369,8 +366,8 @@ public abstract class GeoServerOAuthAuthenticationFilter
                 result = new PreAuthenticatedAuthenticationToken(principal, null, roles);
             }
             result.setDetails(getAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(result);
         }
-        SecurityContextHolder.getContext().setAuthentication(result);
     }
 
     @Override


### PR DESCRIPTION
[![GEOS-11290](https://badgen.net/badge/JIRA/GEOS-11290/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11290) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7373
 **Authored by:** @etj