### PR TITLE
[Backport 2.24.x] [GEOS-11263] hideEmptyRules not working in JSON LegendGraphic

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
@@ -292,6 +292,10 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
                 applicableRules = LegendUtils.getApplicableRules(ftStyles, scaleDenominator);
             }
 
+            if (countProcessor != null && !forceLabelsOff) {
+                applicableRules = updateRuleTitles(countProcessor, legend, applicableRules);
+            }
+
             ArrayList<JSONObject> jRules = new ArrayList<>();
             if (legend instanceof CascadedLegendRequest) {
                 CascadedLegendRequest cascadedLegend = (CascadedLegendRequest) legend;
@@ -385,6 +389,11 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
         /* }*/
 
         return response;
+    }
+
+    protected Rule[] updateRuleTitles(
+            FeatureCountProcessor processor, LegendRequest legend, Rule[] applicableRules) {
+        return processor.preProcessRules(legend, applicableRules);
     }
 
     private JSONObject getLayerTitle(JSONObject in, LegendRequest legend) {

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
@@ -8,6 +8,7 @@ import java.awt.Color;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -18,6 +19,7 @@ import javax.measure.quantity.Length;
 import javax.swing.Icon;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang3.ArrayUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -292,7 +294,9 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
                 applicableRules = LegendUtils.getApplicableRules(ftStyles, scaleDenominator);
             }
 
-            if (countProcessor != null && !forceLabelsOff) {
+            if (countProcessor != null
+                    && request.getKvp() != null
+                    && request.getKvp().containsKey("bbox")) {
                 applicableRules = updateRuleTitles(countProcessor, legend, applicableRules);
             }
 
@@ -393,7 +397,35 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
 
     protected Rule[] updateRuleTitles(
             FeatureCountProcessor processor, LegendRequest legend, Rule[] applicableRules) {
-        return processor.preProcessRules(legend, applicableRules);
+        // skip rules with RasterSymbolizers, as they are not counted
+        Rule[] rasterRules = rasterRules(applicableRules);
+        Rule[] nonRasterRules = nonRasterRules(applicableRules);
+        Rule[] filteredRules = processor.preProcessRules(legend, nonRasterRules);
+        return ArrayUtils.addAll(filteredRules, rasterRules);
+    }
+
+    private Rule[] rasterRules(Rule[] applicableRules) {
+        return Arrays.stream(applicableRules)
+                .filter(r -> allRaster(r.getSymbolizers()))
+                .toArray(Rule[]::new);
+    }
+
+    private Rule[] nonRasterRules(Rule[] applicableRules) {
+        return Arrays.stream(applicableRules)
+                .filter(r -> !allRaster(r.getSymbolizers()))
+                .toArray(Rule[]::new);
+    }
+
+    private <T> boolean allRaster(T[] symbolizers) {
+        if (ArrayUtils.isEmpty(symbolizers)) {
+            return false;
+        }
+        for (T symbolizer : symbolizers) {
+            if (!(symbolizer instanceof RasterSymbolizer)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private JSONObject getLayerTitle(JSONObject in, LegendRequest legend) {

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
@@ -1982,4 +1982,23 @@ public class JSONLegendGraphicOutputFormatTest extends BaseLegendTest<JSONLegend
             if (group != null) catalog.remove(group);
         }
     }
+
+    @Test
+    public void testHideEmptyRules() throws Exception {
+        String url =
+                "wms?LAYER="
+                        + MockData.NAMED_PLACES.getLocalPart()
+                        + "&FORMAT=application/json"
+                        + "&SERVICE=WMS&REQUEST=GetLegendGraphic&VERSION=1.0.0&WIDTH=20&HEIGHT=20";
+        JSONObject legend = (JSONObject) getAsJSON(url);
+        JSONArray rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
+        assertEquals(2, rules.size());
+        assertEquals("ashton", rules.getJSONObject(0).get("name"));
+        assertEquals("goose_island", rules.getJSONObject(1).get("name"));
+
+        url += "&LEGEND_OPTIONS=hideEmptyRules:true&BBOX=0,0,0.1,0.1";
+        legend = (JSONObject) getAsJSON(url);
+        rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
+        assertEquals(1, rules.size());
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicOutputFormatTest.java
@@ -1993,12 +1993,14 @@ public class JSONLegendGraphicOutputFormatTest extends BaseLegendTest<JSONLegend
         JSONObject legend = (JSONObject) getAsJSON(url);
         JSONArray rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
         assertEquals(2, rules.size());
-        assertEquals("ashton", rules.getJSONObject(0).get("name"));
-        assertEquals("goose_island", rules.getJSONObject(1).get("name"));
+        assertEquals("ashton", rules.getJSONObject(0).getString("name"));
+        assertEquals("goose_island", rules.getJSONObject(1).getString("name"));
 
+        // goose_island is placed on negative Y ordinates
         url += "&LEGEND_OPTIONS=hideEmptyRules:true&BBOX=0,0,0.1,0.1";
         legend = (JSONObject) getAsJSON(url);
         rules = legend.getJSONArray("Legend").getJSONObject(0).getJSONArray("rules");
         assertEquals(1, rules.size());
+        assertEquals("ashton", rules.getJSONObject(0).getString("name"));
     }
 }


### PR DESCRIPTION
Backport #7353
 **Authored by:** @iaunzu