### PR TITLE
[GEOS-11325] Add properties to set additional security headers

### DIFF
--- a/doc/en/user/source/production/config.rst
+++ b/doc/en/user/source/production/config.rst
@@ -159,8 +159,17 @@ kinds of security vulnerabilities. See the `OWASP Clickjacking entry <https://ww
 
 If you wish to change this behavior you can do so through the following properties:
 
-* ``geoserver.xframe.shouldSetPolicy``: controls whether the X-Frame-Options filter should be set at all. Default is true.
-* ``geoserver.xframe.policy``: controls what the set the X-Frame-Options header to. Default is ``SAMEORIGIN`` valid options are ``DENY``, ``SAMEORIGIN`` and ``ALLOW-FROM`` [uri]
+* ``geoserver.xframe.shouldSetPolicy``: controls whether the X-Frame-Options header should be set at all. Default is true.
+* ``geoserver.xframe.policy``: controls what to set the X-Frame-Options header to. Default is ``SAMEORIGIN``. Valid options are ``DENY``, ``SAMEORIGIN`` and ``ALLOW-FROM [uri]``.
+
+.. note::
+    The WMS GetMap OpenLayers output format uses iframes to display the WMS GetFeatureInfo output and
+    this may not function properly if the policy is set to something other than ``SAMEORIGIN``.
+
+.. warning::
+    The ``ALLOW-FROM`` option is not supported by modern browsers and should only be used if you know
+    that browsers interacting with your GeoServer will support it. Applying this policy will be treated
+    as if no policy was set by browsers that do not support this (i.e., **NO** protection).
 
 These properties can be set either via Java system property, command line argument (-D), environment
 variable or web.xml init parameter.
@@ -176,6 +185,38 @@ If you wish to change this behavior you can do so through the following property
 * ``geoserver.xContentType.shouldSetPolicy``: controls whether the X-Content-Type-Options header should be set. Default is true.
 
 This property can be set either via Java system property, command line argument (-D), environment
+variable or web.xml init parameter.
+
+X-XSS-Protection Policy
+-----------------------
+
+GeoServer supports setting the X-XSS-Protection HTTP header in order to control the built-in reflected XSS filtering that existed in
+some older browsers. This header is **NOT** enabled by default since it does not affect modern browsers. Enabling the header without
+specifying a policy will default to Spring Security's default of ``0`` (which is also the current OWASP recommendation). See the
+`OWASP X-XSS-Protection entry <https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection>`_ for details.
+
+If you wish to change this behavior you can do so through the following properties:
+
+* ``geoserver.xXssProtection.shouldSetPolicy``: controls whether the X-XSS-Protection header should be set at all. Default is false.
+* ``geoserver.xXssProtection.policy``: controls what to set the X-XSS-Protection header to. Default is ``0``. Valid options are ``0``, ``1`` and ``1; mode=block``.
+
+These properties can be set either via Java system property, command line argument (-D), environment
+variable or web.xml init parameter.
+
+Strict-Transport-Security Policy
+--------------------------------
+
+In order to reduce the possibility of man-in-the-middle attacks GeoServer supports setting the Strict-Transport-Security HTTP header.
+This header is **NOT** enabled by default and, when enabled, this header will only be set on HTTPS requests. If a policy has not been
+set, the default policy will be the same as Spring Security's default of ``max-age=31536000 ; includeSubDomains``. See the
+`OWASP Strict-Transport-Security entry <https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#strict-transport-security-hsts>`_ for details.
+
+If you wish to change this behavior you can do so through the following properties:
+
+* ``geoserver.hsts.shouldSetPolicy``: controls whether the Strict-Transport-Security header should be set at all. Default is false.
+* ``geoserver.hsts.policy``: controls what to set the Strict-Transport-Security header to. Default is ``max-age=31536000 ; includeSubDomains``. Valid options can change the max-age to the desired age in seconds and can omit the includeSubDomains directive.
+
+These properties can be set either via Java system property, command line argument (-D), environment
 variable or web.xml init parameter.
 
 OWS ServiceException XML mimeType

--- a/src/main/src/test/java/org/geoserver/filters/XFrameOptionsFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/filters/XFrameOptionsFilterTest.java
@@ -7,8 +7,8 @@ package org.geoserver.filters;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import java.io.IOException;
-import javax.servlet.ServletException;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -17,78 +17,102 @@ import org.springframework.mock.web.MockHttpServletResponse;
 /** Simple test to make sure the XFrameOptions filter works and is configurable. */
 public class XFrameOptionsFilterTest {
 
-    @Test
-    public void doFilter() throws Exception {
-        String header = getHeader("X-Frame-Options");
-        assertEquals("Expect default XFrameOption to be DENY", "SAMEORIGIN", header);
+    @Before
+    @After
+    public void resetProperties() {
+        System.clearProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY);
+        System.clearProperty(XFrameOptionsFilter.GEOSERVER_HSTS_POLICY);
+        System.clearProperty(XFrameOptionsFilter.GEOSERVER_HSTS_SHOULD_SET_POLICY);
+        System.clearProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY);
+        System.clearProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY);
+        System.clearProperty(XFrameOptionsFilter.GEOSERVER_XXSS_PROTECTION_POLICY);
+        System.clearProperty(XFrameOptionsFilter.GEOSERVER_XXSS_PROTECTION_SHOULD_SET_POLICY);
     }
 
     @Test
-    public void testFilterWithNoSetPolicy() throws IOException, ServletException {
-        String currentShouldSetProperty =
-                System.getProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY);
+    public void testFilterDefaultFrameOptions() throws Exception {
+        assertEquals("SAMEORIGIN", getHeader("X-Frame-Options"));
+    }
+
+    @Test
+    public void testFilterWithoutFrameOptions() throws Exception {
         System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY, "false");
