### PR TITLE
[Backport 2.24.x] [GEOS-11276] Use style_body to define CSS style for a layer

### DIFF
--- a/doc/en/user/source/styling/css/directives.rst
+++ b/doc/en/user/source/styling/css/directives.rst
@@ -15,6 +15,7 @@ For example:
 .. code-block:: scss
 
   @mode 'Flat';
+  @styleName 'The name';
   @styleTitle 'The title;
   @styleAbstract 'This is a longer description'
   
@@ -43,6 +44,10 @@ Supported directives
       * Controls how the CSS is translated to SLD. ``Exclusive``, ``Simple`` and ``Auto`` are cascaded modes, ``Flat`` turns off cascading and has the CSS 
         behave like a simplified syntax SLD sheet. See :ref:`css_cascading` for an explanation of how the various modes work
       * false
+    - * ``styleName``
+      * String
+      * The generated SLD style name
+      * No
     - * ``styleTitle``
       * String
       * The generated SLD style title  

--- a/src/extension/css/src/test/java/org/geoserver/community/css/web/CssHandlerTest.java
+++ b/src/extension/css/src/test/java/org/geoserver/community/css/web/CssHandlerTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.community.css.web;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
@@ -13,6 +14,8 @@ import org.geotools.api.style.PolygonSymbolizer;
 import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.styling.SLD;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 public class CssHandlerTest extends GeoServerSystemTestSupport {
 
@@ -24,5 +27,29 @@ public class CssHandlerTest extends GeoServerSystemTestSupport {
 
         PolygonSymbolizer ps = SLD.polySymbolizer(Styles.style(sld));
         assertNotNull(ps);
+    }
+
+    @Test
+    public void testCssStyleIsAppliedToLayer() throws Exception {
+        String wmsRequest =
+                "wms?service=WMS&version=1.1.1&request=GetFeatureInfo&format=image/png&"
+                        + "query_layers=sf:AggregateGeoFeature&layers=sf:AggregateGeoFeature&info_format=text/xml&"
+                        + "feature_count=10&x=50&y=50&width=101&height=101&bbox=70.9,30.9,73.1,33.0";
+
+        // GetFeatureInfo near a point but without overlapping it
+        Document responseWithDefaultStyle = getAsDOM(wmsRequest);
+        NodeList featuresWithDefaultStyle =
+                responseWithDefaultStyle.getElementsByTagName("gml:featureMember");
+        assertEquals(0, featuresWithDefaultStyle.getLength());
+
+        // GetFeatureInfo in the same point but with a style that increases the mark size so that
+        // now the point should overlap the feature marker
+        String css =
+                "@styleName 'sf:AggregateGeoFeature'; *{mark: symbol(square); mark-size: 100px;}";
+        Document responseWithCssStyle =
+                getAsDOM(wmsRequest + "&style_format=css&style_body=" + css);
+        NodeList featuresWithCssStyle =
+                responseWithCssStyle.getElementsByTagName("gml:featureMember");
+        assertEquals(1, featuresWithCssStyle.getLength());
     }
 }


### PR DESCRIPTION
[![GEOS-11276](https://badgen.net/badge/JIRA/GEOS-11276/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11276) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7365
 **Authored by:** @mirco-romagnoli