### PR TITLE
[Backport 2.24.x] [GEOS-11260] JNDI tutorial uses outdated syntax

### DIFF
--- a/doc/en/user/source/tutorials/tomcat-jndi/tomcat-jndi.rst
+++ b/doc/en/user/source/tutorials/tomcat-jndi/tomcat-jndi.rst
@@ -28,7 +28,7 @@ Once that is done, the Tomcat configuration file :file:`{TOMCAT_HOME}/conf/conte
         driverClassName="oracle.jdbc.driver.OracleDriver"
         url="jdbc:oracle:thin:@localhost:1521:xe"
         username="xxxxx" password="xxxxxx"
-        maxActive="20"
+        maxTotal="20"
         initialSize="0"
         minIdle="0"
         maxIdle="8"
@@ -43,6 +43,8 @@ Once that is done, the Tomcat configuration file :file:`{TOMCAT_HOME}/conf/conte
         rollbackOnReturn="true"
         />
    </Context>
+
+.. note:: The above configuration is valid for Tomcat 8+, while Tomcat 7.x would use ``maxActive`` in place of ``maxTotal``.
 
 
 The example sets up a connection pool connecting to the local Oracle XE instance. 
@@ -113,7 +115,7 @@ Then the following code must be added to the Tomcat configuration file :file:`{T
         driverClassName="org.postgresql.Driver"
         url="jdbc:postgresql://localhost:5432/test"
         username="xxxxx" password="xxxxxx"
-        maxActive="20"
+        maxTotal="20"
         initialSize="0"
         minIdle="0"
         maxIdle="8"
@@ -160,7 +162,7 @@ Then the following code must be written in the Tomcat configuration file :file:`
         driverClassName="com.microsoft.sqlserver.jdbc.SQLServerDriver"
         url="jdbc:sqlserver://localhost:1433;databaseName=test;user=admin;password=admin;"
         username="admin" password="admin"
-        maxActive="20"
+        maxTotal="20"
         initialSize="0"
         minIdle="0"
         maxIdle="8"


### PR DESCRIPTION
[![GEOS-11260](https://badgen.net/badge/JIRA/GEOS-11260/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11260) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7417
 **Authored by:** @aaime