### PR TITLE
[Backport 2.25.x] [GEOS-11216] add graticule assembly to assemeby list so it is built

### DIFF
--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -99,6 +99,7 @@
             <descriptor>release/ext-wps-longitudinal-profile.xml</descriptor>
             <descriptor>release/ext-rat.xml</descriptor>
             <descriptor>release/ext-monitor-kafka.xml</descriptor>
+            <descriptor>release/ext-graticule.xml</descriptor>
           </descriptors>
           <finalName>geoserver-${project.version}</finalName>
         </configuration>


### PR DESCRIPTION
[![GEOS-11216](https://badgen.net/badge/JIRA/GEOS-11216/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11216) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7475
 **Authored by:** @ianturton