### PR TITLE
[Backport 2.24.x] [GEOS-11291] GeoFence: Cleanup stale log4j references

### DIFF
--- a/src/release/ext-geofence-server.xml
+++ b/src/release/ext-geofence-server.xml
@@ -27,8 +27,6 @@
         <include>jackson*</include>
         <include>javassist*</include>
         <include>jta*</include>
-        <include>log4j-api*</include>
-        <include>log4j-slf4j-impl*</include>
         <include>search*</include>
         <include>spring-orm*</include>
         <include>spring-oxm*</include>


### PR DESCRIPTION
[![GEOS-11291](https://badgen.net/badge/JIRA/GEOS-11291/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11291) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7391
 **Authored by:** @etj