### PR TITLE
Temporary File Information Disclosure Vulnerability

### DIFF
--- a/src/community/jdbcstore/src/main/java/org/geoserver/jdbcstore/JDBCResourceStore.java
+++ b/src/community/jdbcstore/src/main/java/org/geoserver/jdbcstore/JDBCResourceStore.java
@@ -233,7 +233,7 @@ public class JDBCResourceStore implements ResourceStore {
                                 events));
             }
             try {
-                return new CachingOutputStreamWrapper(File.createTempFile("out.", entry.getName()));
+                return new CachingOutputStreamWrapper(Files.createTempFile("out.", entry.getName()).toFile());
             } catch (IOException ex) {
                 throw new IllegalStateException(ex);
             }

--- a/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/util/CatalogUtil.java
+++ b/src/community/taskmanager/core/src/main/java/org/geoserver/taskmanager/util/CatalogUtil.java
@@ -260,7 +260,7 @@ public class CatalogUtil {
                 }
             }
 
-            File zipFile = File.createTempFile("style", ".zip");
+            File zipFile = Files.createTempFile("style", ".zip").toFile();
             try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFile))) {
                 ZipEntry zipEntry = new ZipEntry(resStyle.name());
                 out.putNextEntry(zipEntry);

--- a/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/wfs/GeoPackageGetFeatureOutputFormat.java
+++ b/src/extension/geopkg-output/src/main/java/org/geoserver/geopkg/wfs/GeoPackageGetFeatureOutputFormat.java
@@ -95,7 +95,7 @@ public class GeoPackageGetFeatureOutputFormat extends WFSGetFeatureOutputFormat 
     File createTempFile(String prefix, String suffix) throws IOException {
         String customTempDir = GeoServerExtensions.getProperty(CUSTOM_TEMP_DIR_PROPERTY);
         if (!StringUtils.hasText(customTempDir)) {
-            return File.createTempFile("geopkg", ".tmp.gpkg");
+            return Files.createTempFile("geopkg", ".tmp.gpkg").toFile();
         }
         File tempDir = new File(customTempDir);
         if (!tempDir.exists() || !tempDir.isDirectory()) {

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/NetCDFCoverageResponseDelegate.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/wcs/responses/NetCDFCoverageResponseDelegate.java
@@ -78,7 +78,7 @@ public class NetCDFCoverageResponseDelegate extends BaseCoverageResponseDelegate
 
         File tempFile = null;
         try {
-            tempFile = File.createTempFile("tempNetCDF", ".nc");
+            tempFile = Files.createTempFile("tempNetCDF", ".nc").toFile();
             for (NetCDFEncoderFactory factory : encoderFactories) {
                 NetCDFEncoder encoder =
                         factory.getEncoderFor(

--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/GeopkgRasterPPIO.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/GeopkgRasterPPIO.java
@@ -69,7 +69,7 @@ public class GeopkgRasterPPIO extends GeopkgPPIO {
                         upRound(ri.getWidth(), TILE_SIZE),
                         upRound(ri.getHeight(), TILE_SIZE));
 
-        File file = File.createTempFile("geopkg", ".tmp.gpkg");
+        File file = Files.createTempFile("geopkg", ".tmp.gpkg").toFile();
         try {
             // write the geopackage
             try (GeoPackage geopkg = getGeoPackage(file)) {

--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/GeopkgVectorPPIO.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/GeopkgVectorPPIO.java
@@ -25,7 +25,7 @@ public class GeopkgVectorPPIO extends GeopkgPPIO {
     @Override
     public void encode(Object value, OutputStream os) throws Exception {
         SimpleFeatureCollection fc = (SimpleFeatureCollection) value;
-        File file = File.createTempFile("geopkg", ".tmp.gpkg");
+        File file = Files.createTempFile("geopkg", ".tmp.gpkg").toFile();
         try {
             // write the geopackage
             try (GeoPackage geopkg = getGeoPackage(file)) {

--- a/src/platform/src/main/java/org/geoserver/util/IOUtils.java
+++ b/src/platform/src/main/java/org/geoserver/util/IOUtils.java
@@ -190,7 +190,7 @@ public class IOUtils {
      * <p>Strategy is to leverage the system temp directory, then create a sub-directory.
      */
     public static File createTempDirectory(String prefix) throws IOException {
-        File dummyTemp = File.createTempFile("blah", null);
+        File dummyTemp = Files.createTempFile("blah", null).toFile();
         String sysTempDir = dummyTemp.getParentFile().getAbsolutePath();
         dummyTemp.delete();
 

--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapXmlReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapXmlReader.java
@@ -159,7 +159,7 @@ public class GetMapXmlReader extends org.geoserver.ows.XmlRequestReader {
         try {
             if (validateSchema) { // copy POST to a file
                 // make tempfile
-                temp = File.createTempFile("getMapPost", "xml");
+                temp = Files.createTempFile("getMapPost", "xml").toFile();
 
                 try (FileOutputStream fos = new FileOutputStream(temp);
                         BufferedOutputStream out = new BufferedOutputStream(fos)) {


### PR DESCRIPTION
There may has a temporary file information disclosure vulnerability by use File.createTempFile().

The following code is where I have found potential vulnerabilities, perhaps omissions

**Preamble**
The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file permissions are set.

The chain of calls was detected in this repository in a way that leaves this project vulnerable. IOUtils.createTempDirectory() -> file.createNewFile().

**Impact**
This vulnerability can have one of two impacts depending upon which vulnerability it is.

1.Temporary Directory Information Disclosure - Information in this directory is visable to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files. 2.Temporary Directory Hijacking Vulnerability - Same impact as 1. above, but also, ther local users can manipulate/add contents to this directory. If code is being executed out of this temporary directory, it can lead to local priviledge escalation.

**Other Examples**
[CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

**The Fix**
The fix has been to convert the logic above to use the following API that was introduced in Java 1.7. File tmpDir = Files.createTempFile(prefix, suffix).toFile(); The API both created the directory securely, ie with a random, non-conflicting name, with directory permissions that only allow the currently executing user to read or write the contents of this directory.