### PR TITLE
[GEOS-11232] Add Zoom scaled layer templates to MapML

### DIFF
--- a/doc/en/user/source/services/wms/outputformats.rst
+++ b/doc/en/user/source/services/wms/outputformats.rst
@@ -65,6 +65,12 @@ where ``<format>`` is any of the options below.
    * - KMZ
      - ``format=kmz``
      -
+   * - MapML
+     - ``format=text/mapml``
+     -
+   * - MapML HTML Viewer
+     - ``text/html; subtype=mapml``
+     -
    * - OpenLayers
      - ``format=application/openlayers``
      - Generates an OpenLayers HTML application.

--- a/src/extension/mapml/src/test/resources/org/geoserver/mapml/scaleRange.sld
+++ b/src/extension/mapml/src/test/resources/org/geoserver/mapml/scaleRange.sld
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" 
+ xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+ xmlns="http://www.opengis.net/sld" 
+ xmlns:ogc="http://www.opengis.net/ogc" 
+ xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- Limits the scale from 1:2 to whatever, but a bug in GS made this kind of style not generate any kml -->
+  <NamedLayer>
+    <Name>default_polygon</Name>
+    <UserStyle>
+      <Title>Default Polygon</Title>
+      <Abstract>A sample style that draws a polygon</Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <MinScaleDenominator>2</MinScaleDenominator>
+          <MaxScaleDenominator>2500</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+         <Rule>
+          <MinScaleDenominator>2500</MinScaleDenominator>
+          <MaxScaleDenominator>2500</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/src/extension/mapml/src/test/resources/org/geoserver/mapml/scaleRangeExtremes.sld
+++ b/src/extension/mapml/src/test/resources/org/geoserver/mapml/scaleRangeExtremes.sld
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" 
+ xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+ xmlns="http://www.opengis.net/sld" 
+ xmlns:ogc="http://www.opengis.net/ogc" 
+ xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- Limits the scale from 1:2 to whatever, but a bug in GS made this kind of style not generate any kml -->
+  <NamedLayer>
+    <Name>default_polygon</Name>
+    <UserStyle>
+      <Title>Default Polygon</Title>
+      <Abstract>A sample style that draws a polygon</Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <MinScaleDenominator>1</MinScaleDenominator>
+          <MaxScaleDenominator>999999999999</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+         <Rule>
+          <MinScaleDenominator>1</MinScaleDenominator>
+          <MaxScaleDenominator>999999999999</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/src/extension/mapml/src/test/resources/org/geoserver/mapml/scaleRangeNoMax.sld
+++ b/src/extension/mapml/src/test/resources/org/geoserver/mapml/scaleRangeNoMax.sld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" 
+ xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+ xmlns="http://www.opengis.net/sld" 
+ xmlns:ogc="http://www.opengis.net/ogc" 
+ xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- Limits the scale from 1:2 to whatever, but a bug in GS made this kind of style not generate any kml -->
+  <NamedLayer>
+    <Name>default_polygon</Name>
+    <UserStyle>
+      <Title>Default Polygon</Title>
+      <Abstract>A sample style that draws a polygon</Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <MaxScaleDenominator>2500</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+         <Rule>
+          <MaxScaleDenominator>2500</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOS-11232](https://badgen.net/badge/JIRA/GEOS-11232/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11232) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

switched to binary search

working test for zoom input

unit tests and fix for single extent detection

GetMap tests

wms output format documentation

added some edge tests

unused var

ground resolution to scale

updated tests and fixed infinite check

Reproject bounds

- For gwc-backed GetMap request update extentZoomInput.value with the gss.getZoomStop() to match the zoom value used by the location inputs' min/max row and column axes.  Non-GWC backed GetMap zoom input will not carry a value attribute, and it's not necessary

- tbd:  a test to cover it


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->