### PR TITLE
[GEOS-11348] JMS cluster does not allow to publish style via REST '2 step' approach

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSCatalogListener.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSCatalogListener.java
@@ -106,17 +106,20 @@ public class JMSCatalogListener extends JMSAbstractGeoServerProducer implements 
                 } else {
                     styleFile = loader.get("styles/" + sInfo.getFilename());
                 }
-                // checks
-                if (!Resources.exists(styleFile)
-                        || !Resources.canRead(styleFile)
-                        || !(styleFile.getType() == Type.RESOURCE)) {
-                    throw new IllegalStateException(
-                            "Unable to find style for event: " + sInfo.toString());
-                }
 
-                // transmit the file
-                jmsPublisher.publish(
-                        getTopic(), getJmsTemplate(), options, new DocumentFile(styleFile));
+                // according to the REST guide, one can create a style by first upload of the
+                // XML file and then the style (e.g., SLD) file. So the style file might be missing.
+                if (Resources.exists(styleFile)) {
+                    // checks
+                    if (!Resources.canRead(styleFile) || !(styleFile.getType() == Type.RESOURCE)) {
+                        throw new IllegalStateException(
+                                "Unable to find style for event: " + sInfo.toString());
+                    }
+
+                    // transmit the file
+                    jmsPublisher.publish(
+                            getTopic(), getJmsTemplate(), options, new DocumentFile(styleFile));
+                }
             }
 
             // propagate the event

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
@@ -11,11 +11,16 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.jms.Message;
+import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StyleHandler;
 import org.geoserver.catalog.StyleInfo;
@@ -31,6 +36,8 @@ import org.geoserver.cluster.impl.handlers.catalog.JMSCatalogStylesFileHandlerSP
 import org.geoserver.cluster.server.events.StyleModifyEvent;
 import org.geoserver.data.test.MockData;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.security.impl.GeoServerRole;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.api.style.RasterSymbolizer;
 import org.geotools.api.style.Style;
@@ -38,6 +45,7 @@ import org.geotools.api.style.StyledLayerDescriptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /** Tests related with styles events. */
 public final class JmsStylesTest extends GeoServerSystemTestSupport {
@@ -54,6 +62,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
             "JMSCatalogStylesFileHandlerSPI";
     private static final String CATALOG_REMOVE_EVENT_HANDLER_KEY =
             "JMSCatalogRemoveEventHandlerSPI";
+    public static final int MESSAGES_TIMEOUT = 5000;
 
     private WorkspaceInfo testWorkspace;
 
@@ -115,7 +124,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog add event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000,
+                        MESSAGES_TIMEOUT,
                         (selected) -> selected.size() >= 2,
                         CATALOG_ADD_EVENT_HANDLER_KEY,
                         CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
@@ -150,7 +159,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog add event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000,
+                        MESSAGES_TIMEOUT,
                         (selected) -> selected.size() >= 2,
                         CATALOG_ADD_EVENT_HANDLER_KEY,
                         CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
@@ -190,7 +199,9 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog modify event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000, (selected) -> selected.size() >= 1, CATALOG_MODIFY_EVENT_HANDLER_KEY);
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 1,
+                        CATALOG_MODIFY_EVENT_HANDLER_KEY);
         assertThat(messages.size(), is(1));
         // checking that the correct catalog style was published
         List<CatalogEvent> styleModifiedEvent =
@@ -230,7 +241,9 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog remove event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000, (selected) -> selected.size() >= 1, CATALOG_REMOVE_EVENT_HANDLER_KEY);
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 1,
+                        CATALOG_REMOVE_EVENT_HANDLER_KEY);
         assertThat(messages.size(), is(1));
         // checking that the correct style was published
         List<CatalogEvent> styleRemoveEvent =
@@ -241,6 +254,82 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         assertThat(removedStyle.getName(), is(TEST_STYLE_NAME));
     }
 
+    @Test
+    public void testRestStyleUploadTwoSteps() throws Exception {
+        // become superuser
+        login("admin", "geoserver", GeoServerRole.ADMIN_ROLE.toString());
+
+        // REST creation
+        String xml = "<style>" + "<name>foo</name>" + "<filename>foo.sld</filename>" + "</style>";
+        MockHttpServletResponse response =
+                postAsServletResponse(RestBaseController.ROOT_PATH + "/styles", xml);
+        assertEquals(201, response.getStatus());
+
+        // check that we get the catalog add event
+        List<Message> messages =
+                JmsEventsListener.getMessagesByHandlerKey(
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 1,
+                        CATALOG_ADD_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(1));
+
+        assertNotNull(getCatalog().getStyleByName("foo"));
+
+        // now upload the body
+        String sld = loadResource("/test_style.sld");
+        response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/styles/foo.sld?raw=true",
+                        sld,
+                        "application/vnd.ogc.sld+xml");
+        assertEquals(200, response.getStatus());
+
+        // wait for the upload event
+        messages =
+                JmsEventsListener.getMessagesByHandlerKey(
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 2,
+                        CATALOG_MODIFY_EVENT_HANDLER_KEY,
+                        CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(1));
+
+        // style is now usable
+        assertNotNull(getCatalog().getStyleByName("foo").getStyle());
+    }
+
+    @Test
+    public void testRestStyleUploadOneStep() throws Exception {
+        // become superuser
+        login("admin", "geoserver", GeoServerRole.ADMIN_ROLE.toString());
+
+        // now upload the body
+        String sld = loadResource("/test_style.sld");
+        MockHttpServletResponse response =
+                postAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/styles?raw=true&name=foo",
+                        sld,
+                        "application/vnd.ogc.sld+xml");
+        assertEquals(201, response.getStatus());
+
+        // wait for the upload event
+        List<Message> messages =
+                JmsEventsListener.getMessagesByHandlerKey(
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 2,
+                        CATALOG_ADD_EVENT_HANDLER_KEY,
+                        CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(2));
+
+        // style is now usable
+        assertNotNull(getCatalog().getStyleByName("foo").getStyle());
+    }
+
+    private String loadResource(String path) throws IOException {
+        try (InputStream is = getClass().getResourceAsStream(path)) {
+            return IOUtils.toString(is, StandardCharsets.UTF_8);
+        }
+    }
+
     /** Helper method that adds the test style to the catalog and consume the produced events. */
     private void addTestStyle() throws Exception {
         // add the test to the style catalog
@@ -249,7 +338,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog add event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000,
+                        MESSAGES_TIMEOUT,
                         (selected) -> selected.size() >= 2,
                         CATALOG_ADD_EVENT_HANDLER_KEY,
                         CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTest.java
@@ -274,7 +274,7 @@ public final class IntegrationTest {
      * be reached and then checks if the expected number of events were consumed.
      */
     private void waitAndCheckEvents(GeoServerInstance instance, int expectedEvents) {
-        instance.waitEvents(expectedEvents, 1000_000);
+        instance.waitEvents(expectedEvents, 2000);
         assertThat(instance.getConsumedEventsCount(), is(expectedEvents));
         instance.resetConsumedEventsCount();
     }


### PR DESCRIPTION
See ticket for details

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
