### PR TITLE
First class support for MapML Tiled CRS definitions

### DIFF
--- a/doc/en/user/source/extensions/mapml/index.rst
+++ b/doc/en/user/source/extensions/mapml/index.rst
@@ -131,10 +131,24 @@ MapML resources will be available for any published WMS layers by making a GetMa
 
 Note that the WMS SRS or CRS must be one of the projections supported by MapML:
 
-- EPSG:3857
-- EPSG:3978
-- EPSG:5936
-- EPSG:4326
+- MapML:WGS84 (or EPSG:4326)
+- MapML:OSMTILE (or EPSG:3857)
+- MapML:CBMTILE (or EPSG:3978)
+- MapML:APSTILE (or EPSG:5936)
+
+The equivalent EPSG codes are provided for reference, but the MapML names are recommended, as they
+imply not only a coordinate refefence system, but also a tile grid and a set of zoom levels (Tiled CRS), 
+that the MapML client will use when operating in tiled mode. When using tiles, it's also recommended
+to set up tile caching for the same-named gridsets.
+
+If the native SRS of a layer is not a match for the MapML ones, remember to configure the projection
+policy to "reproject native to declare". You might have to save and reload the layer configuration
+in order to re-compute the native bounds correctly.
+
+If the SRS or CRS is not one of the above, the GetMap request will fail with an ``InvalidParameterValue`` exception.
+The main "MapML" link in the preview page generates a HTML client able to consume MapML resources.
+The link is generated so that it always work, if the CRS configured for the layer is not supported, it will automatically fall back on MapML:WGS84.
+
 
 **MapML Output Format**
 

