### PR TITLE
[Backport 2.24.x] [GEOS-11348] JMS cluster does not allow to publish style via REST '2 step' approach

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSCatalogListener.java
+++ b/src/community/jms-cluster/jms-geoserver/src/main/java/org/geoserver/cluster/server/JMSCatalogListener.java
@@ -106,17 +106,20 @@ public class JMSCatalogListener extends JMSAbstractGeoServerProducer implements 
                 } else {
                     styleFile = loader.get("styles/" + sInfo.getFilename());
                 }
-                // checks
-                if (!Resources.exists(styleFile)
-                        || !Resources.canRead(styleFile)
-                        || !(styleFile.getType() == Type.RESOURCE)) {
-                    throw new IllegalStateException(
-                            "Unable to find style for event: " + sInfo.toString());
-                }
 
-                // transmit the file
-                jmsPublisher.publish(
-                        getTopic(), getJmsTemplate(), options, new DocumentFile(styleFile));
+                // according to the REST guide, one can create a style by first upload of the
+                // XML file and then the style (e.g., SLD) file. So the style file might be missing.
+                if (Resources.exists(styleFile)) {
+                    // checks
+                    if (!Resources.canRead(styleFile) || !(styleFile.getType() == Type.RESOURCE)) {
+                        throw new IllegalStateException(
+                                "Unable to find style for event: " + sInfo.toString());
+                    }
+
+                    // transmit the file
+                    jmsPublisher.publish(
+                            getTopic(), getJmsTemplate(), options, new DocumentFile(styleFile));
+                }
             }
 
             // propagate the event

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
@@ -113,6 +113,12 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
             // the test style exists so let's remove it
             catalog.remove(style);
         }
+        // search the upload style
+        style = catalog.getStyleByName("foo");
+        if (style != null) {
+            // the test style exists so let's remove it
+            catalog.remove(style);
+        }
         // clear all pending events
         JmsEventsListener.clear();
     }

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsStylesTest.java
@@ -11,11 +11,16 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.jms.Message;
+import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.StyleHandler;
 import org.geoserver.catalog.StyleInfo;
@@ -31,6 +36,8 @@ import org.geoserver.cluster.impl.handlers.catalog.JMSCatalogStylesFileHandlerSP
 import org.geoserver.cluster.server.events.StyleModifyEvent;
 import org.geoserver.data.test.MockData;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.security.impl.GeoServerRole;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.api.style.RasterSymbolizer;
 import org.geotools.api.style.Style;
@@ -38,6 +45,7 @@ import org.geotools.api.style.StyledLayerDescriptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /** Tests related with styles events. */
 public final class JmsStylesTest extends GeoServerSystemTestSupport {
@@ -54,6 +62,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
             "JMSCatalogStylesFileHandlerSPI";
     private static final String CATALOG_REMOVE_EVENT_HANDLER_KEY =
             "JMSCatalogRemoveEventHandlerSPI";
+    public static final int MESSAGES_TIMEOUT = 5000;
 
     private WorkspaceInfo testWorkspace;
 
@@ -115,7 +124,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog add event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000,
+                        MESSAGES_TIMEOUT,
                         (selected) -> selected.size() >= 2,
                         CATALOG_ADD_EVENT_HANDLER_KEY,
                         CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
@@ -150,7 +159,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog add event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000,
+                        MESSAGES_TIMEOUT,
                         (selected) -> selected.size() >= 2,
                         CATALOG_ADD_EVENT_HANDLER_KEY,
                         CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
@@ -190,7 +199,9 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog modify event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000, (selected) -> selected.size() >= 1, CATALOG_MODIFY_EVENT_HANDLER_KEY);
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 1,
+                        CATALOG_MODIFY_EVENT_HANDLER_KEY);
         assertThat(messages.size(), is(1));
         // checking that the correct catalog style was published
         List<CatalogEvent> styleModifiedEvent =
@@ -230,7 +241,9 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog remove event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000, (selected) -> selected.size() >= 1, CATALOG_REMOVE_EVENT_HANDLER_KEY);
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 1,
+                        CATALOG_REMOVE_EVENT_HANDLER_KEY);
         assertThat(messages.size(), is(1));
         // checking that the correct style was published
         List<CatalogEvent> styleRemoveEvent =
