### PR TITLE
Fix some app schema online tests

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/PagingTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/PagingTest.java
@@ -897,7 +897,7 @@ public class PagingTest extends AbstractAppSchemaTestSupport {
                         "wfs?request=GetFeature&version=2.0.0&typeNames=gsml:MappedFeature&count=1&startIndex=1&outputFormat=csv");
 
         // check the mime type
-        assertEquals("text/csv", resp.getContentType());
+        assertEquals("text/csv", getBaseMimeType(resp.getContentType()));
 
         // check the content disposition
         assertEquals(

--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SRSWfsTest.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/SRSWfsTest.java
@@ -6,7 +6,6 @@
 
 package org.geoserver.test;
 
-import static org.geoserver.test.GeoPackageUtil.isGeopkgTest;
 import static org.junit.Assert.assertEquals;
 
 import org.geoserver.data.test.SystemTestData;
@@ -77,6 +76,11 @@ public class SRSWfsTest extends AbstractAppSchemaTestSupport {
         CRS.reset("all");
     }
 
+    private boolean honorsCrsAxisOrder() {
+        String onlineTestId = System.getProperty("testDatabase");
+        return "geopkg".equals(onlineTestId) || "postgis".equals(onlineTestId);
+    }
+
     /** Test content of GetFeature response. */
     @Test
     public void testGetFeatureContent() throws NoSuchAuthorityCodeException, FactoryException {
@@ -144,41 +148,32 @@ public class SRSWfsTest extends AbstractAppSchemaTestSupport {
                 DIMENSION,
                 "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/@srsDimension",
                 doc);
-        if (!isGeopkgTest()) {
-            assertXpathEvaluatesTo(
-                    "-1.2 52.5 -1.2 52.6 -1.1 52.6 -1.1 52.5 -1.2 52.5",
-                    "(//ex:geomContainer)[1]/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "-1.2 52.5 -1.2 52.6 -1.1 52.6 -1.1 52.5 -1.2 52.5",
-                    "(//ex:geomContainer)[1]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "42.58 31.29",
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "-1.2 52.5 -1.2 52.6 -1.1 52.6 -1.1 52.5 -1.2 52.5",
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
+
+        final String expectedLinearRing;
+        final String expectedPoint;
+        if (honorsCrsAxisOrder()) {
+            expectedLinearRing = "52.5 -1.2 52.6 -1.2 52.6 -1.1 52.5 -1.1 52.5 -1.2";
+            expectedPoint = "31.29 42.58";
         } else {
-            assertXpathEvaluatesTo(
-                    "52.5 -1.2 52.6 -1.2 52.6 -1.1 52.5 -1.1 52.5 -1.2",
-                    "(//ex:geomContainer)[1]/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "52.5 -1.2 52.6 -1.2 52.6 -1.1 52.5 -1.1 52.5 -1.2",
-                    "(//ex:geomContainer)[1]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "31.29 42.58",
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "52.5 -1.2 52.6 -1.2 52.6 -1.1 52.5 -1.1 52.5 -1.2",
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
+            expectedLinearRing = "-1.2 52.5 -1.2 52.6 -1.1 52.6 -1.1 52.5 -1.2 52.5";
+            expectedPoint = "42.58 31.29";
         }
+        assertXpathEvaluatesTo(
+                expectedLinearRing,
+                "(//ex:geomContainer)[1]/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                expectedLinearRing,
+                "(//ex:geomContainer)[1]/ex:shape/gml:LineString/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                expectedPoint,
+                "(//ex:geomContainer)[1]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
+                doc);
+        assertXpathEvaluatesTo(
+                expectedLinearRing,
+                "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
+                doc);
 
         // second feature
         id = "2";
@@ -235,37 +230,27 @@ public class SRSWfsTest extends AbstractAppSchemaTestSupport {
                 "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/@srsDimension",
                 doc);
 
-        if (!isGeopkgTest()) {
-            assertXpathEvaluatesTo(
-                    "42.58 31.29", "(//ex:geomContainer)[2]/ex:geom/gml:Point/gml:pos", doc);
-            assertXpathEvaluatesTo(
-                    "42.58 31.29 42.58 31.29",
-                    "(//ex:geomContainer)[2]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "-1.2 52.5 -1.2 52.6 -1.1 52.6 -1.1 52.5 -1.2 52.5",
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "42.58 31.29",
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
+        final String expectedLineString;
+        if (honorsCrsAxisOrder()) {
+            expectedLineString = "31.29 42.58 31.29 42.58";
         } else {
-            assertXpathEvaluatesTo(
-                    "31.29 42.58", "(//ex:geomContainer)[2]/ex:geom/gml:Point/gml:pos", doc);
-            assertXpathEvaluatesTo(
-                    "31.29 42.58 31.29 42.58",
-                    "(//ex:geomContainer)[2]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "52.5 -1.2 52.6 -1.2 52.6 -1.1 52.5 -1.1 52.5 -1.2",
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "31.29 42.58",
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
+            expectedLineString = "42.58 31.29 42.58 31.29";
         }
+
+        assertXpathEvaluatesTo(
+                expectedPoint, "(//ex:geomContainer)[2]/ex:geom/gml:Point/gml:pos", doc);
+        assertXpathEvaluatesTo(
+                expectedLineString,
+                "(//ex:geomContainer)[2]/ex:shape/gml:LineString/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                expectedLinearRing,
+                "(//ex:geomContainer)[2]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                expectedPoint,
+                "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
+                doc);
     }
 
     /**
@@ -276,38 +261,48 @@ public class SRSWfsTest extends AbstractAppSchemaTestSupport {
             throws NoSuchAuthorityCodeException, FactoryException, MismatchedDimensionException,
                     TransformException {
 
-        // reprojected geometries
-        CoordinateReferenceSystem sourceCRS = CRS.decode(EPSG_4283);
-        CoordinateReferenceSystem targetCRS = CRS.decode(EPSG_4326);
-        MathTransform transform = CRS.findMathTransform(sourceCRS, targetCRS);
-        GeometryFactory factory = new GeometryFactory();
-        Polygon srcPolygon =
-                factory.createPolygon(
-                        factory.createLinearRing(
-                                factory.getCoordinateSequenceFactory()
-                                        .create(
-                                                new Coordinate[] {
-                                                    new Coordinate(-1.2, 52.5),
-                                                    new Coordinate(-1.2, 52.6),
-                                                    new Coordinate(-1.1, 52.6),
-                                                    new Coordinate(-1.1, 52.5),
-                                                    new Coordinate(-1.2, 52.5)
-                                                })),
-                        null);
-        Polygon targetPolygon = (Polygon) JTS.transform(srcPolygon, transform);
-        StringBuffer polygonBuffer = new StringBuffer();
-        CoordinateFormatter formatter = new CoordinateFormatter(8);
-        for (Coordinate coord : targetPolygon.getCoordinates()) {
-            formatter.format(coord.x, polygonBuffer).append(" ");
-            formatter.format(coord.y, polygonBuffer).append(" ");
+        final String targetPolygonCoords;
+        final String targetPointCoord;
+        if (honorsCrsAxisOrder()) {
+            targetPointCoord = "31.29000003 42.58";
+            targetPolygonCoords =
+                    "52.50000004 -1.2 52.60000004 -1.2 52.60000004 -1.1 52.50000004 -1.1 52.50000004 -1.2";
+        } else {
+            // reprojected geometries
+            CoordinateReferenceSystem sourceCRS = CRS.decode(EPSG_4283);
+            CoordinateReferenceSystem targetCRS = CRS.decode(EPSG_4326);
+            MathTransform transform = CRS.findMathTransform(sourceCRS, targetCRS);
+            GeometryFactory factory = new GeometryFactory();
+            Polygon srcPolygon =
+                    factory.createPolygon(
+                            factory.createLinearRing(
+                                    factory.getCoordinateSequenceFactory()
+                                            .create(
+                                                    new Coordinate[] {
+                                                        new Coordinate(-1.2, 52.5),
+                                                        new Coordinate(-1.2, 52.6),
+                                                        new Coordinate(-1.1, 52.6),
+                                                        new Coordinate(-1.1, 52.5),
+                                                        new Coordinate(-1.2, 52.5)
+                                                    })),
+                            null);
+            Polygon targetPolygon = (Polygon) JTS.transform(srcPolygon, transform);
+            StringBuffer polygonBuffer = new StringBuffer();
+            CoordinateFormatter formatter = new CoordinateFormatter(8);
+            for (Coordinate coord : targetPolygon.getCoordinates()) {
+                formatter.format(coord.x, polygonBuffer).append(" ");
+                formatter.format(coord.y, polygonBuffer).append(" ");
+            }
+            targetPolygonCoords = polygonBuffer.toString().trim();
+            Point targetPoint =
+                    (Point)
+                            JTS.transform(
+                                    factory.createPoint(new Coordinate(42.58, 31.29)), transform);
+            targetPointCoord =
+                    formatter.format(targetPoint.getCoordinate().x)
+                            + " "
+                            + formatter.format(targetPoint.getCoordinate().y);
         }
-        String targetPolygonCoords = polygonBuffer.toString().trim();
-        Point targetPoint =
-                (Point) JTS.transform(factory.createPoint(new Coordinate(42.58, 31.29)), transform);
-        String targetPointCoord =
-                formatter.format(targetPoint.getCoordinate().x)
-                        + " "
-                        + formatter.format(targetPoint.getCoordinate().y);
 
         Document doc =
                 getAsDOM(
@@ -374,41 +369,22 @@ public class SRSWfsTest extends AbstractAppSchemaTestSupport {
                 "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/@srsDimension",
                 doc);
 
-        if (!isGeopkgTest()) {
-            assertXpathEvaluatesTo(
-                    targetPolygonCoords,
-                    "(//ex:geomContainer)[1]/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    targetPolygonCoords,
-                    "(//ex:geomContainer)[1]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    targetPolygonCoords,
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    targetPointCoord,
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
-        } else {
-            assertXpathEvaluatesTo(
-                    "52.50000004 -1.2 52.60000004 -1.2 52.60000004 -1.1 52.50000004 -1.1 52.50000004 -1.2",
-                    "(//ex:geomContainer)[1]/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "52.50000004 -1.2 52.60000004 -1.2 52.60000004 -1.1 52.50000004 -1.1 52.50000004 -1.2",
-                    "(//ex:geomContainer)[1]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "52.50000004 -1.2 52.60000004 -1.2 52.60000004 -1.1 52.50000004 -1.1 52.50000004 -1.2",
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "31.29000003 42.58",
-                    "(//ex:geomContainer)[1]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
-        }
+        assertXpathEvaluatesTo(
+                targetPolygonCoords,
+                "(//ex:geomContainer)[1]/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                targetPolygonCoords,
+                "(//ex:geomContainer)[1]/ex:shape/gml:LineString/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                targetPolygonCoords,
+                "(//ex:geomContainer)[1]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                targetPointCoord,
+                "(//ex:geomContainer)[1]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
+                doc);
 
         // second feature
         id = "2";
@@ -464,37 +440,21 @@ public class SRSWfsTest extends AbstractAppSchemaTestSupport {
                 DIMENSION,
                 "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/@srsDimension",
                 doc);
-        if (!isGeopkgTest()) {
-            assertXpathEvaluatesTo(
-                    targetPointCoord, "(//ex:geomContainer)[2]/ex:geom/gml:Point/gml:pos", doc);
-            assertXpathEvaluatesTo(
-                    targetPointCoord + " " + targetPointCoord,
-                    "(//ex:geomContainer)[2]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    targetPolygonCoords,
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    targetPointCoord,
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
-        } else {
-            assertXpathEvaluatesTo(
-                    "31.29000003 42.58", "(//ex:geomContainer)[2]/ex:geom/gml:Point/gml:pos", doc);
-            assertXpathEvaluatesTo(
-                    "31.29000003 42.58 31.29000003 42.58",
-                    "(//ex:geomContainer)[2]/ex:shape/gml:LineString/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "52.50000004 -1.2 52.60000004 -1.2 52.60000004 -1.1 52.50000004 -1.1 52.50000004 -1.2",
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
-                    doc);
-            assertXpathEvaluatesTo(
-                    "31.29000003 42.58",
-                    "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
-                    doc);
-        }
+
+        assertXpathEvaluatesTo(
+                targetPointCoord, "(//ex:geomContainer)[2]/ex:geom/gml:Point/gml:pos", doc);
+        assertXpathEvaluatesTo(
+                targetPointCoord + " " + targetPointCoord,
+                "(//ex:geomContainer)[2]/ex:shape/gml:LineString/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                targetPolygonCoords,
+                "(//ex:geomContainer)[2]/ex:nestedFeature[1]/ex:nestedGeom/ex:geom/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList",
+                doc);
+        assertXpathEvaluatesTo(
+                targetPointCoord,
+                "(//ex:geomContainer)[2]/ex:nestedFeature[2]/ex:nestedGeom/ex:geom/gml:Point/gml:pos",
+                doc);
     }
 
     /** Ensure filters are still working. */


### PR DESCRIPTION
Fix 3 out of 4 failing app schema online tests.

* Fix mimetype assertion in app-schema-test's PagingTest
* Include Postgis in app-schema-test's expectation respecting axis order
  App-schema-test's `SRCWfsTest` checked only if it run against GeoPackage to assert the expected geometries respect the EPSG axis order.
 Include PostGIS too and remove duplicated code.
 Reprojection works fine with the PostGIS online tests and produce the same expected results.


These integration test failures are currently not detected by any of the running build jobs, and are the same errors happening with and without the https://github.com/geotools/geotools/pull/4410 geotools enhancement.

Before:
```
src $> mvn -o clean test -pl :gs-app-schema-postgis-test -Papp-schema,app-schema-online-test
...
[ERROR] Failures: 
[ERROR]   FeatureChainingWfsTest.testEncodeFeatureMember:1868->AbstractAppSchemaTestSupport.assertXpathCount:340 expected:<1> but was:<0>
[ERROR]   PagingTest.testGetFeatureWithCSVFormat:900 expected:<text/csv[]> but was:<text/csv[;charset=UTF-8]>
[ERROR]   SRSWfsTest.testGetFeatureContent:148->AbstractAppSchemaTestSupport.assertXpathEvaluatesTo:329 expected:<[-1.2 52.5 -1.2 52.6 -1.1 52.6 -1.1 52.5 -1.2 52.5]> but was:<[52.5 -1.2 52.6 -1.2 52.6 -1.1 52.5 -1.1 52.5 -1.2]>
[ERROR]   SRSWfsTest.testReproject:378->AbstractAppSchemaTestSupport.assertXpathEvaluatesTo:329 expected:<[-1.2 52.5 -1.2 52.6 -1.1 52.6 -1.1 52.5 -1.2 52.5]> but was:<[52.50000004 -1.2 52.60000004 -1.2 52.60000004 -1.1 52.50000004 -1.1 52.50000004 -1.2]>
[INFO] 
[ERROR] Tests run: 318, Failures: 4, Errors: 0, Skipped: 0
```

After:
```
src $> mvn -o clean test -pl :gs-app-schema-postgis-test -Papp-schema,app-schema-online-test
...
[ERROR] Failures: 
[ERROR]   FeatureChainingWfsTest.testEncodeFeatureMember:1868->AbstractAppSchemaTestSupport.assertXpathCount:340 expected:<1> but was:<0>
[INFO] 
[ERROR] Tests run: 318, Failures: 1, Errors: 0, Skipped: 0
```
---

For the one missing failure, I gave up after a few hours of trying to figure out why
`org.geotools.gml3.bindings.FeaturePropertyTypeBinding.checkXlinkHref()` correctly sets the xlink metadata property on the duplicate `Feature` instances as:
```java
            map.put(toTypeName(XLINK.HREF), "#" + id.toString());
            // make sure the value is not encoded
            att.setValue(Collections.emptyList());
```

but then `org.geotools.gml3.bindings.GML3EncodingUtils.AbstractFeatureTypeEncode(...)` is not called to reach the following code branch:
```java
                if (idSet.idExists(id)) {
                    // XSD type ids can only appear once in the same document, otherwise the
                    // document is
                    // not schema valid. Attributes of the same ids should be encoded as xlink:href
                    // to
                    // the existing attribute.
                    encoding.setAttributeNS(
                            XLINK.NAMESPACE, XLINK.HREF.getLocalPart(), "#" + id.toString());
                    // make sure the attributes aren't encoded
                    feature.setValue(Collections.emptyList());
                    return encoding;
...
```

Consequently, the last three encoded `featureMember` are effectively empty, but lack the `xlink:href` attribute pointing to the above encoded features with the same identifiers, which are nested properties of previously encoded complex features:

```xml
    <gml:featureMember/>
    <gml:featureMember/>
    <gml:featureMember/>
</wfs:FeatureCollection>
```

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->