-        String header = getHeader("X-Frame-Options");
-
-        assertNull("Expect default XFrameOption to be null", header);
-
-        if (currentShouldSetProperty != null) {
-            System.setProperty(
-                    XFrameOptionsFilter.GEOSERVER_XFRAME_SHOULD_SET_POLICY,
-                    currentShouldSetProperty);
-        }
+        assertNull(getHeader("X-Frame-Options"));
     }
 
     @Test
-    public void testFilterWithSameOrigin() throws IOException, ServletException {
-        String currentShouldSetProperty =
-                System.getProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY);
+    public void testFilterCustomFrameOptions() throws Exception {
         System.setProperty(XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY, "DENY");
-        String header = getHeader("X-Frame-Options");
-
-        assertEquals("Expect default XFrameOption to be DENY", "DENY", header);
-
-        if (currentShouldSetProperty != null) {
-            System.setProperty(
-                    XFrameOptionsFilter.GEOSERVER_XFRAME_POLICY, currentShouldSetProperty);
-        }
+        assertEquals("DENY", getHeader("X-Frame-Options"));
     }
 
     @Test
-    public void testFilterWithoutContentTypeOptions() throws IOException, ServletException {
-        String currentShouldSetProperty =
-                System.getProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY);
+    public void testFilterDefaultContentTypeOptions() throws Exception {
+        assertEquals("nosniff", getHeader("X-Content-Type-Options"));
+    }
+
+    @Test
+    public void testFilterWithoutContentTypeOptions() throws Exception {
         System.setProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY, "false");
-        String header = getHeader("X-Content-Type-Options");
-
-        assertNull("Expect X-Content-Type-Options to be null", header);
-
-        if (currentShouldSetProperty != null) {
-            System.setProperty(
-                    XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY,
-                    currentShouldSetProperty);
-        }
+        assertNull(getHeader("X-Content-Type-Options"));
     }
 
     @Test
-    public void testFilterWithContentTypeOptions() throws IOException, ServletException {
-        String currentShouldSetProperty =
-                System.getProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY);
-        System.setProperty(XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY, "true");
-        String header = getHeader("X-Content-Type-Options");
-
-        assertEquals("Expect X-Content-Type-Options to be nosniff", "nosniff", header);
-
-        if (currentShouldSetProperty != null) {
-            System.setProperty(
-                    XFrameOptionsFilter.GEOSERVER_XCONTENT_TYPE_SHOULD_SET_POLICY,
-                    currentShouldSetProperty);
-        }
+    public void testFilterDefaultXssProtection() throws Exception {
+        assertNull(getHeader("X-XSS-Protection"));
     }
 
-    private String getHeader(String name) throws IOException, ServletException {
-        MockHttpServletRequest request =
-                new MockHttpServletRequest("GET", "http://www.geoserver.org");
+    @Test
+    public void testFilterWithXssProtection() throws Exception {
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_XXSS_PROTECTION_SHOULD_SET_POLICY, "true");
+        assertEquals("0", getHeader("X-XSS-Protection"));
+    }
+
+    @Test
+    public void testFilterCustomXssProtection() throws Exception {
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_XXSS_PROTECTION_SHOULD_SET_POLICY, "true");
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_XXSS_PROTECTION_POLICY, "1; mode=block");
+        assertEquals("1; mode=block", getHeader("X-XSS-Protection"));
+    }
+
+    @Test
+    public void testFilterHttpHstsDefault() throws Exception {
+        assertNull(getHeader("Strict-Transport-Security"));
+    }
+
+    @Test
+    public void testFilterHttpHstsEnabled() throws Exception {
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_HSTS_SHOULD_SET_POLICY, "true");
+        assertNull(getHeader("Strict-Transport-Security"));
+    }
+
+    @Test
+    public void testFilterHttpsHstsDefault() throws Exception {
+        assertNull(getHeader(true, "Strict-Transport-Security"));
+    }
+
+    @Test
+    public void testFilterHttpsHstsEnabled() throws Exception {
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_HSTS_SHOULD_SET_POLICY, "true");
+        assertEquals(
+                "max-age=31536000 ; includeSubDomains",
+                getHeader(true, "Strict-Transport-Security"));
+    }
+
+    @Test
+    public void testFilterHttpsHstsCustom() throws Exception {
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_HSTS_SHOULD_SET_POLICY, "true");
+        System.setProperty(XFrameOptionsFilter.GEOSERVER_HSTS_POLICY, "max-age=985500");
+        assertEquals("max-age=985500", getHeader(true, "Strict-Transport-Security"));
+    }
+
+    private static String getHeader(String name) throws Exception {
+        return getHeader(false, name);
+    }
+
+    private static String getHeader(boolean secure, String name) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "");
+        request.setScheme(secure ? "https" : "http");
         MockHttpServletResponse response = new MockHttpServletResponse();
         XFrameOptionsFilter filter = new XFrameOptionsFilter();
         MockFilterChain mockChain = new MockFilterChain();


### PR DESCRIPTION
[![GEOS-11325](https://badgen.net/badge/JIRA/GEOS-11325/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11325) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds system properties to allow GeoServer administrators to configure the X-XSS-Protection and Strict-Transport-Security HTTP response headers similar to how the X-Content-Type-Options and X-Frame-Options headers currently work.  All four of these headers are normally enabled by default by Spring Security but I left the two that are being added here disabled by default so there's no backwards compatibility issues.  I could enable them by default if that is the desired behavior.

Also, while it is probably unnecessary, to address previous concerns about calling GeoServerExtensions.getProperty so many times on every request, the property values are now cached.  I am working on something else that may add a couple more properties here.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->