### PR TITLE
[Backport 2.24.x] Bump org.postgresql:postgresql from 42.6.0 to 42.7.2 in /src

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -141,7 +141,7 @@
     <jackson2.databind.version>2.15.2</jackson2.databind.version>
     <compress-lzf.version>1.0.3</compress-lzf.version>
     <marlin.version>0.9.3</marlin.version>
-    <postgresql.jdbc.version>42.6.0</postgresql.jdbc.version>
+    <postgresql.jdbc.version>42.7.2</postgresql.jdbc.version>
     <postgis.jdbc.version>1.3.3</postgis.jdbc.version>
     <oracle.jdbc.version>19.18.0.0</oracle.jdbc.version>
     <mysql.jdbc.version>8.0.28</mysql.jdbc.version>


### PR DESCRIPTION
Backport #7435
 **Authored by:** @dependabot[bot]