### PR TITLE
[Backport 2.24.x] [GEOS-11312] Inconsistent Memory Units in Legend Image Creation

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/BufferedImageLegendGraphicBuilder.java
@@ -289,7 +289,7 @@ public class BufferedImageLegendGraphicBuilder extends LegendGraphicBuilder {
 
         // final checks
         if (finalLegend == null) throw new IllegalArgumentException("no legend passed");
-        int maxMemory = layersImages.getTally().getMaxMemory();
+        long maxMemory = layersImages.getTally().getMaxMemory();
         if (maxMemory != Tally.UNLIMITED && Tally.computeImageSize(finalLegend) > maxMemory)
             throw new ServiceException(
                     LegendGraphicBuilder.MEMORY_USAGE_EXCEEDED,

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/Tally.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/Tally.java
@@ -11,20 +11,20 @@ import org.geoserver.wms.WMS;
 
 class Tally {
 
-    static final int UNLIMITED = -1;
+    static final long UNLIMITED = -1;
 
-    private int maxMemory;
+    private final long maxMemory;
 
-    private int usedMemory;
+    private long usedMemory;
 
-    public Tally(int maxMemory) {
+    public Tally(long maxMemory) {
         this.maxMemory = maxMemory;
         this.usedMemory = 0;
     }
 
     public Tally(WMS wms) {
         if (wms != null && wms.getMaxRequestMemory() > 0) {
-            this.maxMemory = wms.getMaxRequestMemory() * 1024; // KB to bytes
+            this.maxMemory = wms.getMaxRequestMemory() * 1024L; // KB to bytes
         } else {
             this.maxMemory = UNLIMITED;
         }
@@ -32,9 +32,9 @@ class Tally {
 
     public void addImage(RenderedImage image) {
         if (maxMemory != UNLIMITED) {
-            int imageSize = computeImageSize(image);
+            long imageSize = computeImageSize(image);
             // compute sum as long to avoid overflow
-            if ((((long) usedMemory) + imageSize > maxMemory)) {
+            if (usedMemory + imageSize > maxMemory) {
                 // we don't report the max value as this could be a sub-list
                 throw new ServiceException(
                         LegendGraphicBuilder.MEMORY_USAGE_EXCEEDED,
@@ -44,9 +44,9 @@ class Tally {
         }
     }
 
-    public static int computeImageSize(RenderedImage image) {
+    public static long computeImageSize(RenderedImage image) {
         int pixelSize = IntStream.of(image.getSampleModel().getSampleSize()).sum() / 8;
-        return image.getWidth() * image.getHeight() * (pixelSize);
+        return (long) image.getWidth() * image.getHeight() * (pixelSize);
     }
 
     /** Returns an object representing the residual memory still available before limits kicks in */
@@ -59,11 +59,11 @@ class Tally {
         return new Tally(maxMemory);
     }
 
-    public int getMaxMemory() {
+    public long getMaxMemory() {
         return maxMemory;
     }
 
-    public int getUsedMemory() {
+    public long getUsedMemory() {
         return usedMemory;
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -603,23 +603,11 @@ public class GetLegendGraphicTest extends WMSTestSupport {
     @Test
     public void testMaxMemoryLimit() throws Exception {
         setMemoryLimit(Integer.MAX_VALUE);
-
-        Catalog catalog = getCatalog();
-
-        // setup base group, one layer
-        String groupName = "MEMORY_TEST_GROUP";
-        LayerGroupInfo group = catalog.getFactory().createLayerGroup();
-        group.setName(groupName);
-        group.getLayers().add(catalog.getLayerByName(getLayerId(SF_STATES)));
-        group.getStyles().add(null);
-        new CatalogBuilder(getCatalog()).calculateLayerGroupBounds(group);
-        catalog.add(group);
-
         String request =
-                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
-                        + "&layer=MEMORY_TEST_GROUP"
+                String.format("wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                        + "&layer=%s"
                         + "&style="
-                        + "&format=image/png&width=20&height=20";
+                        + "&format=image/png&width=20&height=20", SF_STATES_ID);
 
         BufferedImage image = getAsImage(request, "image/png");
         assertThat(image.getWidth() * image.getHeight() * 4, Matchers.lessThan(15 * 1024));

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -596,4 +596,32 @@ public class GetLegendGraphicTest extends WMSTestSupport {
         String message = checkLegacyException(dom, ServiceException.MAX_MEMORY_EXCEEDED, null);
         assertEquals(LegendGraphicBuilder.MEMORY_USAGE_EXCEEDED, message.trim());
     }
+
+    /**
+     * [GEOS-11312] Test for respecting int max value as memory limit (kb) for GetLegendGraphic requests
+     */
+    @Test
+    public void testMaxMemoryLimit() throws Exception {
+        setMemoryLimit(Integer.MAX_VALUE);
+
+        Catalog catalog = getCatalog();
+
+        // setup base group, one layer
+        String groupName = "MEMORY_TEST_GROUP";
+        LayerGroupInfo group = catalog.getFactory().createLayerGroup();
+        group.setName(groupName);
+        group.getLayers().add(catalog.getLayerByName(getLayerId(SF_STATES)));
+        group.getStyles().add(null);
+        new CatalogBuilder(getCatalog()).calculateLayerGroupBounds(group);
+        catalog.add(group);
+
+        String request =
+                "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                        + "&layer=MEMORY_TEST_GROUP"
+                        + "&style="
+                        + "&format=image/png&width=20&height=20";
+
+        BufferedImage image = getAsImage(request, "image/png");
+        assertThat(image.getWidth() * image.getHeight() * 4, Matchers.lessThan(15 * 1024));
+    }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -598,16 +598,19 @@ public class GetLegendGraphicTest extends WMSTestSupport {
     }
 
     /**
-     * [GEOS-11312] Test for respecting int max value as memory limit (kb) for GetLegendGraphic requests
+     * [GEOS-11312] Test for respecting int max value as memory limit (kb) for GetLegendGraphic
+     * requests
      */
     @Test
     public void testMaxMemoryLimit() throws Exception {
         setMemoryLimit(Integer.MAX_VALUE);
         String request =
-                String.format("wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
-                        + "&layer=%s"
-                        + "&style="
-                        + "&format=image/png&width=20&height=20", SF_STATES_ID);
+                String.format(
+                        "wms?service=WMS&version=1.1.1&request=GetLegendGraphic"
+                                + "&layer=%s"
+                                + "&style="
+                                + "&format=image/png&width=20&height=20",
+                        SF_STATES_ID);
 
         BufferedImage image = getAsImage(request, "image/png");
         assertThat(image.getWidth() * image.getHeight() * 4, Matchers.lessThan(15 * 1024));


### PR DESCRIPTION
[![GEOS-11312](https://badgen.net/badge/JIRA/GEOS-11312/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11312) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7443
 **Authored by:** @vuvkar