### PR TITLE
[GEOS-11260] JNDI tutorial uses outdated syntax

### DIFF
--- a/doc/en/user/source/tutorials/tomcat-jndi/tomcat-jndi.rst
+++ b/doc/en/user/source/tutorials/tomcat-jndi/tomcat-jndi.rst
@@ -28,7 +28,7 @@ Once that is done, the Tomcat configuration file :file:`{TOMCAT_HOME}/conf/conte
         driverClassName="oracle.jdbc.driver.OracleDriver"
         url="jdbc:oracle:thin:@localhost:1521:xe"
         username="xxxxx" password="xxxxxx"
-        maxActive="20"
+        maxTotal="20"
         initialSize="0"
         minIdle="0"
         maxIdle="8"
@@ -43,6 +43,8 @@ Once that is done, the Tomcat configuration file :file:`{TOMCAT_HOME}/conf/conte
         rollbackOnReturn="true"
         />
    </Context>
+
+.. note:: The above configuration is valid for Tomcat 8+, while Tomcat 7.x would use ``maxActive`` in place of ``maxTotal``.
 
 
 The example sets up a connection pool connecting to the local Oracle XE instance. 
@@ -113,7 +115,7 @@ Then the following code must be added to the Tomcat configuration file :file:`{T
         driverClassName="org.postgresql.Driver"
         url="jdbc:postgresql://localhost:5432/test"
         username="xxxxx" password="xxxxxx"
-        maxActive="20"
+        maxTotal="20"
         initialSize="0"
         minIdle="0"
         maxIdle="8"
@@ -160,7 +162,7 @@ Then the following code must be written in the Tomcat configuration file :file:`
         driverClassName="com.microsoft.sqlserver.jdbc.SQLServerDriver"
         url="jdbc:sqlserver://localhost:1433;databaseName=test;user=admin;password=admin;"
         username="admin" password="admin"
-        maxActive="20"
+        maxTotal="20"
         initialSize="0"
         minIdle="0"
         maxIdle="8"


### PR DESCRIPTION
[![GEOS-11260](https://badgen.net/badge/JIRA/GEOS-11260/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11260) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Avoid inducing users in a faulty pool configuration (one that Tomcat reports no warning about, too).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->