### PR TITLE
[Backport 2.24.x] [GEOS-11278] metadata: only selected tab is submitted

### DIFF
--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/web/panel/MetadataPanel.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/web/panel/MetadataPanel.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
 import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.form.SubmitLink;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -97,7 +98,23 @@ public class MetadataPanel extends Panel {
                         });
             }
 
-            TabbedPanel<AbstractTab> panel = new TabbedPanel<>(id, tabPanels);
+            // we need to override with submit links so that each tab will validate & submit
+            TabbedPanel<AbstractTab> panel =
+                    new TabbedPanel<>(id, tabPanels) {
+                        private static final long serialVersionUID = 2128818273175357135L;
+
+                        @Override
+                        protected WebMarkupContainer newLink(String linkId, final int index) {
+                            return new SubmitLink(linkId) {
+                                private static final long serialVersionUID = -9015199018095752516L;
+
+                                @Override
+                                public void onSubmit() {
+                                    setSelectedTab(index);
+                                }
+                            };
+                        }
+                    };
 
             return panel;
         } else {

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/data/service/ConfigurationServiceTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/data/service/ConfigurationServiceTest.java
@@ -31,7 +31,7 @@ public class ConfigurationServiceTest extends AbstractMetadataTest {
     public void testFileRegistry() throws IOException {
         MetadataConfiguration configuration = yamlService.getMetadataConfiguration();
         Assert.assertNotNull(configuration);
-        Assert.assertEquals(15, configuration.getAttributes().size());
+        Assert.assertEquals(16, configuration.getAttributes().size());
         Assert.assertEquals(3, configuration.getGeonetworks().size());
         Assert.assertEquals(5, configuration.getTypes().size());
 

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/ConditionTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/ConditionTest.java
@@ -45,7 +45,7 @@ public class ConditionTest extends AbstractWicketMetadataTest {
                         tester.getComponentFromLastRenderedPage(
                                 "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items");
         tester.submitForm("publishedinfo");
-        assertEquals(13, c.size());
+        assertEquals(14, c.size());
         logout();
     }
 }

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/LayerMetadataTabTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/LayerMetadataTabTest.java
@@ -88,7 +88,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
                         tester.getComponentFromLastRenderedPage(
                                 "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel");
         // derived field hidden
-        assertEquals(14, panel.getDataProvider().size());
+        assertEquals(15, panel.getDataProvider().size());
 
         FormTester ft = tester.newFormTester("publishedinfo");
         ft.submit("save");
@@ -701,7 +701,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
                 (MarkupContainer)
                         tester.getComponentFromLastRenderedPage(
                                 "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items");
-        assertEquals(14, c.size());
+        assertEquals(15, c.size());
 
         tester.assertComponent(
                 "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:13:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:1:component:generate",

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/TabsTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/TabsTest.java
@@ -4,8 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.util.Map;
 import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.util.file.File;
+import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.metadata.AbstractMetadataTest;
 import org.geoserver.metadata.AbstractWicketMetadataTest;
@@ -53,7 +55,7 @@ public class TabsTest extends AbstractWicketMetadataTest {
                 (GeoServerTablePanel<AttributeConfiguration>)
                         tester.getComponentFromLastRenderedPage(
                                 "publishedinfo:tabs:panel:metadataPanel:panel:attributesPanel:attributesTablePanel");
-        assertEquals(6, attPanel.getDataProvider().size());
+        assertEquals(7, attPanel.getDataProvider().size());
 
         tester.clickLink("publishedinfo:tabs:panel:metadataPanel:tabs-container:tabs:1:link");
         tester.assertComponent("publishedinfo:tabs:panel:metadataPanel:panel", MetadataPanel.class);
@@ -72,5 +74,38 @@ public class TabsTest extends AbstractWicketMetadataTest {
         assertEquals(4, attPanel.getDataProvider().size());
 
         logout();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSave() throws IOException {
+
+        login();
+        layer = geoServer.getCatalog().getLayerByName("mylayer");
+        assertNotNull(layer);
+        ResourceConfigurationPage page = new ResourceConfigurationPage(layer, false);
+        tester.startPage(page);
+        ((TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs"))
+                .setSelectedTab(4);
+        tester.submitForm("publishedinfo");
+        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel", TabbedPanel.class);
+        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel:panel", MetadataPanel.class);
+
+        FormTester formTester = tester.newFormTester("publishedinfo");
+        formTester.setValue(
+                "tabs:panel:metadataPanel:panel:attributesPanel:attributesTablePanel:listContainer:items:7:itemProperties:1:component:textfield",
+                "new-value");
+
+        tester.clickLink("publishedinfo:tabs:panel:metadataPanel:tabs-container:tabs:1:link");
+
+        formTester.submit("save");
+
+        logout();
+
+        layer = geoServer.getCatalog().getLayerByName("mylayer");
+        assertEquals(
+                "new-value",
+                ((Map<String, Object>) layer.getResource().getMetadata().get("custom"))
+                        .get("extra-text"));
     }
 }

--- a/src/extension/metadata/src/test/resources/org/geoserver/metadata/metadata-ui.yaml
+++ b/src/extension/metadata/src/test/resources/org/geoserver/metadata/metadata-ui.yaml
@@ -70,6 +70,9 @@ attributes:
     derivedFrom: source
     occurrence: REPEAT
     tab: tab3
+  - key: extra-text
+    fieldType: TEXT
+    tab: tab1
 csvImports:
   - sourcetarget.csv
 


### PR DESCRIPTION
[![GEOS-11278](https://badgen.net/badge/JIRA/GEOS-11278/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11278) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7364
 **Authored by:** @NielsCharlier