### PR TITLE
[GEOS-11291] GeoFence: Cleanup stale log4j references

### DIFF
--- a/src/release/ext-geofence-server.xml
+++ b/src/release/ext-geofence-server.xml
@@ -27,8 +27,6 @@
         <include>jackson*</include>
         <include>javassist*</include>
         <include>jta*</include>
-        <include>log4j-api*</include>
-        <include>log4j-slf4j-impl*</include>
         <include>search*</include>
         <include>spring-orm*</include>
         <include>spring-oxm*</include>


### PR DESCRIPTION
[![GEOS-11291](https://badgen.net/badge/JIRA/GEOS-11291/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11291) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Assembly files of geofence plugins still include references to log4j stuff.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).