### PR TITLE
[Backport 2.23.x] [GEOS-11348] JMS cluster does not allow to publish style via REST '2 step' approach

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSCatalogListener.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSCatalogListener.java
@@ -106,17 +106,20 @@ public class JMSCatalogListener extends JMSAbstractGeoServerProducer implements 
                 } else {
                     styleFile = loader.get("styles/" + sInfo.getFilename());
                 }
-                // checks
-                if (!Resources.exists(styleFile)
-                        || !Resources.canRead(styleFile)
-                        || !(styleFile.getType() == Type.RESOURCE)) {
-                    throw new IllegalStateException(
-                            "Unable to find style for event: " + sInfo.toString());
-                }
 
-                // transmit the file
-                jmsPublisher.publish(
-                        getTopic(), getJmsTemplate(), options, new DocumentFile(styleFile));
+                // according to the REST guide, one can create a style by first upload of the
+                // XML file and then the style (e.g., SLD) file. So the style file might be missing.
+                if (Resources.exists(styleFile)) {
+                    // checks
+                    if (!Resources.canRead(styleFile) || !(styleFile.getType() == Type.RESOURCE)) {
+                        throw new IllegalStateException(
+                                "Unable to find style for event: " + sInfo.toString());
+                    }
+
+                    // transmit the file
+                    jmsPublisher.publish(
+                            getTopic(), getJmsTemplate(), options, new DocumentFile(styleFile));
+                }
             }
 
             // propagate the event

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
@@ -113,6 +113,12 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
             // the test style exists so let's remove it
             catalog.remove(style);
         }
+        // search the upload style
+        style = catalog.getStyleByName("foo");
+        if (style != null) {
+            // the test style exists so let's remove it
+            catalog.remove(style);
+        }
         // clear all pending events
         JmsEventsListener.clear();
     }

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTest.java
@@ -275,7 +275,7 @@ public final class IntegrationTest {
      * be reached and then checks if the expected number of events were consumed.
      */
     private void waitAndCheckEvents(GeoServerInstance instance, int expectedEvents) {
-        instance.waitEvents(expectedEvents, 1000_000);
+        instance.waitEvents(expectedEvents, 2000);
         assertThat(instance.getConsumedEventsCount(), is(expectedEvents));
         instance.resetConsumedEventsCount();
     }


### PR DESCRIPTION
[![GEOS-11348](https://badgen.net/badge/JIRA/GEOS-11348/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11348) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7526
 **Authored by:** @aaime