### PR TITLE
[GEOS-11297] Escape WMS GetFeatureInfo HTML output by default

### DIFF
--- a/doc/en/user/source/installation/upgrade.rst
+++ b/doc/en/user/source/installation/upgrade.rst
@@ -30,6 +30,18 @@ The general GeoServer upgrade process is as follows:
 Notes on upgrading specific versions
 ------------------------------------
 
+FreeMarker Template HTML Auto-escaping (GeoServer 2.25 and newer)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As of GeoServer 2.25, the FreeMarker library's HTML auto-escaping feature will be enabled by default to prevent
+cross-site scripting (XSS) vulnerabilities in WMS GetFeatureInfo HTML output when using the default FreeMarker
+templates and WMS service settings. Some users may experience incorrectly escaped HTML output when using custom
+templates or if HTML tags are stored in vector data stores.
+
+See the :ref:`production_config_freemarker_escaping` page for information about the limitations of this feature
+and for instructions to disable this feature and delegate to the WMS service setting which defaults to disabling
+HTML auto-escaping.
+
 Spring Security Strict HTTP Firewall (GeoServer 2.25 and newer)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/en/user/source/production/config.rst
+++ b/doc/en/user/source/production/config.rst
@@ -188,6 +188,28 @@ In case you want it set to ``text/xml`` instead, you need to setup the Java Syst
 * ``-Dows10.exception.xml.responsetype=text/xml`` for OWS 1.0.0 version
 * ``-Dows11.exception.xml.responsetype=text/xml`` for OWS 1.1.0 version
 
+.. _production_config_freemarker_escaping:
+
+FreeMarker Template Auto-escaping
+---------------------------------
+
+By default, FreeMarker's built-in automatic escaping functionality will be enabled to mitigate potential cross-site scripting
+(XSS) vulnerabilities in cases where GeoServer uses FreeMarker templates to generate HTML output and administrators are able
+to modify the templates and/or users have significant control over the output through service requests. When the
+``GEOSERVER_FORCE_FREEMARKER_ESCAPING`` property is set to false, auto-escaping will delegate either to the feature's default
+behavior or other settings which allow administrators to enable/disable auto-escaping on a global or per virtual service
+basis. This property can be set to false either via Java system property, command line argument (-D), environment variable or
+web.xml init parameter.
+
+This setting currently applies to the WMS GetFeatureInfo HTML output format and may be applied to other applicable GeoServer
+functionality in the future.
+
+.. warning::
+    While enabling auto-escaping will prevent XSS using the default templates and mitigate many cases where template authors
+    are not considering XSS in their template design, it does **NOT** completely prevent template authors from creating
+    templates that allow XSS (whether this is intentional or not). Additional functionality may be added in the future to
+    mitigate those potential XSS vulnerabilities.
+
 .. _production_config_external_entities:
 
 External Entities Resolution

--- a/doc/en/user/source/services/wms/webadmin.rst
+++ b/doc/en/user/source/services/wms/webadmin.rst
@@ -223,6 +223,8 @@ By default GetFeatureInfo results are printed in the HTML templates without any 
 
 When the flag is checked, values that are printed in the HTML templates for GetFeatureInfo requests results will be automatically escaped. The default FreeMarker templates can be overridden to enable or disable auto-escaping on a per template, per block or per value basis.
 
+.. note:: Auto-escaping is forced to be enabled by default and that property must be disabled for this setting to have any effect. See the :ref:`production_config_freemarker_escaping` page for instructions.
+
 Setting Remote Style max connection and request time
 ----------------------------------------------------
 

--- a/doc/en/user/source/tutorials/GetFeatureInfo/html.rst
+++ b/doc/en/user/source/tutorials/GetFeatureInfo/html.rst
@@ -164,7 +164,7 @@ The ``value`` property of Feature attribute values are given by geoserver in ``S
 
 Auto-Escaping
 `````````````
-Auto-escaping can be used to escape special characters so that they are displayed correctly in clients and to prevent injection. GeoServer administrators can enable or disable auto-escaping for FreeMarker template values for the HTML output format on a global or per virtual service basis. Template authors are able to override the WMS service setting to enable or disable escaping on a per template, per block or per value basis. See `Auto-escaping <https://freemarker.apache.org/docs/dgui_misc_autoescaping.html>` for more information.
+Auto-escaping can be used to escape special characters so that they are displayed correctly in clients and to prevent injection. GeoServer administrators can enable or disable auto-escaping for FreeMarker template values for the HTML output format on a global or per virtual service basis. Template authors are able to override the WMS service setting to enable or disable escaping on a per template, per block or per value basis. See `Auto-escaping <https://freemarker.apache.org/docs/dgui_misc_autoescaping.html>`_ for more information.
 
 Accessing static methods
 ````````````````````````

--- a/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
+++ b/src/wms/src/main/java/org/geoserver/wms/featureinfo/FreeMarkerTemplateManager.java
@@ -47,6 +47,13 @@ import org.geotools.util.logging.Logging;
  */
 public abstract class FreeMarkerTemplateManager {
 
+    /**
+     * System property to control whether or not to enable FreeMarker's auto-escaping of HTML
+     * output. This property will override the WMS setting to enable/disable auto-escaping. Default
+     * is true.
+     */
+    public static final String FORCE_FREEMARKER_ESCAPING = "GEOSERVER_FORCE_FREEMARKER_ESCAPING";
+
     /** Config key determining the restrictions for accessing static members */
     static final String KEY_STATIC_MEMBER_ACCESS = "org.geoserver.htmlTemplates.staticMemberAccess";
 
@@ -275,8 +282,11 @@ public abstract class FreeMarkerTemplateManager {
             templateLoader.setResource(ri);
             templateConfig.setTemplateLoader(templateLoader);
             templateConfig.unsetOutputFormat();
-            if (format.equals(OutputFormat.HTML) && wms.isAutoEscapeTemplateValues()) {
-                templateConfig.setOutputFormat(HTMLOutputFormat.INSTANCE);
+            if (format.equals(OutputFormat.HTML)) {
+                String prop = GeoServerExtensions.getProperty(FORCE_FREEMARKER_ESCAPING);
+                if (!"false".equalsIgnoreCase(prop) || wms.isAutoEscapeTemplateValues()) {
+                    templateConfig.setOutputFormat(HTMLOutputFormat.INSTANCE);
+                }
             }
             Template t = null;
             try {


### PR DESCRIPTION
[![GEOS-11297](https://badgen.net/badge/JIRA/GEOS-11297/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11297) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR enabled FreeMarker's HTML auto-escaping by default and adds a system property to enable/disable it.

This PR includes backward-incompatible changes and should not be backported.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->