### PR TITLE
[Backport 2.24.x] [GEOS-11345] STAC Conformance URIs need to be updated

### DIFF
--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACService.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACService.java
@@ -113,6 +113,10 @@ public class STACService {
 
     public static final String STAC_VERSION = "1.0.0";
 
+    public static final String STAC_CONFORMANCE_VERSION = "v" + STAC_VERSION;
+    public static final String STAC_AUTHORITY = "https://api.stacspec.org/";
+    public static final String STAC_CONFORMANCE_ROOT = STAC_AUTHORITY + STAC_CONFORMANCE_VERSION;
+
     public static final String FEATURE_CORE =
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core";
     public static final String FEATURE_HTML =
@@ -121,18 +125,16 @@ public class STACService {
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson";
     public static final String FEATURE_OAS30 =
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30";
-    public static final String STAC_CORE = "https://api.stacspec.org/v1.0.0-beta.5/core";
-    public static final String STAC_SEARCH = "https://api.stacspec.org/v1.0.0-beta.5/item-search";
-    public static final String STAC_SEARCH_SORT =
-            "https://api.stacspec.org/v1.0.0-beta.5/item-search#sort";
+    public static final String STAC_CORE = STAC_CONFORMANCE_ROOT + "/core";
+    public static final String STAC_SEARCH = STAC_CONFORMANCE_ROOT + "/item-search";
+    public static final String STAC_SEARCH_SORT = STAC_CONFORMANCE_ROOT + "/item-search#sort";
 
-    public static final String STAC_SEARCH_FIELDS =
-            "https://api.stacspec.org/v1.0.0-beta.5/item-search#fields";
+    public static final String STAC_SEARCH_FIELDS = STAC_CONFORMANCE_ROOT + "/item-search#fields";
 
-    public static final String STAC_SEARCH_FILTER =
-            "https://api.stacspec.org/v1.0.0-beta.5/item-search#filter";
-    public static final String STAC_FEATURES =
-            "https://api.stacspec.org/spec/v1.0.0-beta.1/ogcapi-features";
+    public static final String STAC_SEARCH_FILTER = STAC_CONFORMANCE_ROOT + "/item-search#filter";
+    public static final String STAC_FEATURES = STAC_CONFORMANCE_ROOT + "/ogcapi-features";
+
+    public static final String STAC_COLLECTIONS = STAC_CONFORMANCE_ROOT + "/collections";
 
     /** Container type: catalog */
     public static String TYPE_CATALOG = "Catalog";
@@ -195,6 +197,7 @@ public class STACService {
                         FEATURE_OAS30,
                         FEATURE_HTML,
                         FEATURE_GEOJSON,
+                        STAC_COLLECTIONS,
                         STAC_CORE,
                         STAC_FEATURES,
                         STAC_SEARCH,

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/ConformanceTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/ConformanceTest.java
@@ -43,6 +43,7 @@ public class ConformanceTest extends STACTestSupport {
             STACService.FEATURE_OAS30,
             STACService.FEATURE_HTML,
             STACService.FEATURE_GEOJSON,
+            STACService.STAC_COLLECTIONS,
             STACService.STAC_CORE,
             STACService.STAC_FEATURES,
             STACService.STAC_SEARCH,


### PR DESCRIPTION
[![GEOS-11345](https://badgen.net/badge/JIRA/GEOS-11345/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11345) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7513
 **Authored by:** @turingtestfail