### PR TITLE
[Backport 2.25.x] Bump com.nimbusds:nimbus-jose-jwt from 9.37.1 to 9.37.2 in /src/community/security/oauth2-openid-connect/oauth2-openid-connect-core

### DIFF
--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>9.37.1</version>
+      <version>9.37.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Backport #7482
 **Authored by:** @dependabot[bot]