### PR TITLE
[Backport 2.24.x] [GEOS-11285] GWC REST Content-Encoding gzip returns broken response

### DIFF
--- a/src/main/src/main/java/org/geoserver/filters/AlternativesResponseStream.java
+++ b/src/main/src/main/java/org/geoserver/filters/AlternativesResponseStream.java
@@ -27,10 +27,10 @@ public class AlternativesResponseStream extends ServletOutputStream {
     ServletOutputStream myStream;
     Set myCompressibleTypes;
     Logger logger = org.geotools.util.logging.Logging.getLogger("org.geoserver.filters");
-    int contentLength;
+    long contentLength;
 
     public AlternativesResponseStream(
-            HttpServletResponse response, Set compressible, int contentLength) throws IOException {
+            HttpServletResponse response, Set compressible, long contentLength) throws IOException {
         super();
         myResponse = response;
         myCompressibleTypes = compressible;
@@ -73,14 +73,11 @@ public class AlternativesResponseStream extends ServletOutputStream {
         if (type != null && isCompressible(type)) {
             logger.log(Level.FINE, "Compressing output for mimetype: {0}", type);
             myResponse.addHeader("Content-Encoding", "gzip");
-            if (myResponse.getHeader("Content-Length") != null) {
-                myResponse.setHeader("Content-Length", null); // Un-set Content-Length for gzip
-            }
             myStream = new GZIPResponseStream(myResponse);
         } else {
             logger.log(Level.FINE, "Not compressing output for mimetype: {0}", type);
             if (contentLength >= 0) {
-                myResponse.setContentLength(contentLength);
+                myResponse.setContentLengthLong(contentLength);
             }
             myStream = myResponse.getOutputStream();
         }

--- a/src/main/src/main/java/org/geoserver/filters/AlternativesResponseStream.java
+++ b/src/main/src/main/java/org/geoserver/filters/AlternativesResponseStream.java
@@ -73,6 +73,9 @@ public class AlternativesResponseStream extends ServletOutputStream {
         if (type != null && isCompressible(type)) {
             logger.log(Level.FINE, "Compressing output for mimetype: {0}", type);
             myResponse.addHeader("Content-Encoding", "gzip");
+            if (myResponse.getHeader("Content-Length") != null) {
+                myResponse.setHeader("Content-Length", null); // Un-set Content-Length for gzip
+            }
             myStream = new GZIPResponseStream(myResponse);
         } else {
             logger.log(Level.FINE, "Not compressing output for mimetype: {0}", type);

--- a/src/main/src/main/java/org/geoserver/filters/GZIPResponseWrapper.java
+++ b/src/main/src/main/java/org/geoserver/filters/GZIPResponseWrapper.java
@@ -34,7 +34,7 @@ public class GZIPResponseWrapper extends HttpServletResponseWrapper {
     protected Set formatsToCompress;
     protected String requestedURL;
     protected Logger logger = org.geotools.util.logging.Logging.getLogger("org.geoserver.filters");
-    private int contentLength = -1;
+    private long contentLength = -1;
 
     public GZIPResponseWrapper(HttpServletResponse response, Set toCompress, String url) {
         super(response);
@@ -172,6 +172,11 @@ public class GZIPResponseWrapper extends HttpServletResponseWrapper {
 
     @Override
     public void setContentLength(int length) {
+        this.contentLength = length;
+    }
+
+    @Override
+    public void setContentLengthLong(long length) {
         this.contentLength = length;
     }
 }

--- a/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
@@ -59,7 +59,40 @@ public class GZipFilterTest {
     }
 
     @Test
-    public void testGZipRemovesContentLength() throws Exception {
+    public void testGZipRemovesContentLengthInt() throws Exception {
+        MockHttpServletRequest request =
+                new MockHttpServletRequest("GET", "http://www.geoserver.org");
+        request.addHeader("accept-encoding", "gzip");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setContentType("text/plain");
+
+        // run the filter
+        GZIPFilter filter = new GZIPFilter();
+
+        MockServletContext context = new MockServletContext();
+        MockFilterConfig config = new MockFilterConfig(context);
+        config.addInitParameter("compressed-types", "text/plain");
+        filter.init(config);
+
+        MockFilterChain chain =
+                new MockFilterChain() {
+                    @Override
+                    @SuppressWarnings("PMD.CloseResource")
+                    public void doFilter(ServletRequest request, ServletResponse response)
+                            throws IOException, ServletException {
+                        response.setContentLength(1000);
+                        AlternativesResponseStream alternatives =
+                                (AlternativesResponseStream) response.getOutputStream();
+                        ServletOutputStream gzipStream = alternatives.getStream();
+                        gzipStream.write(1);
+                    }
+                };
+        filter.doFilter(request, response, chain);
+        assertFalse(response.containsHeader("Content-Length"));
+    }
+
+    @Test
+    public void testGZipRemovesContentLengthLong() throws Exception {
         MockHttpServletRequest request =
                 new MockHttpServletRequest("GET", "http://www.geoserver.org");
         request.addHeader("accept-encoding", "gzip");
@@ -92,7 +125,42 @@ public class GZipFilterTest {
     }
 
     @Test
-    public void testNotGZippedMaintainsContentLength() throws Exception {
+    public void testNotGZippedMaintainsContentLengthInt() throws Exception {
+        MockHttpServletRequest request =
+                new MockHttpServletRequest("GET", "http://www.geoserver.org");
+        request.addHeader("accept-encoding", "gzip");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setContentType("text/css");
+
+        // run the filter
+        GZIPFilter filter = new GZIPFilter();
+
+        MockServletContext context = new MockServletContext();
+        MockFilterConfig config = new MockFilterConfig(context);
+        config.addInitParameter("compressed-types", "text/plain");
+        filter.init(config);
+
+        MockFilterChain chain =
+                new MockFilterChain() {
+                    @Override
+                    @SuppressWarnings("PMD.CloseResource")
+                    public void doFilter(ServletRequest request, ServletResponse response)
+                            throws IOException, ServletException {
+                        response.setContentLength(1000);
+                        AlternativesResponseStream alternatives =
+                                (AlternativesResponseStream) response.getOutputStream();
+
+                        ServletOutputStream gzipStream = alternatives.getStream();
+                        gzipStream.write(1);
+                    }
+                };
+        filter.doFilter(request, response, chain);
+        assertTrue(response.containsHeader("Content-Length"));
+        assertEquals("1000", response.getHeader("Content-Length"));
+    }
+
+    @Test
+    public void testNotGZippedMaintainsContentLengthLong() throws Exception {
         MockHttpServletRequest request =
                 new MockHttpServletRequest("GET", "http://www.geoserver.org");
         request.addHeader("accept-encoding", "gzip");

--- a/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
@@ -73,14 +73,14 @@ public class GZipFilterTest {
         MockFilterConfig config = new MockFilterConfig(context);
         config.addInitParameter("compressed-types", "text/plain");
         filter.init(config);
-
+        
         MockFilterChain chain =
                 new MockFilterChain() {
                     @Override
                     @SuppressWarnings("PMD.CloseResource")
                     public void doFilter(ServletRequest request, ServletResponse response)
                             throws IOException, ServletException {
-                        response.setContentLength(1000);
+                        response.setContentLengthLong(1000);
                         AlternativesResponseStream alternatives =
                                 (AlternativesResponseStream) response.getOutputStream();
                         ServletOutputStream gzipStream = alternatives.getStream();
@@ -101,9 +101,10 @@ public class GZipFilterTest {
 
         // run the filter
         GZIPFilter filter = new GZIPFilter();
+        
         MockServletContext context = new MockServletContext();
-        context.setInitParameter("compressed-types", "text/plain");
         MockFilterConfig config = new MockFilterConfig(context);
+        config.addInitParameter("compressed-types", "text/plain");
         filter.init(config);
 
         MockFilterChain chain =
@@ -112,7 +113,7 @@ public class GZipFilterTest {
                     @SuppressWarnings("PMD.CloseResource")
                     public void doFilter(ServletRequest request, ServletResponse response)
                             throws IOException, ServletException {
-                        response.setContentLength(1000);
+                        response.setContentLengthLong(1000);
                         AlternativesResponseStream alternatives =
                                 (AlternativesResponseStream) response.getOutputStream();
 

--- a/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
@@ -73,7 +73,7 @@ public class GZipFilterTest {
         MockFilterConfig config = new MockFilterConfig(context);
         config.addInitParameter("compressed-types", "text/plain");
         filter.init(config);
-        
+
         MockFilterChain chain =
                 new MockFilterChain() {
                     @Override
@@ -101,7 +101,7 @@ public class GZipFilterTest {
 
         // run the filter
         GZIPFilter filter = new GZIPFilter();
-        
+
         MockServletContext context = new MockServletContext();
         MockFilterConfig config = new MockFilterConfig(context);
         config.addInitParameter("compressed-types", "text/plain");

--- a/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/GZipFilterTest.java
@@ -92,7 +92,7 @@ public class GZipFilterTest {
     }
 
     @Test
-    public void testNotGZippedMantainsContentLength() throws Exception {
+    public void testNotGZippedMaintainsContentLength() throws Exception {
         MockHttpServletRequest request =
                 new MockHttpServletRequest("GET", "http://www.geoserver.org");
         request.addHeader("accept-encoding", "gzip");


### PR DESCRIPTION
[![GEOS-11285](https://badgen.net/badge/JIRA/GEOS-11285/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11285) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7370
 **Authored by:** @petersmythe