### PR TITLE
[Backport 2.23.x] Bump org.springframework:spring-expression from 3.2.5.RELEASE to 5.2.23.RELEASE in /src/community/jms-cluster/activemqBroker

### DIFF
--- a/src/community/jms-cluster/activemqBroker/pom.xml
+++ b/src/community/jms-cluster/activemqBroker/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <postgres.version>8.3-603.jdbc4</postgres.version>
-    <spring.version>3.2.5.RELEASE</spring.version>
+    <spring.version>5.2.23.RELEASE</spring.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Backport #7374
 **Authored by:** @dependabot[bot]