@@ -241,6 +254,82 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         assertThat(removedStyle.getName(), is(TEST_STYLE_NAME));
     }
 
+    @Test
+    public void testRestStyleUploadTwoSteps() throws Exception {
+        // become superuser
+        login("admin", "geoserver", GeoServerRole.ADMIN_ROLE.toString());
+
+        // REST creation
+        String xml = "<style>" + "<name>foo</name>" + "<filename>foo.sld</filename>" + "</style>";
+        MockHttpServletResponse response =
+                postAsServletResponse(RestBaseController.ROOT_PATH + "/styles", xml);
+        assertEquals(201, response.getStatus());
+
+        // check that we get the catalog add event
+        List<Message> messages =
+                JmsEventsListener.getMessagesByHandlerKey(
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 1,
+                        CATALOG_ADD_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(1));
+
+        assertNotNull(getCatalog().getStyleByName("foo"));
+
+        // now upload the body
+        String sld = loadResource("/test_style.sld");
+        response =
+                putAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/styles/foo.sld?raw=true",
+                        sld,
+                        "application/vnd.ogc.sld+xml");
+        assertEquals(200, response.getStatus());
+
+        // wait for the upload event
+        messages =
+                JmsEventsListener.getMessagesByHandlerKey(
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 2,
+                        CATALOG_MODIFY_EVENT_HANDLER_KEY,
+                        CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(1));
+
+        // style is now usable
+        assertNotNull(getCatalog().getStyleByName("foo").getStyle());
+    }
+
+    @Test
+    public void testRestStyleUploadOneStep() throws Exception {
+        // become superuser
+        login("admin", "geoserver", GeoServerRole.ADMIN_ROLE.toString());
+
+        // now upload the body
+        String sld = loadResource("/test_style.sld");
+        MockHttpServletResponse response =
+                postAsServletResponse(
+                        RestBaseController.ROOT_PATH + "/styles?raw=true&name=foo",
+                        sld,
+                        "application/vnd.ogc.sld+xml");
+        assertEquals(201, response.getStatus());
+
+        // wait for the upload event
+        List<Message> messages =
+                JmsEventsListener.getMessagesByHandlerKey(
+                        MESSAGES_TIMEOUT,
+                        (selected) -> selected.size() >= 2,
+                        CATALOG_ADD_EVENT_HANDLER_KEY,
+                        CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);
+        assertThat(messages.size(), is(2));
+
+        // style is now usable
+        assertNotNull(getCatalog().getStyleByName("foo").getStyle());
+    }
+
+    private String loadResource(String path) throws IOException {
+        try (InputStream is = getClass().getResourceAsStream(path)) {
+            return IOUtils.toString(is, StandardCharsets.UTF_8);
+        }
+    }
+
     /** Helper method that adds the test style to the catalog and consume the produced events. */
     private void addTestStyle() throws Exception {
         // add the test to the style catalog
@@ -249,7 +338,7 @@ public final class JmsStylesTest extends GeoServerSystemTestSupport {
         // waiting for a catalog add event and a style file event
         List<Message> messages =
                 JmsEventsListener.getMessagesByHandlerKey(
-                        5000,
+                        MESSAGES_TIMEOUT,
                         (selected) -> selected.size() >= 2,
                         CATALOG_ADD_EVENT_HANDLER_KEY,
                         CATALOG_STYLES_FILE_EVENT_HANDLER_KEY);

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/integration/IntegrationTest.java
@@ -274,7 +274,7 @@ public final class IntegrationTest {
      * be reached and then checks if the expected number of events were consumed.
      */
     private void waitAndCheckEvents(GeoServerInstance instance, int expectedEvents) {
-        instance.waitEvents(expectedEvents, 1000_000);
+        instance.waitEvents(expectedEvents, 2000);
         assertThat(instance.getConsumedEventsCount(), is(expectedEvents));
         instance.resetConsumedEventsCount();
     }


### PR DESCRIPTION
[![GEOS-11348](https://badgen.net/badge/JIRA/GEOS-11348/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11348) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7526
 **Authored by:** @aaime