--- a/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImportTaskTableTest.java
+++ b/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImportTaskTableTest.java
@@ -101,7 +101,7 @@ public class ImportTaskTableTest extends GeoServerWicketTestSupport {
         // The second (4) should still be set
         tester.assertModelValue(
                 "taskTable:listContainer:items:4:itemProperties:2:component:form:crs:srs",
-                "EPSG:4269");
+                "CRS:83");
     }
 
     void fill(String formPath, String fieldPath, String value) {

--- a/src/extension/mapml/pom.xml
+++ b/src/extension/mapml/pom.xml
@@ -87,8 +87,13 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms</artifactId>
-
       <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-iau-wkt</artifactId>
+      <version>${gt.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLDocumentBuilder.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLDocumentBuilder.java
@@ -641,7 +641,7 @@ public class MapMLDocumentBuilder {
         wmsParams.put(
                 "format_options", MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION + ":" + imageFormat);
         wmsParams.put("layers", layersCommaDelimited);
-        wmsParams.put("crs", projType.getEpsgCode());
+        wmsParams.put("crs", projType.getCRSCode());
         wmsParams.put("version", "1.3.0");
         wmsParams.put("service", "WMS");
         wmsParams.put("request", "GetMap");
@@ -770,7 +770,7 @@ public class MapMLDocumentBuilder {
                 ReferencedEnvelope reprojectedBounds = reproject(projectedBox, pt);
                 // Copy the base params to create one for self style
                 Map<String, String> projParams = new HashMap<>(wmsParams);
-                projParams.put("crs", pt.getEpsgCode());
+                projParams.put("crs", pt.getCRSCode());
                 projParams.put("width", Integer.toString(width));
                 projParams.put("height", Integer.toString(height));
                 projParams.put("bbox", toCommaDelimitedBbox(reprojectedBounds));
@@ -1173,7 +1173,7 @@ public class MapMLDocumentBuilder {
         params.put("version", "1.3.0");
         params.put("service", "WMS");
         params.put("request", "GetMap");
-        params.put("crs", PREVIEW_TCRS_MAP.get(projType.value()).getCode());
+        params.put("crs", projType.getCRSCode());
         params.put("layers", mapMLLayerMetadata.getLayerName());
         params.put("language", this.request.getLocale().getLanguage());
         params.put("styles", mapMLLayerMetadata.getStyleName());
@@ -1318,7 +1318,7 @@ public class MapMLDocumentBuilder {
         params.put("version", "1.3.0");
         params.put("service", "WMS");
         params.put("request", "GetMap");
-        params.put("crs", PREVIEW_TCRS_MAP.get(projType.value()).getCode());
+        params.put("crs", projType.getCRSCode());
         params.put("layers", mapMLLayerMetadata.getLayerName());
         params.put("styles", mapMLLayerMetadata.getStyleName());
         if (mapMLLayerMetadata.isTimeEnabled()) {
@@ -1429,7 +1429,7 @@ public class MapMLDocumentBuilder {
         params.put("service", "WMS");
         params.put("request", "GetFeatureInfo");
         params.put("feature_count", "50");
-        params.put("crs", PREVIEW_TCRS_MAP.get(projType.value()).getCode());
+        params.put("crs", projType.getCRSCode());
         params.put("language", this.request.getLocale().getLanguage());
         params.put("layers", mapMLLayerMetadata.getLayerName());
         params.put("query_layers", mapMLLayerMetadata.getLayerName());
@@ -1587,10 +1587,7 @@ public class MapMLDocumentBuilder {
                 .append("&LAYERS=")
                 .append(escapeHtml4(layer))
                 .append("&BBOX=")
-                .append(String.valueOf(projectedBbox.getMinX()) + ",")
-                .append(String.valueOf(projectedBbox.getMinY()) + ",")
-                .append(String.valueOf(projectedBbox.getMaxX()) + ",")
-                .append(String.valueOf(projectedBbox.getMaxY()))
+                .append(toCommaDelimitedBbox(projectedBbox))
                 .append("&HEIGHT=")
                 .append(height)
                 .append("&WIDTH=")

--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGetFeatureOutputFormat.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLGetFeatureOutputFormat.java
@@ -316,7 +316,7 @@ public class MapMLGetFeatureOutputFormat extends WFSGetFeatureOutputFormat {
                         throw new ServiceException("Invalid TCRS name");
                     }
                     l.setRel(RelType.ALTERNATE);
-                    this.query.put("srsName", projection.getCode());
+                    this.query.put("srsName", "MapML:" + projection.getName());
                     HashMap<String, String> kvp = new HashMap<>(this.query.size());
                     this.query
                             .keySet()

--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/tcrs/TiledCRSFactory.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/tcrs/TiledCRSFactory.java
@@ -1,0 +1,191 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.mapml.tcrs;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.geotools.api.metadata.Identifier;
+import org.geotools.api.metadata.citation.Citation;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.IdentifiedObject;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.ReferenceIdentifier;
+import org.geotools.api.referencing.crs.CRSAuthorityFactory;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.crs.GeographicCRS;
+import org.geotools.api.referencing.crs.ProjectedCRS;
+import org.geotools.api.referencing.crs.SingleCRS;
+import org.geotools.api.referencing.cs.CartesianCS;
+import org.geotools.api.referencing.cs.CoordinateSystem;
+import org.geotools.api.referencing.cs.EllipsoidalCS;
+import org.geotools.api.referencing.datum.Datum;
+import org.geotools.api.referencing.datum.GeodeticDatum;
+import org.geotools.api.referencing.operation.Conversion;
+import org.geotools.gml2.SrsSyntax;
+import org.geotools.gml2.bindings.GML2EncodingUtils;
+import org.geotools.metadata.iso.IdentifierImpl;
+import org.geotools.metadata.iso.citation.CitationImpl;
+import org.geotools.metadata.iso.citation.Citations;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.NamedIdentifier;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.referencing.crs.DefaultProjectedCRS;
+import org.geotools.referencing.factory.AllAuthoritiesFactory;
+import org.geotools.referencing.factory.AuthorityFactoryAdapter;
+import org.geotools.util.factory.Hints;
+
+/**
+ * Exposes available {@link TiledCRS} to GeoServer as valid Coordinate Reference Systems. The
+ * current implementation loads a database of TiledCRS from TiledCRSConstant, will use the TCRS
+ * database in the future, if those are made to be configurable
+ */
+public class TiledCRSFactory extends AuthorityFactoryAdapter implements CRSAuthorityFactory {
+    /** The authority prefix */
+    public static final String AUTHORITY = "MapML";
+
+    public static final Citation MAPML;
+
+    static {
+        final CitationImpl c = new CitationImpl("MapML");
+        c.getIdentifiers().add(new IdentifierImpl(AUTHORITY));
+        c.freeze();
+        MAPML = c;
+    }
+
+    /** Builds the MapML CRS factory with no hints. */
+    public TiledCRSFactory() {
+        this(null);
+    }
+
+    /** Constructs a default factory for the {@code CRS} authority. */
+    public TiledCRSFactory(Hints hints) {
+        super(new AllAuthoritiesFactory(hints));
+    }
+
+    /** Returns the authority for this factory, which is {@link Citations#CRS CRS}. */
+    @Override
+    public Citation getAuthority() {
+        return MAPML;
+    }
+
+    @Override
+    public Set<String> getAuthorityCodes(Class<? extends IdentifiedObject> type)
+            throws FactoryException {
+        return TiledCRSConstants.tiledCRSDefinitions.values().stream()
+                .map(TiledCRSParams::getName)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public CoordinateReferenceSystem createCoordinateReferenceSystem(String code)
+            throws FactoryException, NoSuchAuthorityCodeException {
+        final CRSAuthorityFactory factory = getCRSAuthorityFactory(code);
+        CoordinateReferenceSystem crs =
+                factory.createCoordinateReferenceSystem(toBackingFactoryCode(code));
+        final CoordinateReferenceSystem replaced = replace(crs, code);
+        notifySuccess("createCoordinateReferenceSystem", code, factory, replaced);
+
+        return replaced;
+    }
+
+    @Override
+    protected String toBackingFactoryCode(String code) throws FactoryException {
+        String identifier = getIdentifier(code);
+
+        TiledCRSParams definition = TiledCRSConstants.lookupTCRS(identifier);
+        if (definition == null) {
+            throw new NoSuchAuthorityCodeException("No such CRS: " + code, AUTHORITY, code);
+        }
+
+        // get the backing store code in form "authority:code", axis order handling
+        // happens in wrappers of this factory
+        String definitionCode = definition.getCode();
+        CoordinateReferenceSystem crs = CRS.decode(definitionCode);
+        return GML2EncodingUtils.toURI(crs, SrsSyntax.AUTH_CODE, true);
+    }
+
+    /**
+     * Grabs the identifier from the code, which may be in the form "authority:code" or just "code"
+     *
+     * @param code
+     * @return
+     */
+    private String getIdentifier(String code) {
+        String identifier = trimAuthority(code).toUpperCase();
+        if (identifier.startsWith(AUTHORITY)) {
+            identifier = identifier.substring(AUTHORITY.length());
+        }
+        return identifier;
+    }
+
+    /**
+     * Replaces the CRS with one that has the MapML identifiers. Avoids going throught the CRS
+     * factory to avoid axis flipping issues.
+     *
+     * @throws FactoryException if the CRS is not supported
+     */
+    protected CoordinateReferenceSystem replace(CoordinateReferenceSystem crs, String code)
+            throws FactoryException {
+
+        final Datum datum;
+        if (crs instanceof SingleCRS) {
+            datum = ((SingleCRS) crs).getDatum();
+        } else {
+            datum = null;
+        }
+        CoordinateSystem cs = crs.getCoordinateSystem();
+        final Map<String, ?> properties = getProperties(crs, code);
+
+        if (crs instanceof ProjectedCRS) {
+            final ProjectedCRS projectedCRS = (ProjectedCRS) crs;
+            final CoordinateReferenceSystem baseCRS = projectedCRS.getBaseCRS();
+            Conversion fromBase = projectedCRS.getConversionFromBase();
+            return new DefaultProjectedCRS(
+                    properties,
+                    fromBase,
+                    (GeographicCRS) baseCRS,
+                    ((ProjectedCRS) crs).getConversionFromBase().getMathTransform(),
+                    (CartesianCS) cs);
+        } else if (crs instanceof GeographicCRS) {
+            return new DefaultGeographicCRS(properties, (GeodeticDatum) datum, (EllipsoidalCS) cs);
+        }
+
+        // do not know of a way to attach the code to the copy
+        throw new IllegalArgumentException("Unsupported crs: " + crs);
+    }
+
+    /**
+     * Returns the properties to be given to an object replacing an original one. If the new object
+     * keep the same authority, then all metadata are preserved. Otherwise (i.e. if a new authority
+     * is given to the new object), then the old identifiers will be removed from the new object
+     * metadata.
+     *
+     * @param object The original object.
+     * @return The properties to be given to the object created as a substitute of {@code object}.
+     */
+    private Map<String, Object> getProperties(final IdentifiedObject object, String code) {
+        final Citation authority = getAuthority();
+        String identifier = getIdentifier(code);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(IdentifiedObject.NAME_KEY, identifier);
+        properties.put(Identifier.AUTHORITY_KEY, authority);
+        List<ReferenceIdentifier> aliases = new ArrayList<>(object.getIdentifiers());
+        List<ReferenceIdentifier> identifiers = new ArrayList<>();
+        aliases.add(0, new NamedIdentifier(authority, identifier));
+        properties.put(
+                IdentifiedObject.IDENTIFIERS_KEY,
+                aliases.toArray(new ReferenceIdentifier[identifiers.size()]));
+        properties.put(
+                IdentifiedObject.ALIAS_KEY,
+                aliases.toArray(new ReferenceIdentifier[aliases.size()]));
+
+        return properties;
+    }
+}

--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/tcrs/TiledCRSParams.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/tcrs/TiledCRSParams.java
@@ -61,4 +61,13 @@ public class TiledCRSParams {
     public Point getOrigin() {
         return origin;
     }
+
+    /**
+     * Returns the MapML full CRS name for these params
+     *
+     * @return
+     */
+    public String getSRSName() {
+        return TiledCRSFactory.AUTHORITY + ":" + name;
+    }
 }

--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/xml/ProjType.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/xml/ProjType.java
@@ -77,7 +77,7 @@ public enum ProjType {
         throw new IllegalArgumentException(v);
     }
 
-    public String getEpsgCode() {
-        return "EPSG:" + epsgCode;
+    public String getCRSCode() {
+        return "MapML:" + value;
     }
 }

--- a/src/extension/mapml/src/main/java/org/geoserver/web/demo/MapMLFormatLink.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/web/demo/MapMLFormatLink.java
@@ -4,20 +4,71 @@
  */
 package org.geoserver.web.demo;
 
+import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
+
+import java.util.Map;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.model.StringResourceModel;
 import org.geoserver.mapml.MapMLConstants;
+import org.geoserver.mapml.tcrs.TiledCRSConstants;
+import org.geoserver.mapml.tcrs.TiledCRSParams;
+import org.geoserver.wms.GetMapRequest;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 
 public class MapMLFormatLink extends CommonFormatLink {
 
     @Override
     public ExternalLink getFormatLink(PreviewLayer layer) {
+        String link = layer.getWmsLink(this::customizeRequest);
+
         ExternalLink olLink =
                 new ExternalLink(
                         this.getComponentId(),
-                        layer.getWmsLink() + "&format=" + MapMLConstants.MAPML_HTML_MIME_TYPE,
+                        link,
                         (new StringResourceModel(this.getTitleKey(), null, null)).getString());
         olLink.setVisible(layer.hasServiceSupport("WMS"));
         return olLink;
+    }
+
+    /** Customize the request to use the MapML format and a native MapML CRS if possible */
+    void customizeRequest(GetMapRequest request, Map<String, String> params) {
+        // set the format
+        params.put("format", MapMLConstants.MAPML_HTML_MIME_TYPE);
+
+        // check if we can use a native MapML CRS, otherwise fall back to WGS84 to
+        // have something that can display anyways
+        TiledCRSConstants.tiledCRSDefinitions.values().stream()
+                .filter(tcrs -> matches(request, tcrs))
+                .findFirst()
+                .ifPresentOrElse(
+                        tcrs -> params.put("srs", tcrs.getSRSName()),
+                        () -> {
+                            params.put("srs", "MapML:WGS84");
+                            params.put("bbox", getWGS84Bounds(request));
+                        });
+    }
+
+    /** Check if the request CRS matches the given TiledCRSParams */
+    private static boolean matches(GetMapRequest request, TiledCRSParams tcrs) {
+        try {
+            return CRS.equalsIgnoreMetadata(CRS.decode(tcrs.getSRSName()), request.getCrs());
+        } catch (FactoryException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Get the WGS84 bounds of the request */
+    private static String getWGS84Bounds(GetMapRequest request) {
+        try {
+            ReferencedEnvelope re =
+                    new ReferencedEnvelope(request.getBbox(), CRS.decode(request.getSRS()))
+                            .transform(WGS84, true);
+            return re.getMinX() + "," + re.getMinY() + "," + re.getMaxX() + "," + re.getMaxY();
+        } catch (TransformException | FactoryException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/extension/mapml/src/main/resources/META-INF/services/org.geotools.api.referencing.crs.CRSAuthorityFactory
+++ b/src/extension/mapml/src/main/resources/META-INF/services/org.geotools.api.referencing.crs.CRSAuthorityFactory
@@ -1,0 +1,1 @@
+org.geoserver.mapml.tcrs.TiledCRSFactory

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
@@ -1156,6 +1156,46 @@ public class MapMLWMSTest extends WMSTestSupport {
     }
 
     @Test
+    public void testInvalidProjectionHTML() throws Exception {
+        String path =
+                "cite/wms?LAYERS=Lakes"
+                        + "&STYLES=&FORMAT="
+                        + MapMLConstants.MAPML_HTML_MIME_TYPE
+                        + "&SERVICE=WMS&VERSION=1.3.0"
+                        + "&REQUEST=GetMap"
+                        + "&SRS=EPSG:32632"
+                        + "&BBOX=-13885038,2870337,-7455049,6338174"
+                        + "&WIDTH=150"
+                        + "&HEIGHT=150"
+                        + "&format_options="
+                        + MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION
+                        + ":image/png";
+        org.w3c.dom.Document dom = getAsDOM(path);
+        String message = checkLegacyException(dom, "InvalidParameterValue", "crs").trim();
+        assertEquals("This projection is not supported by MapML: EPSG:32632", message);
+    }
+
+    @Test
+    public void testInvalidProjectionMapML() throws Exception {
+        String path =
+                "cite/wms?LAYERS=Lakes"
+                        + "&STYLES=&FORMAT="
+                        + MapMLConstants.MAPML_MIME_TYPE
+                        + "&SERVICE=WMS&VERSION=1.3.0"
+                        + "&REQUEST=GetMap"
+                        + "&SRS=EPSG:32632"
+                        + "&BBOX=-13885038,2870337,-7455049,6338174"
+                        + "&WIDTH=150"
+                        + "&HEIGHT=150"
+                        + "&format_options="
+                        + MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION
+                        + ":image/png";
+        org.w3c.dom.Document dom = getAsDOM(path);
+        String message = checkLegacyException(dom, "InvalidParameterValue", "crs").trim();
+        assertEquals("This projection is not supported by MapML: EPSG:32632", message);
+    }
+
+    @Test
     public void testLargeBounds() throws Exception {
         // a layer whose bounds exceed the capabilities of the projected MapML TileCRS,
         // projection handler is needed to cut them down to size

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
@@ -7,6 +7,8 @@ package org.geoserver.mapml;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.geowebcache.grid.GridSubsetFactory.createGridSubSet;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -1132,6 +1134,28 @@ public class MapMLWMSTest extends WMSTestSupport {
     }
 
     @Test
+    public void testHTMLWorkspaceQualified() throws Exception {
+        String path =
+                "cite/wms?LAYERS=Lakes"
+                        + "&STYLES=&FORMAT="
+                        + MapMLConstants.MAPML_HTML_MIME_TYPE
+                        + "&SERVICE=WMS&VERSION=1.3.0"
+                        + "&REQUEST=GetMap"
+                        + "&SRS=epsg:3857"
+                        + "&BBOX=-13885038,2870337,-7455049,6338174"
+                        + "&WIDTH=150"
+                        + "&HEIGHT=150"
+                        + "&format_options="
+                        + MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION
+                        + ":image/png";
+        Document doc = getAsJSoup(path);
+        Element layer = doc.select("mapml-viewer > layer-").first();
+        String layerSrc = layer.attr("src");
+        assertThat(layerSrc, startsWith("http://localhost:8080/geoserver/cite/wms?"));
+        assertThat(layerSrc, containsString("LAYERS=Lakes"));
+    }
+
+    @Test
     public void testLargeBounds() throws Exception {
         // a layer whose bounds exceed the capabilities of the projected MapML TileCRS,
         // projection handler is needed to cut them down to size
@@ -1189,11 +1213,11 @@ public class MapMLWMSTest extends WMSTestSupport {
     }
 
     @SuppressWarnings("PMD.SimplifiableTestAssertion")
-    private Document testLayersAndGroupsHTML(Object l, Locale locale) throws Exception {
+    private Document testLayersAndGroupsHTML(PublishedInfo l, Locale locale) throws Exception {
         String layerName;
         String layerLabel;
-        LayerInfo lyrInfo = getCatalog().getLayerByName(((PublishedInfo) l).getName());
-        LayerGroupInfo lyrGpInfo = getCatalog().getLayerGroupByName(((PublishedInfo) l).getName());
+        LayerInfo lyrInfo = getCatalog().getLayerByName(l.getName());
+        LayerGroupInfo lyrGpInfo = getCatalog().getLayerGroupByName(l.getName());
         if (lyrInfo != null) { // layer...
             layerName = lyrInfo.getName();
         } else {

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/tcrs/TiledCRSFactoryTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/tcrs/TiledCRSFactoryTest.java
@@ -1,0 +1,92 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.mapml.tcrs;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import org.geoserver.catalog.ResourcePool;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.operation.projection.Mercator;
+import org.geotools.util.factory.Hints;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TiledCRSFactoryTest {
+
+    @BeforeClass
+    public static void setup() {
+        CRS.reset("all");
+        System.setProperty("org.geotools.referencing.forceXY", "true");
+        Hints.putSystemDefault(Hints.FORCE_AXIS_ORDER_HONORING, "http");
+        Hints.putSystemDefault(Hints.LENIENT_DATUM_SHIFT, true);
+    }
+
+    @Test
+    public void testCodes() throws Exception {
+        Set<String> codes = CRS.getSupportedCodes("MapML");
+        assertThat(codes, hasItems("WGS84", "APSTILE", "OSMTILE", "CBMTILE"));
+    }
+
+    @Test
+    public void testWGS84() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("MapML:WGS84");
+        CoordinateReferenceSystem expected = CRS.decode("EPSG:4326", true);
+        assertFalse(CRS.isTransformationRequired(crs, expected));
+        assertTrue(CRS.equalsIgnoreMetadata(crs, expected));
+        assertEquals("MapML", crs.getName().getCodeSpace());
+        assertEquals("WGS84", crs.getName().getCode());
+        assertEquals("MapML:WGS84", ResourcePool.lookupIdentifier(crs, false));
+    }
+
+    @Test
+    public void testOSM() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("MapML:OSMTILE");
+        CoordinateReferenceSystem expected = CRS.decode("EPSG:3857");
+        assertFalse(CRS.isTransformationRequired(crs, expected));
+        assertTrue(CRS.equalsIgnoreMetadata(crs, expected));
+        assertEquals("MapML", crs.getName().getCodeSpace());
+        assertEquals("OSMTILE", crs.getName().getCode());
+        assertEquals("MapML:OSMTILE", ResourcePool.lookupIdentifier(crs, false));
+    }
+
+    @Test
+    public void testAPS() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("MapML:APSTILE");
+        CoordinateReferenceSystem expected = CRS.decode("EPSG:5936");
+        assertFalse(CRS.isTransformationRequired(crs, expected));
+        assertTrue(CRS.equalsIgnoreMetadata(crs, expected));
+        assertEquals("MapML", crs.getName().getCodeSpace());
+        assertEquals("APSTILE", crs.getName().getCode());
+        assertEquals("MapML:APSTILE", ResourcePool.lookupIdentifier(crs, false));
+    }
+
+    @Test
+    public void testCBM() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("MapML:CBMTILE");
+        CoordinateReferenceSystem expected = CRS.decode("EPSG:3978");
+        assertFalse(CRS.isTransformationRequired(crs, expected));
+        assertTrue(CRS.equalsIgnoreMetadata(crs, expected));
+        assertEquals("MapML", crs.getName().getCodeSpace());
+        assertEquals("CBMTILE", crs.getName().getCode());
+        assertEquals("MapML:CBMTILE", ResourcePool.lookupIdentifier(crs, false));
+    }
+
+    /** @throws Exception */
+    @Test
+    public void testTransform() throws Exception {
+        CoordinateReferenceSystem wgs84 = CRS.decode("MapML:WGS84");
+        CoordinateReferenceSystem webMarcator = CRS.decode("MapML:OSMTILE");
+        MathTransform tx = CRS.findMathTransform(wgs84, webMarcator);
+        assertThat(tx, instanceOf(Mercator.class));
+    }
+}

--- a/src/extension/mapml/src/test/java/org/geoserver/web/demo/MapMLFormatLinkTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/web/demo/MapMLFormatLinkTest.java
@@ -1,0 +1,86 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.demo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.geoserver.wfs.kvp.BBoxKvpParser;
+import org.geoserver.wms.GetMapRequest;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.util.factory.Hints;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MapMLFormatLinkTest {
+
+    @BeforeClass
+    public static void setup() {
+        CRS.reset("all");
+        System.setProperty("org.geotools.referencing.forceXY", "true");
+        Hints.putSystemDefault(Hints.FORCE_AXIS_ORDER_HONORING, "http");
+        Hints.putSystemDefault(Hints.LENIENT_DATUM_SHIFT, true);
+    }
+
+    @Test
+    public void testSupportedCodes() throws Exception {
+        Set<String> codes = CRS.getSupportedCodes("MapML");
+        for (String code : codes) {
+            if ("WGS84(DD)".equals(code)) continue;
+            testSupportedCode("MapML:" + code);
+        }
+    }
+
+    private void testSupportedCode(String code) throws FactoryException {
+        transformLink(code, code);
+    }
+
+    @Test
+    public void testCompatibleCodes() throws Exception {
+        transformLink("CRS:84", "MapML:WGS84");
+        transformLink("EPSG:3857", "MapML:OSMTILE");
+        transformLink("EPSG:5936", "MapML:APSTILE");
+        transformLink("EPSG:3978", "MapML:CBMTILE");
+    }
+
+    @Test
+    public void testIncompatibleCode() throws Exception {
+        MapMLFormatLink link = new MapMLFormatLink();
+        String epsgCode = "EPSG:32632";
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("srs", epsgCode);
+        GetMapRequest request = new GetMapRequest();
+        CoordinateReferenceSystem crs = CRS.decode(epsgCode, true);
+        request.setCrs(crs);
+        request.setSRS(epsgCode);
+        request.setBbox(new ReferencedEnvelope(1000000, 1100000, 4000000, 4100000, crs));
+        link.customizeRequest(request, parameters);
+        assertEquals("MapML:WGS84", parameters.get("srs"));
+        // bbox has been transfomed to WGS84
+        String bbox = parameters.get("bbox");
+        assertNotNull(bbox);
+        ReferencedEnvelope envelope = (ReferencedEnvelope) new BBoxKvpParser().parse(bbox);
+        assertEquals(14.5, envelope.getMinX(), 0.1);
+        assertEquals(36, envelope.getMinY(), 0.1);
+        assertEquals(15.7, envelope.getMaxX(), 0.1);
+        assertEquals(37, envelope.getMaxY(), 0.1);
+    }
+
+    private void transformLink(String epsgCode, String mapMLCode) throws FactoryException {
+        MapMLFormatLink link = new MapMLFormatLink();
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("srs", epsgCode);
+        GetMapRequest request = new GetMapRequest();
+        request.setCrs(CRS.decode(epsgCode, true));
+        link.customizeRequest(request, parameters);
+        assertEquals(mapMLCode, parameters.get("srs"));
+    }
+}

--- a/src/extension/mapml/src/test/java/org/geoserver/web/demo/PreviewLayerTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/web/demo/PreviewLayerTest.java
@@ -1,0 +1,40 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.demo;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.junit.Test;
+
+public class PreviewLayerTest extends GeoServerWicketTestSupport {
+
+    /**
+     * Check MapML srs is preserved for layer groups
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMapmlFormatLink() throws Exception {
+        Catalog cat = getCatalog();
+
+        LayerGroupInfo lg = cat.getFactory().createLayerGroup();
+        lg.setName("foo");
+        lg.setWorkspace(cat.getWorkspaceByName("sf"));
+        lg.getLayers().add(cat.getLayerByName(getLayerId(MockData.PRIMITIVEGEOFEATURE)));
+        lg.setBounds(new ReferencedEnvelope(0, 1, 0, 1, CRS.decode("MapML:OSMTILE")));
+        PreviewLayer layer = new PreviewLayer(lg);
+        layer.getWmsLink(
+                (r, p) -> {
+                    assertEquals("MapML:OSMTILE", p.get("srs"));
+                    assertEquals("0.0,0.0,1.0,1.0", p.get("bbox"));
+                });
+    }
+}

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/PreviewLayer.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
@@ -21,6 +22,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.PublishedType;
+import org.geoserver.catalog.ResourcePool;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.security.DisabledServiceResourceFilter;
@@ -33,6 +35,8 @@ import org.geoserver.wms.MapLayerInfo;
 import org.geotools.api.feature.type.AttributeType;
 import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.feature.type.Name;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.util.ProgressListener;
 import org.geotools.data.util.DefaultProgressListener;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -134,8 +138,8 @@ public class PreviewLayer {
         }
     }
 
-    /** Builds a fake GetMap request */
-    GetMapRequest getRequest() {
+    /** Builds GetMap request */
+    public GetMapRequest getRequest() {
         if (request == null) {
             GeoServerApplication app = GeoServerApplication.get();
             request = new GetMapRequest();
@@ -148,10 +152,8 @@ public class PreviewLayer {
             if (groupInfo != null) {
                 ReferencedEnvelope bounds = groupInfo.getBounds();
                 request.setBbox(bounds);
-                String srs =
-                        GML2EncodingUtils.toURI(
-                                bounds.getCoordinateReferenceSystem(), SrsSyntax.AUTH_CODE, false);
-                request.setSRS(srs);
+                request.setCrs(bounds.getCoordinateReferenceSystem());
+                request.setSRS(lookupSRSFromBounds(bounds));
             }
             try {
                 DefaultWebMapService.autoSetBoundsAndSize(request);
@@ -164,6 +166,18 @@ public class PreviewLayer {
             }
         }
         return request;
+    }
+
+    private static String lookupSRSFromBounds(ReferencedEnvelope bounds) {
+        // try first a method that retains the native authority code, otherwise fall back on
+        // GML2EncodingUtils, which prefers the EPSG authority
+        CoordinateReferenceSystem crs = bounds.getCoordinateReferenceSystem();
+        if (crs == null) return null;
+        try {
+            return ResourcePool.lookupIdentifier(crs, false);
+        } catch (FactoryException e) {
+            return GML2EncodingUtils.toURI(crs, SrsSyntax.AUTH_CODE, false);
+        }
     }
 
     /** Expands the specified name into a list of layer info names */
@@ -213,6 +227,11 @@ public class PreviewLayer {
 
     /** Given a request and a target format, builds the WMS request */
     public String getWmsLink() {
+        // build link with no customization
+        return getWmsLink((r, m) -> {});
+    }
+
+    public String getWmsLink(BiConsumer<GetMapRequest, Map<String, String>> parameterCustomizer) {
         GetMapRequest request = getRequest();
         final Envelope bbox = request.getBbox();
         if (bbox == null) return null;
@@ -231,6 +250,8 @@ public class PreviewLayer {
         params.put(
                 "styles",
                 request.getStyles().size() > 0 ? request.getStyles().get(0).getName() : "");
+        // allow customization of parameters
+        parameterCustomizer.accept(request, params);
         return ResponseUtils.buildURL(getBaseURL(), getPath("wms", false), params, URLType.SERVICE);
     }
 
@@ -347,6 +368,7 @@ public class PreviewLayer {
         AttributeType parent = featureType.getSuper();
         return findFeatureTypeGmlVersion(parent);
     }
+
     /**
      * Returns true if serviceName is available for resource, otherwise false
      *


### PR DESCRIPTION
In short, have "MapML:OSMTILE" and friends act as supported CRS instances, available in all protocols, in capabilities documents, in data and map requests.
See tickes for details.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->